### PR TITLE
Allow build items to be produced weakly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dumps
 *.orig
 *.rej
 .factorypath
+graph-output.dot
+

--- a/builder/src/main/java/org/jboss/builder/BuildChain.java
+++ b/builder/src/main/java/org/jboss/builder/BuildChain.java
@@ -41,13 +41,13 @@ public final class BuildChain {
     private final List<BuildProvider> providers;
     private final int endStepCount;
 
-    BuildChain(final int initialSingleCount, final int initialMultiCount, final List<StepInfo> startSteps, final Set<ItemId> consumed, BuildChainBuilder builder, final int endStepCount) {
+    BuildChain(final int initialSingleCount, final int initialMultiCount, final Set<StepInfo> startSteps, final Set<ItemId> consumed, BuildChainBuilder builder, final int endStepCount) {
         providers = builder.getProviders();
         initialIds = builder.getInitialIds();
         finalIds = builder.getFinalIds();
         this.initialSingleCount = initialSingleCount;
         this.initialMultiCount = initialMultiCount;
-        this.startSteps = startSteps;
+        this.startSteps = new ArrayList<>(startSteps);
         this.consumed = consumed;
         this.endStepCount = endStepCount;
     }

--- a/builder/src/main/java/org/jboss/builder/BuildChainBuilder.java
+++ b/builder/src/main/java/org/jboss/builder/BuildChainBuilder.java
@@ -18,6 +18,10 @@
 
 package org.jboss.builder;
 
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jboss.builder.item.BuildItem;
 import org.jboss.builder.item.NamedBuildItem;
@@ -39,6 +45,8 @@ import org.wildfly.common.Assert;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class BuildChainBuilder {
+
+    private static final String GRAPH_OUTPUT = System.getProperty("jboss.builder.graph-output", "graph-output.dot");
 
     private final BuildStepBuilder finalStep;
     private final List<BuildProvider> providers = new ArrayList<>();
@@ -170,7 +178,6 @@ public final class BuildChainBuilder {
      */
     public BuildChain build() throws ChainBuildException {
         final Set<ItemId> consumed = new HashSet<>();
-        final List<StepInfo> startSteps = new ArrayList<>();
         final Map<BuildStepBuilder, StepInfo> mappedSteps = new HashMap<>();
         int initialSingleCount = 0;
         int initialMultiCount = 0;
@@ -215,13 +222,13 @@ public final class BuildChainBuilder {
         // now begin to wire dependencies
         final Set<ItemId> finalIds = this.finalIds;
         final ArrayDeque<BuildStepBuilder> toAdd = new ArrayDeque<>();
-        final Set<BuildStepBuilder> lastDependencies = new HashSet<>();
+        final Set<Produce> lastDependencies = new HashSet<>();
         for (ItemId finalId : finalIds) {
             addOne(allProduces, included, toAdd, finalId, lastDependencies);
         }
         // now recursively add producers of consumed items
         BuildStepBuilder stepBuilder;
-        Map<BuildStepBuilder, Set<BuildStepBuilder>> dependencies = new HashMap<>();
+        Map<BuildStepBuilder, Set<Produce>> dependencies = new HashMap<>();
         while ((stepBuilder = toAdd.pollFirst()) != null) {
             for (Map.Entry<ItemId, Consume> entry : stepBuilder.getConsumes().entrySet()) {
                 final Consume consume = entry.getValue();
@@ -237,35 +244,118 @@ public final class BuildChainBuilder {
         }
         // calculate dependents
         Map<BuildStepBuilder, Set<BuildStepBuilder>> dependents = new HashMap<>();
-        for (Map.Entry<BuildStepBuilder, Set<BuildStepBuilder>> entry : dependencies.entrySet()) {
+        for (Map.Entry<BuildStepBuilder, Set<Produce>> entry : dependencies.entrySet()) {
             final BuildStepBuilder dependent = entry.getKey();
-            for (BuildStepBuilder dependency : entry.getValue()) {
-                dependents.computeIfAbsent(dependency, x -> new HashSet<>()).add(dependent);
+            for (Produce produce : entry.getValue()) {
+                dependents.computeIfAbsent(produce.getStepBuilder(), x -> new HashSet<>()).add(dependent);
             }
         }
         // detect cycles
         cycleCheck(included, new HashSet<>(), new HashSet<>(), dependencies);
         // recursively build all
-        List<StepInfo> endSteps = new ArrayList<>();
+        final Set<StepInfo> startSteps = new HashSet<>();
+        final Set<StepInfo> endSteps = new HashSet<>();
         for (BuildStepBuilder builder : included) {
-            buildOne(builder, mappedSteps, dependents, dependencies, startSteps, endSteps);
+            buildOne(builder, included, mappedSteps, dependents, dependencies, startSteps, endSteps);
+        }
+        if (GRAPH_OUTPUT != null && ! GRAPH_OUTPUT.isEmpty()) {
+            try (FileOutputStream fos = new FileOutputStream(GRAPH_OUTPUT)) {
+                try (OutputStreamWriter osw = new OutputStreamWriter(fos)) {
+                    try (BufferedWriter writer = new BufferedWriter(osw)) {
+                        writer.write("digraph {");
+                        writer.newLine();
+                        writer.write("    node [shape=rectangle];");
+                        writer.newLine();
+                        writer.write("    rankdir=LR;");
+                        writer.newLine();
+                        writer.newLine();
+                        writer.write("    { rank = same; ");
+                        for (StepInfo startStep : startSteps) {
+                            writer.write(quoteString(startStep.getBuildStep().toString()));
+                            writer.write("; ");
+                        }
+                        writer.write("};");
+                        writer.newLine();
+                        writer.write("    { rank = same; ");
+                        for (StepInfo endStep : endSteps) {
+                            if (! startSteps.contains(endStep)) {
+                                writer.write(quoteString(endStep.getBuildStep().toString()));
+                                writer.write("; ");
+                            }
+                        }
+                        writer.write("};");
+                        writer.newLine();
+                        writer.newLine();
+                        final HashSet<StepInfo> printed = new HashSet<>();
+                        for (StepInfo step : startSteps) {
+                            writeStep(writer, printed, step);
+                        }
+                        writer.write("}");
+                        writer.newLine();
+                    }
+                }
+            } catch (IOException ioe) {
+                throw new RuntimeException("Failed to write debug graph output", ioe);
+            }
         }
         return new BuildChain(initialSingleCount, initialMultiCount, startSteps, consumed, this, endSteps.size());
     }
 
-    private void cycleCheck(Set<BuildStepBuilder> builders, Set<BuildStepBuilder> visited, Set<BuildStepBuilder> checked, final Map<BuildStepBuilder, Set<BuildStepBuilder>> dependencies) throws ChainBuildException {
+    private static void writeStep(final BufferedWriter writer, final HashSet<StepInfo> printed, final StepInfo step) throws IOException {
+        if (printed.add(step)) {
+            final String currentStepName = quoteString(step.getBuildStep().toString());
+            final Set<StepInfo> dependents = step.getDependents();
+            if (! dependents.isEmpty()) {
+                for (StepInfo dependent : dependents) {
+                    final String dependentName = quoteString(dependent.getBuildStep().toString());
+                    writer.write("    ");
+                    writer.write(dependentName);
+                    writer.write(" -> ");
+                    writer.write(currentStepName);
+                    writer.newLine();
+                }
+                writer.newLine();
+                for (StepInfo dependent : dependents) {
+                    writeStep(writer, printed, dependent);
+                }
+            }
+        }
+    }
+
+    private static final Pattern QUOTE_PATTERN = Pattern.compile("[\"]");
+
+    private static String quoteString(String input) {
+        final Matcher matcher = QUOTE_PATTERN.matcher(input);
+        final StringBuffer buf = new StringBuffer();
+        buf.append('"');
+        while (matcher.find()) {
+            matcher.appendReplacement(buf, "\\" + matcher.group(0));
+        }
+        matcher.appendTail(buf);
+        buf.append('"');
+        return buf.toString();
+    }
+
+    private void cycleCheck(Set<BuildStepBuilder> builders, Set<BuildStepBuilder> visited, Set<BuildStepBuilder> checked, final Map<BuildStepBuilder, Set<Produce>> dependencies) throws ChainBuildException {
         for (BuildStepBuilder builder : builders) {
             cycleCheck(builder, visited, checked, dependencies);
         }
     }
 
-    private void cycleCheck(BuildStepBuilder builder, Set<BuildStepBuilder> visited, Set<BuildStepBuilder> checked, final Map<BuildStepBuilder, Set<BuildStepBuilder>> dependencies) throws ChainBuildException {
+    private void cycleCheckProduce(Set<Produce> produceSet, Set<BuildStepBuilder> visited, Set<BuildStepBuilder> checked, final Map<BuildStepBuilder, Set<Produce>> dependencies) throws ChainBuildException {
+        for (Produce produce : produceSet) {
+            cycleCheck(produce.getStepBuilder(), visited, checked, dependencies);
+        }
+    }
+
+    private void cycleCheck(BuildStepBuilder builder, Set<BuildStepBuilder> visited, Set<BuildStepBuilder> checked, final Map<BuildStepBuilder, Set<Produce>> dependencies) throws ChainBuildException {
         if (! checked.contains(builder)) {
             if (! visited.add(builder)) {
                 throw new ChainBuildException("Cycle detected: " + visited);
             }
             try {
-                cycleCheck(dependencies.getOrDefault(builder, Collections.emptySet()), visited, checked, dependencies);
+                final Set<Produce> dependencySet = dependencies.getOrDefault(builder, Collections.emptySet());
+                cycleCheckProduce(dependencySet, visited, checked, dependencies);
             } finally {
                 visited.remove(builder);
             }
@@ -273,34 +363,52 @@ public final class BuildChainBuilder {
         checked.add(builder);
     }
 
-    private void addOne(final Map<ItemId, List<Produce>> allProduces, final Set<BuildStepBuilder> included, final ArrayDeque<BuildStepBuilder> toAdd, final ItemId idToAdd, Set<BuildStepBuilder> dependencies) throws ChainBuildException {
+    private void addOne(final Map<ItemId, List<Produce>> allProduces, final Set<BuildStepBuilder> included, final ArrayDeque<BuildStepBuilder> toAdd, final ItemId idToAdd, Set<Produce> dependencies) throws ChainBuildException {
         for (Produce produce : allProduces.getOrDefault(idToAdd, Collections.emptyList())) {
             final BuildStepBuilder stepBuilder = produce.getStepBuilder();
-            if (included.add(stepBuilder)) {
-                // recursively add
-                toAdd.addLast(stepBuilder);
+            if (! produce.getFlags().contains(ProduceFlag.WEAK)) {
+                if (included.add(stepBuilder)) {
+                    // recursively add
+                    toAdd.addLast(stepBuilder);
+                }
             }
-            dependencies.add(stepBuilder);
+            dependencies.add(produce);
         }
     }
 
-    private StepInfo buildOne(BuildStepBuilder toBuild, Map<BuildStepBuilder, StepInfo> mapped, Map<BuildStepBuilder, Set<BuildStepBuilder>> dependents, Map<BuildStepBuilder, Set<BuildStepBuilder>> dependencies, final List<StepInfo> startSteps, final List<StepInfo> endSteps) {
+    private StepInfo buildOne(BuildStepBuilder toBuild, Set<BuildStepBuilder> included, Map<BuildStepBuilder, StepInfo> mapped, Map<BuildStepBuilder, Set<BuildStepBuilder>> dependents, Map<BuildStepBuilder, Set<Produce>> dependencies, final Set<StepInfo> startSteps, final Set<StepInfo> endSteps) {
         if (mapped.containsKey(toBuild)) {
             return mapped.get(toBuild);
         }
         Set<StepInfo> dependentStepInfos = new HashSet<>();
         final Set<BuildStepBuilder> dependentsOfThis = dependents.getOrDefault(toBuild, Collections.emptySet());
         for (BuildStepBuilder dependentBuilder : dependentsOfThis) {
-            dependentStepInfos.add(buildOne(dependentBuilder, mapped, dependents, dependencies, startSteps, endSteps));
+            if (included.contains(dependentBuilder)) {
+                dependentStepInfos.add(buildOne(dependentBuilder, included, mapped, dependents, dependencies, startSteps, endSteps));
+            }
         }
-        final Set<BuildStepBuilder> dependenciesOfThis = dependencies.getOrDefault(toBuild, Collections.emptySet());
-        final StepInfo stepInfo = new StepInfo(toBuild, dependenciesOfThis.size(), dependentStepInfos);
+        final Set<Produce> dependenciesOfThis = dependencies.getOrDefault(toBuild, Collections.emptySet());
+        int includedDependencies = 0;
+        final Set<BuildStepBuilder> visited = new HashSet<>();
+        for (Produce produce : dependenciesOfThis) {
+            final BuildStepBuilder stepBuilder = produce.getStepBuilder();
+            if (included.contains(stepBuilder) && visited.add(stepBuilder)) {
+                includedDependencies ++;
+            }
+        }
+        int includedDependents = 0;
+        for (BuildStepBuilder dependent : dependentsOfThis) {
+            if (included.contains(dependent)) {
+                includedDependents ++;
+            }
+        }
+        final StepInfo stepInfo = new StepInfo(toBuild, includedDependencies, dependentStepInfos);
         mapped.put(toBuild, stepInfo);
-        if (dependenciesOfThis.isEmpty()) {
+        if (includedDependencies == 0) {
             // it's a start step!
             startSteps.add(stepInfo);
         }
-        if (dependentsOfThis.isEmpty()) {
+        if (includedDependents == 0) {
             // it's an end step!
             endSteps.add(stepInfo);
         }

--- a/builder/src/main/java/org/jboss/builder/BuildStepBuilder.java
+++ b/builder/src/main/java/org/jboss/builder/BuildStepBuilder.java
@@ -54,16 +54,6 @@ public final class BuildStepBuilder {
     }
 
     /**
-     * Set to include this build step even if it would normally be excluded due to producing nothing of ultimate use.
-     *
-     * @param include {@code true} to include the build step, {@code false} to exclude it in this situation
-     * @return this builder
-     */
-    public BuildStepBuilder includeIfNoDependents(boolean include) {
-        return this;
-    }
-
-    /**
      * This build step should complete before any build steps which consume the given item {@code type} are initiated.
      * If no such build steps exist, no ordering constraint is enacted.
      *
@@ -75,7 +65,25 @@ public final class BuildStepBuilder {
         if (NamedBuildItem.class.isAssignableFrom(type)) {
             throw new IllegalArgumentException("Cannot consume a named build item without a name");
         }
-        addProduces(new ItemId(type, null), Constraint.ORDER_ONLY);
+        addProduces(new ItemId(type, null), Constraint.ORDER_ONLY, ProduceFlags.NONE);
+        return this;
+    }
+
+    /**
+     * This build step should complete before any build steps which consume the given item {@code type} are initiated.
+     * If no such build steps exist, no ordering constraint is enacted.
+     *
+     * @param type the item type (must not be {@code null})
+     * @param flag the producer flag to apply (must not be {@code null})
+     * @return this builder
+     */
+    public BuildStepBuilder beforeConsume(Class<? extends BuildItem> type, ProduceFlag flag) {
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("flag", flag);
+        if (NamedBuildItem.class.isAssignableFrom(type)) {
+            throw new IllegalArgumentException("Cannot consume a named build item without a name");
+        }
+        addProduces(new ItemId(type, null), Constraint.ORDER_ONLY, ProduceFlags.of(flag));
         return this;
     }
 
@@ -90,7 +98,24 @@ public final class BuildStepBuilder {
     public <N> BuildStepBuilder beforeConsume(Class<? extends NamedBuildItem<N>> type, N name) {
         Assert.checkNotNullParam("type", type);
         Assert.checkNotNullParam("name", name);
-        addProduces(new ItemId(type, name), Constraint.ORDER_ONLY);
+        addProduces(new ItemId(type, name), Constraint.ORDER_ONLY, ProduceFlags.NONE);
+        return this;
+    }
+
+    /**
+     * This build step should complete before any build steps which consume the given item {@code type} are initiated.
+     * If no such build steps exist, no ordering constraint is enacted.
+     *
+     * @param type the item type (must not be {@code null})
+     * @param name the build item name (must not be {@code null})
+     * @param flag the producer flag to apply (must not be {@code null})
+     * @return this builder
+     */
+    public <N> BuildStepBuilder beforeConsume(Class<? extends NamedBuildItem<N>> type, N name, ProduceFlag flag) {
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("name", name);
+        Assert.checkNotNullParam("flag", flag);
+        addProduces(new ItemId(type, name), Constraint.ORDER_ONLY, ProduceFlags.of(flag));
         return this;
     }
 
@@ -106,7 +131,7 @@ public final class BuildStepBuilder {
         if (NamedBuildItem.class.isAssignableFrom(type)) {
             throw new IllegalArgumentException("Cannot produce a named build item without a name");
         }
-        addConsumes(new ItemId(type, null), Constraint.ORDER_ONLY, ConsumeFlags.OPTIONAL);
+        addConsumes(new ItemId(type, null), Constraint.ORDER_ONLY, ConsumeFlags.of(ConsumeFlag.OPTIONAL));
         return this;
     }
 
@@ -121,7 +146,7 @@ public final class BuildStepBuilder {
     public <N> BuildStepBuilder afterProduce(Class<? extends NamedBuildItem<N>> type, N name) {
         Assert.checkNotNullParam("type", type);
         Assert.checkNotNullParam("name", name);
-        addConsumes(new ItemId(type, name), Constraint.ORDER_ONLY, ConsumeFlags.OPTIONAL);
+        addConsumes(new ItemId(type, name), Constraint.ORDER_ONLY, ConsumeFlags.of(ConsumeFlag.OPTIONAL));
         return this;
     }
 
@@ -138,7 +163,26 @@ public final class BuildStepBuilder {
         if (NamedBuildItem.class.isAssignableFrom(type)) {
             throw new IllegalArgumentException("Cannot produce a named build item without a name");
         }
-        addProduces(new ItemId(type, null), Constraint.REAL);
+        addProduces(new ItemId(type, null), Constraint.REAL, ProduceFlags.NONE);
+        return this;
+    }
+
+    /**
+     * Similarly to {@link #beforeConsume(Class)}, establish that this build step must come before the consumer(s) of the
+     * given item {@code type}; however, only one {@code producer} may exist for the given item.  In addition, the
+     * build step may produce an actual value for this item, which will be shared to all consumers during deployment.
+     *
+     * @param type the item type (must not be {@code null})
+     * @param flag the producer flag to apply (must not be {@code null})
+     * @return this builder
+     */
+    public BuildStepBuilder produces(Class<? extends BuildItem> type, ProduceFlag flag) {
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("flag", flag);
+        if (NamedBuildItem.class.isAssignableFrom(type)) {
+            throw new IllegalArgumentException("Cannot produce a named build item without a name");
+        }
+        addProduces(new ItemId(type, null), Constraint.REAL, ProduceFlags.of(flag));
         return this;
     }
 
@@ -154,7 +198,25 @@ public final class BuildStepBuilder {
     public <N> BuildStepBuilder produces(Class<? extends NamedBuildItem<N>> type, N name) {
         Assert.checkNotNullParam("type", type);
         Assert.checkNotNullParam("name", name);
-        addProduces(new ItemId(type, name), Constraint.REAL);
+        addProduces(new ItemId(type, name), Constraint.REAL, ProduceFlags.NONE);
+        return this;
+    }
+
+    /**
+     * Similarly to {@link #beforeConsume(Class)}, establish that this build step must come before the consumer(s) of the
+     * given item {@code type}; however, only one {@code producer} may exist for the given item.  In addition, the
+     * build step may produce an actual value for this item, which will be shared to all consumers during deployment.
+     *
+     * @param type the item type (must not be {@code null})
+     * @param name the build item name (must not be {@code null})
+     * @param flag the producer flag to apply (must not be {@code null})
+     * @return this builder
+     */
+    public <N> BuildStepBuilder produces(Class<? extends NamedBuildItem<N>> type, N name, ProduceFlag flag) {
+        Assert.checkNotNullParam("type", type);
+        Assert.checkNotNullParam("name", name);
+        Assert.checkNotNullParam("flag", flag);
+        addProduces(new ItemId(type, name), Constraint.REAL, ProduceFlags.of(flag));
         return this;
     }
 
@@ -166,7 +228,21 @@ public final class BuildStepBuilder {
      */
     public BuildStepBuilder beforeVirtual(Enum<?> symbolic) {
         Assert.checkNotNullParam("symbolic", symbolic);
-        addProduces(new ItemId(SymbolicBuildItem.class, symbolic), Constraint.ORDER_ONLY);
+        addProduces(new ItemId(SymbolicBuildItem.class, symbolic), Constraint.ORDER_ONLY, ProduceFlags.NONE);
+        return this;
+    }
+
+    /**
+     * Declare that the build step "produces" a virtual item with the given identifier.
+     *
+     * @param symbolic the item identifier (must not be {@code null})
+     * @param flag the producer flag to apply (must not be {@code null})
+     * @return this builder
+     */
+    public BuildStepBuilder beforeVirtual(Enum<?> symbolic, ProduceFlag flag) {
+        Assert.checkNotNullParam("symbolic", symbolic);
+        Assert.checkNotNullParam("flag", flag);
+        addProduces(new ItemId(SymbolicBuildItem.class, symbolic), Constraint.ORDER_ONLY, ProduceFlags.of(flag));
         return this;
     }
 
@@ -278,8 +354,8 @@ public final class BuildStepBuilder {
         consumes.compute(itemId, (id, c) -> c == null ? new Consume(this, itemId, constraint, flags) : c.combine(constraint, flags));
     }
 
-    private void addProduces(final ItemId itemId, final Constraint constraint) {
-        produces.compute(itemId, (id, p) -> p == null ? new Produce(this, itemId, constraint) : p.combine(constraint));
+    private void addProduces(final ItemId itemId, final Constraint constraint, final ProduceFlags flags) {
+        produces.compute(itemId, (id, p) -> p == null ? new Produce(this, itemId, constraint, flags) : p.combine(constraint, flags));
     }
 
     Map<ItemId, Consume> getConsumes() {

--- a/builder/src/main/java/org/jboss/builder/Consume.java
+++ b/builder/src/main/java/org/jboss/builder/Consume.java
@@ -46,7 +46,9 @@ final class Consume {
     }
 
     Consume combine(final Constraint constraint, final ConsumeFlags flags) {
-        return null;
+        final Constraint outputConstraint = constraint == Constraint.REAL || this.constraint == Constraint.REAL ? Constraint.REAL : Constraint.ORDER_ONLY;
+        final ConsumeFlags outputFlags = !flags.contains(ConsumeFlag.OPTIONAL) || !this.flags.contains(ConsumeFlag.OPTIONAL) ? flags.with(this.flags).without(ConsumeFlag.OPTIONAL) : flags.with(this.flags);
+        return new Consume(buildStepBuilder, itemId, outputConstraint, outputFlags);
     }
 
     Constraint getConstraint() {

--- a/builder/src/main/java/org/jboss/builder/Execution.java
+++ b/builder/src/main/java/org/jboss/builder/Execution.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.builder.diag.Diagnostic;
 import org.jboss.builder.item.BuildItem;
+import org.jboss.logging.Logger;
 import org.jboss.threads.EnhancedQueueExecutor;
 import org.jboss.threads.JBossExecutors;
 import org.jboss.threads.JBossThreadFactory;
@@ -39,6 +40,8 @@ import org.jboss.threads.JBossThreadFactory;
 /**
  */
 final class Execution {
+
+    static final Logger log = Logger.getLogger("org.jboss.builder");
 
     private final BuildChain chain;
     private final ConcurrentHashMap<ItemId, BuildItem> singles;
@@ -146,7 +149,9 @@ final class Execution {
     }
 
     void depFinished() {
-        if (lastStepCount.decrementAndGet() == 0) {
+        final int count = lastStepCount.decrementAndGet();
+        log.tracef("End step completed; %d remaining", count);
+        if (count == 0) {
             done = true;
             unpark(runningThread);
         }

--- a/builder/src/main/java/org/jboss/builder/Produce.java
+++ b/builder/src/main/java/org/jboss/builder/Produce.java
@@ -24,15 +24,29 @@ final class Produce {
     private final BuildStepBuilder stepBuilder;
     private final ItemId itemId;
     private final Constraint constraint;
+    private final ProduceFlags flags;
 
-    Produce(final BuildStepBuilder stepBuilder, final ItemId itemId, final Constraint constraint) {
+    Produce(final BuildStepBuilder stepBuilder, final ItemId itemId, final Constraint constraint, final ProduceFlags flags) {
         this.stepBuilder = stepBuilder;
         this.itemId = itemId;
         this.constraint = constraint;
+        this.flags = flags;
     }
 
-    Produce combine(final Constraint constraint) {
-        return null;
+    Produce combine(final Constraint constraint, final ProduceFlags flags) {
+        final Constraint outputConstraint;
+        final ProduceFlags outputFlags;
+        if (constraint == Constraint.REAL || this.constraint == Constraint.REAL) {
+            outputConstraint = Constraint.REAL;
+        } else {
+            outputConstraint = Constraint.ORDER_ONLY;
+        }
+        if (! flags.contains(ProduceFlag.WEAK) || ! this.flags.contains(ProduceFlag.WEAK)) {
+            outputFlags = flags.with(this.flags).without(ProduceFlag.WEAK);
+        } else {
+            outputFlags = flags.with(this.flags);
+        }
+        return new Produce(stepBuilder, itemId, outputConstraint, outputFlags);
     }
 
     BuildStepBuilder getStepBuilder() {
@@ -45,5 +59,9 @@ final class Produce {
 
     Constraint getConstraint() {
         return constraint;
+    }
+
+    ProduceFlags getFlags() {
+        return flags;
     }
 }

--- a/builder/src/main/java/org/jboss/builder/ProduceFlag.java
+++ b/builder/src/main/java/org/jboss/builder/ProduceFlag.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.builder;
+
+/**
+ */
+public enum ProduceFlag {
+    /**
+     * Only produce this item weakly: if only weak items produced by a build step are consumed, the step will not be included.
+     */
+    WEAK,
+}

--- a/builder/src/main/java/org/jboss/builder/ProduceFlags.java
+++ b/builder/src/main/java/org/jboss/builder/ProduceFlags.java
@@ -24,47 +24,47 @@ import org.wildfly.common.flags.Flags;
 /**
  * Flags which can be set on consume declarations.
  */
-public final class ConsumeFlags extends Flags<ConsumeFlag, ConsumeFlags> {
+public final class ProduceFlags extends Flags<ProduceFlag, ProduceFlags> {
 
-    protected ConsumeFlags value(final int bits) {
+    protected ProduceFlags value(final int bits) {
         return values[bits & enumValues.length - 1];
     }
 
-    protected ConsumeFlags this_() {
+    protected ProduceFlags this_() {
         return this;
     }
 
-    protected ConsumeFlag itemOf(final int index) {
+    protected ProduceFlag itemOf(final int index) {
         return enumValues[index];
     }
 
-    protected ConsumeFlag castItemOrNull(final Object obj) {
-        return obj instanceof ConsumeFlag ? (ConsumeFlag) obj : null;
+    protected ProduceFlag castItemOrNull(final Object obj) {
+        return obj instanceof ProduceFlag ? (ProduceFlag) obj : null;
     }
 
-    protected ConsumeFlags castThis(final Object obj) {
-        return (ConsumeFlags) obj;
+    protected ProduceFlags castThis(final Object obj) {
+        return (ProduceFlags) obj;
     }
 
-    private ConsumeFlags(int val) {
+    private ProduceFlags(int val) {
         super(val);
     }
 
-    private static final ConsumeFlag[] enumValues = ConsumeFlag.values();
-    private static final ConsumeFlags[] values;
+    private static final ProduceFlag[] enumValues = ProduceFlag.values();
+    private static final ProduceFlags[] values;
 
     static {
-        final ConsumeFlags[] flags = new ConsumeFlags[1 << ConsumeFlag.values().length];
+        final ProduceFlags[] flags = new ProduceFlags[1 << ProduceFlag.values().length];
         for (int i = 0; i < flags.length; i++) {
-            flags[i] = new ConsumeFlags(i);
+            flags[i] = new ProduceFlags(i);
         }
         values = flags;
     }
 
-    public static ConsumeFlags of(ConsumeFlag flag) {
+    public static ProduceFlags of(ProduceFlag flag) {
         Assert.checkNotNullParam("flag", flag);
         return values[1 << flag.ordinal()];
     }
 
-    public static final ConsumeFlags NONE = values[0];
+    public static final ProduceFlags NONE = values[0];
 }

--- a/examples/permissive/pom.xml
+++ b/examples/permissive/pom.xml
@@ -95,6 +95,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.manager</name>
+                            <value>org.jboss.logmanager.LogManager</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
 
         </plugins>
     </build>

--- a/examples/permissive/src/test/java/org/jboss/shamrock/example/test/LoggingConfig.java
+++ b/examples/permissive/src/test/java/org/jboss/shamrock/example/test/LoggingConfig.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.example.test;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.EmbeddedConfigurator;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.ConsoleHandler;
+
+/**
+ */
+public class LoggingConfig implements EmbeddedConfigurator {
+    public Level getMinimumLevelOf(final String loggerName) {
+        return loggerName.equals("javax.management") ? Level.OFF : loggerName.isEmpty() ? Level.ALL : null;
+    }
+
+    public Level getLevelOf(final String loggerName) {
+        return loggerName.isEmpty() ? org.jboss.logmanager.Level.TRACE : null;
+    }
+
+    public Handler[] getHandlersOf(final String loggerName) {
+        return loggerName.isEmpty() ? new Handler[] {
+            new ConsoleHandler(new PatternFormatter("%d{HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n"))
+        } : NO_HANDLERS;
+    }
+}

--- a/examples/permissive/src/test/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
+++ b/examples/permissive/src/test/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
@@ -1,0 +1,1 @@
+org.jboss.shamrock.example.test.LoggingConfig


### PR DESCRIPTION
This allows build steps to only produce certain things (such as bytecode for the main/static init method(s) or resources) when the significant product of the build step is consumed.  If only weakly-produced outputs are consumed, the build step is not emitted.