### PR TITLE
[LOGMGR-236] Check the correct array for the index.

### DIFF
--- a/independent-projects/jboss-logmanager-embedded/src/main/java/org/jboss/logmanager/JDKSpecific.java
+++ b/independent-projects/jboss-logmanager-embedded/src/main/java/org/jboss/logmanager/JDKSpecific.java
@@ -73,7 +73,7 @@ final class JDKSpecific {
                         return;
                     }
                 }
-                if (j == classes.length) {
+                if (j == stackTrace.length) {
                     logRecord.setUnknownCaller();
                     return;
                 }


### PR DESCRIPTION
I'm not sure if this is the correct way to do this if not please let me know. This was fixed in the upstream log manager however (https://github.com/jboss-logging/jboss-logmanager/pull/227). I thought we should fix it here as well.