### PR TITLE
Improve the granularity of the URLResponse information

### DIFF
--- a/examples/strict/src/main/java/org/jboss/shamrock/example/web/TestSecureServlet.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/web/TestSecureServlet.java
@@ -1,0 +1,28 @@
+package org.jboss.shamrock.example.web;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Basic secured servlet test target
+ */
+@ServletSecurity(
+        @HttpConstraint(
+                rolesAllowed={"Tester"}
+        )
+)
+@WebServlet(name = "MySecureServlet", urlPatterns = "/secure-test", initParams = {@WebInitParam(name = "message", value = "A secured message")})
+public class TestSecureServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().write(getInitParameter("message"));
+    }
+
+}

--- a/examples/strict/src/test/java/org/jboss/shamrock/example/test/DataSourceTransactionTestCase.java
+++ b/examples/strict/src/test/java/org/jboss/shamrock/example/test/DataSourceTransactionTestCase.java
@@ -14,12 +14,8 @@ public class DataSourceTransactionTestCase {
     public void testTransactionalAnnotation() {
         Assert.assertEquals("PASSED", URLTester.relative("rest/datasource/txninterceptor0").invokeURL().asString());
 
-        try {
-            URLResponse resp = URLTester.relative("rest/datasource/txninterceptor1").invokeURL();
-            Assert.fail(resp.asString());
-        } catch (RuntimeException expected) {
-
-        }
+        URLResponse resp = URLTester.relative("rest/datasource/txninterceptor1").invokeURL();
+        Assert.assertTrue(resp.exception() != null);
         Assert.assertEquals("PASSED", URLTester.relative("rest/datasource/txninterceptor2").invokeURL().asString());
 
 

--- a/examples/strict/src/test/java/org/jboss/shamrock/example/test/ServletTestCase.java
+++ b/examples/strict/src/test/java/org/jboss/shamrock/example/test/ServletTestCase.java
@@ -1,5 +1,8 @@
 package org.jboss.shamrock.example.test;
 
+import java.io.IOException;
+
+import org.jboss.shamrock.example.testutils.URLResponse;
 import org.jboss.shamrock.example.testutils.URLTester;
 import org.jboss.shamrock.junit.ShamrockTest;
 import org.junit.Assert;
@@ -30,9 +33,10 @@ public class ServletTestCase {
     }
 
     // Basic @ServletSecurity test
-    @Test(expected = Exception.class)
+    @Test()
     public void testSecureAccessFailure() {
-        String msg = URLTester.relative("secure-test").invokeURL().asString();
-        Assert.assertEquals("A secured message", msg);
+        URLResponse response = URLTester.relative("secure-test").invokeURL();
+        Assert.assertEquals(403, response.statusCode());
+        Assert.assertTrue(response.exception() != null);
     }
 }

--- a/examples/strict/src/test/java/org/jboss/shamrock/example/testutils/URLResponse.java
+++ b/examples/strict/src/test/java/org/jboss/shamrock/example/testutils/URLResponse.java
@@ -1,5 +1,6 @@
 package org.jboss.shamrock.example.testutils;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import javax.json.JsonReader;
@@ -7,6 +8,8 @@ import javax.json.JsonReader;
 public interface URLResponse {
 
     int statusCode();
+
+    IOException exception();
 
     String asString();
 


### PR DESCRIPTION
The previous pull request missed adding the actual target TestSecureServlet because the unit test was not able to validate that a 403 response code was seen. This pull request captures both the response code and any IOException in the URLResponse for use in unit tests.