### PR TITLE
Add JBoss Log Manager in JPA cache tests

### DIFF
--- a/integration-tests/infinispan-cache-jpa-stress/pom.xml
+++ b/integration-tests/infinispan-cache-jpa-stress/pom.xml
@@ -89,6 +89,16 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/integration-tests/infinispan-cache-jpa/pom.xml
+++ b/integration-tests/infinispan-cache-jpa/pom.xml
@@ -87,6 +87,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/infinispan-cache-jpa/src/main/resources/META-INF/microprofile-config.properties
+++ b/integration-tests/infinispan-cache-jpa/src/main/resources/META-INF/microprofile-config.properties
@@ -8,4 +8,4 @@ quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.cache."com.example.EntityA".memory.object-count=200
 quarkus.hibernate-orm.cache."com.example.EntityB".expiration.max-idle=86400
 #quarkus.log.level=TRACE
-#quarkus.log.console.level=TRACE
+#quarkus.log.file.level=TRACE


### PR DESCRIPTION
* Comment file based TRACE logging rather than console,
  since the former it's more useful.