### PR TITLE
Update smallrye reactive stream operators to 0.4

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -42,7 +42,7 @@
       <smallrye-open-api.version>1.0.2</smallrye-open-api.version>
       <smallrye-opentracing.version>1.2.0</smallrye-opentracing.version>
       <smallrye-fault-tolerance.version>1.0.2</smallrye-fault-tolerance.version>
-      <smallrye-reactive-streams-operators.version>0.3.1</smallrye-reactive-streams-operators.version>
+      <smallrye-reactive-streams-operators.version>0.4.0</smallrye-reactive-streams-operators.version>
       <javax.activation.version>1.1.1</javax.activation.version>
       <javax.inject.version>1</javax.inject.version>
       <javax.annotation-api.version>1.3</javax.annotation-api.version>
@@ -82,7 +82,7 @@
       <rxjava.version>2.2.5</rxjava.version>
       <microprofile-rest-client-api.version>1.0</microprofile-rest-client-api.version>
       <microprofile-opentracing-api.version>1.2</microprofile-opentracing-api.version>
-      <microprofile-reactive-streams-operators.version>1.0-RC3</microprofile-reactive-streams-operators.version>
+      <microprofile-reactive-streams-operators.version>1.0-RC4</microprofile-reactive-streams-operators.version>
       <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
       <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
       <log4j.version>1.2.16</log4j.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -79,7 +79,7 @@
       <agroal.version>1.2</agroal.version>
       <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
       <javax.persistence-api.version>2.2</javax.persistence-api.version>
-      <rxjava.version>2.2.4</rxjava.version>
+      <rxjava.version>2.2.5</rxjava.version>
       <microprofile-rest-client-api.version>1.0</microprofile-rest-client-api.version>
       <microprofile-opentracing-api.version>1.2</microprofile-opentracing-api.version>
       <microprofile-reactive-streams-operators.version>1.0-RC3</microprofile-reactive-streams-operators.version>

--- a/extensions/reactive-streams-operators/reactive-streams-operators/deployment/pom.xml
+++ b/extensions/reactive-streams-operators/reactive-streams-operators/deployment/pom.xml
@@ -39,15 +39,4 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-jroper-maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/jroper/maven</url>
-        </repository>
-    </repositories>
-
 </project>

--- a/extensions/reactive-streams-operators/reactive-streams-operators/deployment/src/main/java/org/jboss/shamrock/rsops/ReactiveStreamsOperatorsProcessor.java
+++ b/extensions/reactive-streams-operators/reactive-streams-operators/deployment/src/main/java/org/jboss/shamrock/rsops/ReactiveStreamsOperatorsProcessor.java
@@ -17,9 +17,9 @@
 package org.jboss.shamrock.rsops;
 
 import io.smallrye.reactive.streams.Engine;
-import org.eclipse.microprofile.reactive.streams.ReactiveStreamsFactory;
-import org.eclipse.microprofile.reactive.streams.core.ReactiveStreamsFactoryImpl;
-import org.eclipse.microprofile.reactive.streams.spi.ReactiveStreamsEngine;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreamsFactory;
+import org.eclipse.microprofile.reactive.streams.operators.core.ReactiveStreamsFactoryImpl;
+import org.eclipse.microprofile.reactive.streams.operators.spi.ReactiveStreamsEngine;
 import org.jboss.shamrock.annotations.BuildProducer;
 import org.jboss.shamrock.annotations.BuildStep;
 import org.jboss.shamrock.deployment.builditem.substrate.ServiceProviderBuildItem;

--- a/extensions/reactive-streams-operators/reactive-streams-operators/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/reactive-streams-operators/runtime/pom.xml
@@ -30,12 +30,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.microprofile.reactive.streams</groupId>
-            <artifactId>microprofile-reactive-streams-operators</artifactId>
+            <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
+            <artifactId>microprofile-reactive-streams-operators-api</artifactId>
             <version>${microprofile-reactive-streams-operators.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+            <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
             <artifactId>microprofile-reactive-streams-operators-core</artifactId>
             <version>${microprofile-reactive-streams-operators.version}</version>
         </dependency>

--- a/extensions/reactive-streams-operators/reactive-streams-operators/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/reactive-streams-operators/runtime/pom.xml
@@ -65,15 +65,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-jroper-maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/jroper/maven</url>
-        </repository>
-    </repositories>
-
 </project>

--- a/integration-tests/main/src/main/java/org/jboss/shamrock/example/reactive/ReactiveStreamOpsResource.java
+++ b/integration-tests/main/src/main/java/org/jboss/shamrock/example/reactive/ReactiveStreamOpsResource.java
@@ -17,7 +17,7 @@
 package org.jboss.shamrock.example.reactive;
 
 import io.reactivex.Flowable;
-import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;


### PR DESCRIPTION
This PR:

* updates MicroProfile Reactive Streams Operators version to 1.0-RC4
* updates the SmallRye implementation to 0.4
* updates RX Java 2 versions
* updates the spec GAV and package names