### PR TITLE
ArC - add "remove unused beans" optimization

### DIFF
--- a/extensions/agroal/deployment/src/main/java/org/jboss/shamrock/agroal/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/org/jboss/shamrock/agroal/AgroalProcessor.java
@@ -45,7 +45,7 @@ class AgroalProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem registerBean() {
-        return new AdditionalBeanBuildItem(DataSourceProducer.class);
+        return new AdditionalBeanBuildItem(false, DataSourceProducer.class);
     }
 
     @Record(STATIC_INIT)

--- a/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/AdditionalBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/AdditionalBeanBuildItem.java
@@ -26,7 +26,7 @@ import org.jboss.builder.item.MultiBuildItem;
 /**
  * This build item is used to specify additional bean classes to be analyzed.
  * <p>
- * By default, the resulting beans should be removed if they're considered unused as described in {@link ArcConfig#removeUnusedBeans}. 
+ * By default, the resulting beans may be removed if they are considered unused and {@link ArcConfig#removeUnusedBeans} is enabled. 
  */
 public final class AdditionalBeanBuildItem extends MultiBuildItem {
 

--- a/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/AdditionalBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/AdditionalBeanBuildItem.java
@@ -16,29 +16,50 @@
 
 package org.jboss.shamrock.arc.deployment;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jboss.builder.item.MultiBuildItem;
 
+/**
+ * This build item is used to specify additional bean classes to be analyzed.
+ * <p>
+ * By default, the resulting beans should be removed if they're considered unused as described in {@link ArcConfig#removeUnusedBeans}. 
+ */
 public final class AdditionalBeanBuildItem extends MultiBuildItem {
 
-    private final List<String> beanNames;
-
-    public AdditionalBeanBuildItem(String... beanNames) {
-        this.beanNames = Arrays.asList(beanNames);
+    private final List<String> beanClasses;
+    private final boolean removable;
+    
+    public AdditionalBeanBuildItem(String... beanClasses) {
+        this(true, beanClasses);
+    }
+    
+    public AdditionalBeanBuildItem(boolean removable, String... beanClasses) {
+        this(Arrays.asList(beanClasses), removable);
     }
 
-    public AdditionalBeanBuildItem(Class<?>... beanClasss) {
-        beanNames = new ArrayList<>(beanClasss.length);
-        for (Class<?> i : beanClasss) {
-            beanNames.add(i.getName());
-        }
+    public AdditionalBeanBuildItem(Class<?>... beanClasses) {
+        this(true, beanClasses);
+    }
+    
+    public AdditionalBeanBuildItem(boolean removable, Class<?>... beanClasses) {
+        this(Arrays.stream(beanClasses).map(Class::getName).collect(Collectors.toList()), removable);
+    }
+    
+    AdditionalBeanBuildItem(List<String> beanClasses, boolean removable) {
+        this.beanClasses = beanClasses;
+        this.removable = removable;
     }
 
-    public List<String> getBeanNames() {
-        return Collections.unmodifiableList(beanNames);
+    public List<String> getBeanClasses() {
+        return Collections.unmodifiableList(beanClasses);
     }
+
+    public boolean isRemovable() {
+        return removable;
+    }
+    
 }

--- a/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/ArcConfig.java
@@ -1,0 +1,28 @@
+package org.jboss.shamrock.arc.deployment;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shamrock.runtime.ConfigGroup;
+
+@ConfigGroup
+public class ArcConfig {
+
+    /**
+     * If set to true the container will attempt to remove all unused beans.
+     * <p>
+     * An unused bean:
+     * <ul>
+     * <li>is not a built-in bean or interceptor,</li>
+     * <li>is not eligible for injection to any injection point,</li>
+     * <li>is not excluded by any extension,</li>
+     * <li>does not have a name,</li>
+     * <li>does not declare an observer,</li>
+     * <li>does not declare any producer which is eligible for injection to any injection point,</li>
+     * <li>is not directly eligible for injection into any {@link javax.enterprise.inject.Instance} injection point</li>
+     * </ul>
+     * 
+     * @see UnremovableBeanBuildItem
+     */
+    @ConfigProperty(name = "remove-unused-beans", defaultValue = "true")
+    public boolean removeUnusedBeans;
+
+}

--- a/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/BeanDefiningAnnotationBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/BeanDefiningAnnotationBuildItem.java
@@ -23,7 +23,7 @@ import org.jboss.jandex.DotName;
  * This build item is used to specify additional bean defining annotations. See also
  * <a href="http://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#bean_defining_annotations">2.5.1. Bean defining annotations</a>.
  * <p>
- * By default, the resulting beans should not be removed if they're considered unused as described in {@link ArcConfig#removeUnusedBeans}.
+ * By default, the resulting beans must not be removed even if they are considered unused and {@link ArcConfig#removeUnusedBeans} is enabled.
  */
 public final class BeanDefiningAnnotationBuildItem extends MultiBuildItem {
 

--- a/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/BeanDefiningAnnotationBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/BeanDefiningAnnotationBuildItem.java
@@ -22,19 +22,27 @@ import org.jboss.jandex.DotName;
 /**
  * This build item is used to specify additional bean defining annotations. See also
  * <a href="http://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#bean_defining_annotations">2.5.1. Bean defining annotations</a>.
+ * <p>
+ * By default, the resulting beans should not be removed if they're considered unused as described in {@link ArcConfig#removeUnusedBeans}.
  */
 public final class BeanDefiningAnnotationBuildItem extends MultiBuildItem {
 
     private final DotName name;
     private final DotName defaultScope;
+    private final boolean removable;
 
     public BeanDefiningAnnotationBuildItem(DotName name) {
         this(name, null);
     }
 
     public BeanDefiningAnnotationBuildItem(DotName name, DotName defaultScope) {
+        this(name, defaultScope, false);
+    }
+
+    public BeanDefiningAnnotationBuildItem(DotName name, DotName defaultScope, boolean removable) {
         this.name = name;
         this.defaultScope = defaultScope;
+        this.removable = removable;
     }
 
     public DotName getName() {
@@ -44,4 +52,13 @@ public final class BeanDefiningAnnotationBuildItem extends MultiBuildItem {
     public DotName getDefaultScope() {
         return defaultScope;
     }
+
+    /**
+     * 
+     * @return true if the resulting beans should be removed if they're considered unused as described in {@link ArcConfig#removeUnusedBeans}
+     */
+    public boolean isRemovable() {
+        return removable;
+    }
+
 }

--- a/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/UnremovableBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/org/jboss/shamrock/arc/deployment/UnremovableBeanBuildItem.java
@@ -1,0 +1,74 @@
+package org.jboss.shamrock.arc.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.jboss.builder.item.MultiBuildItem;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.protean.arc.processor.BeanInfo;
+
+/**
+ * This build item is used to exclude beans that would be normally removed if the config property {@link ArcConfig#removeUnusedBeans} is set to true.
+ */
+public final class UnremovableBeanBuildItem extends MultiBuildItem {
+
+    private final Predicate<BeanInfo> predicate;
+
+    public UnremovableBeanBuildItem(Predicate<BeanInfo> predicate) {
+        this.predicate = predicate;
+    }
+
+    public Predicate<BeanInfo> getPredicate() {
+        return predicate;
+    }
+
+    public static class BeanClassNameExclusion implements Predicate<BeanInfo> {
+
+        private final String className;
+
+        public BeanClassNameExclusion(String className) {
+            this.className = Objects.requireNonNull(className);
+        }
+
+        @Override
+        public boolean test(BeanInfo bean) {
+            return bean.getBeanClass().toString().equals(className);
+        }
+
+    }
+
+    public static class BeanClassAnnotationExclusion implements Predicate<BeanInfo> {
+
+        private final String nameStartsWith;
+
+        private final DotName name;
+
+        public BeanClassAnnotationExclusion(String nameStartsWith) {
+            this.nameStartsWith = Objects.requireNonNull(nameStartsWith);
+            this.name = null;
+        }
+
+        public BeanClassAnnotationExclusion(DotName name) {
+            this.nameStartsWith = null;
+            this.name = name;
+        }
+
+        @Override
+        public boolean test(BeanInfo bean) {
+            if (bean.isClassBean()) {
+                Map<DotName, List<AnnotationInstance>> annotations = bean.getTarget().get().asClass().annotations();
+                if (name != null) {
+                    return annotations.containsKey(name);
+                } else {
+                    return annotations.keySet().stream().anyMatch(a -> a.toString().startsWith(nameStartsWith));
+                }
+            }
+            return false;
+        }
+
+    }
+
+}

--- a/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
+++ b/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
@@ -442,7 +442,7 @@ public class JaxrsScanningProcessor {
         }
         template.setupIntegration(beanContainerBuildItem.getValue(), unwrappers);
     }
-
+    
     @BuildStep
     List<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations() {
         return Collections.singletonList(new BeanDefiningAnnotationBuildItem(PATH, singletonResources ? SINGLETON_SCOPE : null));

--- a/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateResourceProcessor.java
+++ b/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateResourceProcessor.java
@@ -134,7 +134,7 @@ public final class HibernateResourceProcessor {
 
     @BuildStep
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans, CombinedIndexBuildItem combinedIndex, List<PersistenceUnitDescriptorBuildItem> descriptors) {
-        additionalBeans.produce(new AdditionalBeanBuildItem(JPAConfig.class, TransactionEntityManagers.class));
+        additionalBeans.produce(new AdditionalBeanBuildItem(false, JPAConfig.class, TransactionEntityManagers.class));
 
         if (descriptors.size() == 1) {
             // There is only one persistence unit - register CDI beans for EM and EMF if no

--- a/extensions/reactive-messaging/deployment/src/main/java/org/jboss/shamrock/reactivemessaging/deployment/ReactiveMessagingProcessor.java
+++ b/extensions/reactive-messaging/deployment/src/main/java/org/jboss/shamrock/reactivemessaging/deployment/ReactiveMessagingProcessor.java
@@ -18,6 +18,7 @@ package org.jboss.shamrock.reactivemessaging.deployment;
 import static org.jboss.shamrock.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,8 @@ import org.jboss.shamrock.annotations.Record;
 import org.jboss.shamrock.arc.deployment.AdditionalBeanBuildItem;
 import org.jboss.shamrock.arc.deployment.BeanContainerBuildItem;
 import org.jboss.shamrock.arc.deployment.BeanDeploymentValidatorBuildItem;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem;
 import org.jboss.shamrock.deployment.builditem.FeatureBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import org.jboss.shamrock.reactivemessaging.runtime.ReactiveMessagingLifecycle;
@@ -89,6 +92,12 @@ public class ReactiveMessagingProcessor {
                 }
             }
         });
+    }
+
+    @BuildStep
+    public List<UnremovableBeanBuildItem> removalExclusions() {
+        return Arrays.asList(new UnremovableBeanBuildItem(new BeanClassAnnotationExclusion(NAME_INCOMING)),
+                new UnremovableBeanBuildItem(new BeanClassAnnotationExclusion(NAME_OUTGOING)));
     }
 
     @BuildStep

--- a/extensions/scheduler/deployment/src/main/java/org/jboss/shamrock/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/org/jboss/shamrock/scheduler/deployment/SchedulerProcessor.java
@@ -20,6 +20,7 @@ import static org.jboss.shamrock.annotations.ExecutionTime.STATIC_INIT;
 import java.text.ParseException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +59,8 @@ import org.jboss.shamrock.arc.deployment.AdditionalBeanBuildItem;
 import org.jboss.shamrock.arc.deployment.AnnotationsTransformerBuildItem;
 import org.jboss.shamrock.arc.deployment.BeanContainerBuildItem;
 import org.jboss.shamrock.arc.deployment.BeanDeploymentValidatorBuildItem;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem;
 import org.jboss.shamrock.deployment.builditem.FeatureBuildItem;
 import org.jboss.shamrock.deployment.builditem.GeneratedClassBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveClassBuildItem;
@@ -187,11 +190,18 @@ public class SchedulerProcessor {
             }
         });
     }
+    
+    @BuildStep
+    public List<UnremovableBeanBuildItem> unremovableBeans() {
+        return Arrays.asList(new UnremovableBeanBuildItem(new BeanClassAnnotationExclusion(SCHEDULED_NAME)),
+                new UnremovableBeanBuildItem(new BeanClassAnnotationExclusion(SCHEDULEDS_NAME)));
+    }
 
     @BuildStep
     @Record(STATIC_INIT)
     public void build(SchedulerDeploymentTemplate template, BeanContainerBuildItem beanContainer, List<ScheduledBusinessMethodItem> scheduledBusinessMethods,
-            BuildProducer<GeneratedClassBuildItem> generatedResource, BuildProducer<ReflectiveClassBuildItem> reflectiveClass, BuildProducer<FeatureBuildItem> feature) {
+            BuildProducer<GeneratedClassBuildItem> generatedResource, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<FeatureBuildItem> feature) {
 
         feature.produce(new FeatureBuildItem(FeatureBuildItem.SCHEDULER));
         List<Map<String, Object>> scheduleConfigurations = new ArrayList<>();

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
@@ -285,7 +285,7 @@ public class BeanInfo {
             bound.addAll(interception.interceptors);
         }
         if (!interceptedMethods.isEmpty()) {
-            bound.addAll(interceptedMethods.values().stream().map(m -> m.interceptors).flatMap(list -> list.stream()).collect(Collectors.toList()));
+            bound.addAll(interceptedMethods.values().stream().flatMap(ii -> ii.interceptors.stream()).collect(Collectors.toList()));
         }
         return bound.isEmpty() ? Collections.emptyList() : bound.stream().distinct().sorted().collect(Collectors.toList());
     }

--- a/independent-projects/arc/tests/src/test/java/org/jboss/protean/arc/test/unused/RemoveUnusedBeansTest.java
+++ b/independent-projects/arc/tests/src/test/java/org/jboss/protean/arc/test/unused/RemoveUnusedBeansTest.java
@@ -1,0 +1,120 @@
+package org.jboss.protean.arc.test.unused;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jboss.protean.arc.Arc;
+import org.jboss.protean.arc.ArcContainer;
+import org.jboss.protean.arc.test.ArcTestContainer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RemoveUnusedBeansTest {
+
+    @Rule
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(HasObserver.class, Foo.class, FooAlternative.class, HasName.class, UnusedProducers.class, InjectedViaInstance.class, Excluded.class, UsedProducers.class)
+            .removeUnusedBeans(true)
+            .addRemovalExclusion(b -> b.getBeanClass().toString().equals(Excluded.class.getName()))
+            .build();
+
+    @Test
+    public void testRemoval() {
+        ArcContainer container = Arc.container();
+        assertTrue(container.instance(HasObserver.class).isAvailable());
+        assertTrue(container.instance(HasName.class).isAvailable());
+        assertTrue(container.instance(InjectedViaInstance.class).isAvailable());
+        assertTrue(container.instance(String.class).isAvailable());
+        assertTrue(container.instance(UsedProducers.class).isAvailable());
+        assertFalse(container.instance(UnusedProducers.class).isAvailable());
+        assertFalse(container.instance(BigDecimal.class).isAvailable());
+        // Foo is injected in HasObserver#observe()
+        assertEquals(FooAlternative.class.getName(), container.instance(Foo.class).get().ping());
+        assertEquals(1, container.beanManager().getBeans(Foo.class).size());
+        assertEquals("pong", container.instance(Excluded.class).get().ping());
+    }
+
+    @Dependent
+    static class HasObserver {
+
+        void observe(@Observes String event, Foo foo) {
+        }
+
+    }
+
+    @Named
+    @Dependent
+    static class HasName {
+
+    }
+
+    @Dependent
+    static class Foo {
+
+        String ping() {
+            return getClass().getName();
+        }
+
+    }
+
+    @Alternative
+    @Priority(1)
+    @Dependent
+    static class FooAlternative extends Foo {
+
+        @Inject
+        Instance<InjectedViaInstance> instance;
+        
+        @Inject
+        String foo;
+
+    }
+
+    @Singleton
+    static class InjectedViaInstance {
+
+    }
+
+    @Singleton
+    static class UnusedProducers {
+
+        @Produces
+        BigDecimal unusedNumber() {
+            return BigDecimal.ZERO;
+        }
+
+    }
+    
+    @Singleton
+    static class UsedProducers {
+
+        @Produces
+        String usedString() {
+            return "ok";
+        }
+
+    }
+    
+    @Singleton
+    static class Excluded {
+        
+        String ping() {
+            return "pong";
+        }
+        
+    }
+
+}


### PR DESCRIPTION
So this is basically a framework-level dead code elimination. The container attempts to remove all unused beans before the wiring metadata classes are generated. The algorithm is described in javadoc and is very similar to the Weld implementation.

The optimization is enabled by default, but could be disabled by `shamrock.arc.remove-unused-beans=false`.

Extensions can register `BeanRemovalExclusionBuildItem`s to eliminate false positives such as JAX-RS resources (in general application entry points and beans that are only accessed programatically).

In terms of build times - for `quickstarts/getting-started` the difference is:
```
[DEBUG] [org.jboss.protean.arc.processor.BeanDeployment] Bean deployment created in 53 ms
[DEBUG] [org.jboss.protean.arc.processor.BeanDeployment] Removed 11 unused beans in 5 ms
[DEBUG] [org.jboss.protean.arc.processor.BeanDeployment] Bean deployment initialized in 14 ms
[DEBUG] [org.jboss.protean.arc.processor.BeanProcessor] Generated 9 resources in 27 ms
[DEBUG] [org.jboss.builder] Finished step "org.jboss.shamrock.arc.deployment.ArcAnnotationProcessor.build" in 174 ms

[DEBUG] [org.jboss.protean.arc.processor.BeanDeployment] Bean deployment created in 52 ms
[DEBUG] [org.jboss.protean.arc.processor.BeanDeployment] Bean deployment initialized in 8 ms
[DEBUG] [org.jboss.protean.arc.processor.BeanProcessor] Generated 31 resources in 57 ms
[DEBUG] [org.jboss.builder] Finished step "org.jboss.shamrock.arc.deployment.ArcAnnotationProcessor.build" in 193 ms
```
So the build is a bit faster and we generate 22 classes less.