### PR TITLE
Logging format adjustments

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -33,7 +33,7 @@ public class ConsoleConfig {
     /**
      * The log format
      */
-    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{1.}] (%t) %s%e%n")
+    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{3.}] (%t) %s%e%n")
     String format;
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -33,7 +33,7 @@ public class ConsoleConfig {
     /**
      * The log format
      */
-    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{3.}] (%t) %s%e%n")
+    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n")
     String format;
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -34,7 +34,7 @@ public class FileConfig {
     /**
      * The log format
      */
-    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{1.}] (%t) %s%e%n")
+    @ConfigItem(defaultValue = "%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{3.}] (%t) %s%e%n")
     String format;
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InitialConfigurator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InitialConfigurator.java
@@ -28,7 +28,7 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
         if (loggerName.isEmpty()) {
             if (ImageInfo.inImageBuildtimeCode()) {
                 final ConsoleHandler handler = new ConsoleHandler(new PatternFormatter(
-                        "%d{HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n"));
+                        "%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
                 handler.setLevel(Level.INFO);
                 // we can't set a cleanup filter without the build items ready
                 return new Handler[] {

--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -14,7 +14,7 @@ Console logging is enabled by default.  To configure or disable it, the followin
 |===
 |Property Name|Default|Description
 |quarkus.logging.console.enable|true|Determine whether console logging is enabled.
-|quarkus.logging.console.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{3.}] (%t) %s%e%n|The format pattern to use for logging to the console; see <<format_string>>.
+|quarkus.logging.console.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n|The format pattern to use for logging to the console; see <<format_string>>.
 |quarkus.logging.console.level|INFO|The minimum log level to display to the console.
 |quarkus.logging.console.color|true|Allow color rendering to be used on the console, if it is supported by the terminal.
 |===

--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -14,7 +14,7 @@ Console logging is enabled by default.  To configure or disable it, the followin
 |===
 |Property Name|Default|Description
 |quarkus.logging.console.enable|true|Determine whether console logging is enabled.
-|quarkus.logging.console.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{1.}] (%t) %s%e%n|The format pattern to use for logging to the console; see <<format_string>>.
+|quarkus.logging.console.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{3.}] (%t) %s%e%n|The format pattern to use for logging to the console; see <<format_string>>.
 |quarkus.logging.console.level|INFO|The minimum log level to display to the console.
 |quarkus.logging.console.color|true|Allow color rendering to be used on the console, if it is supported by the terminal.
 |===
@@ -27,7 +27,7 @@ Logging to a file is also supported and enabled by default.  To configure or dis
 |===
 |Property Name|Default|Description
 |quarkus.logging.file.enable|true|Determine whether file logging is enabled.
-|quarkus.logging.file.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{1.}] (%t) %s%e%n|The format pattern to use for logging to a file; see <<format_string>>.
+|quarkus.logging.file.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %h %N[%i] %-5p [%c{3.}] (%t) %s%e%n|The format pattern to use for logging to a file; see <<format_string>>.
 |quarkus.logging.file.level|INFO|The minimum log level to write to the log file.
 |quarkus.logging.file.path|quarkus.log|The path of the log file.
 |===


### PR DESCRIPTION
 * Make the log category a bit more readable
 * Reintroduce the logging format we agreed on for console logging.

In the initial config patch, console logging was the following:
https://github.com/jbossas/protean-shamrock/pull/458/files#diff-e2b865cc153ddece3ce207265f638210R34

IIRC, this change was made following some discussion about the host/binary name not being very useful.

The format got rewritten later but it seems sensible to have this one for console logging.