### PR TITLE
Modify BeanArchiveProcessor so that implicit bean archives are added to the index

### DIFF
--- a/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/ArcAnnotationProcessor.java
+++ b/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/ArcAnnotationProcessor.java
@@ -123,6 +123,7 @@ public class ArcAnnotationProcessor implements ResourceProcessor {
             ArcContainer container = template.getContainer();
             template.initBeanContainer(container);
             template.setupInjection(container);
+            template.setupRequestScope(null, null);
         }
     }
 

--- a/arc/runtime/pom.xml
+++ b/arc/runtime/pom.xml
@@ -22,6 +22,10 @@
       <groupId>org.jboss.shamrock</groupId>
       <artifactId>shamrock-core-runtime</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.undertow</groupId>
+      <artifactId>undertow-servlet</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/BeanArchiveProcessor.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/BeanArchiveProcessor.java
@@ -1,11 +1,17 @@
 package org.jboss.shamrock.deployment;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.CompositeIndex;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
 public class BeanArchiveProcessor implements ResourceProcessor {
@@ -15,14 +21,55 @@ public class BeanArchiveProcessor implements ResourceProcessor {
 
     @Override
     public void process(ArchiveContext archiveContext, ProcessorContext processorContext) throws Exception {
+
+        Set<ApplicationArchive> archives = archiveContext.getAllApplicationArchives();
+
+        // The list is not exhaustive - it merely contains all annotations supported by Arc
+        List<DotName> beanDefiningAnnotations = new ArrayList<>();
+        beanDefiningAnnotations.add(DotName.createSimple("javax.enterprise.context.Dependent"));
+        beanDefiningAnnotations.add(DotName.createSimple("javax.enterprise.context.RequestScoped"));
+        beanDefiningAnnotations.add(DotName.createSimple("javax.enterprise.context.ApplicationScoped"));
+        beanDefiningAnnotations.add(DotName.createSimple("javax.interceptor.Interceptor"));
+        // TODO: we could also add @Inject and @Singleton although these are not officialy included
+
+        // First find annotations annotated with "meta" bean defining annotations
+        List<DotName> metaBeanDefiningAnnotations = Collections.singletonList(DotName.createSimple("javax.enterprise.inject.Stereotype"));
+        for (ApplicationArchive archive : archives) {
+            for (DotName metaAnnotation : metaBeanDefiningAnnotations) {
+                Collection<AnnotationInstance> annotations = archive.getIndex().getAnnotations(metaAnnotation);
+                if (!annotations.isEmpty()) {
+                    for (AnnotationInstance annotationInstance : annotations) {
+                        if (annotationInstance.target().kind() == Kind.CLASS) {
+                            beanDefiningAnnotations.add(annotationInstance.target().asClass().name());
+                        }
+                    }
+                }
+            }
+        }
+        DotName extensionName = DotName.createSimple("javax.enterprise.inject.spi.Extension");
+
         List<IndexView> indexes = new ArrayList<>();
-        for(ApplicationArchive archive : archiveContext.getAllApplicationArchives()) {
-            //TODO: this should not really be in core
-            if(archive.getChildPath("META-INF/beans.xml") != null) {
-                indexes.add(archive.getIndex());
-            } else if(archive.getChildPath("WEB-INF/beans.xml") != null) {
-                //TODO: how to handle WEB-INF?
-                indexes.add(archive.getIndex());
+
+        for (ApplicationArchive archive : archives) {
+
+            IndexView index = archive.getIndex();
+
+            // TODO: this should not really be in core
+            if (archive.getChildPath("META-INF/beans.xml") != null) {
+                indexes.add(index);
+            } else if (archive.getChildPath("WEB-INF/beans.xml") != null) {
+                // TODO: how to handle WEB-INF?
+                indexes.add(index);
+            } else {
+                // Implicit bean archive without beans.xml - contains one or more bean classes with a bean defining annotation and no extension
+                if (index.getAllKnownImplementors(extensionName).isEmpty()) {
+                    for (DotName beanDefiningAnnotation : beanDefiningAnnotations) {
+                        if (!index.getAnnotations(beanDefiningAnnotation).isEmpty()) {
+                            indexes.add(index);
+                            break;
+                        }
+                    }
+                }
             }
         }
         beanArchiveIndex.setIndex(CompositeIndex.create(indexes));
@@ -30,7 +77,7 @@ public class BeanArchiveProcessor implements ResourceProcessor {
 
     @Override
     public int getPriority() {
-        //we want this to run early
+        // we want this to run early
         return -1000;
     }
 }

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/arc/RequestScopedBean.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/arc/RequestScopedBean.java
@@ -1,0 +1,14 @@
+package org.jboss.shamrock.example.arc;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestScopedBean {
+
+    int count;
+
+    public int incrementAndGet() {
+        return ++count;
+    }
+
+}

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/arc/TestRequestScopeEndpoint.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/arc/TestRequestScopeEndpoint.java
@@ -1,0 +1,23 @@
+package org.jboss.shamrock.example.arc;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/request-scoped")
+public class TestRequestScopeEndpoint {
+
+    @Inject
+    private RequestScopedBean requestScopedBean;
+
+    @GET
+    public String manualValidation() {
+
+        requestScopedBean.incrementAndGet();
+        requestScopedBean.incrementAndGet();
+        return "" + requestScopedBean.incrementAndGet();
+
+    }
+
+
+}

--- a/examples/strict/src/test/java/org/jboss/shamrock/example/test/RequestScopeITCase.java
+++ b/examples/strict/src/test/java/org/jboss/shamrock/example/test/RequestScopeITCase.java
@@ -1,0 +1,9 @@
+package org.jboss.shamrock.example.test;
+
+import org.jboss.shamrock.junit.GraalTest;
+import org.junit.runner.RunWith;
+
+@RunWith(GraalTest.class)
+public class RequestScopeITCase extends RequestScopeTestCase {
+
+}

--- a/examples/strict/src/test/java/org/jboss/shamrock/example/test/RequestScopeTestCase.java
+++ b/examples/strict/src/test/java/org/jboss/shamrock/example/test/RequestScopeTestCase.java
@@ -1,0 +1,19 @@
+package org.jboss.shamrock.example.test;
+
+import org.jboss.shamrock.example.testutils.URLTester;
+import org.jboss.shamrock.junit.ShamrockTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ShamrockTest.class)
+public class RequestScopeTestCase {
+
+    @Test
+    public void testRequestScope() {
+        Assert.assertEquals("3", URLTester.relative("rest/request-scoped").invokeURL().asString());
+        Assert.assertEquals("3", URLTester.relative("rest/request-scoped").invokeURL().asString());
+    }
+
+
+}

--- a/ext/arc/runtime/src/main/java/org/jboss/protean/arc/RequestContext.java
+++ b/ext/arc/runtime/src/main/java/org/jboss/protean/arc/RequestContext.java
@@ -70,7 +70,7 @@ public class RequestContext implements AlterableContext {
                     try {
                         instance.destroy();
                     } catch (Exception e) {
-                        throw new IllegalStateException("Unable to destroy instance" + instance.get());
+                        throw new IllegalStateException("Unable to destroy instance" + instance.get(), e);
                     }
                 }
             }

--- a/undertow/runtime/src/main/java/org/jboss/shamrock/undertow/runtime/UndertowDeploymentTemplate.java
+++ b/undertow/runtime/src/main/java/org/jboss/shamrock/undertow/runtime/UndertowDeploymentTemplate.java
@@ -56,6 +56,7 @@ public class UndertowDeploymentTemplate {
         }
         d.setClassLoader(cl);
         d.setResourceManager(new ClassPathResourceManager(d.getClassLoader(), "META-INF/resources"));
+        d.addWelcomePages("index.html", "index.htm");
         return d;
     }
 
@@ -112,7 +113,7 @@ public class UndertowDeploymentTemplate {
 
 
     public void registerListener(@ContextObject("deploymentInfo") DeploymentInfo info, Class<?> listenerClass, InstanceFactory<? extends EventListener> factory) {
-        info.addListener(new ListenerInfo((Class<? extends EventListener>)listenerClass, factory));
+        info.addListener(new ListenerInfo((Class<? extends EventListener>) listenerClass, factory));
     }
 
     public void addServletContextParameter(@ContextObject("deploymentInfo") DeploymentInfo info, String name, String value) {

--- a/undertow/runtime/src/main/java/org/jboss/shamrock/undertow/runtime/UndertowDeploymentTemplate.java
+++ b/undertow/runtime/src/main/java/org/jboss/shamrock/undertow/runtime/UndertowDeploymentTemplate.java
@@ -16,6 +16,7 @@ import org.jboss.shamrock.runtime.StartupContext;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.CanonicalPathHandler;
 import io.undertow.server.handlers.resource.ClassPathResourceManager;
 import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
@@ -122,7 +123,7 @@ public class UndertowDeploymentTemplate {
         if (undertow == null) {
             undertow = Undertow.builder()
                     .addHttpListener(Integer.parseInt(port), "localhost")
-                    .setHandler(ROOT_HANDLER)
+                    .setHandler(new CanonicalPathHandler(ROOT_HANDLER))
                     .build();
             undertow.start();
         }


### PR DESCRIPTION
- note that an archive contains an extension and no beans.xml file is
NOT a bean archive

I've tried to modify Ken's `GreetingEndpoint` in the rest-http demo to just inject and invoke some bean and it seems to work, without the need to add `beans.xml`.