### PR TITLE
Remove a duplicated dependency in the Agroal deployment artifact

### DIFF
--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -44,10 +44,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-transactions-deployment</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
It causes a big warning to be displayed when launching `mvn clean install`.