### PR TITLE
Disable isolates by default

### DIFF
--- a/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -267,9 +268,8 @@ public class NativeImageMojo extends AbstractMojo {
                 command.add("-H:-StackTrace");
             }
 
-            System.out.println(command);
+            getLog().info(command.stream().collect(Collectors.joining(" ")));
             CountDownLatch errorReportLatch = new CountDownLatch(1);
-
 
             ProcessBuilder pb = new ProcessBuilder(command.toArray(new String[0]));
             pb.directory(outputDirectory);

--- a/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
@@ -63,6 +63,7 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "${native-image.debug-build-process}")
     private boolean debugBuildProcess;
 
+
     @Parameter(readonly = true, required = true, defaultValue = "${project.build.finalName}")
     private String finalName;
 
@@ -83,6 +84,9 @@ public class NativeImageMojo extends AbstractMojo {
 
     @Parameter
     private boolean enableCodeSizeReporting;
+
+    @Parameter
+    private boolean enableIsolates;
 
     @Parameter(defaultValue = "${env.GRAALVM_HOME}")
     private String graalvmHome;
@@ -232,6 +236,9 @@ public class NativeImageMojo extends AbstractMojo {
             }
             if (enableCodeSizeReporting) {
                 command.add("-H:+PrintCodeSizeReport");
+            }
+            if (! enableIsolates) {
+                command.add("-H:-SpawnIsolates");
             }
             if (enableJni) {
                 command.add("-H:+JNI");


### PR DESCRIPTION
Fix #256. 

* Disable the isolates by default
* A new parameter is now exposed so the user can re-enabled them