### PR TITLE
Update of Vert.x, MP Reactive Streams Operators, SmallRye Reactive Stream Operators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <rxjava.version>2.2.3</rxjava.version>
         <microprofile-rest-client-api.version>1.0</microprofile-rest-client-api.version>
         <microprofile-opentracing-api.version>1.2</microprofile-opentracing-api.version>
+        <microprofile-reactive-streams-operators.version>1.0-RC3</microprofile-reactive-streams-operators.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <log4j.version>1.2.16</log4j.version>
         <log4j2.version>2.0</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <wildfly-common.version>1.5.0.Alpha3-format-001</wildfly-common.version>
         <jboss-modules.version>1.8.0.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Alpha4</jboss-threads.version>
-        <vertx.version>3.5.4</vertx.version>
+        <vertx.version>3.6.0.CR2</vertx.version>
         <httpclient.version>4.5.4</httpclient.version>
         <httpcore.version>4.4.7</httpcore.version>
         <quartz.version>2.3.0</quartz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <wildfly-common.version>1.5.0.Alpha3-format-001</wildfly-common.version>
         <jboss-modules.version>1.8.0.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Alpha4</jboss-threads.version>
-        <vertx.version>3.6.0</vertx.version>
+        <vertx.version>3.5.4</vertx.version>
         <httpclient.version>4.5.4</httpclient.version>
         <httpcore.version>4.4.7</httpcore.version>
         <quartz.version>2.3.0</quartz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <wildfly-common.version>1.5.0.Alpha3-format-001</wildfly-common.version>
         <jboss-modules.version>1.8.0.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Alpha4</jboss-threads.version>
-        <vertx.version>3.6.0.CR2</vertx.version>
+        <vertx.version>3.6.0</vertx.version>
         <httpclient.version>4.5.4</httpclient.version>
         <httpcore.version>4.4.7</httpcore.version>
         <quartz.version>2.3.0</quartz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-open-api.version>1.0.2</smallrye-open-api.version>
         <smallrye-opentracing.version>1.2.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>1.0.2</smallrye-fault-tolerance.version>
-        <smallrye-reactive-streams-operators.version>0.2.1</smallrye-reactive-streams-operators.version>
+        <smallrye-reactive-streams-operators.version>0.3.1</smallrye-reactive-streams-operators.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.annotation-api.version>1.3</javax.annotation-api.version>

--- a/reactive-streams-operators/reactive-streams-operators/deployment/pom.xml
+++ b/reactive-streams-operators/reactive-streams-operators/deployment/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>org.eclipse.microprofile.reactive.streams</groupId>
             <artifactId>microprofile-reactive-streams-operators</artifactId>
-            <version>1.0-RC2</version>
+            <version>${microprofile-reactive-streams-operators.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.reactive.streams</groupId>
             <artifactId>microprofile-reactive-streams-operators-core</artifactId>
-            <version>1.0-RC2</version>
+            <version>${microprofile-reactive-streams-operators.version}</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>


### PR DESCRIPTION
* Update Vert.x version to 3.6.0
* Update MicroProfile Reactive Streams Operators version to 1.0-RC3
* Update the version of SmallRye Reactive Streams Operators to 0.3.1

We are not impacted by the Vert.x issue about async DNS in OpenShift as it's disabled by the Vert.x runtime.