### PR TITLE
Address #511 Support for import.sql and related property in JPA with no persistence.xml

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -96,6 +96,10 @@ public class Gift {
 <1> Inject your entity manager and have fun
 <2> Mark your CDI bean method as `@Transactional` and the `EntityManager` will enlist and flush at commit.
 
+To load some SQL statements when Hibernate ORM starts, add a `import.sql` in the root of your resources directory.
+It contains SQL DML statements (one by line).
+This is useful to have a data set ready for your tests or demos.
+
 === Properties to refine your Hibernate ORM configuration
 
 There are optional properties useful to refine your `EntityManagerFactory` or guide guesses of {project-name}.
@@ -109,6 +113,10 @@ Options are `none`, `create`, `drop-and-create`, `drop`
 
 `shamrock.hibernate.show_sql`:: (defaults to `false`).
 Show SQL logs and format them nicely.
+
+`shamrock.hibernate.sql-load-script-source`::
+(defaults to `/import.sql`) Name of the file containing the SQL statements to execute when Hibernate ORM starts.
+By default, simply add `import.sql` in the root of your resources directory and it will be picked up without having to set this property.
 
 [NOTE]
 --

--- a/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateOrmConfig.java
+++ b/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateOrmConfig.java
@@ -31,8 +31,16 @@ public class HibernateOrmConfig {
     @ConfigProperty(name="show_sql")
     public Optional<Boolean> showSql;
 
+    /**
+     * To populate the database tables with data before the application loads,
+     * specify the location of a load script.
+     * The location specified in this property is relative to the root of the persistence unit.
+     */
+    @ConfigProperty(name="sql-load-script-source")
+    public Optional<String> sqlLoadScriptSource;
+
     public boolean isAnyPropertySet() {
-        return dialect.isPresent() || schemaGeneration.isPresent() || showSql.isPresent();
+        return dialect.isPresent() || schemaGeneration.isPresent() || showSql.isPresent() || sqlLoadScriptSource.isPresent();
     }
 
 }

--- a/integration-tests/jpa/src/main/java/org/shamrock/jpa/tests/configurationless/CRUDResource.java
+++ b/integration-tests/jpa/src/main/java/org/shamrock/jpa/tests/configurationless/CRUDResource.java
@@ -72,4 +72,17 @@ public class CRUDResource {
         }
         return map;
     }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    @Path("/import")
+    public Map<String, String> get() {
+        Gift gift = em.find(Gift.class, 100000L);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("jpa", gift != null ? "OK" : "Boooo");
+        return map;
+    }
+
 }

--- a/integration-tests/jpa/src/main/resources/import.sql
+++ b/integration-tests/jpa/src/main/resources/import.sql
@@ -1,0 +1,2 @@
+DELETE FROM Gift WHERE id=100000
+INSERT INTO Gift (id,name) VALUES (100000,'Teddy bear');

--- a/integration-tests/jpa/src/test/java/org/shamrock/jpa/tests/configurationless/JPALoadScriptTest.java
+++ b/integration-tests/jpa/src/test/java/org/shamrock/jpa/tests/configurationless/JPALoadScriptTest.java
@@ -1,0 +1,21 @@
+package org.shamrock.jpa.tests.configurationless;
+
+import io.restassured.RestAssured;
+import org.jboss.shamrock.test.ShamrockTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.core.StringContains.containsString;
+
+/**
+ * @author Emmanuel Bernard emmanuel@hibernate.org
+ */
+@RunWith(ShamrockTest.class)
+public class JPALoadScriptTest {
+
+    @Test
+    public void testImportExecuted() {
+        RestAssured.when().get("/jpa-test/import").then()
+                .body(containsString("jpa=OK"));
+    }
+}

--- a/integration-tests/jpa/src/test/java/org/shamrock/jpa/tests/configurationless/JPALoadScriptTestInGraalITCase.java
+++ b/integration-tests/jpa/src/test/java/org/shamrock/jpa/tests/configurationless/JPALoadScriptTestInGraalITCase.java
@@ -1,0 +1,11 @@
+package org.shamrock.jpa.tests.configurationless;
+
+import org.jboss.shamrock.test.SubstrateTest;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Emmanuel Bernard emmanuel@hibernate.org
+ */
+@RunWith(SubstrateTest.class)
+public class JPALoadScriptTestInGraalITCase extends JPALoadScriptTest {
+}


### PR DESCRIPTION
Code is OK I think.
Doc is done.

There is an annoying warning raised by Hibernate when no `import.sql` is present.
We would need https://github.com/jbossas/protean-shamrock/issues/406 to address that.

Test is partial: A proper testing strategy can be done once https://github.com/jbossas/protean-shamrock/issues/534 is fixed.

Should we merge and add a follow up?