### PR TITLE
Vertx CDI integration - introduce ConsumeEvent annotation

### DIFF
--- a/extensions/vertx/deployment/pom.xml
+++ b/extensions/vertx/deployment/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-vertx-runtime</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-junit5-internal</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/EventConsumerBusinessMethodItem.java
+++ b/extensions/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/EventConsumerBusinessMethodItem.java
@@ -1,0 +1,33 @@
+package org.jboss.shamrock.vertx;
+
+import org.jboss.builder.item.MultiBuildItem;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.protean.arc.processor.BeanInfo;
+
+public final class EventConsumerBusinessMethodItem extends MultiBuildItem {
+
+    private final BeanInfo bean;
+    private final AnnotationInstance consumeEvent;
+    private final MethodInfo method;
+
+    public EventConsumerBusinessMethodItem(BeanInfo bean, MethodInfo method, AnnotationInstance consumeEvent) {
+        this.bean = bean;
+        this.method = method;
+        this.consumeEvent = consumeEvent;
+    }
+
+    public BeanInfo getBean() {
+        return bean;
+    }
+
+    public MethodInfo getMethod() {
+        return method;
+    }
+
+    public AnnotationInstance getConsumeEvent() {
+        return consumeEvent;
+    }
+
+    
+}

--- a/extensions/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/org/jboss/shamrock/vertx/VertxProcessor.java
@@ -16,29 +16,79 @@
 
 package org.jboss.shamrock.vertx;
 
-import javax.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+import org.jboss.protean.arc.Arc;
+import org.jboss.protean.arc.ArcContainer;
+import org.jboss.protean.arc.InjectableBean;
+import org.jboss.protean.arc.InstanceHandle;
+import org.jboss.protean.arc.processor.AnnotationStore;
+import org.jboss.protean.arc.processor.AnnotationsTransformer;
+import org.jboss.protean.arc.processor.BeanDeploymentValidator;
+import org.jboss.protean.arc.processor.BeanInfo;
+import org.jboss.protean.arc.processor.DotNames;
+import org.jboss.protean.arc.processor.ScopeInfo;
+import org.jboss.protean.gizmo.BytecodeCreator;
+import org.jboss.protean.gizmo.ClassCreator;
+import org.jboss.protean.gizmo.ClassOutput;
+import org.jboss.protean.gizmo.FunctionCreator;
+import org.jboss.protean.gizmo.MethodCreator;
+import org.jboss.protean.gizmo.MethodDescriptor;
+import org.jboss.protean.gizmo.ResultHandle;
+import org.jboss.shamrock.arc.deployment.AdditionalBeanBuildItem;
+import org.jboss.shamrock.arc.deployment.AnnotationsTransformerBuildItem;
+import org.jboss.shamrock.arc.deployment.BeanContainerBuildItem;
+import org.jboss.shamrock.arc.deployment.BeanDeploymentValidatorBuildItem;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem;
+import org.jboss.shamrock.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
 import org.jboss.shamrock.deployment.annotations.BuildProducer;
 import org.jboss.shamrock.deployment.annotations.BuildStep;
 import org.jboss.shamrock.deployment.annotations.ExecutionTime;
 import org.jboss.shamrock.deployment.annotations.Record;
-import org.jboss.shamrock.arc.deployment.AdditionalBeanBuildItem;
-import org.jboss.shamrock.arc.deployment.BeanContainerListenerBuildItem;
 import org.jboss.shamrock.deployment.builditem.FeatureBuildItem;
+import org.jboss.shamrock.deployment.builditem.GeneratedClassBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateConfigBuildItem;
+import org.jboss.shamrock.vertx.runtime.ConsumeEvent;
+import org.jboss.shamrock.vertx.runtime.EventConsumerInvoker;
 import org.jboss.shamrock.vertx.runtime.VertxConfiguration;
 import org.jboss.shamrock.vertx.runtime.VertxProducer;
 import org.jboss.shamrock.vertx.runtime.VertxTemplate;
 
-class VertxProcessor {
+import io.vertx.core.eventbus.Message;
 
+class VertxProcessor {
+    
+    private static final Logger LOGGER = Logger.getLogger(VertxProcessor.class.getName());
+    
+    private static final DotName CONSUME_EVENT = DotName.createSimple(ConsumeEvent.class.getName());
+    private static final DotName MESSAGE = DotName.createSimple(Message.class.getName());
+    private static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
+    private static final String INVOKER_SUFFIX = "_VertxInvoker";
+    
     @Inject
     BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
 
     @BuildStep
     SubstrateConfigBuildItem build() {
-
         // This one may not be required after Vert.x 3.6.0 lands
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioSocketChannel"));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "java.util.LinkedHashMap"));
@@ -56,7 +106,6 @@ class VertxProcessor {
                 .build();
     }
 
-
     /**
      * The Vert.x configuration, if set.
      */
@@ -64,19 +113,169 @@ class VertxProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem registerBean() {
-        return new AdditionalBeanBuildItem(VertxProducer.class);
+        return new AdditionalBeanBuildItem(false, VertxProducer.class);
     }
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    BeanContainerListenerBuildItem build(VertxTemplate template, BuildProducer<FeatureBuildItem> feature) {
+    void build(VertxTemplate template, BeanContainerBuildItem beanContainer, BuildProducer<FeatureBuildItem> feature,
+            List<EventConsumerBusinessMethodItem> messageConsumerBusinessMethods, BuildProducer<GeneratedClassBuildItem> generatedClass) {
         feature.produce(new FeatureBuildItem(FeatureBuildItem.VERTX));
-        return new BeanContainerListenerBuildItem(template.configureVertx(vertx));
+        List<Map<String, String>> messageConsumerConfigurations = new ArrayList<>();
+        ClassOutput classOutput = new ClassOutput() {
+            @Override
+            public void write(String name, byte[] data) {
+                generatedClass.produce(new GeneratedClassBuildItem(true, name, data));
+            }
+        };
+        for (EventConsumerBusinessMethodItem businessMethod : messageConsumerBusinessMethods) {
+            Map<String, String> config = new HashMap<>();
+            String invokerClass = generateInvoker(businessMethod.getBean(), businessMethod.getMethod(), classOutput);
+            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, invokerClass));
+            config.put("invokerClazz", invokerClass);
+            AnnotationValue addressValue = businessMethod.getConsumeEvent().value();
+            config.put("address", addressValue != null ? addressValue.asString() : businessMethod.getBean().getBeanClass().toString());
+            AnnotationValue localValue = businessMethod.getConsumeEvent().value("local");
+            config.put("local", localValue != null ? localValue.asString() : Boolean.FALSE.toString());
+            messageConsumerConfigurations.add(config);
+        }
+        template.configureVertx(beanContainer.getValue(), vertx, messageConsumerConfigurations);
+    }
+    
+    @BuildStep
+    public UnremovableBeanBuildItem unremovableBeans() {
+        return new UnremovableBeanBuildItem(new BeanClassAnnotationExclusion(CONSUME_EVENT));
     }
 
+    @BuildStep
+    BeanDeploymentValidatorBuildItem beanDeploymentValidator(BuildProducer<EventConsumerBusinessMethodItem> messageConsumerBusinessMethods) {
 
+        return new BeanDeploymentValidatorBuildItem(new BeanDeploymentValidator() {
 
+            @Override
+            public void validate(ValidationContext validationContext) {
+                // We need to collect all business methods annotated with @MessageConsumer first
+                AnnotationStore annotationStore = validationContext.get(Key.ANNOTATION_STORE);
+                for (BeanInfo bean : validationContext.get(Key.BEANS)) {
+                    if (bean.isClassBean()) {
+                        // TODO: inherited business methods?
+                        for (MethodInfo method : bean.getTarget().get().asClass().methods()) {
+                            AnnotationInstance consumeEvent = annotationStore.getAnnotation(method, CONSUME_EVENT);
+                            if (consumeEvent != null) {
+                                // Validate method params and return type
+                                List<Type> params = method.parameters();
+                                if (params.size() != 1) {
+                                    throw new IllegalStateException(String.format("Event consumer business method must accept exactly one parameter: %s [method: %s, bean:%s", params, method, bean));
+                                }
+                                messageConsumerBusinessMethods.produce(new EventConsumerBusinessMethodItem(bean, method, consumeEvent));
+                                LOGGER.debugf("Found event consumer business method %s declared on %s", method, bean);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+    
+    @BuildStep
+    AnnotationsTransformerBuildItem annotationTransformer() {
+        return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
 
+            @Override
+            public boolean appliesTo(org.jboss.jandex.AnnotationTarget.Kind kind) {
+                return kind == org.jboss.jandex.AnnotationTarget.Kind.CLASS;
+            }
 
+            @Override
+            public void transform(TransformationContext context) {
+                if (context.getAnnotations().isEmpty()) {
+                    // Class with no annotations but with a method annotated with @ConsumeMessage
+                    if (context.getTarget().asClass().annotations().containsKey(CONSUME_EVENT)) {
+                        LOGGER.debugf("Found event consumer business methods on a class %s with no scope annotation - adding @Singleton", context.getTarget());
+                        context.transform().add(Singleton.class).done();
+                    }
+                }
+            }
+        });
+    }
+    
+    private String generateInvoker(BeanInfo bean, MethodInfo method, ClassOutput classOutput) {
 
+        String baseName;
+        if (bean.getImplClazz().enclosingClass() != null) {
+            baseName = DotNames.simpleName(bean.getImplClazz().enclosingClass()) + "_" + DotNames.simpleName(bean.getImplClazz().name());
+        } else {
+            baseName = DotNames.simpleName(bean.getImplClazz().name());
+        }
+        String targetPackage = DotNames.packageName(bean.getImplClazz().name());
+        
+        StringBuilder sigBuilder = new StringBuilder();
+        sigBuilder.append(method.name()).append("_").append(method.returnType().name().toString());
+        for (Type i : method.parameters()) {
+            sigBuilder.append(i.name().toString());
+        }
+        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + INVOKER_SUFFIX + "_" + method.name() + "_" + sha1(sigBuilder.toString());
+
+        ClassCreator invokerCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName).interfaces(EventConsumerInvoker.class).build();
+
+        MethodCreator invoke = invokerCreator.getMethodCreator("invoke", void.class, Message.class);
+        // InjectableBean<Foo: bean = Arc.container().bean("1");
+        // InstanceHandle<Foo> handle = Arc.container().instance(bean);
+        // handle.get().foo(message);
+        ResultHandle containerHandle = invoke.invokeStaticMethod(MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class));
+        ResultHandle beanHandle = invoke.invokeInterfaceMethod(MethodDescriptor.ofMethod(ArcContainer.class, "bean", InjectableBean.class, String.class),
+                containerHandle, invoke.load(bean.getIdentifier()));
+        ResultHandle instanceHandle = invoke.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod(ArcContainer.class, "instance", InstanceHandle.class, InjectableBean.class), containerHandle, beanHandle);
+        ResultHandle beanInstanceHandle = invoke.invokeInterfaceMethod(MethodDescriptor.ofMethod(InstanceHandle.class, "get", Object.class), instanceHandle);
+
+        Type paramType = method.parameters().get(0);
+        if (paramType.name().equals(MESSAGE)) {
+            // Parameter is io.vertx.core.eventbus.Message
+            invoke.invokeVirtualMethod(MethodDescriptor.ofMethod(bean.getImplClazz().name().toString(), method.name(), void.class, Message.class),
+                    beanInstanceHandle, invoke.getMethodParam(0));
+        } else {
+            // Parameter is payload
+            ResultHandle payloadHandle = invoke.invokeInterfaceMethod(MethodDescriptor.ofMethod(Message.class, "body", Object.class), invoke.getMethodParam(0));
+            ResultHandle replyHandle = invoke.invokeVirtualMethod(MethodDescriptor.ofMethod(bean.getImplClazz().name().toString(), method.name(),
+                    method.returnType().name().toString(), paramType.name().toString()), beanInstanceHandle, payloadHandle);
+            if (replyHandle != null) {
+                if (method.returnType().name().equals(COMPLETION_STAGE)) {
+                    // If the return type is CompletionStage use thenAccept()
+                    FunctionCreator func = invoke.createFunction(Consumer.class);
+                    BytecodeCreator funcBytecode = func.getBytecode();
+                    funcBytecode.invokeInterfaceMethod(MethodDescriptor.ofMethod(Message.class, "reply", void.class, Object.class), invoke.getMethodParam(0),
+                            funcBytecode.getMethodParam(0));
+                    funcBytecode.returnValue(null);
+                    // returnValue.thenAccept(reply -> Message.reply(reply))
+                    invoke.invokeInterfaceMethod(MethodDescriptor.ofMethod(CompletionStage.class, "thenAccept", CompletionStage.class, Consumer.class),
+                            replyHandle, func.getInstance());
+                } else {
+                    // Message.reply(returnValue)
+                    invoke.invokeInterfaceMethod(MethodDescriptor.ofMethod(Message.class, "reply", void.class, Object.class), invoke.getMethodParam(0),
+                            replyHandle);
+                }
+            }
+        }
+
+        // handle.destroy() - destroy dependent instance afterwards
+        if (bean.getScope() == ScopeInfo.DEPENDENT) {
+            invoke.invokeInterfaceMethod(MethodDescriptor.ofMethod(InstanceHandle.class, "destroy", void.class), instanceHandle);
+        }
+        invoke.returnValue(null);
+
+        invokerCreator.close();
+        return generatedName.replace('/', '.');
+    }
+
+    static String sha1(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            return Base64.getUrlEncoder()
+                    .encodeToString(md.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+    
 }

--- a/extensions/vertx/deployment/src/test/java/org/jboss/shamrock/vertx/MessageConsumerMethodTest.java
+++ b/extensions/vertx/deployment/src/test/java/org/jboss/shamrock/vertx/MessageConsumerMethodTest.java
@@ -126,24 +126,24 @@ public class MessageConsumerMethodTest {
         }
         
         @ConsumeEvent("foo")
-        String send(String message) {
+        String reply(String message) {
             return message.toUpperCase();
         }
 
         @ConsumeEvent("pub")
-        void pub(String message) {
+        void consume(String message) {
             MESSAGES.add(message.toLowerCase());
             latch.countDown();
         }
 
         @ConsumeEvent("pub")
-        void pub(Message<String> message) {
+        void consume(Message<String> message) {
             MESSAGES.add(message.body().toUpperCase());
             latch.countDown();
         }
         
         @ConsumeEvent("foo-async")
-        CompletionStage<String> sendAsync(String message) {
+        CompletionStage<String> replyAsync(String message) {
             return CompletableFuture.completedFuture(new StringBuilder(message).reverse().toString());
         }
     }

--- a/extensions/vertx/deployment/src/test/java/org/jboss/shamrock/vertx/MessageConsumerMethodTest.java
+++ b/extensions/vertx/deployment/src/test/java/org/jboss/shamrock/vertx/MessageConsumerMethodTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.vertx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jboss.protean.arc.Arc;
+import org.jboss.shamrock.test.ShamrockUnitTest;
+import org.jboss.shamrock.vertx.runtime.ConsumeEvent;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+
+public class MessageConsumerMethodTest {
+
+    @RegisterExtension
+    static final ShamrockUnitTest config = new ShamrockUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(SimpleBean.class));
+
+    @Inject
+    SimpleBean simpleBean;
+
+    @Test
+    public void testSend() throws InterruptedException {
+        EventBus eventBus = Arc.container().instance(EventBus.class).get();
+        BlockingQueue<Object> synchronizer = new LinkedBlockingQueue<>();
+        eventBus.send("foo", "hello", ar -> {
+            if (ar.succeeded()) {
+                try {
+                    synchronizer.put(ar.result().body());
+                } catch (InterruptedException e) {
+                    fail(e);
+                }
+            } else {
+                fail(ar.cause());
+            }
+        });
+        assertEquals("HELLO", synchronizer.poll(2, TimeUnit.SECONDS));
+    }
+    
+    @Test
+    public void testSendAsync() throws InterruptedException {
+        EventBus eventBus = Arc.container().instance(EventBus.class).get();
+        BlockingQueue<Object> synchronizer = new LinkedBlockingQueue<>();
+        eventBus.send("foo-async", "hello", ar -> {
+            if (ar.succeeded()) {
+                try {
+                    synchronizer.put(ar.result().body());
+                } catch (InterruptedException e) {
+                    fail(e);
+                }
+            } else {
+                fail(ar.cause());
+            }
+        });
+        assertEquals("olleh", synchronizer.poll(2, TimeUnit.SECONDS));
+    }
+    
+    @Test
+    public void testSendDefaultAddress() throws InterruptedException {
+        EventBus eventBus = Arc.container().instance(EventBus.class).get();
+        BlockingQueue<Object> synchronizer = new LinkedBlockingQueue<>();
+        eventBus.send("org.jboss.shamrock.vertx.MessageConsumerMethodTest$SimpleBean", "Hello", ar -> {
+            if (ar.succeeded()) {
+                try {
+                    synchronizer.put(ar.result().body());
+                } catch (InterruptedException e) {
+                    fail(e);
+                }
+            } else {
+                fail(ar.cause());
+            }
+        });
+        assertEquals("hello", synchronizer.poll(2, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testPublish() throws InterruptedException {
+        EventBus eventBus = Arc.container().instance(EventBus.class).get();
+        SimpleBean.latch = new CountDownLatch(2);
+        eventBus.publish("pub", "Hello");
+        SimpleBean.latch.await(2, TimeUnit.SECONDS);
+        assertTrue(SimpleBean.MESSAGES.contains("hello"));
+        assertTrue(SimpleBean.MESSAGES.contains("HELLO"));
+    }
+
+    static class SimpleBean {
+
+        static volatile CountDownLatch latch;
+
+        static final List<String> MESSAGES = new CopyOnWriteArrayList<>();
+
+        @ConsumeEvent // org.jboss.shamrock.vertx.MessageConsumerMethodTest$SimpleBean
+        String sendDefaultAddress(String message) {
+            return message.toLowerCase();
+        }
+        
+        @ConsumeEvent("foo")
+        String send(String message) {
+            return message.toUpperCase();
+        }
+
+        @ConsumeEvent("pub")
+        void pub(String message) {
+            MESSAGES.add(message.toLowerCase());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("pub")
+        void pub(Message<String> message) {
+            MESSAGES.add(message.body().toUpperCase());
+            latch.countDown();
+        }
+        
+        @ConsumeEvent("foo-async")
+        CompletionStage<String> sendAsync(String message) {
+            return CompletableFuture.completedFuture(new StringBuilder(message).reverse().toString());
+        }
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/ConsumeEvent.java
+++ b/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/ConsumeEvent.java
@@ -1,0 +1,56 @@
+package org.jboss.shamrock.vertx.runtime;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.CompletionStage;
+
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+
+/**
+ * Marks a business method to be automatically registered as a Vertx message consumer.
+ * <p>
+ * The method must accept exactly one parameter. If it accepts {@link Message} then the return type must be void. For any other type the {@link Message#body()}
+ * is passed as the parameter value and the method may return an object that is passed to {@link Message#reply(Object)}, either directly or via
+ * {@link CompletionStage#thenAccept(java.util.function.Consumer)} in case of the method returns a completion stage.
+ * 
+ * <pre>
+ * &#64;ApplicationScoped
+ * class MyService {
+ *
+ *     &#64;ConsumeEvent("echo")
+ *     String echo(String msg) {
+ *         return msg.toUpperCase();
+ *     }
+ * 
+ *     &#64;ConsumeEvent("echo")
+ *     void echoMessage(Message<String> msg) {
+ *         msg.reply(msg.body().toUpperCase());
+ *     }
+ * }
+ * </pre>
+ * 
+ * @see EventBus
+ */
+@Target({ METHOD })
+@Retention(RUNTIME)
+public @interface ConsumeEvent {
+
+    /**
+     * The address a consumer will be registered to. By default, the fully qualified name of the declaring bean class is assumed.
+     *
+     * @return the address
+     */
+    String value() default "";
+
+    /**
+     * 
+     * @return {@code true} if the address should not be propagated across the cluster
+     * @see EventBus#localConsumer(String)
+     */
+    boolean local() default false;
+
+}

--- a/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/EventConsumerInvoker.java
+++ b/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/EventConsumerInvoker.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shamrock.vertx.runtime;
+
+import io.vertx.core.eventbus.Message;
+
+/**
+ * Invokes a business method annotated with {@link ConsumeEvent}.
+ */
+public interface EventConsumerInvoker {
+
+    void invoke(Message<Object> message);
+
+}

--- a/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/VertxProducer.java
+++ b/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/VertxProducer.java
@@ -252,7 +252,11 @@ public class VertxProducer {
     @SuppressWarnings("unchecked")
     private EventConsumerInvoker createInvoker(String invokerClassName) {
         try {
-            Class<? extends EventConsumerInvoker> invokerClazz = (Class<? extends EventConsumerInvoker>) Thread.currentThread().getContextClassLoader().loadClass(invokerClassName);
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl == null) {
+                cl = VertxProducer.class.getClassLoader();
+            }
+            Class<? extends EventConsumerInvoker> invokerClazz = (Class<? extends EventConsumerInvoker>) cl.loadClass(invokerClassName);
             return invokerClazz.getDeclaredConstructor().newInstance();
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
             throw new IllegalStateException("Unable to create invoker: " + invokerClassName, e);

--- a/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/VertxProducer.java
+++ b/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/VertxProducer.java
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.EventBusOptions;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.file.FileSystemOptions;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.net.JksOptions;
@@ -16,8 +17,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -30,9 +33,8 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class VertxProducer {
 
-
-    private VertxConfiguration conf;
-    private Vertx vertx;
+    private volatile VertxConfiguration conf;
+    private volatile Vertx vertx;
 
     private void initialize() {
         if (conf == null) {
@@ -216,5 +218,44 @@ public class VertxProducer {
 
     void configure(VertxConfiguration config) {
         this.conf = config;
+    }
+
+    void registerMessageConsumers(List<Map<String, String>> messageConsumers) {
+        if (!messageConsumers.isEmpty()) {
+            EventBus eventBus = eventbus();
+            CountDownLatch latch = new CountDownLatch(messageConsumers.size());
+            for (Map<String, String> messageConsumer : messageConsumers) {
+                EventConsumerInvoker invoker = createInvoker(messageConsumer.get("invokerClazz"));
+                String address = messageConsumer.get("address");
+                MessageConsumer<Object> consumer;
+                if (Boolean.valueOf(messageConsumer.get("local"))) {
+                    consumer = eventBus.localConsumer(address);
+                } else {
+                    consumer = eventBus.consumer(address);
+                }
+                consumer.handler(m -> invoker.invoke(m));
+                consumer.completionHandler(ar -> {
+                    if (ar.succeeded()) {
+                        latch.countDown();
+                    }
+                });
+            }
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Unable to register all message consumer methods", e);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private EventConsumerInvoker createInvoker(String invokerClassName) {
+        try {
+            Class<? extends EventConsumerInvoker> invokerClazz = (Class<? extends EventConsumerInvoker>) Thread.currentThread().getContextClassLoader().loadClass(invokerClassName);
+            return invokerClazz.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
+            throw new IllegalStateException("Unable to create invoker: " + invokerClassName, e);
+        }
     }
 }

--- a/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/VertxTemplate.java
+++ b/extensions/vertx/runtime/src/main/java/org/jboss/shamrock/vertx/runtime/VertxTemplate.java
@@ -1,15 +1,17 @@
 package org.jboss.shamrock.vertx.runtime;
 
-import org.jboss.shamrock.arc.runtime.BeanContainerListener;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.shamrock.arc.runtime.BeanContainer;
 import org.jboss.shamrock.runtime.annotations.Template;
 
 @Template
 public class VertxTemplate {
 
-    public BeanContainerListener configureVertx(VertxConfiguration config) {
-        return container -> {
-            VertxProducer instance = container.instance(VertxProducer.class);
-            instance.configure(config);
-        };
+    public void configureVertx(BeanContainer container, VertxConfiguration config, List<Map<String, String>> messageConsumerConfigurations) {
+        VertxProducer instance = container.instance(VertxProducer.class);
+        instance.configure(config);
+        instance.registerMessageConsumers(messageConsumerConfigurations);
     }
 }


### PR DESCRIPTION
@cescoffier @FroMage This is what I have so far. Let me know what you think about the API...

```java
    @Dependent
    class SimpleBean {

        @ConsumeMessage("foo") // -> EventBus.consumer("foo").handler(m -> m.reply(m.body().toUpperCase()))
        String send(String message) {
            return message.toUpperCase();
        }

        @ConsumeMessage("pub") // -> EventBus.consumer("pub").handler(m -> System.out.println(message.body()))
        void pub(String message) {
          System.out.println(message);
        }

        @ConsumeMessage(value = "pub", local = true) // -> EventBus.localConsumer("pub").handler(m -> System.out.println(message.body()))
        void pub(Message<String> message) {
          System.out.println(message.body());
        }
        
        @ConsumeMessage("foo-async") // -> EventBus.consumer("foo-async").handler(m -> CompletableFuture.completedFuture(message.toUpperCase()).thenAccept(r -> m.reply(r)))
        CompletionStage<String> sendAsync(String message) {
            return CompletableFuture.completedFuture(message.toUpperCase());
        }
    }
```

WRT the annotation name - we cannot use `@Consumes` because of JAX-RS. I don't like `@Address`. And I find `@ConsumeMessage` quite self-explanatory.