### PR TITLE
Properly override varargs methods

### DIFF
--- a/ext/gizmo/src/main/java/org/jboss/protean/gizmo/FunctionCreatorImpl.java
+++ b/ext/gizmo/src/main/java/org/jboss/protean/gizmo/FunctionCreatorImpl.java
@@ -130,7 +130,7 @@ class FunctionCreatorImpl implements FunctionCreator {
             }
         }
 
-        ResultHandle[] resolve(ResultHandle[] handle) {
+        ResultHandle[] resolve(ResultHandle... handle) {
             ResultHandle[] ret = new ResultHandle[handle.length];
             for (int i = 0; i < handle.length; ++i) {
                 ret[i] = resolve(handle[i]);

--- a/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/RestClientBuilderImpl.java
+++ b/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/RestClientBuilderImpl.java
@@ -388,7 +388,7 @@ class RestClientBuilderImpl implements RestClientBuilder {
     }
 
     @Override
-    public RestClientBuilder register(Class<?> aClass, Class<?>[] classes) {
+    public RestClientBuilder register(Class<?> aClass, Class<?>... classes) {
         this.register(newInstanceOf(aClass), classes);
         return this;
     }
@@ -443,7 +443,7 @@ class RestClientBuilderImpl implements RestClientBuilder {
     }
 
     @Override
-    public RestClientBuilder register(Object o, Class<?>[] classes) {
+    public RestClientBuilder register(Object o, Class<?>... classes) {
 
         // local
         for (Class<?> aClass : classes) {


### PR DESCRIPTION
This is minor but got caught by Eclipse and I think it should be fixed.