### PR TITLE
Stop runner before resources

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -249,8 +249,8 @@ public class QuarkusTestExtension implements BeforeAllCallback, BeforeEachCallba
 
         @Override
         public void close() throws Throwable {
-            testResourceManager.stop();
             resource.close();
+            testResourceManager.stop();
         }
 
         public boolean isSubstrate() {


### PR DESCRIPTION
The runner should be stopped before the resources. Resources are normally things that the runner will connect to, so we should stop the runner first so these won't print exceptions, which the Infinispan Client would do.