### PR TITLE
Panache field access

### DIFF
--- a/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateEnhancersRegisteredBuildItem.java
+++ b/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateEnhancersRegisteredBuildItem.java
@@ -1,0 +1,12 @@
+package org.jboss.shamrock.jpa;
+
+import org.jboss.builder.item.SimpleBuildItem;
+
+/**
+ * Purely marker build item so that you can register enhancers after Hibernate
+ * registers its enhancers, which would make your enhancers run before the
+ * Hibernate enhancers
+ */
+public final class HibernateEnhancersRegisteredBuildItem extends SimpleBuildItem {
+
+}

--- a/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateEntityEnhancer.java
+++ b/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/HibernateEntityEnhancer.java
@@ -16,9 +16,6 @@
 
 package org.jboss.shamrock.jpa;
 
-import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.Objects;
 import java.util.function.BiFunction;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;

--- a/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/JpaEntitiesBuildItems.java
+++ b/extensions/jpa/deployment/src/main/java/org/jboss/shamrock/jpa/JpaEntitiesBuildItems.java
@@ -16,13 +16,32 @@
 
 package org.jboss.shamrock.jpa;
 
+import java.util.HashSet;
 import java.util.Set;
+
+import org.jboss.builder.item.SimpleBuildItem;
+import org.jboss.shamrock.deployment.annotations.BuildProducer;
+import org.jboss.shamrock.deployment.builditem.substrate.ReflectiveClassBuildItem;
 
 /**
  * Internal model to represent which objects are likely needing enhancement
  * via HibernateEntityEnhancer.
  */
-public interface KnownDomainObjects {
+public final class JpaEntitiesBuildItems extends SimpleBuildItem {
 
-    Set<String> getClassNames();
+    private final Set<String> classNames = new HashSet<String>();
+    
+    void addEntity(final String className) {
+        classNames.add(className);
+    }
+
+    void registerAllForReflection(final BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        for (String className : classNames) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, className));
+        }
+    }
+
+    public Set<String> getClassNames() {
+        return classNames;
+    }
 }

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/EntityField.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/EntityField.java
@@ -1,0 +1,22 @@
+package org.jboss.shamrock.panache;
+
+
+public class EntityField {
+
+    final String name;
+    final String descriptor;
+
+    public EntityField(String name, String descriptor) {
+        this.name = name;
+        this.descriptor = descriptor;
+    }
+
+    public String getGetterName() {
+        return JavaBeanUtil.getGetterName(name, descriptor);
+    }
+
+    public String getSetterName() {
+        return JavaBeanUtil.getSetterName(name);
+    }
+
+}

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/EntityModel.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/EntityModel.java
@@ -1,0 +1,19 @@
+package org.jboss.shamrock.panache;
+
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+
+public class EntityModel {
+
+    final String name;
+    final String superClassName;
+    final  Map<String, EntityField> fields;
+
+    public EntityModel(ClassInfo classInfo, Map<String, EntityField> fields) {
+        this.name = classInfo.name().toString();
+        this.superClassName = classInfo.superName().toString();
+        this.fields = fields;
+    }
+
+}

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/JavaBeanUtil.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/JavaBeanUtil.java
@@ -1,0 +1,44 @@
+package org.jboss.shamrock.panache;
+
+
+public class JavaBeanUtil {
+
+    public static String getGetterName(String name, String type) {
+        String prefix = type.equals("Z") ? "is" : "get";
+        return prefix + capitalize(name);
+    }
+
+    public static String getSetterName(String name) {
+        return "set" + capitalize(name);
+    }
+
+    // See conventions expressed by https://docs.oracle.com/javase/7/docs/api/java/beans/Introspector.html#decapitalize(java.lang.String)
+    public static String capitalize(String name) {
+        if (name != null && name.length() != 0) {
+            if (name.length() > 1 && Character.isUpperCase(name.charAt(1))) {
+                return name;
+            } else {
+                char[] chars = name.toCharArray();
+                chars[0] = Character.toUpperCase(chars[0]);
+                return new String(chars);
+            }
+        } else {
+            return name;
+        }
+    }
+
+    // See conventions expressed by https://docs.oracle.com/javase/7/docs/api/java/beans/Introspector.html#decapitalize(java.lang.String)
+    public static String decapitalize(String name) {
+        if (name != null && name.length() != 0) {
+            if (name.length() > 1 && Character.isUpperCase(name.charAt(1))) {
+                return name;
+            } else {
+                char[] chars = name.toCharArray();
+                chars[0] = Character.toLowerCase(chars[0]);
+                return new String(chars);
+            }
+        } else {
+            return name;
+        }
+    }
+}

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheFieldAccessEnhancer.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheFieldAccessEnhancer.java
@@ -1,0 +1,40 @@
+package org.jboss.shamrock.panache;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class PanacheFieldAccessEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    private Map<String, EntityModel> entities;
+
+    public PanacheFieldAccessEnhancer(Map<String, EntityModel> entities) {
+        this.entities = entities;
+    }
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        return new FieldAccessClassVisitor(className, outputClassVisitor, entities);
+    }
+
+    static class FieldAccessClassVisitor extends ClassVisitor {
+
+        private Map<String, EntityModel> entities;
+        private String classBinaryName;
+
+        public FieldAccessClassVisitor(String className, ClassVisitor outputClassVisitor, Map<String, EntityModel> entities) {
+            super(Opcodes.ASM6, outputClassVisitor);
+            this.entities = entities;
+            this.classBinaryName = className.replace('.', '/');
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String methodName, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor superVisitor = super.visitMethod(access, methodName, descriptor, signature, exceptions);
+            return new PanacheFieldAccessMethodVisitor(superVisitor, classBinaryName, methodName, descriptor, entities);
+        }
+    }
+}

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheFieldAccessMethodVisitor.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheFieldAccessMethodVisitor.java
@@ -28,7 +28,6 @@ class PanacheFieldAccessMethodVisitor extends MethodVisitor {
         if((opcode == Opcodes.GETFIELD
                 || opcode == Opcodes.PUTFIELD)
                 && isEntityField(owner.replace('/', '.'), fieldName)) {
-            System.err.println("Visiting field access to "+owner+"."+fieldName+" in method "+methodName);
             String methodName;
             String methodDescriptor;
             if(opcode == Opcodes.GETFIELD) {

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheFieldAccessMethodVisitor.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheFieldAccessMethodVisitor.java
@@ -1,0 +1,68 @@
+package org.jboss.shamrock.panache;
+
+import java.util.Map;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+class PanacheFieldAccessMethodVisitor extends MethodVisitor {
+
+    private final String methodName;
+    private Map<String, EntityModel> entities;
+    private String owner;
+    private String methodDescriptor;
+
+    PanacheFieldAccessMethodVisitor(MethodVisitor methodVisitor, String owner, 
+                                    String methodName, String methodDescriptor,
+                                    Map<String, EntityModel> entities) {
+        super(Opcodes.ASM6, methodVisitor);
+        this.owner = owner;
+        this.methodName = methodName;
+        this.methodDescriptor = methodDescriptor;
+        this.entities = entities;
+    }
+
+    @Override
+    public void visitFieldInsn(int opcode, String owner, String fieldName, String descriptor) {
+        // FIXME: do not substitute to accessors to this or super fields inside constructor?
+        if((opcode == Opcodes.GETFIELD
+                || opcode == Opcodes.PUTFIELD)
+                && isEntityField(owner.replace('/', '.'), fieldName)) {
+            System.err.println("Visiting field access to "+owner+"."+fieldName+" in method "+methodName);
+            String methodName;
+            String methodDescriptor;
+            if(opcode == Opcodes.GETFIELD) {
+                methodName = JavaBeanUtil.getGetterName(fieldName, descriptor);
+                methodDescriptor = "()"+descriptor;
+            } else {
+                methodName = JavaBeanUtil.getSetterName(fieldName);
+                methodDescriptor = "("+descriptor+")V";
+            }
+            if(!owner.equals(this.owner)
+                    || !methodName.equals(this.methodName)
+                    || !methodDescriptor.equals(this.methodDescriptor)) {
+                super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, owner, methodName, methodDescriptor, false);
+            } else {
+                // do not substitute to accessors inside its own accessor
+                super.visitFieldInsn(opcode, owner, fieldName, descriptor);
+            }
+        } else {
+            super.visitFieldInsn(opcode, owner, fieldName, descriptor);
+        }
+    }
+
+    /**
+     * @param className a dot-separated class name
+     */
+    boolean isEntityField(String className, String fieldName) {
+        EntityModel entityModel = entities.get(className);
+        if(entityModel == null)
+            return false;
+        EntityField field = entityModel.fields.get(fieldName);
+        if(field != null)
+            return true;
+        if(entityModel.superClassName != null)
+            return isEntityField(entityModel.superClassName, fieldName);
+        return false;
+    }
+}

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheJpaModelEnhancer.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheJpaModelEnhancer.java
@@ -260,7 +260,6 @@ public class PanacheJpaModelEnhancer implements BiFunction<String, ClassVisitor,
         for (FieldInfo fieldInfo : classInfo.fields()) {
             String name = fieldInfo.name();
             if(Modifier.isPublic(fieldInfo.flags())
-                    && !Modifier.isTransient(fieldInfo.flags())
                     && !fieldInfo.hasAnnotation(DOTNAME_TRANSIENT)) {
                 fields.put(name, new EntityField(name, DescriptorUtils.typeToString(fieldInfo.type())));
             }

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheResourceProcessor.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheResourceProcessor.java
@@ -90,19 +90,21 @@ public final class PanacheResourceProcessor {
                BuildProducer<NonJpaModelBuildItem> nonJpaModelBuildItems) throws Exception {
 
         PanacheJpaDaoEnhancer daoEnhancer = new PanacheJpaDaoEnhancer();
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(DOTNAME_DAO_BASE)) {
+        for (ClassInfo classInfo : index.getIndex().getAllKnownImplementors(DOTNAME_DAO_BASE)) {
             transformers.produce(new BytecodeTransformerBuildItem(classInfo.name().toString(), daoEnhancer));
         }
 
         PanacheJpaModelEnhancer modelEnhancer = new PanacheJpaModelEnhancer();
         Set<String> modelClasses = new HashSet<>();
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectSubclasses(DOTNAME_ENTITY_BASE)) {
+        // Note that we do this in two passes because for some reason Jandex does not give us subtypes
+        // of Model if we ask for subtypes of EntityBase
+        for (ClassInfo classInfo : index.getIndex().getAllKnownSubclasses(DOTNAME_ENTITY_BASE)) {
             // skip Model
             if(classInfo.name().equals(DOTNAME_MODEL))
                 continue;
             modelClasses.add(classInfo.name().toString());
         }
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectSubclasses(DOTNAME_MODEL)) {
+        for (ClassInfo classInfo : index.getIndex().getAllKnownSubclasses(DOTNAME_MODEL)) {
             modelClasses.add(classInfo.name().toString());
         }
         for (String modelClass : modelClasses) {

--- a/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheResourceProcessor.java
+++ b/extensions/panache/deployment/src/main/java/org/jboss/shamrock/panache/PanacheResourceProcessor.java
@@ -105,6 +105,7 @@ public final class PanacheResourceProcessor {
             modelClasses.add(classInfo.name().toString());
         }
         for (ClassInfo classInfo : index.getIndex().getAllKnownSubclasses(DOTNAME_MODEL)) {
+            modelEnhancer.collectFields(classInfo);
             modelClasses.add(classInfo.name().toString());
         }
         for (String modelClass : modelClasses) {

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
@@ -32,13 +32,22 @@ public class AccessorEntity extends GenericEntity<Integer> {
     public float f;
     public double d;
     transient public Object trans1;
+    transient public Object trans1b;
     @Transient
     public Object trans2;
+    @Transient
+    public Object trans2b;
+    
+    // FIXME: those appear to be mapped by hibernate
+    transient int getBCalls = 0;
+    transient int setICalls = 0;
+    transient int getTrans1bCalls = 0;
+    transient int setTrans2bCalls = 0;
     
     public void method() {
         // touch some fields
-        b = 2;
-        System.err.println(i);
+        System.err.println(b);
+        i = 2;
         t = 1;
         t2 = 2;
     }
@@ -46,10 +55,23 @@ public class AccessorEntity extends GenericEntity<Integer> {
     // explicit getter or setter
     
     public byte getB() {
+        getBCalls++;
         return b;
     }
     
     public void setI(int i) {
+        setICalls++;
         this.i = i;
+    }
+
+    
+    public Object getTrans1b() {
+        getTrans1bCalls++;
+        return trans1b;
+    }
+
+    public void setTrans2b(Object trans2b) {
+        setTrans2bCalls++;
+        this.trans2b = trans2b;
     }
 }

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
@@ -31,18 +31,16 @@ public class AccessorEntity extends GenericEntity<Integer> {
     public long l;
     public float f;
     public double d;
-    transient public Object trans1;
-    transient public Object trans1b;
+    @Transient
+    public Object trans;
     @Transient
     public Object trans2;
-    @Transient
-    public Object trans2b;
     
     // FIXME: those appear to be mapped by hibernate
     transient int getBCalls = 0;
     transient int setICalls = 0;
-    transient int getTrans1bCalls = 0;
-    transient int setTrans2bCalls = 0;
+    transient int getTransCalls = 0;
+    transient int setTransCalls = 0;
     
     public void method() {
         // touch some fields
@@ -65,13 +63,13 @@ public class AccessorEntity extends GenericEntity<Integer> {
     }
 
     
-    public Object getTrans1b() {
-        getTrans1bCalls++;
-        return trans1b;
+    public Object getTrans() {
+        getTransCalls++;
+        return trans;
     }
 
-    public void setTrans2b(Object trans2b) {
-        setTrans2bCalls++;
-        this.trans2b = trans2b;
+    public void setTrans(Object trans) {
+        setTransCalls++;
+        this.trans = trans;
     }
 }

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
@@ -44,7 +44,7 @@ public class AccessorEntity extends GenericEntity<Integer> {
     
     public void method() {
         // touch some fields
-        System.err.println(b);
+        byte b2 = b;
         i = 2;
         t = 1;
         t2 = 2;

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/AccessorEntity.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.example.panache;
+
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+
+@Entity
+public class AccessorEntity extends GenericEntity<Integer> {
+
+    public String string;
+    public char c;
+    public boolean bool;
+    public byte b;
+    public short s;
+    public int i;
+    public long l;
+    public float f;
+    public double d;
+    transient public Object trans1;
+    @Transient
+    public Object trans2;
+    
+    public void method() {
+        // touch some fields
+        b = 2;
+        System.err.println(i);
+        t = 1;
+        t2 = 2;
+    }
+    
+    // explicit getter or setter
+    
+    public byte getB() {
+        return b;
+    }
+    
+    public void setI(int i) {
+        this.i = i;
+    }
+}

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/GenericEntity.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/GenericEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.shamrock.example.panache;
+
+import javax.persistence.MappedSuperclass;
+
+import org.jboss.panache.jpa.Model;
+
+@MappedSuperclass
+public abstract class GenericEntity<T> extends Model {
+    public T t;
+    public T t2;
+    
+    public T getT2() {
+        return t2;
+    }
+    
+    public void setT2(T t2) {
+        this.t2 = t2;
+    }
+}

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/TestEndpoint.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/TestEndpoint.java
@@ -16,6 +16,7 @@
 
 package org.jboss.shamrock.example.panache;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -164,5 +165,56 @@ public class TestEndpoint {
         person.dogs.add(dog);
         
         return person;
+    }
+    
+    @GET
+    @Path("accessors")
+    public String testAccessors() throws NoSuchMethodException, SecurityException {
+        checkMethod(AccessorEntity.class, "getString", String.class);
+        checkMethod(AccessorEntity.class, "isBool", boolean.class);
+        checkMethod(AccessorEntity.class, "getC", char.class);
+        checkMethod(AccessorEntity.class, "getS", short.class);
+        checkMethod(AccessorEntity.class, "getI", int.class);
+        checkMethod(AccessorEntity.class, "getL", long.class);
+        checkMethod(AccessorEntity.class, "getF", float.class);
+        checkMethod(AccessorEntity.class, "getD", double.class);
+        checkMethod(AccessorEntity.class, "getT", Object.class);
+        checkMethod(AccessorEntity.class, "getT2", Object.class);
+
+        checkMethod(AccessorEntity.class, "setString", void.class, String.class);
+        checkMethod(AccessorEntity.class, "setBool", void.class, boolean.class);
+        checkMethod(AccessorEntity.class, "setC", void.class, char.class);
+        checkMethod(AccessorEntity.class, "setS", void.class, short.class);
+        checkMethod(AccessorEntity.class, "setI", void.class, int.class);
+        checkMethod(AccessorEntity.class, "setL", void.class, long.class);
+        checkMethod(AccessorEntity.class, "setF", void.class, float.class);
+        checkMethod(AccessorEntity.class, "setD", void.class, double.class);
+        checkMethod(AccessorEntity.class, "setT", void.class, Object.class);
+        checkMethod(AccessorEntity.class, "setT2", void.class, Object.class);
+        
+        try {
+            checkMethod(AccessorEntity.class, "getTrans1", Object.class);
+            Assertions.fail("transient field should have no getter: trans1");
+        }catch(NoSuchMethodException x) {}
+        try {
+            checkMethod(AccessorEntity.class, "getTrans2", Object.class);
+            Assertions.fail("transient field should have no getter: trans2");
+        }catch(NoSuchMethodException x) {}
+
+        try {
+            checkMethod(AccessorEntity.class, "setTrans1", void.class, Object.class);
+            Assertions.fail("transient field should have no setter: trans1");
+        }catch(NoSuchMethodException x) {}
+        try {
+            checkMethod(AccessorEntity.class, "setTrans2", void.class, Object.class);
+            Assertions.fail("transient field should have no setter: trans2");
+        }catch(NoSuchMethodException x) {}
+
+        return "OK";
+    }
+
+    private void checkMethod(Class<?> klass, String name, Class<?> returnType, Class<?>... params) throws NoSuchMethodException, SecurityException {
+        Method method = klass.getMethod(name, params);
+        Assertions.assertEquals(returnType, method.getReturnType());
     }
 }

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/TestEndpoint.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/TestEndpoint.java
@@ -193,18 +193,10 @@ public class TestEndpoint {
         checkMethod(AccessorEntity.class, "setT2", void.class, Object.class);
         
         try {
-            checkMethod(AccessorEntity.class, "getTrans1", Object.class);
-            Assertions.fail("transient field should have no getter: trans1");
-        }catch(NoSuchMethodException x) {}
-        try {
             checkMethod(AccessorEntity.class, "getTrans2", Object.class);
             Assertions.fail("transient field should have no getter: trans2");
         }catch(NoSuchMethodException x) {}
 
-        try {
-            checkMethod(AccessorEntity.class, "setTrans1", void.class, Object.class);
-            Assertions.fail("transient field should have no setter: trans1");
-        }catch(NoSuchMethodException x) {}
         try {
             checkMethod(AccessorEntity.class, "setTrans2", void.class, Object.class);
             Assertions.fail("transient field should have no setter: trans2");
@@ -216,10 +208,10 @@ public class TestEndpoint {
         Assertions.assertEquals(1, entity.getBCalls);
         entity.i = 2;
         Assertions.assertEquals(1, entity.setICalls);
-        Object trans = entity.trans1b;
-        Assertions.assertEquals(0, entity.getTrans1bCalls);
-        entity.trans1b = trans;
-        Assertions.assertEquals(0, entity.setTrans2bCalls);
+        Object trans = entity.trans;
+        Assertions.assertEquals(0, entity.getTransCalls);
+        entity.trans = trans;
+        Assertions.assertEquals(0, entity.setTransCalls);
         
         // accessors inside the entity itself
         entity.method();

--- a/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/TestEndpoint.java
+++ b/integration-tests/panache/src/main/java/org/jboss/shamrock/example/panache/TestEndpoint.java
@@ -210,6 +210,22 @@ public class TestEndpoint {
             Assertions.fail("transient field should have no setter: trans2");
         }catch(NoSuchMethodException x) {}
 
+        // Now check that accessors are called
+        AccessorEntity entity = new AccessorEntity();
+        byte b = entity.b;
+        Assertions.assertEquals(1, entity.getBCalls);
+        entity.i = 2;
+        Assertions.assertEquals(1, entity.setICalls);
+        Object trans = entity.trans1b;
+        Assertions.assertEquals(0, entity.getTrans1bCalls);
+        entity.trans1b = trans;
+        Assertions.assertEquals(0, entity.setTrans2bCalls);
+        
+        // accessors inside the entity itself
+        entity.method();
+        Assertions.assertEquals(2, entity.getBCalls);
+        Assertions.assertEquals(2, entity.setICalls);
+        
         return "OK";
     }
 

--- a/integration-tests/panache/src/test/java/org/jboss/shamrock/example/test/PanacheFunctionalityTest.java
+++ b/integration-tests/panache/src/test/java/org/jboss/shamrock/example/test/PanacheFunctionalityTest.java
@@ -33,6 +33,7 @@ public class PanacheFunctionalityTest {
     public void testPanacheFunctionality() throws Exception {
         RestAssured.when().get("/test/model-dao").then().body(is("OK"));
         RestAssured.when().get("/test/model").then().body(is("OK"));
+        RestAssured.when().get("/test/accessors").then().body(is("OK"));
     }
 
 }


### PR DESCRIPTION
Another part of #646: we now auto-generate accessors for every non-`@Transient` public field, unless they already exist, and we replace every field access to them by the accessors (except in the accessors themselves).