### PR TITLE
Fixes #575, make the resource leak detector initialized at runtime

### DIFF
--- a/extensions/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
@@ -55,7 +55,7 @@ class VertxProcessor {
                 .addRuntimeInitializedClass("io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
-
+                .addNativeImageSystemProperty("io.netty.leakDetection.level", "DISABLED") //TODO: make configurable
                 .build();
     }
 


### PR DESCRIPTION
Otherwise if a buffer was registered with the leak detector it is possible
for the native image build to fail randomly