### PR TITLE
No longer need to have examples depend on shamrock-maven-plugin

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,13 +21,4 @@
         <module>undertow</module>
     </modules>
 
-    <dependencies>
-        <!-- Apparently maven is not smart enough to realize it needs to build this first-->
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-maven-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 </project>


### PR DESCRIPTION
I need this dependency gone so to better be able to verify our dependencies,
and it happens I verified this workaround does not seem necessary; not sure if that's because of my Maven version or because the project layout evolved.

Using Maven 3.5.3.

The reactor dependency is established, we can verify this by running:

    mvn clean package -DskipTests --projects :shamrock-maven-plugin --amd -Dno-native

This will run module `shamrock-maven-plugin` followed by any project *depending* on it. As you can see all examples which need it are listed as follow-up items.

If you have it necessary with an older Maven version, I can add an enforcer rule to require this version ? Let me know.

Thanks!
