### PR TITLE
Build warnings reduction

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -46,7 +46,7 @@
       <javax.activation.version>1.1.1</javax.activation.version>
       <javax.inject.version>1</javax.inject.version>
       <javax.annotation-api.version>1.3</javax.annotation-api.version>
-      <jboss-classfilewriter.version>1.2.1.Final</jboss-classfilewriter.version>
+      <jboss-classfilewriter.version>1.2.3.Final</jboss-classfilewriter.version>
       <jboss-invocation.version>1.5.1.Final</jboss-invocation.version>
       <javax.json.version>1.1.3</javax.json.version>
       <javax.xml.bind.version>2.3.1</javax.xml.bind.version>

--- a/examples/common-jpa-entities/pom.xml
+++ b/examples/common-jpa-entities/pom.xml
@@ -38,5 +38,22 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>1.0.5</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/examples/jpa-postgresql/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java
+++ b/examples/jpa-postgresql/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java
@@ -48,7 +48,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             className = getTrickedClassName(className);
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
         }
         catch (Exception e) {
             reportException(errorMessage, e, resp);
@@ -60,7 +60,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             String className = getTrickedClassName(org.jboss.shamrock.example.jpa.Customer.class.getName());
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
             Field id = custClass.getDeclaredField("id");
             id.setAccessible(true);
             if (id.get(instance) != null) {
@@ -83,7 +83,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             String className = getTrickedClassName(org.jboss.shamrock.example.jpa.WorkAddress.class.getName());
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
             Method setter = custClass.getDeclaredMethod("setCompany", String.class);
             Method getter = custClass.getDeclaredMethod("getCompany");
             setter.invoke(instance, "Red Hat");
@@ -100,7 +100,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             String className = getTrickedClassName(org.jboss.shamrock.example.jpa.Address.class.getName());
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
             Method setter = custClass.getDeclaredMethod("setStreet1", String.class);
             Method getter = custClass.getDeclaredMethod("getStreet1");
             setter.invoke(instance, "1 rue du General Leclerc");
@@ -119,7 +119,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
 
             Class<?> custClass = Class.forName(className);
             resp.getWriter().write("Should not be able to find a non referenced non entity class");
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
         }
         catch (Exception e) {
             // Expected outcome

--- a/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java
+++ b/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java
@@ -48,7 +48,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             className = getTrickedClassName(className);
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
         }
         catch (Exception e) {
             reportException(errorMessage, e, resp);
@@ -60,7 +60,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             String className = getTrickedClassName(org.jboss.shamrock.example.jpa.Customer.class.getName());
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
             Field id = custClass.getDeclaredField("id");
             id.setAccessible(true);
             if (id.get(instance) != null) {
@@ -83,7 +83,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             String className = getTrickedClassName(org.jboss.shamrock.example.jpa.WorkAddress.class.getName());
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
             Method setter = custClass.getDeclaredMethod("setCompany", String.class);
             Method getter = custClass.getDeclaredMethod("getCompany");
             setter.invoke(instance, "Red Hat");
@@ -100,7 +100,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
             String className = getTrickedClassName(org.jboss.shamrock.example.jpa.Address.class.getName());
 
             Class<?> custClass = Class.forName(className);
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
             Method setter = custClass.getDeclaredMethod("setStreet1", String.class);
             Method getter = custClass.getDeclaredMethod("getStreet1");
             setter.invoke(instance, "1 rue du General Leclerc");
@@ -119,7 +119,7 @@ public class JPATestReflectionEndpoint extends HttpServlet {
 
             Class<?> custClass = Class.forName(className);
             resp.getWriter().write("Should not be able to find a non referenced non entity class");
-            Object instance = custClass.newInstance();
+            Object instance = custClass.getDeclaredConstructor().newInstance();
         }
         catch (Exception e) {
             // Expected outcome

--- a/examples/strict/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/strict/src/main/resources/META-INF/microprofile-config.properties
@@ -16,6 +16,9 @@
 
 org.jboss.shamrock.example.rest.RestInterface/mp-rest/url=http://localhost:8080/rest
 
+shamrock.index-dependency.json-api.artifactId=javax.json-api
+shamrock.index-dependency.json-api.groupId=javax.json
+
 shamrock.datasource.url: ${postgres.url}
 shamrock.datasource.driver: org.postgresql.Driver
 shamrock.datasource.username: hibernate_orm_test

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/ArrayTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/ArrayTestCase.java
@@ -32,7 +32,7 @@ public class ArrayTestCase {
             method.returnValue(arrayHandle);
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
-        Supplier myInterface = (Supplier) clazz.newInstance();
+        Supplier myInterface = (Supplier) clazz.getDeclaredConstructor().newInstance();
         Object o = myInterface.get();
         Assert.assertEquals(String[].class, o.getClass());
         String[] res = (String[]) o;
@@ -50,7 +50,7 @@ public class ArrayTestCase {
             method.returnValue(arrayHandle);
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
-        Supplier myInterface = (Supplier) clazz.newInstance();
+        Supplier myInterface = (Supplier) clazz.getDeclaredConstructor().newInstance();
         Object o = myInterface.get();
         Assert.assertEquals(String[].class, o.getClass());
         String[] res = (String[]) o;

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/ExceptionThrowingTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/ExceptionThrowingTestCase.java
@@ -31,7 +31,7 @@ public class ExceptionThrowingTestCase {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        MyInterface myInterface = (MyInterface) clazz.newInstance();
+        MyInterface myInterface = (MyInterface) clazz.getDeclaredConstructor().newInstance();
         try {
             myInterface.transform("ignored");
             Assert.fail();

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/FunctionTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/FunctionTestCase.java
@@ -43,7 +43,7 @@ public class FunctionTestCase {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        MyInterface myInterface = (MyInterface) clazz.newInstance();
+        MyInterface myInterface = (MyInterface) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals("input-func", myInterface.transform("input"));
     }
 
@@ -65,7 +65,7 @@ public class FunctionTestCase {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        MyInterface myInterface = (MyInterface) clazz.newInstance();
+        MyInterface myInterface = (MyInterface) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals("input-func", myInterface.transform("input"));
     }
 
@@ -88,7 +88,7 @@ public class FunctionTestCase {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        Superclass superclass = (Superclass) clazz.newInstance();
+        Superclass superclass = (Superclass) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals("Superclass-func", superclass.getMessage());
     }
 
@@ -111,7 +111,7 @@ public class FunctionTestCase {
             bc.returnValue(bc.invokeInterfaceMethod(getAsInt, f1.getInstance()));
         }
         Class<? extends IntSupplier> clazz = cl.loadClass("com.MyTest").asSubclass(IntSupplier.class);
-        IntSupplier supplier = clazz.newInstance();
+        IntSupplier supplier = clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals(11, supplier.getAsInt());
     }
 }

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/LoadClassTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/LoadClassTestCase.java
@@ -32,7 +32,7 @@ public class LoadClassTestCase {
             method.returnValue(stringHandle);
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
-        Supplier myInterface = (Supplier) clazz.newInstance();
+        Supplier myInterface = (Supplier) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals(String.class, myInterface.get());
     }
 

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/LoadNullTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/LoadNullTestCase.java
@@ -32,7 +32,7 @@ public class LoadNullTestCase {
             method.returnValue(method.loadNull());
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
-        Supplier myInterface = (Supplier) clazz.newInstance();
+        Supplier myInterface = (Supplier) clazz.getDeclaredConstructor().newInstance();
         assertNull(myInterface.get());
     }
 

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/SampleTest.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/SampleTest.java
@@ -31,7 +31,7 @@ public class SampleTest {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        MyInterface myInterface = (MyInterface) clazz.newInstance();
+        MyInterface myInterface = (MyInterface) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals("MESSAGE", myInterface.transform("ignored"));
     }
 

--- a/ext/gizmo/src/test/java/org/jboss/protean/gizmo/TryCatchTestCase.java
+++ b/ext/gizmo/src/test/java/org/jboss/protean/gizmo/TryCatchTestCase.java
@@ -34,7 +34,7 @@ public class TryCatchTestCase {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        MyInterface myInterface = (MyInterface) clazz.newInstance();
+        MyInterface myInterface = (MyInterface) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals("caught-exception", myInterface.transform("ignored"));
     }
 
@@ -51,7 +51,7 @@ public class TryCatchTestCase {
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         Assert.assertTrue(clazz.isSynthetic());
-        MyInterface myInterface = (MyInterface) clazz.newInstance();
+        MyInterface myInterface = (MyInterface) clazz.getDeclaredConstructor().newInstance();
         Assert.assertEquals("complete", myInterface.transform("ignored"));
     }
 }

--- a/jboss-logging-embedded/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
+++ b/jboss-logging-embedded/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
@@ -58,8 +58,8 @@ final class Slf4jLoggerProvider extends AbstractLoggerProvider implements Logger
         MDC.remove(key);
     }
 
+    @SuppressWarnings({"unchecked"})
     public Map<String, Object> getMdcMap() {
-        @SuppressWarnings({"unchecked"})
         final Map<String, String> map = MDC.getCopyOfContextMap();
         return map == null ? Collections.emptyMap() : (Map) map;
     }

--- a/legacy/launcher/src/main/java/org/jboss/shamrock/legacy/launcher/Main.java
+++ b/legacy/launcher/src/main/java/org/jboss/shamrock/legacy/launcher/Main.java
@@ -56,7 +56,7 @@ public class Main {
         try {
             List<URL> urls = new ArrayList<>();
             for (File i : libDir.listFiles()) {
-                urls.add(i.toURL());
+                urls.add(i.toURI().toURL());
             }
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             URLClassLoader ucl = new URLClassLoader(urls.toArray(new URL[urls.size()]));

--- a/maven/src/it/setup-on-existing-pom-it/pom.xml
+++ b/maven/src/it/setup-on-existing-pom-it/pom.xml
@@ -10,6 +10,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/maven/src/it/setup-with-custom-shamrock-version-it/pom.xml
+++ b/maven/src/it/setup-with-custom-shamrock-version-it/pom.xml
@@ -9,6 +9,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/ExceptionMapping.java
+++ b/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/ExceptionMapping.java
@@ -46,7 +46,7 @@ class ExceptionMapping implements ClientResponseFilter {
         Map<ResponseExceptionMapper, Integer> mappers = new HashMap<>();
         for (Object o : instances) {
             if (o instanceof ResponseExceptionMapper) {
-                ResponseExceptionMapper candiate = (ResponseExceptionMapper) o;
+                ResponseExceptionMapper<?> candiate = (ResponseExceptionMapper) o;
                 if (candiate.handles(response.getStatus(), response.getHeaders())) {
                     mappers.put(candiate, candiate.getPriority());
                 }

--- a/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/PartialResponse.java
+++ b/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/PartialResponse.java
@@ -73,6 +73,7 @@ public class PartialResponse extends Response implements Serializable {
 
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T readEntity(Class<T> entityType) {
 
         if (entityType.isAssignableFrom(String.class)) {

--- a/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/RestClientBuilderImpl.java
+++ b/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/RestClientBuilderImpl.java
@@ -368,7 +368,7 @@ class RestClientBuilderImpl implements RestClientBuilder {
 
     private static Object newInstanceOf(Class<?> clazz) {
         try {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (Throwable t) {
             throw new RuntimeException("Failed to register " + clazz, t);
         }

--- a/scheduler/runtime/src/main/java/org/jboss/shamrock/scheduler/runtime/SchedulerConfiguration.java
+++ b/scheduler/runtime/src/main/java/org/jboss/shamrock/scheduler/runtime/SchedulerConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.shamrock.scheduler.runtime;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,8 +52,8 @@ public class SchedulerConfiguration {
     ScheduledInvoker createInvoker(String invokerClassName) {
         try {
             Class<? extends ScheduledInvoker> invokerClazz = (Class<? extends ScheduledInvoker>) Thread.currentThread().getContextClassLoader().loadClass(invokerClassName);
-            return invokerClazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            return invokerClazz.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
             throw new IllegalStateException("Unable to create invoker: " + invokerClassName, e);
         }
     }

--- a/transactions/runtime/src/main/java/org/jboss/shamrock/transactions/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/transactions/runtime/src/main/java/org/jboss/shamrock/transactions/runtime/interceptor/TransactionalInterceptorBase.java
@@ -119,13 +119,13 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
         Transactional transactional = getTransactional(ic);
 
-        for (Class dontRollbackOnClass : transactional.dontRollbackOn()) {
+        for (Class<?> dontRollbackOnClass : transactional.dontRollbackOn()) {
             if (dontRollbackOnClass.isAssignableFrom(e.getClass())) {
                 throw e;
             }
         }
 
-        for (Class rollbackOnClass : transactional.rollbackOn()) {
+        for (Class<?> rollbackOnClass : transactional.rollbackOn()) {
             if (rollbackOnClass.isAssignableFrom(e.getClass())) {
                 tx.setRollbackOnly();
                 throw e;


### PR DESCRIPTION
Build warnings reduction

Summary:
```
[WARNING] /Users/rsvoboda/git/protean-shamrock/legacy/launcher/src/main/java/org/jboss/shamrock/legacy/launcher/Main.java:[59,27] toURL() in java.io.File has been deprecated
```
toURL() => toURI().toURL()

```
[INFO] --- shamrock-maven-plugin:1.0.0.Alpha1-SNAPSHOT:build (default) @ shamrock-strict-example ---
[WARNING] [org.jboss.shamrock.deployment.steps.ReflectiveHierarchyStep] Unable to find annotation info for javax.json.JsonObject, it may not be correctly registered for reflection
[WARNING] [org.jboss.shamrock.jpa] Did not find `org.jboss.shamrock.examples.common.Clown` in the indexed jars. You likely forgot to tell Shamrock to index your dependency jar. See https://github.com/protean-project/shamrock/#indexing-and-application-classes for more info.
```
jandex for common-jpa-entities, shamrock.index-dependency... for json-api

```
[WARNING] /Users/rsvoboda/git/protean-shamrock/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java:[51,40] newInstance() in java.lang.Class has been deprecated
[WARNING] /Users/rsvoboda/git/protean-shamrock/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java:[63,40] newInstance() in java.lang.Class has been deprecated
[WARNING] /Users/rsvoboda/git/protean-shamrock/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java:[86,40] newInstance() in java.lang.Class has been deprecated
[WARNING] /Users/rsvoboda/git/protean-shamrock/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java:[103,40] newInstance() in java.lang.Class has been deprecated
[WARNING] /Users/rsvoboda/git/protean-shamrock/examples/strict/src/main/java/org/jboss/shamrock/example/jpa/JPATestReflectionEndpoint.java:[122,40] newInstance() in java.lang.Class has been deprecated

[WARNING] /Users/rsvoboda/git/protean-shamrock/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/RestClientBuilderImpl.java:[371,25] newInstance() in java.lang.Class has been deprecated

and many more
```
clazz.newInstance() => clazz.getDeclaredConstructor().newInstance()
Future fix, deprecated in Java 9.


```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jboss.classfilewriter.ClassFile$1 (file:/Users/rsvoboda/.m2/repository/org/jboss/classfilewriter/jboss-classfilewriter/1.2.1.Final/jboss-classfilewriter-1.2.1.Final.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int)
WARNING: Please consider reporting this to the maintainers of org.jboss.classfilewriter.ClassFile$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
Future fix, upgrade to 1.2.3.Final

```
[INFO] Compiling 12 source files to /Users/rsvoboda/git/protean-shamrock/transactions/runtime/target/classes
[WARNING] /Users/rsvoboda/git/protean-shamrock/transactions/runtime/src/main/java/org/jboss/shamrock/transactions/runtime/interceptor/TransactionalInterceptorBase.java:[124,53] unchecked call to isAssignableFrom(java.lang.Class<?>) as a member of the raw type java.lang.Class
[WARNING] /Users/rsvoboda/git/protean-shamrock/transactions/runtime/src/main/java/org/jboss/shamrock/transactions/runtime/interceptor/TransactionalInterceptorBase.java:[130,49] unchecked call to isAssignableFrom(java.lang.Class<?>) as a member of the raw type java.lang.Class
[WARNING] /Users/rsvoboda/git/protean-shamrock/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/ExceptionMapping.java:[50,37] unchecked call to handles(int,javax.ws.rs.core.MultivaluedMap<java.lang.String,java.lang.Object>) as a member of the raw type org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper

```
Added `<?>` to few places

```
[INFO] [WARNING] Some problems were encountered while building the effective model for org.acme:shamrock-setup-demo:jar:0.1-SNAPSHOT
[INFO] [WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 11, column 21
```
Added  maven-compiler-plugin version for relevant tests.

```
[INFO] Compiling 10 source files to /Users/rsvoboda/git/protean-shamrock/rest-client/runtime/target/classes
[WARNING] /Users/rsvoboda/git/protean-shamrock/rest-client/runtime/src/main/java/org/jboss/shamrock/restclient/runtime/PartialResponse.java:[79,40] unchecked cast
  required: T
  found:    java.lang.String
```
looks like false alarm to me, @SuppressWarnings({"unchecked"}) added

```
[WARNING] /Users/rsvoboda/git/protean-shamrock/jboss-logging-embedded/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java:[64,71] unchecked conversion
  required: java.util.Map<java.lang.String,java.lang.Object>
  found:    java.util.Map
```
move of @SuppressWarnings({"unchecked"}) to the method level