### PR TITLE
Only log a warning if GRAALVM_HOME is not set and SSL is enabled

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/SubstrateConfigBuildStep.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/SubstrateConfigBuildStep.java
@@ -79,12 +79,13 @@ class SubstrateConfigBuildStep {
 
             String graalVmHome = System.getenv("GRAALVM_HOME");
 
-            if (graalVmHome == null) {
-                throw new RuntimeException("GRAALVM_HOME environment variable required");
+            if (graalVmHome != null) {
+                systemProperty.produce(
+                        new SystemPropertyBuildItem("java.library.path", graalVmHome + File.separator + "jre" + File.separator + "lib" + File.separator + "amd64"));
+            } else {
+                log.warn(
+                        "SSL is enabled but the GRAALVM_HOME environment variable is not set. The java.library.path property has not been set and will need to be set manually.");
             }
-
-            systemProperty.produce(
-                    new SystemPropertyBuildItem("java.library.path", graalVmHome + File.separator + "jre" + File.separator + "lib" + File.separator + "amd64"));
         }
 
         nativeImage.produce(new SubstrateSystemPropertyBuildItem("shamrock.ssl.native", sslNativeEnabled.toString()));


### PR DESCRIPTION
It was an issue prior to my SSL fixes but was hidden as
shamrock.ssl.native was never enabled on CI.

This is now the case as it can be enabled by default by an extension.

For the record, CI currently does not have GRAALVM_HOME set and uses a
Docker environment to build native images.