### PR TITLE
chore: ignore META-INF/resources while building the Undertow JAR

### DIFF
--- a/extensions/undertow/deployment/src/main/java/org/jboss/shamrock/undertow/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/org/jboss/shamrock/undertow/UndertowBuildStep.java
@@ -197,6 +197,10 @@ public class UndertowBuildStep {
                 Files.walk(resource).forEach(new Consumer<Path>() {
                     @Override
                     public void accept(Path path) {
+                        // Skip META-INF/resources entry
+                        if (resource.equals(path)) {
+                            return;
+                        }
                         Path rel = resource.relativize(path);
                         if (Files.isDirectory(rel)) {
                             knownDirectories.add(rel.toString());


### PR DESCRIPTION
Fixes #506