### PR TITLE
Simplify spi registration

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/builditem/substrate/ServiceProviderBuildItem.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/builditem/substrate/ServiceProviderBuildItem.java
@@ -1,0 +1,43 @@
+package org.jboss.shamrock.deployment.builditem.substrate;
+
+import org.jboss.builder.item.MultiBuildItem;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a Service Provider registration.
+ * When processed, it embeds the service interface descriptor (META-INF/services/...) and allow reflection (instantiation only) on a set of provider
+ * classes.
+ */
+public final class ServiceProviderBuildItem extends MultiBuildItem {
+
+    public static final String SPI_ROOT = "META-INF/services/";
+    private final String serviceInterface;
+    private final List<String> providers;
+
+    public ServiceProviderBuildItem(String serviceInterfaceClassName, String... providerClassNames) {
+        serviceInterface = Objects.requireNonNull(serviceInterfaceClassName, "The service interface must not be `null`");
+        providers = Arrays.asList(Objects.requireNonNull(providerClassNames));
+
+        // Validation
+        if (serviceInterface.length() == 0) {
+            throw new IllegalArgumentException("The serviceDescriptorFile interface cannot be blank");
+        }
+
+        providers.forEach(s -> {
+            if (s == null || s.length() == 0) {
+                throw new IllegalArgumentException("The provider class name cannot be blank");
+            }
+        });
+    }
+
+    public List<String> providers() {
+        return providers;
+    }
+
+    public String serviceDescriptorFile() {
+        return SPI_ROOT + serviceInterface;
+    }
+}

--- a/reactive-streams-operators/reactive-streams-operators/deployment/src/main/java/org/jboss/shamrock/rsops/ReactiveStreamsOperatorsProcessor.java
+++ b/reactive-streams-operators/reactive-streams-operators/deployment/src/main/java/org/jboss/shamrock/rsops/ReactiveStreamsOperatorsProcessor.java
@@ -6,18 +6,14 @@ import org.eclipse.microprofile.reactive.streams.core.ReactiveStreamsFactoryImpl
 import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
 import org.jboss.shamrock.annotations.BuildProducer;
 import org.jboss.shamrock.annotations.BuildStep;
-import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveClassBuildItem;
-import org.jboss.shamrock.deployment.builditem.substrate.SubstrateResourceBuildItem;
+import org.jboss.shamrock.deployment.builditem.substrate.ServiceProviderBuildItem;
 
 public class ReactiveStreamsOperatorsProcessor {
 
     @BuildStep
-    public void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-                      BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ReactiveStreamsFactoryImpl.class.getName(), Engine.class.getName()));
-
-        resource.produce(new SubstrateResourceBuildItem("META-INF/services/" + ReactiveStreamsEngine.class.getName()));
-        resource.produce(new SubstrateResourceBuildItem("META-INF/services/" + ReactiveStreamsFactory.class.getName()));
+    public void build(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(new ServiceProviderBuildItem(ReactiveStreamsEngine.class.getName(), Engine.class.getName()));
+        serviceProvider.produce(new ServiceProviderBuildItem(ReactiveStreamsFactory.class.getName(), ReactiveStreamsFactoryImpl.class.getName()));
     }
 
 }


### PR DESCRIPTION
Provide a `BuildItem` that:

* embeds the SPI descriptor (the `META-INF/services/...` file)
* allows reflection on the provider classes (just class access, no field, and method access)