### PR TITLE
ArC - document "remove unused beans" optimization

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -137,6 +137,8 @@ BeanDefiningAnnotationBuildItem additionalBeanDefiningAnnotation() {
 }
 ----
 
+NOTE: Bean registrations that are result of a `BeanDefiningAnnotationBuildItem` are unremovable by default. See also <<remove_unused_beans>>.
+
 === Resource Annotations
 
 `ResourceAnnotationBuildItem` is used to specify resource annotations  that make it possible to resolve non-CDI injection points, such as Java EE resources.
@@ -167,6 +169,8 @@ List<AdditionalBeanBuildItem> additionalBeans() {
           new AdditionalBeanBuildItem(HealthServlet.class));
 }
 ----
+
+NOTE: A bean registration that is a result of an `AdditionalBeanBuildItem` is removable by default. See also <<remove_unused_beans>>.
 
 === Synthetic Beans
 
@@ -223,3 +227,21 @@ BeanDeploymentValidatorBuildItem beanDeploymentValidator() {
 ----
 
 NOTE: See also `org.jboss.protean.arc.processor.BuildExtension.Key` to discover the available metadata.
+
+[[remove_unused_beans]]
+== Removing Unused Beans
+
+The container attempts to remove all unused beans during build by default.
+This optimization can be disabled: `shamrock.arc.remove-unused-beans=false`.
+
+An unused bean:
+
+* is not a built-in bean or an interceptor,
+* is not eligible for injection to any injection point,
+* is not excluded by any extension,
+* does not have a name,
+* does not declare an observer,
+* does not declare any producer which is eligible for injection to any injection point,
+* is not directly eligible for injection into any `javax.enterprise.inject.Instance` injection point
+ 
+The extensions can eliminate possible false positives by producing `UnremovableBeanBuildItem`.

--- a/extensions/arc/runtime/src/main/java/org/jboss/shamrock/arc/runtime/BeanContainer.java
+++ b/extensions/arc/runtime/src/main/java/org/jboss/shamrock/arc/runtime/BeanContainer.java
@@ -20,12 +20,27 @@ import java.lang.annotation.Annotation;
 
 import org.jboss.protean.arc.ManagedContext;
 
+/**
+ * Represents a CDI bean container.
+ */
 public interface BeanContainer {
 
+    /**
+     * 
+     * @param type
+     * @param qualifiers
+     * @return a bean instance or {@code null} if no matching bean is found
+     */
     default <T> T instance(Class<T> type, Annotation... qualifiers) {
         return instanceFactory(type, qualifiers).get();
     }
 
+    /**
+     * 
+     * @param type
+     * @param qualifiers
+     * @return a bean instance factory, never {@code null} 
+     */
     <T> Factory<T> instanceFactory(Class<T> type, Annotation... qualifiers);
 
     /**
@@ -49,7 +64,18 @@ public interface BeanContainer {
     ManagedContext requestContext();
 
     interface Factory<T> {
-
+        
+        Factory<Object> EMPTY = new Factory<Object>() {
+            @Override
+            public Object get() {
+                return null;
+            }
+        };
+        
+        /**
+         * 
+         * @return a bean instance or {@code null} if no matching bean is found
+         */
         T get();
     }
 

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
@@ -445,10 +445,10 @@ public class BeanInfo {
         builder.append(", qualifiers=");
         builder.append(qualifiers);
         builder.append(", target=");
-        builder.append(target);
+        builder.append(target.isPresent() ? target.get() : "n/a");
         if (declaringBean != null) {
             builder.append(", declaringBean=");
-            builder.append(declaringBean.target);
+            builder.append(declaringBean.target.isPresent() ? declaringBean.target.get() : "n/a");
         }
         builder.append("]");
         return builder.toString();


### PR DESCRIPTION
- log a warning message when an extension template attempts to use a
removed bean
- resolves #658 

NOTE: This is just the first attempt to address #658 and improve the UX.