### PR TITLE
Exclude any doc subdirectories from build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ pr:
       - master
   paths:
     exclude:
-      - docs/src/main/*
+      - docs/src/main/**
 
 jobs:
 - job: Build_Native_Linux


### PR DESCRIPTION
I saw that for #1093 the build ran although it was only a docs change 