### PR TITLE
Panache fixes

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/HibernateEntityEnhancer.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/HibernateEntityEnhancer.java
@@ -20,7 +20,6 @@ import java.util.function.BiFunction;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.bytecode.enhance.spi.Enhancer;
-import org.hibernate.bytecode.enhance.spi.UnloadedClass;
 import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -49,12 +48,6 @@ public final class HibernateEntityEnhancer implements BiFunction<String, ClassVi
             @Override
             public ClassLoader getLoadingClassLoader() {
                 return Thread.currentThread().getContextClassLoader();
-            }
-
-            @Override
-            public boolean doDirtyCheckingInline(UnloadedClass classDescriptor) {
-                // perhaps only for subtypes of Model/RxModel?
-                return false;
             }
         };
         this.enhancer = provider.getEnhancer(enhancementContext);

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/enhancer/HibernateEntityEnhancerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/enhancer/HibernateEntityEnhancerTest.java
@@ -65,8 +65,8 @@ public class HibernateEntityEnhancerTest {
         Set<Class> interfaces = new HashSet<Class>(Arrays.asList(modifiedClass.getInterfaces()));
         //Assert it now implements these three interfaces:
         return interfaces.contains(ManagedEntity.class) &&
-                interfaces.contains(PersistentAttributeInterceptable.class);// &&
-        //interfaces.contains(SelfDirtinessTracker.class);
+                interfaces.contains(PersistentAttributeInterceptable.class) &&
+                interfaces.contains(SelfDirtinessTracker.class);
     }
 
 }

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Sort {
-    private enum Direction {
+    public enum Direction {
         Ascending, Descending;
     }
 


### PR DESCRIPTION
- Restore Hibernate ORM dirty checking
- Fix stupid public access to `Sort.Direction` in Panache