### PR TITLE
Disable jpa-mariadb on macOS but enable it on Linux

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -49,11 +49,12 @@
     <profiles>
         <profile>
             <activation>
-                <property>
-                    <name>mariadb-example</name>
-                </property>
+                <os>
+                    <family>!mac</family>
+                </os>
             </activation>
             <modules>
+                <!-- waiting on the availability of the port does not work on macOS so disabling the module -->
                 <module>jpa-mariadb</module>
             </modules>
         </profile>


### PR DESCRIPTION
@cescoffier let's disable the jpa-mariadb example on macOS only