### PR TITLE
Remove unnecessary setting of frameworkClassesPath

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -94,7 +94,6 @@ public class QuarkusTestExtension implements BeforeAllCallback, BeforeEachCallba
                 .setLaunchMode(LaunchMode.TEST)
                 .setClassLoader(getClass().getClassLoader())
                 .setTarget(appClassLocation)
-                .setFrameworkClassesPath(testClassLocation)
                 .setClassOutput(new ClassOutput() {
                     @Override
                     public void writeClass(boolean applicationClass, String className, byte[] data) throws IOException {


### PR DESCRIPTION
This is no longer needed since classOutput is being set (which means
that frameworkClassesPath will never be consulted)