### PR TITLE
Use bom in generated projects

### DIFF
--- a/maven/src/main/java/org/jboss/shamrock/maven/CreateProjectMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/CreateProjectMojo.java
@@ -108,7 +108,6 @@ public class CreateProjectMojo extends AbstractMojo {
         createDirectories();
         templates.generate(project, root, path, className, getLog());
         Optional<Plugin> maybe = MojoUtils.hasPlugin(project, PLUGIN_KEY);
-
         if (maybe.isPresent()) {
             printUserInstructions(pomFile);
             return;
@@ -116,10 +115,27 @@ public class CreateProjectMojo extends AbstractMojo {
 
         // The plugin is not configured, add it.
         addVersionProperty(model);
+        addBom(model);
         addMainPluginConfig(model);
         addExtensions(model, extensions, getLog());
         addNativeProfile(model);
         save(pomFile, model);
+    }
+
+    private void addBom(Model model) {
+        Dependency bom = new Dependency();
+        bom.setArtifactId(MojoUtils.get("bom-artifactId"));
+        bom.setGroupId(PLUGIN_GROUPID);
+        bom.setVersion("${shamrock.version}");
+        bom.setType("pom");
+        bom.setScope("import");
+
+        DependencyManagement dm = model.getDependencyManagement();
+        if (dm == null) {
+            dm = new DependencyManagement();
+        }
+        dm.addDependency(bom);
+        model.setDependencyManagement(dm);
     }
 
     private void printUserInstructions(File pomFile) {

--- a/maven/src/main/java/org/jboss/shamrock/maven/components/dependencies/Extension.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/components/dependencies/Extension.java
@@ -126,7 +126,7 @@ public class Extension {
         return list;
     }
 
-    public Dependency toDependency() {
+    public Dependency toDependency(boolean stripVersion) {
         Dependency dependency = new Dependency();
         dependency.setGroupId(groupId);
         dependency.setArtifactId(artifactId);
@@ -136,7 +136,7 @@ public class Extension {
         if (classifier != null && !classifier.isEmpty()) {
             dependency.setClassifier(classifier);
         }
-        if (version != null  && ! version.isEmpty()) {
+        if (version != null  && ! version.isEmpty()  && ! stripVersion) {
             dependency.setVersion(version);
         }
         return dependency;

--- a/maven/src/main/resources/shamrock-maven-plugin.properties
+++ b/maven/src/main/resources/shamrock-maven-plugin.properties
@@ -19,3 +19,4 @@ maven-jar-plugin-version=3.1.0
 maven-resources-plugin=3.1.0
 shamrock-version=${shamrock.version}
 doc-root=http://10.8.247.58/nfs/protean
+bom-artifactId=shamrock-bom

--- a/maven/src/main/templates/templates/pom-template.ftl
+++ b/maven/src/main/templates/templates/pom-template.ftl
@@ -13,26 +13,32 @@
         <shamrock.version>${shamrockVersion}</shamrock.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.shamrock</groupId>
+                <artifactId>shamrock-bom</artifactId>
+                <version>${r"${shamrock.version}"}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-jaxrs-deployment</artifactId>
-            <scope>provided</scope>
-            <version>${r"${shamrock.version}"}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-arc-deployment</artifactId>
-            <scope>provided</scope>
-            <version>${r"${shamrock.version}"}</version>
         </dependency>
 
         <!-- Test extensions -->
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-junit</artifactId>
-            <version>${r"${shamrock.version}"}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
Fix #322 - the generated project now use the BOM

This commit updates the generated project but also add the BOM when a pom.xml exists
It also changes how it adds extensions as we must strip the version if the bom is present.