### PR TITLE
Suppress unchecked cast warnings in extension annotation processor

### DIFF
--- a/core/processor/src/main/java/org/jboss/shamrock/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/org/jboss/shamrock/annotation/processor/ExtensionAnnotationProcessor.java
@@ -502,9 +502,11 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
             final String fieldName = field.getSimpleName().toString();
             final JMethodDef getter = classDef.method(JMod.PUBLIC | JMod.STATIC, publicType, "get_" + fieldName);
+            getter.annotate(SuppressWarnings.class).value("unchecked");
             getter.param(JType.OBJECT, INSTANCE_SYM);
             getter.body()._return(instanceName.cast(clazzType).field(fieldName));
             final JMethodDef setter = classDef.method(JMod.PUBLIC | JMod.STATIC, JType.VOID, "set_" + fieldName);
+            setter.annotate(SuppressWarnings.class).value("unchecked");
             setter.param(JType.OBJECT, INSTANCE_SYM);
             setter.param(publicType, fieldName);
             final JAssignableExpr fieldExpr = JExprs.name(fieldName);


### PR DESCRIPTION
We started to have a lot of compilation warnings due to the new extension annotation processor.

This PR fixes it.