### PR TITLE
Vertx support for Shamrock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <wildfly-common.version>1.5.0.Alpha1-format-002</wildfly-common.version>
         <jboss-modules.version>1.8.0.Final</jboss-modules.version>
+        <vertx.version>3.5.4</vertx.version>
 
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
 
@@ -96,6 +97,7 @@
         <module>fault-tolerance</module>
         <module>examples</module>
         <module>legacy</module>
+        <module>vertx</module>
     </modules>
     <build>
         <pluginManagement>
@@ -363,6 +365,16 @@
             <dependency>
                 <groupId>org.jboss.shamrock</groupId>
                 <artifactId>shamrock-fault-tolerance-runtime</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shamrock</groupId>
+                <artifactId>shamrock-vertx-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shamrock</groupId>
+                <artifactId>shamrock-vertx-runtime</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -873,6 +885,13 @@
                 <artifactId>jsoup</artifactId>
                 <version>1.10.2</version>
             </dependency>
+
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-core</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/vertx/deployment/pom.xml
+++ b/vertx/deployment/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-vertx</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-vertx-deployment</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-vertx-runtime</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
+++ b/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
@@ -1,0 +1,135 @@
+package org.jboss.shamrock.vertx;
+
+import org.jboss.shamrock.deployment.ArchiveContext;
+import org.jboss.shamrock.deployment.ProcessorContext;
+import org.jboss.shamrock.deployment.ResourceProcessor;
+
+class VertxProcessor implements ResourceProcessor {
+
+//    private static final Logger log = Logger.getLogger(RestClientProxy.class.getName());
+//
+//    private static final DotName REGISTER_REST_CLIENT = DotName.createSimple(RegisterRestClient.class.getName());
+//    @Inject
+//    private BeanDeployment beanDeployment;
+//
+//    @Inject
+//    private ShamrockConfig config;
+//
+//    private static final DotName[] CLIENT_ANNOTATIONS = {
+//            DotName.createSimple("javax.ws.rs.GET"),
+//            DotName.createSimple("javax.ws.rs.HEAD"),
+//            DotName.createSimple("javax.ws.rs.DELETE"),
+//            DotName.createSimple("javax.ws.rs.OPTIONS"),
+//            DotName.createSimple("javax.ws.rs.PATCH"),
+//            DotName.createSimple("javax.ws.rs.POST"),
+//            DotName.createSimple("javax.ws.rs.PUT"),
+//            DotName.createSimple("javax.ws.rs.PUT"),
+//            DotName.createSimple(RegisterRestClient.class.getName()),
+//            DotName.createSimple(Path.class.getName())
+//    };
+
+    @Override
+    public void process(ArchiveContext archiveContext, ProcessorContext processorContext) throws Exception {
+    	processorContext.addNativeImageSystemProperty("io.netty.noUnsafe", "true");
+    	processorContext.addRuntimeInitializedClasses(
+    			"io.netty.handler.ssl.OpenSsl",
+    			"io.netty.handler.ssl.ReferenceCountedOpenSslEngine",
+    			"io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator",
+    			"io.netty.handler.codec.http.HttpObjectEncoder",
+    			"io.netty.handler.codec.http2.Http2CodecUtil",
+    			"io.netty.handler.codec.http2.DefaultHttp2FrameWriter",
+    			"io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder");
+    	/* 
+    	 * native-image --delay-class-initialization-to-runtime= \
+    	 *   io.netty.handler.ssl.ReferenceCountedOpenSslEngine,\
+    	 *   io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,\
+    	 *   io.netty.handler.codec.http.HttpObjectEncoder,\
+    	 *   io.netty.handler.codec.http2.Http2CodecUtil,\
+    	 *   io.netty.handler.codec.http2.DefaultHttp2FrameWriter,\
+    	 *   io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder \
+    	 *   --report-unsupported-elements-at-runtime -H:ReflectionConfigurationFiles=reflect.json 
+    	 *   -H:DynamicProxyConfigurationFiles=/home/stephane/src/java-eclipse/redpipe/proxies.json 
+    	 *   -Dio.netty.noUnsafe=true  
+    	 *   -H:EnableURLProtocols=http 
+    	 *   -Djava.net.preferIPv4Stack=true 
+    	 *   '-H:IncludeResources=META-INF/.*'  
+    	 */
+    			
+    	
+//        processorContext.addReflectiveClass(false, false,
+//                DefaultResponseExceptionMapper.class.getName(),
+//                LogFactoryImpl.class.getName(),
+//                Jdk14Logger.class.getName());
+//        processorContext.addReflectiveClass(false, false, ClientRequestFilter[].class.getName());
+//        processorContext.addReflectiveClass(false, false, ClientResponseFilter[].class.getName());
+//        processorContext.addProxyDefinition("javax.ws.rs.ext.Providers");
+//        beanDeployment.addAdditionalBean(RestClient.class);
+//        processorContext.addResource("META-INF/services/javax.ws.rs.ext.Providers");
+//        //TODO: fix this, we don't want to just add all the providers
+//        processorContext.addReflectiveClass(false, false, "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl");
+//        processorContext.addReflectiveClass(false, false, "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");
+//        processorContext.addReflectiveClass(true, true, "org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider", "org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider");
+//        processorContext.addProxyDefinition(ResteasyConfiguration.class.getName());
+//        Map<DotName, ClassInfo> interfaces = new HashMap<>();
+//        for (DotName type : CLIENT_ANNOTATIONS) {
+//            for (AnnotationInstance annotation : archiveContext.getCombinedIndex().getAnnotations(type)) {
+//                AnnotationTarget target = annotation.target();
+//                ClassInfo theInfo;
+//                if (target.kind() == AnnotationTarget.Kind.CLASS) {
+//                    theInfo = target.asClass();
+//                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
+//                    theInfo = target.asMethod().declaringClass();
+//                } else {
+//                    continue;
+//                }
+//                if (!Modifier.isInterface(theInfo.flags())) {
+//                    continue;
+//                }
+//                interfaces.put(theInfo.name(), theInfo);
+//            }
+//        }
+//
+//        for (Map.Entry<DotName, ClassInfo> entry : interfaces.entrySet()) {
+//            String iName = entry.getKey().toString();
+//            processorContext.addProxyDefinition(iName, ResteasyClientProxy.class.getName());
+//            processorContext.addProxyDefinition(iName, RestClientProxy.class.getName());
+//            processorContext.addReflectiveClass(true, false, iName);
+//
+//            //now generate CDI beans
+//            //TODO: do we need to check if CDI is enabled? Are we just assuming it always is?
+//            String className = iName + "$$RestClientProxy";
+//            AtomicReference<byte[]> bytes= new AtomicReference<>();
+//            try (ClassCreator creator = new ClassCreator(new ClassOutput() {
+//                @Override
+//                public void write(String name, byte[] data) {
+//                    try {
+//                        bytes.set(data);
+//                        processorContext.addGeneratedClass(true, name, data);
+//                    } catch (IOException e) {
+//                        throw new RuntimeException(e);
+//                    }
+//                }
+//            }, className, null, RestClientBase.class.getName())) {
+//
+//                creator.addAnnotation(Dependent.class);
+//                MethodCreator producer = creator.getMethodCreator("producerMethod", iName);
+//                producer.addAnnotation(Produces.class);
+//                producer.addAnnotation(RestClient.class);
+//                producer.addAnnotation(ApplicationScoped.class);
+//
+//                ResultHandle ret = producer.invokeVirtualMethod(MethodDescriptor.ofMethod(RestClientBase.class, "create", Object.class), producer.getThis());
+//                producer.returnValue(ret);
+//
+//                MethodCreator ctor = creator.getMethodCreator(MethodDescriptor.ofConstructor(className));
+//                ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(RestClientBase.class, Class.class), ctor.getThis(), ctor.loadClass(iName));
+//                ctor.returnValue(null);
+//            }
+//            beanDeployment.addGeneratedBean(className, bytes.get());
+//        }
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+}

--- a/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
+++ b/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
@@ -6,126 +6,20 @@ import org.jboss.shamrock.deployment.ResourceProcessor;
 
 class VertxProcessor implements ResourceProcessor {
 
-//    private static final Logger log = Logger.getLogger(RestClientProxy.class.getName());
-//
-//    private static final DotName REGISTER_REST_CLIENT = DotName.createSimple(RegisterRestClient.class.getName());
-//    @Inject
-//    private BeanDeployment beanDeployment;
-//
-//    @Inject
-//    private ShamrockConfig config;
-//
-//    private static final DotName[] CLIENT_ANNOTATIONS = {
-//            DotName.createSimple("javax.ws.rs.GET"),
-//            DotName.createSimple("javax.ws.rs.HEAD"),
-//            DotName.createSimple("javax.ws.rs.DELETE"),
-//            DotName.createSimple("javax.ws.rs.OPTIONS"),
-//            DotName.createSimple("javax.ws.rs.PATCH"),
-//            DotName.createSimple("javax.ws.rs.POST"),
-//            DotName.createSimple("javax.ws.rs.PUT"),
-//            DotName.createSimple("javax.ws.rs.PUT"),
-//            DotName.createSimple(RegisterRestClient.class.getName()),
-//            DotName.createSimple(Path.class.getName())
-//    };
-
     @Override
     public void process(ArchiveContext archiveContext, ProcessorContext processorContext) throws Exception {
     	processorContext.addNativeImageSystemProperty("io.netty.noUnsafe", "true");
-    	processorContext.addRuntimeInitializedClasses(
-    			"io.netty.handler.ssl.OpenSsl",
-    			"io.netty.handler.ssl.ReferenceCountedOpenSslEngine",
-    			"io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator",
-    			"io.netty.handler.codec.http.HttpObjectEncoder",
-    			"io.netty.handler.codec.http2.Http2CodecUtil",
-    			"io.netty.handler.codec.http2.DefaultHttp2FrameWriter",
-    			"io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder");
-    	/* 
-    	 * native-image --delay-class-initialization-to-runtime= \
-    	 *   io.netty.handler.ssl.ReferenceCountedOpenSslEngine,\
-    	 *   io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,\
-    	 *   io.netty.handler.codec.http.HttpObjectEncoder,\
-    	 *   io.netty.handler.codec.http2.Http2CodecUtil,\
-    	 *   io.netty.handler.codec.http2.DefaultHttp2FrameWriter,\
-    	 *   io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder \
-    	 *   --report-unsupported-elements-at-runtime -H:ReflectionConfigurationFiles=reflect.json 
-    	 *   -H:DynamicProxyConfigurationFiles=/home/stephane/src/java-eclipse/redpipe/proxies.json 
-    	 *   -Dio.netty.noUnsafe=true  
-    	 *   -H:EnableURLProtocols=http 
-    	 *   -Djava.net.preferIPv4Stack=true 
-    	 *   '-H:IncludeResources=META-INF/.*'  
-    	 */
-    			
     	
-//        processorContext.addReflectiveClass(false, false,
-//                DefaultResponseExceptionMapper.class.getName(),
-//                LogFactoryImpl.class.getName(),
-//                Jdk14Logger.class.getName());
-//        processorContext.addReflectiveClass(false, false, ClientRequestFilter[].class.getName());
-//        processorContext.addReflectiveClass(false, false, ClientResponseFilter[].class.getName());
-//        processorContext.addProxyDefinition("javax.ws.rs.ext.Providers");
-//        beanDeployment.addAdditionalBean(RestClient.class);
-//        processorContext.addResource("META-INF/services/javax.ws.rs.ext.Providers");
-//        //TODO: fix this, we don't want to just add all the providers
-//        processorContext.addReflectiveClass(false, false, "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl");
-//        processorContext.addReflectiveClass(false, false, "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");
-//        processorContext.addReflectiveClass(true, true, "org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider", "org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider");
-//        processorContext.addProxyDefinition(ResteasyConfiguration.class.getName());
-//        Map<DotName, ClassInfo> interfaces = new HashMap<>();
-//        for (DotName type : CLIENT_ANNOTATIONS) {
-//            for (AnnotationInstance annotation : archiveContext.getCombinedIndex().getAnnotations(type)) {
-//                AnnotationTarget target = annotation.target();
-//                ClassInfo theInfo;
-//                if (target.kind() == AnnotationTarget.Kind.CLASS) {
-//                    theInfo = target.asClass();
-//                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
-//                    theInfo = target.asMethod().declaringClass();
-//                } else {
-//                    continue;
-//                }
-//                if (!Modifier.isInterface(theInfo.flags())) {
-//                    continue;
-//                }
-//                interfaces.put(theInfo.name(), theInfo);
-//            }
-//        }
-//
-//        for (Map.Entry<DotName, ClassInfo> entry : interfaces.entrySet()) {
-//            String iName = entry.getKey().toString();
-//            processorContext.addProxyDefinition(iName, ResteasyClientProxy.class.getName());
-//            processorContext.addProxyDefinition(iName, RestClientProxy.class.getName());
-//            processorContext.addReflectiveClass(true, false, iName);
-//
-//            //now generate CDI beans
-//            //TODO: do we need to check if CDI is enabled? Are we just assuming it always is?
-//            String className = iName + "$$RestClientProxy";
-//            AtomicReference<byte[]> bytes= new AtomicReference<>();
-//            try (ClassCreator creator = new ClassCreator(new ClassOutput() {
-//                @Override
-//                public void write(String name, byte[] data) {
-//                    try {
-//                        bytes.set(data);
-//                        processorContext.addGeneratedClass(true, name, data);
-//                    } catch (IOException e) {
-//                        throw new RuntimeException(e);
-//                    }
-//                }
-//            }, className, null, RestClientBase.class.getName())) {
-//
-//                creator.addAnnotation(Dependent.class);
-//                MethodCreator producer = creator.getMethodCreator("producerMethod", iName);
-//                producer.addAnnotation(Produces.class);
-//                producer.addAnnotation(RestClient.class);
-//                producer.addAnnotation(ApplicationScoped.class);
-//
-//                ResultHandle ret = producer.invokeVirtualMethod(MethodDescriptor.ofMethod(RestClientBase.class, "create", Object.class), producer.getThis());
-//                producer.returnValue(ret);
-//
-//                MethodCreator ctor = creator.getMethodCreator(MethodDescriptor.ofConstructor(className));
-//                ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(RestClientBase.class, Class.class), ctor.getThis(), ctor.loadClass(iName));
-//                ctor.returnValue(null);
-//            }
-//            beanDeployment.addGeneratedBean(className, bytes.get());
-//        }
+    	processorContext.addRuntimeInitializedClasses(
+    			"io.netty.handler.codec.http.HttpObjectEncoder"
+    			// These may need to be added depending on the application
+//    			"io.netty.handler.codec.http2.Http2CodecUtil",
+//    			"io.netty.handler.codec.http2.DefaultHttp2FrameWriter",
+//    			"io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder"
+    			);
+
+    	// This one may not be required after Vert.x 3.6.0 lands
+    	processorContext.addReflectiveClass(false, false, "io.netty.channel.socket.nio.NioSocketChannel");
     }
 
     @Override

--- a/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxSetup.java
+++ b/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxSetup.java
@@ -1,0 +1,11 @@
+package org.jboss.shamrock.vertx;
+
+import org.jboss.shamrock.deployment.SetupContext;
+import org.jboss.shamrock.deployment.ShamrockSetup;
+
+public class VertxSetup implements ShamrockSetup {
+    @Override
+    public void setup(SetupContext context) {
+        context.addResourceProcessor(new VertxProcessor());
+    }
+}

--- a/vertx/deployment/src/main/resources/META-INF/services/org.jboss.shamrock.deployment.ShamrockSetup
+++ b/vertx/deployment/src/main/resources/META-INF/services/org.jboss.shamrock.deployment.ShamrockSetup
@@ -1,0 +1,1 @@
+org.jboss.shamrock.vertx.VertxSetup

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-parent</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-vertx</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/vertx/runtime/pom.xml
+++ b/vertx/runtime/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-vertx</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-vertx-runtime</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-core-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.graalvm</groupId>
+            <artifactId>graal-annotations</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/JdkSubstitutions.java
+++ b/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/JdkSubstitutions.java
@@ -1,0 +1,78 @@
+package org.jboss.shamrock.vertx.runtime.graal;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.net.URL;
+import java.security.AccessControlContext;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+
+@TargetClass(className = "sun.misc.URLClassPath$Loader")
+final class Target_sun_misc_URLClassPath$Loader {
+
+	@Alias
+	public Target_sun_misc_URLClassPath$Loader(URL url) {
+	}
+}
+
+@TargetClass(className = "sun.misc.URLClassPath$FileLoader")
+final class Target_sun_misc_URLClassPath$FileLoader {
+
+	@Alias
+	public Target_sun_misc_URLClassPath$FileLoader(URL url) {
+	}
+}
+
+@TargetClass(className = "sun.misc.URLClassPath")
+final class Target_sun_misc_URLClassPath {
+
+	@Alias
+    private AccessControlContext acc;
+
+	@Substitute
+    private Target_sun_misc_URLClassPath$Loader getLoader(final URL url) throws IOException {
+        try {
+            return java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedExceptionAction<Target_sun_misc_URLClassPath$Loader>() {
+                public Target_sun_misc_URLClassPath$Loader run() throws IOException {
+                    String file = url.getFile();
+                    if (file != null && file.endsWith("/")) {
+                        if ("file".equals(url.getProtocol())) {
+                            return (Target_sun_misc_URLClassPath$Loader)(Object)new Target_sun_misc_URLClassPath$FileLoader(url);
+                        } else {
+                            return new Target_sun_misc_URLClassPath$Loader(url);
+                        }
+                    } else {
+                    	// that must be wrong, but JarLoader is deleted by SVM
+                        return (Target_sun_misc_URLClassPath$Loader)(Object)new Target_sun_misc_URLClassPath$FileLoader(url);
+                    }
+                }
+            }, acc);
+        } catch (java.security.PrivilegedActionException pae) {
+            throw (IOException)pae.getException();
+        }
+    }
+	
+	@Substitute
+    private int[] getLookupCache(String name) {
+		return null;
+    }
+}
+
+
+@TargetClass(className = "sun.nio.ch.DatagramChannelImpl")
+final class Target_sun_nio_ch_DatagramChannelImpl {
+
+    @Substitute
+    private static void disconnect0(FileDescriptor fd, boolean isIPv6)
+            throws IOException{
+    	throw new RuntimeException("Unimplemented: sun.nio.ch.DatagramChannelImpl.disconnect0(FileDescriptor, boolean)");
+    }
+}
+
+class JdkSubstitutions {
+
+}

--- a/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/NettySubstitutions.java
+++ b/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/NettySubstitutions.java
@@ -1,0 +1,212 @@
+package org.jboss.shamrock.vertx.runtime.graal;
+
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.annotate.TargetElement;
+
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.CipherSuiteFilter;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.JdkLoggerFactory;
+import io.vertx.core.net.impl.transport.Transport;
+
+@TargetClass(className = "io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess")
+final class Target_io_netty_util_internal_shaded_org_jctools_util_UnsafeRefArrayAccess {
+     @Alias
+     @RecomputeFieldValue(kind = Kind.ArrayIndexShift, declClass = Object[].class)
+     public static int REF_ELEMENT_SHIFT;
+}
+
+@TargetClass(className = "io.vertx.core.net.impl.transport.Transport")
+final class Target_io_vertx_core_net_impl_transport_Transport {
+	@Substitute
+	public static Transport nativeTransport() {
+		return Transport.JDK;
+	}
+}
+
+@Substitute
+@TargetClass(className = "io.netty.handler.ssl.OpenSsl")
+final class Target_io_netty_handler_ssl_OpenSsl {
+	private static final Throwable UNAVAILABILITY_CAUSE = new NoClassDefFoundError("NO NATIVE SSL ON GRAALVM");
+	private static final boolean USE_KEYMANAGER_FACTORY = false;
+	
+	@Substitute
+	public static boolean isAvailable() {
+		return false;
+	}
+	@Substitute
+    public static boolean isAlpnSupported() {
+    	return false;
+    }
+	@Substitute
+    public static Throwable unavailabilityCause() {
+        return UNAVAILABILITY_CAUSE;
+    }
+	@Substitute
+    @SuppressWarnings("unchecked")
+	public static Set<String> availableOpenSslCipherSuites() {
+        return Collections.EMPTY_SET;
+    }
+	@Substitute
+    public static void ensureAvailability() {
+        if (UNAVAILABILITY_CAUSE != null) {
+            throw (Error) new UnsatisfiedLinkError(
+                    "failed to load the required native library").initCause(UNAVAILABILITY_CAUSE);
+        }
+    }
+	@Substitute
+    static boolean useKeyManagerFactory() {
+        return USE_KEYMANAGER_FACTORY;
+    }
+}
+
+@Delete
+@TargetClass(className = "io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
+final class Target_io_netty_handler_ssl_ReferenceCountedOpenSslEngine {
+}
+
+@Delete
+@TargetClass(className = "io.netty.handler.ssl.ReferenceCountedOpenSslClientContext")
+final class Target_io_netty_handler_ssl_ReferenceCountedOpenSslClientContext {
+}
+
+@TargetClass(className = "io.netty.handler.ssl.JdkSslServerContext")
+final class Target_io_netty_handler_ssl_JdkSslServerContext{
+	@Alias
+	Target_io_netty_handler_ssl_JdkSslServerContext(Provider provider,
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout,
+            ClientAuth clientAuth, String[] protocols, boolean startTls) throws SSLException {
+	}
+}
+
+@TargetClass(className = "io.netty.handler.ssl.JdkSslClientContext")
+final class Target_io_netty_handler_ssl_JdkSslClientContext{
+	@Alias
+	Target_io_netty_handler_ssl_JdkSslClientContext(Provider sslContextProvider,
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout)
+            		throws SSLException {
+    }
+}
+
+@TargetClass(className = "io.netty.handler.ssl.SslHandler$SslEngineType")
+final class Target_io_netty_handler_ssl_SslHandler$SslEngineType {
+	@Alias
+	public static Target_io_netty_handler_ssl_SslHandler$SslEngineType JDK;
+
+	@Alias
+    Cumulator cumulator;
+}
+
+@TargetClass(className = "io.netty.handler.ssl.SslHandler")
+final class Target_io_netty_handler_ssl_SslHandler {
+	@Alias
+    private final SSLEngine engine;
+	@Alias
+    private final Target_io_netty_handler_ssl_SslHandler$SslEngineType engineType;
+
+	@Alias
+    private final Executor delegatedTaskExecutor;
+	@Alias
+    private final boolean jdkCompatibilityMode;
+	@Alias
+    private final boolean startTls;
+    
+	@TargetElement(name = TargetElement.CONSTRUCTOR_NAME)
+    @Substitute
+	Target_io_netty_handler_ssl_SslHandler(SSLEngine engine, boolean startTls, Executor delegatedTaskExecutor) {
+        if (engine == null) {
+            throw new NullPointerException("engine");
+        }
+        if (delegatedTaskExecutor == null) {
+            throw new NullPointerException("delegatedTaskExecutor");
+        }
+        this.engine = engine;
+        engineType = Target_io_netty_handler_ssl_SslHandler$SslEngineType.JDK;
+        this.delegatedTaskExecutor = delegatedTaskExecutor;
+        this.startTls = startTls;
+        this.jdkCompatibilityMode = true;
+        ((ByteToMessageDecoder)(Object)this).setCumulator(engineType.cumulator);
+    }
+}
+
+@TargetClass(className = "io.netty.handler.ssl.SslContext")
+final class Target_io_netty_handler_ssl_SslContext {
+	@Substitute
+    static SslContext newServerContextInternal(
+            SslProvider provider,
+            Provider sslContextProvider,
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
+            boolean enableOcsp) throws SSLException {
+
+    	if (enableOcsp) {
+    		throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
+    	}
+    	return (SslContext)(Object)new Target_io_netty_handler_ssl_JdkSslServerContext(sslContextProvider,
+    			trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+    			keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+    			clientAuth, protocols, startTls);
+    }
+	
+	@Substitute
+	static SslContext newClientContextInternal(
+	        SslProvider provider,
+	        Provider sslContextProvider,
+	        X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
+	        X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+	        Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+	        long sessionCacheSize, long sessionTimeout, boolean enableOcsp) throws SSLException {
+		if (enableOcsp) {
+			throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
+		}
+		return (SslContext)(Object)new Target_io_netty_handler_ssl_JdkSslClientContext(sslContextProvider,
+				trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
+				keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout);
+	}
+
+}
+
+
+@TargetClass(className = "io.netty.util.internal.logging.InternalLoggerFactory")
+final class Target_io_netty_util_internal_logging_InternalLoggerFactory {
+	@Substitute
+    private static InternalLoggerFactory newDefaultFactory(String name) {
+        JdkLoggerFactory f = (JdkLoggerFactory) JdkLoggerFactory.INSTANCE;
+        f.newInstance(name).debug("Using java.util.logging as the default logging framework");
+        return f;
+    }
+}
+
+public class NettySubstitutions {
+
+}

--- a/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/VertxSubstitutions.java
+++ b/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/VertxSubstitutions.java
@@ -1,0 +1,18 @@
+package org.jboss.shamrock.vertx.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.vertx.core.net.impl.transport.Transport;
+
+@TargetClass(className = "io.vertx.core.net.impl.transport.Transport")
+final class Target_io_vertx_core_net_impl_transport_Transport {
+	@Substitute
+	public static Transport nativeTransport() {
+		return Transport.JDK;
+	}
+}
+
+class VertxSubstitutions {
+
+}


### PR DESCRIPTION
This is enough to get the crud-http test going using a Vert.x Reactive PG client. I haven't tested Vert.x server applications, which may require more work, but that's a start.

Lots of substs for Netty to make it not use SSL. Some for the JDK too.