### PR TITLE
Curate the Hibernate ORM Runtime Dependencies

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1217,18 +1217,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate-orm.version}</version>
-            <exclusions>
-               <!-- JAXB is now an explicit dependency to help JDK11 users, 
-                  but we don't really need it on JDK8 -->
-               <exclusion>
-                  <groupId>org.jvnet.jaxb2_commons</groupId>
-                  <artifactId>jaxb2-basics</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>com.sun.xml.bind</groupId>
-                  <artifactId>jaxb-impl</artifactId>
-               </exclusion>
-            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.glassfish.web</groupId>

--- a/extensions/jpa/deployment/pom.xml
+++ b/extensions/jpa/deployment/pom.xml
@@ -51,11 +51,21 @@
         </dependency>
 
         <!--
-           Re-import this so to dodge the Byte Buddy exclusion we declared in shamrock-jpa-runtime
-           I prefer to use exclusions only so to transitively let Hibernate ORM manage the versions -->
+           Exclusions currently not listed in the parent pom as they need to be different in runtime vs deployment:
+           Re-import this so to dodge the Byte Buddy exclusion we declared in shamrock-jpa-runtime;
+           to help Java 11 users the explicit dependency to XML parsers might also be useful
+           (yet not needed at runtime).
+           I prefer to use exclusions only so to transitively let Hibernate ORM manage the versions.
+           -->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/extensions/jpa/runtime/pom.xml
+++ b/extensions/jpa/runtime/pom.xml
@@ -43,11 +43,39 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <exclusions>
+
                 <!-- Byte Buddy is needed during augmentation but not at runtime -->
                 <exclusion>
                     <groupId>net.bytebuddy</groupId>
                     <artifactId>byte-buddy</artifactId>
                 </exclusion>
+
+                <!-- Javassist is never used in Protean -->
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+
+                <!-- XML parsers only needed to parse configurations during the deployment phase -->
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+
+                <!-- Following dependencies are only necessary during metadata initialization -->
+                <exclusion>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jandex</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
There are some important differences between dependencies when thinking about them in terms of runtime vs augmentation.

Taking advantage of that to trim our runtime needs.