### PR TITLE
Extend InjectionPoint metadata support

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
@@ -67,11 +67,12 @@ class AnnotationLiteralProcessor {
      * @param classOutput
      * @param annotationClass
      * @param annotationInstance
-     * @param targetPackage
+     * @param targetPackage Target package is only used if annotation literals are not shared
      * @return an annotation literal result handle
      */
     ResultHandle process(BytecodeCreator bytecode, ClassOutput classOutput, ClassInfo annotationClass, AnnotationInstance annotationInstance,
             String targetPackage) {
+        Objects.requireNonNull(annotationClass, "Annotation class not available: " + annotationInstance);
         if (cache != null) {
             Literal literal = cache.getValue(new Key(annotationInstance.name(), annotationClass));
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -30,7 +30,7 @@ import io.quarkus.arc.InjectableReferenceProvider;
 import io.quarkus.arc.InjectionPointProvider;
 import io.quarkus.arc.InstanceProvider;
 import io.quarkus.arc.ResourceProvider;
-import io.quarkus.arc.processor.InjectionPointInfo.Kind;
+import io.quarkus.arc.processor.InjectionPointInfo.InjtetionPointKind;
 import org.jboss.protean.gizmo.ClassCreator;
 import org.jboss.protean.gizmo.ClassOutput;
 import org.jboss.protean.gizmo.FieldDescriptor;
@@ -145,7 +145,7 @@ enum BuiltinBean {
             constructor.writeInstanceField(FieldDescriptor.of(clazzCreator.getClassName(), providerName, InjectableReferenceProvider.class.getName()),
                     constructor.getThis(), resourceProvider);
         }
-    }, ip -> ip.getKind() == Kind.RESOURCE);
+    }, ip -> ip.getKind() == InjtetionPointKind.RESOURCE);
 
     private final DotName rawTypeDotName;
 
@@ -154,7 +154,7 @@ enum BuiltinBean {
     private final Predicate<InjectionPointInfo> matcher;
 
     BuiltinBean(DotName rawTypeDotName, Generator generator) {
-        this(rawTypeDotName, generator, ip -> ip.getKind() == Kind.CDI && rawTypeDotName.equals(ip.getRequiredType().name()));
+        this(rawTypeDotName, generator, ip -> ip.getKind() == InjtetionPointKind.CDI && rawTypeDotName.equals(ip.getRequiredType().name()));
     }
 
     BuiltinBean(DotName rawTypeDotName, Generator generator, Predicate<InjectionPointInfo> matcher) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -17,6 +17,7 @@
 package io.quarkus.arc.processor;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
@@ -85,6 +86,8 @@ final class MethodDescriptors {
     static final MethodDescriptor REFLECTIONS_FIND_METHOD = MethodDescriptor.ofMethod(Reflections.class, "findMethod", Method.class, Class.class, String.class,
             Class[].class);
 
+    static final MethodDescriptor REFLECTIONS_FIND_FIELD = MethodDescriptor.ofMethod(Reflections.class, "findField", Field.class, Class.class, String.class);
+    
     static final MethodDescriptor REFLECTIONS_WRITE_FIELD = MethodDescriptor.ofMethod(Reflections.class, "writeField", void.class, Class.class, String.class,
             Object.class, Object.class);
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/CurrentInjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/CurrentInjectionPointProvider.java
@@ -17,35 +17,45 @@
 package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.AnnotatedMember;
+import javax.enterprise.inject.spi.AnnotatedCallable;
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 /**
- * TODO: add support for AnnotatedMember.getDeclaringType() and AnnotatedMember.getJavaMember() so that smallrye-config could derive the default name for
- * ConfigProperty
  *
  * @author Martin Kouba
  */
 public class CurrentInjectionPointProvider<T> implements InjectableReferenceProvider<T> {
 
-    static final InjectionPoint EMPTY = new InjectionPointImpl(Object.class, Collections.emptySet(), null);
+    static final InjectionPoint EMPTY = new InjectionPointImpl(Object.class, Collections.emptySet(), null, null, null, -1);
 
     private final InjectableReferenceProvider<T> delegate;
 
     private final InjectionPoint injectionPoint;
 
-    public CurrentInjectionPointProvider(InjectableBean<?> bean, InjectableReferenceProvider<T> delegate, Type requiredType, Set<Annotation> qualifiers) {
+    public CurrentInjectionPointProvider(InjectableBean<?> bean, InjectableReferenceProvider<T> delegate, Type requiredType,
+            Set<Annotation> qualifiers, Set<Annotation> annotations, Member javaMember, int position) {
         this.delegate = delegate;
-        this.injectionPoint = new InjectionPointImpl(requiredType, qualifiers, bean);
+        this.injectionPoint = new InjectionPointImpl(requiredType, qualifiers, bean, annotations, javaMember, position);
     }
 
     @Override
@@ -66,18 +76,22 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
     private static class InjectionPointImpl implements InjectionPoint {
 
         private final Type requiredType;
-
         private final Set<Annotation> qualifiers;
-
         private final InjectableBean<?> bean;
-        
-        private final AnnotatedMember<?> annotatedMember;
+        private final Annotated annotated;
+        private final Member member;
 
-        InjectionPointImpl(Type requiredType, Set<Annotation> qualifiers, InjectableBean<?> bean) {
+        InjectionPointImpl(Type requiredType, Set<Annotation> qualifiers, InjectableBean<?> bean, Set<Annotation> annotations,
+                Member javaMember, int position) {
             this.requiredType = requiredType;
             this.qualifiers = qualifiers;
             this.bean = bean;
-            this.annotatedMember = new AnnotatedMemberImpl<>(requiredType);
+            if (javaMember instanceof Executable) {
+                this.annotated = new AnnotatedParameterImpl<>(requiredType, annotations, position, (Executable) javaMember);
+            } else {
+                this.annotated = new AnnotatedFieldImpl<>(requiredType, annotations, (Field) javaMember);
+            }
+            this.member = javaMember;
         }
 
         @Override
@@ -97,12 +111,12 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
 
         @Override
         public Member getMember() {
-            throw new UnsupportedOperationException();
+            return member;
         }
 
         @Override
         public Annotated getAnnotated() {
-            return annotatedMember;
+            return annotated;
         }
 
         @Override
@@ -116,13 +130,70 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
         }
 
     }
-    
-    private static class AnnotatedMemberImpl<X> implements AnnotatedMember<X> {
+
+    static class AnnotatedFieldImpl<X> extends AnnotatedBase implements AnnotatedField<X> {
+
+        private final Field field;
+
+        AnnotatedFieldImpl(Type baseType, Set<Annotation> annotations, Field field) {
+            super(baseType, annotations);
+            this.field = field;
+        }
+
+        @Override
+        public boolean isStatic() {
+            return Modifier.isStatic(field.getModifiers());
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public AnnotatedType<X> getDeclaringType() {
+            return new AnnotatedTypeImpl<>((Class<X>) field.getDeclaringClass());
+        }
+
+        @Override
+        public Field getJavaMember() {
+            return field;
+        }
+
+    }
+
+    static class AnnotatedParameterImpl<X> extends AnnotatedBase implements AnnotatedParameter<X> {
+
+        private final int position;
+        private final Executable executable;
+
+        AnnotatedParameterImpl(Type baseType, Set<Annotation> annotations, int position, Executable executable) {
+            super(baseType, annotations);
+            this.position = position;
+            this.executable = executable;
+        }
+
+        @Override
+        public int getPosition() {
+            return position;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public AnnotatedCallable<X> getDeclaringCallable() {
+            if (executable instanceof Method) {
+                return new AnnotatedMethodImpl<>((Method) executable);
+            } else {
+                return new AnnotatedConstructorImpl<X>((Constructor<X>) executable);
+            }
+        }
+
+    }
+
+    static abstract class AnnotatedBase implements Annotated {
 
         private final Type baseType;
-        
-        AnnotatedMemberImpl(Type baseType) {
+        private final Set<Annotation> annotations;
+
+        AnnotatedBase(Type baseType, Set<Annotation> annotations) {
             this.baseType = baseType;
+            this.annotations = annotations;
         }
 
         @Override
@@ -135,41 +206,142 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
-            throw new UnsupportedOperationException();
+            if (annotations == null) {
+                throw new UnsupportedOperationException();
+            }
+            for (Annotation annotation : annotations) {
+                if (annotation.annotationType().equals(annotationType)) {
+                    return (T) annotation;
+                }
+            }
+            return null;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
-            throw new UnsupportedOperationException();
+            if (annotations == null) {
+                throw new UnsupportedOperationException();
+            }
+            Set<T> found = new HashSet<>();
+            for (Annotation annotation : annotations) {
+                if (annotation.annotationType().equals(annotationType)) {
+                    found.add((T) annotation);
+                }
+            }
+            return found;
         }
 
         @Override
         public Set<Annotation> getAnnotations() {
-            throw new UnsupportedOperationException();
+            if (annotations == null) {
+                throw new UnsupportedOperationException();
+            }
+            return Collections.unmodifiableSet(annotations);
         }
 
         @Override
         public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+            return getAnnotation(annotationType) != null;
+        }
+
+    }
+
+    static class AnnotatedTypeImpl<X> extends AnnotatedBase implements AnnotatedType<X> {
+
+        private final Class<X> clazz;
+
+        AnnotatedTypeImpl(Class<X> clazz) {
+            super(clazz, null);
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Class<X> getJavaClass() {
+            return clazz;
+        }
+
+        @Override
+        public Set<AnnotatedConstructor<X>> getConstructors() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public Member getJavaMember() {
+        public Set<AnnotatedMethod<? super X>> getMethods() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<AnnotatedField<? super X>> getFields() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    static class AnnotatedMethodImpl<X> extends AnnotatedBase implements AnnotatedMethod<X> {
+
+        private final Method method;
+
+        AnnotatedMethodImpl(Method method) {
+            super(method.getGenericReturnType(), null);
+            this.method = method;
+        }
+
+        @Override
+        public List<AnnotatedParameter<X>> getParameters() {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public boolean isStatic() {
+            return Modifier.isStatic(method.getModifiers());
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public AnnotatedType<X> getDeclaringType() {
+            return new AnnotatedTypeImpl<>((Class<X>) method.getDeclaringClass());
+        }
+
+        @Override
+        public Method getJavaMember() {
+            return method;
+        }
+
+    }
+
+    static class AnnotatedConstructorImpl<X> extends AnnotatedBase implements AnnotatedConstructor<X> {
+
+        private final Constructor<X> constructor;
+
+        public AnnotatedConstructorImpl(Constructor<X> constructor) {
+            super(constructor.getDeclaringClass(), null);
+            this.constructor = constructor;
+        }
+
+        @Override
+        public List<AnnotatedParameter<X>> getParameters() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public AnnotatedType<X> getDeclaringType() {
-            throw new UnsupportedOperationException();
+        public boolean isStatic() {
+            return false;
         }
-        
+
+        @Override
+        public AnnotatedType<X> getDeclaringType() {
+            return new AnnotatedTypeImpl<>((Class<X>) constructor.getDeclaringClass());
+        }
+
+        @Override
+        public Constructor<X> getJavaMember() {
+            return constructor;
+        }
+
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Reflections.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Reflections.java
@@ -31,6 +31,17 @@ public final class Reflections {
 
     private Reflections() {
     }
+    
+    public static Field findField(Class<?> clazz, String fieldName) {
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            if (clazz.getSuperclass() != null) {
+                return findField(clazz.getSuperclass(), fieldName);
+            }
+            throw new IllegalArgumentException(e);
+        }
+    }
 
     public static Method findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
         try {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
@@ -25,27 +25,34 @@ import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
-import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Rule;
-import org.junit.Test;
 
 public class InjectionPointMetadataTest {
 
     @Rule
     public ArcTestContainer container = new ArcTestContainer(Controller.class, Controlled.class);
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testInjectionPointMetadata() {
         ArcContainer arc = Arc.container();
         Controller controller = arc.instance(Controller.class).get();
+
+        // Field
         InjectionPoint injectionPoint = controller.controlled.injectionPoint;
         assertNotNull(injectionPoint);
         assertEquals(Controlled.class, injectionPoint.getType());
@@ -54,12 +61,42 @@ public class InjectionPointMetadataTest {
         assertEquals(Default.class, qualifiers.iterator().next().annotationType());
         Bean<?> bean = injectionPoint.getBean();
         assertNotNull(bean);
-        assertTrue(bean.getTypes()
-                .stream()
-                .anyMatch(t -> t.equals(Controller.class)));
-        Annotated annotated = injectionPoint.getAnnotated();
-        assertNotNull(annotated);
-        assertEquals(Controlled.class, annotated.getBaseType());
+        assertTrue(bean.getTypes().stream().anyMatch(t -> t.equals(Controller.class)));
+        assertNotNull(injectionPoint.getAnnotated());
+        assertTrue(injectionPoint.getAnnotated() instanceof AnnotatedField);
+        AnnotatedField<Controller> annotatedField = (AnnotatedField<Controller>) injectionPoint.getAnnotated();
+        assertEquals("controlled", annotatedField.getJavaMember().getName());
+        assertEquals(Controlled.class, annotatedField.getBaseType());
+        assertTrue(annotatedField.isAnnotationPresent(Inject.class));
+        assertTrue(annotatedField.getAnnotation(Singleton.class) == null);
+        assertTrue(annotatedField.getAnnotations(Singleton.class).isEmpty());
+        assertEquals(1, annotatedField.getAnnotations().size());
+
+        // Method
+        InjectionPoint methodInjectionPoint = controller.controlledMethod.injectionPoint;
+        assertNotNull(methodInjectionPoint);
+        assertEquals(Controlled.class, methodInjectionPoint.getType());
+        assertTrue(methodInjectionPoint.getAnnotated() instanceof AnnotatedParameter);
+        assertEquals(bean, methodInjectionPoint.getBean());
+        AnnotatedParameter<Controller> methodParam = (AnnotatedParameter<Controller>) methodInjectionPoint.getAnnotated();
+        assertEquals(0, methodParam.getPosition());
+        assertEquals(Controller.class, methodParam.getDeclaringCallable().getJavaMember().getDeclaringClass());
+        assertEquals("setControlled", methodParam.getDeclaringCallable().getJavaMember().getName());
+
+        // Constructor
+        InjectionPoint ctorInjectionPoint = controller.controlledCtor.injectionPoint;
+        assertNotNull(ctorInjectionPoint);
+        assertEquals(Controlled.class, methodInjectionPoint.getType());
+        assertTrue(ctorInjectionPoint.getAnnotated() instanceof AnnotatedParameter);
+        assertEquals(bean, ctorInjectionPoint.getBean());
+        AnnotatedParameter<Controller> ctorParam = (AnnotatedParameter<Controller>) ctorInjectionPoint.getAnnotated();
+        assertEquals(1, ctorParam.getPosition());
+        assertTrue(ctorParam.isAnnotationPresent(Singleton.class));
+        assertTrue(ctorParam.getAnnotation(Singleton.class) != null);
+        assertTrue(!ctorParam.getAnnotations(Singleton.class).isEmpty());
+        assertEquals(1, ctorParam.getAnnotations().size());
+        assertTrue(ctorParam.getDeclaringCallable() instanceof AnnotatedConstructor);
+        assertEquals(Controller.class, ctorParam.getDeclaringCallable().getJavaMember().getDeclaringClass());
     }
 
     @Singleton
@@ -67,6 +104,20 @@ public class InjectionPointMetadataTest {
 
         @Inject
         Controlled controlled;
+
+        Controlled controlledMethod;
+
+        Controlled controlledCtor;
+
+        @Inject
+        public Controller(BeanManager beanManager, @Singleton Controlled controlled) {
+            this.controlledCtor = controlled;
+        }
+
+        @Inject
+        void setControlled(Controlled controlled, BeanManager beanManager) {
+            this.controlledMethod = controlled;
+        }
 
     }
 


### PR DESCRIPTION
- we still do not support the full Annotated hierarchy as it would
require significantly more complex adjustments and the generated Bean
classes would grow a lot with small added value
- resolves #969