### PR TITLE
Disable PDF generation for now

### DIFF
--- a/docs/assembly.xml
+++ b/docs/assembly.xml
@@ -26,7 +26,7 @@
     <fileSets>
         <fileSet>
             <directory>target/generated-docs</directory>
-            <outputDirectory/>            
+            <outputDirectory/>
         </fileSet>
         <fileSet>
             <directory>target/graphviz</directory>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -32,7 +32,6 @@
     <packaging>pom</packaging>
     <properties>
         <version.asciidoctor>1.5.7</version.asciidoctor>
-        <asciidoctorj-pdf.version>1.5.0-alpha.16</asciidoctorj-pdf.version>
     </properties>
 
     <name>Shamrock - Documentation</name>
@@ -47,13 +46,6 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${version.asciidoctor}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>${asciidoctorj-pdf.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <attributes>
                         <shamrock-version>${project.version}</shamrock-version>
@@ -85,16 +77,6 @@
                                 <linkcss>true</linkcss>
                                 <copycss>true</copycss>
                             </attributes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>generate-pdf-doc</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>process-asciidoc</goal>
-                        </goals>
-                        <configuration>
-                            <backend>pdf</backend>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We don't use it and it generates warnings so let's get rid of it for now
and enable it later if needed.

As discussed in https://github.com/jbossas/protean-shamrock/issues/394.