### PR TITLE
Generate extensions.json

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -163,13 +163,23 @@
             </exclusions>
          </dependency>
          <dependency>
-            <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-caffeine-deployment</artifactId>
-            <version>${project.version}</version>
+             <groupId>org.jboss.shamrock</groupId>
+             <artifactId>shamrock-caffeine-deployment</artifactId>
+             <version>${project.version}</version>
+         </dependency>
+         <dependency>
+             <groupId>org.jboss.shamrock</groupId>
+             <artifactId>shamrock-caffeine-runtime</artifactId>
+             <version>${project.version}</version>
+         </dependency>
+         <dependency>
+             <groupId>org.jboss.shamrock</groupId>
+             <artifactId>cli-common</artifactId>
+             <version>${project.version}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-caffeine-runtime</artifactId>
+            <artifactId>common-core</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -179,7 +179,7 @@
          </dependency>
          <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>common-core</artifactId>
+            <artifactId>cli-common-core</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>

--- a/cli/aesh/src/main/java/org/jboss/shamrock/cli/commands/AddExtensionCommand.java
+++ b/cli/aesh/src/main/java/org/jboss/shamrock/cli/commands/AddExtensionCommand.java
@@ -13,6 +13,7 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 import org.aesh.io.Resource;
 import org.jboss.shamrock.dependencies.Extension;
+import org.jboss.shamrock.maven.utilities.MojoUtils;
 
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
@@ -56,7 +57,7 @@ public class AddExtensionCommand implements Command<CommandInvocation>{
     }
 
     private boolean findExtension(String name) {
-        for(Extension ext : AddExtensions.get()) {
+        for(Extension ext : MojoUtils.loadExtensions()) {
             if(ext.getName().equalsIgnoreCase(name))
                 return true;
         }

--- a/cli/aesh/src/main/java/org/jboss/shamrock/cli/commands/ListExtensionsCommand.java
+++ b/cli/aesh/src/main/java/org/jboss/shamrock/cli/commands/ListExtensionsCommand.java
@@ -9,6 +9,7 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Arguments;
 import org.aesh.command.option.Option;
 import org.jboss.shamrock.dependencies.Extension;
+import org.jboss.shamrock.maven.utilities.MojoUtils;
 
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
@@ -30,13 +31,13 @@ public class ListExtensionsCommand implements Command <CommandInvocation>{
             commandInvocation.println(commandInvocation.getHelpInfo("protean list-extensions"));
         }
         else if(name) {
-            for(Extension ext : AddExtensions.get()) {
+            for(Extension ext : MojoUtils.loadExtensions()) {
                 commandInvocation.println(ext.getName());
             }
 
         }
         else {
-            for(Extension ext : AddExtensions.get()) {
+            for(Extension ext : MojoUtils.loadExtensions()) {
                 commandInvocation.println(
                         ext.getName()+ " ("+ext.getGroupId()+":"+ext.getArtifactId()+":"+ext.getVersion()+")");
             }

--- a/cli/common-core/pom.xml
+++ b/cli/common-core/pom.xml
@@ -26,8 +26,8 @@
         <version>1.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>common-core</artifactId>
-    <name>Shamrock - Common Core</name>
+    <artifactId>cli-common-core</artifactId>
+    <name>Shamrock - CLI Common Core</name>
 
     <dependencies>
         <dependency>

--- a/cli/common-core/pom.xml
+++ b/cli/common-core/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright (c) 2019 Red Hat, Inc.
+  ~
+  ~  Red Hat licenses this file to you under the Apache License, version
+  ~  2.0 (the "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~  implied.  See the License for the specific language governing
+  ~  permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.shamrock</groupId>
+        <artifactId>shamrock-cli-all</artifactId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>common-core</artifactId>
+    <name>Shamrock - Common Core</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/cli/common-core/src/main/java/org/jboss/shamrock/dependencies/Extension.java
+++ b/cli/common-core/src/main/java/org/jboss/shamrock/dependencies/Extension.java
@@ -167,12 +167,12 @@ public class Extension {
         return dependency;
     }
 
-    public String ga() {
+    public String managementKey() {
         return getGroupId() + ":" + getArtifactId();
     }
 
     public String gav() {
-        return ga() + ":" + version;
+        return managementKey() + ":" + version;
     }
 
     @Override

--- a/cli/common-core/src/main/java/org/jboss/shamrock/dependencies/Extension.java
+++ b/cli/common-core/src/main/java/org/jboss/shamrock/dependencies/Extension.java
@@ -17,7 +17,6 @@
 package org.jboss.shamrock.dependencies;
 
 import org.apache.maven.model.Dependency;
-import org.jboss.shamrock.maven.utilities.MojoUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,24 +25,32 @@ import java.util.stream.Stream;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ * @author <a href="http://kenfinnigan.me">Ken Finnigan</a>
  */
 public class Extension {
 
     private String artifactId;
     private String groupId;
     private String scope;
-    private String version = MojoUtils.SHAMROCK_VERSION_PROPERTY;
+    private String version;
 
     private String type;
     private String classifier;
 
     private String name;
+    private String description;
+    private boolean internal = false;
     private String[] labels;
 
     public Extension() {
         // Use by mapper.
     }
 
+    public Extension(String groupId, String artifactId, String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
 
     public String getArtifactId() {
         return artifactId;
@@ -117,6 +124,24 @@ public class Extension {
         return this;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public Extension setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public boolean isInternal() {
+        return internal;
+    }
+
+    public Extension setInternal(boolean internal) {
+        this.internal = internal;
+        return this;
+    }
+
     public List<String> labels() {
         List<String> list = new ArrayList<>();
         if (labels != null) {
@@ -142,8 +167,69 @@ public class Extension {
         return dependency;
     }
 
-    public String toCoordinates() {
+    public String ga() {
         return getGroupId() + ":" + getArtifactId();
     }
-}
 
+    public String gav() {
+        return ga() + ":" + version;
+    }
+
+    @Override
+    public String toString() {
+        return gav();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
+        result = prime * result + ((artifactId == null) ? 0 : artifactId.hashCode());
+        result = prime * result + ((version == null) ? 0 : version.hashCode());
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        Extension other = (Extension) obj;
+        if (groupId == null) {
+            if (other.groupId != null) {
+                return false;
+            }
+        } else if (!groupId.equals(other.groupId)) {
+            return false;
+        }
+
+        if (artifactId == null) {
+            if (other.artifactId != null) {
+                return false;
+            }
+        } else if (!artifactId.equals(other.artifactId)) {
+            return false;
+        }
+
+        if (version == null) {
+            if (other.version != null) {
+                return false;
+            }
+        } else if (!version.equals(other.version)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/cli/common/pom.xml
+++ b/cli/common/pom.xml
@@ -51,7 +51,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>common-core</artifactId>
+            <artifactId>cli-common-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/cli/common/pom.xml
+++ b/cli/common/pom.xml
@@ -31,13 +31,27 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.shamrock</groupId>
+                <artifactId>shamrock-extension-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-extension-list</id>
+                        <goals>
+                            <goal>extension-list</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>3.5.4</version>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>common-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/cli/common/src/main/java/org/jboss/shamrock/cli/commands/AddExtensions.java
+++ b/cli/common/src/main/java/org/jboss/shamrock/cli/commands/AddExtensions.java
@@ -5,7 +5,6 @@ import static org.jboss.shamrock.maven.utilities.MojoUtils.readPom;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -15,10 +14,6 @@ import org.apache.maven.model.Model;
 import org.jboss.shamrock.dependencies.Extension;
 import org.jboss.shamrock.maven.utilities.MojoUtils;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class AddExtensions {
     private Model model;
     private File pom;
@@ -26,20 +21,6 @@ public class AddExtensions {
     public AddExtensions(final File pom) throws IOException {
         this.model = MojoUtils.readPom(pom);
         this.pom = pom;
-    }
-
-    public static List<Extension> get() {
-        ObjectMapper mapper = new ObjectMapper()
-                .enable(JsonParser.Feature.ALLOW_COMMENTS)
-                .enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS);
-        URL url = AddExtensions.class.getClassLoader().getResource("extensions.json");
-        try {
-            return mapper.readValue(url, new TypeReference<List<Extension>>() {
-                // Do nothing.
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to load the extensions.json file", e);
-        }
     }
 
     public boolean addExtensions(final Set<String> extensions) throws IOException {
@@ -65,13 +46,13 @@ public class AddExtensions {
                 final Extension extension = optional.get();
 
                 if (!MojoUtils.hasDependency(model, extension.getGroupId(), extension.getArtifactId())) {
-                    System.out.println("Adding extension " + extension.toCoordinates());
+                    System.out.println("Adding extension " + extension.ga());
                     model.addDependency(extension
                                             .toDependency(containsBOM(model) &&
                                                           isDefinedInBom(dependenciesFromBom, extension)));
                     updated = true;
                 } else {
-                    System.out.println("Skipping extension " + extension.toCoordinates() + ": already present");
+                    System.out.println("Skipping extension " + extension.ga() + ": already present");
                 }
             } else if (dependency.contains(":")) {
                 Dependency parsed = MojoUtils.parse(dependency);

--- a/cli/common/src/main/java/org/jboss/shamrock/cli/commands/AddExtensions.java
+++ b/cli/common/src/main/java/org/jboss/shamrock/cli/commands/AddExtensions.java
@@ -46,13 +46,13 @@ public class AddExtensions {
                 final Extension extension = optional.get();
 
                 if (!MojoUtils.hasDependency(model, extension.getGroupId(), extension.getArtifactId())) {
-                    System.out.println("Adding extension " + extension.ga());
+                    System.out.println("Adding extension " + extension.managementKey());
                     model.addDependency(extension
                                             .toDependency(containsBOM(model) &&
                                                           isDefinedInBom(dependenciesFromBom, extension)));
                     updated = true;
                 } else {
-                    System.out.println("Skipping extension " + extension.ga() + ": already present");
+                    System.out.println("Skipping extension " + extension.managementKey() + ": already present");
                 }
             } else if (dependency.contains(":")) {
                 Dependency parsed = MojoUtils.parse(dependency);

--- a/cli/common/src/main/java/org/jboss/shamrock/maven/utilities/MojoUtils.java
+++ b/cli/common/src/main/java/org/jboss/shamrock/maven/utilities/MojoUtils.java
@@ -228,8 +228,13 @@ public class MojoUtils {
             ObjectMapper mapper = new ObjectMapper()
                                       .enable(JsonParser.Feature.ALLOW_COMMENTS)
                                       .enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS);
-            return mapper.readValue(MojoUtils.class.getClassLoader().getResourceAsStream("extensions.json"),
-                new TypeReference<List<Extension>>() {});
+            List<Extension> extensions = mapper.readValue(MojoUtils.class.getClassLoader().getResourceAsStream("extensions.json"),
+                    new TypeReference<List<Extension>>() {
+                // Do nothing.
+            });
+            //TODO This is temporary until "extensions.json" is the generated version
+            extensions.forEach(e -> e.setVersion(MojoUtils.SHAMROCK_VERSION_PROPERTY));
+            return extensions;
         } catch (IOException e) {
             throw new RuntimeException("Unable to load the extensions.json file", e);
         }

--- a/cli/extension-plugin/pom.xml
+++ b/cli/extension-plugin/pom.xml
@@ -48,7 +48,7 @@
 
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>common-core</artifactId>
+            <artifactId>cli-common-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/cli/extension-plugin/pom.xml
+++ b/cli/extension-plugin/pom.xml
@@ -54,6 +54,30 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -73,6 +97,54 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <cloneClean>true</cloneClean>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                    <addTestClassPath>true</addTestClassPath>
+                    <skipInvocation>${maven.test.skip}</skipInvocation>
+                    <streamLogs>true</streamLogs>
+                    <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--suppress MavenModelInspection -->
+                        <maven.home>${maven.home}</maven.home>
+                        <maven.repo>${settings.localRepository}</maven.repo>
+                        <project.version>${project.version}</project.version>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/cli/extension-plugin/pom.xml
+++ b/cli/extension-plugin/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-build-parent</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-extension-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Shamrock - Extension plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>common-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/cli/extension-plugin/src/it/settings.xml
+++ b/cli/extension-plugin/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/AbstractExtensionMojo.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/AbstractExtensionMojo.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2019 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.jboss.shamrock.maven;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.*;
+import org.jboss.shamrock.dependencies.Extension;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="http://kenfinnigan.me">Ken Finnigan</a>
+ */
+public abstract class AbstractExtensionMojo extends AbstractMojo {
+
+    @Inject
+    protected MavenSession mavenSession;
+
+    @Inject
+    public ProjectBuilder projectBuilder;
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    public MavenProject project;
+
+    private static List<MavenProject> PROBABLE_EXTENSIONS = null;
+
+    protected synchronized Set<Extension> extensions() throws MojoExecutionException {
+        return probableExtensionProjects()
+                .stream()
+                .map(ExtensionRegistry.INSTANCE::of)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private List<MavenProject> probableExtensionProjects() throws MojoExecutionException {
+        if (null == PROBABLE_EXTENSIONS) {
+            PROBABLE_EXTENSIONS = mavenSession.getAllProjects()
+                    .stream()
+                    .filter(this::isExtension)
+                    .collect(Collectors.toList());
+
+            if (PROBABLE_EXTENSIONS.size() < 5) {
+                getLog().warn("MavenSession does not contain all extensions, rebuilding the project hierarchy directly");
+                buildProjects();
+            }
+        }
+
+        return PROBABLE_EXTENSIONS;
+    }
+
+    private void buildProjects() throws MojoExecutionException {
+        final ProjectBuildingRequest request = new DefaultProjectBuildingRequest();
+        request.setProcessPlugins(false);
+        request.setSystemProperties(System.getProperties());
+        request.setRemoteRepositories(project.getRemoteArtifactRepositories());
+        request.setRepositorySession(mavenSession.getRepositorySession());
+        request.setResolveDependencies(false);
+
+        try {
+            PROBABLE_EXTENSIONS = this.projectBuilder
+                    .build(Collections.singletonList(findRoot(this.project).getFile()), true, request)
+                    .stream()
+                    .map(ProjectBuildingResult::getProject)
+                    .collect(Collectors.toList());
+        } catch (ProjectBuildingException e) {
+            throw new MojoExecutionException("Error generating list of PROBABLE_EXTENSIONS", e);
+        }
+    }
+
+    private MavenProject findRoot(MavenProject current) {
+        if (current.getArtifactId().equals("shamrock-parent")) {
+            return current;
+        }
+        return findRoot(current.getParent());
+    }
+
+    private boolean isExtension(MavenProject project) {
+        return project.getArtifactId().contains("-deployment");
+    }
+}

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/AbstractExtensionMojo.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/AbstractExtensionMojo.java
@@ -97,6 +97,7 @@ public abstract class AbstractExtensionMojo extends AbstractMojo {
     }
 
     private boolean isExtension(MavenProject project) {
+        //TODO Change how we determine what is the "extension" artifact when Toronto model implemented
         return project.getArtifactId().contains("-deployment");
     }
 }

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/ExtensionRegistry.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/ExtensionRegistry.java
@@ -26,10 +26,10 @@ import java.util.Map;
  * @author <a href="http://kenfinnigan.me">Ken Finnigan</a>
  */
 class ExtensionRegistry {
-    private static final String EXTENSION_NAME_PROPERTY_NAME = "extension.name";
-    private static final String EXTENSION_DESC_PROPERTY_NAME = "extension.desc";
-    private static final String EXTENSION_LABELS_PROPERTY_NAME = "extension.labels";
-    private static final String EXTENSION_INTERNAL_PROPERTY_NAME = "extension.internal";
+    private static final String EXTENSION_NAME_PROPERTY_NAME = "shamrock.extension.name";
+    private static final String EXTENSION_DESC_PROPERTY_NAME = "shamrock.extension.desc";
+    private static final String EXTENSION_LABELS_PROPERTY_NAME = "shamrock.extension.labels";
+    private static final String EXTENSION_INTERNAL_PROPERTY_NAME = "shamrock.extension.internal";
 
     private Map<Key, Extension> extensionRegistry = new HashMap<>();
 

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/ExtensionRegistry.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/ExtensionRegistry.java
@@ -77,33 +77,29 @@ class ExtensionRegistry {
     }
 
     private static class Key {
-        private final String groupId;
-        private final String artifactId;
-        private final String version;
+        private final String gav;
 
         Key(String groupId, String artifactId, String version) {
-            this.groupId = groupId;
-            this.artifactId = artifactId;
-            this.version = version;
+            this.gav = groupId + ":" + artifactId + ":" + version;
         }
 
-        String compositeKey() {
-            return this.groupId + ":" + this.artifactId + ":" + this.version;
+        String gav() {
+            return this.gav;
         }
 
         @Override
         public int hashCode() {
-            return compositeKey().hashCode();
+            return gav().hashCode();
         }
 
         @Override
         public boolean equals(Object obj) {
-            return obj instanceof Key && compositeKey().equals(((Key) obj).compositeKey());
+            return obj instanceof Key && gav().equals(((Key) obj).gav());
         }
 
         @Override
         public String toString() {
-            return compositeKey();
+            return gav();
         }
 
         static Key of(MavenProject project) {

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/ExtensionRegistry.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/ExtensionRegistry.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2019 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.jboss.shamrock.maven;
+
+import org.apache.maven.project.MavenProject;
+import org.jboss.shamrock.dependencies.Extension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="http://kenfinnigan.me">Ken Finnigan</a>
+ */
+class ExtensionRegistry {
+    private static final String EXTENSION_NAME_PROPERTY_NAME = "extension.name";
+    private static final String EXTENSION_DESC_PROPERTY_NAME = "extension.desc";
+    private static final String EXTENSION_LABELS_PROPERTY_NAME = "extension.labels";
+    private static final String EXTENSION_INTERNAL_PROPERTY_NAME = "extension.internal";
+
+    private Map<Key, Extension> extensionRegistry = new HashMap<>();
+
+    static final ExtensionRegistry INSTANCE = new ExtensionRegistry();
+
+    private ExtensionRegistry() {
+
+    }
+
+    Extension of(MavenProject project) {
+        if (project == null) {
+            return null;
+        }
+
+        Key key = Key.of(project);
+        if (extensionRegistry.containsKey(key)) {
+            return extensionRegistry.get(key);
+        }
+
+        Extension extension = build(project);
+        extensionRegistry.put(key, extension);
+        return extension;
+    }
+
+    private Extension build(MavenProject project) {
+        Extension extension = new Extension(project.getGroupId(), project.getArtifactId(), project.getVersion());
+
+        String name = project.getProperties().getProperty(EXTENSION_NAME_PROPERTY_NAME);
+        extension.setName(name == null ? project.getName() : name);
+
+        String desc = project.getProperties().getProperty(EXTENSION_DESC_PROPERTY_NAME);
+        extension.setDescription(desc == null ? project.getDescription() : desc);
+
+        String labels = project.getProperties().getProperty(EXTENSION_LABELS_PROPERTY_NAME);
+        if (labels != null) {
+            extension.setLabels(labels.split(","));
+        }
+
+        String internal = project.getProperties().getProperty(EXTENSION_INTERNAL_PROPERTY_NAME);
+        if (internal != null && internal.equals("true")) {
+            extension.setInternal(true);
+        }
+
+        return extension;
+    }
+
+    private static class Key {
+        private final String groupId;
+        private final String artifactId;
+        private final String version;
+
+        Key(String groupId, String artifactId, String version) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.version = version;
+        }
+
+        String compositeKey() {
+            return this.groupId + ":" + this.artifactId + ":" + this.version;
+        }
+
+        @Override
+        public int hashCode() {
+            return compositeKey().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof Key && compositeKey().equals(((Key) obj).compositeKey());
+        }
+
+        @Override
+        public String toString() {
+            return compositeKey();
+        }
+
+        static Key of(MavenProject project) {
+            return new Key(project.getGroupId(), project.getArtifactId(), project.getVersion());
+        }
+    }
+}

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/extensionlist/ExtensionListMojo.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/extensionlist/ExtensionListMojo.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2019 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.jboss.shamrock.maven.extensionlist;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.jboss.shamrock.dependencies.Extension;
+import org.jboss.shamrock.maven.AbstractExtensionMojo;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * @author <a href="http://kenfinnigan.me">Ken Finnigan</a>
+ */
+@Mojo(
+        name = "extension-list",
+        defaultPhase = LifecyclePhase.GENERATE_RESOURCES,
+        requiresDependencyCollection = ResolutionScope.COMPILE,
+        requiresDependencyResolution = ResolutionScope.COMPILE
+)
+public class ExtensionListMojo extends AbstractExtensionMojo {
+
+    private static final String FILE_NAME = "extension-list";
+
+    @Parameter(defaultValue = "${project.version}", readonly = true)
+    private String version;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Set<Extension> extensions = extensions();
+
+        generateJSON(extensions);
+        generateJavascript(extensions);
+    }
+
+    private void generateJSON(Set<Extension> extensions) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        File outFile = new File(this.project.getBuild().getOutputDirectory(), FILE_NAME + ".json");
+
+        outFile.getParentFile().mkdirs();
+
+        try {
+            mapper.writeValue(outFile, extensions);
+        } catch (IOException e) {
+            getLog().error(e);
+        }
+
+        addArtifact("json", outFile);
+    }
+
+    private void generateJavascript(Set<Extension> extensions) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+
+        File outFile = new File(this.project.getBuild().getOutputDirectory(), FILE_NAME + ".js");
+        try (FileWriter writer = new FileWriter(outFile)) {
+            writer.write("version = '" + version + "';");
+            writer.write("extensionList = ");
+            mapper.writeValue(writer, extensions);
+            writer.write(";");
+            writer.flush();
+        } catch (IOException e) {
+            getLog().error(e);
+        }
+
+        addArtifact("js", outFile);
+    }
+
+    private void addArtifact(String type, File file) {
+        DefaultArtifact artifact = new DefaultArtifact(
+                this.project.getGroupId(),
+                this.project.getArtifactId(),
+                this.project.getVersion(),
+                "compile",
+                type,
+                "",
+                new DefaultArtifactHandler(type)
+        );
+
+        artifact.setFile(file);
+        this.project.addAttachedArtifact(artifact);
+    }
+}

--- a/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/extensionlist/ExtensionListMojo.java
+++ b/cli/extension-plugin/src/main/java/org/jboss/shamrock/maven/extensionlist/ExtensionListMojo.java
@@ -46,6 +46,7 @@ import java.util.Set;
 )
 public class ExtensionListMojo extends AbstractExtensionMojo {
 
+    //TODO Change file name when we replace the current hand coded file
     private static final String FILE_NAME = "extension-list";
 
     @Parameter(defaultValue = "${project.version}", readonly = true)

--- a/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/ExtensionListIT.java
+++ b/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/ExtensionListIT.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2019 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.jboss.shamrock.maven.it;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.utils.StringUtils;
+import org.jboss.shamrock.maven.it.verifier.MavenProcessInvocationResult;
+import org.jboss.shamrock.maven.it.verifier.RunningInvoker;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExtensionListIT {
+
+    private RunningInvoker running;
+    private File testDir;
+
+    @Test
+    public void testExtensionListCreation() throws MavenInvocationException, IOException, InterruptedException {
+        testDir = initProject();
+
+        running = new RunningInvoker(testDir, false);
+        final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"), Collections.emptyMap());
+
+        assertThat(result.getProcess().waitFor()).isEqualTo(0);
+
+        File jsonFile = new File(new File(testDir, "extension-list/target/classes"), "extension-list.json");
+        assertThat(jsonFile).isFile();
+
+        String data = FileUtils.readFileToString(jsonFile, "UTF-8");
+        assertThat(data).contains("\"artifactId\" : \"dummy-extension-deployment\",");
+        assertThat(data).contains("\"name\" : \"Agroal\",");
+        assertThat(data).contains("\"description\" : \"Description of the Agroal extension\",");
+        assertThat(data).contains("\"labels\" : [ \"agroal\", \"database-connection-pool\", \"jsf\" ]");
+        assertThat(data).contains("\"internal\" : false,");
+    }
+
+
+    static File initProject() {
+        String name = "projects/extension-check";
+        String output = "projects/project-extension-check";
+
+        File tc = new File("target/test-classes");
+        if (!tc.isDirectory()) {
+            boolean mkdirs = tc.mkdirs();
+            Logger.getLogger(ExtensionListIT.class.getName())
+                    .log(Level.FINE, "test-classes created? " + mkdirs);
+        }
+
+        File in = new File("src/test/resources", name);
+        if (!in.isDirectory()) {
+            throw new RuntimeException("Cannot find directory: " + in.getAbsolutePath());
+        }
+
+        File out = new File(tc, output);
+        if (out.isDirectory()) {
+            FileUtils.deleteQuietly(out);
+        }
+        boolean mkdirs = out.mkdirs();
+        Logger.getLogger(ExtensionListIT.class.getName())
+                .log(Level.FINE, out.getAbsolutePath() + " created? " + mkdirs);
+        try {
+            System.out.println("Copying " + in.getAbsolutePath() + " to " + out.getParentFile().getAbsolutePath());
+            org.codehaus.plexus.util.FileUtils.copyDirectoryStructure(in, out);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot copy project resources", e);
+        }
+
+        File extMod = new File(out, "extension-list");
+        if (!extMod.isDirectory()) {
+            boolean dirs = extMod.mkdirs();
+            Logger.getLogger(ExtensionListIT.class.getName())
+                    .log(Level.FINE, "extension-list created? " + dirs);
+        }
+
+        File pom = new File(extMod, "pom.xml");
+        try {
+            filter(pom, ImmutableMap.of("@project.version@", System.getProperty("project.version")));
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return out;
+    }
+
+    static void filter(File input, Map<String, String> variables) throws IOException {
+        assertThat(input).isFile();
+        String data = FileUtils.readFileToString(input, "UTF-8");
+
+        for (Map.Entry<String, String> token : variables.entrySet()) {
+            String value = String.valueOf(token.getValue());
+            data = StringUtils.replace(data, token.getKey(), value);
+        }
+        FileUtils.write(input, data, "UTF-8");
+    }
+
+    public static void installPluginToLocalRepository(File local) {
+        File repo = new File(local, "org.jboss.shamrock/shamrock-extension-plugin/" + System.getProperty("project.version"));
+        if (!repo.isDirectory()) {
+            boolean mkdirs = repo.mkdirs();
+            Logger.getLogger(ExtensionListIT.class.getName())
+                    .log(Level.FINE, repo.getAbsolutePath() + " created? " + mkdirs);
+        }
+
+        File plugin = new File("target", "shamrock-extension-plugin-" + System.getProperty("project.version") + ".jar");
+        if (!plugin.isFile()) {
+            File[] files = new File("target").listFiles(
+                    file -> file.getName().startsWith("shamrock-extension-plugin") && file.getName().endsWith(".jar"));
+            if (files != null && files.length != 0) {
+                plugin = files[0];
+            }
+        }
+
+        try {
+            FileUtils.copyFileToDirectory(plugin, repo);
+            String installedPomName = "shamrock-extension-plugin-" + System.getProperty("project.version") + ".pom";
+            FileUtils.copyFile(new File("pom.xml"), new File(repo, installedPomName));
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot copy the plugin jar, or the pom file, to the local repository", e);
+        }
+    }
+}

--- a/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/ExtensionListIT.java
+++ b/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/ExtensionListIT.java
@@ -118,7 +118,7 @@ public class ExtensionListIT {
     }
 
     public static void installPluginToLocalRepository(File local) {
-        File repo = new File(local, "org.jboss.shamrock/shamrock-extension-plugin/" + System.getProperty("project.version"));
+        File repo = new File(local, "org/jboss/shamrock/shamrock-extension-plugin/" + System.getProperty("project.version"));
         if (!repo.isDirectory()) {
             boolean mkdirs = repo.mkdirs();
             Logger.getLogger(ExtensionListIT.class.getName())

--- a/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/verifier/MavenProcessInvocationResult.java
+++ b/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/verifier/MavenProcessInvocationResult.java
@@ -1,0 +1,60 @@
+package org.jboss.shamrock.maven.it.verifier;
+
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.utils.cli.CommandLineException;
+
+/**
+ * Result of {@link MavenProcessInvoker#execute(InvocationRequest)}. It keeps a reference on the created process.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class MavenProcessInvocationResult implements InvocationResult {
+
+    private Process process;
+    private CommandLineException exception;
+
+    void destroy() {
+        if (process != null) {
+            process.destroy();
+            try {
+                process.waitFor();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                e.printStackTrace();
+            }
+        }
+    }
+
+    MavenProcessInvocationResult setProcess(Process process) {
+        this.process = process;
+        return this;
+    }
+
+    public MavenProcessInvocationResult setException(CommandLineException exception) {
+        // Print the stack trace immediately to give some feedback early
+        // In intellij, the used `mvn` executable is not "executable" by default on Mac and probably linux.
+        // You need to chmod +x the file.
+        exception.printStackTrace();
+        this.exception = exception;
+        return this;
+    }
+
+    @Override
+    public CommandLineException getExecutionException() {
+        return exception;
+    }
+
+    @Override
+    public int getExitCode() {
+        if (process == null) {
+            throw new IllegalStateException("No process");
+        } else {
+            return process.exitValue();
+        }
+    }
+
+    public Process getProcess() {
+        return process;
+    }
+}

--- a/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/verifier/MavenProcessInvoker.java
+++ b/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/verifier/MavenProcessInvoker.java
@@ -1,0 +1,111 @@
+package org.jboss.shamrock.maven.it.verifier;
+
+import org.apache.maven.shared.invoker.*;
+import org.apache.maven.shared.utils.cli.CommandLineException;
+import org.apache.maven.shared.utils.cli.Commandline;
+import org.apache.maven.shared.utils.cli.StreamConsumer;
+import org.apache.maven.shared.utils.cli.StreamPumper;
+
+import java.io.File;
+
+/**
+ * An implementation of {@link DefaultInvoker} launching Maven, but does not wait for the termination of the process.
+ * The launched process is passed in the {@link InvocationResult}.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class MavenProcessInvoker extends DefaultInvoker {
+
+    private static final InvocationOutputHandler DEFAULT_OUTPUT_HANDLER = new SystemOutHandler();
+
+    private InvocationOutputHandler outputHandler = DEFAULT_OUTPUT_HANDLER;
+
+    private InvocationOutputHandler errorHandler = DEFAULT_OUTPUT_HANDLER;
+
+    @Override
+    public InvocationResult execute(InvocationRequest request) throws MavenInvocationException {
+        MavenCommandLineBuilder cliBuilder = new MavenCommandLineBuilder();
+
+        InvokerLogger logger = getLogger();
+        if (logger != null) {
+            cliBuilder.setLogger(getLogger());
+        }
+
+        File localRepo = getLocalRepositoryDirectory();
+        if (localRepo != null) {
+            cliBuilder.setLocalRepositoryDirectory(getLocalRepositoryDirectory());
+        }
+
+        File mavenHome = getMavenHome();
+        if (mavenHome != null) {
+            cliBuilder.setMavenHome(getMavenHome());
+        }
+
+        File mavenExecutable = getMavenExecutable();
+        if (mavenExecutable != null) {
+            cliBuilder.setMavenExecutable(mavenExecutable);
+        }
+
+        File workingDirectory = getWorkingDirectory();
+        if (workingDirectory != null) {
+            cliBuilder.setWorkingDirectory(getWorkingDirectory());
+        }
+
+        request.setBatchMode(true);
+
+        Commandline cli;
+        try {
+            cli = cliBuilder.build(request);
+        } catch (CommandLineConfigurationException e) {
+            throw new MavenInvocationException("Error configuring command-line. Reason: " + e.getMessage(), e);
+        }
+
+        MavenProcessInvocationResult result = new MavenProcessInvocationResult();
+
+        try {
+            Process process = executeCommandLine(cli, request);
+            result.setProcess(process);
+        } catch (CommandLineException e) {
+            result.setException(e);
+        }
+
+        return result;
+    }
+
+    private Process executeCommandLine(Commandline cli, InvocationRequest request)
+            throws CommandLineException {
+        InvocationOutputHandler outputHandler = request.getOutputHandler(this.outputHandler);
+        InvocationOutputHandler errorHandler = request.getErrorHandler(this.errorHandler);
+        return executeCommandLine(cli, outputHandler, errorHandler);
+    }
+
+
+    private static Process executeCommandLine(Commandline cl, StreamConsumer systemOut, StreamConsumer systemErr)
+            throws CommandLineException {
+        if (cl == null) {
+            throw new IllegalArgumentException("the command line cannot be null.");
+        } else {
+            final Process p = cl.execute();
+            final StreamPumper outputPumper = new StreamPumper(p.getInputStream(), systemOut);
+            final StreamPumper errorPumper = new StreamPumper(p.getErrorStream(), systemErr);
+
+            outputPumper.start();
+            errorPumper.start();
+
+            new Thread(() -> {
+                try {
+                    // Wait for termination
+                    p.waitFor();
+                    outputPumper.waitUntilDone();
+                    errorPumper.waitUntilDone();
+                } catch (Exception e) {
+                    outputPumper.disable();
+                    errorPumper.disable();
+                    e.printStackTrace();
+                }
+            }).start();
+
+            return p;
+        }
+    }
+}

--- a/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/verifier/RunningInvoker.java
+++ b/cli/extension-plugin/src/test/java/org/jboss/shamrock/maven/it/verifier/RunningInvoker.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2019 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.jboss.shamrock.maven.it.verifier;
+
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.shared.invoker.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.jboss.shamrock.maven.it.ExtensionListIT.installPluginToLocalRepository;
+
+/**
+ * Implementation of verifier using a forked process that is still running while verifying. The process is stop when
+ * {@link RunningInvoker#stop()} is called.
+ */
+public class RunningInvoker extends MavenProcessInvoker {
+
+    private final boolean debug;
+    private MavenProcessInvocationResult result;
+    private final File log;
+    private final PrintStreamHandler logHandler;
+
+    public RunningInvoker(File basedir, boolean debug) throws FileNotFoundException {
+        this.debug = debug;
+        setWorkingDirectory(basedir);
+        String repo = System.getProperty("maven.repo");
+        if (repo == null) {
+            repo = new File(System.getProperty("user.home"), ".m2/repository").getAbsolutePath();
+        }
+        installPluginToLocalRepository(new File(repo));
+        setLocalRepositoryDirectory(new File(repo));
+        log = new File(basedir, "build-" + basedir.getName() + ".log");
+        PrintStream stream = new PrintStream(log);
+        logHandler = new PrintStreamHandler(stream, true);
+        setErrorHandler(logHandler);
+        setOutputHandler(logHandler);
+        setLogger(new PrintStreamLogger(stream, InvokerLogger.DEBUG));
+    }
+
+    public MavenProcessInvocationResult execute(List<String> goals, Map<String, String> envVars) throws MavenInvocationException {
+        DefaultInvocationRequest request = new DefaultInvocationRequest();
+        request.setGoals(goals);
+        request.setDebug(debug);
+        request.setLocalRepositoryDirectory(getLocalRepositoryDirectory());
+        request.setBaseDirectory(getWorkingDirectory());
+        request.setPomFile(new File(getWorkingDirectory(), "pom.xml"));
+
+        if (System.getProperty("mavenOpts") != null) {
+            request.setMavenOpts(System.getProperty("mavenOpts"));
+        }
+
+        request.setShellEnvironmentInherited(true);
+        envVars.forEach(request::addShellEnvironment);
+        request.setOutputHandler(logHandler);
+        request.setErrorHandler(logHandler);
+        this.result = (MavenProcessInvocationResult) execute(request);
+        return result;
+    }
+
+    @Override
+    public InvocationResult execute(InvocationRequest request) throws MavenInvocationException {
+        return super.execute(request);
+    }
+
+    public String log() throws IOException {
+        return FileUtils.readFileToString(log, "UTF-8");
+    }
+}

--- a/cli/extension-plugin/src/test/resources/projects/extension-check/dummy-extension-deployment/pom.xml
+++ b/cli/extension-plugin/src/test/resources/projects/extension-check/dummy-extension-deployment/pom.xml
@@ -28,10 +28,10 @@
 
   <artifactId>dummy-extension-deployment</artifactId>
   <properties>
-    <extension.name>Agroal</extension.name>
-    <extension.desc>Description of the Agroal extension</extension.desc>
-    <extension.labels>agroal,database-connection-pool,jsf</extension.labels>
-    <extension.internal>false</extension.internal>
+    <shamrock.extension.name>Agroal</shamrock.extension.name>
+    <shamrock.extension.desc>Description of the Agroal extension</shamrock.extension.desc>
+    <shamrock.extension.labels>agroal,database-connection-pool,jsf</shamrock.extension.labels>
+    <shamrock.extension.internal>false</shamrock.extension.internal>
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/cli/extension-plugin/src/test/resources/projects/extension-check/dummy-extension-deployment/pom.xml
+++ b/cli/extension-plugin/src/test/resources/projects/extension-check/dummy-extension-deployment/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  ~  Copyright (c) 2019 Red Hat, Inc.
+  ~
+  ~  Red Hat licenses this file to you under the Apache License, version
+  ~  2.0 (the "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~  implied.  See the License for the specific language governing
+  ~  permissions and limitations under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>shamrock-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dummy-extension-deployment</artifactId>
+  <properties>
+    <extension.name>Agroal</extension.name>
+    <extension.desc>Description of the Agroal extension</extension.desc>
+    <extension.labels>agroal,database-connection-pool,jsf</extension.labels>
+    <extension.internal>false</extension.internal>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+</project>

--- a/cli/extension-plugin/src/test/resources/projects/extension-check/extension-list/pom.xml
+++ b/cli/extension-plugin/src/test/resources/projects/extension-check/extension-list/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+  ~  Copyright (c) 2019 Red Hat, Inc.
+  ~
+  ~  Red Hat licenses this file to you under the Apache License, version
+  ~  2.0 (the "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~  implied.  See the License for the specific language governing
+  ~  permissions and limitations under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>shamrock-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>extension-list</artifactId>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jboss.shamrock</groupId>
+        <artifactId>shamrock-extension-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>generate-extension-list</id>
+            <goals>
+              <goal>extension-list</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/cli/extension-plugin/src/test/resources/projects/extension-check/pom.xml
+++ b/cli/extension-plugin/src/test/resources/projects/extension-check/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~  Copyright (c) 2019 Red Hat, Inc.
+  ~
+  ~  Red Hat licenses this file to you under the Apache License, version
+  ~  2.0 (the "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~  implied.  See the License for the specific language governing
+  ~  permissions and limitations under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>shamrock-parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <modules>
+    <module>dummy-extension-deployment</module>
+    <module>extension-list</module>
+  </modules>
+</project>

--- a/cli/maven/pom.xml
+++ b/cli/maven/pom.xml
@@ -207,7 +207,6 @@
                         <goals>
                             <goal>install</goal>
                             <goal>run</goal>
-                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/cli/maven/pom.xml
+++ b/cli/maven/pom.xml
@@ -207,6 +207,7 @@
                         <goals>
                             <goal>install</goal>
                             <goal>run</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/cli/maven/pom.xml
+++ b/cli/maven/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>cli-common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/cli/maven/src/main/java/org/jboss/shamrock/maven/ListExtensionsMojo.java
+++ b/cli/maven/src/main/java/org/jboss/shamrock/maven/ListExtensionsMojo.java
@@ -3,6 +3,7 @@ package org.jboss.shamrock.maven;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.jboss.shamrock.cli.commands.AddExtensions;
+import org.jboss.shamrock.maven.utilities.MojoUtils;
 
 @Mojo(name = "list-extensions", requiresProject = false)
 public class ListExtensionsMojo extends AbstractMojo {
@@ -10,7 +11,7 @@ public class ListExtensionsMojo extends AbstractMojo {
     @Override
     public void execute() {
         getLog().info("Available extensions:");
-        AddExtensions.get().stream()
+        MojoUtils.loadExtensions().stream()
                      .sorted((o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName()))
                      .forEach(ext -> getLog().info("\t * " + ext.getName() + " (" + ext.getGroupId() + ":" + ext.getArtifactId() + ")"));
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -36,6 +36,8 @@
     </properties>
 
     <modules>
+        <module>common-core</module>
+        <module>extension-plugin</module>
         <module>common</module>
         <module>maven</module>
         <module>aesh</module>


### PR DESCRIPTION
This is the first step in switching to generating `extensions.json` from the artifacts in the Maven build.

An `extension-plugin` will create the JSON and JS files as part of the `common-cli` module as a replacement for the currently manual `extensions.json`.

Currently it generates a file called `extension-list.json` to not clash with the existing file while the generation process is reviewed. Once merged a subsequent PR is required to switch the name of the generated file and add the necessary `pom.xml` properties to each extension module for `name`, `description` and `labels`.

Note: The current `extensions.json` contains a reference to a non Shamrock extension, the RESTEasy Jackson provider. I don't know whether that is meant to be considered an extension or whether it's there for convenience at present