### PR TITLE
[Preview] Enable MariaDB integration tests on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,9 @@ jobs:
 
   steps:
 
+    - script: docker run --rm --publish 3308:3306 --name build-mariadb -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -d mariadb:10.4
+        displayName: 'start mariadb'
+
   - script: docker run --rm --publish 5432:5432 --name build-postgres -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -d postgres:10.5
     displayName: 'start postgres'
 
@@ -21,7 +24,7 @@ jobs:
     displayName: 'Maven Build'
     inputs:
       goals: 'install'
-      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dnative-image.xmx=4g -Dnative'
+      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-mariadb -Dexternal-mariadb -Dtest-postgresql -Dnative-image.xmx=4g -Dnative'
 
   - script: |
       docker build -f docker/strict-example/Dockerfile -t jtgdocker1/shamrock-strict-example examples/strict/

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -176,6 +176,18 @@
         </profile>
 
         <profile>
+            <id>external-mariadb</id>
+            <activation>
+                <property>
+                    <name>external-mariadb</name>
+                </property>
+            </activation>
+            <properties>
+                <mariadb.url>jdbc:mariadb://localhost:3308/hibernate_orm_test</mariadb.url>
+            </properties>
+        </profile>
+
+        <profile>
             <id>docker-mariadb</id>
             <activation>
                 <property>


### PR DESCRIPTION
This enables MariaDB on CI.. I'm not sure how well it will work though, as MariaDB has a race condition: after boot is reports "ready" but we're often able to initiate a connection before it really is, in which case you get an exception.

Might be worth giving a shot, or it needs some nasty "waift for" scripting..