### PR TITLE
Fix generated native profiles

### DIFF
--- a/cli/CLI Specification.md
+++ b/cli/CLI Specification.md
@@ -26,7 +26,7 @@ Regardless of the initial conditions, the final product should include:
     3. shamrock-jaxrs-deployment
     4. shamrock-junit4
 5. The shamrock-maven-plugin
-5. The native-image profile
+5. The `native` profile
 6. A common property to track shamrock versions  (Debatable!)
 
 ## Target applications:

--- a/cli/common/src/main/java/org/jboss/shamrock/cli/commands/CreateProject.java
+++ b/cli/common/src/main/java/org/jboss/shamrock/cli/commands/CreateProject.java
@@ -123,7 +123,7 @@ public class CreateProject {
     }
 
     private void addNativeProfile(Model model) {
-        final boolean match = model.getProfiles().stream().anyMatch(p -> p.getId().equals("native-image"));
+        final boolean match = model.getProfiles().stream().anyMatch(p -> p.getId().equals("native"));
         if (!match) {
             PluginExecution exec = new PluginExecution();
             exec.addGoal("native-image");
@@ -136,12 +136,12 @@ public class CreateProject {
             buildBase.addPlugin(plg);
 
             Profile profile = new Profile();
-            profile.setId("native-image");
+            profile.setId("native");
             profile.setBuild(buildBase);
 
             final Activation activation = new Activation();
             final ActivationProperty property = new ActivationProperty();
-            property.setName("!no-native");
+            property.setName("native");
 
             activation.setProperty(property);
             profile.setActivation(activation);

--- a/cli/common/src/main/resources/templates/pom-template.ftl
+++ b/cli/common/src/main/resources/templates/pom-template.ftl
@@ -76,6 +76,11 @@
     <profiles>
         <profile>
             <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/cli/maven/src/test/java/org/jboss/shamrock/maven/it/CreateProjectMojoIT.java
+++ b/cli/maven/src/test/java/org/jboss/shamrock/maven/it/CreateProjectMojoIT.java
@@ -79,6 +79,9 @@ public class CreateProjectMojoIT extends MojoTestBase {
         assertThat(model.getDependencies().stream().anyMatch(d ->
                 d.getArtifactId().equalsIgnoreCase("shamrock-jaxrs-deployment")
                         && d.getVersion() == null)).isTrue();
+
+        assertThat(model.getProfiles()).hasSize(1);
+        assertThat(model.getProfiles().get(0).getId()).isEqualTo("native");
     }
 
     private Model load(File directory) {
@@ -117,6 +120,9 @@ public class CreateProjectMojoIT extends MojoTestBase {
                         && d.getType().equalsIgnoreCase("pom"))).isTrue();
 
         assertThat(model.getDependencies()).isEmpty();
+
+        assertThat(model.getProfiles()).hasSize(1);
+        assertThat(model.getProfiles().get(0).getId()).isEqualTo("native");
     }
 
     @Test

--- a/cli/maven/src/test/java/org/jboss/shamrock/maven/it/assertions/SetupVerifier.java
+++ b/cli/maven/src/test/java/org/jboss/shamrock/maven/it/assertions/SetupVerifier.java
@@ -73,7 +73,7 @@ public class SetupVerifier {
         // Check profile
         assertThat(model.getProfiles()).hasSize(1);
         Profile profile = model.getProfiles().get(0);
-        assertThat(profile.getId()).isEqualTo("native-image");
+        assertThat(profile.getId()).isEqualTo("native");
         Plugin actual = profile.getBuild().getPluginsAsMap().get(CreateProjectMojo.PLUGIN_KEY);
         assertThat(actual).isNotNull();
         assertThat(actual.getExecutions()).hasSize(1).allSatisfy(exec -> {


### PR DESCRIPTION
Fix #748:

* Always use `native` as profile id
* Disable the default activation
* Enable the activation using -Dnative
* Avoid inserting duplicated profiles