### PR TITLE
Log the stop-time in seconds aligned with start time.

### DIFF
--- a/core/runtime/src/main/java/org/jboss/shamrock/runtime/Application.java
+++ b/core/runtime/src/main/java/org/jboss/shamrock/runtime/Application.java
@@ -147,15 +147,14 @@ public abstract class Application {
         } finally {
             stateLock.unlock();
         }
-        final long mark = System.nanoTime();
+        Timing.staticInitStopped();
         try {
             doStop();
         } finally {
             stateLock.lock();
             try {
                 state = ST_STOPPED;
-                final long time = System.nanoTime() - mark;
-                Logger.getLogger("org.jboss.shamrock").infof("Shamrock stopped in %d.%03dms", Long.valueOf(time / 1_000_000), Long.valueOf(time % 1_000_000 / 1_000));
+                Timing.printStopTime();
                 stateCond.signalAll();
             } finally {
                 stateLock.unlock();

--- a/core/runtime/src/main/java/org/jboss/shamrock/runtime/Timing.java
+++ b/core/runtime/src/main/java/org/jboss/shamrock/runtime/Timing.java
@@ -30,9 +30,17 @@ public class Timing {
 
     private static volatile long bootStartTime = -1;
 
+    private static volatile long bootStopTime = -1;
+
     public static void staticInitStarted() {
         if (bootStartTime < 0) {
             bootStartTime = System.nanoTime();
+        }
+    }
+
+    public static void staticInitStopped() {
+        if (bootStopTime < 0) {
+            bootStopTime = System.nanoTime();
         }
     }
 
@@ -50,12 +58,23 @@ public class Timing {
         final long bootTimeNanoSeconds = System.nanoTime() - bootStartTime;
         final Logger logger = Logger.getLogger("org.jboss.shamrock");
         //Use a BigDecimal so we can render in seconds with 3 digits precision, as requested:
-        final BigDecimal secondsRepresentation = BigDecimal
-              .valueOf(bootTimeNanoSeconds) // As nanoseconds
-              .divide(BigDecimal.valueOf(1_000_000), BigDecimal.ROUND_HALF_UP) // Convert to milliseconds, discard remaining digits while rounding
-              .divide(BigDecimal.valueOf(1_000), 3, BigDecimal.ROUND_HALF_UP); // Convert to seconds, while preserving 3 digits
+        final BigDecimal secondsRepresentation = convertToBigDecimalSeconds(bootTimeNanoSeconds);
         logger.infof("Shamrock %s started in %ss. %s", version, secondsRepresentation, httpServer);
         logger.infof("Installed features: [%s]", features);
+    }
+
+    public static void printStopTime() {
+        final long stopTimeNanoSeconds = System.nanoTime() - bootStopTime;
+        final Logger logger = Logger.getLogger("org.jboss.shamrock");
+        final BigDecimal secondsRepresentation = convertToBigDecimalSeconds(stopTimeNanoSeconds);
+        logger.infof("Shamrock stopped in %ss", secondsRepresentation);
+    }
+
+    private static BigDecimal convertToBigDecimalSeconds (final long timeNanoSeconds) {
+        final BigDecimal secondsRepresentation = BigDecimal.valueOf(timeNanoSeconds) // As nanoseconds
+              .divide(BigDecimal.valueOf(1_000_000), BigDecimal.ROUND_HALF_UP) // Convert to milliseconds, discard remaining digits while rounding
+              .divide(BigDecimal.valueOf(1_000), 3, BigDecimal.ROUND_HALF_UP); // Convert to seconds, while preserving 3 digits
+        return secondsRepresentation;
     }
 
 }


### PR DESCRIPTION
Resolves issue #628 

Aligns the time format with the Start time.