### PR TITLE
Fix for #924 + other minor fixes

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/configuration/ConfigDefinition.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/configuration/ConfigDefinition.java
@@ -9,7 +9,7 @@ import static org.jboss.shamrock.deployment.util.StringUtil.camelHumpsIterator;
 import static org.jboss.shamrock.deployment.util.StringUtil.hyphenate;
 import static org.jboss.shamrock.deployment.util.StringUtil.join;
 import static org.jboss.shamrock.deployment.util.StringUtil.lowerCase;
-import static org.jboss.shamrock.deployment.util.StringUtil.lowerCastFirst;
+import static org.jboss.shamrock.deployment.util.StringUtil.lowerCaseFirst;
 import static org.jboss.shamrock.deployment.util.StringUtil.withoutSuffix;
 
 import java.lang.reflect.AnnotatedElement;
@@ -134,7 +134,7 @@ public class ConfigDefinition extends CompoundConfigType {
         if (configRoot.isAnnotationPresent(ConfigGroup.class)) {
             throw reportError(configRoot, "Roots cannot have a @ConfigGroup annotation");
         }
-        final String containingName = join(withoutSuffix(lowerCastFirst(camelHumpsIterator(configRoot.getSimpleName())), "config", "configuration"));
+        final String containingName = join(withoutSuffix(lowerCaseFirst(camelHumpsIterator(configRoot.getSimpleName())), "Config", "Configuration"));
         final String name = configRootAnnotation.name();
         final String rootName;
         if (name.equals(ConfigItem.PARENT)) {

--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/StringUtil.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/StringUtil.java
@@ -44,7 +44,8 @@ public final class StringUtil {
                                 idx = nextIdx;
                                 nextIdx = str.offsetByCodePoints(idx, 1);
                             }
-                            // consumed the whole remainder
+                            // consumed the whole remainder, update idx to length
+                            idx = str.length();
                             return str.substring(start);
                         } else {
                             // initial caps, trailing lowercase
@@ -117,7 +118,7 @@ public final class StringUtil {
         return b.toString();
     }
 
-    public static Iterator<String> lowerCastFirst(Iterator<String> orig) {
+    public static Iterator<String> lowerCaseFirst(Iterator<String> orig) {
         return new Iterator<String>() {
             boolean first = true;
 

--- a/core/deployment/src/test/java/org/jboss/shamrock/deployment/util/StringUtilTestCase.java
+++ b/core/deployment/src/test/java/org/jboss/shamrock/deployment/util/StringUtilTestCase.java
@@ -1,0 +1,96 @@
+package org.jboss.shamrock.deployment.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.jboss.shamrock.deployment.util.StringUtil.camelHumpsIterator;
+import static org.jboss.shamrock.deployment.util.StringUtil.join;
+import static org.jboss.shamrock.deployment.util.StringUtil.lowerCase;
+import static org.jboss.shamrock.deployment.util.StringUtil.lowerCaseFirst;
+import static org.jboss.shamrock.deployment.util.StringUtil.withoutSuffix;
+
+/**
+ * Tests of the {@linkplain StringUtil} methods
+ */
+public class StringUtilTestCase {
+
+    /**
+     * Test word beginning with mulitiple uppercase letters
+     */
+    @Test
+    public void testHypentateUppercaseBegin() {
+        String hyphenated = StringUtil.hyphenate("SBVbt");
+        Assert.assertEquals("sb-vbt", hyphenated);
+    }
+    /**
+     * Test word with only uppercase letters
+     */
+    @Test
+    public void testHypentateAllUppercase() {
+        String hyphenated = StringUtil.hyphenate("SHOUT");
+        Assert.assertEquals("shout", hyphenated);
+    }
+
+    /**
+     * Test word with multiple uppercase letters in middle
+     */
+    @Test
+    public void testHypentateUppercaseMiddle() {
+        String hyphenated = StringUtil.hyphenate("btSBVsuffix");
+        Assert.assertEquals("bt-sb-vsuffix", hyphenated);
+    }
+    /**
+     * Test word with multiple uppercase letters at end
+     */
+    @Test
+    public void testHypentateUppercaseEnd() {
+        String hyphenated = StringUtil.hyphenate("btSBV");
+        Assert.assertEquals("bt-sbv", hyphenated);
+    }
+
+    /**
+     * Test the special case of a word with JBoss in it as the JB are treated as one
+     */
+    @Test
+    public void testHypentateJBossWord() {
+        String hyphenated = StringUtil.hyphenate("JBossHome");
+        Assert.assertEquals("jboss-home", hyphenated);
+    }
+    /**
+     * Test the special case of a word with JBoss in it as the JB are treated as one
+     */
+    @Test
+    public void testHypentateJBossWordAtEnd() {
+        String hyphenated = StringUtil.hyphenate("HomeOfJBoss");
+        Assert.assertEquals("home-of-jboss", hyphenated);
+    }
+
+    /**
+     * Test only lower casing first word
+     */
+    @Test
+    public void testLowerCaseFirst() {
+        String result = StringUtil.join(StringUtil.lowerCaseFirst(StringUtil.camelHumpsIterator("SomeRootConfig")));
+        Assert.assertEquals("someRootConfig", result);
+    }
+    /**
+     * Test only lower casing first word and removing a suffix word
+     */
+    @Test
+    public void testLowerCaseFirstNoSuffix() {
+        String result = join(withoutSuffix(lowerCaseFirst(camelHumpsIterator("SomeRootConfig")), "Config", "Class"));
+        Assert.assertEquals("someRoot", result);
+        result = join(withoutSuffix(lowerCaseFirst(camelHumpsIterator("SomeRootClass")), "Config", "Class"));
+        Assert.assertEquals("someRoot", result);
+    }
+    /**
+     * Test only lower casing and removing a suffix word
+     */
+    @Test
+    public void testLowerCaseNoSuffix() {
+        String result = join(withoutSuffix(lowerCase(camelHumpsIterator("SomeRootConfig")), "config", "class"));
+        Assert.assertEquals("someroot", result);
+        result = join(withoutSuffix(lowerCase(camelHumpsIterator("SomeRootClass")), "config", "class"));
+        Assert.assertEquals("someroot", result);
+    }
+}


### PR DESCRIPTION
This fixes the problem with #924 as well as:

- StringUtil#lowerCaseFirst had a typo, was lowerCastFirst
- ConfigDefinition line 137 was passing in lower case values for the config and configuration root class suffixes when using lowerCaseFirst.
- Added a StringUtilTestCase to start testing different scenarios