### PR TITLE
Make the parameter order consistent across generators

### DIFF
--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanProcessor.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanProcessor.java
@@ -155,7 +155,7 @@ public class BeanProcessor {
         BeanGenerator beanGenerator = new BeanGenerator(annotationLiterals, applicationClassPredicate);
         ClientProxyGenerator clientProxyGenerator = new ClientProxyGenerator(applicationClassPredicate);
         InterceptorGenerator interceptorGenerator = new InterceptorGenerator(annotationLiterals, applicationClassPredicate);
-        SubclassGenerator subclassGenerator = new SubclassGenerator(applicationClassPredicate, annotationLiterals);
+        SubclassGenerator subclassGenerator = new SubclassGenerator(annotationLiterals, applicationClassPredicate);
         ObserverGenerator observerGenerator = new ObserverGenerator(annotationLiterals, applicationClassPredicate);
         AnnotationLiteralGenerator annotationLiteralsGenerator = new AnnotationLiteralGenerator();
 

--- a/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/SubclassGenerator.java
+++ b/ext/arc/processor/src/main/java/org/jboss/protean/arc/processor/SubclassGenerator.java
@@ -76,10 +76,10 @@ public class SubclassGenerator extends AbstractGenerator {
 
     /**
      *
-     * @param applicationClassPredicate
      * @param annotationLiterals
+     * @param applicationClassPredicate
      */
-    public SubclassGenerator(Predicate<DotName> applicationClassPredicate, AnnotationLiteralProcessor annotationLiterals) {
+    public SubclassGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate) {
         this.applicationClassPredicate = applicationClassPredicate;
         this.annotationLiterals = annotationLiterals;
     }

--- a/ext/arc/processor/src/test/java/org/jboss/protean/arc/processor/SubclassGeneratorTest.java
+++ b/ext/arc/processor/src/test/java/org/jboss/protean/arc/processor/SubclassGeneratorTest.java
@@ -52,7 +52,7 @@ public class SubclassGeneratorTest {
 
         AnnotationLiteralProcessor annotationLiteralProcessor = new AnnotationLiteralProcessor(BeanProcessor.DEFAULT_NAME, true);
         BeanGenerator beanGenerator = new BeanGenerator(annotationLiteralProcessor, TruePredicate.INSTANCE);
-        SubclassGenerator generator = new SubclassGenerator(TruePredicate.INSTANCE, annotationLiteralProcessor);
+        SubclassGenerator generator = new SubclassGenerator(annotationLiteralProcessor, TruePredicate.INSTANCE);
         BeanInfo simpleBean = deployment.getBeans().stream()
                 .filter(b -> b.getTarget().get().asClass().name().equals(DotName.createSimple(SimpleBean.class.getName()))).findAny().get();
         for (Resource resource : beanGenerator.generate(simpleBean, ReflectionRegistration.NOOP)) {


### PR DESCRIPTION
This is a very minor follow-up of https://github.com/protean-project/shamrock/commit/6894c7d0dc3796d4f7d5ffa2f7b6e6d5c37694ba#diff-288e2d2f25319061085d1667c3c685bfR158 .