### PR TITLE
chore: fixed minor typo

### DIFF
--- a/docs/src/main/asciidoc/panache-jpa-guide.adoc
+++ b/docs/src/main/asciidoc/panache-jpa-guide.adoc
@@ -1,7 +1,7 @@
 = {project-name} - Simplified Hibernate ORM and JPA with Panache
 :config-file: microprofile-config.properties
 
-Hibernate ORM is the de facto JPA implementation and offers you the full breath of an Object Relational Mapper.
+Hibernate ORM is the de facto JPA implementation and offers you the full breadth of an Object Relational Mapper.
 It makes complex mappings possible, but it does not make simple and common mappings trivial.
 Panache focuses on making your entities trivial and fun to write in {project-name}.
 


### PR DESCRIPTION
I believe the author meant `Breadth` instead of `Breath`