### PR TITLE
Trim javadoc comment of configuration properties after extraction

### DIFF
--- a/core/deployment-api/src/main/java/org/jboss/shamrock/annotations/BuildAnnotationProcessor.java
+++ b/core/deployment-api/src/main/java/org/jboss/shamrock/annotations/BuildAnnotationProcessor.java
@@ -545,13 +545,14 @@ public class BuildAnnotationProcessor extends AbstractProcessor {
                 }
 
                 if(ret.type != ConfigType.MAP && ret.type != ConfigType.CUSTOM_TYPE) {
-                    ret.javadoc = processingEnv.getElementUtils().getDocComment(field);
-                    if (ret.javadoc == null) {
-                        ret.javadoc = tryLoadJavadocFromFile(field);
-                        if (ret.javadoc == null) {
+                    String rawJavadoc = processingEnv.getElementUtils().getDocComment(field);
+                    if (rawJavadoc == null) {
+                        rawJavadoc = tryLoadJavadocFromFile(field);
+                        if (rawJavadoc == null) {
                             throw new RuntimeException("Field must include a javadoc description "  + field.getEnclosingElement() + "." + field);
                         }
                     }
+                    ret.javadoc = rawJavadoc.trim();
                 }
                 return ret;
             }


### PR DESCRIPTION
This makes the generated `shamrock-descriptions.properties` cleaner.

Fixes #368.