### PR TITLE
Replacing private members with package-private approach

### DIFF
--- a/integration-tests/spring-di/src/main/java/org/jboss/shamrock/spring/tests/GreeterBean.java
+++ b/integration-tests/spring-di/src/main/java/org/jboss/shamrock/spring/tests/GreeterBean.java
@@ -28,14 +28,14 @@ public class GreeterBean {
 
     @Autowired
     @Qualifier("noop")
-    private StringFunction noopStringFunction;
+    StringFunction noopStringFunction;
 
     @Autowired
     @Qualifier("cap")
-    private StringFunction capitalizerStringFunction;
+    StringFunction capitalizerStringFunction;
 
     @Value("${greeting.suffix:!}")
-    private String suffix;
+    String suffix;
 
     public GreeterBean(MessageProducer messageProducer) {
         this.messageProducer = messageProducer;

--- a/integration-tests/spring-di/src/main/java/org/jboss/shamrock/spring/tests/InjectedSpringBeansResource.java
+++ b/integration-tests/spring-di/src/main/java/org/jboss/shamrock/spring/tests/InjectedSpringBeansResource.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.MediaType;
 public class InjectedSpringBeansResource {
 
     @Inject
-    private GreeterBean greeterBean;
+    GreeterBean greeterBean;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/integration-tests/spring-di/src/main/java/org/jboss/shamrock/spring/tests/MessageProducer.java
+++ b/integration-tests/spring-di/src/main/java/org/jboss/shamrock/spring/tests/MessageProducer.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 public class MessageProducer {
 
     @Value("${greeting.message}")
-    private String message;
+    String message;
 
     public String getPrefix() {
         return message;

--- a/integration-tests/vertx/src/main/java/org/jboss/shamrock/vertx/tests/VertxProducerResource.java
+++ b/integration-tests/vertx/src/main/java/org/jboss/shamrock/vertx/tests/VertxProducerResource.java
@@ -20,10 +20,10 @@ import java.util.concurrent.CompletionStage;
 public class VertxProducerResource {
 
     @Inject
-    private Vertx vertx;
+    Vertx vertx;
 
     @Inject
-    private EventBus eventBus;
+    EventBus eventBus;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)


### PR DESCRIPTION
Replacing private members with package-private approach to get rid of `Found unrecommended usage of private members (use package-private instead) in application beans` warnings in Quarkus build.

We recommend something, we should follow that recommendation.