### PR TITLE
Fix Hibernate cache random failures #694

### DIFF
--- a/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/DomainDataRegionImpl.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/DomainDataRegionImpl.java
@@ -190,7 +190,7 @@ final class DomainDataRegionImpl implements DomainDataRegion, ExtendedStatistics
                 break;
             case VERSIONED_ENTRIES:
                 // no need to use this as a function - simply override all
-                VersionedEntry evict = new VersionedEntry(regionFactory.nextTimestamp(), PutFromLoadValidator.EXPIRATION_PERIOD);
+                VersionedEntry evict = new VersionedEntry(regionFactory.nextTimestamp(), VersionedEntry.TOMBSTONE_LIFESPAN);
                 removeEntries(entry -> cache.put(entry.getKey(), evict));
                 break;
         }

--- a/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/InfinispanRegionFactory.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/InfinispanRegionFactory.java
@@ -14,6 +14,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.jboss.logging.Logger;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -70,8 +71,7 @@ public final class InfinispanRegionFactory implements RegionFactory {
                         if (key.contains(SIZE_SUFFIX)) {
                             cacheConfig.setMaxSize(Long.parseLong(value));
                         } else if (key.contains(MAX_IDLE_SUFFIX)) {
-                            final long nanosIdle = TimeUnit.SECONDS.toNanos(Long.parseLong(value));
-                            cacheConfig.setMaxIdle(nanosIdle);
+                            cacheConfig.setMaxIdle(Duration.ofSeconds(Long.parseLong(value)));
                         }
 
                         return cacheConfig;

--- a/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/InternalCacheConfig.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/InternalCacheConfig.java
@@ -1,15 +1,17 @@
 package org.infinispan.protean.hibernate.cache;
 
+import java.time.Duration;
+
 final class InternalCacheConfig {
 
     long maxSize = -1;
-    long maxIdle = -1;
+    Duration maxIdle; // in seconds
 
     void setMaxSize(long maxSize) {
         this.maxSize = maxSize;
     }
 
-    void setMaxIdle(long maxIdle) {
+    void setMaxIdle(Duration maxIdle) {
         this.maxIdle = maxIdle;
     }
 

--- a/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/PutFromLoadValidator.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/PutFromLoadValidator.java
@@ -80,7 +80,7 @@ public final class PutFromLoadValidator {
     /**
      * Period (in nanoseconds) after which ongoing invalidation is removed.
      */
-    public static final long EXPIRATION_PERIOD = 60_000_000;
+    public static final long EXPIRATION_PERIOD = Duration.ofSeconds(60).toNanos();
 
     /**
      * Registry of expected, future, isPutValid calls. If a key+owner is registered in this map, it

--- a/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/PutFromLoadValidator.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/PutFromLoadValidator.java
@@ -78,9 +78,11 @@ public final class PutFromLoadValidator {
     private static final boolean trace = log.isTraceEnabled();
 
     /**
-     * Period (in nanoseconds) after which ongoing invalidation is removed.
+     * Period (in milliseconds) after which ongoing invalidation is removed.
+     * Needs to be milliseconds because it will be compared with {@link RegionFactory#nextTimestamp()},
+     * and that method is expected to return milliseconds.
      */
-    public static final long EXPIRATION_PERIOD = Duration.ofSeconds(60).toNanos();
+    private static final long EXPIRATION_PERIOD = Duration.ofSeconds(60).toMillis();
 
     /**
      * Registry of expected, future, isPutValid calls. If a key+owner is registered in this map, it
@@ -120,7 +122,7 @@ public final class PutFromLoadValidator {
         this.nextTimestamp = regionFactory::nextTimestamp;
 
         this.pendingPuts = Caffeine.newBuilder()
-                .expireAfterAccess(Duration.ofNanos(EXPIRATION_PERIOD))
+                .expireAfterAccess(Duration.ofMillis(EXPIRATION_PERIOD))
                 .build();
     }
 


### PR DESCRIPTION
* Caffeine offers no strict guarantees on which entity is evicted.
Once the max is reached, there's no strict guarantees on which
entity will be evicted, so we can't really to try to deterministically
choose an entity to query after it's been evicted.
* Caffeine is not strict in its max size, it can run over for a little.
* Fix incorrect conversion from seconds to nanoseconds.