### PR TITLE
Move logs generated during the Maven mojo ITs 

### DIFF
--- a/maven/src/test/java/org/jboss/shamrock/maven/it/CreateProjectMojoIT.java
+++ b/maven/src/test/java/org/jboss/shamrock/maven/it/CreateProjectMojoIT.java
@@ -157,7 +157,8 @@ public class CreateProjectMojoIT extends MojoTestBase {
         ));
         request.setProperties(params);
         getEnv().forEach(request::addShellEnvironment);
-        PrintStreamLogger logger = new PrintStreamLogger(new PrintStream(new FileOutputStream("build-create.log")),
+        File log = new File(testDir.getParentFile(), "build-create-" + testDir.getName() + ".log");
+        PrintStreamLogger logger = new PrintStreamLogger(new PrintStream(new FileOutputStream(log)),
                 InvokerLogger.DEBUG);
         invoker.setLogger(logger);
         invoker.execute(request);


### PR DESCRIPTION
into the target/test-classes/project directory where they should have been since the beginning.


This PR fixes #196.