### PR TITLE
Revert "Fixes #880, add Resteasy to the bom so the version aligns"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -22,10 +22,6 @@
    <name>Shamrock - BOM</name>
    <packaging>pom</packaging>
 
-   <properties>
-      <resteasy.version>4.0.0.Beta8</resteasy.version>
-   </properties>
-
    <dependencyManagement>
       <dependencies>
 
@@ -237,64 +233,6 @@
             <artifactId>shamrock-junit5</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-         </dependency>
-
-         <!-- Additional artifacts that we need to specify the version for-->
-
-         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-bom</artifactId>
-            <version>${resteasy.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-         </dependency>
-
-         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-rxjava2</artifactId>
-            <version>${resteasy.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-core</artifactId>
-            <version>${resteasy.version}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.jboss.spec.javax.annotation</groupId>
-                  <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>javax.activation</groupId>
-                  <artifactId>activation</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
-         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-core-spi</artifactId>
-            <version>${resteasy.version}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.jboss.spec.javax.annotation</groupId>
-                  <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>javax.activation</groupId>
-                  <artifactId>activation</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
-         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${resteasy.version}</version>
-            <exclusions>
-               <!-- The JBoss JAXB API artifact is used instead -->
-               <exclusion>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-               </exclusion>
-            </exclusions>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -29,6 +29,7 @@
       
       <aesh.version>1.11</aesh.version>
       <jandex.version>2.1.0.Final</jandex.version>
+      <resteasy.version>4.0.0.Beta8</resteasy.version>
       <opentracing.version>0.31.0</opentracing.version>
       <opentracing-jaxrs.version>0.3.1</opentracing-jaxrs.version>
       <opentracing-web-servlet-filter.version>0.2.2</opentracing-web-servlet-filter.version>
@@ -127,13 +128,6 @@
 
    <dependencyManagement>
       <dependencies>
-         <dependency>
-            <groupId>org.jboss.shamrock</groupId>
-            <artifactId>shamrock-bom</artifactId>
-            <version>${project.version}</version>
-             <type>pom</type>
-             <scope>import</scope>
-         </dependency>
          <dependency>
             <groupId>org.jboss.shamrock</groupId>
             <artifactId>shamrock-agroal-deployment</artifactId>
@@ -1054,6 +1048,73 @@
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-integration</artifactId>
             <version>${narayana.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+            <version>${resteasy.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${resteasy.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+            <version>${resteasy.version}</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>org.jboss.spec.javax.annotation</groupId>
+                  <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>javax.activation</groupId>
+                  <artifactId>activation</artifactId>
+               </exclusion>
+            </exclusions>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core-spi</artifactId>
+            <version>${resteasy.version}</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>org.jboss.spec.javax.annotation</groupId>
+                  <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>javax.activation</groupId>
+                  <artifactId>activation</artifactId>
+               </exclusion>
+            </exclusions>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>${resteasy.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-p-provider</artifactId>
+            <version>${resteasy.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+            <version>${resteasy.version}</version>
+            <exclusions>
+               <!-- The JBoss JAXB API artifact is used instead -->
+               <exclusion>
+                  <groupId>javax.xml.bind</groupId>
+                  <artifactId>jaxb-api</artifactId>
+               </exclusion>
+            </exclusions>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-rxjava2</artifactId>
+            <version>${resteasy.version}</version>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
This reverts commit 956ac1a9624e4b5b47b0691ce4fef4eedf914fb0.

Introducing the RESTEasy bom downgrades a lot of components. We cannot
do that.