### PR TITLE
Unused code removal, Map.Entry usage, static inner classes

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/recording/BytecodeRecorderImpl.java
@@ -607,7 +607,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
         }
     }
 
-    class ProxyInstance {
+    private static final class ProxyInstance {
         final Object proxy;
         final String key;
 

--- a/extensions/jpa/runtime/src/main/java/org/jboss/shamrock/jpa/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/jpa/runtime/src/main/java/org/jboss/shamrock/jpa/runtime/FastBootHibernatePersistenceProvider.java
@@ -123,7 +123,6 @@ final class FastBootHibernatePersistenceProvider implements PersistenceProvider 
                 persistenceUnitName);
 
         verifyProperties(properties);
-        Map integration = Collections.emptyMap();
 
         // These are pre-parsed during image generation:
         final List<PersistenceUnitDescriptor> units = PersistenceUnitsHolder.getPersistenceUnitDescriptors();

--- a/independent-projects/gizmo/src/main/java/org/jboss/protean/gizmo/FunctionCreatorImpl.java
+++ b/independent-projects/gizmo/src/main/java/org/jboss/protean/gizmo/FunctionCreatorImpl.java
@@ -122,7 +122,7 @@ class FunctionCreatorImpl implements FunctionCreator {
                     FieldCreator field = functionCreator.classCreator.getFieldCreator(name, handle.getType());
                     field.setModifiers(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL);
                     ResultHandle sub = super.readInstanceField(field.getFieldDescriptor(), getMethod().getThis());
-                    capture = functionCreator.new CapturedResultHandle(sub, field.getFieldDescriptor());
+                    capture = new CapturedResultHandle(sub, field.getFieldDescriptor());
                     functionCreator.capturedResultHandles.put(handle, capture);
                     return sub;
                 }
@@ -172,7 +172,7 @@ class FunctionCreatorImpl implements FunctionCreator {
         }
     }
 
-    private final class CapturedResultHandle {
+    private static final class CapturedResultHandle {
         final ResultHandle substitute;
         final FieldDescriptor descriptor;
 


### PR DESCRIPTION
Unused code removal - private method + unused empty map

Map.Entry usage is more efficient than iterating through keySet() & calling map.get(key)

static inner classes to avoid reference to the owner object