### PR TITLE
Remove the need for Docker for a default run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ If you have not done so on this machine, you need to:
     * macOS
         * `xcode-select --install` 
 * Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux or `$location/JDK/GraalVM/Contents/Home` on macOS
-* To build Shamrock, you also need Docker running. Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
-* If you just install docker, be sure that your current user can run a container (no root required). 
+* The default build does not require Docker but you need it running to build some of the modules that are not enabled by default (e.g. the `jpa-mariadb` and `jpa-postgresql` examples). Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
+* If you just install Docker, be sure that your current user can run a container (no root required). 
 On Linux, check [the post-installation guide](https://docs.docker.com/install/linux/linux-postinstall/)         
         
 ## Build

--- a/examples/jpa-mariadb/pom.xml
+++ b/examples/jpa-mariadb/pom.xml
@@ -141,10 +141,10 @@
         </profile>
 
         <profile>
-            <id>mariadb</id>
+            <id>docker-mariadb</id>
             <activation>
                 <property>
-                    <name>!no-mariadb</name>
+                    <name>!no-docker</name>
                 </property>
             </activation>
             <properties>

--- a/examples/jpa-postgresql/pom.xml
+++ b/examples/jpa-postgresql/pom.xml
@@ -140,10 +140,10 @@
         </profile>
 
         <profile>
-            <id>postgres</id>
+            <id>docker-postgres</id>
             <activation>
                 <property>
-                    <name>!no-postgres</name>
+                    <name>!no-docker</name>
                 </property>
             </activation>
             <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,20 +42,30 @@
         <module>bean-validation-strict</module>
         <module>common-jpa-entities</module>
         <module>strict</module>
-        <module>jpa-postgresql</module>
         <module>jpa-h2</module>
     </modules>
 
     <profiles>
         <profile>
+            <id>jpa-mariadb-example</id>
             <activation>
-                <os>
-                    <family>!mac</family>
-                </os>
+                <property>
+                    <name>jpa-mariadb-example</name>
+                </property>
             </activation>
             <modules>
-                <!-- waiting on the availability of the port does not work on macOS so disabling the module -->
                 <module>jpa-mariadb</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jpa-postgresql-example</id>
+            <activation>
+                <property>
+                    <name>jpa-postgresql-example</name>
+                </property>
+            </activation>
+            <modules>
+                <module>jpa-postgresql</module>
             </modules>
         </profile>
     </profiles>

--- a/examples/strict/pom.xml
+++ b/examples/strict/pom.xml
@@ -135,7 +135,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-jdbc-postgresql-deployment</artifactId>
+            <artifactId>shamrock-jdbc-h2-deployment</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -171,6 +171,52 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <includeProjectDependencies>false</includeProjectDependencies>
+                    <includePluginDependencies>true</includePluginDependencies>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-h2</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.h2.tools.Server</mainClass>
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                            <arguments>
+                                <argument>-tcp</argument>
+                                <argument>-tcpDaemon</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-h2</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.h2.tools.Server</mainClass>
+                            <arguments>
+                                <argument>-tcpShutdown</argument>
+                                <argument>tcp://localhost:9092</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <version>${h2.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -227,73 +273,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>postgres</id>
-            <activation>
-                <property>
-                    <name>!no-postgres</name>
-                </property>
-            </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>postgres:10.5</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres:10.5 images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
-
 
 </project>

--- a/examples/strict/pom.xml
+++ b/examples/strict/pom.xml
@@ -33,16 +33,6 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>common-jpa-entities</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-jaxrs-deployment</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-class-transformer-example</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -63,27 +53,6 @@
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-opentracing-deployment</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-json-p-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-jpa-deployment</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -116,6 +85,39 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-fault-tolerance-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-scheduler-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-jaxrs-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-p-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-rxjava2</artifactId>
         </dependency>
@@ -124,9 +126,11 @@
             <artifactId>shamrock-rest-client-deployment</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- JPA -->
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-fault-tolerance-deployment</artifactId>
+            <artifactId>shamrock-jpa-deployment</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -136,8 +140,8 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-scheduler-deployment</artifactId>
-            <scope>provided</scope>
+            <artifactId>common-jpa-entities</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/Customer.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/Customer.java
@@ -34,16 +34,6 @@ public class Customer extends Human {
     private Address address;
     private WorkAddress workAddress;
 
-    private String name;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
     // Address is referenced but not marked as @Embeddable
     @Embedded
     public Address getAddress() {

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestBootstrapEndpoint.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestBootstrapEndpoint.java
@@ -60,7 +60,6 @@ public class JPATestBootstrapEndpoint extends HttpServlet {
         resp.getWriter().write("OK");
     }
 
-
     public void testStoreLoadOnJPA() throws Exception {
         doStuffWithHibernate( entityManagerFactory );
         System.out.println( "Hibernate EntityManagerFactory: shut down" );
@@ -113,10 +112,6 @@ public class JPATestBootstrapEndpoint extends HttpServlet {
 
     private static String randomName() {
         return UUID.randomUUID().toString();
-    }
-
-    private void reportException(final Exception e, final HttpServletResponse resp) throws IOException {
-        reportException(null, e, resp);
     }
 
     private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestEMInjectionEndpoint.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestEMInjectionEndpoint.java
@@ -55,7 +55,6 @@ public class JPATestEMInjectionEndpoint extends HttpServlet {
         resp.getWriter().write("OK");
     }
 
-
     public void testStoreLoadOnJPA() throws Exception {
         doStuffWithHibernate();
         System.out.println("Hibernate EntityManagerFactory: shut down");
@@ -98,10 +97,6 @@ public class JPATestEMInjectionEndpoint extends HttpServlet {
 
     private static String randomName() {
         return UUID.randomUUID().toString();
-    }
-
-    private void reportException(final Exception e, final HttpServletResponse resp) throws IOException {
-        reportException(null, e, resp);
     }
 
     private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java
@@ -66,8 +66,8 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             if (id.get(instance) != null) {
                 resp.getWriter().write("id should be reachable and null");
             }
-            Method setter = custClass.getDeclaredMethod("setName", String.class);
-            Method getter = custClass.getDeclaredMethod("getName");
+            Method setter = custClass.getMethod("setName", String.class);
+            Method getter = custClass.getMethod("getName");
             setter.invoke(instance, "Emmanuel");
             if (! "Emmanuel".equals(getter.invoke(instance))) {
                 resp.getWriter().write("getter / setter should be reachable and usable");

--- a/examples/strict/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/strict/src/main/resources/META-INF/microprofile-config.properties
@@ -16,10 +16,8 @@
 
 org.jboss.shamrock.example.rest.RestInterface/mp-rest/url=http://localhost:8080/rest
 
-shamrock.datasource.url: ${postgres.url}
-shamrock.datasource.driver: org.postgresql.Driver
-shamrock.datasource.username: hibernate_orm_test
-shamrock.datasource.password: hibernate_orm_test
+shamrock.datasource.url=jdbc:h2:tcp://localhost/mem:test
+shamrock.datasource.driver=org.h2.Driver
 
 web-message=A message
 schedulerservice.cron.expr=0/10 * * * * ?

--- a/jpa/integrationtests/pom.xml
+++ b/jpa/integrationtests/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-jdbc-postgresql-deployment</artifactId>
+            <artifactId>shamrock-jdbc-h2-deployment</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -55,6 +55,52 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <includeProjectDependencies>false</includeProjectDependencies>
+                    <includePluginDependencies>true</includePluginDependencies>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-h2</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.h2.tools.Server</mainClass>
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                            <arguments>
+                                <argument>-tcp</argument>
+                                <argument>-tcpDaemon</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-h2</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.h2.tools.Server</mainClass>
+                            <arguments>
+                                <argument>-tcpShutdown</argument>
+                                <argument>tcp://localhost:9092</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <version>${h2.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -107,73 +153,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>postgres</id>
-            <activation>
-                <property>
-                    <name>!no-postgres</name>
-                </property>
-            </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>postgres:10.5</name>
-                                    <alias>postgresql</alias>
-                                    <run>
-                                        <env>
-                                            <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
-                                            <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
-                                            <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
-                                        </env>
-                                        <ports>
-                                            <port>5431:5432</port>
-                                        </ports>
-                                        <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <!--Stops all postgres:10.5 images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
-
 
 </project>

--- a/jpa/integrationtests/src/main/resources/META-INF/microprofile-config.properties
+++ b/jpa/integrationtests/src/main/resources/META-INF/microprofile-config.properties
@@ -1,9 +1,6 @@
-shamrock.datasource.url: ${postgres.url}
-shamrock.datasource.driver: org.postgresql.Driver
-shamrock.datasource.username: hibernate_orm_test
-shamrock.datasource.password: hibernate_orm_test
+shamrock.datasource.url=jdbc:h2:tcp://localhost/mem:test
+shamrock.datasource.driver=org.h2.Driver
 
-#shamrock.hibernate.dialect: org.hibernate.dialect.PostgreSQL95Dialect
-shamrock.hibernate.dialect: org.hibernate.dialect.PostgreSQL95Dialect
+shamrock.hibernate.dialect: org.hibernate.dialect.H2Dialect
 shamrock.hibernate.show_sql: true
 shamrock.hibernate.schema-generation.database.action: drop-and-create

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
                         <show>package</show>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.6.0</version>
+                </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
@@ -231,6 +236,25 @@
                                         </versionRange>
                                         <goals>
                                             <goal>resolve</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.codehaus.mojo
+                                        </groupId>
+                                        <artifactId>
+                                            exec-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [1.6.0,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>java</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>


### PR DESCRIPTION
As discussed on the mailing list.

- Strict example moved to H2
- JPA integration tests moved to H2
- MariaDB and PostgreSQL examples not running by default

We need to change the CI run to use: `-Dno-docker -Djpa-mariadb-example -Djpa-postgresql-example` to be on par with the current configuration. @stuartwdouglas mentioning you so that you're aware of the CI change.

You don't need Docker to build Shamrock with the default configuration anymore.

Fixes #359.