### PR TITLE
 Include subclasses/implementations in serialization declaration for JAX-RS

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/ReflectiveHierarchyStep.java
@@ -105,10 +105,10 @@ public class ReflectiveHierarchyStep {
             for (FieldInfo i : info.fields()) {
                 addReflectiveHierarchy(i.type(), processedReflectiveHierarchies);
             }
-            for (MethodInfo i : info.methods()) {
-                addReflectiveHierarchy(i.returnType(), processedReflectiveHierarchies);
-                for (Type p : i.parameters()) {
-                    addReflectiveHierarchy(p, processedReflectiveHierarchies);
+            for (MethodInfo method : info.methods()) {
+                // we only add the return types of the potential getters
+                if (method.parameters().size() == 0) {
+                    addReflectiveHierarchy(method.returnType(), processedReflectiveHierarchies);
                 }
             }
         }

--- a/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
+++ b/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
@@ -37,13 +37,18 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 import javax.servlet.DispatcherType;
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -92,38 +97,38 @@ import org.jboss.shamrock.undertow.ServletInitParamBuildItem;
  */
 public class JaxrsScanningProcessor {
 
-    private static final String JAVAX_WS_RS_APPLICATION = "javax.ws.rs.Application";
+    private static final String JAVAX_WS_RS_APPLICATION = Application.class.getName();
     private static final String JAX_RS_FILTER_NAME = JAVAX_WS_RS_APPLICATION;
     private static final String JAX_RS_SERVLET_NAME = JAVAX_WS_RS_APPLICATION;
     private static final String JAX_RS_APPLICATION_PARAMETER_NAME = JAVAX_WS_RS_APPLICATION;
 
-    private static final DotName APPLICATION_PATH = DotName.createSimple("javax.ws.rs.ApplicationPath");
+    private static final DotName APPLICATION_PATH = DotName.createSimple(ApplicationPath.class.getName());
 
-    private static final DotName PATH = DotName.createSimple("javax.ws.rs.Path");
-    private static final DotName PROVIDER = DotName.createSimple("javax.ws.rs.ext.Provider");
+    private static final DotName PATH = DotName.createSimple(Path.class.getName());
+    private static final DotName PROVIDER = DotName.createSimple(Provider.class.getName());
     private static final DotName DYNAMIC_FEATURE = DotName.createSimple(DynamicFeature.class.getName());
+    private static final DotName CONTEXT = DotName.createSimple(Context.class.getName());
+
+    private static final DotName GET = DotName.createSimple(javax.ws.rs.GET.class.getName());
+    private static final DotName HEAD = DotName.createSimple(javax.ws.rs.HEAD.class.getName());
+    private static final DotName DELETE = DotName.createSimple(javax.ws.rs.DELETE.class.getName());
+    private static final DotName OPTIONS = DotName.createSimple(javax.ws.rs.OPTIONS.class.getName());
+    private static final DotName PATCH = DotName.createSimple(javax.ws.rs.PATCH.class.getName());
+    private static final DotName POST = DotName.createSimple(javax.ws.rs.POST.class.getName());
+    private static final DotName PUT = DotName.createSimple(javax.ws.rs.PUT.class.getName());
+
+    private static final DotName CONSUMES = DotName.createSimple(Consumes.class.getName());
+    private static final DotName PRODUCES = DotName.createSimple(Produces.class.getName());
+
+    private static final DotName RESTEASY_QUERY_PARAM = DotName.createSimple(org.jboss.resteasy.annotations.jaxrs.QueryParam.class.getName());
+    private static final DotName RESTEASY_FORM_PARAM = DotName.createSimple(org.jboss.resteasy.annotations.jaxrs.FormParam.class.getName());
+    private static final DotName RESTEASY_COOKIE_PARAM = DotName.createSimple(org.jboss.resteasy.annotations.jaxrs.CookieParam.class.getName());
+    private static final DotName RESTEASY_PATH_PARAM = DotName.createSimple(org.jboss.resteasy.annotations.jaxrs.PathParam.class.getName());
+    private static final DotName RESTEASY_HEADER_PARAM = DotName.createSimple(org.jboss.resteasy.annotations.jaxrs.HeaderParam.class.getName());
+    private static final DotName RESTEASY_MATRIX_PARAM = DotName.createSimple(org.jboss.resteasy.annotations.jaxrs.MatrixParam.class.getName());
 
     private static final DotName XML_ROOT = DotName.createSimple("javax.xml.bind.annotation.XmlRootElement");
     private static final DotName JSONB_ANNOTATION = DotName.createSimple("javax.json.bind.annotation.JsonbAnnotation");
-    private static final DotName CONTEXT = DotName.createSimple("javax.ws.rs.core.Context");
-
-    private static final DotName GET = DotName.createSimple("javax.ws.rs.GET");
-    private static final DotName HEAD = DotName.createSimple("javax.ws.rs.HEAD");
-    private static final DotName DELETE = DotName.createSimple("javax.ws.rs.DELETE");
-    private static final DotName OPTIONS = DotName.createSimple("javax.ws.rs.OPTIONS");
-    private static final DotName PATCH = DotName.createSimple("javax.ws.rs.PATCH");
-    private static final DotName POST = DotName.createSimple("javax.ws.rs.POST");
-    private static final DotName PUT = DotName.createSimple("javax.ws.rs.PUT");
-
-    private static final DotName RESTEASY_QUERY_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.QueryParam");
-    private static final DotName RESTEASY_FORM_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.FormParam");
-    private static final DotName RESTEASY_COOKIE_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.CookieParam");
-    private static final DotName RESTEASY_PATH_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.PathParam");
-    private static final DotName RESTEASY_HEADER_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.HeaderParam");
-    private static final DotName RESTEASY_MATRIX_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.MatrixParam");
-
-    private static final DotName CONSUMES = DotName.createSimple("javax.ws.rs.Consumes");
-    private static final DotName PRODUCES = DotName.createSimple("javax.ws.rs.Produces");
 
     private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(Arrays.asList(
             DotName.createSimple("javax.json.JsonObject"),

--- a/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
+++ b/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
@@ -236,8 +236,6 @@ public class JaxrsScanningProcessor {
                 "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
                 "com.fasterxml.jackson.databind.ser.std.SqlDateSerializer"));
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ArrayList.class.getName()));
-
         resource.produce(new SubstrateResourceBuildItem("META-INF/services/javax.ws.rs.client.ClientBuilder"));
         IndexView index = combinedIndexBuildItem.getIndex();
 

--- a/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
+++ b/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
@@ -228,13 +228,16 @@ public class JaxrsScanningProcessor {
                       CombinedIndexBuildItem combinedIndexBuildItem
     ) throws Exception {
 
+        // required by JSON-P support
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "org.glassfish.json.JsonProviderImpl"));
 
-        //this is pretty yuck, and does not really belong here, but it is needed to get the json-p
-        //provider to work
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "org.glassfish.json.JsonProviderImpl",
+        // required by Jackson
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
                 "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
                 "com.fasterxml.jackson.databind.ser.std.SqlDateSerializer"));
+
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ArrayList.class.getName()));
+
         resource.produce(new SubstrateResourceBuildItem("META-INF/services/javax.ws.rs.client.ClientBuilder"));
         IndexView index = combinedIndexBuildItem.getIndex();
 
@@ -366,6 +369,8 @@ public class JaxrsScanningProcessor {
             return;
         }
 
+        // Declare reflection for all the types implicated in the Rest end points (return types and parameters).
+        // It might be needed for serialization.
         for (DotName annotationType : METHOD_ANNOTATIONS) {
             Collection<AnnotationInstance> instances = index.getAnnotations(annotationType);
             for (AnnotationInstance instance : instances) {

--- a/integration-tests/main/src/main/java/org/jboss/shamrock/example/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/org/jboss/shamrock/example/rest/TestResource.java
@@ -124,7 +124,26 @@ public class TestResource {
         subComponent.getData().add("sub component list value");
         ret.setSubComponent(subComponent);
         return Collections.singletonList(ret);
+    }
 
+    @GET
+    @Path("/subclass")
+    @Produces("application/json")
+    public ParentClass subclass() {
+        ChildClass child = new ChildClass();
+        child.setName("my name");
+        child.setValue("my value");
+        return child;
+    }
+
+    @GET
+    @Path("/implementor")
+    @Produces("application/json")
+    public MyInterface implementor() {
+        MyImplementor child = new MyImplementor();
+        child.setName("my name");
+        child.setValue("my value");
+        return child;
     }
 
     @GET
@@ -132,6 +151,26 @@ public class TestResource {
     @Produces("application/foo")
     public String fooProvider() {
         return "hello";
+    }
+
+    @GET
+    @Path("params/{path}")
+    public void regularParams(@PathParam("path") String path,
+                              @FormParam("form") String form,
+                              @CookieParam("cookie") String cookie,
+                              @HeaderParam("header") String header,
+                              @MatrixParam("matrix") String matrix,
+                              @QueryParam("query") String query) {
+    }
+
+    @GET
+    @Path("params2/{path}")
+    public void resteasyParams(@org.jboss.resteasy.annotations.jaxrs.PathParam String path,
+                               @org.jboss.resteasy.annotations.jaxrs.FormParam String form,
+                               @org.jboss.resteasy.annotations.jaxrs.CookieParam String cookie,
+                               @org.jboss.resteasy.annotations.jaxrs.HeaderParam String header,
+                               @org.jboss.resteasy.annotations.jaxrs.MatrixParam String matrix,
+                               @org.jboss.resteasy.annotations.jaxrs.QueryParam String query) {
     }
 
     @XmlRootElement
@@ -169,23 +208,57 @@ public class TestResource {
         }
     }
 
-    @Path("params/{path}")
-    @GET
-    public void regularParams(@PathParam("path") String path,
-                              @FormParam("form") String form,
-                              @CookieParam("cookie") String cookie,
-                              @HeaderParam("header") String header,
-                              @MatrixParam("matrix") String matrix,
-                              @QueryParam("query") String query) {
+    public static class ParentClass {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 
-    @Path("params2/{path}")
-    @GET
-    public void resteasyParams(@org.jboss.resteasy.annotations.jaxrs.PathParam String path,
-                               @org.jboss.resteasy.annotations.jaxrs.FormParam String form,
-                               @org.jboss.resteasy.annotations.jaxrs.CookieParam String cookie,
-                               @org.jboss.resteasy.annotations.jaxrs.HeaderParam String header,
-                               @org.jboss.resteasy.annotations.jaxrs.MatrixParam String matrix,
-                               @org.jboss.resteasy.annotations.jaxrs.QueryParam String query) {
+    public static class ChildClass extends ParentClass {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class MyImplementor implements MyInterface {
+        private String name;
+        private String value;
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public interface MyInterface {
+
+        String getValue();
+
+        String getName();
     }
 }

--- a/integration-tests/main/src/test/java/org/jboss/shamrock/example/test/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/org/jboss/shamrock/example/test/JaxRSTestCase.java
@@ -104,4 +104,18 @@ public class JaxRSTestCase {
                         "[0].subComponent.data.size()", is(1),
                         "[0].subComponent.data[0]", is("sub component list value"));
     }
+
+    @Test
+    public void testSubclass() {
+        RestAssured.when().get("/test/subclass").then()
+                .body("name", is("my name"),
+                        "value", is("my value"));
+    }
+
+    @Test
+    public void testImplementor() {
+        RestAssured.when().get("/test/implementor").then()
+                .body("name", is("my name"),
+                        "value", is("my value"));
+    }
 }


### PR DESCRIPTION
Fixes #445.

Also trimmed down a bit what is considered by `ReflectiveHierarchyStep` as discussed with Stuart.

And a couple of other cleanups in JAX-RS processor.

Best reviewed commit per commit.