### PR TITLE
Rename standard jar when uberJar option is used

### DIFF
--- a/cli/maven/src/main/java/org/jboss/shamrock/maven/BuildMojo.java
+++ b/cli/maven/src/main/java/org/jboss/shamrock/maven/BuildMojo.java
@@ -45,7 +45,7 @@ import org.jboss.shamrock.creator.resolver.maven.ResolvedMavenArtifactDeps;
  *
  * @author Alexey Loubyansky
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class BuildMojo extends AbstractMojo {
 
     /**

--- a/cli/maven/src/test/java/org/jboss/shamrock/maven/it/PackageIT.java
+++ b/cli/maven/src/test/java/org/jboss/shamrock/maven/it/PackageIT.java
@@ -25,6 +25,9 @@ public class PackageIT extends MojoTestBase {
         final MavenProcessInvocationResult result = running.execute(Collections.singletonList("package"), Collections.emptyMap());
 
         assertThat(result.getProcess().waitFor()).isEqualTo(0);
+
+        final File targetDir = getTargetDir();
+        assertThat(getNumberOfFilesEndingWith(targetDir, ".jar")).isEqualTo(2);
     }
 
     @Test
@@ -36,5 +39,18 @@ public class PackageIT extends MojoTestBase {
             put("UBER_JAR", "true");
         }});
         assertThat(result.getProcess().waitFor()).isEqualTo(0);
+
+        final File targetDir = getTargetDir();
+        assertThat(getNumberOfFilesEndingWith(targetDir, ".jar")).isEqualTo(1);
+        assertThat(getNumberOfFilesEndingWith(targetDir, ".original")).isEqualTo(1);
+    }
+
+    private int getNumberOfFilesEndingWith(File dir, String suffix) {
+        final File[] files = dir.listFiles((d, name) -> name.endsWith(suffix));
+        return files != null ? files.length : 0;
+    }
+
+    private File getTargetDir() {
+        return new File(testDir.getAbsoluteFile() + "/target");
     }
 }

--- a/core/creator/src/main/java/org/jboss/shamrock/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/org/jboss/shamrock/creator/phase/runnerjar/RunnerJarPhase.java
@@ -178,6 +178,16 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
             throw new AppCreatorException("Failed to build a runner jar", e);
         }
 
+        // when using uberJar, we rename the standard jar to include the .original suffix
+        // this greatly aids tools (such as s2i) that look for a single jar in the output directory to work OOTB
+        if (uberJar) {
+            try {
+                Files.move(outputDir.resolve(finalName + ".jar"), outputDir.resolve(finalName + ".jar.original"));
+            } catch (IOException e) {
+                throw new AppCreatorException("Unable to build uberjar", e);
+            }
+        }
+
         ctx.pushOutcome(RunnerJarOutcome.class, this);
     }
 


### PR DESCRIPTION
When `uberJar` is specified we rename the standard jar by adding the
`.original` suffix.
This is done in order to help tools that expect a single jar in the
output directory to work out of the box (a prominent case being Openshift S2I)