### PR TITLE
 Fixes #721 @ApplicationScoped does not work in combination with @ServerEndpoint

### DIFF
--- a/extensions/undertow-websockets/deployment/src/main/java/io/quarkus/undertow/websockets/UndertowWebsocketProcessor.java
+++ b/extensions/undertow-websockets/deployment/src/main/java/io/quarkus/undertow/websockets/UndertowWebsocketProcessor.java
@@ -31,6 +31,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
+import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -119,5 +120,12 @@ public class UndertowWebsocketProcessor {
     ServiceStartBuildItem setupWorker(UndertowWebsocketTemplate template, UndertowBuildItem undertow) {
         template.setupWorker(undertow.getUndertow());
         return new ServiceStartBuildItem("Websockets");
+    }
+
+    @BuildStep
+    void beanDefiningAnnotations(BuildProducer<BeanDefiningAnnotationBuildItem> annotations) {
+        annotations.produce(new BeanDefiningAnnotationBuildItem(SERVER_ENDPOINT));
+        annotations.produce(new BeanDefiningAnnotationBuildItem(ENDPOINT));
+        annotations.produce(new BeanDefiningAnnotationBuildItem(CLIENT_ENDPOINT));
     }
 }


### PR DESCRIPTION
Fix for the #721. 
The ServerEndpoint bean was deleted during the deployment, therefore,
the @ApplicationScoped annotation was ignored during the runtime.

I have added the ServerEndpoint annotation as a BeanDefiningAnnotationBuildItem in
order to avoid removing it during the deployment, since it was considered as unused.
(The WebServlet etc. do this as well)

I have created a test for this as well [1], however I am not sure whether to include it here as well.

[1] https://github.com/MMarus/protean-shamrock/commit/aeb32cdeb868e62b86f1f81082ef3a730fde0498