### PR TITLE
Explicitly declare javax.validation dependency to use the correct version

### DIFF
--- a/jaxrs/runtime/pom.xml
+++ b/jaxrs/runtime/pom.xml
@@ -45,6 +45,10 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Per Clément's gripe.