### PR TITLE
#176 : Native image build occasionally fails with NPE

### DIFF
--- a/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/graal/InternalLocatableAnnotationSubstitutions.java
+++ b/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/graal/InternalLocatableAnnotationSubstitutions.java
@@ -49,7 +49,7 @@ final class InternalLocatableAnnotationSubstitutions {
             try {
                 Class.forName("com.sun.xml.internal.bind.v2.model.annotation.LocatableAnnotation");
                 return true;
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
                 return false;
             }
         }

--- a/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/graal/LocatableAnnotationSubstitutions.java
+++ b/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/graal/LocatableAnnotationSubstitutions.java
@@ -42,7 +42,7 @@ final class LocatableAnnotationSubstitutions {
             try {
                 Class.forName("com.sun.xml.bind.v2.model.annotation.LocatableAnnotation");
                 return true;
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
                 return false;
             }
         }


### PR DESCRIPTION
Occasionally when compiling an application to a native-image, the native-image generator fails with a NPE.

org.jboss.shamrock.jaxrs.runtime.graal.LocatableAnnotationSubstitutions$Selector.getAsBoolean() and org.jboss.shamrock.jaxrs.runtime.graal.InternalLocatableAnnotationSubstitutions$Selector.getAsBoolean() do not handle NoClassDefFoundError in exception logic. If the CL throws a NoClassDefFoundError, this error propagates through the call stack back to com.oracle.svm.hosted.NativeImageGenerator.run(), which causes the native image build to fail and a NPE to be thrown