### PR TITLE
Allow bytecode transformers to run in parallel when using shamrock:run

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/BuildTimeGenerator.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/BuildTimeGenerator.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -86,7 +87,7 @@ public class BuildTimeGenerator {
     private final DeploymentProcessorInjection injection;
     private final ClassLoader classLoader;
     private final boolean useStaticInit;
-    private final List<Function<String, Function<ClassVisitor, ClassVisitor>>> bytecodeTransformers = new ArrayList<>();
+    private final Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> byteCodeTransformers = new HashMap<>();
     private final Set<String> applicationArchiveMarkers;
     private final ArchiveContextBuilder archiveContextBuilder;
     private final Set<String> capabilities;
@@ -110,8 +111,8 @@ public class BuildTimeGenerator {
         this.capabilities = new HashSet<>(setupContext.capabilities);
     }
 
-    public List<Function<String, Function<ClassVisitor, ClassVisitor>>> getBytecodeTransformers() {
-        return bytecodeTransformers;
+    public Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> getByteCodeTransformers() {
+        return byteCodeTransformers;
     }
 
     public void run(Path root) throws IOException {
@@ -342,8 +343,8 @@ public class BuildTimeGenerator {
         }
 
         @Override
-        public void addByteCodeTransformer(Function<String, Function<ClassVisitor, ClassVisitor>> visitorFunction) {
-            bytecodeTransformers.add(visitorFunction);
+        public void addByteCodeTransformer(String className, BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction) {
+            byteCodeTransformers.computeIfAbsent(className, (e) -> new ArrayList<>()).add(visitorFunction);
         }
 
         @Override
@@ -438,7 +439,6 @@ public class BuildTimeGenerator {
                 ResultHandle dup = mv.newInstance(ofConstructor(holder.className));
                 mv.invokeInterfaceMethod(ofMethod(StartupTask.class, "deploy", void.class, StartupContext.class), dup, startupContext);
             }
-
             mv.invokeStaticMethod(ofMethod(Timing.class, "printStartupTime", void.class));
             mv.returnValue(null);
 

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/ProcessorContext.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/ProcessorContext.java
@@ -3,6 +3,7 @@ package org.jboss.shamrock.deployment;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.jboss.jandex.FieldInfo;
@@ -41,9 +42,9 @@ public interface ProcessorContext {
      * This method is used to indicate that a given class requires reflection.
      * <p>
      * It is used in the graal output to allow the class to be reflected when running on substrate VM
-     *
+     * <p>
      * This will add all constructors, as well as all methods and fields if the appropriate fields are set.
-     *
+     * <p>
      * Where possible consider using the more fine grained addReflective* variants
      *
      * @param className The class name
@@ -60,36 +61,35 @@ public interface ProcessorContext {
 
     /**
      * Attempts to register a complete type hierarchy for reflection.
-     *
+     * <p>
      * This is intended to be used to register types that are going to be serialized,
      * e.g. by Jackson or some other JSON mapper.
-     *
+     * <p>
      * This will do 'smart discovery' and in addition to registering the type itself it will also attempt to
      * register the following:
-     *
+     * <p>
      * - Superclasses
      * - Component types of collections
      * - Types used in bean properties if (if method reflection is enabled)
      * - Field types (if field reflection is enabled)
-     *
+     * <p>
      * This discovery is applied recursively, so any additional types that are registered will also have their dependencies
      * discovered
-     *
      */
     void addReflectiveHierarchy(Type type);
 
 
     /**
-     *
      * @param applicationClass If this class should be loaded by the application class loader when in runtime mode
-     * @param name The class name
-     * @param classData The class bytes
+     * @param name             The class name
+     * @param classData        The class bytes
      * @throws IOException
      */
     void addGeneratedClass(boolean applicationClass, String name, byte[] classData) throws IOException;
 
     /**
      * Creates a resources with the provided contents
+     *
      * @param name
      * @param data
      * @throws IOException
@@ -97,19 +97,20 @@ public interface ProcessorContext {
     void createResource(String name, byte[] data) throws IOException;
 
     /**
-     * Adds a bytecode transformer that can transform application classes.
+     * Adds a bytecode transformer that can transform application classes
      * <p>
-     * This takes the form of a function that takes the class name as a String, and returns a Function that wraps an
-     * ASM {@link ClassVisitor}.
-     *
-     * If this function returns null then no transform is applied. If it returns a function then it will be transformed.
-     *
+     * This is added on a per-class basis, by specifying the class name. The transformer is a function that
+     * can be used to wrap an ASM {@link ClassVisitor}.
+     * <p>
      * The transformation is applied by calling each function that has been registered it turn to create a chain
      * of visitors. These visitors are then applied and the result is saved to the output.
-     *
+     * <p>
      * At present these transformations are only applied to application classes, not classes provided by dependencies
+     * <p>
+     * These transformations may be run concurrently in multiple threads, so if a function is registered for multiple
+     * classes it must be thread safe
      */
-    void addByteCodeTransformer(Function<String, Function<ClassVisitor, ClassVisitor>> visitorFunction);
+    void addByteCodeTransformer(String classToTransform, BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction);
 
     /**
      * Adds a resource to the image that will be accessible when running under substrate.
@@ -126,25 +127,24 @@ public interface ProcessorContext {
      *
      * @param classes The classes to lazily init
      */
-    void addRuntimeInitializedClasses(String ... classes);
+    void addRuntimeInitializedClasses(String... classes);
 
     /**
      * Adds a proxy definition to allow proxies to be created using {@link java.lang.reflect.Proxy}
      *
      * @param proxyClasses The interface names that this proxy will implement
      */
-    void addProxyDefinition(String ... proxyClasses);
+    void addProxyDefinition(String... proxyClasses);
 
     /**
      * Set a system property to be passed in to the native image tool.
      *
-     * @param name the property name (must not be {@code null})
+     * @param name  the property name (must not be {@code null})
      * @param value the property value
      */
     void addNativeImageSystemProperty(String name, String value);
 
     /**
-     *
      * @param capability
      * @return if the given capability is present
      * @see Capabilities

--- a/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeClassLoader.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeClassLoader.java
@@ -33,7 +33,7 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
-public class RuntimeClassLoader extends ClassLoader implements ClassOutput, Consumer<Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>>> {
+public class RuntimeClassLoader extends ClassLoader implements ClassOutput {
 
     private static final Logger log = Logger.getLogger(RuntimeClassLoader.class);
 
@@ -261,7 +261,7 @@ public class RuntimeClassLoader extends ClassLoader implements ClassOutput, Cons
         }
     }
 
-    public void accept(Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> functions) {
+    public void setTransformers(Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> functions) {
         this.bytecodeTransformers = functions;
     }
 

--- a/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeRunner.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeRunner.java
@@ -44,7 +44,7 @@ public class RuntimeRunner implements Runnable, Closeable {
         try {
             BuildTimeGenerator buildTimeGenerator = new BuildTimeGenerator(loader, loader, false, archiveContextBuilder);
             buildTimeGenerator.run(target);
-            loader.accept(buildTimeGenerator.getByteCodeTransformers());
+            loader.setTransformers(buildTimeGenerator.getByteCodeTransformers());
             if(!buildTimeGenerator.getByteCodeTransformers().isEmpty()) {
                 //transformation can be slow, and classes that are transformed are generally always loaded on startup
                 //to speed this along we eagerly load the classes in parallel

--- a/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeRunner.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeRunner.java
@@ -10,11 +10,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import org.jboss.shamrock.deployment.ArchiveContextBuilder;
 import org.jboss.shamrock.deployment.BuildTimeGenerator;
-import org.jboss.shamrock.runtime.Timing;
 import org.objectweb.asm.ClassVisitor;
 
 /**
@@ -28,10 +26,10 @@ public class RuntimeRunner implements Runnable, Closeable {
     private Closeable closeTask;
     private final ArchiveContextBuilder archiveContextBuilder;
 
-    public RuntimeRunner(ClassLoader classLoader, Path target, Path frameworkClassesPath, ArchiveContextBuilder archiveContextBuilder) {
+    public RuntimeRunner(ClassLoader classLoader, Path target, Path frameworkClassesPath, Path transformerCache, ArchiveContextBuilder archiveContextBuilder) {
         this.target = target;
         this.archiveContextBuilder = archiveContextBuilder;
-        this.loader = new RuntimeClassLoader(classLoader, target, frameworkClassesPath);
+        this.loader = new RuntimeClassLoader(classLoader, target, frameworkClassesPath, transformerCache);
     }
 
     @Override

--- a/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateEntityEnhancer.java
+++ b/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateEntityEnhancer.java
@@ -1,6 +1,7 @@
 package org.jboss.shamrock.jpa;
 
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
@@ -22,7 +23,7 @@ import org.objectweb.asm.Opcodes;
  *
  * @author Sanne Grinovero  <sanne@hibernate.org>
  */
-public final class HibernateEntityEnhancer implements Function<String, Function<ClassVisitor, ClassVisitor>> {
+public final class HibernateEntityEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
 
     private final Enhancer enhancer;
     private final KnownDomainObjects classnameWhitelist;
@@ -41,29 +42,8 @@ public final class HibernateEntityEnhancer implements Function<String, Function<
     }
 
     @Override
-    public Function<ClassVisitor, ClassVisitor> apply(String classname) {
-        if (classnameWhitelist.contains(classname))
-            return new HibernateTransformingVisitorFunction(classname);
-        else
-            return null;
-    }
-
-    /**
-     * Having to convert a ClassVisitor into another, this allows visitor chaining: the returned ClassVisitor needs to
-     * refer to the previous ClassVisitor in the chain to forward input events (optionally transformed).
-     */
-    private class HibernateTransformingVisitorFunction implements Function<ClassVisitor, ClassVisitor> {
-
-        private final String className;
-
-        public HibernateTransformingVisitorFunction(String className) {
-            this.className = className;
-        }
-
-        @Override
-        public ClassVisitor apply(ClassVisitor outputClassVisitor) {
-            return new HibernateEnhancingClassVisitor(className, outputClassVisitor);
-        }
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        return new HibernateEnhancingClassVisitor(className, outputClassVisitor);
     }
 
     private class HibernateEnhancingClassVisitor extends ClassVisitor {

--- a/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateResourceProcessor.java
+++ b/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateResourceProcessor.java
@@ -71,7 +71,10 @@ public final class HibernateResourceProcessor implements ResourceProcessor {
     }
 
     private void enhanceEntities(final KnownDomainObjects domainObjects, ArchiveContext archiveContext, ProcessorContext processorContext) {
-        processorContext.addByteCodeTransformer(new HibernateEntityEnhancer(domainObjects));
+        HibernateEntityEnhancer hibernateEntityEnhancer = new HibernateEntityEnhancer(domainObjects);
+        for(String i : domainObjects.getClassNames()) {
+            processorContext.addByteCodeTransformer(i, hibernateEntityEnhancer);
+        }
     }
 
     @Override

--- a/jpa/deployment/src/test/java/org/jboss/shamrock/jpa/enhancer/HibernateEntityEnhancerTest.java
+++ b/jpa/deployment/src/test/java/org/jboss/shamrock/jpa/enhancer/HibernateEntityEnhancerTest.java
@@ -38,7 +38,7 @@ public class HibernateEntityEnhancerTest {
         ClassWriter writer = new ClassWriter(classReader, ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
         ClassVisitor visitor = writer;
         HibernateEntityEnhancer hibernateEntityEnhancer = new HibernateEntityEnhancer(new TestingKnownDomainObjects());
-        visitor = hibernateEntityEnhancer.apply(TEST_CLASSNAME).apply(visitor);
+        visitor = hibernateEntityEnhancer.apply(TEST_CLASSNAME, visitor);
         classReader.accept(visitor, 0);
         final byte[] modifiedBytecode = writer.toByteArray();
 

--- a/legacy/runner/src/main/java/org/jboss/shamrock/legacy/Main.java
+++ b/legacy/runner/src/main/java/org/jboss/shamrock/legacy/Main.java
@@ -96,7 +96,7 @@ public class Main {
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             try {
                 Thread.currentThread().setContextClassLoader(ucl);
-                RuntimeRunner runner = new RuntimeRunner(ucl, archive, archive, archiveContextBuilder);
+                RuntimeRunner runner = new RuntimeRunner(ucl, archive, archive, null, archiveContextBuilder);
                 runner.run();
             } finally {
                 Thread.currentThread().setContextClassLoader(old);

--- a/maven/src/main/java/org/jboss/shamrock/maven/BuildMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/BuildMojo.java
@@ -2,7 +2,6 @@ package org.jboss.shamrock.maven;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,6 +26,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.jar.Attributes;
@@ -280,16 +280,11 @@ public class BuildMojo extends AbstractMojo {
 //                                if (!pathName.isEmpty()) {
 //                                    out.putNextEntry(new ZipEntry(pathName + "/"));
 //                                }
-                                } else if (pathName.endsWith(".class") && !buildTimeGenerator.getBytecodeTransformers().isEmpty()) {
+                                } else if (pathName.endsWith(".class") && !buildTimeGenerator.getByteCodeTransformers().isEmpty()) {
                                     String className = pathName.substring(0, pathName.length() - 6).replace("/", ".");
-                                    List<Function<ClassVisitor, ClassVisitor>> visitors = new ArrayList<>();
-                                    for (Function<String, Function<ClassVisitor, ClassVisitor>> t : buildTimeGenerator.getBytecodeTransformers()) {
-                                        Function<ClassVisitor, ClassVisitor> visitor = t.apply(className);
-                                        if (visitor != null) {
-                                            visitors.add(visitor);
-                                        }
-                                    }
-                                    if (visitors.isEmpty()) {
+                                    List<BiFunction<String, ClassVisitor, ClassVisitor>> visitors = buildTimeGenerator.getByteCodeTransformers().get(className);
+
+                                    if (visitors == null || visitors.isEmpty()) {
                                         runner.putNextEntry(new ZipEntry(pathName));
                                         try (FileInputStream in = new FileInputStream(path.toFile())) {
                                             doCopy(runner, in);
@@ -302,8 +297,8 @@ public class BuildMojo extends AbstractMojo {
                                                 ClassReader cr = new ClassReader(fileContent);
                                                 ClassWriter writer = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
                                                 ClassVisitor visitor = writer;
-                                                for (Function<ClassVisitor, ClassVisitor> i : visitors) {
-                                                    visitor = i.apply(visitor);
+                                                for (BiFunction<String, ClassVisitor, ClassVisitor> i : visitors) {
+                                                    visitor = i.apply(className, visitor);
                                                 }
                                                 cr.accept(visitor, 0);
                                                 return new FutureEntry(writer.toByteArray(), pathName);

--- a/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojo.java
@@ -55,6 +55,10 @@ public class RunMojo extends AbstractMojo {
     private File sourceDir;
 
 
+    @Parameter(defaultValue = "${jvm.args}")
+    private String jvmArgs;
+
+
     @Override
     public void execute() throws MojoFailureException {
         try {
@@ -69,6 +73,9 @@ public class RunMojo extends AbstractMojo {
                 } else {
                     args.add("-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y");
                 }
+            }
+            if(jvmArgs != null) {
+                args.add(jvmArgs);
             }
 
             for (Resource r : project.getBuild().getResources()) {

--- a/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojo.java
@@ -152,6 +152,7 @@ public class RunMojo extends AbstractMojo {
             args.add(tempFile.getAbsolutePath());
             args.add(outputDirectory.getAbsolutePath());
             args.add(wiringClassesDirectory.getAbsolutePath());
+            args.add(new File(buildDir, "transformer-cache").getAbsolutePath());
             Process p = Runtime.getRuntime().exec(args.toArray(new String[0]), null, outputDirectory);
             new Thread(new ProcessReader(p.getErrorStream(), true)).start();
             new Thread(new ProcessReader(p.getInputStream(), false)).start();

--- a/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojoMain.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojoMain.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
+import org.jboss.logging.Logger;
 import org.jboss.shamrock.deployment.ArchiveContextBuilder;
 import org.jboss.shamrock.runtime.Timing;
 
@@ -15,6 +16,8 @@ import org.jboss.shamrock.runtime.Timing;
  * The main entry point for the run mojo execution
  */
 public class RunMojoMain {
+
+    private static final Logger log = Logger.getLogger(RunMojoMain.class);
 
     private static volatile boolean keepCl = false;
     private static volatile ClassLoader currentAppClassLoader;
@@ -71,6 +74,7 @@ public class RunMojoMain {
             }
         } catch (Throwable t) {
             deploymentProblem = t;
+            log.error("Failed to start shamrock", t);
         }
     }
 

--- a/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojoMain.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/runner/RunMojoMain.java
@@ -24,6 +24,7 @@ public class RunMojoMain {
     private static volatile URLClassLoader runtimeCl;
     private static File classesRoot;
     private static File wiringDir;
+    private static File cacheDir;
 
     private static Closeable closeable;
     static volatile Throwable deploymentProblem;
@@ -33,6 +34,7 @@ public class RunMojoMain {
         //the path that contains the compiled classes
         classesRoot = new File(args[0]);
         wiringDir = new File(args[1]);
+        cacheDir = new File(args[2]);
         //TODO: we can't handle an exception on startup with hot replacement, as Undertow might not have started
 
         doStart();
@@ -64,8 +66,8 @@ public class RunMojoMain {
                 Thread.currentThread().setContextClassLoader(runtimeCl);
                 Class<?> runnerClass = runtimeCl.loadClass("org.jboss.shamrock.runner.RuntimeRunner");
                 ArchiveContextBuilder acb = new ArchiveContextBuilder();
-                Constructor ctor = runnerClass.getDeclaredConstructor(ClassLoader.class, Path.class, Path.class, ArchiveContextBuilder.class);
-                Object runner = ctor.newInstance(runtimeCl, classesRoot.toPath(), wiringDir.toPath(), acb);
+                Constructor ctor = runnerClass.getDeclaredConstructor(ClassLoader.class, Path.class, Path.class, Path.class, ArchiveContextBuilder.class);
+                Object runner = ctor.newInstance(runtimeCl, classesRoot.toPath(), wiringDir.toPath(), cacheDir.toPath(), acb);
                 ((Runnable) runner).run();
                 closeable = ((Closeable) runner);
                 deploymentProblem = null;

--- a/test-framework/junit/src/main/java/org/jboss/shamrock/junit/ShamrockTest.java
+++ b/test-framework/junit/src/main/java/org/jboss/shamrock/junit/ShamrockTest.java
@@ -67,7 +67,7 @@ public class ShamrockTest extends BlockJUnit4ClassRunner {
                                 String testClassLocation = resource.getPath().substring(0, resource.getPath().length() - classFileName.length());
                                 String appClassLocation = testClassLocation.replace("test-classes", "classes");
                                 Path appRoot = Paths.get(appClassLocation);
-                                RuntimeRunner runtimeRunner = new RuntimeRunner(getClass().getClassLoader(), appRoot, Paths.get(testClassLocation), new ArchiveContextBuilder());
+                                RuntimeRunner runtimeRunner = new RuntimeRunner(getClass().getClassLoader(), appRoot, Paths.get(testClassLocation), null, new ArchiveContextBuilder());
                                 runtimeRunner.run();
                             } catch (RuntimeException e) {
                                 failed = true;


### PR DESCRIPTION
This drops startup time from 17s to 12s in the 1k entity test on my laptop