### PR TITLE
Handle both custom port and host for RestAssured

### DIFF
--- a/test-framework/common/src/main/java/org/jboss/shamrock/test/common/RestAssuredURLManager.java
+++ b/test-framework/common/src/main/java/org/jboss/shamrock/test/common/RestAssuredURLManager.java
@@ -11,24 +11,31 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * <p>
  * TODO: do we actually want this here, or should it be in a different module?
  */
-public class RestAssuredPortManager {
+public class RestAssuredURLManager {
 
     private static final Field portField;
+    private static final Field baseURIField;
     private static int oldPort;
+    private static String oldBaseURI;
 
     static  {
         Field p;
+        Field base;
         try {
             Class<?> restAssured = Class.forName("io.restassured.RestAssured");
             p = restAssured.getField("port");
             p.setAccessible(true);
+            base = restAssured.getField("baseURI");
+            base.setAccessible(true);
         } catch (Exception e) {
             p = null;
+            base = null;
         }
         portField = p;
+        baseURIField = base;
     }
 
-    public static void setPort() {
+    public static void setURL() {
         if (portField != null) {
             try {
                 oldPort = (Integer) portField.get(null);
@@ -38,12 +45,28 @@ public class RestAssuredPortManager {
                 e.printStackTrace();
             }
         }
+        if (baseURIField != null) {
+            try {
+                oldBaseURI = (String) baseURIField.get(null);
+                String baseURI = "http://" + ConfigProvider.getConfig().getOptionalValue("shamrock.http.host", String.class).orElse("localhost");
+                baseURIField.set(null, baseURI);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
-    public static void clearPort() {
+    public static void clearURL() {
         if (portField != null) {
             try {
                 portField.set(null, oldPort);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        if (baseURIField != null) {
+            try {
+                baseURIField.set(null, oldBaseURI);
             } catch (IllegalAccessException e) {
                 e.printStackTrace();
             }

--- a/test-framework/junit4/src/main/java/org/jboss/shamrock/test/junit4/AbstractShamrockRunListener.java
+++ b/test-framework/junit4/src/main/java/org/jboss/shamrock/test/junit4/AbstractShamrockRunListener.java
@@ -19,7 +19,7 @@ package org.jboss.shamrock.test.junit4;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jboss.shamrock.test.common.RestAssuredPortManager;
+import org.jboss.shamrock.test.common.RestAssuredURLManager;
 import org.jboss.shamrock.test.common.TestResourceManager;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
@@ -46,7 +46,7 @@ abstract class AbstractShamrockRunListener extends RunListener {
 
     @Override
     public void testStarted(Description description) throws Exception {
-        RestAssuredPortManager.setPort();
+        RestAssuredURLManager.setURL();
         if (!started) {
             List<RunListener> stopListeners = new ArrayList<>();
 
@@ -92,7 +92,7 @@ abstract class AbstractShamrockRunListener extends RunListener {
     @Override
     public void testFinished(Description description) throws Exception {
         super.testFinished(description);
-        RestAssuredPortManager.clearPort();
+        RestAssuredURLManager.clearURL();
     }
 
     protected abstract void startShamrock() throws Exception;

--- a/test-framework/junit5-internal/src/main/java/org/jboss/shamrock/test/ShamrockUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/org/jboss/shamrock/test/ShamrockUnitTest.java
@@ -47,7 +47,7 @@ import org.jboss.shamrock.runtime.InjectionFactoryTemplate;
 import org.jboss.shamrock.runtime.InjectionInstance;
 import org.jboss.shamrock.runtime.LaunchMode;
 import org.jboss.shamrock.test.common.PathTestHelper;
-import org.jboss.shamrock.test.common.RestAssuredPortManager;
+import org.jboss.shamrock.test.common.RestAssuredURLManager;
 import org.jboss.shamrock.test.common.TestResourceManager;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -286,11 +286,11 @@ public class ShamrockUnitTest implements BeforeAllCallback, AfterAllCallback, Te
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        RestAssuredPortManager.clearPort();
+        RestAssuredURLManager.clearURL();
     }
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        RestAssuredPortManager.setPort();
+        RestAssuredURLManager.setURL();
     }
 }

--- a/test-framework/junit5/src/main/java/org/jboss/shamrock/test/junit/ShamrockTestExtension.java
+++ b/test-framework/junit5/src/main/java/org/jboss/shamrock/test/junit/ShamrockTestExtension.java
@@ -20,13 +20,11 @@ import static org.jboss.shamrock.test.common.PathTestHelper.getAppClassLocation;
 import static org.jboss.shamrock.test.common.PathTestHelper.getTestClassesLocation;
 
 import java.io.Closeable;
-import java.util.Collections;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.shamrock.runner.RuntimeRunner;
 import org.jboss.shamrock.runtime.LaunchMode;
 import org.jboss.shamrock.test.common.NativeImageLauncher;
-import org.jboss.shamrock.test.common.RestAssuredPortManager;
+import org.jboss.shamrock.test.common.RestAssuredURLManager;
 import org.jboss.shamrock.test.common.TestResourceManager;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -74,12 +72,12 @@ public class ShamrockTestExtension implements BeforeAllCallback, BeforeEachCallb
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        RestAssuredPortManager.clearPort();
+        RestAssuredURLManager.clearURL();
     }
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        RestAssuredPortManager.setPort();
+        RestAssuredURLManager.setURL();
     }
 
 


### PR DESCRIPTION
Handle both custom port and host for RestAssured
Follow-up of https://github.com/jbossas/protean-shamrock/pull/869

Covering just RestAssured, Stuart @stuartwdouglas handles rest via #887 - https://github.com/jbossas/protean-shamrock/pull/887/files#diff-cd9659ce5e39771f30bd707a28e45254R25
