### PR TITLE
Point to CDI guide when private members are used

### DIFF
--- a/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/org/jboss/protean/arc/processor/BeanProcessor.java
@@ -592,11 +592,11 @@ public class BeanProcessor {
                 if (appDescriptions.size() > limit) {
                     info += "\n\t- and " + (appDescriptions.size() - limit) + " more - please enable debug logging to see the full list";
                 }
-                LOGGER.infof("Found unrecommended usage of private members in application beans:\n%s", info);
+                LOGGER.infof("Found unrecommended usage of private members (use package-private instead) in application beans:%n%s", info);
             }
             // Log fwk problems
             if (fwkDescriptions != null && !fwkDescriptions.isEmpty()) {
-                LOGGER.debugf("Found unrecommended usage of private members in framework beans:\n%s",
+                LOGGER.debugf("Found unrecommended usage of private members (use package-private instead) in framework beans:%n%s",
                         fwkDescriptions.stream().map(d -> "\t- " + d).collect(Collectors.joining(",\n")));
             }
         }


### PR DESCRIPTION
Small usability enhancement to point users to CDI guide when they see warning about private members being used