### PR TITLE
Disable building the main IT native image test by default

### DIFF
--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -247,10 +247,10 @@
             </dependencies>
         </profile>
         <profile>
-            <id>native-image</id>
+            <id>native-image-it-main</id>
             <activation>
                 <property>
-                    <name>!no-native</name>
+                    <name>native</name>
                 </property>
             </activation>
             <build>


### PR DESCRIPTION
I was against it until now but, with the recent additions made to the main IT tests (I think the Kafka one was the one making it fail for me), it becomes very hard to get the main IT to build the native image on a typical laptop with other applications running.

We will have more people testing the build soon and they will most probably have errors due to that. Sometimes the error is clear and GraalVM complains about being unable to allocate memory but sometimes you end up with an error with a code 137 and no explanation.

With this patch, you have two possibilities to run the main native image test:
- `-Dnative` will run it along with all the other native tests;
- `-Pnative-image-it-main` will only test native image for the main IT.

