### PR TITLE
Suppress warnings for internal proprietary API - Signal and SignalHandler

### DIFF
--- a/core/runtime/src/main/java/org/jboss/shamrock/runtime/Application.java
+++ b/core/runtime/src/main/java/org/jboss/shamrock/runtime/Application.java
@@ -32,6 +32,7 @@ import sun.misc.SignalHandler;
  * The application base class, which is extended and implemented by a generated class which implements the application
  * setup logic.  The base class does some basic error checking.
  */
+@SuppressWarnings("restriction")
 public abstract class Application {
     private static final int ST_INITIAL = 0;
     private static final int ST_STARTING = 1;


### PR DESCRIPTION
Suppress warnings for internal proprietary API - Signal and SignalHandler warnings
Discussed in https://github.com/jbossas/protean-shamrock/issues/398

Solution based on https://stackoverflow.com/questions/9613857/cannot-stop-ant-from-generating-compiler-sun-proprietary-api-warnings/34966719#34966719 and https://stackoverflow.com/questions/13855700/suppress-javac-warning-is-internal-proprietary-api-and-may-be-removed-in-a-f/42406330#42406330 threads

Simple `@SuppressWarnings` is not working as warning about proprietary API is tricky beast.

For Java 6 there was no way to suppress them - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6476630

For Java 7 and 8 the way is via `-XDenableSunApiLintControl`.

For Java 9+ `-XDenableSunApiLintControl` way doesn't work and I wasn't able to find any solution for Java 9+.

So this is just partial fix just for Java 8, once the base moves to Java 11 warnings will be back.