### PR TITLE
Add native integration test to generated projects

### DIFF
--- a/cli/common/src/main/java/org/jboss/shamrock/BasicRest.java
+++ b/cli/common/src/main/java/org/jboss/shamrock/BasicRest.java
@@ -82,8 +82,10 @@ public class BasicRest extends ShamrockTemplate {
     private void createClasses() throws IOException {
         File classFile = new File(srcMain, className + MojoUtils.JAVA_EXTENSION);
         File testClassFile = new File(testMain, className + "Test" + MojoUtils.JAVA_EXTENSION);
+        File itTestClassFile = new File(testMain, "Native" + className + "IT" + MojoUtils.JAVA_EXTENSION);
         generate("templates/resource-template.ftl", context, classFile, "resource code");
         generate("templates/test-resource-template.ftl", context, testClassFile, "test code");
+        generate("templates/native-test-resource-template.ftl", context, itTestClassFile, "IT code");
     }
 
     @SuppressWarnings("unchecked")

--- a/cli/common/src/main/resources/templates/native-test-resource-template.ftl
+++ b/cli/common/src/main/resources/templates/native-test-resource-template.ftl
@@ -1,0 +1,9 @@
+package ${package_name};
+
+import org.jboss.shamrock.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class Native${class_name}IT extends ${class_name}Test {
+
+    // Execute the same tests but in native mode.
+}

--- a/cli/common/src/main/resources/templates/pom-template.ftl
+++ b/cli/common/src/main/resources/templates/pom-template.ftl
@@ -98,6 +98,24 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/cli/common/src/test/java/org/jboss/shamrock/cli/commands/CreateProjectTest.java
+++ b/cli/common/src/test/java/org/jboss/shamrock/cli/commands/CreateProjectTest.java
@@ -103,6 +103,7 @@ public class CreateProjectTest {
         assertThat(new File(testDir, "src/main/java/org/foo/MyResource.java")).isFile();
         assertThat(new File(testDir, "src/test/java")).isDirectory();
         assertThat(new File(testDir, "src/test/java/org/foo/MyResourceTest.java")).isFile();
+        assertThat(new File(testDir, "src/test/java/org/foo/NativeMyResourceIT.java")).isFile();
 
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
                 .containsIgnoringCase(getBomArtifactId());


### PR DESCRIPTION
Fix #775

Generated project should contain a native test. This PR add the native test and configure the native profile to run it.