### PR TITLE
Note about MariaDB and Docker on macOS, typo fix

### DIFF
--- a/integration-tests/jpa-mariadb/README.md
+++ b/integration-tests/jpa-mariadb/README.md
@@ -10,7 +10,10 @@ To run the tests in a standard JVM with MariaDB started as a Docker container, y
 mvn clean install -Dtest-mariadb -Ddocker
 ```
 
-Additionaly, you can generate a native image and run the tests for this native image by adding `-Dnative`:
+Please note that waiting on the availability of MariaDB port does not work on macOS.
+This module does not work with `-Ddocker` option on this operating system.
+
+Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
 mvn clean install -Dtest-mariadb -Ddocker -Dnative

--- a/integration-tests/jpa-postgresql/README.md
+++ b/integration-tests/jpa-postgresql/README.md
@@ -10,7 +10,7 @@ To run the tests in a standard JVM with PostgreSQL started as a Docker container
 mvn clean install -Dtest-postgresql -Ddocker
 ```
 
-Additionaly, you can generate a native image and run the tests for this native image by adding `-Dnative`:
+Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
 mvn clean install -Dtest-postgresql -Ddocker -Dnative


### PR DESCRIPTION
Note about MariaDB and Docker on macOS: similar note was in pom.xml but removed via https://github.com/jbossas/protean-shamrock/commit/a5b96f5eb6091290dd2c53f50b6a2e50d9c55be7

typo fix: Additionaly => Additionally