### PR TITLE
Fix a few things in the README.md while studying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://dev.azure.com/protean-ci/Shamrock/_apis/build/status/protean-project.shamrock)](https://dev.azure.com/protean-ci/Shamrock/_build/latest?definitionId=1)
 
-Shamrock is framework that allows you process Java EE and Microprofile metadata at build time,
+Shamrock is a framework that allows you to process Java EE and Microprofile metadata at build time,
 and use it to create low overhead jar files, as well as native images using Graal/Substrate VM.
 
 At the moment is has the following features:
@@ -13,7 +13,7 @@ At the moment is has the following features:
 - Support for injection into build time processors
 - Support for build and runtime config through MP config
 - 'Instant Start' support on Graal through the use of static init to perform boot
-- A light weight CDI implementation called Arc
+- A lightweight CDI implementation called Arc
 - A user friendly method for generating custom bytecode called Gizmo
 - Various levels of support for:
     - JAX-RS (Resteasy)
@@ -28,19 +28,18 @@ At the moment is has the following features:
     - Datasources (Agroal)
 - A maven plugin to run the build, and create native images
 - A JUnit runner that can run tests, and supports IDE usage
-- A JUnit runner that can test a native image produced by the maven plugin
+- A JUnit runner that can test a native image produced by the Maven plugin
 
 
 ## How to build Shamrock
 
 * Install platform C developer tools:
-
-** OSX
-*** `xcode-select --install`
-** Linux
-*** TBD
+    * OSX
+        * `xcode-select --install`
+    * Linux
+        * TBD
 * Install GraalVM (minimum RC9)
-* set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/Users/emmanuel/JDK/GraalVM/Contents/Home`
+* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/Users/emmanuel/JDK/GraalVM/Contents/Home`
 * `mvn install`
 
 The default build will create two different native images, which is quite time consuming. You can skip this
@@ -54,7 +53,7 @@ not being invalidated correctly in some cases. To run a build with a new instanc
 
 ## How to use Shamrock
 
-At the moment Shamrock requires the use of maven. To use Shamrock add the following to your `pom.xml`:
+At the moment Shamrock requires the use of Maven. To use Shamrock add the following to your `pom.xml`:
 
 ```
 <plugin>
@@ -131,7 +130,7 @@ Shamrock runs in two distinct phases. The first phase is build time processing, 
 https://github.com/protean-project/shamrock/blob/master/core/deployment/src/main/java/org/jboss/shamrock/deployment/ResourceProcessor.java
 
 These processors run in priority order, in general they will read information from the Jandex index, and either directly output bytecode for
-use at runtiime, or provide information for later processors to write out.
+use at runtime, or provide information for later processors to write out.
 
 These processors write out bytecode in the form of implementations of StartupTask:
 
@@ -140,7 +139,7 @@ https://github.com/protean-project/shamrock/blob/master/core/runtime/src/main/ja
 When these tasks are created you can choose if you want them run from a static init method, or as part of the main() method execution.
 This has no real effect when running on the JVM,
 however when building a native image anything that runs from the static init method will be run at build time.
-This is how shamrock can provide instant start, as all deployment processing is done at image build time.
+This is how Shamrock can provide instant start, as all deployment processing is done at image build time.
 It is also why Weld can work without modification, as proxy generation etc is done at build time.
 
 As part of the build process shamrock generates a main method that invokes all generated startup tasks in order.
@@ -150,7 +149,7 @@ As part of the build process shamrock generates a main method that invokes all g
 In general there will be two distinct artifacts, a runtime and a deployment time artifact. 
 
 The runtime artifact should have a `dependencies.runtime` file in the root of the jar. This is a file that is produced
-by the maven dependencies plugin:
+by the Maven dependencies plugin:
 
 ```
 <plugin>
@@ -174,17 +173,17 @@ This file tells the build plugin which dependencies are actually needed at runti
 
 ### Packaging and dependencies
 
-The deployment time artifact should have a dependency on the runtime artifact. When using shamrock you just declare a
+The deployment time artifact should have a dependency on the runtime artifact. When using Shamrock you just declare a
 dependency on the deployment time artifacts for the features you want. This dependency *must* be scope `provided`.
 
-The shamrock plugin will not copy provided artifacts to the lib directory (and hence they will not be included in the
+The Shamrock plugin will not copy provided artifacts to the lib directory (and hence they will not be included in the
 native image). The exception to this is artifacts that contain a `dependencies.runtime` files (as described above).
 
-If this artifact has this file, or its maven coordinates were listed in another artifacts file then it will be included
+If this artifact has this file, or its Maven coordinates were listed in another artifact's file then it will be included
 (this match does not take version into account, so if dependency resolution has resulted in a different version being
 selected it will still be included).
 
-This mechanism means that you only need to declare a single dependency per feature, but shamrock still has enough information
+This mechanism means that you only need to declare a single dependency per feature, but Shamrock still has enough information
 to only include necessary runtime components.
 
 ## The Deployment Framework
@@ -197,7 +196,7 @@ To extend Shamrock you need to include a class that implements:
 
     org.jboss.shamrock.deployment.ShamrockSetup
     
-This class can then be used to all implementation of the following:    
+This class can then be used to all implementation of the following:
 
     org.jboss.shamrock.deployment.ResourceProcessor
     org.jboss.shamrock.deployment.InjectionProvider
@@ -218,7 +217,7 @@ If you only need simple integrations like adding a bean or a Servlet then this i
 For example the health check integration requires no bytecode generation, as it just adds a servlet and some beans.
 The integration basically just adds them to a list, and a later processor handles writing out the bytecode:
 
-https://github.com/protean-project/shamrock/blob/master/health/deployment/src/main/java/org/jboss/shamrock/health/HealthProcessor.java#L30
+https://github.com/protean-project/shamrock/blob/master/health/deployment/src/main/java/org/jboss/shamrock/health/HealthProcessor.java
 
 This is the Weld deployment time processor:
 
@@ -228,44 +227,44 @@ Using this runtime template:
 
 https://github.com/protean-project/shamrock/blob/master/weld/runtime/src/main/java/org/jboss/shamrock/weld/runtime/WeldDeploymentTemplate.java
 
-The first thing that happens is the processor gets a bytecode recorder by calling addStaticInitTask.
+The first thing that happens is the processor getting a bytecode recorder by calling `addStaticInitTask()`.
 The priority number that is passed in here controls the order in which the tasks are executed.
-It then gets a copy of the template by calling getRecordingProxy.
+It then gets a copy of the template by calling `getRecordingProxy()`.
 
-The next call to createWeld() will start recording bytecode.
+The next call to `createWeld()` will start recording bytecode.
 The proxy will record the invocation and write it out to bytecode when the recorder is closed.
 The return value of this method is also a proxy.
 This proxy cannot be invoked on, but can be passed back into template methods,
-and the recorded will automatically write out bytecode that does the same.
+and the recorder will automatically write out bytecode that does the same.
 
-We see an example of this with the template.addClass call, which adds a class to the deployment.
-The first parameter is the proxy from the createWeld call.
-This method also shows how Class objects are handled.
-Because this method takes a 'Class' object,
-and the actual classes are not loadable at build time we use the classProxy method to create a Class object to pass in.
+We see an example of this with the `template.addClass()` call, which adds a class to the deployment.
+The first parameter is the proxy from the `createWeld()` call.
+This method also shows how `Class` objects are handled.
+Because this method takes a `Class` object,
+and the actual classes are not loadable at build time we use the `classProxy()` method to create a `Class` object to pass in.
 
 In general these invocations on the templates should look very similar to the same sequence of invocations you would actually make to start weld.
 
 The next example is the Undertow processor, which is a bit more complex:
 
-https://github.com/protean-project/shamrock/blob/master/undertow/deployment/src/main/java/org/jboss/shamrock/undertow/ServletAnnotationProcessor.java#L41
+https://github.com/protean-project/shamrock/blob/master/undertow/deployment/src/main/java/org/jboss/shamrock/undertow/UndertowBuildStep.java#L90
 
 https://github.com/protean-project/shamrock/blob/master/undertow/runtime/src/main/java/org/jboss/shamrock/undertow/runtime/UndertowDeploymentTemplate.java#L27
 
-This example uses the @ContextObject annotation to pass parameters around, instead of relying on proxies.
+This example uses the `@ContextObject` annotation to pass parameters around, instead of relying on proxies.
 
-If this annotation is applied to a method then the return value of that method will be placed in the StartupContext under the provided key name.
+If this annotation is applied to a method then the return value of that method will be placed in the `StartupContext` under the provided key name.
 If the annotation is applied to a parameter then the value of that parameter will be looked up from the startup context.
 This allows processors to interact with each other,
-e.g. an early processor can create the DeploymentInfo and store it in the StartupContext,
+e.g. an early processor can create the `DeploymentInfo` and store it in the `StartupContext`,
 and then a later processor can actually boot undertow.
 
-In this case there are four processors, one that creates the DeploymentInfo,
+In this case there are four processors, one that creates the `DeploymentInfo`,
 another that actually adds all discovered Servlets, one that performs the actual deployment,
 and one that actually starts undertow (which runs from the main method instead of static init).
 
 The last of these also has an example of using MP config.
-If you inject ShamrockConfig into your application the bytecode recorded will treat String's returned from config in a special manner.
+If you inject `ShamrockConfig` into your application the bytecode recorded will treat String's returned from config in a special manner.
 If the recorder detects that a String has come from config then instead of just writing the value it will write some bytecode
 that loads the value from MP config, and defaulting to the build time value if it is not present.
 This means configuration can be applied at both build and runtime.
@@ -274,8 +273,8 @@ To pass to the StartupTask a list of class without loading the classes themselve
 
     org.jboss.shamrock.deployment.codegen.BytecodeRecorder#classProxy
 
-to pass in class objects. it is a work around for the classes you need not being loadable from the processor.
-you just pass in the class name, and it returns a Class object that is a proxy for the real Class.
+to pass in class objects. It is a work around for the classes you need not being loadable from the processor.
+You just pass in the class name, and it returns a Class object that is a proxy for the real Class.
 There are examples in the Undertow one.
 
 ## Testing
@@ -291,7 +290,7 @@ When running the tests this process is performed once, and then all tests are ru
 The runner for this test is `org.jboss.shamrock.junit.ShamrockTest`.
 
 These tests should be run by the Maven Surefire plugin, and as such should follow the standard surefire naming rules 
-(*TestCase). The application is started once at the beginning of the test suite run, and is shut down at the end. At
+(\*TestCase). The application is started once at the beginning of the test suite run, and is shut down at the end. At
 present there is no support for Arquillian style 'micro deployments', the whole application is under test.
 
 Both the application and the test itself run in the same JVM, so in addition to integration testing over HTTP it is
@@ -302,10 +301,10 @@ also possible to directly test application components.
 To test the native image you can use the `org.jboss.shamrock.junit.GraalTest` runner.
 
 These tests must be integration tests, as the image is generally built during the packaging phase.
-As such they should follow the Maven Failsafe naming convention (*ITCase). 
+As such they should follow the Maven Failsafe naming convention (\*ITCase). 
 
 These tests work by simply booting the native image, and then allowing you to evecute remote requests against it.
-At present to unit testing type functionality is supported (i.e. you cannot run test logic directly in the native image), 
+At present unit testing type functionality is supported (i.e. you cannot run test logic directly in the native image), 
 although this will likely change. 
 
 To run the tests from an IDE you will need to make sure the image has been built, and you may need to set
@@ -316,7 +315,7 @@ assuming that the image name is `*-runner` and is located in the parent director
 ## Reflection
 
 In order to make reflection work Shamrock provides an API to easily register classes for reflection.
-If you call ProcessorContext.addReflectiveClass then a Graal AutoFeature will be written out that contains the bytecode to
+If you call `ProcessorContext.addReflectiveClass()` then a Graal AutoFeature will be written out that contains the bytecode to
 register this class for reflection.
 
 The reason why bytecode is used instead of JSON is that this does not require any arguments to the native-image command, it 'just works'.
@@ -329,7 +328,7 @@ but if we did decide to use this as the basis for the PoC it would be easy enoug
 
 ## Plugin Output
 
-The shamrock build plugin generating wiring metadata for you application. The end result of this
+The Shamrock build plugin generating wiring metadata for you application. The end result of this
 is:
 
 *   ${project.build.finalName}-runner.jar 
@@ -337,9 +336,9 @@ is:
     This jar can be executed directly using `java -jar`, or can be turned into a native image in the same manner.
      
 *   ${project.build.finalName}.jar 
-    The unmodified project jar, the shamrock plugin does not modify this.
+    The unmodified project jar, the Shamrock plugin does not modify this.
     
-*   lib/*
+*   lib/\*
     A directory that contains all runtime dependencies. These are referenced by the `class-path` manifest entry in the runner jar.
     
 ## Shamrock Run Modes
@@ -347,7 +346,7 @@ is:
 Shamrock supports a few different run modes, to meet the various use cases. The core of how it works is the same in each
 mode, however there are some differences. The two basic modes are:
 
-*   Built Time Mode
+*   Build Time Mode
     This mode involves building the wiring jar at build/provisioning time, and then executing the resulting output as a
     separate step. This mode is the basis for native image generation, as native images are generated from the output
     of this command. This is the only mode that is supported for production use.
@@ -373,7 +372,7 @@ Note that at the moment loading pre-computed indexes is not supported, and likel
 
 Three different mechanisms are provided to do this. The most common one will be to define application marker files.
 If any of these files are discovered on the class path then the archive that contains these files will be considered
-an application class. The most common of these marker files will be `META-IND/beans.xml`. 
+an application class. The most common of these marker files will be `META-INF/beans.xml`. 
  
 There are two different configuration based approaches both of them configured in `shamrock-build.yaml`. 
 


### PR DESCRIPTION
Here are a few fixes/improvements to the README.md, made while reading it.

There's one thing I haven't fixed: there are references to `@ContextObject` and it seems this annotation does not exist anymore.