### PR TITLE
Cleanup of no-native leftovers to have non GraalVM run by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,7 @@ mvn clean install
 # Wait... success!
 ```
 
-The default build will create two different native images, which is quite time consuming. You can skip this
-by disabling the `native-image` profile: `mvn install -Dno-native`.
+By default only Java mode is run. You can build native images (which is quite time consuming) by enabling the `native-image` profile: `mvn install -Dnative`.
 
 By default the build will use the native image server. This speeds up the build, but can cause problems due to the cache
 not being invalidated correctly in some cases. To run a build with a new instance of the server you can use

--- a/README.md
+++ b/README.md
@@ -251,8 +251,7 @@ To run the tests from an IDE you will need to make sure the image has been built
 `-Dnative.image.path=full-path-to-image`. If this is not set Shamrock will try and guess the correct image location, by
 assuming that the image name is `*-runner` and is located in the parent directory of the `test-classes` classpath entry.
 
-By default only the `strict` example is run, you can build all native images using `-Dnative`. You can prevent
-the strict image from being built using `-Dno-native`.
+By default only Java mode is run, you can build all native images using `-Dnative`.
 
 ### Reflection
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,4 +92,4 @@ jobs:
     displayName: 'Maven Build'
     inputs:
       goals: 'install'
-      options: '-B --settings azure-mvn-settings.xml -Dno-native'
+      options: '-B --settings azure-mvn-settings.xml'

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -220,7 +220,7 @@
             <id>native-image</id>
             <activation>
                 <property>
-                    <name>!no-native</name>
+                    <name>native</name>
                 </property>
             </activation>
             <build>


### PR DESCRIPTION
Cleanup of no-native leftovers to have non GraalVM run by default

I noticed this when running `mvn clean install -DskipTests` with Java 8 and got failure saying GRAALVM_HOME is not set. When I used GraalVM I burned my CPU with unnecessary execution of native-image command in shamrock-integration-test-main.

 - adjusted `integration-tests/main/pom.xml` to follow activation by `native` property
 - .md files updated not to mention `no-native` property (suggestions for more adequate wording welcome)
 - drop of `-Dno-native` from `azure-pipelines.yml`