### PR TITLE
Source code highlighter for .pdf docs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -95,6 +95,7 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
+                            <sourceHighlighter>coderay</sourceHighlighter>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Source code highlighter for .pdf docs

HTML based docs have source code highlighter enabled, but PDF docs do not have it enabled.