### PR TITLE
ArC - collect and log all dependencies resolution errors

### DIFF
--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanInfo.java
@@ -343,14 +343,14 @@ public class BeanInfo {
         // TODO we should add way more validations
     }
 
-    void init() {
+    void init(List<Throwable> errors) {
         for (Injection injection : injections) {
             for (InjectionPointInfo injectionPoint : injection.injectionPoints) {
-                Beans.resolveInjectionPoint(beanDeployment, this, injectionPoint);
+                Beans.resolveInjectionPoint(beanDeployment, this, injectionPoint, errors);
             }
         }
         if (disposer != null) {
-            disposer.init();
+            disposer.init(errors);
         }
         interceptedMethods = initInterceptedMethods();
         lifecycleInterceptors = initLifecycleInterceptors();

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/DisposerInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/DisposerInfo.java
@@ -69,9 +69,9 @@ public class DisposerInfo {
         return injectionPoints;
     }
 
-    void init() {
+    void init(List<Throwable> errors) {
         for (InjectionPointInfo injectionPoint : injection.injectionPoints) {
-            Beans.resolveInjectionPoint(declaringBean.getDeployment(), null, injectionPoint);
+            Beans.resolveInjectionPoint(declaringBean.getDeployment(), null, injectionPoint, errors);
         }
     }
 

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/InjectionPointInfo.java
@@ -135,7 +135,7 @@ public class InjectionPointInfo {
     }
     
     /**
-     * For injectected params, this method returns the corresponding method and not the param itself.
+     * For injected params, this method returns the corresponding method and not the param itself.
      * 
      * @return the annotation target
      */

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/InjectionPointInfo.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
@@ -44,11 +45,11 @@ public class InjectionPointInfo {
                 qualifiers.add(annotation);
             }
         }
-        return new InjectionPointInfo(field.type(), qualifiers.isEmpty() ? Collections.emptySet() : qualifiers);
+        return new InjectionPointInfo(field.type(), qualifiers.isEmpty() ? Collections.emptySet() : qualifiers, field);
     }
 
     static InjectionPointInfo fromResourceField(FieldInfo field, BeanDeployment beanDeployment) {
-        return new InjectionPointInfo(field.type(), new HashSet<>(field.annotations()), Kind.RESOURCE);
+        return new InjectionPointInfo(field.type(), new HashSet<>(field.annotations()), Kind.RESOURCE, field);
     }
 
     static List<InjectionPointInfo> fromMethod(MethodInfo method, BeanDeployment beanDeployment) {
@@ -76,7 +77,7 @@ public class InjectionPointInfo {
                     paramQualifiers.add(paramAnnotation);
                 }
             }
-            injectionPoints.add(new InjectionPointInfo(paramType, paramQualifiers));
+            injectionPoints.add(new InjectionPointInfo(paramType, paramQualifiers, method));
         }
         return injectionPoints;
     }
@@ -88,18 +89,21 @@ public class InjectionPointInfo {
     private final Kind kind;
     
     private final boolean hasDefaultedQualifier;
+    
+    private final AnnotationTarget target;
 
-    InjectionPointInfo(Type requiredType, Set<AnnotationInstance> requiredQualifiers) {
-        this(requiredType, requiredQualifiers, Kind.CDI);
+    InjectionPointInfo(Type requiredType, Set<AnnotationInstance> requiredQualifiers, AnnotationTarget target) {
+        this(requiredType, requiredQualifiers, Kind.CDI, target);
     }
 
-    InjectionPointInfo(Type requiredType, Set<AnnotationInstance> requiredQualifiers, Kind kind) {
+    InjectionPointInfo(Type requiredType, Set<AnnotationInstance> requiredQualifiers, Kind kind, AnnotationTarget target) {
         this.typeAndQualifiers = new TypeAndQualifiers(requiredType,
                 requiredQualifiers.isEmpty() ? Collections.singleton(AnnotationInstance.create(DotNames.DEFAULT, null, Collections.emptyList()))
                         : requiredQualifiers);
         this.resolvedBean = new AtomicReference<BeanInfo>(null);
         this.kind = kind;
         this.hasDefaultedQualifier = requiredQualifiers.isEmpty();
+        this.target = target;
     }
 
     void resolve(BeanInfo bean) {
@@ -128,6 +132,26 @@ public class InjectionPointInfo {
     
     TypeAndQualifiers getTypeAndQualifiers() {
         return typeAndQualifiers;
+    }
+    
+    /**
+     * For injectected params, this method returns the corresponding method and not the param itself.
+     * 
+     * @return the annotation target
+     */
+    public AnnotationTarget getTarget() {
+        return target;
+    }
+    
+    public String getTargetInfo() {
+        switch (target.kind()) {
+            case FIELD:
+                return target.asField().declaringClass().name() + "#" + target.asField().name(); 
+            case METHOD:
+                return target.asMethod().declaringClass().name() + "#" + target.asMethod().name() + "()"; 
+            default:
+                return target.toString();
+        }
     }
 
     @Override

--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/ObserverInfo.java
@@ -91,9 +91,9 @@ public class ObserverInfo {
         return isAsync;
     }
 
-    void init() {
+    void init(List<Throwable> errors) {
         for (InjectionPointInfo injectionPoint : injection.injectionPoints) {
-            Beans.resolveInjectionPoint(declaringBean.getDeployment(), null, injectionPoint);
+            Beans.resolveInjectionPoint(declaringBean.getDeployment(), getDeclaringBean(), injectionPoint, errors);
         }
     }
 


### PR DESCRIPTION
- instead of failing the build when a first problem occurs
- resolves #900 

NOTE: We validate the deployment in two batches: 1) dependencies, 2) other bean attributes + custom validators.

Example build failure:
```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.340 s
[INFO] Finished at: 2019-02-18T13:00:30+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.jboss.shamrock:shamrock-maven-plugin:1.0.0.Alpha1-SNAPSHOT:build (default) on project application-configuration: Failed to build a runnable JAR: Failed to build a runner jar: Failed to augment application classes: Build failure: Build failed due to errors
[ERROR] 	[error]: Build step org.jboss.shamrock.arc.deployment.ArcAnnotationProcessor#build threw an exception: javax.enterprise.inject.spi.DeploymentException: Found 3 deployment problems: 
[ERROR] [1] Unsatisfied dependency for type java.math.BigDecimal and qualifiers [@Default]
[ERROR] 	- java member: org.acme.config.SimpleBean#number
[ERROR] 	- declared on CLASS bean [types=[org.acme.config.SimpleBean, java.lang.Object], qualifiers=[@Default, @Any], target=org.acme.config.SimpleBean]
[ERROR] [2] Unsatisfied dependency for type java.lang.String and qualifiers [@Default]
[ERROR] 	- java member: org.acme.config.SimpleBean#someString
[ERROR] 	- declared on CLASS bean [types=[org.acme.config.SimpleBean, java.lang.Object], qualifiers=[@Default, @Any], target=org.acme.config.SimpleBean]
[ERROR] [3] Unsatisfied dependency for type java.lang.String and qualifiers [@Default]
[ERROR] 	- java member: org.acme.config.SimpleBean#myObserver()
[ERROR] 	- declared on CLASS bean [types=[org.acme.config.SimpleBean, java.lang.Object], qualifiers=[@Default, @Any], target=org.acme.config.SimpleBean]
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```