### PR TITLE
Update the GraalVM artifacts to 1.0.0-rc10

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -63,7 +63,7 @@
       <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
       <!-- What we actually depend on for the annotations, as latest Graal 
          is not available in Maven fast enough: -->
-      <graal-sdk.version>1.0.0-rc9</graal-sdk.version>
+      <graal-sdk.version>1.0.0-rc10</graal-sdk.version>
       <!-- The Graal version we suggest using in documentation - as that's 
          what we work with by self downloading it: -->
       <graal-sdk.version-for-documentation>1.0.0-rc10</graal-sdk.version-for-documentation>


### PR DESCRIPTION
I let the 2 different versions for docs and artifacts as I'm pretty sure we will have a similar issue with rc11.