### PR TITLE
Improve build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ Don't forget to indicate your Java, Maven and GraalVM version.
 
 ## Before you contribute
 
-To contribute, use Github Pull Requests. 
+To contribute, use Github Pull Requests, from your **own** fork.
 
 ### Code reviews
 
-All submissions, including submissions by project members, require review.
+All submissions, including submissions by project members, need to be reviewed before being merged.
 
 ### Continuous Integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,30 @@ If you have not done so on this machine, you need to:
             * Otherwise `sudo apt-get install libz-dev`
     * macOS
         * `xcode-select --install` 
-* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux or `$location/JDK/GraalVM/Contents/Home` on macOS         
+* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux or `$location/JDK/GraalVM/Contents/Home` on macOS
+* To build Shamrock, you also need Docker running. Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
+* If you just install docker, be sure that your current user can run a container (no root required). 
+On Linux, check [the post-installation guide](https://docs.docker.com/install/linux/linux-postinstall/)         
         
 ## Build
 
-* Clone the repository
+* Clone the repository: `git clone https://github.com/jbossas/protean-shamrock.git`
+* Navigate to the directory: `cd protean-shamrock`
 * Invoke `mvn clean install` from the root directory
+
+```bash
+git clone https://github.com/jbossas/protean-shamrock.git
+cd protean-shamrock
+mvn clean install
+# Wait... success!
+```
+
+The default build will create two different native images, which is quite time consuming. You can skip this
+by disabling the `native-image` profile: `mvn install -Dno-native`.
+
+By default the build will use the native image server. This speeds up the build, but can cause problems due to the cache
+not being invalidated correctly in some cases. To run a build with a new instance of the server you can use
+`mvn install -Dnative-image.new-server=true`.
 
 ## The small print
 

--- a/README.md
+++ b/README.md
@@ -61,27 +61,7 @@ At the moment is has the following features:
 
 ### How to build Shamrock
 
-* Install platform C developer tools:
-    * Linux
-        * Make sure headers are available on your system (you'll hit 'Basic header file missing (<zlib.h>)' error if they aren't).
-            * On Fedora `sudo dnf install zlib-devel`
-            * Otherwise `sudo apt-get install libz-dev`
-    * macOS
-        * `xcode-select --install`
-* Install GraalVM (minimum RC10)
-* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux or `/Users/emmanuel/JDK/GraalVM/Contents/Home` on macOS
-* `git clone https://github.com/jbossas/protean-shamrock.git`
-* `cd protean-shamrock`
-* `mvn install`
-
-The default build will create two different native images, which is quite time consuming. You can skip this
-by disabling the `native-image` profile: `mvn install -Dno-native`.
-
-Wait. Success!
-
-By default the build will use the native image server. This speeds up the build, but can cause problems due to the cache
-not being invalidated correctly in some cases. To run a build with a new instance of the server you can use
-`mvn install -Dnative-image.new-server=true`.
+The build instructions are available in the [contribution guide](CONTRIBUTING.md).
 
 ### Architecture Overview
 


### PR DESCRIPTION
Extend the contribution guide

* move the build instructions there (avoid duplication)
* add a link from the `README.md`
* add instructions to install Docker
* small edits in the contribution guide

This PR is related to #314 and #313 (content moved to the contribution guide).