### PR TITLE
Components upgrades

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -44,12 +44,12 @@
       <smallrye-reactive-streams-operators.version>0.4.0</smallrye-reactive-streams-operators.version>
       <javax.activation.version>1.1.1</javax.activation.version>
       <javax.inject.version>1</javax.inject.version>
-      <javax.annotation-api.version>1.3</javax.annotation-api.version>
+      <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
       <jboss-classfilewriter.version>1.2.3.Final</jboss-classfilewriter.version>
       <jboss-invocation.version>1.5.1.Final</jboss-invocation.version>
-      <javax.json.version>1.1.3</javax.json.version>
+      <javax.json.version>1.1.4</javax.json.version>
       <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
-      <jboss-jaxrs-api_2.1_spec.version>1.0.0.Final</jboss-jaxrs-api_2.1_spec.version>
+      <jboss-jaxrs-api_2.1_spec.version>1.0.2.Final</jboss-jaxrs-api_2.1_spec.version>
       <asm.version>6.2.1</asm.version>
       <cdi-api.version>2.0.SP1</cdi-api.version>
       <fakereplace.version>1.0.0.Alpha7</fakereplace.version>
@@ -73,15 +73,15 @@
       <classmate.version>1.3.4</classmate.version>
       <javax.el-impl.version>3.0.1.b08-redhat-1</javax.el-impl.version>
       <hibernate-validator.version>6.1.0.Alpha2</hibernate-validator.version>
-      <narayana.version>5.8.0.Final</narayana.version>
+      <narayana.version>5.9.2.Final</narayana.version>
       <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
-      <agroal.version>1.2</agroal.version>
+      <agroal.version>1.3</agroal.version>
       <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
       <javax.persistence-api.version>2.2</javax.persistence-api.version>
       <rxjava.version>2.2.5</rxjava.version>
       <microprofile-config-api.version>1.3</microprofile-config-api.version>
-      <microprofile-rest-client-api.version>1.0</microprofile-rest-client-api.version>
-      <microprofile-opentracing-api.version>1.2</microprofile-opentracing-api.version>
+      <microprofile-rest-client-api.version>1.0.1</microprofile-rest-client-api.version>
+      <microprofile-opentracing-api.version>1.2.1</microprofile-opentracing-api.version>
       <microprofile-reactive-streams-operators.version>1.0-RC4</microprofile-reactive-streams-operators.version>
       <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
       <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
@@ -90,11 +90,11 @@
       <slf4j.version>1.7.25</slf4j.version>
       <slf4j-jboss-logging.version>1.1.0.Final</slf4j-jboss-logging.version>
       <wildfly-common.version>1.5.0.Alpha3-format-001</wildfly-common.version>
-      <jboss-modules.version>1.8.0.Final</jboss-modules.version>
+      <jboss-modules.version>1.8.7.Final</jboss-modules.version>
       <jboss-threads.version>3.0.0.Alpha4</jboss-threads.version>
-      <vertx.version>3.6.0.CR2</vertx.version>
-      <httpclient.version>4.5.4</httpclient.version>
-      <httpcore.version>4.4.7</httpcore.version>
+      <vertx.version>3.6.2</vertx.version>
+      <httpclient.version>4.5.6</httpclient.version>
+      <httpcore.version>4.4.10</httpcore.version>
       <quartz.version>2.3.0</quartz.version>
       <jakarta-activation.version>1.2.1</jakarta-activation.version>
       <h2.version>1.4.197</h2.version>


### PR DESCRIPTION
Minor version bumps:
* Agroal
* Narayana
* Vert.X

The rest is micro version bump, the biggest micro bump is on jboss-modules.

Testsuite passed locally

com.fasterxml classmate / jackson can be updated once new RESTEasy version is released (which includes https://github.com/resteasy/Resteasy/commit/5a14906f786ab4a7d90bf54f73101561659f6f2d)