### PR TITLE
ArC - ComputingCache may contain uninitialized values

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AbstractSharedContext.java
@@ -131,6 +131,11 @@ abstract class AbstractSharedContext implements InjectableContext {
             return true;
         }
 
+        @Override
+        public String toString() {
+            return "Key [contextual=" + contextual + "]";
+        }
+        
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ComputingCache.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ComputingCache.java
@@ -87,7 +87,7 @@ public class ComputingCache<K, V> {
     }
     
     public Set<V> getPresentValues() {
-        return map.values().stream().map(LazyValue::get).collect(Collectors.toSet());
+        return map.values().stream().map(LazyValue::getIfPresent).filter(Objects::nonNull).collect(Collectors.toSet());
     }
 
     public void forEachEntry(BiConsumer<? super K, ? super V> action) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandleImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandleImpl.java
@@ -98,4 +98,10 @@ class InstanceHandleImpl<T> implements InstanceHandle<T> {
         }
     }
 
+    @Override
+    public String toString() {
+        return "InstanceHandleImpl [bean=" + bean + ", instance=" + instance + ", creationalContext=" + creationalContext
+                + ", parentCreationalContext=" + parentCreationalContext + ", destroyed=" + destroyed + "]";
+    }
+    
 }


### PR DESCRIPTION
@gsmet This should fix your problem with a singleton bean being initialized twice. The problem was that since the bean creation failed the value holder in the cache was not initalized and thus ArC attempted to initialize the bean again during context destruction.