### PR TITLE
Exclude jboss-annotations-api_1.3_spec as we already have javax.annotation-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ dumps
 *.rej
 .factorypath
 graph-output.dot
+*.swp
+*.swo
 
 
 docker/distroless/bazel-*

--- a/ext/arc/example/pom.xml
+++ b/ext/arc/example/pom.xml
@@ -53,6 +53,12 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <version>${version.weld}</version>
+      <exclusions>
+          <exclusion>
+              <groupId>org.jboss.spec.javax.annotation</groupId>
+              <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <!-- Needed for native image -->
     <dependency>

--- a/ext/arc/pom.xml
+++ b/ext/arc/pom.xml
@@ -157,6 +157,29 @@
             <doclint>none</doclint>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce</id>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <!-- Use javax.annotation-api -->
+                      <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
+                      <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
+                    </excludes>
+                  </bannedDependencies>
+                </rules>
+              </configuration>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,9 @@
                                     </requireMavenVersion>
                                     <bannedDependencies>
                                         <excludes>
-                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec
-                                            </exclude>
+                                            <!-- Use javax.annotation-api -->
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
                                             <!-- use our jboss-logging -->
                                             <exclude>org.jboss.logging:jboss-logging</exclude>
                                             <!-- use our jboss-logmanager -->


### PR DESCRIPTION
This removes several warnings when shading.