### PR TITLE
No longer needing the redhat-ga-repository Maven repository

### DIFF
--- a/azure-mvn-settings.xml
+++ b/azure-mvn-settings.xml
@@ -2,7 +2,7 @@
   <mirrors>
     <mirror>
       <id>jboss-public-repository-group</id>
-      <mirrorOf>*,!redhat-ga-repository,!protean-nexus-release,!protean-nexus-snapshot</mirrorOf>
+      <mirrorOf>*,!protean-nexus-release,!protean-nexus-snapshot</mirrorOf>
       <name>jboss</name>
       <url>http://repository.jboss.org/nexus/content/groups/developer/</url>
     </mirror>
@@ -24,20 +24,6 @@
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
           </snapshots>
-        </repository>
-        <repository>
-          <id>redhat-ga-repository</id>
-          <name>Red Hat GA repository</name>
-          <url>http://maven.repository.redhat.com/ga/</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-            <snapshots>
-              <enabled>false</enabled>
-              <updatePolicy>daily</updatePolicy>
-           </snapshots>
         </repository>
         <!-- Forgot the password? see https://github.com/protean-project/hibernate-protean/wiki/Protean-Nexus-credentials -->
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -94,20 +94,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>redhat-ga-repository</id>
-            <name>Red Hat GA repository</name>
-            <url>http://maven.repository.redhat.com/ga/</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-        </repository>
 
         <!-- Forgot the password? see https://github.com/protean-project/hibernate-protean/wiki/Protean-Nexus-credentials -->
         <repository>


### PR DESCRIPTION
This repository was useful when we worked on "class data sharing" optimisations. We no longer care? 

Either way, the code modules requiring it are now gone.