### PR TITLE
Centralize sha1 implementation

### DIFF
--- a/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/HashUtil.java
+++ b/core/deployment/src/main/java/org/jboss/shamrock/deployment/util/HashUtil.java
@@ -1,0 +1,25 @@
+package org.jboss.shamrock.deployment.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class HashUtil {
+
+    private HashUtil() {
+    }
+
+    public static String sha1(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(40);
+            for (int i = 0; i < digest.length; ++i) {
+                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/core/deployment/src/test/java/org/jboss/shamrock/deployment/util/HashUtilTest.java
+++ b/core/deployment/src/test/java/org/jboss/shamrock/deployment/util/HashUtilTest.java
@@ -1,0 +1,14 @@
+package org.jboss.shamrock.deployment.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+
+public class HashUtilTest {
+
+    @Test
+    public void testSha1() {
+        assertEquals("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", HashUtil.sha1("test"));
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/Hashes.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/Hashes.java
@@ -18,15 +18,18 @@ package org.jboss.protean.arc.processor;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 
 final class Hashes {
 
     static String sha1(String value) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
-            return Base64.getUrlEncoder()
-                    .encodeToString(md.digest(value.getBytes(StandardCharsets.UTF_8)));
+            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(40);
+            for (int i = 0; i < digest.length; ++i) {
+                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+            }
+            return sb.toString();
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
And make it more general purpose: using Base64 might work for file names
but it doesn't work for Java identifiers (typically method) as it can
contain characters that are not valid.

Also modified Arc implementation.

**The main reason for this change is that I needed a hash method usable for method names. With Base64, we end up with invalid identifiers**

@mkouba I changed the Arc implementation too so please take a look.

One of the consequence is that the filename/class name will be longer. Not sure if it's an issue?