### PR TITLE
Remove obsolete debugging options from NativeImageMojo

### DIFF
--- a/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
@@ -174,9 +174,6 @@ public class NativeImageMojo extends AbstractMojo {
                 command.add("-g");
             }
             if (debugBuildProcess) {
-                command.add("-J-Xdebug");
-                command.add("-J-Xnoagent");
-                command.add("-J-Djava.compiler=NONE");
                 command.add("-J-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y");
             }
             if (dumpProxies) {


### PR DESCRIPTION

I was puzzled about these debugging options, so I investigated a bit. Turns out these are very old and no longer recommended to be used.

Any objection to remove?