### PR TITLE
Assign runner jar the proper permissions

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -196,6 +197,12 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
             buildRunner(zipFs, appState, ctx.resolveOutcome(AugmentOutcome.class));
         } catch (Exception e) {
             throw new AppCreatorException("Failed to build a runner jar", e);
+        }
+
+        try {
+            runnerJar.toFile().setReadable(true, false);
+        } catch (Exception e) {
+            log.warn("Unable to set proper permissions on " + runnerJar);
         }
 
         // when using uberJar, we rename the standard jar to include the .original suffix


### PR DESCRIPTION
Without this fix I was seeing the following on my path:

`ls -l target/`

```
...
drwxrwxr-x  2 gandrian gandrian  4096 Μάρ   4 12:23 lib/
-rw-rw-r--  1 gandrian gandrian 10106 Μάρ   4 12:23 example-1.0.0.Alpha1-SNAPSHOT.jar
-rw-------  1 gandrian gandrian 58209 Μάρ   4 12:23 example-1.0.0.Alpha1-SNAPSHOT-runner.jar
-rw-rw-r--  1 gandrian gandrian 11167 Μάρ   4 12:23 example-1.0.0.Alpha1-SNAPSHOT-sources.jar
...
```

which makes it harder to include `example-1.0.0.Alpha1-SNAPSHOT-runner.jar` in a Docker image that extends from `fabric8/java-jboss-openjdk8-jdk`.

This fix sets read permissions for all users to `example-1.0.0.Alpha1-SNAPSHOT-runner.jar`.

The one thing I don't know is if the fix will work on Windows (although even if it doesn't it shouldn't change anything)