### PR TITLE
docs: add missing target/*-native-* in launch command

### DIFF
--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -89,7 +89,7 @@ We use a profile because, you will see very soon, packaging the native image tak
 Now run: `mvn package -Pnative`
 
 In addition to the regular files, the build also produces `target/shamrock-quickstart-1.0-SNAPSHOT-runner`.
-You can run it using: `target/shamrock-quickstart-1.0-SNAPSHOT-runner`.
+You can run it using: `target/shamrock-quickstart-native-1.0-SNAPSHOT-runner`.
 
 == Testing the native executable
 


### PR DESCRIPTION
BTW this 1.766ms is friggin' **_AMAZING_**:

    2018-12-14 23:29:00,637 khany shamrock-quickstart-native-1.0-SNAPSHOT-runner[27034] INFO  [o.j.shamrock] (main) Shamrock started in 1.766ms

I mean [I knew about it](https://twitter.com/vorburger/status/971699850684354560), but seeing a "real" (enterprise-y) working app built... wow.