### PR TITLE
If putFromLoad happens too close to region evict, try again

### DIFF
--- a/independent-projects/infinispan-hibernate-cache-protean/pom.xml
+++ b/independent-projects/infinispan-hibernate-cache-protean/pom.xml
@@ -33,6 +33,10 @@
         <version.hibernate>5.4.1.Final</version.hibernate>
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
 
+        <!-- Test dependency versions -->
+        <junit4.version>4.12</junit4.version>
+        <mockito-core.version>2.22.0</mockito-core.version>
+
         <!-- Build settings -->
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -75,6 +79,25 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>${version.caffeine}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy-agent</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/Time.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/main/java/org/infinispan/protean/hibernate/cache/Time.java
@@ -1,0 +1,17 @@
+package org.infinispan.protean.hibernate.cache;
+
+public class Time {
+
+    @FunctionalInterface
+    public interface NanosService {
+        long nanoTime();
+    }
+
+    @FunctionalInterface
+    public interface MillisService {
+        MillisService SYSTEM = System::currentTimeMillis;
+
+        long milliTime();
+    }
+
+}

--- a/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionEvictTest.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionEvictTest.java
@@ -1,0 +1,62 @@
+package org.infinispan.protean.hibernate.cache;
+
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CacheRegionEvictTest {
+
+    @Test
+    public void testReadWriteAccess() {
+        CacheRegionTesting testing = CacheRegionTesting.cacheRegion("test", new HashMap());
+        SharedSessionContractImplementor session = testing.session;
+
+        EntityDataAccess cacheAccess = testing.entityCache(AccessType.READ_WRITE);
+
+        putFromLoad(cacheAccess, session);
+        assertEquals(3, testing.region().getElementCountInMemory());
+        getCacheFound(session, cacheAccess);
+
+        cacheAccess.evictAll();
+        assertEquals(0, testing.region().getElementCountInMemory());
+        getCacheNotFound(session, cacheAccess);
+
+        putFromLoad(cacheAccess, session);
+        assertEquals(0, testing.region().getElementCountInMemory());
+        getCacheNotFound(session, cacheAccess);
+
+        // Advance transaction time so it happens after region eviction
+        testing.regionTimeService.advance(1, TimeUnit.MILLISECONDS);
+
+        putFromLoad(cacheAccess, session);
+        assertEquals(3, testing.region().getElementCountInMemory());
+
+        getCacheFound(session, cacheAccess);
+    }
+
+    private static void getCacheNotFound(SharedSessionContractImplementor session, EntityDataAccess cacheAccess) {
+        assertNull(cacheAccess.get(session, 1));
+        assertNull(cacheAccess.get(session, 2));
+        assertNull(cacheAccess.get(session, 3));
+    }
+
+    private static void getCacheFound(SharedSessionContractImplementor session, EntityDataAccess cacheAccess) {
+        assertEquals("1-v1", cacheAccess.get(session, 1));
+        assertEquals("2-v1", cacheAccess.get(session, 2));
+        assertEquals("3-v1", cacheAccess.get(session, 3));
+    }
+
+    private static void putFromLoad(EntityDataAccess cacheAccess, SharedSessionContractImplementor session) {
+        cacheAccess.putFromLoad(session, 1, "1-v1", null, false);
+        cacheAccess.putFromLoad(session, 2, "2-v1", null, false);
+        cacheAccess.putFromLoad(session, 3, "3-v1", null, false);
+    }
+
+}

--- a/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionMaxIdleTest.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionMaxIdleTest.java
@@ -1,0 +1,55 @@
+package org.infinispan.protean.hibernate.cache;
+
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.protean.hibernate.cache.Eventually.eventually;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CacheRegionMaxIdleTest {
+
+    @Test
+    public void testMaxIdle() {
+        final Map configValues = new HashMap();
+        configValues.put("hibernate.cache.com.acme.EntityA.expiration.max_idle", "60");
+
+        CacheRegionTesting testing = CacheRegionTesting.cacheRegion("com.acme.EntityA", configValues);
+        SharedSessionContractImplementor session = testing.session;
+
+        EntityDataAccess cacheAccess = testing.entityCache(AccessType.READ_WRITE);
+        putFromLoad(cacheAccess, session);
+        assertEquals(3, testing.region().getElementCountInMemory());
+        getCacheFound(session, cacheAccess);
+
+        // Advance beyond max idle time
+        testing.cacheTimeService.advance(90, TimeUnit.SECONDS);
+
+        eventually(() -> getCacheNotFound(session, cacheAccess));
+    }
+
+    private static void getCacheNotFound(SharedSessionContractImplementor session, EntityDataAccess cacheAccess) {
+        assertNull(cacheAccess.get(session, 1));
+        assertNull(cacheAccess.get(session, 2));
+        assertNull(cacheAccess.get(session, 3));
+    }
+
+    private static void getCacheFound(SharedSessionContractImplementor session, EntityDataAccess cacheAccess) {
+        assertEquals("1-v1", cacheAccess.get(session, 1));
+        assertEquals("2-v1", cacheAccess.get(session, 2));
+        assertEquals("3-v1", cacheAccess.get(session, 3));
+    }
+
+    private static void putFromLoad(EntityDataAccess cacheAccess, SharedSessionContractImplementor session) {
+        cacheAccess.putFromLoad(session, 1, "1-v1", null, false);
+        cacheAccess.putFromLoad(session, 2, "2-v1", null, false);
+        cacheAccess.putFromLoad(session, 3, "3-v1", null, false);
+    }
+
+}

--- a/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionMaxSizeTest.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionMaxSizeTest.java
@@ -1,0 +1,47 @@
+package org.infinispan.protean.hibernate.cache;
+
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.infinispan.protean.hibernate.cache.Eventually.eventually;
+import static org.junit.Assert.assertEquals;
+
+public class CacheRegionMaxSizeTest {
+
+    @Test
+    public void testMaxSize() {
+        final Map configValues = new HashMap();
+        configValues.put("hibernate.cache.com.acme.EntityB.memory.size", "3");
+
+        CacheRegionTesting testing = CacheRegionTesting.cacheRegion("com.acme.EntityB", configValues);
+        SharedSessionContractImplementor session = testing.session;
+
+        EntityDataAccess cacheAccess = testing.entityCache(AccessType.READ_WRITE);
+        putFromLoad(cacheAccess, session);
+        assertEquals(3, testing.region().getElementCountInMemory());
+        getCacheFound(session, cacheAccess);
+
+        // Add another entity that makes the cache exceed its size
+        cacheAccess.putFromLoad(session, 4, "4-v1", null, false);
+
+        eventually(() -> assertEquals(3, testing.region().getElementCountInMemory()));
+    }
+
+    private static void getCacheFound(SharedSessionContractImplementor session, EntityDataAccess cacheAccess) {
+        assertEquals("1-v1", cacheAccess.get(session, 1));
+        assertEquals("2-v1", cacheAccess.get(session, 2));
+        assertEquals("3-v1", cacheAccess.get(session, 3));
+    }
+
+    private static void putFromLoad(EntityDataAccess cacheAccess, SharedSessionContractImplementor session) {
+        cacheAccess.putFromLoad(session, 1, "1-v1", null, false);
+        cacheAccess.putFromLoad(session, 2, "2-v1", null, false);
+        cacheAccess.putFromLoad(session, 3, "3-v1", null, false);
+    }
+
+}

--- a/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionTesting.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/CacheRegionTesting.java
@@ -1,0 +1,144 @@
+package org.infinispan.protean.hibernate.cache;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.cfg.internal.DomainDataRegionConfigImpl;
+import org.hibernate.cache.cfg.spi.DomainDataCachingConfig;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.ExtendedStatisticsSupport;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.metamodel.model.domain.NavigableRole;
+import org.hibernate.type.VersionType;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class CacheRegionTesting {
+
+    final SharedSessionContractImplementor session;
+    private final DomainDataRegion region;
+    private final DomainDataRegionConfig config;
+    final ManualMillisService regionTimeService;
+    final ManualNanosService cacheTimeService;
+
+    private CacheRegionTesting(
+            SharedSessionContractImplementor session,
+            DomainDataRegion region,
+            DomainDataRegionConfig config,
+            ManualMillisService regionTimeService,
+            ManualNanosService cacheTimeService) {
+        this.session = session;
+        this.region = region;
+        this.config = config;
+        this.regionTimeService = regionTimeService;
+        this.cacheTimeService = cacheTimeService;
+    }
+
+    @SuppressWarnings("unchecked")
+    <T extends DomainDataRegion & ExtendedStatisticsSupport> T region() {
+        return (T) region;
+    }
+
+    EntityDataAccess entityCache(AccessType accessType) {
+        final NavigableRole role = config.getEntityCaching().stream()
+                .filter(c -> c.getAccessType() == accessType)
+                .map(DomainDataCachingConfig::getNavigableRole)
+                .findFirst().orElseThrow(IllegalArgumentException::new);
+
+        return region.getEntityDataAccess(role);
+    }
+
+    static CacheRegionTesting cacheRegion(String regionName, Map configValues) {
+        ProteanInfinispanRegionFactory regionFactory = new ProteanInfinispanRegionFactory();
+        ManualMillisService regionTimeService = new ManualMillisService();
+        regionFactory.setRegionTimeService(regionTimeService);
+        ManualNanosService cacheTimeService = new ManualNanosService();
+        regionFactory.setCacheTimeService(cacheTimeService);
+
+        SessionFactoryOptions sessionFactoryOptions = sessionFactoryOptionsMock();
+        regionFactory.start(sessionFactoryOptions, configValues);
+
+        RootClass persistentClass = rootClassMock(regionName);
+        DomainDataRegionConfig config = new DomainDataRegionConfigImpl.Builder(regionName)
+                .addEntityConfig(persistentClass, AccessType.READ_WRITE)
+                .build();
+        DomainDataRegion region = regionFactory.buildDomainDataRegion(config, null);
+
+        SharedSessionContractImplementor session = mock(SharedSessionContractImplementor.class);
+        when(session.getTransactionStartTimestamp()).thenAnswer(x -> regionFactory.nextTimestamp());
+
+        return new CacheRegionTesting(session, region, config, regionTimeService, cacheTimeService);
+    }
+
+    private static SessionFactoryOptions sessionFactoryOptionsMock() {
+        StrategySelector strategySelector = mock(StrategySelector.class);
+        StandardServiceRegistry registry = mock(StandardServiceRegistry.class);
+        when(registry.getService(StrategySelector.class)).thenReturn(strategySelector);
+        SessionFactoryOptions sessionFactoryOptions = mock(SessionFactoryOptions.class);
+        when(sessionFactoryOptions.getServiceRegistry()).thenReturn(registry);
+        return sessionFactoryOptions;
+    }
+
+    private static RootClass rootClassMock(String entityName) {
+        RootClass persistentClass = mock(RootClass.class);
+        when(persistentClass.getRootClass()).thenReturn(persistentClass);
+        when(persistentClass.getEntityName()).thenReturn(entityName);
+        Property versionMock = mock(Property.class);
+        VersionType typeMock = mock(VersionType.class);
+        when(typeMock.getComparator()).thenReturn(UNIVERSAL_COMPARATOR);
+        when(versionMock.getType()).thenReturn(typeMock);
+        when(persistentClass.getVersion()).thenReturn(versionMock);
+        when(persistentClass.isVersioned()).thenReturn(true);
+        when(persistentClass.isMutable()).thenReturn(true);
+        return persistentClass;
+    }
+
+    private static final Comparator<Object> UNIVERSAL_COMPARATOR = (o1, o2) -> {
+        if (o1 instanceof Long && o2 instanceof Long) {
+            return ((Long) o1).compareTo((Long) o2);
+        } else if (o1 instanceof Integer && o2 instanceof Integer) {
+            return ((Integer) o1).compareTo((Integer) o2);
+        }
+        throw new UnsupportedOperationException();
+    };
+
+    static final class ManualMillisService implements Time.MillisService {
+        private final AtomicLong millis = new AtomicLong();
+
+        public void advance(long time, TimeUnit timeUnit) {
+            final long milliseconds = timeUnit.toMillis(time);
+            millis.addAndGet(milliseconds);
+        }
+
+        @Override
+        public long milliTime() {
+            return millis.get();
+        }
+    }
+
+    static final class ManualNanosService implements Time.NanosService {
+        private final AtomicLong nanos = new AtomicLong();
+
+        public void advance(long time, TimeUnit timeUnit) {
+            final long nanoseconds = timeUnit.toNanos(time);
+            nanos.addAndGet(nanoseconds);
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanos.get();
+        }
+    }
+
+}

--- a/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/Eventually.java
+++ b/independent-projects/infinispan-hibernate-cache-protean/src/test/java/org/infinispan/protean/hibernate/cache/Eventually.java
@@ -1,0 +1,40 @@
+package org.infinispan.protean.hibernate.cache;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+final class Eventually {
+
+    private Eventually() {
+    }
+
+    static void eventually(Runnable condition) {
+        final long timeout = Duration.ofSeconds(10).toMillis();
+        final long pollInterval = Duration.ofMillis(500).toMillis();
+        final TimeUnit unit = TimeUnit.MILLISECONDS;
+
+        if (pollInterval <= 0) {
+            throw new IllegalArgumentException("Check interval must be positive");
+        }
+        try {
+            long expectedEndTime = System.nanoTime() + TimeUnit.NANOSECONDS.convert(timeout, unit);
+            long sleepMillis = TimeUnit.MILLISECONDS.convert(pollInterval, unit);
+            AssertionError lastError = new AssertionError("");
+            while (expectedEndTime - System.nanoTime() > 0) {
+                try {
+                    condition.run();
+                    return;
+                } catch (AssertionError error) {
+                    lastError = error;
+                }
+
+                Thread.sleep(sleepMillis);
+            }
+
+            throw lastError;
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected!", e);
+        }
+    }
+
+}

--- a/integration-tests/infinispan-cache-jpa/src/main/java/org/jboss/shamrock/example/infinispancachejpa/InfinispanCacheJPAFunctionalityTestEndpoint.java
+++ b/integration-tests/infinispan-cache-jpa/src/main/java/org/jboss/shamrock/example/infinispancachejpa/InfinispanCacheJPAFunctionalityTestEndpoint.java
@@ -3,19 +3,14 @@ package org.jboss.shamrock.example.infinispancachejpa;
 import org.hibernate.NaturalIdLoadAccess;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.stat.CacheRegionStatistics;
 import org.hibernate.stat.Statistics;
-import org.infinispan.protean.hibernate.cache.ProteanInfinispanRegionFactory;
-import org.infinispan.protean.hibernate.cache.ManualTestService;
+import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -36,6 +31,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 @WebServlet(name = "InfinispanCacheJPAFunctionalityTestEndpoint", urlPatterns = "/infinispan-cache-jpa/testfunctionality")
 public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
+
+    private static final Logger log = Logger.getLogger(InfinispanCacheJPAFunctionalityTestEndpoint.class);
 
     @PersistenceUnit(unitName = "templatePU")
     EntityManagerFactory entityManagerFactory;
@@ -66,9 +63,6 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
 
         testReadOnlyNaturalId(entityManagerFactory);
         testReadWriteNaturalId(entityManagerFactory);
-
-        testMaxSize(entityManagerFactory);
-        testMaxIdle(entityManagerFactory);
 
         //Delete all
         testDeleteViaRemove(entityManagerFactory);
@@ -101,17 +95,6 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
         em.close();
 
         assertRegionStats(counts, stats);
-    }
-
-    private static void testMaxIdle(EntityManagerFactory entityManagerFactory) {
-        final CacheImplementor cacherImplementor = entityManagerFactory.getCache().unwrap(CacheImplementor.class);
-        final ProteanInfinispanRegionFactory regionFactory = (ProteanInfinispanRegionFactory) cacherImplementor.getRegionFactory();
-        ManualTestService manualTestService = regionFactory.getTimeService();
-        manualTestService.advance(120, TimeUnit.SECONDS);
-
-        final Statistics stats = verifyFindCountryByNaturalId(entityManagerFactory, "+41", "Switzerland");
-        assertRegionStatsEventually(new Counts(1, 0, 1, 1), Country.class.getName(), stats);
-        assertRegionStats(new Counts(0, 1, 0, 3), Country.class.getName() + "##NaturalId", stats);
     }
 
     private static void testReadWriteNaturalId(EntityManagerFactory entityManagerFactory) {
@@ -392,24 +375,6 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
         System.out.print(sb);
     }
 
-    private static void testMaxSize(EntityManagerFactory emf) {
-        addItemBeyondMaxSize(emf);
-    }
-
-    private static void addItemBeyondMaxSize(EntityManagerFactory emf) {
-        Statistics stats = getStatistics(emf);
-
-        EntityManager em = emf.createEntityManager();
-        EntityTransaction transaction = em.getTransaction();
-        transaction.begin();
-        final Item cap = new Item("cap", "Hibernate Cap");
-        em.persist(cap);
-        transaction.commit();
-        em.close();
-
-        assertRegionStatsEventually(new Counts(1, 0, 0, 3), Item.class.getName(), stats);
-    }
-
     private static void testQuery(EntityManagerFactory entityManagerFactory) {
         //Load all persons and run some checks on the query results:
         Map<String, Counts> counts = new TreeMap<>();
@@ -429,27 +394,11 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
         storeTestPersons(entityManagerFactory, new Counts(4, 0, 0, 4));
 
         //Load all persons and run some checks on the cache hits
-        verifyFindByIdPersons(entityManagerFactory, new Counts(0, 4, 0, 4));
-
-        //Evict persons from cache
-        evictPersons(entityManagerFactory);
-
-        //Load all persons and run some checks on the cache hits
-        verifyFindByIdPersons(entityManagerFactory, new Counts(4, 0, 4, 4));
+        Statistics beforeEvictStats = verifyFindByIdPersons(entityManagerFactory);
+        assertRegionStats(new Counts(0, 4, 0, 4), Person.class.getName(), beforeEvictStats);
     }
 
-    private static void evictPersons(final EntityManagerFactory emf) {
-        Statistics stats = getStatistics(emf);
-
-        EntityManager em = emf.createEntityManager();
-        em.getEntityManagerFactory().getCache().evict(Person.class);
-        em.close();
-
-        final Counts expected = new Counts(0, 0, 0, 0);
-        assertRegionStats(expected, Person.class.getName(), stats);
-    }
-
-    private static void verifyFindByIdPersons(final EntityManagerFactory emf, Counts expected) {
+    private static Statistics verifyFindByIdPersons(final EntityManagerFactory emf) {
         Statistics stats = getStatistics(emf);
 
         EntityManager em = emf.createEntityManager();
@@ -459,7 +408,7 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
         transaction.commit();
         em.close();
 
-        assertRegionStats(expected, Person.class.getName(), stats);
+        return stats;
     }
 
     private static void findByIdPersons(EntityManager em) {
@@ -681,10 +630,6 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
         assertRegionStats(expected, Pokemon.class.getName(), stats);
     }
 
-    private static String randomName() {
-        return UUID.randomUUID().toString();
-    }
-
     private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {
         final PrintWriter writer = resp.getWriter();
         if (errorMessage != null) {
@@ -707,79 +652,35 @@ public class InfinispanCacheJPAFunctionalityTestEndpoint extends HttpServlet {
         for (Map.Entry<String, Counts> entry : counts.entrySet()) {
             final String region = entry.getKey();
             final Counts expected = entry.getValue();
-            final CacheRegionStatistics cacheStats = stats.getDomainDataRegionStatistics(region);
-            final Counts actual = new Counts(
-                    cacheStats.getPutCount()
-                    , cacheStats.getHitCount()
-                    , cacheStats.getMissCount()
-                    , cacheStats.getElementCountInMemory()
-            );
+            final Counts actual = statsToCounts(region, stats);
             assertCountEquals(expected, actual, region);
         }
     }
 
     private static void assertRegionStats(Counts expected, String region, Statistics stats) {
+        final Counts actual = statsToCounts(region, stats);
+        assertCountEquals(expected, actual, region);
+    }
+
+    private static Counts statsToCounts(String region, Statistics stats) {
         final CacheRegionStatistics cacheStats = stats.getDomainDataRegionStatistics(region);
-        final Counts actual = new Counts(
+        return new Counts(
                 cacheStats.getPutCount()
                 , cacheStats.getHitCount()
                 , cacheStats.getMissCount()
                 , cacheStats.getElementCountInMemory()
         );
-        assertCountEquals(expected, actual, region);
     }
 
     private static void assertCountEquals(Counts expected, Counts actual, String msg) {
-        //FIXME this is currently failing often on CI, needs to be investigated.
-        //Seems to fail more often in native mode.
-        // - https://github.com/jbossas/protean-shamrock/issues/694
-        /*if (!expected.equals(actual))
-            throw new RuntimeException(
-                    "[" + msg + "] expected " + expected + " second level cache count, instead got: " + actual
-        );*/
+        if (!expected.equals(actual))
+            throw unequalCounts(expected, msg, actual);
     }
 
-    private static void assertRegionStatsEventually(Counts expected, String region, Statistics stats) {
-        eventually(() -> {
-            final CacheRegionStatistics cacheStats = stats.getDomainDataRegionStatistics(region);
-            final Counts actual = new Counts(
-                    cacheStats.getPutCount()
-                    , cacheStats.getHitCount()
-                    , cacheStats.getMissCount()
-                    , cacheStats.getElementCountInMemory()
-            );
-            if (!expected.equals(actual)) {
-                return new RuntimeException(
-                        "[" + region + "] expected " + expected + " second level cache count, instead got: " + actual
-                );
-            }
-
-            return null;
-        });
-    }
-
-    static void eventually(Supplier<RuntimeException> condition) {
-        eventually(Duration.ofSeconds(10).toMillis(), Duration.ofMillis(500).toMillis(), TimeUnit.MILLISECONDS, condition);
-    }
-
-    static void eventually(long timeout, long pollInterval, TimeUnit unit, Supplier<RuntimeException> condition) {
-        if (pollInterval <= 0) {
-            throw new IllegalArgumentException("Check interval must be positive");
-        }
-        try {
-            long expectedEndTime = System.nanoTime() + TimeUnit.NANOSECONDS.convert(timeout, unit);
-            long sleepMillis = TimeUnit.MILLISECONDS.convert(pollInterval, unit);
-            while (expectedEndTime - System.nanoTime() > 0) {
-                if (condition.get() == null) return;
-                Thread.sleep(sleepMillis);
-            }
-
-            final RuntimeException exception = condition.get();
-            if (exception != null)
-                throw exception;
-        } catch (Exception e) {
-            throw new RuntimeException("Unexpected!", e);
-        }
+    private static RuntimeException unequalCounts(Counts expected, String region, Counts actual) {
+        return new RuntimeException(
+                "[" + region + "] expected " + expected + " second level cache count, instead got: " + actual
+        );
     }
 
     static final class Counts {

--- a/integration-tests/infinispan-cache-jpa/src/main/resources/META-INF/persistence.xml
+++ b/integration-tests/infinispan-cache-jpa/src/main/resources/META-INF/persistence.xml
@@ -5,28 +5,9 @@
              version="2.1">
 
     <persistence-unit name="templatePU" transaction-type="JTA">
-        <!--
-        <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
-        TODO does not work ^
-        -->
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
             <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
-
-            <!-- These are the new defaults when running in Protean:
-            <property name="hibernate.cache.use_second_level_cache" value="true"/>
-            <property name="hibernate.cache.use_query_cache" value="true"/>
-            <property name="javax.persistence.sharedCache.mode" value="ENABLE_SELECTIVE"/>
-            -->
-
-            <!-- Limit size of region -->
-            <property name="hibernate.cache.org.jboss.shamrock.example.infinispancachejpa.Item.memory.size" value="3"/>
-
-            <!-- Limit max idle (seconds) of region -->
-            <property name="hibernate.cache.org.jboss.shamrock.example.infinispancachejpa.Country.expiration.max_idle" value="60"/>
-
-            <!-- Testing only: use manual time service -->
-            <property name="test.hibernate.cache.time_service" value="manual"/>
 
             <!-- Generate statistics to see effects of second level cache -->
             <property name="hibernate.generate_statistics" value="true" />


### PR DESCRIPTION
* A put from load might not to be allowed if too close to region
  invalidation for strict data access pattern.