### PR TITLE
Add MP-Metrics support for Jaeger

### DIFF
--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -47,6 +47,10 @@
             <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerMetricsFactory.java
+++ b/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerMetricsFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.jaeger.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+
+import io.jaegertracing.internal.metrics.Counter;
+import io.jaegertracing.internal.metrics.Gauge;
+import io.jaegertracing.internal.metrics.Timer;
+import io.jaegertracing.spi.MetricsFactory;
+import io.smallrye.metrics.MetricRegistries;
+
+public class ShamrockJaegerMetricsFactory implements MetricsFactory {
+
+    MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.BASE);
+    
+    @Override
+    public Counter createCounter(final String name, final Map<String, String> tags) {
+      org.eclipse.microprofile.metrics.Counter counter=
+            registry.counter(meta(name, tags, MetricType.COUNTER));
+
+      return new Counter() {
+        @Override
+        public void inc(long delta) {
+          counter.inc(delta);
+        }
+      };
+    }
+  
+    @Override
+    public Timer createTimer(final String name, final Map<String, String> tags) {
+      org.eclipse.microprofile.metrics.Timer timer=
+            registry.timer(meta(name, tags, MetricType.TIMER));
+
+      return new Timer() {
+        @Override
+        public void durationMicros(long time) {
+          timer.update(time, TimeUnit.MICROSECONDS);
+        }
+      };
+    }
+  
+    @Override
+    public Gauge createGauge(final String name, final Map<String, String> tags) {
+      JaegerGauge gauge=registry.register(meta(name, tags, MetricType.GAUGE), new JaegerGauge());
+
+      return new Gauge() {
+        @Override
+        public void update(long amount) {
+          gauge.update(amount);
+        }
+      };
+    }
+
+    static Metadata meta(final String name, final Map<String, String> tags, MetricType type) {
+      Metadata meta = new Metadata(name, type);
+      meta.setDisplayName(name);
+      meta.setUnit("none");
+      meta.setDescription(name);
+      meta.setTags(new HashMap<String,String>(tags));
+      meta.setReusable(true);
+      return meta;
+    }
+  
+    static class JaegerGauge implements org.eclipse.microprofile.metrics.Gauge<Long> {
+      private AtomicLong value=new AtomicLong();
+  
+      public void update(long value) {
+        this.value.set(value);
+      }
+
+      @Override
+      public Long getValue() {
+        return value.get();
+      }
+    }
+}
+

--- a/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerMetricsFactory.java
+++ b/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerMetricsFactory.java
@@ -33,6 +33,8 @@ import io.smallrye.metrics.MetricRegistries;
 
 public class ShamrockJaegerMetricsFactory implements MetricsFactory {
 
+    private static final String METRICS_PREFIX = "jaeger_tracer_";
+
     MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.BASE);
     
     @Override
@@ -73,7 +75,11 @@ public class ShamrockJaegerMetricsFactory implements MetricsFactory {
       };
     }
 
-    static Metadata meta(final String name, final Map<String, String> tags, MetricType type) {
+    static Metadata meta(String name, final Map<String, String> tags, MetricType type) {
+      if (!name.startsWith(METRICS_PREFIX)) {
+        // Add default prefix
+        name = METRICS_PREFIX + name;
+      }
       Metadata meta = new Metadata(name, type);
       meta.setDisplayName(name);
       meta.setUnit("none");

--- a/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerMetricsFactory.java
+++ b/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerMetricsFactory.java
@@ -33,8 +33,6 @@ import io.smallrye.metrics.MetricRegistries;
 
 public class ShamrockJaegerMetricsFactory implements MetricsFactory {
 
-    private static final String METRICS_PREFIX = "jaeger_tracer_";
-
     MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.BASE);
     
     @Override
@@ -76,10 +74,6 @@ public class ShamrockJaegerMetricsFactory implements MetricsFactory {
     }
 
     static Metadata meta(String name, final Map<String, String> tags, MetricType type) {
-      if (!name.startsWith(METRICS_PREFIX)) {
-        // Add default prefix
-        name = METRICS_PREFIX + name;
-      }
       Metadata meta = new Metadata(name, type);
       meta.setDisplayName(name);
       meta.setUnit("none");

--- a/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerTracer.java
+++ b/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/ShamrockJaegerTracer.java
@@ -44,7 +44,7 @@ public class ShamrockJaegerTracer implements Tracer {
             if (orig != null) {
                 return orig;
             }
-            return Configuration.fromEnv().getTracer();
+            return Configuration.fromEnv().withMetricsFactory(new ShamrockJaegerMetricsFactory()).getTracer();
         });
     }
 

--- a/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/Target_Metrics.java
+++ b/extensions/jaeger/runtime/src/main/java/org/jboss/shamrock/jaeger/runtime/Target_Metrics.java
@@ -101,81 +101,81 @@ public final class Target_Metrics {
         Map<String, String> tags = new HashMap<String, String>();
         tags.put("state", "started");
         tags.put("sampled", "y");
-        traceStartedSampled = factory.createCounter("traces", tags);
+        traceStartedSampled = factory.createCounter(metricsPrefix + "traces", tags);
 
         tags = new HashMap<String, String>();
         tags.put("state", "started");
         tags.put("sampled", "n");
-        traceStartedNotSampled = factory.createCounter("traces", tags);
+        traceStartedNotSampled = factory.createCounter(metricsPrefix + "traces", tags);
 
         tags = new HashMap<String, String>();
         tags.put("state", "joined");
         tags.put("sampled", "y");
-        tracesJoinedSampled = factory.createCounter("traces", tags);
+        tracesJoinedSampled = factory.createCounter(metricsPrefix + "traces", tags);
 
         tags = new HashMap<String, String>();
         tags.put("state", "joined");
         tags.put("sampled", "n");
-        tracesJoinedNotSampled = factory.createCounter("traces", tags);
+        tracesJoinedNotSampled = factory.createCounter(metricsPrefix + "traces", tags);
 
         tags = new HashMap<String, String>();
         tags.put("sampled", "y");
-        spansStartedSampled = factory.createCounter("started_spans", tags);
+        spansStartedSampled = factory.createCounter(metricsPrefix + "started_spans", tags);
 
         tags = new HashMap<String, String>();
         tags.put("sampled", "n");
-        spansStartedNotSampled = factory.createCounter("started_spans", tags);
+        spansStartedNotSampled = factory.createCounter(metricsPrefix + "started_spans", tags);
 
-        spansFinished = factory.createCounter("finished_spans", Collections.emptyMap());
+        spansFinished = factory.createCounter(metricsPrefix + "finished_spans", Collections.emptyMap());
 
-        decodingErrors = factory.createCounter("span_context_decoding_errors", Collections.emptyMap());
+        decodingErrors = factory.createCounter(metricsPrefix + "span_context_decoding_errors", Collections.emptyMap());
 
         tags = new HashMap<String, String>();
         tags.put("result", "ok");
-        reporterSuccess = factory.createCounter("reporter_spans", tags);
+        reporterSuccess = factory.createCounter(metricsPrefix + "reporter_spans", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "err");
-        reporterFailure = factory.createCounter("reporter_spans", tags);
+        reporterFailure = factory.createCounter(metricsPrefix + "reporter_spans", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "dropped");
-        reporterDropped = factory.createCounter("reporter_spans", tags);
+        reporterDropped = factory.createCounter(metricsPrefix + "reporter_spans", tags);
 
-        reporterQueueLength = factory.createGauge("reporter_queue_length", Collections.emptyMap());
-
-        tags = new HashMap<String, String>();
-        tags.put("result", "ok");
-        samplerRetrieved = factory.createCounter("sampler_queries", tags);
-
-        tags = new HashMap<String, String>();
-        tags.put("result", "err");
-        samplerQueryFailure = factory.createCounter("sampler_queries", tags);
+        reporterQueueLength = factory.createGauge(metricsPrefix + "reporter_queue_length", Collections.emptyMap());
 
         tags = new HashMap<String, String>();
         tags.put("result", "ok");
-        samplerUpdated = factory.createCounter("sampler_updates", tags);
+        samplerRetrieved = factory.createCounter(metricsPrefix + "sampler_queries", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "err");
-        samplerParsingFailure = factory.createCounter("sampler_updates", tags);
+        samplerQueryFailure = factory.createCounter(metricsPrefix + "sampler_queries", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "ok");
-        baggageUpdateSuccess = factory.createCounter("baggage_updates", tags);
+        samplerUpdated = factory.createCounter(metricsPrefix + "sampler_updates", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "err");
-        baggageUpdateFailure = factory.createCounter("baggage_updates", tags);
-
-        baggageTruncate = factory.createCounter("baggage_truncations", Collections.emptyMap());
+        samplerParsingFailure = factory.createCounter(metricsPrefix + "sampler_updates", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "ok");
-        baggageRestrictionsUpdateSuccess = factory.createCounter("baggage_restrictions_updates", tags);
+        baggageUpdateSuccess = factory.createCounter(metricsPrefix + "baggage_updates", tags);
 
         tags = new HashMap<String, String>();
         tags.put("result", "err");
-        baggageRestrictionsUpdateFailure = factory.createCounter("baggage_restrictions_updates", tags);
+        baggageUpdateFailure = factory.createCounter(metricsPrefix + "baggage_updates", tags);
+
+        baggageTruncate = factory.createCounter(metricsPrefix + "baggage_truncations", Collections.emptyMap());
+
+        tags = new HashMap<String, String>();
+        tags.put("result", "ok");
+        baggageRestrictionsUpdateSuccess = factory.createCounter(metricsPrefix + "baggage_restrictions_updates", tags);
+
+        tags = new HashMap<String, String>();
+        tags.put("result", "err");
+        baggageRestrictionsUpdateFailure = factory.createCounter(metricsPrefix + "baggage_restrictions_updates", tags);
     }
 }


### PR DESCRIPTION
Fixes #482 

To test, add the following dependency to the `using-opentracing` quickstart:
```
    <dependency>
      <groupId>org.jboss.shamrock</groupId>
      <artifactId>shamrock-metrics-deployment</artifactId>
    </dependency>
```
and then check the `http://localhost:8080/metrics` endpoint after performing a hello request, and you will see metrics with the prefix `base:jaeger_tracer_`.