### PR TITLE
Various minor things

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ At the moment is has the following features:
 ## How to build Shamrock
 
 * Install platform C developer tools:
-    * OSX
-        * `xcode-select --install`
     * Linux
         * Make sure headers are available on your system (you'll hit 'Basic header file missing (<zlib.h>)' error if they aren't).
             * On Fedora `sudo dnf install zlib-devel`
             * Otherwise `sudo apt-get install libz-dev`
+    * macOS
+        * `xcode-select --install`
 * Install GraalVM (minimum RC9)
-* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/Users/emmanuel/JDK/GraalVM/Contents/Home`
+* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux or `/Users/emmanuel/JDK/GraalVM/Contents/Home` on macOS
 * `mvn install`
 
 The default build will create two different native images, which is quite time consuming. You can skip this

--- a/core/runtime/src/main/java/org/jboss/shamrock/runtime/cdi/BeanContainerListener.java
+++ b/core/runtime/src/main/java/org/jboss/shamrock/runtime/cdi/BeanContainerListener.java
@@ -20,7 +20,7 @@ package org.jboss.shamrock.runtime.cdi;
  * An interface that can be used to configure beans immediately after the {@link BeanContainer} has been
  * created. The container is passed to the interface and beans can be obtained and be modified.
  *
- * This provides a convenient way to pass configuration from from the deployment processors into runtime beans.
+ * This provides a convenient way to pass configuration from the deployment processors into runtime beans.
  */
 public interface BeanContainerListener {
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -55,6 +55,14 @@
                         <version>${asciidoctorj-pdf.version}</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <attributes>
+                        <shamrock-version>${project.version}</shamrock-version>
+                        <surefire-version>${version.surefire.plugin}</surefire-version>
+                        <graal-version>${graal-sdk.version}</graal-version>
+                        <restassured-version>3.2.0</restassured-version>
+                    </attributes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>output-html</id>
@@ -73,11 +81,6 @@
                                 <idprefix/>
                                 <idseparator>-</idseparator>
                                 <docinfo1>true</docinfo1>
-
-                                <shamrock-version>${project.version}</shamrock-version>
-                                <surefire-version>2.21.0</surefire-version>
-                                <graal-version>${graal-sdk.version}</graal-version>
-                                <restassured-version>3.2.0</restassured-version>
                             </attributes>
                         </configuration>
                     </execution>
@@ -89,11 +92,6 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
-                            <attributes>
-                                <shamrock-version>${project.version}</shamrock-version>
-                                <surefire-version>2.21.0</surefire-version>
-                                <graal-version>${graal-sdk.version}</graal-version>
-                            </attributes>
                         </configuration>
                     </execution>
                 </executions>

--- a/examples/jpa-strict/src/main/java/org/jboss/shamrock/example/jpa/JPAFunctionalityTestEndpoint.java
+++ b/examples/jpa-strict/src/main/java/org/jboss/shamrock/example/jpa/JPAFunctionalityTestEndpoint.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Various tests convering JPA functionality. All tests should work in both standard JVM and SubstrateVM.
+ * Various tests covering JPA functionality. All tests should work in both standard JVM and SubstrateVM.
  */
 @WebServlet(name = "JPATestBootstrapEndpoint", urlPatterns = "/jpa/testfunctionality")
 public class JPAFunctionalityTestEndpoint extends HttpServlet {

--- a/ext/arc/example/pom.xml
+++ b/ext/arc/example/pom.xml
@@ -166,6 +166,41 @@
       </plugin>
 
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only.
+        It has no influence on the Maven build itself. -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>
+                      org.jboss.protean.arc
+                    </groupId>
+                    <artifactId>
+                      arc-maven-plugin
+                    </artifactId>
+                    <versionRange>
+                      [1.0.0.Alpha1-SNAPSHOT,)
+                    </versionRange>
+                    <goals>
+                      <goal>run</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/jpa/runtime/src/main/java/org/jboss/shamrock/jpa/runtime/ShamrockScanner.java
+++ b/jpa/runtime/src/main/java/org/jboss/shamrock/jpa/runtime/ShamrockScanner.java
@@ -31,8 +31,8 @@ import org.hibernate.boot.archive.scan.spi.Scanner;
 import org.hibernate.boot.archive.spi.InputStreamAccess;
 
 /**
- * A hard coded scanner. This scanner is serialized to bytecode, and used to avoid scanning on hibernate startup.
- * Technically the scanners are receiving all classes and categorizw them as JPA sueful or not.
+ * A hard coded scanner. This scanner is serialized to bytecode, and used to avoid scanning on Hibernate startup.
+ * Technically the scanners are receiving all classes and categorize them as JPA useful or not.
  * In Shamrock's case, we detect the JPA friendly ones and not list the other ones.
  * Emmanuel thinks it's fine as AFAICS, Hibernate ORM filter out the non JPA specific ones.
  */

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,74 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>io.fabric8</groupId>
+                                        <artifactId>
+                                            docker-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [0.26.1,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>start</goal>
+                                            <goal>stop</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.apache.maven.plugins
+                                        </groupId>
+                                        <artifactId>
+                                            maven-antrun-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [1.8,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.apache.maven.plugins
+                                        </groupId>
+                                        <artifactId>
+                                            maven-dependency-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [3.1.1,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>resolve</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
A series of minor improvements:
 * fix a few typos in the Javadoc
 * avoid having to declare doc attributes twice (we already forgot one in the PDF part so seems to be a good thing)
 * declare the lifecycle mapping elements for Eclipse for unsupported plugins to avoid having compilation errors
 * some very minor improvements to the README, mostly to have Linux as a first class citizen