### PR TITLE
Support Infinispan Client in Protean

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -113,6 +113,7 @@
       <junit4.version>4.12</junit4.version>
       <junit.jupiter.version>5.3.2</junit.jupiter.version>
       <assertj.version>3.11.1</assertj.version>
+      <infinispan.version>10.0.0.Alpha3</infinispan.version>
    </properties>
 
    <dependencyManagement>
@@ -455,6 +456,16 @@
          <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-security-runtime</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-infinispan-client-runtime</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-infinispan-client-deployment</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
@@ -1261,6 +1272,21 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-provider</artifactId>
             <version>${smallrye-reactive-messaging.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <version>${infinispan.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-client</artifactId>
+            <version>${infinispan.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query-dsl</artifactId>
+            <version>${infinispan.version}</version>
          </dependency>
 
       </dependencies>

--- a/extensions/infinispan-client/README.MD
+++ b/extensions/infinispan-client/README.MD
@@ -1,0 +1,132 @@
+# Infinispan Client for Protean
+
+## Status
+
+The RemoteCache by default only supports byte[] key and values. However a user can plug in a Marshaller to workaround
+that. Please see the next few sections about features that currently work and those that don't
+
+## Things that work
+
+### Marshalling
+
+Can be supplied via hotrod-client.properties file. The class must have a no arg public constructor. This
+can also be configured at runtime by supplying DataFormat with the appropriate Marshaller instances on a key or value
+basis. You can also add infinispan-remote-query-client as a dependency and configure the marshaller in the
+hotrod.client-properties file to be `infinispan.client.hotrod.marshaller=org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller`
+which allows support for protobuf marshalling. You can also provide `org.infinispan.protostream.MessageMarshaller` via @Produces
+and we will automatically register those marshallers with the global ProtoStreamMarshaller.
+
+### Protobuf Marshalling 
+
+A user can define Injected protobuf Marshaller and FileDescriptorSource to configure the
+ProtoStreamMarshaller if it is in use.
+
+The code here would be part of the user application to allow protobuf marshalling for User types Book and Author.
+
+```java
+   @Produces
+   MessageMarshaller bookMarshaller() {
+      return new BookMarshaller();
+   }
+
+   @Produces
+   MessageMarshaller authorMarshaller() {
+      return new AuthorMarshaller();
+   }
+
+   @Produces
+   FileDescriptorSource bookProtoDefinition() {
+      return FileDescriptorSource.fromString("library.proto", "package book_sample;\n" +
+            "\n" +
+            "message Book {\n" +
+            "  required string title = 1;\n" +
+            "  required string description = 2;\n" +
+            "  required int32 publicationYear = 3; // no native Date type available in Protobuf\n" +
+            "\n" +
+            "  repeated Author authors = 4;\n" +
+            "}\n" +
+            "\n" +
+            "message Author {\n" +
+            "  required string name = 1;\n" +
+            "  required string surname = 2;\n" +
+            "}");
+   }
+```
+
+You may also now supply a file(s) in the META-INF directory of your project ending in .proto. Any such file will
+be read and parsed as a protobuf file and automatically registered with the protostream marshaller if configured. Note
+that the programmatic way via @Produces will overwrite any same named files (ie. library.proto).
+
+### CDI
+
+RemoteCache and RemoteCacheManager can both be injected via @Inject. The former allows named cache injection by
+adding the Remote annotation, specifying the name of the cache. Currently the RemoteCacheManager is configured via the
+hotrod-client.properties and/or microprofile-config.properties (with micro profile config replacing properties if both
+are present).
+
+### Near Caching
+
+Bounded and Unbounded both work. Exception encountered when protobuf marshalling is enabled
+
+### TLS/SSL
+
+This is working, but requires some additional steps to get configured.
+
+#### Configure truststore information (optionally keystore)
+
+This is configured via hotrod-client.properties file located in META-INF. Everything is the same as normal in that
+you have to add the certificate from the server to the configured truststore if it already trusted in the default
+java cacerts file.
+
+#### Configure your project to allow security services (enable JNI optional)
+
+You (currently) need to enable all security services in Substrate
+(https://github.com/oracle/graal/blob/master/substratevm/JCA-SECURITY-SERVICES.md). This can be done by adding
+`<enableAllSecurityServices>true</enableAllSecurityServices>` to the shamrock-maven-plugin configuration values.
+
+You may have to also enable JNI, depending on the security provider by also adding `<enableJni>true</enableJni>` to the
+same configuration values. If you have to enable JNI you will then also have to add the appropriate shared library to
+be contained in a directory defined by `java.library.path`. In many times this shared library will be `sunec`, which
+can be located at `<JAVA_HOME>/jre/lib/<platform>/libsunec.so`.
+
+### Authentication
+
+DIGEST_MD5, PLAIN, EXTERNAL were all tested to work.
+
+### Querying
+
+Querying is also supported. To be able to do DSL based queries you need to add the infinispan-query-dsl artifact to your
+list of dependencies and then you can use it as normal. A simple example can be seen at
+http://infinispan.org/docs/dev/user_guide/user_guide.html#a_remote_query_example
+
+### Counters
+
+Counters work :)
+
+### Continuous Query
+
+Continuous Query works
+
+### Listeners
+
+This is working
+
+## Things to do
+
+Annotation based protobuf marshalling is not yet currently supported. This requires additional changes as classes
+must be generated at compile time and protostream, underlying library powering protobuf marshalling, only supports
+runtime based class generation.
+
+## Things to still verify work
+
+
+
+
+
+### Multimap
+
+Need to verify what is needed
+
+### Transactions
+
+This will need additional dependencies and verification

--- a/extensions/infinispan-client/deployment/pom.xml
+++ b/extensions/infinispan-client/deployment/pom.xml
@@ -19,34 +19,27 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>shamrock-build-parent</artifactId>
+        <artifactId>shamrock-infinispan-client</artifactId>
         <groupId>org.jboss.shamrock</groupId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
-        <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>shamrock-integration-tests-parent</artifactId>
-    <name>Shamrock - Integration Tests</name>
+    <artifactId>shamrock-infinispan-client-deployment</artifactId>
+    <name>Shamrock - Infinispan - Client - Deployment</name>
 
-    <packaging>pom</packaging>
-
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <modules>
-        <module>class-transformer</module>
-        <module>shared-library</module>
-        <module>bean-validation</module>
-        <module>common-jpa-entities</module>
-        <module>infinispan-client</module>
-        <module>main</module>
-        <module>jpa</module>
-        <module>jpa-postgresql</module>
-        <module>jpa-mariadb</module>
-        <module>jpa-h2</module>
-        <module>vertx</module>
-        <module>spring-di</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-infinispan-client-runtime</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/extensions/infinispan-client/deployment/src/main/java/org/jboss/shamrock/infinispan/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/org/jboss/shamrock/infinispan/InfinispanClientProcessor.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.infinispan;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.util.FileLookupFactory;
+import org.infinispan.commons.util.Util;
+import org.infinispan.protean.runtime.InfinispanClientProducer;
+import org.infinispan.protean.runtime.InfinispanConfiguration;
+import org.infinispan.protean.runtime.InfinispanTemplate;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.jboss.protean.arc.processor.BeanInfo;
+import org.jboss.shamrock.annotations.BuildProducer;
+import org.jboss.shamrock.annotations.BuildStep;
+import org.jboss.shamrock.annotations.ExecutionTime;
+import org.jboss.shamrock.annotations.Record;
+import org.jboss.shamrock.arc.deployment.AdditionalBeanBuildItem;
+import org.jboss.shamrock.arc.deployment.BeanContainerListenerBuildItem;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem;
+import org.jboss.shamrock.deployment.ApplicationArchive;
+import org.jboss.shamrock.deployment.builditem.ApplicationArchivesBuildItem;
+import org.jboss.shamrock.deployment.builditem.ApplicationIndexBuildItem;
+import org.jboss.shamrock.deployment.builditem.HotDeploymentConfigFileBuildItem;
+import org.jboss.shamrock.deployment.builditem.SystemPropertyBuildItem;
+import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveClassBuildItem;
+
+class InfinispanClientProcessor {
+    private static final Log log = LogFactory.getLog(InfinispanClientProcessor.class);
+
+    private static final String META_INF = "META-INF";
+    private static final String HOTROD_CLIENT_PROPERTIES = META_INF + File.separator + "/hotrod-client.properties";
+    private static final String PROTO_EXTENSION = ".proto";
+
+    @BuildStep
+    PropertiesBuildItem setup(ApplicationArchivesBuildItem applicationArchivesBuildItem,
+          BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+          BuildProducer<HotDeploymentConfigFileBuildItem> hotDeployment,
+          BuildProducer<SystemPropertyBuildItem> systemProperties,
+          BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+          ApplicationIndexBuildItem applicationIndexBuildItem) throws ClassNotFoundException, IOException {
+
+        additionalBeans.produce(new AdditionalBeanBuildItem(InfinispanClientProducer.class));
+        systemProperties.produce(new SystemPropertyBuildItem("io.netty.noUnsafe", "true"));
+        hotDeployment.produce(new HotDeploymentConfigFileBuildItem(HOTROD_CLIENT_PROPERTIES));
+
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        InputStream stream = FileLookupFactory.newInstance().lookupFile(HOTROD_CLIENT_PROPERTIES, cl);
+        Properties properties;
+        if (stream == null) {
+            properties = null;
+            log.couldNotFindPropertiesFile(HOTROD_CLIENT_PROPERTIES);
+        } else {
+            try {
+                properties = loadFromStream(stream);
+                log.infof("Found HotRod properties of %s",  properties);
+            } finally {
+                Util.close(stream);
+            }
+
+            InfinispanClientProducer.replaceProperties(properties);
+
+            // We use caffeine for bounded near cache - so register that reflection if we have a bounded near cache
+            if (properties.containsKey(ConfigurationProperties.NEAR_CACHE_MAX_ENTRIES)) {
+                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.github.benmanes.caffeine.cache.SSMS"));
+                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.github.benmanes.caffeine.cache.PSMS"));
+            }
+
+            Object marshaller = properties.get(ConfigurationProperties.MARSHALLER);
+
+            if (InfinispanClientProducer.isProtoBufAvailable(marshaller)) {
+               ApplicationArchive applicationArchive = applicationArchivesBuildItem.getRootArchive();
+               // If we have properties file we may have to care about
+               Path metaPath = applicationArchive.getChildPath(META_INF);
+
+               Iterator<Path> protoFiles = Files.list(metaPath)
+                     .filter(Files::isRegularFile)
+                     .filter(p -> p.toString().endsWith(PROTO_EXTENSION))
+                     .iterator();
+               // We monitor the entire meta inf directory if properties are available
+               if (protoFiles.hasNext()) {
+                  // Protean doesn't currently support hot deployment watching directories
+//                hotDeployment.produce(new HotDeploymentConfigFileBuildItem(META_INF));
+               }
+
+               while (protoFiles.hasNext()) {
+                  Path path = protoFiles.next();
+                  byte[] bytes = Files.readAllBytes(path);
+                  // This uses the default file encoding - should we enforce UTF-8?
+                  properties.put(InfinispanClientProducer.PROTOBUF_FILE_PREFIX + path.getFileName().toString(),
+                        new String(bytes));
+               }
+
+               InfinispanClientProducer.handleQueryRequirements(properties);
+            }
+        }
+
+        // Add any user project listeners to allow reflection in native code
+        Index index = applicationIndexBuildItem.getIndex();
+        List<AnnotationInstance> listenerInstances = index.getAnnotations(
+              DotName.createSimple("org.infinispan.client.hotrod.annotation.ClientListener"));
+        for (AnnotationInstance instance : listenerInstances) {
+            AnnotationTarget target = instance.target();
+            if (target.kind() == AnnotationTarget.Kind.CLASS) {
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, target.asClass().name().toString()));
+            }
+        }
+
+        // This is required for netty to work properly
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioSocketChannel"));
+        // We use reflection to have continuous queries work
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "org.infinispan.client.hotrod.event.ContinuousQueryImpl$ClientEntryListener"));
+        // We use reflection to allow for near cache invalidations
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "org.infinispan.client.hotrod.near.NearCacheService$InvalidatedNearCacheListener"));
+        // This is required when a cache is clustered to tell us topology
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash"));
+
+        return new PropertiesBuildItem(properties);
+    }
+
+    private Properties loadFromStream(InputStream stream) {
+        Properties properties = new Properties();
+        try {
+            properties.load(stream);
+        } catch (IOException e) {
+            throw new HotRodClientException("Issues configuring from client hotrod-client.properties", e);
+        }
+        return properties;
+    }
+
+
+    /**
+     * The Infinispan client configuration, if set.
+     */
+    @ConfigProperty(name = "shamrock.infinispan-client")
+    Optional<InfinispanConfiguration> infinispanConfig;
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    BeanContainerListenerBuildItem build(InfinispanTemplate template, PropertiesBuildItem builderBuildItem) {
+        Properties properties = builderBuildItem.getProperties();
+        if (infinispanConfig.isPresent()) {
+            InfinispanConfiguration conf = infinispanConfig.get();
+            log.infof("Applying micro profile configuration on top of hotrod properties: %s", conf);
+            if (properties == null) {
+                properties = new Properties();
+            }
+            properties.put(ConfigurationProperties.SERVER_LIST, conf.serverList);
+        }
+
+        return new BeanContainerListenerBuildItem(template.configureInfinispan(properties));
+    }
+
+    private static final Set<DotName> UNREMOVABLE_BEANS = Collections.unmodifiableSet(
+          new HashSet<>(Arrays.asList(
+                DotName.createSimple("org.infinispan.protostream.MessageMarshaller"),
+                DotName.createSimple("org.infinispan.protostream.FileDescriptorSource")
+          )));
+
+    @BuildStep
+    UnremovableBeanBuildItem ensureBeanLookupAvailible2() {
+        return new UnremovableBeanBuildItem(beanInfo -> {
+                Set<Type> types = beanInfo.getTypes();
+                for (Type t : types) {
+                    if (UNREMOVABLE_BEANS.contains(t.name())) {
+                        return true;
+                    }
+                }
+
+                return false;
+        });
+    }
+}

--- a/extensions/infinispan-client/deployment/src/main/java/org/jboss/shamrock/infinispan/PropertiesBuildItem.java
+++ b/extensions/infinispan-client/deployment/src/main/java/org/jboss/shamrock/infinispan/PropertiesBuildItem.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.infinispan;
+
+import java.util.Properties;
+
+import org.jboss.builder.item.SimpleBuildItem;
+
+public final class PropertiesBuildItem extends SimpleBuildItem {
+
+    private final Properties properties;
+
+    public PropertiesBuildItem(Properties properties) {
+        this.properties = properties;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/extensions/infinispan-client/pom.xml
+++ b/extensions/infinispan-client/pom.xml
@@ -22,31 +22,15 @@
         <artifactId>shamrock-build-parent</artifactId>
         <groupId>org.jboss.shamrock</groupId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
-        <relativePath>../build-parent/pom.xml</relativePath>
+        <relativePath>../../build-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>shamrock-integration-tests-parent</artifactId>
-    <name>Shamrock - Integration Tests</name>
-
+    <artifactId>shamrock-infinispan-client</artifactId>
+    <name>Shamrock - Infinispan - Client</name>
     <packaging>pom</packaging>
-
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <modules>
-        <module>class-transformer</module>
-        <module>shared-library</module>
-        <module>bean-validation</module>
-        <module>common-jpa-entities</module>
-        <module>infinispan-client</module>
-        <module>main</module>
-        <module>jpa</module>
-        <module>jpa-postgresql</module>
-        <module>jpa-mariadb</module>
-        <module>jpa-h2</module>
-        <module>vertx</module>
-        <module>spring-di</module>
+        <module>deployment</module>
+        <module>runtime</module>
     </modules>
 </project>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-infinispan-client</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-infinispan-client-runtime</artifactId>
+    <name>Shamrock - Infinispan - Client - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-core-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-arc-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-client</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.substratevm</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Mark this as a runtime dependency, so to make sure it's included on the final classpath during native-image -->
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/HandleProtostreamMarshaller.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/HandleProtostreamMarshaller.java
@@ -1,0 +1,82 @@
+package org.infinispan.protean.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Scanner;
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.MessageMarshaller;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.remote.client.impl.MarshallerRegistration;
+
+/**
+ * This class handles loading protostream marshaller. No other current class should reference classes from the
+ * protostream or infinispan-remote-query-client modules besides this one.
+ * @author William Burns
+ */
+class HandleProtostreamMarshaller {
+
+   static void handleQueryRequirements(Properties properties) {
+      properties.put(InfinispanClientProducer.PROTOBUF_FILE_PREFIX + MarshallerRegistration.QUERY_PROTO_RES,
+            getContents(MarshallerRegistration.QUERY_PROTO_RES));
+      properties.put(InfinispanClientProducer.PROTOBUF_FILE_PREFIX + MarshallerRegistration.MESSAGE_PROTO_RES,
+            getContents(MarshallerRegistration.MESSAGE_PROTO_RES));
+   }
+
+   private static String getContents(String fileName) {
+      InputStream stream = HandleProtostreamMarshaller.class.getResourceAsStream(fileName);
+      return new Scanner(stream).useDelimiter("\\A").next();
+   }
+
+   static void handlePossibleMarshaller(Object marshallerInstance, Properties properties, BeanManager beanManager) {
+      ProtoStreamMarshaller marshaller = (ProtoStreamMarshaller) marshallerInstance;
+      SerializationContext serializationContext = marshaller.getSerializationContext();
+
+      FileDescriptorSource fileDescriptorSource = null;
+      for (Map.Entry<Object, Object> property : properties.entrySet()) {
+         Object key = property.getKey();
+         if (key instanceof String) {
+            String keyString = (String) key;
+            if (keyString.startsWith(InfinispanClientProducer.PROTOBUF_FILE_PREFIX)) {
+               String fileName = keyString.substring(InfinispanClientProducer.PROTOBUF_FILE_PREFIX.length());
+               String fileContents = (String) property.getValue();
+               if (fileDescriptorSource == null) {
+                  fileDescriptorSource = new FileDescriptorSource();
+               }
+               fileDescriptorSource.addProtoFile(fileName, fileContents);
+            }
+         }
+      }
+
+      try {
+         if (fileDescriptorSource != null) {
+            serializationContext.registerProtoFiles(fileDescriptorSource);
+         }
+
+         Set<Bean<FileDescriptorSource>> protoFileBeans = (Set) beanManager.getBeans(FileDescriptorSource.class);
+         for (Bean<FileDescriptorSource> bean : protoFileBeans) {
+            CreationalContext<FileDescriptorSource> ctx = beanManager.createCreationalContext(bean);
+            FileDescriptorSource fds = (FileDescriptorSource) beanManager.getReference(bean, FileDescriptorSource.class, ctx);
+            serializationContext.registerProtoFiles(fds);
+         }
+      } catch (IOException e) {
+         // TODO: pick a better exception
+         throw new RuntimeException(e);
+      }
+
+      Set<Bean<MessageMarshaller>> beans = (Set) beanManager.getBeans(MessageMarshaller.class);
+      for (Bean<MessageMarshaller> bean : beans) {
+         CreationalContext<MessageMarshaller> ctx = beanManager.createCreationalContext(bean);
+         MessageMarshaller messageMarshaller = (MessageMarshaller) beanManager.getReference(bean, MessageMarshaller.class, ctx);
+         serializationContext.registerMarshaller(messageMarshaller);
+      }
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/InfinispanClientProducer.java
@@ -1,0 +1,185 @@
+package org.infinispan.protean.runtime;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.RemoteCounterManagerFactory;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.Util;
+import org.infinispan.counter.api.CounterManager;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+
+/**
+ * Produces a configured remote cache manager instance
+ */
+@ApplicationScoped
+public class InfinispanClientProducer {
+   private static final Log log = LogFactory.getLog(InfinispanClientProducer.class);
+
+   static final String protobufMarshallerClassName = "org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller";
+   public static final String PROTOBUF_FILE_PREFIX = "infinispan.client.hotrod.protofile.";
+
+    private Properties properties;
+    private RemoteCacheManager cacheManager;
+    @Inject
+    private BeanManager beanManager;
+
+    private void initialize() {
+       log.info("Intializing CacheManager");
+       Configuration conf;
+        if (properties == null) {
+           // We already loaded and it wasn't present - so use an empty config
+           conf = new ConfigurationBuilder().build();
+        } else {
+           conf = builderFromProperties(properties).build();
+        }
+        cacheManager = new RemoteCacheManager(conf);
+
+        // TODO: do we want to automatically register all the proto file definitions?
+        RemoteCache<String, String> protobufMetadataCache = null;
+        for (Map.Entry<Object, Object> property : properties.entrySet()) {
+           Object key = property.getKey();
+           if (key instanceof String) {
+              String keyString = (String) key;
+              if (keyString.startsWith(InfinispanClientProducer.PROTOBUF_FILE_PREFIX)) {
+                 String fileName = keyString.substring(InfinispanClientProducer.PROTOBUF_FILE_PREFIX.length());
+                 String fileContents = (String) property.getValue();
+                 if (protobufMetadataCache == null) {
+                    protobufMetadataCache = cacheManager.getCache(
+                          ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+                 }
+                 protobufMetadataCache.put(fileName, fileContents);
+              }
+           }
+        }
+    }
+
+   /**
+    * This method is designed to be called during static initialization time. This is so we have access to the
+    * classes, and thus we can use reflection to find and instantiate any instances we may need
+    * @param properties properties file read from hot rod
+    * @throws ClassNotFoundException if a class is not actually found that should be present
+    */
+    public static void replaceProperties(Properties properties) throws ClassNotFoundException {
+        // If you are changing this method, you will most likely have to change builderFromProperties as well
+        String marshallerClassName = (String) properties.get(ConfigurationProperties.MARSHALLER);
+        if (marshallerClassName != null) {
+            Class<?> marshallerClass = Class.forName(marshallerClassName);
+            properties.put(ConfigurationProperties.MARSHALLER, Util.getInstance(marshallerClass));
+        }
+    }
+
+   /**
+    * Sets up additional properties for use when querying is available. Note this method should only be invoked if
+    * protobuf is available (ie. {@link #isProtoBufAvailable(Object)}).
+    * @param properties the properties to be updated for querying
+    */
+    public static void handleQueryRequirements(Properties properties) {
+       // We only apply this if we are substrate in build time to apply to the properties
+       // Note that the other half is done in QuerySubstitutions.SubstituteMarshallerRegistration class
+       // Note that the registration of these files are done twice in normal VM mode
+       // (once during init and once at runtime)
+       HandleProtostreamMarshaller.handleQueryRequirements(properties);
+    }
+
+   /**
+    * The mirror side of {@link #replaceProperties(Properties)} so that we can take out any objects that were
+    * instantiated during static init time and inject them properly
+    * @param properties the properties that was static constructed
+    * @return the configuration builder based on the provided properties
+    */
+    private ConfigurationBuilder builderFromProperties(Properties properties) {
+       // If you are changing this method, you will most likely have to change replaceProperties as well
+        ConfigurationBuilder builder = new ConfigurationBuilder();
+        Object marshallerInstance = properties.remove(ConfigurationProperties.MARSHALLER);
+        if (marshallerInstance != null) {
+            injectProtoMarshallers(marshallerInstance, properties);
+            builder.marshaller((Marshaller) marshallerInstance);
+        }
+        builder.withProperties(properties);
+        return builder;
+    }
+
+    // NOTE: that this method is removed during substitution in graal if protostream is not in the class path
+    private void injectProtoMarshallers(Object marshallerInstance, Properties properties) {
+       if (isProtoBufAvailable(marshallerInstance)) {
+          HandleProtostreamMarshaller.handlePossibleMarshaller(marshallerInstance, properties, beanManager);
+       }
+    }
+
+    public static boolean isProtoBufAvailable(Object marshallerInstance) {
+       // proto stream is optional and we can't do Class.forName at Runtime and we don't want to attempt to load
+       // it in this class so we check the name and if present invoke another class that handles it
+       return marshallerInstance != null &&
+             marshallerInstance.getClass().getName().equals("org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller");
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (cacheManager != null) {
+            cacheManager.stop();
+        }
+    }
+
+    @Remote
+    @Produces
+    public <K, V> RemoteCache<K, V> getRemoteCache(InjectionPoint injectionPoint) {
+        final RemoteCacheManager cacheManager = remoteCacheManager();
+        Set<Annotation> annotationSet = injectionPoint.getQualifiers();
+        final Remote remote = getRemoteAnnotation(annotationSet);
+
+        if (remote != null && !remote.value().isEmpty()) {
+           return cacheManager.getCache(remote.value());
+        }
+        return cacheManager.getCache();
+    }
+
+    @Produces
+    public CounterManager counterManager() {
+       return RemoteCounterManagerFactory.asCounterManager(remoteCacheManager());
+    }
+
+    @Produces
+    public synchronized RemoteCacheManager remoteCacheManager() {
+        if (cacheManager != null) {
+            return cacheManager;
+        }
+        initialize();
+        return cacheManager;
+    }
+
+    void configure(Properties properties) {
+        this.properties = properties;
+    }
+
+   /**
+    * Retrieves the {@link Remote} annotation instance from the set
+    *
+    * @param annotationSet the annotation set.
+    * @return the {@link Remote} annotation instance or {@code null} if not found.
+    */
+   private Remote getRemoteAnnotation(Set<Annotation> annotationSet) {
+      for (Annotation annotation : annotationSet) {
+         if (annotation instanceof Remote) {
+            return (Remote) annotation;
+         }
+      }
+      return null;
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/InfinispanConfiguration.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/InfinispanConfiguration.java
@@ -1,0 +1,23 @@
+package org.infinispan.protean.runtime;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shamrock.runtime.ConfigGroup;
+
+/**
+ * @author William Burns
+ */
+@ConfigGroup
+public class InfinispanConfiguration {
+   /**
+    * Sets the host name to connect to
+    */
+   @ConfigProperty(name = "server_list")
+   public String serverList;
+
+   @Override
+   public String toString() {
+      return "InfinispanConfiguration{" +
+            "serverList='" + serverList + '\'' +
+            '}';
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/InfinispanTemplate.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/InfinispanTemplate.java
@@ -1,0 +1,17 @@
+package org.infinispan.protean.runtime;
+
+import java.util.Properties;
+
+import org.jboss.shamrock.runtime.Template;
+import org.jboss.shamrock.arc.runtime.BeanContainerListener;
+
+@Template
+public class InfinispanTemplate {
+
+    public BeanContainerListener configureInfinispan(Properties properties) {
+        return container -> {
+            InfinispanClientProducer instance = container.instance(InfinispanClientProducer.class);
+            instance.configure(properties);
+        };
+    }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/QuerySubstitutions.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/QuerySubstitutions.java
@@ -1,0 +1,47 @@
+package org.infinispan.protean.runtime;
+
+import java.io.IOException;
+import java.util.function.BooleanSupplier;
+
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.remote.client.impl.MarshallerRegistration;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Class that has all the query substitutions necessary to remove code that is loaded when proto marshaller is in use
+ * Note this class is in the runtime package to reference package protected class name
+ * @author William Burns
+ */
+final class QuerySubstitutions { }
+
+@TargetClass(value = InfinispanClientProducer.class, onlyWith = Selector.class)
+final class SubstituteInfinispanClientProducer {
+   @Substitute
+   private void injectProtoMarshallers(Object marshallerInstance) {
+      // Don't even attempt proto stream updates
+   }
+}
+
+final class Selector implements BooleanSupplier {
+
+   @Override
+   public boolean getAsBoolean() {
+      try {
+         Class.forName(InfinispanClientProducer.protobufMarshallerClassName);
+         return false;
+      } catch (ClassNotFoundException | NoClassDefFoundError e) {
+         // If the classes aren't found we have to remove the places that reference it
+         return true;
+      }
+   }
+}
+
+@TargetClass(value = MarshallerRegistration.class)
+final class SubstituteMarshallerRegistration {
+   @Substitute
+   public static void init(SerializationContext ctx) throws IOException {
+      MarshallerRegistration.registerMarshallers(ctx);
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/Remote.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/runtime/Remote.java
@@ -1,0 +1,30 @@
+package org.infinispan.protean.runtime;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier used to specify which remote cache will be injected.
+ *
+ * @author William Burns
+ */
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface Remote {
+   /**
+    * The remote cache name. If no value is provided the default cache is assumed.
+    */
+   @Nonbinding String value() default "";
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/CaffeineSubstitutions.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/CaffeineSubstitutions.java
@@ -1,0 +1,17 @@
+package org.infinispan.protean.substitutions;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * @author William Burns
+ */
+@TargetClass(className = "com.github.benmanes.caffeine.cache.UnsafeRefArrayAccess")
+public final class CaffeineSubstitutions {
+
+   @Alias
+   @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayIndexShift, declClass = Object[].class)
+   public static int REF_ELEMENT_SHIFT;
+
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/DeleteJBossBasedClasses.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/DeleteJBossBasedClasses.java
@@ -1,0 +1,36 @@
+package org.infinispan.protean.substitutions;
+
+import org.infinispan.commons.dataconversion.DefaultTranscoder;
+import org.infinispan.commons.dataconversion.GenericJbossMarshallerEncoder;
+import org.infinispan.commons.marshall.jboss.AbstractJBossMarshaller;
+import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
+
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * This class removes jboss marshalling based classes in client, which we don't support with substrate
+ * @author William Burns
+ */
+
+final class DeleteJBossBasedClasses { }
+
+@TargetClass(GenericJBossMarshaller.class)
+@Delete
+final class DeleteGenericJBossMarshaller {
+}
+
+@TargetClass(AbstractJBossMarshaller.class)
+@Delete
+final class DeleteAbstractJBossMarshaller {
+}
+
+@TargetClass(GenericJbossMarshallerEncoder.class)
+@Delete
+final class DeleteGenericJbossMarshallerEncoder {
+}
+
+@TargetClass(DefaultTranscoder.class)
+@Delete
+final class DeleteGenericDefaultTranscoder {
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteConfigurationBuilder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteConfigurationBuilder.java
@@ -1,0 +1,24 @@
+package org.infinispan.protean.substitutions;
+
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.marshall.BytesOnlyMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * We only support byte[] by default for marshalling
+ * @author William Burns
+ */
+@TargetClass(ConfigurationBuilder.class)
+public final class SubstituteConfigurationBuilder {
+   @Alias
+   private Marshaller marshaller;
+
+   @Substitute
+   private void handleNullMarshaller() {
+      marshaller = BytesOnlyMarshaller.INSTANCE;
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteConfigurationProperties.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteConfigurationProperties.java
@@ -1,0 +1,25 @@
+package org.infinispan.protean.substitutions;
+
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.marshall.BytesOnlyMarshaller;
+import org.infinispan.commons.util.TypedProperties;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * @author William Burns
+ */
+@TargetClass(ConfigurationProperties.class)
+public final class SubstituteConfigurationProperties {
+   @Alias
+   public static String MARSHALLER = null;
+   @Alias
+   private TypedProperties props = null;
+
+   @Substitute
+   public String getMarshaller() {
+      return props.getProperty(MARSHALLER, BytesOnlyMarshaller.class.getName());
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteExecutorFactoryConfigurationBuilder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteExecutorFactoryConfigurationBuilder.java
@@ -1,0 +1,40 @@
+package org.infinispan.protean.substitutions;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.configuration.ExecutorFactoryConfiguration;
+import org.infinispan.client.hotrod.configuration.ExecutorFactoryConfigurationBuilder;
+import org.infinispan.client.hotrod.impl.async.DefaultAsyncExecutorFactory;
+import org.infinispan.commons.executors.ExecutorFactory;
+import org.infinispan.commons.util.TypedProperties;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Avoids using reflection for DefaultAsyncExecutorFactory class
+ * @author William Burns
+ */
+@TargetClass(ExecutorFactoryConfigurationBuilder.class)
+public final class SubstituteExecutorFactoryConfigurationBuilder {
+   @Alias
+   private ExecutorFactory factory;
+   @Alias
+   private Properties properties;
+
+   @Substitute
+   public SubstituteExecutorFactoryConfiguration create() {
+      if (factory != null)
+         return new SubstituteExecutorFactoryConfiguration(factory, TypedProperties.toTypedProperties(properties));
+      else
+         return new SubstituteExecutorFactoryConfiguration(new DefaultAsyncExecutorFactory(), TypedProperties.toTypedProperties(properties));
+   }
+}
+
+@TargetClass(ExecutorFactoryConfiguration.class)
+final class SubstituteExecutorFactoryConfiguration {
+   @Alias
+   SubstituteExecutorFactoryConfiguration(ExecutorFactory factory, TypedProperties properties) { }
+
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteRemoteCacheImpl.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteRemoteCacheImpl.java
@@ -1,0 +1,33 @@
+package org.infinispan.protean.substitutions;
+
+import javax.management.ObjectName;
+
+import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
+import org.infinispan.commons.marshall.Marshaller;
+
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * This class is here solely to remove the mbeanObjectName field and all methods that would access it
+ * @author William Burns
+ */
+@TargetClass(RemoteCacheImpl.class)
+public final class SubstituteRemoteCacheImpl {
+   @Delete
+   private ObjectName mbeanObjectName;
+
+   @Substitute
+   private void registerMBean(ObjectName jmxParent) { }
+
+   @Substitute
+   private void unregisterMBean() { }
+
+   // Sadly this method is public, so technically a user could get a Runtime error if they were referencing
+   // it before - but it is the only way to make graal happy
+   @Delete
+   public void init(Marshaller marshaller, OperationsFactory operationsFactory, int estimateKeySize,
+         int estimateValueSize, int batchSize, ObjectName jmxParent) { }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteRemoteCacheManager.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteRemoteCacheManager.java
@@ -1,0 +1,40 @@
+package org.infinispan.protean.substitutions;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
+import org.infinispan.commons.marshall.Marshaller;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * This class is here solely to remove the mbeanObjectName field and all methods that would access it
+ * @author William Burns
+ */
+@TargetClass(RemoteCacheManager.class)
+public final class SubstituteRemoteCacheManager {
+   @Alias
+   private Marshaller marshaller;
+   @Alias
+   private Configuration configuration;
+
+   @Substitute
+   private void initRemoteCache(RemoteCacheImpl remoteCache, OperationsFactory operationsFactory) {
+      // Invoke the init method that doesn't have the JMX ObjectName argument
+      remoteCache.init(marshaller, operationsFactory, configuration.keySizeEstimate(),
+            configuration.valueSizeEstimate(), configuration.batchSize());
+   }
+
+   @Substitute
+   private void registerMBean() {
+
+   }
+
+   @Substitute
+   private void unregisterMBean() {
+
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteStatisticsConfiguration.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteStatisticsConfiguration.java
@@ -1,0 +1,18 @@
+package org.infinispan.protean.substitutions;
+
+import org.infinispan.client.hotrod.configuration.StatisticsConfiguration;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * JMX is always disabled in substrate
+ * @author William Burns
+ */
+@TargetClass(StatisticsConfiguration.class)
+public final class SubstituteStatisticsConfiguration {
+   @Substitute
+   public boolean jmxEnabled() {
+      return false;
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteStatisticsConfigurationBuilder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteStatisticsConfigurationBuilder.java
@@ -1,0 +1,18 @@
+package org.infinispan.protean.substitutions;
+
+import org.infinispan.client.hotrod.configuration.StatisticsConfigurationBuilder;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Don't allow the user to enable jmx in substrate
+ * @author William Burns
+ */
+@TargetClass(StatisticsConfigurationBuilder.class)
+public final class SubstituteStatisticsConfigurationBuilder {
+   @Substitute
+   public StatisticsConfigurationBuilder jmxEnabled(boolean enabled) {
+      throw new UnsupportedOperationException("JMX is not available in Substrate");
+   }
+}

--- a/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteTransportHelper.java
+++ b/extensions/infinispan-client/runtime/src/main/java/org/infinispan/protean/substitutions/SubstituteTransportHelper.java
@@ -1,0 +1,30 @@
+package org.infinispan.protean.substitutions;
+
+import java.util.concurrent.ExecutorService;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+/**
+ * This class is here so there are no code paths to loading up native epoll
+ * @author William Burns
+ */
+@Substitute
+@TargetClass(className = "org.infinispan.client.hotrod.impl.transport.netty.TransportHelper")
+final class SubstituteTransportHelper {
+
+   @Substitute
+   static Class<? extends SocketChannel> socketChannel() {
+      return NioSocketChannel.class;
+   }
+
+   @Substitute
+   static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
+      return new NioEventLoopGroup(maxExecutors, executorService);
+   }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -68,6 +68,9 @@
 
         <!-- Security -->
         <module>security</module>
+
+        <!-- Infinispan -->
+        <module>infinispan-client</module>
     </modules>
 
 </project>

--- a/integration-tests/infinispan-client/README.md
+++ b/integration-tests/infinispan-client/README.md
@@ -1,0 +1,35 @@
+# Infinispan client example
+
+## Running the tests
+
+By default, the tests of this module are disabled.
+
+To run the tests in a standard JVM with Infinispan Server started as a Docker container, you can run the following command:
+
+```
+mvn clean install -Dtest-infinispan-client -Ddocker
+```
+
+Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
+
+```
+mvn clean install -Dtest-infinispan-client -Ddocker -Dnative
+```
+
+If you don't want to run Infinispan Server as a Docker container, you can start your own Infinispan Server. It needs to listen on the 11232 port and have a cache named `default` accessible.
+
+You can then run the tests as follows (either with `-Dnative` or not):
+
+```
+mvn clean install -Dtest-infinispan-client
+```
+
+Note that the native tests will currently fail due to a TimeoutException that is fixed with a 10.0.0-Beta1 server or newer. This is a bug in the server itself only.
+
+## Enabling logging for server in docker
+
+You can log the output from the docker container running the Infinispan Server by specifying `-Ddocker.showLogs` to command line.
+
+```
+mvn clean install -Dtest-infinispan-client -Ddocker -Ddocker.showLogs
+```

--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-integration-tests-parent</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-integration-test-infinispan-client</artifactId>
+    <name>Shamrock - Integration Tests - Infinispan Client</name>
+    <description>Module that contains Infinispan Client related tests</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-infinispan-client-deployment</artifactId>
+        </dependency>
+
+        <!-- adds in remote querying protobuf marshalling -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- This is required to use DSL queries -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query-dsl</artifactId>
+        </dependency>
+
+        <!-- Allow some basic support for @Inject (required for JAXRS) -->
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-arc-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- .. and some REST endpoints -->
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-jaxrs-deployment</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <excludes>
+                    <exclude>**/*.jks</exclude>
+                </excludes>
+            </resource>
+            <!-- Don't filter any java keystores that may be in the directory used for testing purposes -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/*.jks</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>shamrock-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-infinispan-client</id>
+            <activation>
+                <property>
+                    <name>test-infinispan-client</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>shamrock-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <!-- Requires Protean Graal fork to work, will fail otherwise
+                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
+                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
+                                    -->
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <!-- next two are to enable security - If not needed it is recommended not to enable these-->
+                                    <enableJni>true</enableJni>
+                                    <enableAllSecurityServices>true</enableAllSecurityServices>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>docker-infinispan</id>
+            <activation>
+                <property>
+                    <name>docker</name>
+                </property>
+            </activation>
+            <properties>
+              <!-- do we need properties ? -->
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                  <name>jboss/infinispan-server:${infinispan.version}</name>
+                                    <alias>infinispan-server</alias>
+                                    <run>
+                                        <env>
+                                            <APP_USER>myuser</APP_USER>
+                                            <APP_PASS>qwer1234!</APP_PASS>
+                                        </env>
+                                        <ports>
+                                            <port>11232:11222</port>
+                                        </ports>
+                                        <wait>
+                                            <log>HotRodServer listening on</log>
+                                            <time>10000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                            <!--Stops all infinispan server images currently running, not just those we just started.
+                              Useful to stop processes still running from a previously failed integration test run -->
+                            <allContainers>true</allContainers>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>docker-start</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>docker-stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/Author.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/Author.java
@@ -1,0 +1,38 @@
+package org.jboss.shamrock.example.infinispanclient;
+
+import java.util.Objects;
+
+/**
+ * @author William Burns
+ */
+public class Author {
+   private final String name;
+   private final String surname;
+
+   public Author(String name, String surname) {
+      this.name = Objects.requireNonNull(name);
+      this.surname = Objects.requireNonNull(surname);
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getSurname() {
+      return surname;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Author author = (Author) o;
+      return name.equals(author.name) &&
+            surname.equals(author.surname);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, surname);
+   }
+}

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/AuthorMarshaller.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/AuthorMarshaller.java
@@ -1,0 +1,34 @@
+package org.jboss.shamrock.example.infinispanclient;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller;
+
+/**
+ * @author William Burns
+ */
+public class AuthorMarshaller implements MessageMarshaller<Author> {
+
+   @Override
+   public String getTypeName() {
+      return "book_sample.Author";
+   }
+
+   @Override
+   public Class<? extends Author> getJavaClass() {
+      return Author.class;
+   }
+
+   @Override
+   public void writeTo(ProtoStreamWriter writer, Author author) throws IOException {
+      writer.writeString("name", author.getName());
+      writer.writeString("surname", author.getSurname());
+   }
+
+   @Override
+   public Author readFrom(ProtoStreamReader reader) throws IOException {
+      String name = reader.readString("name");
+      String surname = reader.readString("surname");
+      return new Author(name, surname);
+   }
+}

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/Book.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/Book.java
@@ -1,0 +1,53 @@
+package org.jboss.shamrock.example.infinispanclient;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author William Burns
+ */
+public class Book {
+   private final String title;
+   private final String description;
+   private final int publicationYear;
+   private final Set<Author> authors;
+
+   public Book(String title, String description, int publicationYear, Set<Author> authors) {
+      this.title = Objects.requireNonNull(title);
+      this.description = Objects.requireNonNull(description);
+      this.publicationYear = publicationYear;
+      this.authors = Objects.requireNonNull(authors);
+   }
+
+   public String getTitle() {
+      return title;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public int getPublicationYear() {
+      return publicationYear;
+   }
+
+   public Set<Author> getAuthors() {
+      return authors;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Book book = (Book) o;
+      return publicationYear == book.publicationYear &&
+            title.equals(book.title) &&
+            description.equals(book.description) &&
+            authors.equals(book.authors);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(title, description, publicationYear, authors);
+   }
+}

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/BookMarshaller.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/BookMarshaller.java
@@ -1,0 +1,40 @@
+package org.jboss.shamrock.example.infinispanclient;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.protostream.MessageMarshaller;
+
+/**
+ * @author William Burns
+ */
+public class BookMarshaller implements MessageMarshaller<Book> {
+
+   @Override
+   public String getTypeName() {
+      return "book_sample.Book";
+   }
+
+   @Override
+   public Class<? extends Book> getJavaClass() {
+      return Book.class;
+   }
+
+   @Override
+   public void writeTo(ProtoStreamWriter writer, Book book) throws IOException {
+      writer.writeString("title", book.getTitle());
+      writer.writeString("description", book.getDescription());
+      writer.writeInt("publicationYear", book.getPublicationYear());
+      writer.writeCollection("authors", book.getAuthors(), Author.class);
+   }
+
+   @Override
+   public Book readFrom(ProtoStreamReader reader) throws IOException {
+      String title = reader.readString("title");
+      String description = reader.readString("description");
+      int publicationYear = reader.readInt("publicationYear");
+      Set<Author> authors = reader.readCollection("authors", new HashSet<>(), Author.class);
+      return new Book(title, description, publicationYear, authors);
+   }
+}

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/MarshallerConfiguration.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/MarshallerConfiguration.java
@@ -1,0 +1,42 @@
+package org.jboss.shamrock.example.infinispanclient;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.MessageMarshaller;
+
+/**
+ * Handles configuration of marshalling code for marshalling
+ * @author William Burns
+ */
+@ApplicationScoped
+public class MarshallerConfiguration {
+   @Produces
+   MessageMarshaller bookMarshaller() {
+      return new BookMarshaller();
+   }
+
+   @Produces
+   MessageMarshaller authorMarshaller() {
+      return new AuthorMarshaller();
+   }
+
+   @Produces
+   FileDescriptorSource bookProtoDefinition() {
+      return FileDescriptorSource.fromString("library.proto", "package book_sample;\n" +
+            "\n" +
+            "message Book {\n" +
+            "  required string title = 1;\n" +
+            "  required string description = 2;\n" +
+            "  required int32 publicationYear = 3; // no native Date type available in Protobuf\n" +
+            "\n" +
+            "  repeated Author authors = 4;\n" +
+            "}\n" +
+            "\n" +
+            "message Author {\n" +
+            "  required string name = 1;\n" +
+            "  required string surname = 2;\n" +
+            "}");
+   }
+}

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/MyApplication.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/MyApplication.java
@@ -1,0 +1,9 @@
+package org.jboss.shamrock.example.infinispanclient;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/test")
+public class MyApplication extends Application {
+
+}

--- a/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/TestServlet.java
+++ b/integration-tests/infinispan-client/src/main/java/org/jboss/shamrock/example/infinispanclient/TestServlet.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.example.infinispanclient;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientCacheEntryCreatedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryRemovedEvent;
+import org.infinispan.client.hotrod.jmx.RemoteCacheClientStatisticsMXBean;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.counter.api.CounterConfiguration;
+import org.infinispan.counter.api.CounterManager;
+import org.infinispan.counter.api.CounterType;
+import org.infinispan.counter.api.StrongCounter;
+import org.infinispan.protean.runtime.Remote;
+import org.infinispan.query.api.continuous.ContinuousQuery;
+import org.infinispan.query.api.continuous.ContinuousQueryListener;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.jboss.shamrock.runtime.StartupEvent;
+
+@Path("/")
+@ApplicationScoped
+public class TestServlet {
+    private static final Log log = LogFactory.getLog(TestServlet.class);
+
+    @Inject @Remote("default")
+    RemoteCache<String, Book> cache;
+
+    @Inject
+    CounterManager counterManager;
+
+    CountDownLatch waitUntilStarted = new CountDownLatch(1);
+
+    final Map<String, Book> matches = new ConcurrentHashMap<>();
+
+    void onStart(@Observes StartupEvent ev) {
+        log.info("Servlet has started");
+
+        cache.addClientListener(new EventPrintListener());
+
+        log.info("Added client listener");
+
+        ContinuousQuery<String, Book> continuousQuery = Search.getContinuousQuery(cache);
+
+        QueryFactory queryFactory = Search.getQueryFactory(cache);
+        Query query = queryFactory.from(Book.class)
+              .having("publicationYear").gt(2011)
+              .build();
+
+        ContinuousQueryListener<String, Book> listener = new ContinuousQueryListener<String, Book>() {
+            @Override
+            public void resultJoining(String key, Book value) {
+                log.warn("Adding key: " + key + " for book: " + value);
+                matches.put(key, value);
+            }
+            @Override
+            public void resultLeaving(String key) {
+                log.warn("Removing key: " + key);
+                matches.remove(key);
+            }
+        };
+
+        continuousQuery.addContinuousQueryListener(query, listener);
+
+        log.info("Added continuous query listener");
+
+        cache.put("book1", new Book("Game of Thrones", "Lots of people perish", 2010,
+              Collections.singleton(new Author("George", "Martin"))));
+        cache.put("book2", new Book("Game of Thrones Path 2", "They win?", 2023,
+              Collections.singleton(new Author("Son", "Martin"))));
+
+        log.info("Inserted values");
+
+        waitUntilStarted.countDown();
+    }
+
+   @ClientListener
+   static class EventPrintListener {
+
+      @ClientCacheEntryCreated
+      public void handleCreatedEvent(ClientCacheEntryCreatedEvent e) {
+         log.warn("Someone has created an entry: " + e);
+      }
+
+      @ClientCacheEntryModified
+      public void handleModifiedEvent(ClientCacheEntryModifiedEvent e) {
+         log.warn("Someone has modified an entry: " + e);
+      }
+
+      @ClientCacheEntryRemoved
+      public void handleRemovedEvent(ClientCacheEntryRemovedEvent e) {
+         log.warn("Someone has removed an entry: " + e);
+      }
+
+   }
+
+   /**
+    * This is needed because start notification is done async - you can receive requests while running start
+    */
+   private void ensureStart() {
+      try {
+         if (!waitUntilStarted.await(10, TimeUnit.SECONDS)) {
+            throw new RuntimeException(new TimeoutException());
+         }
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public List<String> getIDs() {
+       ensureStart();
+       log.fatal("Retrieving all IDs");
+        return cache.keySet().stream().sorted().collect(Collectors.toList());
+    }
+
+    @Path("{id}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getCachedValue(@PathParam("id") String id) {
+       ensureStart();
+        Book book = cache.get(id);
+        return book.getTitle();
+    }
+
+    @Path("query/{id}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String queryAuthorSurname(@PathParam("id") String name) {
+       ensureStart();
+        QueryFactory queryFactory = Search.getQueryFactory(cache);
+        Query query = queryFactory.from(Book.class)
+              .having("authors.name").like("%" + name + "%")
+              .build();
+        List<Book> list = query.list();
+        if (list.isEmpty()) {
+            return "No one found for " + name;
+        }
+
+        return list.stream()
+              .map(Book::getAuthors)
+              .flatMap(Set::stream)
+              .map(author -> author.getName() + " " + author.getSurname())
+              .sorted()
+              .collect(Collectors.joining(",", "[", "]"));
+    }
+
+    @Path("icklequery/{id}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String ickleQueryAuthorSurname(@PathParam("id") String name) {
+       ensureStart();
+        QueryFactory queryFactory = Search.getQueryFactory(cache);
+        Query query = queryFactory.create("from book_sample.Book b where b.authors.name like '%" + name + "%'");
+        List<Book> list = query.list();
+        if (list.isEmpty()) {
+            return "No one found for " + name;
+        }
+        return list.stream()
+              .map(Book::getAuthors)
+              .flatMap(Set::stream)
+              .map(author -> author.getName() + " " + author.getSurname())
+              .sorted()
+              .collect(Collectors.joining(",", "[", "]"));
+    }
+
+    @Path("incr/{id}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Long> incrementCounter(@PathParam("id") String id) {
+       ensureStart();
+        CounterConfiguration configuration = counterManager.getConfiguration(id);
+        if (configuration == null) {
+            configuration = CounterConfiguration.builder(CounterType.BOUNDED_STRONG).build();
+            counterManager.defineCounter(id, configuration);
+        }
+        StrongCounter strongCounter = counterManager.getStrongCounter(id);
+        return strongCounter.incrementAndGet();
+    }
+
+    @Path("cq")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String continuousQuery() {
+       ensureStart();
+        return matches.values().stream()
+              .mapToInt(Book::getPublicationYear)
+              .mapToObj(Integer::toString)
+              .collect(Collectors.joining(","));
+    }
+
+    @Path("nearcache")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String nearCache() {
+       ensureStart();
+       RemoteCacheClientStatisticsMXBean stats = cache.clientStatistics();
+       long nearCacheMisses = stats.getNearCacheMisses();
+       long nearCacheHits = stats.getNearCacheHits();
+       long nearCacheInvalidations = stats.getNearCacheInvalidations();
+
+       Book nearCacheBook = new Book("Near Cache Book", "Just here to test", 2010,
+             Collections.emptySet());
+
+       String id = "nearcache";
+       cache.put(id, nearCacheBook);
+
+       Book retrievedBook = cache.get(id);
+       if (retrievedBook == null) {
+          return "Couldn't retrieve id on first attempt";
+       }
+
+       long misses = stats.getNearCacheMisses();
+       if (nearCacheMisses + 1 != misses) {
+          return "Near cache didn't miss for some reason. Expected: " + nearCacheMisses + 1 + " but got: " + misses;
+       }
+
+       if (!retrievedBook.equals(nearCacheBook)) {
+          return "first retrieved book doesn't match";
+       }
+
+       retrievedBook = cache.get(id);
+       if (retrievedBook == null) {
+          return "Couldn't retrieve id on second attempt";
+       }
+
+       long hits = stats.getNearCacheHits();
+
+       if (nearCacheHits + 1 != hits) {
+          return "Near cache didn't hit for some reason. Expected: " + nearCacheHits + 1 + " but got: " + hits;
+       }
+
+       if (!retrievedBook.equals(nearCacheBook)) {
+          return "second retrieved book doesn't match";
+       }
+
+       nearCacheBook = new Book("Near Cache Book", "Just here to test", 2011, Collections.emptySet());
+
+       cache.put(id, nearCacheBook);
+
+       long invalidations = stats.getNearCacheInvalidations();
+       if (nearCacheInvalidations + 1 != invalidations) {
+          return "Near cache didn't invalidate for some reason. Expected: " + nearCacheInvalidations + 1 + " but got: " + invalidations;
+       }
+
+       cache.remove(id);
+
+       return "worked";
+    }
+
+    @Path("{id}")
+    @PUT
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response createItem(String value, @PathParam("id") String id) {
+       ensureStart();
+        Book book = new Book(id, value, 2019, Collections.emptySet());
+        Book previous = cache.putIfAbsent(id, book);
+        if (previous == null) {
+            //status code 201
+            return Response.status(Response.Status.CREATED)
+                  .entity(id)
+                  .build();
+        } else {
+            return Response.noContent()
+                  .build();
+        }
+    }
+}

--- a/integration-tests/infinispan-client/src/main/resources/META-INF/hotrod-client.properties
+++ b/integration-tests/infinispan-client/src/main/resources/META-INF/hotrod-client.properties
@@ -1,0 +1,16 @@
+# infinispan.client.hotrod.server_list=localhost:11232
+# infinispan.client.hotrod.marshaller=org.infinispan.commons.marshall.UTF8StringMarshaller
+infinispan.client.hotrod.marshaller=org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller
+infinispan.client.hotrod.near_cache.mode=INVALIDATED
+infinispan.client.hotrod.near_cache.max_entries=2
+
+# infinispan.client.hotrod.sasl_mechanism=SIMPLE
+# infinispan.client.hotrod.auth_username=myuser
+# infinispan.client.hotrod.auth_password=qwer1234!
+# infinispan.client.hotrod.auth_server_name=myserver
+
+# infinispan.client.hotrod.key_store_file_name=/home/wburns/RedHat/protean-shamrock/examples/infinispan-client/src/main/resources/keystore-client.jks
+# infinispan.client.hotrod.key_store_type=PKCS12
+# infinispan.client.hotrod.key_store_password=secret
+# infinispan.client.hotrod.trust_store_file_name=/home/wburns/RedHat/protean-shamrock/examples/infinispan-client/src/main/resources/myTrustStore.jks
+# infinispan.client.hotrod.trust_store_password=secret

--- a/integration-tests/infinispan-client/src/main/resources/META-INF/library.proto
+++ b/integration-tests/infinispan-client/src/main/resources/META-INF/library.proto
@@ -1,0 +1,14 @@
+package book_sample;
+
+message Book {
+  required string title = 1;
+  required string description = 2;
+  required int32 publicationYear = 3; // no native Date type available in Protobuf
+
+  repeated Author authors = 4;
+}
+
+message Author {
+  required string name = 1;
+  required string surname = 2;
+}

--- a/integration-tests/infinispan-client/src/main/resources/META-INF/microprofile-config.properties
+++ b/integration-tests/infinispan-client/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,4 @@
+shamrock.infinispan-client.server_list=localhost:11232
+
+# shamrock.log.level=DEBUG
+# shamrock.log.console.level=DEBUG

--- a/integration-tests/infinispan-client/src/test/java/org/jboss/shamrock/example/test/InfinispanClientFunctionalityInGraalITCase.java
+++ b/integration-tests/infinispan-client/src/test/java/org/jboss/shamrock/example/test/InfinispanClientFunctionalityInGraalITCase.java
@@ -1,0 +1,11 @@
+package org.jboss.shamrock.example.test;
+
+import org.jboss.shamrock.test.junit.SubstrateTest;
+
+/**
+ * @author William Burns
+ */
+@SubstrateTest
+public class InfinispanClientFunctionalityInGraalITCase extends InfinispanClientFunctionalityTest {
+
+}

--- a/integration-tests/infinispan-client/src/test/java/org/jboss/shamrock/example/test/InfinispanClientFunctionalityTest.java
+++ b/integration-tests/infinispan-client/src/test/java/org/jboss/shamrock/example/test/InfinispanClientFunctionalityTest.java
@@ -1,0 +1,47 @@
+package org.jboss.shamrock.example.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.shamrock.test.junit.ShamrockTest;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+/**
+ * @author William Burns
+ */
+@ShamrockTest
+public class InfinispanClientFunctionalityTest {
+   @Test
+   public void testClientFunctionalityFromServlet() {
+      RestAssured.when().get("/test").then().body(is("[book1, book2]"));
+   }
+
+   @Test public void testQuery() {
+      RestAssured.when().get("/test/query/So").then().body(is("[Son Martin]"));
+      RestAssured.when().get("/test/query/org").then().body(is("[George Martin]"));
+      RestAssured.when().get("/test/query/o").then().body(is("[George Martin,Son Martin]"));
+   }
+
+   @Test public void testIckleQuery() {
+      RestAssured.when().get("/test/icklequery/So").then().body(is("[Son Martin]"));
+      RestAssured.when().get("/test/icklequery/org").then().body(is("[George Martin]"));
+      RestAssured.when().get("/test/icklequery/o").then().body(is("[George Martin,Son Martin]"));
+   }
+
+   @Test public void increment() {
+      String initialValue = RestAssured.when().get("test/incr/somevalue").body().print();
+      String nextValue = RestAssured.when().get("test/incr/somevalue").body().print();
+      assertEquals(Integer.parseInt(initialValue) + 1, Integer.parseInt(nextValue));
+   }
+
+   @Test public void cq() {
+      RestAssured.when().get("/test/cq").then().body(is("2023"));
+   }
+
+   @Test
+   public void testNearCacheInvalidation() {
+      RestAssured.when().get("/test/nearcache").then().body(is("worked"));
+   }
+}


### PR DESCRIPTION
Add in support infinispan remote client dependent on 10.0.0.Alpha3.
All tests in both JVM and native mode pass.

As mentioned in README, the following features are working properly:

* CDI - allowing for injection using javax.inject
 Includes named caches via @Remote annotation
* Marshalling both user configured or via protostream
* Counters
* Query - Indexed and NonIndexed
* Continous Query
* Near Cache - Unbounded and Bounded
* Security - DIGEST_MD5, SIMPLE & EXTERNAL
* Encryption via TLS
* Remote Listeners

Note this build requires rc11 of graal now.