### PR TITLE
InstanceHandle.close() - do not always delegate to destroy()

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandle.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandle.java
@@ -16,6 +16,8 @@
 
 package io.quarkus.arc;
 
+import javax.enterprise.context.Dependent;
+
 /**
  * Represents an instance handle.
  *
@@ -55,11 +57,15 @@ public interface InstanceHandle<T> extends AutoCloseable {
     }
 
     /**
-     * Delegates to {@link #destroy()}.
+     * Delegates to {@link #destroy()} if the handle does not represent a CDI contextual instance or if it represents a
+     * {@link Dependent} CDI contextual instance.
      */
     @Override
     default void close() {
-        destroy();
+        InjectableBean<T> bean = getBean();
+        if (bean == null || Dependent.class.equals(bean.getScope())) {
+            destroy();
+        }
     }
 
 }


### PR DESCRIPTION
- only if the handle does not represent a CDI contextual instance or if
it represents a Dependent contextual instance