### PR TITLE
fix a typo and add the jackson provider to the extension list

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -30,7 +30,6 @@
 
     <properties>
         <shamrock.version>${project.version}</shamrock.version>
-
     </properties>
     <dependencies>
 

--- a/maven/src/main/resources/extensions.json
+++ b/maven/src/main/resources/extensions.json
@@ -26,7 +26,7 @@
       "validation"
     ],
     "groupId": "org.jboss.shamrock",
-    "artifactId": "shamrock-bean-validation"
+    "artifactId": "shamrock-bean-validation-deployment"
   },
   {
     "name": "Fault Tolerance",
@@ -181,5 +181,15 @@
     ],
     "groupId": "org.jboss.shamrock",
     "artifactId": "shamrock-websockets-deployment"
+  },
+  {
+    "name": "JSON",
+    "labels": [
+      "json",
+      "jackson"
+    ],
+    "groupId": "org.jboss.resteasy",
+    "artifactId": "resteasy-jackson2-provider",
+    "version": "${resteasy.version}"
   }
 ]


### PR DESCRIPTION
The `extensions.json` file is a temporary way to ease the project creation. This files had:

* a typo around bean validation
* missing the jackson provider

These are required to simplify the creation of the bean validation guide.

Again, this approach is a temporary hack until we get a proper CLI.