### PR TITLE
Update the documentation url to the new location

### DIFF
--- a/maven/src/main/resources/shamrock-maven-plugin.properties
+++ b/maven/src/main/resources/shamrock-maven-plugin.properties
@@ -18,6 +18,6 @@ maven-compiler-plugin-version=3.8.0
 maven-jar-plugin-version=3.1.0
 maven-resources-plugin=3.1.0
 shamrock-version=${shamrock.version}
-doc-root=http://10.8.247.58/nfs/protean
+doc-root=http://10.0.144.40/nfs/protean
 bom-artifactId=shamrock-bom
 restAssuredVersion=${rest-assured.version}


### PR DESCRIPTION
```
The documentation has moved to a new location, still behind VPN: http://10.0.144.40/nfs/protean/. 
This is due to a migration to the upshift infrastructure.
```