### PR TITLE
Arc processor - various perf improvements

### DIFF
--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanProcessor.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanProcessor.java
@@ -145,7 +145,7 @@ public class BeanProcessor {
         for (Resource resource : resources) {
             output.writeResource(resource);
         }
-        LOGGER.infof("%s resources written in %s ms", resources.size(), System.currentTimeMillis() - start);
+        LOGGER.infof("%s resources generated/written in %s ms", resources.size(), System.currentTimeMillis() - start);
         return beanDeployment;
     }
 

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BuiltinBean.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BuiltinBean.java
@@ -33,11 +33,11 @@ enum BuiltinBean {
                 MethodCreator constructor, String providerName, AnnotationLiteralProcessor annotationLiterals) {
 
             ResultHandle qualifiers = constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-            if (!injectionPoint.requiredQualifiers.isEmpty()) {
+            if (!injectionPoint.getRequiredQualifiers().isEmpty()) {
                 // Set<Annotation> instanceProvider1Qualifiers = new HashSet<>()
                 // instanceProvider1Qualifiers.add(javax.enterprise.inject.Default.Literal.INSTANCE)
 
-                for (AnnotationInstance qualifierAnnotation : injectionPoint.requiredQualifiers) {
+                for (AnnotationInstance qualifierAnnotation : injectionPoint.getRequiredQualifiers()) {
                     BuiltinQualifier qualifier = BuiltinQualifier.of(qualifierAnnotation);
                     if (qualifier != null) {
                         constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers, qualifier.getLiteralInstance(constructor));
@@ -51,7 +51,7 @@ enum BuiltinBean {
                     }
                 }
             }
-            ResultHandle parameterizedType = Types.getTypeHandle(constructor, injectionPoint.requiredType);
+            ResultHandle parameterizedType = Types.getTypeHandle(constructor, injectionPoint.getRequiredType());
             ResultHandle instanceProvider = constructor.newInstance(
                     MethodDescriptor.ofConstructor(InstanceProvider.class, java.lang.reflect.Type.class, Set.class), parameterizedType, qualifiers);
             constructor.writeInstanceField(FieldDescriptor.of(clazzCreator.getClassName(), providerName, InjectableReferenceProvider.class.getName()),
@@ -85,11 +85,11 @@ enum BuiltinBean {
                 MethodCreator constructor, String providerName, AnnotationLiteralProcessor annotationLiterals) {
 
             ResultHandle qualifiers = constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-            if (!injectionPoint.requiredQualifiers.isEmpty()) {
+            if (!injectionPoint.getRequiredQualifiers().isEmpty()) {
                 // Set<Annotation> instanceProvider1Qualifiers = new HashSet<>()
                 // instanceProvider1Qualifiers.add(javax.enterprise.inject.Default.Literal.INSTANCE)
 
-                for (AnnotationInstance qualifierAnnotation : injectionPoint.requiredQualifiers) {
+                for (AnnotationInstance qualifierAnnotation : injectionPoint.getRequiredQualifiers()) {
                     BuiltinQualifier qualifier = BuiltinQualifier.of(qualifierAnnotation);
                     if (qualifier != null) {
                         constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers, qualifier.getLiteralInstance(constructor));
@@ -103,7 +103,7 @@ enum BuiltinBean {
                     }
                 }
             }
-            ResultHandle parameterizedType = Types.getTypeHandle(constructor, injectionPoint.requiredType);
+            ResultHandle parameterizedType = Types.getTypeHandle(constructor, injectionPoint.getRequiredType());
             ResultHandle eventProvider = constructor.newInstance(MethodDescriptor.ofConstructor(EventProvider.class, java.lang.reflect.Type.class, Set.class),
                     parameterizedType, qualifiers);
             constructor.writeInstanceField(FieldDescriptor.of(clazzCreator.getClassName(), providerName, InjectableReferenceProvider.class.getName()),
@@ -115,9 +115,9 @@ enum BuiltinBean {
                 MethodCreator constructor, String providerName, AnnotationLiteralProcessor annotationLiterals) {
 
             ResultHandle annotations = constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-            // For a resource field the requiredQualifiers field contains all annotations declared on the field
-            if (!injectionPoint.requiredQualifiers.isEmpty()) {
-                for (AnnotationInstance annotation : injectionPoint.requiredQualifiers) {
+            // For a resource field the required qualifiers contain all annotations declared on the field
+            if (!injectionPoint.getRequiredQualifiers().isEmpty()) {
+                for (AnnotationInstance annotation : injectionPoint.getRequiredQualifiers()) {
                     // Create annotation literal first
                     ClassInfo annotationClass = beanDeployment.getIndex().getClassByName(annotation.name());
                     String annotationLiteralName = annotationLiterals.process(classOutput, annotationClass, annotation,
@@ -126,13 +126,13 @@ enum BuiltinBean {
                             constructor.newInstance(MethodDescriptor.ofConstructor(annotationLiteralName)));
                 }
             }
-            ResultHandle parameterizedType = Types.getTypeHandle(constructor, injectionPoint.requiredType);
+            ResultHandle parameterizedType = Types.getTypeHandle(constructor, injectionPoint.getRequiredType());
             ResultHandle resourceProvider = constructor.newInstance(
                     MethodDescriptor.ofConstructor(ResourceProvider.class, java.lang.reflect.Type.class, Set.class), parameterizedType, annotations);
             constructor.writeInstanceField(FieldDescriptor.of(clazzCreator.getClassName(), providerName, InjectableReferenceProvider.class.getName()),
                     constructor.getThis(), resourceProvider);
         }
-    }, ip -> ip.kind == Kind.RESOURCE);
+    }, ip -> ip.getKind() == Kind.RESOURCE);
 
     private final DotName rawTypeDotName;
 
@@ -141,7 +141,7 @@ enum BuiltinBean {
     private final Predicate<InjectionPointInfo> matcher;
 
     BuiltinBean(DotName rawTypeDotName, Generator generator) {
-        this(rawTypeDotName, generator, ip -> ip.kind == Kind.CDI && rawTypeDotName.equals(ip.requiredType.name()));
+        this(rawTypeDotName, generator, ip -> ip.getKind() == Kind.CDI && rawTypeDotName.equals(ip.getRequiredType().name()));
     }
 
     BuiltinBean(DotName rawTypeDotName, Generator generator, Predicate<InjectionPointInfo> matcher) {

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/InterceptorInfo.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/InterceptorInfo.java
@@ -43,10 +43,25 @@ class InterceptorInfo extends BeanInfo implements Comparable<InterceptorInfo> {
                 null, null, null, Collections.emptyList());
         this.bindings = bindings;
         this.priority = priority;
-        this.aroundInvoke = target.asClass().methods().stream().filter(m -> m.hasAnnotation(DotNames.AROUND_INVOKE)).findAny().orElse(null);
-        this.aroundConstruct = target.asClass().methods().stream().filter(m -> m.hasAnnotation(DotNames.AROUND_CONSTRUCT)).findAny().orElse(null);
-        this.postConstruct = target.asClass().methods().stream().filter(m -> m.hasAnnotation(DotNames.POST_CONSTRUCT)).findAny().orElse(null);
-        this.preDestroy = target.asClass().methods().stream().filter(m -> m.hasAnnotation(DotNames.PRE_DESTROY)).findAny().orElse(null);
+        MethodInfo aroundInvoke = null;
+        MethodInfo aroundConstruct = null;
+        MethodInfo postConstruct = null;
+        MethodInfo preDestroy = null;
+        for (MethodInfo method : target.asClass().methods()) {
+            if (aroundInvoke == null && method.hasAnnotation(DotNames.AROUND_INVOKE)) {
+                aroundInvoke = method;
+            } else if (aroundConstruct == null && method.hasAnnotation(DotNames.AROUND_CONSTRUCT)) {
+                aroundConstruct = method;
+            } else if (postConstruct == null && method.hasAnnotation(DotNames.POST_CONSTRUCT)) {
+                postConstruct = method;
+            } else if (preDestroy == null && method.hasAnnotation(DotNames.PRE_DESTROY)) {
+                preDestroy = method;
+            }
+        }
+        this.aroundInvoke = aroundInvoke;
+        this.aroundConstruct = aroundConstruct;
+        this.postConstruct = postConstruct;
+        this.preDestroy = preDestroy;
     }
 
     Set<AnnotationInstance> getBindings() {

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/MethodDescriptors.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/MethodDescriptors.java
@@ -9,17 +9,24 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.EventContext;
 import javax.enterprise.inject.spi.EventMetadata;
+import javax.interceptor.InvocationContext;
 
+import org.jboss.protean.arc.Arc;
+import org.jboss.protean.arc.ArcContainer;
 import org.jboss.protean.arc.ClientProxy;
 import org.jboss.protean.arc.CreationalContextImpl;
 import org.jboss.protean.arc.InjectableBean;
+import org.jboss.protean.arc.InjectableContext;
 import org.jboss.protean.arc.InjectableInterceptor;
 import org.jboss.protean.arc.InjectableReferenceProvider;
 import org.jboss.protean.arc.InvocationContextImpl;
 import org.jboss.protean.arc.InvocationContextImpl.InterceptorInvocation;
+import org.jboss.protean.arc.LazyValue;
 import org.jboss.protean.arc.Reflections;
 import org.jboss.protean.gizmo.MethodDescriptor;
 
@@ -33,6 +40,8 @@ final class MethodDescriptors {
             CreationalContext.class);
 
     static final MethodDescriptor MAP_GET = MethodDescriptor.ofMethod(Map.class, "get", Object.class, Object.class);
+
+    static final MethodDescriptor MAP_PUT = MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class);
 
     static final MethodDescriptor INJECTABLE_REF_PROVIDER_GET = MethodDescriptor.ofMethod(InjectableReferenceProvider.class, "get", Object.class,
             CreationalContext.class);
@@ -51,7 +60,13 @@ final class MethodDescriptors {
     static final MethodDescriptor INTERCEPTOR_INVOCATION_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(InterceptorInvocation.class, "aroundConstruct",
             InterceptorInvocation.class, InjectableInterceptor.class, Object.class);
 
+    static final MethodDescriptor INTERCEPTOR_INVOCATION_AROUND_INVOKE = MethodDescriptor.ofMethod(InterceptorInvocation.class, "aroundInvoke",
+            InterceptorInvocation.class, InjectableInterceptor.class, Object.class);
+
     static final MethodDescriptor REFLECTIONS_FIND_CONSTRUCTOR = MethodDescriptor.ofMethod(Reflections.class, "findConstructor", Constructor.class, Class.class,
+            Class[].class);
+
+    static final MethodDescriptor REFLECTIONS_FIND_METHOD = MethodDescriptor.ofMethod(Reflections.class, "findMethod", Method.class, Class.class, String.class,
             Class[].class);
 
     static final MethodDescriptor REFLECTIONS_WRITE_FIELD = MethodDescriptor.ofMethod(Reflections.class, "writeField", void.class, Class.class, String.class,
@@ -89,10 +104,20 @@ final class MethodDescriptors {
     static final MethodDescriptor INVOCATION_CONTEXT_PRE_DESTROY = MethodDescriptor.ofMethod(InvocationContextImpl.class, "preDestroy",
             InvocationContextImpl.class, Object.class, List.class, Set.class);
 
-    static final MethodDescriptor CREATIONAL_CTX_ADD_DEP_TO_PARENT = MethodDescriptor.ofMethod(CreationalContextImpl.class, "addDependencyToParent", void.class, InjectableBean.class,
-            Object.class, CreationalContext.class);
+    static final MethodDescriptor INVOCATION_CONTEXT_PROCEED = MethodDescriptor.ofMethod(InvocationContext.class, "proceed", Object.class);
+
+    static final MethodDescriptor CREATIONAL_CTX_ADD_DEP_TO_PARENT = MethodDescriptor.ofMethod(CreationalContextImpl.class, "addDependencyToParent", void.class,
+            InjectableBean.class, Object.class, CreationalContext.class);
 
     static final MethodDescriptor COLLECTIONS_UNMODIFIABLE_SET = MethodDescriptor.ofMethod(Collections.class, "unmodifiableSet", Set.class, Set.class);
+
+    static final MethodDescriptor ARC_CONTAINER = MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class);
+
+    static final MethodDescriptor ARC_CONTAINER_GET_CONTEXT = MethodDescriptor.ofMethod(ArcContainer.class, "getContext", InjectableContext.class, Class.class);
+
+    static final MethodDescriptor CONTEXT_GET = MethodDescriptor.ofMethod(Context.class, "get", Object.class, Contextual.class, CreationalContext.class);
+
+    static final MethodDescriptor LAZY_VALUE_GET = MethodDescriptor.ofMethod(LazyValue.class, "get", Object.class);
 
     private MethodDescriptors() {
     }

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/ObserverGenerator.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/ObserverGenerator.java
@@ -118,7 +118,7 @@ public class ObserverGenerator extends AbstractGenerator {
     protected void initMaps(ObserverInfo observer, Map<InjectionPointInfo, String> injectionPointToProvider) {
         int providerIdx = 1;
         for (InjectionPointInfo injectionPoint : observer.getInjection().injectionPoints) {
-            String name = providerName(DotNames.simpleName(injectionPoint.requiredType.name())) + "Provider" + providerIdx++;
+            String name = providerName(DotNames.simpleName(injectionPoint.getRequiredType().name())) + "Provider" + providerIdx++;
             injectionPointToProvider.put(injectionPoint, name);
         }
     }
@@ -249,11 +249,11 @@ public class ObserverGenerator extends AbstractGenerator {
                         injectionPointToProviderField.get(injectionPoint), annotationLiterals);
             } else {
                 if (injectionPoint.getResolvedBean().getAllInjectionPoints().stream()
-                        .anyMatch(ip -> BuiltinBean.INJECTION_POINT.getRawTypeDotName().equals(ip.requiredType.name()))) {
+                        .anyMatch(ip -> BuiltinBean.INJECTION_POINT.getRawTypeDotName().equals(ip.getRequiredType().name()))) {
                     // IMPL NOTE: Injection point resolves to a dependent bean that injects InjectionPoint metadata and so we need to wrap the injectable
                     // reference provider
                     ResultHandle requiredQualifiersHandle = constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-                    for (AnnotationInstance qualifierAnnotation : injectionPoint.requiredQualifiers) {
+                    for (AnnotationInstance qualifierAnnotation : injectionPoint.getRequiredQualifiers()) {
                         BuiltinQualifier qualifier = BuiltinQualifier.of(qualifierAnnotation);
                         if (qualifier != null) {
                             constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, requiredQualifiersHandle, qualifier.getLiteralInstance(constructor));
@@ -269,7 +269,7 @@ public class ObserverGenerator extends AbstractGenerator {
                     ResultHandle wrapHandle = constructor.newInstance(
                             MethodDescriptor.ofConstructor(CurrentInjectionPointProvider.class, InjectableReferenceProvider.class, java.lang.reflect.Type.class,
                                     Set.class),
-                            constructor.getMethodParam(paramIdx++), Types.getTypeHandle(constructor, injectionPoint.requiredType), requiredQualifiersHandle);
+                            constructor.getMethodParam(paramIdx++), Types.getTypeHandle(constructor, injectionPoint.getRequiredType()), requiredQualifiersHandle);
                     constructor.writeInstanceField(FieldDescriptor.of(observerCreator.getClassName(), injectionPointToProviderField.get(injectionPoint),
                             InjectableReferenceProvider.class.getName()), constructor.getThis(), wrapHandle);
                 } else {

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/SubclassGenerator.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/SubclassGenerator.java
@@ -3,7 +3,6 @@ package org.jboss.protean.arc.processor;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -25,11 +24,8 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
-import org.jboss.protean.arc.CreationalContextImpl;
 import org.jboss.protean.arc.InjectableInterceptor;
-import org.jboss.protean.arc.InjectableReferenceProvider;
 import org.jboss.protean.arc.InvocationContextImpl.InterceptorInvocation;
-import org.jboss.protean.arc.Reflections;
 import org.jboss.protean.arc.Subclass;
 import org.jboss.protean.arc.processor.BeanInfo.InterceptionInfo;
 import org.jboss.protean.arc.processor.ResourceOutput.Resource;
@@ -104,7 +100,7 @@ public class SubclassGenerator extends AbstractGenerator {
         Optional<Injection> constructorInjection = bean.getConstructorInjection();
         if (constructorInjection.isPresent()) {
             for (InjectionPointInfo injectionPoint : constructorInjection.get().injectionPoints) {
-                parameterTypes.add(injectionPoint.requiredType.name().toString());
+                parameterTypes.add(injectionPoint.getRequiredType().name().toString());
             }
         }
         int superParamsSize = parameterTypes.size();
@@ -146,16 +142,13 @@ public class SubclassGenerator extends AbstractGenerator {
                     constructor.newInstance(MethodDescriptor.ofConstructor(ArrayList.class)));
             for (InterceptorInfo interceptor : preDestroys.interceptors) {
                 // preDestroys.add(InvocationContextImpl.InterceptorInvocation.preDestroy(provider1,provider1.get(CreationalContextImpl.child(ctx))))
-                ResultHandle creationalContext = constructor.invokeStaticMethod(
-                        MethodDescriptor.ofMethod(CreationalContextImpl.class, "child", CreationalContextImpl.class, CreationalContext.class),
-                        creationalContextHandle);
-                ResultHandle interceptorInstance = constructor.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(InjectableReferenceProvider.class, "get", Object.class, CreationalContext.class),
+                ResultHandle creationalContext = constructor.invokeStaticMethod(MethodDescriptors.CREATIONAL_CTX_CHILD, creationalContextHandle);
+                ResultHandle interceptorInstance = constructor.invokeInterfaceMethod(MethodDescriptors.INJECTABLE_REF_PROVIDER_GET,
                         interceptorToResultHandle.get(interceptor), creationalContext);
                 ResultHandle interceptionInvocation = constructor.invokeStaticMethod(MethodDescriptor.ofMethod(InterceptorInvocation.class, "preDestroy",
                         InterceptorInvocation.class, InjectableInterceptor.class, Object.class), interceptorToResultHandle.get(interceptor),
                         interceptorInstance);
-                constructor.invokeInterfaceMethod(MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class),
+                constructor.invokeInterfaceMethod(MethodDescriptors.LIST_ADD,
                         constructor.readInstanceField(preDestroysField.getFieldDescriptor(), constructor.getThis()), interceptionInvocation);
             }
         }
@@ -185,21 +178,15 @@ public class SubclassGenerator extends AbstractGenerator {
             InterceptionInfo interceptedMethod = entry.getValue();
             for (InterceptorInfo interceptor : interceptedMethod.interceptors) {
                 // m1Chain.add(InvocationContextImpl.InterceptorInvocation.aroundInvoke(p3,p3.get(CreationalContextImpl.child(ctx))))
-                ResultHandle creationalContext = constructor.invokeStaticMethod(
-                        MethodDescriptor.ofMethod(CreationalContextImpl.class, "child", CreationalContextImpl.class, CreationalContext.class),
-                        creationalContextHandle);
-                ResultHandle interceptorInstance = constructor.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(InjectableReferenceProvider.class, "get", Object.class, CreationalContext.class),
+                ResultHandle creationalContext = constructor.invokeStaticMethod(MethodDescriptors.CREATIONAL_CTX_CHILD, creationalContextHandle);
+                ResultHandle interceptorInstance = constructor.invokeInterfaceMethod(MethodDescriptors.INJECTABLE_REF_PROVIDER_GET,
                         interceptorToResultHandle.get(interceptor), creationalContext);
-                ResultHandle interceptionInvocation = constructor.invokeStaticMethod(MethodDescriptor.ofMethod(InterceptorInvocation.class, "aroundInvoke",
-                        InterceptorInvocation.class, InjectableInterceptor.class, Object.class), interceptorToResultHandle.get(interceptor),
-                        interceptorInstance);
-                constructor.invokeInterfaceMethod(MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class), chainHandle,
-                        interceptionInvocation);
+                ResultHandle interceptionInvocation = constructor.invokeStaticMethod(MethodDescriptors.INTERCEPTOR_INVOCATION_AROUND_INVOKE,
+                        interceptorToResultHandle.get(interceptor), interceptorInstance);
+                constructor.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, chainHandle, interceptionInvocation);
             }
             // interceptorChains.put("m1", m1Chain)
-            constructor.invokeInterfaceMethod(MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class), interceptorChainsHandle,
-                    methodIdHandle, chainHandle);
+            constructor.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, interceptorChainsHandle, methodIdHandle, chainHandle);
             // methods.put("m1", Reflections.findMethod(org.jboss.weld.arc.test.interceptors.SimpleBean.class,"foo",java.lang.String.class))
             ResultHandle[] paramsHandles = new ResultHandle[3];
             paramsHandles[0] = constructor.loadClass(providerTypeName);
@@ -213,10 +200,8 @@ public class SubclassGenerator extends AbstractGenerator {
             } else {
                 paramsHandles[2] = constructor.newArray(Class.class, constructor.load(0));
             }
-            ResultHandle methodHandle = constructor.invokeStaticMethod(
-                    MethodDescriptor.ofMethod(Reflections.class, "findMethod", Method.class, Class.class, String.class, Class[].class), paramsHandles);
-            constructor.invokeInterfaceMethod(MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class, Object.class), methodsHandle,
-                    methodIdHandle, methodHandle);
+            ResultHandle methodHandle = constructor.invokeStaticMethod(MethodDescriptors.REFLECTIONS_FIND_METHOD, paramsHandles);
+            constructor.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, methodsHandle, methodIdHandle, methodHandle);
 
             // Needed when running on substrate VM
             reflectionRegistration.registerMethod(method);
@@ -286,7 +271,7 @@ public class SubclassGenerator extends AbstractGenerator {
         ResultHandle invocationContext = forwardMethod.invokeStaticMethod(MethodDescriptors.INVOCATION_CONTEXT_AROUND_INVOKE, forwardMethod.getThis(),
                 interceptedMethodHandle, paramsHandle, interceptedChainHandle, func.getInstance(), bindingsHandle);
         // InvocationContext.proceed()
-        ResultHandle ret = forwardMethod.invokeInterfaceMethod(MethodDescriptor.ofMethod(InvocationContext.class, "proceed", Object.class), invocationContext);
+        ResultHandle ret = forwardMethod.invokeInterfaceMethod(MethodDescriptors.INVOCATION_CONTEXT_PROCEED, invocationContext);
         forwardMethod.returnValue(superResult != null ? ret : null);
         tryCatch.complete();
     }
@@ -325,7 +310,7 @@ public class SubclassGenerator extends AbstractGenerator {
                     bindingsHandle);
 
             // InvocationContext.proceed()
-            destroy.invokeInterfaceMethod(MethodDescriptor.ofMethod(InvocationContext.class, "proceed", Object.class), invocationContext);
+            destroy.invokeInterfaceMethod(MethodDescriptors.INVOCATION_CONTEXT_PROCEED, invocationContext);
             tryCatch.complete();
             destroy.returnValue(null);
         }

--- a/ext/arc/processor/src/test/java/org/jboss/protean/arc/processor/BeanInfoInjectionsTest.java
+++ b/ext/arc/processor/src/test/java/org/jboss/protean/arc/processor/BeanInfoInjectionsTest.java
@@ -45,19 +45,19 @@ public class BeanInfoInjectionsTest {
         for (Injection injection : injections) {
             if (injection.target.kind().equals(org.jboss.jandex.AnnotationTarget.Kind.FIELD) && injection.target.asField().name().equals("foo")) {
                 assertEquals(1, injection.injectionPoints.size());
-                assertEquals(fooType, injection.injectionPoints.get(0).requiredType);
-                assertEquals(1, injection.injectionPoints.get(0).requiredQualifiers.size());
+                assertEquals(fooType, injection.injectionPoints.get(0).getRequiredType());
+                assertEquals(1, injection.injectionPoints.get(0).getRequiredQualifiers().size());
             } else if (injection.target.kind().equals(org.jboss.jandex.AnnotationTarget.Kind.METHOD) && injection.target.asMethod().name().equals("<init>")) {
                 // Constructor
                 assertEquals(2, injection.injectionPoints.size());
-                assertEquals(listStringType, injection.injectionPoints.get(0).requiredType);
-                assertEquals(fooType, injection.injectionPoints.get(1).requiredType);
-                assertEquals(1, injection.injectionPoints.get(1).requiredQualifiers.size());
+                assertEquals(listStringType, injection.injectionPoints.get(0).getRequiredType());
+                assertEquals(fooType, injection.injectionPoints.get(1).getRequiredType());
+                assertEquals(1, injection.injectionPoints.get(1).getRequiredQualifiers().size());
             } else if (injection.target.kind().equals(org.jboss.jandex.AnnotationTarget.Kind.METHOD) && injection.target.asMethod().name().equals("init")) {
                 // Initializer
                 assertEquals(2, injection.injectionPoints.size());
-                assertEquals(listStringType, injection.injectionPoints.get(1).requiredType);
-                assertEquals(fooType, injection.injectionPoints.get(0).requiredType);
+                assertEquals(listStringType, injection.injectionPoints.get(1).getRequiredType());
+                assertEquals(fooType, injection.injectionPoints.get(0).getRequiredType());
             } else {
                 Assert.fail();
             }

--- a/ext/gizmo/src/main/java/org/jboss/protean/gizmo/DescriptorUtils.java
+++ b/ext/gizmo/src/main/java/org/jboss/protean/gizmo/DescriptorUtils.java
@@ -64,15 +64,28 @@ public class DescriptorUtils {
         } else if (boolean.class.equals(c)) {
             return "Z";
         } else if (c.isArray()) {
-            return c.getName().replace(".", "/");
+            return replace(c.getName(), '.', '/');
         } else {
             return extToInt(c.getName());
         }
     }
 
     public static String extToInt(String className) {
-        String repl = className.replace(".", "/");
+        String repl = replace(className, '.', '/');
         return 'L' + repl + ';';
+    }
+
+    static String replace(CharSequence target, char toReplace, char replacement) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < target.length(); i++) {
+            char character = target.charAt(i);
+            if (character == toReplace) {
+                builder.append(replacement);
+            } else {
+                builder.append(character);
+            }
+        }
+        return builder.toString();
     }
 
     public static boolean isPrimitive(String descriptor) {

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/DescriptorUtilsTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/DescriptorUtilsTestCase.java
@@ -1,0 +1,17 @@
+package org.jboss.protean.gizmo;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class DescriptorUtilsTestCase {
+
+	@Test
+	public void testReplace() {
+		assertEquals("java/lang/String", DescriptorUtils.replace(String.class.getName(), '.', '/'));
+		assertEquals("java/util/Map", DescriptorUtils.replace(Map.class.getName(), '.', '/'));
+	}
+
+}


### PR DESCRIPTION
- cache results of typesafe resolution
- replace streams and lambdas in hot paths
- reuse some more gizmo method descriptors

@stuartwdouglas @Sanne These reduce the bean deployment init (part 2/3 of Arc bootstrap) from ~400ms to ~37ms on my laptop... but we're cheating here a little bit, because in the example all the endpoints inject the same bean ;-)