### PR TITLE
Arc - add basic BeanManager support

### DIFF
--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanGenerator.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanGenerator.java
@@ -75,7 +75,11 @@ public class BeanGenerator extends AbstractGenerator {
 
     private static final AtomicInteger PRODUCER_INDEX = new AtomicInteger();
 
-    private static final String FIELD_NAME_DECLARING_PROVIDER = "declaringProvider";
+    protected static final String FIELD_NAME_DECLARING_PROVIDER = "declaringProvider";
+    protected static final String FIELD_NAME_BEAN_TYPES = "types";
+    protected static final String FIELD_NAME_QUALIFIERS = "qualifiers";
+    protected static final String FIELD_NAME_STEREOTYPES = "stereotypes";
+    protected static final String FIELD_NAME_PROXY = "proxy";
 
     protected final AnnotationLiteralProcessor annotationLiterals;
 
@@ -121,14 +125,18 @@ public class BeanGenerator extends AbstractGenerator {
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName).interfaces(InjectableBean.class).build();
 
         // Fields
-        FieldCreator beanTypes = beanCreator.getFieldCreator("beanTypes", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        FieldCreator beanTypes = beanCreator.getFieldCreator(FIELD_NAME_BEAN_TYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         FieldCreator qualifiers = null;
         if (!bean.getQualifiers().isEmpty() && !bean.hasDefaultQualifiers()) {
-            qualifiers = beanCreator.getFieldCreator("qualifiers", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+            qualifiers = beanCreator.getFieldCreator(FIELD_NAME_QUALIFIERS, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
         if (bean.getScope().isNormal()) {
             // For normal scopes a client proxy is generated too
-            beanCreator.getFieldCreator("proxy", LazyValue.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+            beanCreator.getFieldCreator(FIELD_NAME_PROXY, LazyValue.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        }
+        FieldCreator stereotypes = null;
+        if (!bean.getStereotypes().isEmpty()) {
+            stereotypes = beanCreator.getFieldCreator(FIELD_NAME_STEREOTYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
 
         Map<InjectionPointInfo, String> injectionPointToProviderField = new HashMap<>();
@@ -155,6 +163,10 @@ public class BeanGenerator extends AbstractGenerator {
         if (bean.isAlternative()) {
             implementGetAlternativePriority(bean, beanCreator);
         }
+        if (stereotypes != null) {
+            implementGetStereotypes(bean, beanCreator, stereotypes.getFieldDescriptor());
+        }
+        implementGetBeanClass(bean, beanCreator);
 
         beanCreator.close();
         return classOutput.getResources();
@@ -183,14 +195,18 @@ public class BeanGenerator extends AbstractGenerator {
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName).interfaces(InjectableBean.class).build();
 
         // Fields
-        FieldCreator beanTypes = beanCreator.getFieldCreator("beanTypes", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        FieldCreator beanTypes = beanCreator.getFieldCreator(FIELD_NAME_BEAN_TYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         FieldCreator qualifiers = null;
         if (!bean.getQualifiers().isEmpty() && !bean.hasDefaultQualifiers()) {
-            qualifiers = beanCreator.getFieldCreator("qualifiers", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+            qualifiers = beanCreator.getFieldCreator(FIELD_NAME_QUALIFIERS, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
         if (bean.getScope().isNormal()) {
             // For normal scopes a client proxy is generated too
-            beanCreator.getFieldCreator("proxy", LazyValue.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+            beanCreator.getFieldCreator(FIELD_NAME_PROXY, LazyValue.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        }
+        FieldCreator stereotypes = null;
+        if (!bean.getStereotypes().isEmpty()) {
+            stereotypes = beanCreator.getFieldCreator(FIELD_NAME_STEREOTYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
 
         Map<InjectionPointInfo, String> injectionPointToProviderField = new HashMap<>();
@@ -215,6 +231,10 @@ public class BeanGenerator extends AbstractGenerator {
             implementGetQualifiers(bean, beanCreator, qualifiers.getFieldDescriptor());
         }
         implementGetDeclaringBean(beanCreator);
+        if (stereotypes != null) {
+            implementGetStereotypes(bean, beanCreator, stereotypes.getFieldDescriptor());
+        }
+        implementGetBeanClass(bean, beanCreator);
 
         beanCreator.close();
         return classOutput.getResources();
@@ -243,14 +263,18 @@ public class BeanGenerator extends AbstractGenerator {
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName).interfaces(InjectableBean.class).build();
 
         // Fields
-        FieldCreator beanTypes = beanCreator.getFieldCreator("beanTypes", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        FieldCreator beanTypes = beanCreator.getFieldCreator(FIELD_NAME_BEAN_TYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         FieldCreator qualifiers = null;
         if (!bean.getQualifiers().isEmpty() && !bean.hasDefaultQualifiers()) {
-            qualifiers = beanCreator.getFieldCreator("qualifiers", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+            qualifiers = beanCreator.getFieldCreator(FIELD_NAME_QUALIFIERS, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
         if (bean.getScope().isNormal()) {
             // For normal scopes a client proxy is generated too
-            beanCreator.getFieldCreator("proxy", LazyValue.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+            beanCreator.getFieldCreator(FIELD_NAME_PROXY, LazyValue.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        }
+        FieldCreator stereotypes = null;
+        if (!bean.getStereotypes().isEmpty()) {
+            stereotypes = beanCreator.getFieldCreator(FIELD_NAME_STEREOTYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
         }
 
         createProviderFields(beanCreator, bean, Collections.emptyMap(), Collections.emptyMap());
@@ -271,6 +295,10 @@ public class BeanGenerator extends AbstractGenerator {
             implementGetQualifiers(bean, beanCreator, qualifiers.getFieldDescriptor());
         }
         implementGetDeclaringBean(beanCreator);
+        if (stereotypes != null) {
+            implementGetStereotypes(bean, beanCreator, stereotypes.getFieldDescriptor());
+        }
+        implementGetBeanClass(bean, beanCreator);
 
         beanCreator.close();
         return classOutput.getResources();
@@ -410,9 +438,8 @@ public class BeanGenerator extends AbstractGenerator {
         for (org.jboss.jandex.Type type : bean.getTypes()) {
             constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, typesHandle, Types.getTypeHandle(constructor, type));
         }
-        ResultHandle unmodifiableTypesHandle = constructor
-                .invokeStaticMethod(MethodDescriptor.ofMethod(Collections.class, "unmodifiableSet", Set.class, Set.class), typesHandle);
-        constructor.writeInstanceField(FieldDescriptor.of(beanCreator.getClassName(), "beanTypes", Set.class.getName()), constructor.getThis(),
+        ResultHandle unmodifiableTypesHandle = constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_UNMODIFIABLE_SET, typesHandle);
+        constructor.writeInstanceField(FieldDescriptor.of(beanCreator.getClassName(), FIELD_NAME_BEAN_TYPES, Set.class.getName()), constructor.getThis(),
                 unmodifiableTypesHandle);
 
         // Qualifiers
@@ -433,10 +460,21 @@ public class BeanGenerator extends AbstractGenerator {
                             constructor.newInstance(MethodDescriptor.ofConstructor(annotationLiteralName)));
                 }
             }
-            ResultHandle unmodifiableQualifiersHandle = constructor
-                    .invokeStaticMethod(MethodDescriptor.ofMethod(Collections.class, "unmodifiableSet", Set.class, Set.class), qualifiersHandle);
-            constructor.writeInstanceField(FieldDescriptor.of(beanCreator.getClassName(), "qualifiers", Set.class.getName()), constructor.getThis(),
+            ResultHandle unmodifiableQualifiersHandle = constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_UNMODIFIABLE_SET, qualifiersHandle);
+            constructor.writeInstanceField(FieldDescriptor.of(beanCreator.getClassName(), FIELD_NAME_QUALIFIERS, Set.class.getName()), constructor.getThis(),
                     unmodifiableQualifiersHandle);
+        }
+
+        // Stereotypes
+        if (!bean.getStereotypes().isEmpty()) {
+            ResultHandle stereotypesHandle = constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+            for (StereotypeInfo stereotype : bean.getStereotypes()) {
+                constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, stereotypesHandle,
+                        constructor.loadClass(stereotype.getTarget().name().toString()));
+            }
+            ResultHandle unmodifiableStereotypesHandle = constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_UNMODIFIABLE_SET, stereotypesHandle);
+            constructor.writeInstanceField(FieldDescriptor.of(beanCreator.getClassName(), FIELD_NAME_STEREOTYPES, Set.class.getName()), constructor.getThis(),
+                    unmodifiableStereotypesHandle);
         }
 
         if (bean.getScope().isNormal()) {
@@ -1064,6 +1102,16 @@ public class BeanGenerator extends AbstractGenerator {
         MethodCreator getAlternativePriority = beanCreator.getMethodCreator("getAlternativePriority", Integer.class).setModifiers(ACC_PUBLIC);
         getAlternativePriority.returnValue(getAlternativePriority.newInstance(MethodDescriptor.ofConstructor(Integer.class, int.class),
                 getAlternativePriority.load(bean.getAlternativePriority())));
+    }
+
+    protected void implementGetStereotypes(BeanInfo bean, ClassCreator beanCreator, FieldDescriptor stereotypesField) {
+        MethodCreator getStereotypes = beanCreator.getMethodCreator("getStereotypes", Set.class).setModifiers(ACC_PUBLIC);
+        getStereotypes.returnValue(getStereotypes.readInstanceField(stereotypesField, getStereotypes.getThis()));
+    }
+
+    protected void implementGetBeanClass(BeanInfo bean, ClassCreator beanCreator) {
+        MethodCreator getBeanClass = beanCreator.getMethodCreator("getBeanClass", Class.class).setModifiers(ACC_PUBLIC);
+        getBeanClass.returnValue(getBeanClass.loadClass(bean.getBeanClass().toString()));
     }
 
 }

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
@@ -18,6 +18,7 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.protean.arc.processor.Methods.MethodKey;
@@ -98,6 +99,13 @@ class BeanInfo {
 
     boolean isProducerField() {
         return Kind.FIELD.equals(target.kind());
+    }
+
+    DotName getBeanClass() {
+        if (declaringBean != null) {
+            return declaringBean.target.asClass().name();
+        }
+        return target.asClass().name();
     }
 
     boolean isInterceptor() {

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/InterceptorGenerator.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/InterceptorGenerator.java
@@ -40,6 +40,8 @@ public class InterceptorGenerator extends BeanGenerator {
 
     private static final Logger LOGGER = Logger.getLogger(InterceptorGenerator.class);
 
+    protected static final String FIELD_NAME_BINDINGS = "bindings";
+
     /**
      *
      * @param annotationLiterals
@@ -76,8 +78,8 @@ public class InterceptorGenerator extends BeanGenerator {
                 .build();
 
         // Fields
-        FieldCreator beanTypes = interceptorCreator.getFieldCreator("beanTypes", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
-        FieldCreator bindings = interceptorCreator.getFieldCreator("bindings", Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        FieldCreator beanTypes = interceptorCreator.getFieldCreator(FIELD_NAME_BEAN_TYPES, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+        FieldCreator bindings = interceptorCreator.getFieldCreator(FIELD_NAME_BINDINGS, Set.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
 
         Map<InjectionPointInfo, String> injectionPointToProviderField = new HashMap<>();
         Map<InterceptorInfo, String> interceptorToProviderField = new HashMap<>();

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/InterceptorInfo.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/InterceptorInfo.java
@@ -40,7 +40,7 @@ class InterceptorInfo extends BeanInfo implements Comparable<InterceptorInfo> {
      */
     InterceptorInfo(AnnotationTarget target, BeanDeployment beanDeployment, Set<AnnotationInstance> bindings, List<Injection> injections, int priority) {
         super(target, beanDeployment, ScopeInfo.DEPENDENT, Collections.singleton(Type.create(target.asClass().name(), Kind.CLASS)), new HashSet<>(), injections,
-                null, null, null, null);
+                null, null, null, Collections.emptyList());
         this.bindings = bindings;
         this.priority = priority;
         this.aroundInvoke = target.asClass().methods().stream().filter(m -> m.hasAnnotation(DotNames.AROUND_INVOKE)).findAny().orElse(null);

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/MethodDescriptors.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/MethodDescriptors.java
@@ -2,6 +2,7 @@ package org.jboss.protean.arc.processor;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -90,6 +91,8 @@ final class MethodDescriptors {
 
     static final MethodDescriptor CREATIONAL_CTX_ADD_DEP_TO_PARENT = MethodDescriptor.ofMethod(CreationalContextImpl.class, "addDependencyToParent", void.class, InjectableBean.class,
             Object.class, CreationalContext.class);
+
+    static final MethodDescriptor COLLECTIONS_UNMODIFIABLE_SET = MethodDescriptor.ofMethod(Collections.class, "unmodifiableSet", Set.class, Set.class);
 
     private MethodDescriptors() {
     }

--- a/ext/arc/runtime/pom.xml
+++ b/ext/arc/runtime/pom.xml
@@ -17,12 +17,6 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.el</groupId>
-          <artifactId>javax.el-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/ext/arc/runtime/src/main/java/org/jboss/protean/arc/BeanManagerImpl.java
+++ b/ext/arc/runtime/src/main/java/org/jboss/protean/arc/BeanManagerImpl.java
@@ -1,0 +1,261 @@
+package org.jboss.protean.arc;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMember;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedParameter;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanAttributes;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Decorator;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
+import javax.enterprise.inject.spi.InterceptionFactory;
+import javax.enterprise.inject.spi.InterceptionType;
+import javax.enterprise.inject.spi.Interceptor;
+import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.ProducerFactory;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class BeanManagerImpl implements BeanManager {
+
+    static final LazyValue<BeanManagerImpl> INSTANCE = new LazyValue<>(BeanManagerImpl::new);
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public Object getReference(Bean<?> bean, Type beanType, CreationalContext<?> ctx) {
+        Objects.requireNonNull(bean);
+        Objects.requireNonNull(ctx);
+        if (bean instanceof InjectableBean && ctx instanceof CreationalContextImpl) {
+            return ArcContainerImpl.instance().beanInstanceHandle((InjectableBean) bean, (CreationalContextImpl) ctx).get();
+        }
+        throw new IllegalArgumentException(
+                "Arguments must be instances of " + InjectableBean.class + " and " + CreationalContextImpl.class + ": \nbean: " + bean + "\nctx: " + ctx);
+    }
+
+    @Override
+    public Object getInjectableReference(InjectionPoint ij, CreationalContext<?> ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> CreationalContext<T> createCreationalContext(Contextual<T> contextual) {
+        return new CreationalContextImpl<>();
+    }
+
+    @Override
+    public Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers) {
+        Objects.requireNonNull(beanType);
+        return ArcContainerImpl.instance().getBeans(beanType, qualifiers);
+    }
+
+    @Override
+    public Set<Bean<?>> getBeans(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Bean<?> getPassivationCapableBean(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <X> Bean<? extends X> resolve(Set<Bean<? extends X>> beans) {
+        return ArcContainerImpl.instance().resolve(beans);
+    }
+
+    @Override
+    public void validate(InjectionPoint injectionPoint) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void fireEvent(Object event, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Set<ObserverMethod<? super T>> resolveObserverMethods(T event, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Decorator<?>> resolveDecorators(Set<Type> types, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Interceptor<?>> resolveInterceptors(InterceptionType type, Annotation... interceptorBindings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isScope(Class<? extends Annotation> annotationType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isNormalScope(Class<? extends Annotation> annotationType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPassivatingScope(Class<? extends Annotation> annotationType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isQualifier(Class<? extends Annotation> annotationType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isInterceptorBinding(Class<? extends Annotation> annotationType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isStereotype(Class<? extends Annotation> annotationType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Annotation> getInterceptorBindingDefinition(Class<? extends Annotation> bindingType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Annotation> getStereotypeDefinition(Class<? extends Annotation> stereotype) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean areQualifiersEquivalent(Annotation qualifier1, Annotation qualifier2) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean areInterceptorBindingsEquivalent(Annotation interceptorBinding1, Annotation interceptorBinding2) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getQualifierHashCode(Annotation qualifier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInterceptorBindingHashCode(Annotation interceptorBinding) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Context getContext(Class<? extends Annotation> scopeType) {
+        return Arc.container().getContext(scopeType);
+    }
+
+    @Override
+    public ELResolver getELResolver() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionFactory wrapExpressionFactory(ExpressionFactory expressionFactory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> AnnotatedType<T> createAnnotatedType(Class<T> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> InjectionTarget<T> createInjectionTarget(AnnotatedType<T> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> InjectionTargetFactory<T> getInjectionTargetFactory(AnnotatedType<T> annotatedType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <X> ProducerFactory<X> getProducerFactory(AnnotatedField<? super X> field, Bean<X> declaringBean) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <X> ProducerFactory<X> getProducerFactory(AnnotatedMethod<? super X> method, Bean<X> declaringBean) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> BeanAttributes<T> createBeanAttributes(AnnotatedType<T> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Bean<T> createBean(BeanAttributes<T> attributes, Class<T> beanClass, InjectionTargetFactory<T> injectionTargetFactory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T, X> Bean<T> createBean(BeanAttributes<T> attributes, Class<X> beanClass, ProducerFactory<X> producerFactory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InjectionPoint createInjectionPoint(AnnotatedField<?> field) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InjectionPoint createInjectionPoint(AnnotatedParameter<?> parameter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Extension> T getExtension(Class<T> extensionClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> InterceptionFactory<T> createInterceptionFactory(CreationalContext<T> ctx, Class<T> clazz) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Event<Object> getEvent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instance<Object> createInstance() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/ext/arc/runtime/src/main/java/org/jboss/protean/arc/BeanManagerProvider.java
+++ b/ext/arc/runtime/src/main/java/org/jboss/protean/arc/BeanManagerProvider.java
@@ -4,7 +4,7 @@ import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.BeanManager;
 
 /**
- * Dummy {@link BeanManager} provider.
+ * {@link BeanManager} provider.
  *
  * @author Martin Kouba
  */
@@ -12,8 +12,7 @@ public class BeanManagerProvider<T> implements InjectableReferenceProvider<BeanM
 
     @Override
     public BeanManager get(CreationalContext<BeanManager> creationalContext) {
-        // TODO log a warning
-        return null;
+        return BeanManagerImpl.INSTANCE.get();
     }
 
 }

--- a/ext/arc/runtime/src/main/java/org/jboss/protean/arc/InitializedInterceptor.java
+++ b/ext/arc/runtime/src/main/java/org/jboss/protean/arc/InitializedInterceptor.java
@@ -79,4 +79,9 @@ public class InitializedInterceptor<T> implements InjectableInterceptor<T> {
         return delegate.getPriority();
     }
 
+    @Override
+    public Class<?> getBeanClass() {
+        return delegate.getBeanClass();
+    }
+
 }

--- a/ext/arc/runtime/src/main/java/org/jboss/protean/arc/InjectableBean.java
+++ b/ext/arc/runtime/src/main/java/org/jboss/protean/arc/InjectableBean.java
@@ -2,20 +2,22 @@ package org.jboss.protean.arc;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
-import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.InjectionPoint;
 
 /**
- * Represents an injectable bean. It is an alternative to {@link javax.enterprise.inject.spi.Bean}.
+ * Represents an injectable bean.
  *
  * @author Martin Kouba
  *
  * @param <T>
  */
-public interface InjectableBean<T> extends Contextual<T>, InjectableReferenceProvider<T> {
+public interface InjectableBean<T> extends Bean<T>, InjectableReferenceProvider<T> {
 
     /**
      *
@@ -27,7 +29,7 @@ public interface InjectableBean<T> extends Contextual<T>, InjectableReferencePro
 
     /**
      *
-     * @return the set of bean type
+     * @return the set of bean types
      */
     Set<Type> getTypes();
 
@@ -50,6 +52,31 @@ public interface InjectableBean<T> extends Contextual<T>, InjectableReferencePro
      */
     default InjectableBean<?> getDeclaringBean() {
         return null;
+    }
+
+    @Override
+    default String getName() {
+        return null;
+    }
+
+    @Override
+    default Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    default Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    default boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    default boolean isAlternative() {
+        return getAlternativePriority() != null;
     }
 
     /**

--- a/ext/arc/runtime/src/main/java/org/jboss/protean/arc/InstanceImpl.java
+++ b/ext/arc/runtime/src/main/java/org/jboss/protean/arc/InstanceImpl.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
@@ -48,13 +47,13 @@ class InstanceImpl<T> implements Instance<T> {
     @SuppressWarnings("unchecked")
     @Override
     public T get() {
-        List<InjectableBean<?>> beans = getBeans();
+        Set<InjectableBean<?>> beans = getBeans();
         if (beans.isEmpty()) {
             throw new UnsatisfiedResolutionException();
         } else if (beans.size() > 1) {
             throw new AmbiguousResolutionException();
         }
-        return getBeanInstance((InjectableBean<T>) beans.get(0));
+        return getBeanInstance((InjectableBean<T>) beans.iterator().next());
     }
 
     @Override
@@ -107,8 +106,8 @@ class InstanceImpl<T> implements Instance<T> {
         return instance;
     }
 
-    private List<InjectableBean<?>> getBeans() {
-        return ArcContainerImpl.unwrap(Arc.container()).geBeans(type, qualifiers.toArray(EMPTY_ANNOTATION_ARRAY));
+    private Set<InjectableBean<?>> getBeans() {
+        return ArcContainerImpl.instance().getResolvedBeans(type, qualifiers.toArray(EMPTY_ANNOTATION_ARRAY));
     }
 
     class InstanceIterator implements Iterator<T> {

--- a/ext/arc/tests/src/test/java/org/jboss/protean/arc/test/beanmanager/BeanManagerTest.java
+++ b/ext/arc/tests/src/test/java/org/jboss/protean/arc/test/beanmanager/BeanManagerTest.java
@@ -1,0 +1,116 @@
+package org.jboss.protean.arc.test.beanmanager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.jboss.protean.arc.Arc;
+import org.jboss.protean.arc.test.ArcTestContainer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BeanManagerTest {
+
+    @Rule
+    public ArcTestContainer container = new ArcTestContainer(Legacy.class, AlternativeLegacy.class, Fool.class);
+
+    @Test
+    public void testGetBeans() {
+        BeanManager beanManager = Arc.container().instance(Legacy.class).get().getBeanManager();
+        Set<Bean<?>> beans = beanManager.getBeans(Legacy.class);
+        assertEquals(2, beans.size());
+        assertEquals(AlternativeLegacy.class, beanManager.resolve(beans).getBeanClass());
+    }
+
+    @Test
+    public void testGetReference() {
+        Fool.DESTROYED.set(false);
+        Legacy.DESTROYED.set(false);
+
+        BeanManager beanManager = Arc.container().instance(Legacy.class).get().getBeanManager();
+
+        Set<Bean<?>> foolBeans = beanManager.getBeans(Fool.class);
+        assertEquals(1, foolBeans.size());
+        @SuppressWarnings("unchecked")
+        Bean<Fool> foolBean = (Bean<Fool>) foolBeans.iterator().next();
+        Fool fool1 = (Fool) beanManager.getReference(foolBean, Fool.class, beanManager.createCreationalContext(foolBean));
+        Arc.container().withinRequest(() -> assertEquals(fool1.getId(),
+                ((Fool) beanManager.getReference(foolBean, Fool.class, beanManager.createCreationalContext(foolBean))).getId())).run();
+        assertTrue(Fool.DESTROYED.get());
+
+        Set<Bean<?>> legacyBeans = beanManager.getBeans(AlternativeLegacy.class);
+        assertEquals(1, legacyBeans.size());
+        @SuppressWarnings("unchecked")
+        Bean<AlternativeLegacy> legacyBean = (Bean<AlternativeLegacy>) legacyBeans.iterator().next();
+        CreationalContext<AlternativeLegacy> ctx = beanManager.createCreationalContext(legacyBean);
+        Legacy legacy = (Legacy) beanManager.getReference(legacyBean, Legacy.class, ctx);
+        assertNotNull(legacy.getBeanManager());
+        ctx.release();
+        assertTrue(Legacy.DESTROYED.get());
+    }
+
+    @Dependent
+    static class Legacy {
+
+        static final AtomicBoolean DESTROYED = new AtomicBoolean();
+
+        @Inject
+        BeanManager beanManager;
+
+        public BeanManager getBeanManager() {
+            return beanManager;
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+
+    }
+
+    @Priority(1)
+    @Alternative
+    @Dependent
+    static class AlternativeLegacy extends Legacy {
+
+    }
+
+    @RequestScoped
+    static class Fool {
+
+        static final AtomicBoolean DESTROYED = new AtomicBoolean();
+
+        private String id;
+
+        @PostConstruct
+        void init() {
+            id = UUID.randomUUID().toString();
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+
+        String getId() {
+            return id;
+        }
+
+    }
+
+}


### PR DESCRIPTION
- a lot of frameworks still rely on BeanManager's
getBeans()/createCreationalContext()/getReference() combo at runtime
- resolves #57