### PR TITLE
Gracefully stop rather than hang when there are no steps

### DIFF
--- a/core/builder/src/main/java/org/jboss/builder/Execution.java
+++ b/core/builder/src/main/java/org/jboss/builder/Execution.java
@@ -66,6 +66,8 @@ final class Execution {
         buildTargetName = builder.getBuildTargetName();
         executor = executorBuilder.build();
         lastStepCount.set(builder.getChain().getEndStepCount());
+        if(lastStepCount.get() == 0)
+            done = true;
     }
 
     List<Diagnostic> getDiagnostics() {


### PR DESCRIPTION
Otherwise the runner just hangs waiting for steps. Admittedly that only happens when the APT processor failed to create the appropriate build steps, but it happens.