### PR TITLE
Make version properties naming consistent

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -24,8 +24,7 @@
    <packaging>pom</packaging>
 
    <properties>
-      <!-- TODO: unify version properties names - version.foo-name -->
-      <version.org.jandex>2.1.0.Beta3</version.org.jandex>
+      <jandex.version>2.1.0.Beta3</jandex.version>
       <resteasy.version>4.0.0.Beta6</resteasy.version>
       <opentracing.version>0.31.0</opentracing.version>
       <opentracing-jaxrs.version>0.3.1</opentracing-jaxrs.version>
@@ -816,7 +815,7 @@
          <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
-            <version>${version.org.jandex}</version>
+            <version>${jandex.version}</version>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
As seen in https://github.com/jbossas/protean-shamrock/pull/444 , the current inconsistency make things complicated for new contributors.

Let's make things consistent the easy way. Then we can discuss of if we want to change the convention.