### PR TITLE
REST client with native and SSL

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -104,6 +104,13 @@
 
          <dependency>
             <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-resteasy-common-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+         </dependency>
+
+         <dependency>
+            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-jaxrs-deployment</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -393,6 +393,16 @@
          </dependency>
          <dependency>
             <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-resteasy-common-deployment</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-resteasy-common-runtime</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-integration-test-shared-library</artifactId>
             <version>${project.version}</version>
          </dependency>

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/SubstrateConfigBuildStep.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/steps/SubstrateConfigBuildStep.java
@@ -80,8 +80,12 @@ class SubstrateConfigBuildStep {
             String graalVmHome = System.getenv("GRAALVM_HOME");
 
             if (graalVmHome != null) {
+                String graalVmLibDirectory = graalVmHome + File.separator + "jre" + File.separator + "lib" + File.separator;
+
                 systemProperty.produce(
-                        new SystemPropertyBuildItem("java.library.path", graalVmHome + File.separator + "jre" + File.separator + "lib" + File.separator + "amd64"));
+                        new SystemPropertyBuildItem("java.library.path", graalVmLibDirectory + "amd64"));
+                systemProperty.produce(
+                        new SystemPropertyBuildItem("javax.net.ssl.trustStore", graalVmLibDirectory + "security" + File.separator + "cacerts"));
             } else {
                 log.warn(
                         "SSL is enabled but the GRAALVM_HOME environment variable is not set. The java.library.path property has not been set and will need to be set manually.");

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/ServiceUtil.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/ServiceUtil.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -19,8 +20,17 @@ public final class ServiceUtil {
 
     public static Iterable<Class<?>> classesNamedIn(ClassLoader classLoader, String fileName) throws IOException, ClassNotFoundException {
         final ArrayList<Class<?>> list = new ArrayList<>();
+        for (String className : classNamesNamedIn(classLoader, fileName)) {
+            list.add(Class.forName(className, true, classLoader));
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    public static Set<String> classNamesNamedIn(ClassLoader classLoader, String fileName) throws IOException {
         final Enumeration<URL> resources = classLoader.getResources(fileName);
-        final Set<Class<?>> found = new HashSet<>();
+
+        final Set<String> classNames = new HashSet<>();
+
         while (resources.hasMoreElements()) {
             final URL url = resources.nextElement();
             try (InputStream is = url.openStream()) {
@@ -29,17 +39,23 @@ public final class ServiceUtil {
                         try (BufferedReader br = new BufferedReader(isr)) {
                             String line;
                             while ((line = br.readLine()) != null) {
-                                line = line.trim();
-                                final Class<?> clazz = Class.forName(line, true, classLoader);
-                                if (found.add(clazz)) {
-                                    list.add(clazz);
+                                if (line.contains("#")) {
+                                    line = line.substring(line.indexOf("#"));
                                 }
+                                line = line.trim();
+
+                                if (line.isEmpty()) {
+                                    continue;
+                                }
+
+                                classNames.add(line);
                             }
                         }
                     }
                 }
             }
         }
-        return list;
+
+        return Collections.unmodifiableSet(classNames);
     }
 }

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/ServiceUtil.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/ServiceUtil.java
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -29,7 +29,7 @@ public final class ServiceUtil {
     public static Set<String> classNamesNamedIn(ClassLoader classLoader, String fileName) throws IOException {
         final Enumeration<URL> resources = classLoader.getResources(fileName);
 
-        final Set<String> classNames = new HashSet<>();
+        final Set<String> classNames = new LinkedHashSet<>();
 
         while (resources.hasMoreElements()) {
             final URL url = resources.nextElement();
@@ -39,8 +39,9 @@ public final class ServiceUtil {
                         try (BufferedReader br = new BufferedReader(isr)) {
                             String line;
                             while ((line = br.readLine()) != null) {
-                                if (line.contains("#")) {
-                                    line = line.substring(line.indexOf("#"));
+                                int commentMarkerIndex = line.indexOf('#');
+                                if (commentMarkerIndex > 0) {
+                                    line = line.substring(commentMarkerIndex);
                                 }
                                 line = line.trim();
 

--- a/extensions/jaxrs/deployment/pom.xml
+++ b/extensions/jaxrs/deployment/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-resteasy-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-undertow-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
+++ b/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
@@ -225,7 +225,9 @@ public class JaxrsScanningProcessor {
     }
 
     @BuildStep
-    public void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+    public void build(
+                      BuildProducer<FeatureBuildItem> feature,
+                      BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
                       BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
                       BuildProducer<SubstrateProxyDefinitionBuildItem> proxyDefinition,
                       BuildProducer<SubstrateResourceBuildItem> resource,
@@ -235,6 +237,8 @@ public class JaxrsScanningProcessor {
                       BuildProducer<ServletInitParamBuildItem> servletContextParams,
                       CombinedIndexBuildItem combinedIndexBuildItem
     ) throws Exception {
+        feature.produce(new FeatureBuildItem(FeatureBuildItem.JAXRS));
+
         IndexView index = combinedIndexBuildItem.getIndex();
 
         resource.produce(new SubstrateResourceBuildItem("META-INF/services/javax.ws.rs.client.ClientBuilder"));
@@ -382,11 +386,7 @@ public class JaxrsScanningProcessor {
     void registerProviders(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
                            BuildProducer<ServletInitParamBuildItem> servletContextParams,
                            CombinedIndexBuildItem combinedIndexBuildItem,
-                           List<JaxrsProviderBuildItem> contributedProviderBuildItems,
-                           JaxrsTemplate template,
-                           BeanContainerBuildItem beanContainerBuildItem,
-                           List<ProxyUnwrapperBuildItem> proxyUnwrappers,
-                           BuildProducer<FeatureBuildItem> feature) throws Exception {
+                           List<JaxrsProviderBuildItem> contributedProviderBuildItems) throws Exception {
         IndexView index = combinedIndexBuildItem.getIndex();
 
         Set<String> contributedProviders = new HashSet<>();
@@ -437,9 +437,15 @@ public class JaxrsScanningProcessor {
         for (String providerToRegister : providersToRegister) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, providerToRegister));
         }
+    }
 
+    @Record(STATIC_INIT)
+    @BuildStep
+    void setupInjection(JaxrsTemplate template,
+            BuildProducer<ServletInitParamBuildItem> servletContextParams,
+            BeanContainerBuildItem beanContainerBuildItem,
+            List<ProxyUnwrapperBuildItem> proxyUnwrappers) {
 
-        feature.produce(new FeatureBuildItem(FeatureBuildItem.JAXRS));
         List<Function<Object, Object>> unwrappers = new ArrayList<>();
         for (ProxyUnwrapperBuildItem i : proxyUnwrappers) {
             unwrappers.add(i.getUnwrapper());

--- a/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
+++ b/extensions/jaxrs/deployment/src/main/java/org/jboss/shamrock/jaxrs/JaxrsScanningProcessor.java
@@ -75,10 +75,10 @@ import org.jboss.shamrock.deployment.builditem.substrate.SubstrateConfigBuildIte
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateProxyDefinitionBuildItem;
 import org.jboss.shamrock.deployment.builditem.substrate.SubstrateResourceBuildItem;
 import org.jboss.shamrock.deployment.util.ServiceUtil;
+import org.jboss.shamrock.jaxrs.runtime.JaxrsTemplate;
 import org.jboss.shamrock.jaxrs.runtime.ResteasyFilter;
 import org.jboss.shamrock.jaxrs.runtime.RolesFilterRegistrar;
-import org.jboss.shamrock.jaxrs.runtime.graal.JaxrsTemplate;
-import org.jboss.shamrock.jaxrs.runtime.graal.ShamrockInjectorFactory;
+import org.jboss.shamrock.jaxrs.runtime.ShamrockInjectorFactory;
 import org.jboss.shamrock.runtime.annotations.ConfigItem;
 import org.jboss.shamrock.runtime.annotations.ConfigRoot;
 import org.jboss.shamrock.undertow.FilterBuildItem;

--- a/extensions/jaxrs/runtime/pom.xml
+++ b/extensions/jaxrs/runtime/pom.xml
@@ -47,8 +47,8 @@
             <artifactId>shamrock-arc-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-core</artifactId>
+            <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-resteasy-common-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/JaxrsTemplate.java
+++ b/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/JaxrsTemplate.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.jaxrs.runtime;
 
 import java.util.List;
 import java.util.function.Function;
@@ -22,9 +22,6 @@ import java.util.function.Function;
 import org.jboss.shamrock.arc.runtime.BeanContainer;
 import org.jboss.shamrock.runtime.annotations.Template;
 
-/**
- * Created by bob on 7/31/18.
- */
 @Template
 public class JaxrsTemplate {
 

--- a/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/ShamrockConstructorInjector.java
+++ b/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/ShamrockConstructorInjector.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.jaxrs.runtime;
 
 import java.lang.reflect.Constructor;
 import java.util.concurrent.CompletableFuture;

--- a/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/ShamrockInjectorFactory.java
+++ b/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/ShamrockInjectorFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.jaxrs.runtime;
 
 import java.lang.reflect.Constructor;
 import java.util.concurrent.CompletionStage;

--- a/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/graal/DeleteDocumentProvider.java
+++ b/extensions/jaxrs/runtime/src/main/java/org/jboss/shamrock/jaxrs/runtime/graal/DeleteDocumentProvider.java
@@ -18,9 +18,12 @@ package org.jboss.shamrock.jaxrs.runtime.graal;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+
+import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.w3c.dom.Document;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
@@ -39,6 +42,10 @@ import java.lang.reflect.Type;
  */
 @TargetClass(className = "org.jboss.resteasy.plugins.providers.DocumentProvider")
 final class DeleteDocumentProvider {
+
+    @Substitute
+    public DeleteDocumentProvider(final @Context ResteasyConfiguration config) {
+    }
 
     @Substitute
     public boolean isReadable(Class<?> clazz, Type type, Annotation[] annotation, MediaType mediaType) {

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -46,6 +46,7 @@
         <module>jaeger</module>
 
         <!-- REST services -->
+        <module>resteasy-common</module>
         <module>jaxrs</module>
         <module>jaxrs-json</module>
         <module>rest-client</module>

--- a/extensions/rest-client/deployment/pom.xml
+++ b/extensions/rest-client/deployment/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
+            <artifactId>shamrock-resteasy-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-rest-client-runtime</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-common/deployment/pom.xml
@@ -19,32 +19,20 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>shamrock-rest-client</artifactId>
+        <artifactId>shamrock-resteasy-common</artifactId>
         <groupId>org.jboss.shamrock</groupId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>shamrock-rest-client-runtime</artifactId>
-    <name>Shamrock - REST client - Runtime</name>
+    <artifactId>shamrock-resteasy-common-deployment</artifactId>
+    <name>Shamrock - RESTEasy - Common - Deployment</name>
 
     <dependencies>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-core-runtime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-resteasy-common-runtime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>
@@ -54,9 +42,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
@@ -71,4 +56,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/extensions/resteasy-common/pom.xml
+++ b/extensions/resteasy-common/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>shamrock-build-parent</artifactId>
+        <groupId>org.jboss.shamrock</groupId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shamrock-resteasy-common</artifactId>
+    <name>Shamrock - RESTEasy - Common</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -19,36 +19,28 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>shamrock-rest-client</artifactId>
+        <artifactId>shamrock-resteasy-common</artifactId>
         <groupId>org.jboss.shamrock</groupId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>shamrock-rest-client-runtime</artifactId>
-    <name>Shamrock - REST client - Runtime</name>
+    <artifactId>shamrock-resteasy-common-runtime</artifactId>
+    <name>Shamrock - RESTEasy - Common - Runtime</name>
 
     <dependencies>
+        <dependency>
+            <groupId>com.oracle.substratevm</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-core-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-resteasy-common-runtime</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.substratevm</groupId>
-            <artifactId>svm</artifactId>
+            <artifactId>resteasy-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/DeleteDocumentProvider.java
+++ b/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/DeleteDocumentProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.resteasy.common.runtime.graal;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;

--- a/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/DeleteIIOImageProvider.java
+++ b/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/DeleteIIOImageProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.resteasy.common.runtime.graal;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/ImageIOSubstitutions.java
+++ b/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/ImageIOSubstitutions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.resteasy.common.runtime.graal;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;

--- a/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/InternalLocatableAnnotationSubstitutions.java
+++ b/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/InternalLocatableAnnotationSubstitutions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.resteasy.common.runtime.graal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/LCMSSubstitutions.java
+++ b/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/LCMSSubstitutions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.resteasy.common.runtime.graal;
 
 import java.awt.color.ICC_Profile;
 

--- a/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/LocatableAnnotationSubstitutions.java
+++ b/extensions/resteasy-common/runtime/src/main/java/org/jboss/shamrock/resteasy/common/runtime/graal/LocatableAnnotationSubstitutions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jboss.shamrock.jaxrs.runtime.graal;
+package org.jboss.shamrock.resteasy.common.runtime.graal;
 
 import java.lang.annotation.Annotation;
 import java.util.function.BooleanSupplier;

--- a/extensions/smallrye-openapi/deployment/src/main/java/org/jboss/shamrock/smallrye/openapi/RESTEasyExtension.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/org/jboss/shamrock/smallrye/openapi/RESTEasyExtension.java
@@ -1,12 +1,8 @@
 package org.jboss.shamrock.smallrye.openapi;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Enumeration;
 import java.util.List;
 
 import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
@@ -18,6 +14,7 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
+import org.jboss.shamrock.deployment.util.ServiceUtil;
 import org.jboss.shamrock.jaxrs.JaxrsConfig;
 
 import io.smallrye.openapi.api.OpenApiConstants;
@@ -52,15 +49,9 @@ public class RESTEasyExtension extends DefaultAnnotationScannerExtension {
         try {
             Class<?> asyncResponseProvider = Class.forName("org.jboss.resteasy.spi.AsyncResponseProvider");
             // can't use the ServiceLoader API because Providers is not an interface
-            Enumeration<URL> resources = getClass().getClassLoader().getResources("META-INF/services/javax.ws.rs.ext.Providers");
-            while(resources.hasMoreElements()) {
-                URL resource = resources.nextElement();
-                try(BufferedReader r = new BufferedReader(new InputStreamReader(resource.openStream()))){
-                    String line;
-                    while((line = r.readLine()) != null) {
-                        scanAsyncResponseProvidersFromClassName(asyncResponseProvider, line.trim());
-                    }
-                }
+            for (String provider : ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
+                    "META-INF/services/javax.ws.rs.ext.Providers")) {
+                scanAsyncResponseProvidersFromClassName(asyncResponseProvider, provider);
             }
         } catch (IOException e) {
             // failed to index, never mind


### PR DESCRIPTION
I just wanted to write the SSL guide and thought the REST client quickstart would be nice to base this guide on.

Unfortunately, it was a rabbit hole.

This PR changes a few various things:
* Fix a SSL issue for access to the trust store as it was required by the REST Client
* Improves `ServiceUtil` a bit as I needed it, @dmlloyd could you take a look at this particular commit: https://github.com/jbossas/protean-shamrock/commit/ba3f1bea50071444d1503446ff6b237de8e55d5e ?
* Declares reflection for all the providers in the REST client extension as we need that for now: we will have a much better approach later (see https://github.com/jbossas/protean-shamrock/issues/797) but we don't want to invest time in it now as we will switch to another client soon enough
* move the RESTEasy substitutions to a common internal extension: this extension is just an empty shell for the substitutions, it will probably be removed as soon as we will switch to the reactive client but for now it is useful
* clean up a few things in the JAX-RS extension as things were added in places where they shouldn't have been added

Best reviewed commit per commit as they are not directly related even if they have the same goal: being able to use the REST client extension in native mode to access SSL services.

Hopefully, once we have moved to the SmallRye REST client, we will work a bit more on it to better optimize it.