### PR TITLE
Set proper error message when building native image without prior packaging

### DIFF
--- a/cli/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
+++ b/cli/maven/src/main/java/org/jboss/shamrock/maven/NativeImageMojo.java
@@ -126,6 +126,11 @@ public class NativeImageMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
+        if (! buildDir.isDirectory()  || ! new File(buildDir, "lib").isDirectory()) {
+            throw new MojoFailureException("Unable to find the required build output. " +
+                    "Please ensure that the 'build' goal has been properly configured for the project - since it is a prerequisite of the 'native-image' goal");
+        }
+
         try(AppCreator appCreator = AppCreator.builder()
                 // configure the build phase we want the app to go through
                 .addPhase(new NativeImagePhase()

--- a/core/creator/src/main/java/org/jboss/shamrock/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/org/jboss/shamrock/creator/phase/nativeimage/NativeImagePhase.java
@@ -237,6 +237,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
         final String runnerJarName = runnerJar.getFileName().toString();
 
         Path outputLibDir = outputDir.resolve(runnerJarOutcome.getLibDir().getFileName());
+        boolean outputLibDirCopied = false;
         if (Files.exists(outputLibDir)) {
             outputLibDir = null;
         } else {
@@ -245,6 +246,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
             } catch (IOException e) {
                 throw new AppCreatorException("Failed to copy the runnable jar and the lib to the docker project dir", e);
             }
+            outputLibDirCopied = true;
         }
 
         final Config config = SmallRyeConfigProviderResolver.instance().getConfig();
@@ -411,7 +413,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
             if(runnerJarCopied) {
                 IoUtils.recursiveDelete(runnerJar);
             }
-            if(outputLibDir != null) {
+            if(outputLibDirCopied) {
                 IoUtils.recursiveDelete(outputLibDir);
             }
         }


### PR DESCRIPTION
Fixes: #684

The `lib` directory is [always created](https://github.com/jbossas/protean-shamrock/blob/5d0b7050534e1c7940175209c6b445ac0db210dc/core/creator/src/main/java/org/jboss/shamrock/creator/phase/runnerjar/RunnerJarPhase.java#L163) by the execution of RunnerJar creation phase, so I don't think there is a need to put some special marker file in there.

The change to `NativeImagePhase` was not strictly necessary, but I thought that is cleaned up the code a little