### PR TITLE
SmallRye, Jandex, OpenTracing version updates

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -25,22 +25,22 @@
 
    <properties>
       <!-- TODO: unify version properties names - version.foo-name -->
-      <version.org.jandex>2.1.0.Beta1</version.org.jandex>
+      <version.org.jandex>2.1.0.Beta3</version.org.jandex>
       <resteasy.version>4.0.0.Beta6</resteasy.version>
       <opentracing.version>0.31.0</opentracing.version>
-      <opentracing-jaxrs.version>0.1.7</opentracing-jaxrs.version>
-      <opentracing-web-servlet-filter.version>0.1.0.redhat-00027</opentracing-web-servlet-filter.version>
-      <opentracing-tracerresolver.version>0.1.4</opentracing-tracerresolver.version>
-      <opentracing-concurrent.version>0.0.1</opentracing-concurrent.version>
+      <opentracing-jaxrs.version>0.3.1</opentracing-jaxrs.version>
+      <opentracing-web-servlet-filter.version>0.2.2</opentracing-web-servlet-filter.version>
+      <opentracing-tracerresolver.version>0.1.5</opentracing-tracerresolver.version>
+      <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
       <jaeger.version>0.27.0</jaeger.version>
       <undertow.version>2.0.16.Final</undertow.version>
       <xnio.version>3.6.5.Final</xnio.version>
       <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
       <smallrye-config.version>1.3.1</smallrye-config.version>
-      <smallrye-health.version>1.0.1</smallrye-health.version>
-      <smallrye-metrics.version>1.1.0</smallrye-metrics.version>
-      <smallrye-open-api.version>1.0.2</smallrye-open-api.version>
-      <smallrye-opentracing.version>1.2.0</smallrye-opentracing.version>
+      <smallrye-health.version>1.0.2</smallrye-health.version>
+      <smallrye-metrics.version>1.1.2</smallrye-metrics.version>
+      <smallrye-open-api.version>1.0.3</smallrye-open-api.version>
+      <smallrye-opentracing.version>1.2.1</smallrye-opentracing.version>
       <smallrye-fault-tolerance.version>1.0.2</smallrye-fault-tolerance.version>
       <smallrye-reactive-streams-operators.version>0.4.0</smallrye-reactive-streams-operators.version>
       <javax.activation.version>1.1.1</javax.activation.version>


### PR DESCRIPTION
SmallRye, Jandex, OpenTracing version updates to the latest

smallrye-config and smallrye-fault-tolerance couldn't be updated, https://github.com/jbossas/protean-shamrock/issues/432 and https://github.com/jbossas/protean-shamrock/issues/433 created

There are more components which can be updated, but it's safer to do upgrades in more chunks.