### PR TITLE
No longer need the workaround to disable Validator extensions for JavaFX

### DIFF
--- a/extensions/bean-validation/deployment/src/main/java/org/jboss/shamrock/beanvalidation/BeanValidationProcessor.java
+++ b/extensions/bean-validation/deployment/src/main/java/org/jboss/shamrock/beanvalidation/BeanValidationProcessor.java
@@ -47,7 +47,6 @@ import org.jboss.shamrock.beanvalidation.runtime.interceptor.MethodValidationInt
 import org.jboss.shamrock.deployment.builditem.CombinedIndexBuildItem;
 import org.jboss.shamrock.deployment.builditem.FeatureBuildItem;
 import org.jboss.shamrock.deployment.builditem.HotDeploymentConfigFileBuildItem;
-import org.jboss.shamrock.deployment.builditem.SystemPropertyBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveFieldBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveMethodBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateConfigBuildItem;
@@ -58,12 +57,6 @@ class BeanValidationProcessor {
     private static final DotName VALIDATE_ON_EXECUTION = DotName.createSimple(ValidateOnExecution.class.getName());
 
     private static final DotName VALID = DotName.createSimple(Valid.class.getName());
-
-    @BuildStep
-    SystemPropertyBuildItem disableJavaFXIntegrations() {
-        // Bug in GraalVM rc10: see https://github.com/oracle/graal/issues/851
-        return new SystemPropertyBuildItem("org.hibernate.validator.force-disable-javafx-integration", "true");
-    }
 
     @BuildStep
     HotDeploymentConfigFileBuildItem configFile() {


### PR DESCRIPTION
Revert "Have Hibernate Validator disable the JavaFX value extractors integration"

This reverts commit 68b767fa8e0a951fb6fbe028aa89875424a3a0b3.