### PR TITLE
Enable configurable support for SSL on native, working on netty/vertx

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/SslConfig.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/SslConfig.java
@@ -1,0 +1,30 @@
+package org.jboss.shamrock.deployment;
+
+import java.io.File;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shamrock.annotations.BuildStep;
+import org.jboss.shamrock.deployment.builditem.SystemPropertyBuildItem;
+
+public class SslConfig {
+    /**
+     * Enable support for SSL on the resulting native binary
+     */
+    @ConfigProperty(name = "shamrock.ssl.native", defaultValue = "false")
+    boolean enableSsl;
+    
+    @BuildStep
+    SystemPropertyBuildItem setupNativeSsl() {
+        String graalVmHome = System.getenv("GRAALVM_HOME");
+        if(enableSsl) {
+            // I assume we only fail if we actually enable it, but perhaps there's a no-native called that we can't
+            // see here?
+            
+            // FIXME: fail build? what sort of error here?
+            if(graalVmHome == null)
+                throw new RuntimeException("GRAALVM_HOME environment variable required");
+            return new SystemPropertyBuildItem("java.library.path", graalVmHome+File.separator+"jre"+File.separator+"lib"+File.separator+"amd64");
+        }
+        return null;
+    }
+}

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/builditem/substrate/RuntimeReinitializedClassBuildItem.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/builditem/substrate/RuntimeReinitializedClassBuildItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.deployment.builditem.substrate;
+
+import org.jboss.builder.item.MultiBuildItem;
+
+public final class RuntimeReinitializedClassBuildItem extends MultiBuildItem {
+
+    private final String className;
+
+    public RuntimeReinitializedClassBuildItem(String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/builditem/substrate/SubstrateConfigBuildItem.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/builditem/substrate/SubstrateConfigBuildItem.java
@@ -29,12 +29,14 @@ import org.jboss.builder.item.MultiBuildItem;
 public final class SubstrateConfigBuildItem extends MultiBuildItem {
 
     private final Set<String> runtimeInitializedClasses;
+    private final Set<String> runtimeReinitializedClasses;
     private final Set<String> resourceBundles;
     private final Set<List<String>> proxyDefinitions;
     private final Map<String, String> nativeImageSystemProperties;
 
     public SubstrateConfigBuildItem(Builder builder) {
         this.runtimeInitializedClasses = Collections.unmodifiableSet(builder.runtimeInitializedClasses);
+        this.runtimeReinitializedClasses = Collections.unmodifiableSet(builder.runtimeReinitializedClasses);
         this.resourceBundles = Collections.unmodifiableSet(builder.resourceBundles);
         this.proxyDefinitions = Collections.unmodifiableSet(builder.proxyDefinitions);
         this.nativeImageSystemProperties = Collections.unmodifiableMap(builder.nativeImageSystemProperties);
@@ -42,6 +44,10 @@ public final class SubstrateConfigBuildItem extends MultiBuildItem {
 
     public Iterable<String> getRuntimeInitializedClasses() {
         return runtimeInitializedClasses;
+    }
+
+    public Iterable<String> getRuntimeReinitializedClasses() {
+        return runtimeReinitializedClasses;
     }
 
     public Iterable<String> getResourceBundles() {
@@ -63,12 +69,18 @@ public final class SubstrateConfigBuildItem extends MultiBuildItem {
     public static class Builder {
 
         final Set<String> runtimeInitializedClasses = new HashSet<>();
+        final Set<String> runtimeReinitializedClasses = new HashSet<>();
         final Set<String> resourceBundles = new HashSet<>();
         final Set<List<String>> proxyDefinitions = new HashSet<>();
         final Map<String, String> nativeImageSystemProperties = new HashMap<>();
 
         public Builder addRuntimeInitializedClass(String className) {
             runtimeInitializedClasses.add(className);
+            return this;
+        }
+
+        public Builder addRuntimeReinitializedClass(String className) {
+            runtimeReinitializedClasses.add(className);
             return this;
         }
 

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/MainClassBuildStep.java
@@ -66,7 +66,7 @@ class MainClassBuildStep {
         MethodCreator mv = file.getMethodCreator("<clinit>", void.class);
         mv.setModifiers(Modifier.PUBLIC | Modifier.STATIC);
 
-        //very first thing is to set system props
+        //very first thing is to set system props (for build time)
         for (SystemPropertyBuildItem i : properties) {
             mv.invokeStaticMethod(ofMethod(System.class, "setProperty", String.class, String.class, String.class), mv.load(i.getKey()), mv.load(i.getValue()));
         }
@@ -94,6 +94,12 @@ class MainClassBuildStep {
 
         mv = file.getMethodCreator("doStart", void.class, String[].class);
         mv.setModifiers(Modifier.PROTECTED | Modifier.FINAL);
+
+        // very first thing is to set system props (for run time, which use substitutions for a different
+        // storage from build-time)
+        for (SystemPropertyBuildItem i : properties) {
+            mv.invokeStaticMethod(ofMethod(System.class, "setProperty", String.class, String.class, String.class), mv.load(i.getKey()), mv.load(i.getValue()));
+        }
 
         mv.invokeStaticMethod(ofMethod(Timing.class, "mainStarted", void.class));
         startupContext = mv.readStaticField(scField.getFieldDescriptor());

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/SubstrateConfigBuildStep.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/SubstrateConfigBuildStep.java
@@ -25,6 +25,7 @@ import org.jboss.shamrock.deployment.builditem.substrate.SubstrateSystemProperty
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateProxyDefinitionBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateResourceBundleBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.RuntimeInitializedClassBuildItem;
+import org.jboss.shamrock.deployment.builditem.substrate.RuntimeReinitializedClassBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateConfigBuildItem;
 
 //TODO: this should go away, once we decide on which one of the API's we want
@@ -35,10 +36,14 @@ class SubstrateConfigBuildStep {
                BuildProducer<SubstrateProxyDefinitionBuildItem> proxy,
                BuildProducer<SubstrateResourceBundleBuildItem> resourceBundle,
                BuildProducer<RuntimeInitializedClassBuildItem> runtimeInit,
+               BuildProducer<RuntimeReinitializedClassBuildItem> runtimeReinit,
                BuildProducer<SubstrateSystemPropertyBuildItem> nativeImage) {
         for (SubstrateConfigBuildItem substrateConfigBuildItem : substrateConfigBuildItems) {
             for (String i : substrateConfigBuildItem.getRuntimeInitializedClasses()) {
                 runtimeInit.produce(new RuntimeInitializedClassBuildItem(i));
+            }
+            for (String i : substrateConfigBuildItem.getRuntimeReinitializedClasses()) {
+                runtimeReinit.produce(new RuntimeReinitializedClassBuildItem(i));
             }
             for (Map.Entry<String, String> e : substrateConfigBuildItem.getNativeImageSystemProperties().entrySet()) {
                 nativeImage.produce(new SubstrateSystemPropertyBuildItem(e.getKey(), e.getValue()));

--- a/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
@@ -35,6 +35,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.microprofile.config.Config;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
 
 @Mojo(name = "native-image", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class NativeImageMojo extends AbstractMojo {
@@ -121,6 +124,8 @@ public class NativeImageMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
+        Config config = SmallRyeConfigProviderResolver.instance().getConfig();
+        
         boolean vmVersionOutOfDate = isThisGraalVMRC7();
 
         HashMap<String, String> env = new HashMap<>(System.getenv());
@@ -168,6 +173,13 @@ public class NativeImageMojo extends AbstractMojo {
                     } else {
                         command.add("-J-D" + propertyName + "=" + propertyValue);
                     }
+                }
+            }
+            if(config != null) {
+                if(config.getOptionalValue("shamrock.ssl.native", Boolean.class).orElse(false)) {
+                    enableHttpsUrlHandler = true;
+                    enableJni = true;
+                    enableAllSecurityServices = true;
                 }
             }
             if (additionalBuildArgs != null) {

--- a/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
@@ -70,6 +70,12 @@ public class NativeImageMojo extends AbstractMojo {
     private boolean enableHttpUrlHandler;
 
     @Parameter
+    private boolean enableHttpsUrlHandler;
+
+    @Parameter
+    private boolean enableAllSecurityServices;
+
+    @Parameter
     private boolean enableRetainedHeapReporting;
 
     @Parameter
@@ -193,8 +199,18 @@ public class NativeImageMojo extends AbstractMojo {
             if(nativeImageXmx != null) {
                 command.add("-J-Xmx" + nativeImageXmx);
             }
+            List<String> protocols = new ArrayList<>(2);
             if(enableHttpUrlHandler) {
-                command.add("-H:EnableURLProtocols=http");
+                protocols.add("http");
+            }
+            if(enableHttpsUrlHandler) {
+                protocols.add("https");
+            }
+            if(!protocols.isEmpty()) {
+                command.add("-H:EnableURLProtocols="+String.join(",", protocols));
+            }
+            if(enableAllSecurityServices) {
+                command.add("--enable-all-security-services");
             }
             if (enableRetainedHeapReporting) {
                 command.add("-H:+PrintRetainedHeapHistogram");

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <wildfly-common.version>1.5.0.Alpha3-format-001</wildfly-common.version>
         <jboss-modules.version>1.8.0.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Alpha4</jboss-threads.version>
-        <vertx.version>3.5.4</vertx.version>
+        <vertx.version>3.6.0.CR2</vertx.version>
         <httpclient.version>4.5.4</httpclient.version>
         <httpcore.version>4.4.7</httpcore.version>
 

--- a/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
+++ b/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
@@ -40,15 +40,21 @@ class VertxProcessor {
 
     @BuildStep
     SubstrateConfigBuildItem build() {
+
         // This one may not be required after Vert.x 3.6.0 lands
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioSocketChannel"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "java.util.LinkedHashMap"));
 
         return SubstrateConfigBuildItem.builder()
                 .addNativeImageSystemProperty("io.netty.noUnsafe", "true")
+                .addNativeImageSystemProperty("vertx.disableDnsResolver", "true")
+                .addRuntimeReinitializedClass("io.netty.handler.codec.http2.Http2CodecUtil")
                 .addRuntimeInitializedClass("io.netty.handler.codec.http.HttpObjectEncoder")
-                .addRuntimeInitializedClass("io.netty.handler.codec.http2.Http2CodecUtil")
                 .addRuntimeInitializedClass("io.netty.handler.codec.http2.DefaultHttp2FrameWriter")
                 .addRuntimeInitializedClass("io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder")
+                .addRuntimeInitializedClass("io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator")
+                .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
+
                 .build();
     }
 

--- a/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/NettySubstitutions.java
+++ b/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/NettySubstitutions.java
@@ -19,9 +19,6 @@ package org.jboss.shamrock.vertx.runtime.graal;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.Executor;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
@@ -34,15 +31,12 @@ import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.annotate.TargetElement;
 
 import io.netty.bootstrap.AbstractBootstrapConfig;
 import io.netty.bootstrap.ChannelFactory;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.DefaultChannelPromise;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.CipherSuiteFilter;
@@ -55,191 +49,162 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.JdkLoggerFactory;
 
-@TargetClass(className = "io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess")
-final class Target_io_netty_util_internal_shaded_org_jctools_util_UnsafeRefArrayAccess {
-     @Alias
-     @RecomputeFieldValue(kind = Kind.ArrayIndexShift, declClass = Object[].class)
-     public static int REF_ELEMENT_SHIFT;
+/**
+ * This substitution avoid having loggers added to the build
+ */
+@TargetClass(className = "io.netty.util.internal.logging.InternalLoggerFactory")
+final class Target_io_netty_util_internal_logging_InternalLoggerFactory {
+
+    @Substitute
+    private static InternalLoggerFactory newDefaultFactory(String name) {
+        return JdkLoggerFactory.INSTANCE;
+    }
 }
 
-@Substitute
-@TargetClass(className = "io.netty.handler.ssl.OpenSsl")
-final class Target_io_netty_handler_ssl_OpenSsl {
-	private static final Throwable UNAVAILABILITY_CAUSE = new NoClassDefFoundError("NO NATIVE SSL ON GRAALVM");
-	private static final boolean USE_KEYMANAGER_FACTORY = false;
-	
-	@Substitute
-	public static boolean isAvailable() {
-		return false;
-	}
-	@Substitute
-    public static boolean isAlpnSupported() {
-    	return false;
-    }
-	@Substitute
-    public static Throwable unavailabilityCause() {
-        return UNAVAILABILITY_CAUSE;
-    }
-	@Substitute
-    @SuppressWarnings("unchecked")
-	public static Set<String> availableOpenSslCipherSuites() {
-        return Collections.EMPTY_SET;
-    }
-	@Substitute
-    public static void ensureAvailability() {
-        if (UNAVAILABILITY_CAUSE != null) {
-            throw (Error) new UnsatisfiedLinkError(
-                    "failed to load the required native library").initCause(UNAVAILABILITY_CAUSE);
-        }
-    }
-	@Substitute
-    static boolean useKeyManagerFactory() {
-        return USE_KEYMANAGER_FACTORY;
-    }
+/**
+ * This substitution allows the usage of platform specific code to do low level
+ * buffer related tasks
+ */
+@TargetClass(className = "io.netty.util.internal.CleanerJava6")
+final class Target_io_netty_util_internal_CleanerJava6 {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, declClassName = "java.nio.DirectByteBuffer", name = "cleaner")
+    private static long CLEANER_FIELD_OFFSET;
 }
+
+/**
+ * This substitution allows the usage of platform specific code to do low level
+ * buffer related tasks
+ */
+@TargetClass(className = "io.netty.util.internal.PlatformDependent0")
+final class Target_io_netty_util_internal_PlatformDependent0 {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, declClassName = "java.nio.Buffer", name = "address")
+    private static long ADDRESS_FIELD_OFFSET;
+}
+
+/**
+ * This substitution allows the usage of platform specific code to do low level
+ * buffer related tasks
+ */
+@TargetClass(className = "io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess")
+final class Target_io_netty_util_internal_shaded_org_jctools_util_UnsafeRefArrayAccess {
+
+    @Alias
+    @RecomputeFieldValue(kind = Kind.ArrayIndexShift, declClass = Object[].class)
+    public static int REF_ELEMENT_SHIFT;
+}
+
+// SSL
+// This whole section is mostly about removing static analysis references to openssl/tcnative
 
 @Delete
 @TargetClass(className = "io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
-final class Target_io_netty_handler_ssl_ReferenceCountedOpenSslEngine {
-}
-
-@Delete
-@TargetClass(className = "io.netty.handler.ssl.ReferenceCountedOpenSslClientContext")
-final class Target_io_netty_handler_ssl_ReferenceCountedOpenSslClientContext {
-}
+final class Target_io_netty_handler_ssl_ReferenceCountedOpenSslEngine {}
 
 @TargetClass(className = "io.netty.handler.ssl.JdkSslServerContext")
-final class Target_io_netty_handler_ssl_JdkSslServerContext{
-	@Alias
-	Target_io_netty_handler_ssl_JdkSslServerContext(Provider provider,
-            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
-            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
-            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
-            ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout,
-            ClientAuth clientAuth, String[] protocols, boolean startTls) throws SSLException {
-	}
+final class Target_io_netty_handler_ssl_JdkSslServerContext {
+
+    @Alias
+    Target_io_netty_handler_ssl_JdkSslServerContext(Provider provider, X509Certificate[] trustCertCollection,
+                                                    TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
+                                                    String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                                                    CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, long sessionCacheSize,
+                                                    long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls)
+            throws SSLException {}
 }
 
 @TargetClass(className = "io.netty.handler.ssl.JdkSslClientContext")
-final class Target_io_netty_handler_ssl_JdkSslClientContext{
-	@Alias
-	Target_io_netty_handler_ssl_JdkSslClientContext(Provider sslContextProvider,
-            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
-            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
-            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
-            ApplicationProtocolConfig apn, String[] protocols, long sessionCacheSize, long sessionTimeout)
-            		throws SSLException {
-    }
+final class Target_io_netty_handler_ssl_JdkSslClientContext {
+
+    @Alias
+    Target_io_netty_handler_ssl_JdkSslClientContext(Provider sslContextProvider, X509Certificate[] trustCertCollection,
+                                                    TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
+                                                    String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                                                    CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+                                                    long sessionCacheSize, long sessionTimeout)
+            throws SSLException {}
 }
 
 @TargetClass(className = "io.netty.handler.ssl.SslHandler$SslEngineType")
 final class Target_io_netty_handler_ssl_SslHandler$SslEngineType {
-	@Alias
-	public static Target_io_netty_handler_ssl_SslHandler$SslEngineType JDK;
 
-	@Alias
-    Cumulator cumulator;
-}
+    @Alias
+    public static Target_io_netty_handler_ssl_SslHandler$SslEngineType JDK;
 
-@TargetClass(className = "io.netty.handler.ssl.SslHandler")
-final class Target_io_netty_handler_ssl_SslHandler {
-	@Alias
-    private final SSLEngine engine;
-	@Alias
-    private final Target_io_netty_handler_ssl_SslHandler$SslEngineType engineType;
+    @Alias
+    public static Target_io_netty_handler_ssl_SslHandler$SslEngineType CONSCRYPT;
 
-	@Alias
-    private final Executor delegatedTaskExecutor;
-	@Alias
-    private final boolean jdkCompatibilityMode;
-	@Alias
-    private final boolean startTls;
-    
-	@TargetElement(name = TargetElement.CONSTRUCTOR_NAME)
     @Substitute
-	Target_io_netty_handler_ssl_SslHandler(SSLEngine engine, boolean startTls, Executor delegatedTaskExecutor) {
-        if (engine == null) {
-            throw new NullPointerException("engine");
-        }
-        if (delegatedTaskExecutor == null) {
-            throw new NullPointerException("delegatedTaskExecutor");
-        }
-        this.engine = engine;
-        engineType = Target_io_netty_handler_ssl_SslHandler$SslEngineType.JDK;
-        this.delegatedTaskExecutor = delegatedTaskExecutor;
-        this.startTls = startTls;
-        this.jdkCompatibilityMode = true;
-        ((ByteToMessageDecoder)(Object)this).setCumulator(engineType.cumulator);
+    static Target_io_netty_handler_ssl_SslHandler$SslEngineType forEngine(SSLEngine engine) {
+        return (Object)engine instanceof Target_io_netty_handler_ssl_ConscryptAlpnSslEngine ? CONSCRYPT : JDK;
     }
+
+
 }
+
+@TargetClass(className = "io.netty.handler.ssl.ConscryptAlpnSslEngine")
+final class Target_io_netty_handler_ssl_ConscryptAlpnSslEngine {
+}
+
 
 @TargetClass(className = "io.netty.handler.ssl.SslContext")
 final class Target_io_netty_handler_ssl_SslContext {
-	@Substitute
-    static SslContext newServerContextInternal(
-            SslProvider provider,
-            Provider sslContextProvider,
-            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
-            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
-            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
-            boolean enableOcsp) throws SSLException {
 
-    	if (enableOcsp) {
-    		throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
-    	}
-    	return (SslContext)(Object)new Target_io_netty_handler_ssl_JdkSslServerContext(sslContextProvider,
-    			trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-    			keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-    			clientAuth, protocols, startTls);
+    @Substitute
+    static SslContext newServerContextInternal(SslProvider provider, Provider sslContextProvider, X509Certificate[] trustCertCollection,
+                                               TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
+                                               String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                                               CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, long sessionCacheSize,
+                                               long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
+                                               boolean enableOcsp)
+            throws SSLException {
+
+        if (enableOcsp) {
+            throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
+        }
+        return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslServerContext(sslContextProvider, trustCertCollection,
+                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize,
+                sessionTimeout, clientAuth, protocols, startTls);
     }
-	
-	@Substitute
-	static SslContext newClientContextInternal(
-	        SslProvider provider,
-	        Provider sslContextProvider,
-	        X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
-	        X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
-	        Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-	        long sessionCacheSize, long sessionTimeout, boolean enableOcsp) throws SSLException {
-		if (enableOcsp) {
-			throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
-		}
-		return (SslContext)(Object)new Target_io_netty_handler_ssl_JdkSslClientContext(sslContextProvider,
-				trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
-				keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout);
-	}
 
-}
-
-
-@TargetClass(className = "io.netty.util.internal.logging.InternalLoggerFactory")
-final class Target_io_netty_util_internal_logging_InternalLoggerFactory {
-	@Substitute
-    private static InternalLoggerFactory newDefaultFactory(String name) {
-        JdkLoggerFactory f = (JdkLoggerFactory) JdkLoggerFactory.INSTANCE;
-        f.newInstance(name).debug("Using java.util.logging as the default logging framework");
-        return f;
+    @Substitute
+    static SslContext newClientContextInternal(SslProvider provider, Provider sslContextProvider, X509Certificate[] trustCert,
+                                               TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
+                                               String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                                               CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+                                               long sessionCacheSize, long sessionTimeout, boolean enableOcsp)
+            throws SSLException {
+        if (enableOcsp) {
+            throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
+        }
+        return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslClientContext(sslContextProvider, trustCert, trustManagerFactory,
+                keyCertChain, key, keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout);
     }
+
 }
 
 @TargetClass(className = "io.netty.handler.ssl.JdkDefaultApplicationProtocolNegotiator")
 final class Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator {
-	@Alias
+
+    @Alias
     public static Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator INSTANCE;
 }
 
 @TargetClass(className = "io.netty.handler.ssl.JdkSslContext")
-final class Target_io_netty_handler_ssl_JdkSslContext{
-	@Substitute
+final class Target_io_netty_handler_ssl_JdkSslContext {
+
+    @Substitute
     static JdkApplicationProtocolNegotiator toNegotiator(ApplicationProtocolConfig config, boolean isServer) {
         if (config == null) {
-            return (JdkApplicationProtocolNegotiator)(Object)Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator.INSTANCE;
+            return (JdkApplicationProtocolNegotiator) (Object) Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator.INSTANCE;
         }
 
-        switch(config.protocol()) {
+        switch (config.protocol()) {
         case NONE:
-            return (JdkApplicationProtocolNegotiator)(Object)Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator.INSTANCE;
+            return (JdkApplicationProtocolNegotiator) (Object) Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator.INSTANCE;
         case ALPN:
             if (isServer) {
             	// GRAAL RC9 bug: https://github.com/oracle/graal/issues/813
@@ -253,28 +218,28 @@ final class Target_io_netty_handler_ssl_JdkSslContext{
 //                    .append(config.selectorFailureBehavior()).append(" failure behavior").toString());
 //                }
                 SelectorFailureBehavior behavior = config.selectorFailureBehavior();
-                if(behavior == SelectorFailureBehavior.FATAL_ALERT)
+                if (behavior == SelectorFailureBehavior.FATAL_ALERT)
                     return new JdkAlpnApplicationProtocolNegotiator(true, config.supportedProtocols());
-                else if(behavior == SelectorFailureBehavior.NO_ADVERTISE)
+                else if (behavior == SelectorFailureBehavior.NO_ADVERTISE)
                     return new JdkAlpnApplicationProtocolNegotiator(false, config.supportedProtocols());
                 else {
                     throw new UnsupportedOperationException(new StringBuilder("JDK provider does not support ")
-                    .append(config.selectorFailureBehavior()).append(" failure behavior").toString());
+                            .append(config.selectorFailureBehavior()).append(" failure behavior").toString());
                 }
             } else {
-                switch(config.selectedListenerFailureBehavior()) {
+                switch (config.selectedListenerFailureBehavior()) {
                 case ACCEPT:
                     return new JdkAlpnApplicationProtocolNegotiator(false, config.supportedProtocols());
                 case FATAL_ALERT:
                     return new JdkAlpnApplicationProtocolNegotiator(true, config.supportedProtocols());
                 default:
                     throw new UnsupportedOperationException(new StringBuilder("JDK provider does not support ")
-                    .append(config.selectedListenerFailureBehavior()).append(" failure behavior").toString());
+                            .append(config.selectedListenerFailureBehavior()).append(" failure behavior").toString());
                 }
             }
         default:
-            throw new UnsupportedOperationException(new StringBuilder("JDK provider does not support ")
-            .append(config.protocol()).append(" protocol").toString());
+            throw new UnsupportedOperationException(
+                    new StringBuilder("JDK provider does not support ").append(config.protocol()).append(" protocol").toString());
         }
     }
 
@@ -286,25 +251,27 @@ final class Target_io_netty_handler_ssl_JdkSslContext{
  */
 @TargetClass(className = "io.netty.bootstrap.AbstractBootstrap")
 final class Target_io_netty_bootstrap_AbstractBootstrap {
-	@Alias
+
+    @Alias
     private ChannelFactory channelFactory;
 
-	@Alias
-    void init(Channel channel) throws Exception{}
-	
-	@Alias
-    public AbstractBootstrapConfig config() { return null; }
+    @Alias
+    void init(Channel channel) throws Exception {}
 
+    @Alias
+    public AbstractBootstrapConfig config() {
+        return null;
+    }
 
-	@Substitute
+    @Substitute
     final ChannelFuture initAndRegister() {
         Channel channel = null;
         try {
             channel = channelFactory.newChannel();
             init(channel);
         } catch (Throwable t) {
-        	// THE FIX IS HERE:
-        	t.printStackTrace();
+            // THE FIX IS HERE:
+            t.printStackTrace();
             if (channel != null) {
                 // channel can be null if newChannel crashed (eg SocketException("too many open files"))
                 channel.unsafe().closeForcibly();
@@ -337,5 +304,5 @@ final class Target_io_netty_bootstrap_AbstractBootstrap {
 }
 
 class NettySubstitutions {
-
+    
 }

--- a/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/VertxSubstitutions.java
+++ b/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/graal/VertxSubstitutions.java
@@ -19,7 +19,11 @@ package org.jboss.shamrock.vertx.runtime.graal;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.core.impl.resolver.DefaultResolverProvider;
 import io.vertx.core.net.impl.transport.Transport;
+import io.vertx.core.spi.resolver.ResolverProvider;
 
 @TargetClass(className = "io.vertx.core.net.impl.transport.Transport")
 final class Target_io_vertx_core_net_impl_transport_Transport {
@@ -27,6 +31,32 @@ final class Target_io_vertx_core_net_impl_transport_Transport {
 	public static Transport nativeTransport() {
 		return Transport.JDK;
 	}
+}
+
+/**
+ * This substitution forces the usage of the blocking DNS resolver
+ */
+@TargetClass(className = "io.vertx.core.spi.resolver.ResolverProvider")
+final class TargetResolverProvider {
+
+	@Substitute
+	public static ResolverProvider factory(Vertx vertx, AddressResolverOptions options) {
+		return new DefaultResolverProvider();
+	}
+}
+
+@TargetClass(className = "io.vertx.core.net.OpenSSLEngineOptions")
+final class Target_io_vertx_core_net_OpenSSLEngineOptions {
+
+    @Substitute
+    public static boolean isAvailable() {
+      return false;
+    }
+
+    @Substitute
+    public static boolean isAlpnAvailable() {
+      return false;
+    }
 }
 
 class VertxSubstitutions {


### PR DESCRIPTION
This PR does:

- Add support for runtime-reinitialised classes
- Add `https` and `allSecurityServices` NativeImageMojo configuration
- Add a configuration `shamrock.ssl.native` (defaults to false) which enables `https`, JNI and `allSecurityServices` in the NativeImageMojo and sets the `java.library.path` runtime system property to the `GRAALVM_HOME/...lib` folder required at run-time to have SSL work on native
- Check and fix all netty ssl substitutions to make SSL work on native
- Upgrade to latest vertx CR