### PR TITLE
docs: add --rm to docker run in building-native-image-guide

### DIFF
--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -212,7 +212,7 @@ And finally, run it with:
 
 [source]
 ----
-docker run -i -p 8080:8080 shamrock-quickstart/quickstart
+docker run -i --rm -p 8080:8080 shamrock-quickstart/quickstart
 ----
 
 == What's next?


### PR DESCRIPTION
because you, typically, don't want to keep that container
around after it stopped, but just start a new one every time.