### PR TITLE
Rename substitutions packages to graal to be consistent

### DIFF
--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/CompareMode.java
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/CompareMode.java
@@ -1,4 +1,4 @@
-package org.jboss.shamrock.jdbc.h2.runtime.graalsubstitutions;
+package org.jboss.shamrock.jdbc.h2.runtime.graal;
 
 import org.h2.engine.SysProperties;
 

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/Engine.java
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/Engine.java
@@ -1,4 +1,4 @@
-package org.jboss.shamrock.jdbc.h2.runtime.graalsubstitutions;
+package org.jboss.shamrock.jdbc.h2.runtime.graal;
 
 import org.h2.engine.ConnectionInfo;
 import org.h2.engine.Session;

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/H2ServerDisable.java
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/H2ServerDisable.java
@@ -1,4 +1,4 @@
-package org.jboss.shamrock.jdbc.h2.runtime.graalsubstitutions;
+package org.jboss.shamrock.jdbc.h2.runtime.graal;
 
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.TargetClass;

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/RemoteOnly.java
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/RemoteOnly.java
@@ -1,4 +1,4 @@
-package org.jboss.shamrock.jdbc.h2.runtime.graalsubstitutions;
+package org.jboss.shamrock.jdbc.h2.runtime.graal;
 
 import org.h2.engine.ConnectionInfo;
 

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/SessionDisable.java
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/java/org/jboss/shamrock/jdbc/h2/runtime/graal/SessionDisable.java
@@ -1,4 +1,4 @@
-package org.jboss.shamrock.jdbc.h2.runtime.graalsubstitutions;
+package org.jboss.shamrock.jdbc.h2.runtime.graal;
 
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.TargetClass;

--- a/extensions/netty/runtime/src/main/java/org/jboss/shamrock/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/org/jboss/shamrock/netty/runtime/graal/NettySubstitutions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.netty.runtime.graalsubstitutions;
+package org.jboss.shamrock.netty.runtime.graal;
 
 import java.security.PrivateKey;
 import java.security.Provider;

--- a/extensions/netty/runtime/src/main/java/org/jboss/shamrock/netty/runtime/graal/ZLibSubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/org/jboss/shamrock/netty/runtime/graal/ZLibSubstitutions.java
@@ -1,4 +1,4 @@
-package org.jboss.shamrock.netty.runtime.graalsubstitutions;
+package org.jboss.shamrock.netty.runtime.graal;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;


### PR DESCRIPTION
Rename the packages to be consistent with the other modules

:package::paintbrush:  as demanded by @gsmet ;)