### PR TITLE
add a dependency to core runtime

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -66,6 +66,10 @@
             <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager-embedded</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
add a dependency to core runtime to provide classes for logging without needing an explicit dependency in the user application

---
I'm not 100% sure this is the absolute best option but it did remove the need for a dep on `shamrock-logging-deployment` in my pom.