### PR TITLE
Add jboss-logging-annotations as as core dependency

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -84,6 +84,7 @@
       <microprofile-opentracing-api.version>1.2</microprofile-opentracing-api.version>
       <microprofile-reactive-streams-operators.version>1.0-RC3</microprofile-reactive-streams-operators.version>
       <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
+      <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
       <log4j.version>1.2.16</log4j.version>
       <log4j2.version>2.0</log4j2.version>
       <slf4j.version>1.7.25</slf4j.version>
@@ -824,6 +825,11 @@
             <groupId>org.jboss.invocation</groupId>
             <artifactId>jboss-invocation</artifactId>
             <version>${jboss-invocation.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <version>${jboss-logging-annotations.version}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.metadata</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -48,6 +48,14 @@
             <artifactId>jboss-logging-embedded</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager-embedded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+         </dependency>
+        <dependency>
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
         </dependency>
@@ -66,10 +74,6 @@
         <dependency>
             <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager-embedded</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.common</groupId>


### PR DESCRIPTION
We had quite a lot of warnings when building transactions/runtime
and bean-validation/runtime.

Typically this:
```
[WARNING] /data/home/gsmet/git/shamrock/transactions/runtime/src/main/java/org/jboss/shamrock/transactions/runtime/interceptor/TransactionalInterceptorBase.java: unknown enum constant org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT
  reason: class file for org.jboss.logging.annotations.Message$Format not found
```