### PR TITLE
Skip shamrock:dev on projects that do not have the build goal configured

### DIFF
--- a/maven/src/main/java/org/jboss/shamrock/maven/CreateProjectMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/CreateProjectMojo.java
@@ -54,9 +54,7 @@ public class CreateProjectMojo extends AbstractMojo {
     public static final String VERSION_PROP = "shamrock-version";
     public static final String PLUGIN_VERSION_PROPERTY_NAME = "shamrock.version";
     public static final String PLUGIN_VERSION_PROPERTY = "${" + PLUGIN_VERSION_PROPERTY_NAME + "}";
-    public static final String PLUGIN_GROUPID = "org.jboss.shamrock";
-    public static final String PLUGIN_ARTIFACTID = "shamrock-maven-plugin";
-    public static final String PLUGIN_KEY = PLUGIN_GROUPID + ":" + PLUGIN_ARTIFACTID;
+    public static final String PLUGIN_KEY = MavenConstants.PLUGIN_GROUPID + ":" + MavenConstants.PLUGIN_ARTIFACTID;
 
     /**
      * The Maven project which will define and configure the shamrock-maven-plugin
@@ -139,7 +137,7 @@ public class CreateProjectMojo extends AbstractMojo {
     private void addBom(Model model) {
         Dependency bom = new Dependency();
         bom.setArtifactId(MojoUtils.get("bom-artifactId"));
-        bom.setGroupId(PLUGIN_GROUPID);
+        bom.setGroupId(MavenConstants.PLUGIN_GROUPID);
         bom.setVersion("${shamrock.version}");
         bom.setType("pom");
         bom.setScope("import");
@@ -166,7 +164,7 @@ public class CreateProjectMojo extends AbstractMojo {
         Profile profile = new Profile();
         profile.setId("native");
         BuildBase buildBase = new BuildBase();
-        Plugin plg = plugin(PLUGIN_GROUPID, PLUGIN_ARTIFACTID, PLUGIN_VERSION_PROPERTY);
+        Plugin plg = plugin(MavenConstants.PLUGIN_GROUPID, MavenConstants.PLUGIN_ARTIFACTID, PLUGIN_VERSION_PROPERTY);
         PluginExecution exec = new PluginExecution();
         exec.addGoal("native-image");
         MojoUtils.Element element = new MojoUtils.Element("enableHttpUrlHandler", "true");
@@ -178,13 +176,13 @@ public class CreateProjectMojo extends AbstractMojo {
     }
 
     private void addMainPluginConfig(Model model) {
-        Plugin plugin = plugin(PLUGIN_GROUPID, PLUGIN_ARTIFACTID, PLUGIN_VERSION_PROPERTY);
+        Plugin plugin = plugin(MavenConstants.PLUGIN_GROUPID, MavenConstants.PLUGIN_ARTIFACTID, PLUGIN_VERSION_PROPERTY);
         if (isParentPom(model)) {
             addPluginManagementSection(model, plugin);
             //strip the shamrockVersion off
-            plugin = plugin(PLUGIN_GROUPID, PLUGIN_ARTIFACTID);
+            plugin = plugin(MavenConstants.PLUGIN_GROUPID, MavenConstants.PLUGIN_ARTIFACTID);
         } else {
-            plugin = plugin(PLUGIN_GROUPID, PLUGIN_ARTIFACTID, PLUGIN_VERSION_PROPERTY);
+            plugin = plugin(MavenConstants.PLUGIN_GROUPID, MavenConstants.PLUGIN_ARTIFACTID, PLUGIN_VERSION_PROPERTY);
         }
         PluginExecution pluginExec = new PluginExecution();
         pluginExec.addGoal("build");

--- a/maven/src/main/java/org/jboss/shamrock/maven/DevMojo.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/DevMojo.java
@@ -33,6 +33,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
@@ -107,6 +109,24 @@ public class DevMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
+
+        boolean found = false;
+        for(Plugin i : project.getBuildPlugins()) {
+            if(i.getGroupId().equals(MavenConstants.PLUGIN_GROUPID)
+                    && i.getArtifactId().equals(MavenConstants.PLUGIN_ARTIFACTID)) {
+                for(PluginExecution p : i.getExecutions()) {
+                    if(p.getGoals().contains("build")) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if(!found) {
+            getLog().warn("The shamrock-maven-plugin build goal was not configured for this project, skipping shamrock:dev as this is assumed to be a support library. If you want to run shamrock dev on this project make sure the shamrock-maven-plugin is configured with a build goal.");
+            return;
+        }
+
         if (! sourceDir.isDirectory()) {
             throw new MojoFailureException("The `src/main/java` directory is required, please create it.");
         }

--- a/maven/src/main/java/org/jboss/shamrock/maven/MavenConstants.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/MavenConstants.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.maven;
+
+public class MavenConstants {
+
+    public static final String PLUGIN_GROUPID = "org.jboss.shamrock";
+    public static final String PLUGIN_ARTIFACTID = "shamrock-maven-plugin";
+
+    private MavenConstants() {
+
+    }
+}

--- a/maven/src/main/java/org/jboss/shamrock/maven/components/dependencies/Extensions.java
+++ b/maven/src/main/java/org/jboss/shamrock/maven/components/dependencies/Extensions.java
@@ -43,7 +43,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 
-import static org.jboss.shamrock.maven.CreateProjectMojo.PLUGIN_GROUPID;
+import static org.jboss.shamrock.maven.MavenConstants.PLUGIN_GROUPID;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>

--- a/maven/src/test/java/org/jboss/shamrock/maven/it/CreateProjectMojoIT.java
+++ b/maven/src/test/java/org/jboss/shamrock/maven/it/CreateProjectMojoIT.java
@@ -7,6 +7,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.shared.invoker.*;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.jboss.shamrock.maven.MavenConstants;
 import org.jboss.shamrock.maven.CreateProjectMojo;
 import org.jboss.shamrock.maven.it.verifier.RunningInvoker;
 import org.jboss.shamrock.maven.utilities.MojoUtils;
@@ -102,7 +103,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         setup(new Properties());
         assertThat(new File(testDir, "pom.xml")).isFile();
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
-                .contains(CreateProjectMojo.PLUGIN_ARTIFACTID, CreateProjectMojo.PLUGIN_VERSION_PROPERTY, CreateProjectMojo.PLUGIN_GROUPID);
+                .contains(MavenConstants.PLUGIN_ARTIFACTID, CreateProjectMojo.PLUGIN_VERSION_PROPERTY, MavenConstants.PLUGIN_GROUPID);
         assertThat(new File(testDir, "src/main/java")).isDirectory();
 
         assertThat(new File(testDir, "src/main/resources/META-INF/microprofile-config.properties")).doesNotExist();

--- a/maven/src/test/java/org/jboss/shamrock/maven/it/MojoTestBase.java
+++ b/maven/src/test/java/org/jboss/shamrock/maven/it/MojoTestBase.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.shared.utils.StringUtils;
+import org.jboss.shamrock.maven.MavenConstants;
 import org.jboss.shamrock.maven.CreateProjectMojo;
 import org.jboss.shamrock.maven.utilities.MojoUtils;
 import org.junit.BeforeClass;
@@ -34,8 +35,8 @@ public class MojoTestBase {
         assertThat(VERSION).isNotNull();
 
         VARIABLES = ImmutableMap.of(
-                "@project.groupId@", CreateProjectMojo.PLUGIN_GROUPID,
-                "@project.artifactId@", CreateProjectMojo.PLUGIN_ARTIFACTID,
+                "@project.groupId@", MavenConstants.PLUGIN_GROUPID,
+                "@project.artifactId@", MavenConstants.PLUGIN_ARTIFACTID,
                 "@project.version@", VERSION,
                 "@rest-assured.version@", MojoUtils.get("restAssuredVersion"));
     }
@@ -95,18 +96,18 @@ public class MojoTestBase {
     }
 
     public static void installPluginToLocalRepository(File local) {
-        File repo = new File(local, CreateProjectMojo.PLUGIN_GROUPID.replace(".", "/") + "/"
-                + CreateProjectMojo.PLUGIN_ARTIFACTID + "/" + MojoTestBase.VERSION);
+        File repo = new File(local, MavenConstants.PLUGIN_GROUPID.replace(".", "/") + "/"
+                + MavenConstants.PLUGIN_ARTIFACTID + "/" + MojoTestBase.VERSION);
         if (!repo.isDirectory()) {
             boolean mkdirs = repo.mkdirs();
             Logger.getLogger(MojoTestBase.class.getName())
                     .log(Level.FINE, repo.getAbsolutePath() + " created? " + mkdirs);
         }
 
-        File plugin = new File("target", CreateProjectMojo.PLUGIN_ARTIFACTID + "-" + MojoTestBase.VERSION + ".jar");
+        File plugin = new File("target", MavenConstants.PLUGIN_ARTIFACTID + "-" + MojoTestBase.VERSION + ".jar");
         if (!plugin.isFile()) {
             File[] files = new File("target").listFiles(
-                    file -> file.getName().startsWith(CreateProjectMojo.PLUGIN_ARTIFACTID) && file.getName().endsWith(".jar"));
+                    file -> file.getName().startsWith(MavenConstants.PLUGIN_ARTIFACTID) && file.getName().endsWith(".jar"));
             if (files != null && files.length != 0) {
                 plugin = files[0];
             }
@@ -114,7 +115,7 @@ public class MojoTestBase {
 
         try {
             FileUtils.copyFileToDirectory(plugin, repo);
-            String installedPomName = CreateProjectMojo.PLUGIN_ARTIFACTID + "-" + MojoTestBase.VERSION + ".pom";
+            String installedPomName = MavenConstants.PLUGIN_ARTIFACTID + "-" + MojoTestBase.VERSION + ".pom";
             FileUtils.copyFile(new File("pom.xml"), new File(repo, installedPomName));
         } catch (IOException e) {
             throw new RuntimeException("Cannot copy the plugin jar, or the pom file, to the local repository", e);

--- a/maven/src/test/java/org/jboss/shamrock/maven/it/assertions/SetupVerifier.java
+++ b/maven/src/test/java/org/jboss/shamrock/maven/it/assertions/SetupVerifier.java
@@ -6,6 +6,7 @@ import org.apache.maven.model.Profile;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jboss.shamrock.maven.MavenConstants;
 import org.jboss.shamrock.maven.CreateProjectMojo;
 import org.jboss.shamrock.maven.utilities.MojoUtils;
 
@@ -58,8 +59,8 @@ public class SetupVerifier {
         // Check plugin is set
         Plugin plugin = maybe.orElseThrow(() -> new AssertionError("Plugin expected"));
         assertThat(plugin).isNotNull().satisfies(p -> {
-            assertThat(p.getArtifactId()).isEqualTo(CreateProjectMojo.PLUGIN_ARTIFACTID);
-            assertThat(p.getGroupId()).isEqualTo(CreateProjectMojo.PLUGIN_GROUPID);
+            assertThat(p.getArtifactId()).isEqualTo(MavenConstants.PLUGIN_ARTIFACTID);
+            assertThat(p.getGroupId()).isEqualTo(MavenConstants.PLUGIN_GROUPID);
             assertThat(p.getVersion()).isEqualTo(CreateProjectMojo.PLUGIN_VERSION_PROPERTY);
         });
 


### PR DESCRIPTION
This allows Shamrock to work in multi-module project, the dev goal will only
be run for the actual shamrock app, not parent poms or support libraries.