### PR TITLE
Make RuntimeLoggingConfigurator consistent with LoggingResourceProcessor

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeLoggingConfigurator.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/runner/RuntimeLoggingConfigurator.java
@@ -77,7 +77,7 @@ public class RuntimeLoggingConfigurator implements EmbeddedConfigurator {
         boolean color = config.getOptionalValue("shamrock.log.console.format", Boolean.class)
                 .orElse(true);
 
-        if (color) {
+        if (color && System.console() != null) {
             return loggerName.isEmpty() ? new Handler[]{
                     new ConsoleHandler(new ColorPatternFormatter(format))
             } : NO_HANDLERS;


### PR DESCRIPTION
Fixes #403 and the issue with IDE logging.

So the issue was that `LoggingResourceProcessor` was testing the presence of a console whereas `RuntimeLoggingConfigurator` was not.

Consequences of the fix:
- we don't have any colors in the IDE - which is good
- we don't have any colors when running the tests - which is less nice IMHO

For the record, the only property mentioning Eclipse when running a JUnit test from the IDE is: `sun.java.command=org.eclipse.jdt.internal.junit.runner.RemoteTestRunner`.