### PR TITLE
Allow multiple jvm args

### DIFF
--- a/maven/src/main/java/org/jboss/shamrock/maven/DevMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/DevMojo.java
@@ -23,6 +23,7 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -105,7 +106,7 @@ public class DevMojo extends AbstractMojo {
                 }
             }
             if(jvmArgs != null) {
-                args.add(jvmArgs);
+                args.addAll(Arrays.asList(jvmArgs.split(" ")));
             }
 
             for (Resource r : project.getBuild().getResources()) {


### PR DESCRIPTION
Found a problem when trying to pass multiple system properties to `mvn compile shamrock:dev` for initialising the Jaeger tracer.