### PR TITLE
Add elytron-security integration tests

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_org_wildfly_security_x500_util_X500PrincipalUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_org_wildfly_security_x500_util_X500PrincipalUtil.java
@@ -1,5 +1,7 @@
 package io.quarkus.runtime.graal;
 
+import static org.wildfly.security.x500._private.ElytronMessages.log;
+
 import java.lang.invoke.MethodHandle;
 import java.security.Principal;
 
@@ -24,8 +26,22 @@ final class Target_org_wildfly_security_x500_util_X500PrincipalUtil {
     @Delete
     static MethodHandle AS_X500_PRINCIPAL_HANDLE;
 
+    /**
+     * Only handle the case of converting a {@linkplain Principal#getName()} to {@linkplain X500Principal}
+     * 
+     * @param principal - Principal with name that maps to valid DN
+     * @param convert - whether one should convert to X500Principal
+     * @return X500Principal if convert is true and valid DN is seen, null otherwise
+     */
     @Substitute
     public static X500Principal asX500Principal(Principal principal, boolean convert) {
+        if (convert) {
+            try {
+                return new X500Principal(principal.getName());
+            } catch (IllegalArgumentException ignored) {
+                log.trace("Unable to convert to X500Principal", ignored);
+            }
+        }
         return null;
     }
 }

--- a/integration-tests/elytron-security/pom.xml
+++ b/integration-tests/elytron-security/pom.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-main</artifactId>
+    <name>Quarkus - Integration Tests - Elytron Security</name>
+    <description>The elytron-security integration tests module</description>
+
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <uberJar>true</uberJar>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image-it-main</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
+                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
+                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
+                                    -->
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
+</project>

--- a/integration-tests/elytron-security/pom.xml
+++ b/integration-tests/elytron-security/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-integration-test-main</artifactId>
+    <artifactId>quarkus-integration-test-elytron-security</artifactId>
     <name>Quarkus - Integration Tests - Elytron Security</name>
     <description>The elytron-security integration tests module</description>
 

--- a/integration-tests/elytron-security/src/main/java/io/quarkus/example/X500PrincipalEndpoint.java
+++ b/integration-tests/elytron-security/src/main/java/io/quarkus/example/X500PrincipalEndpoint.java
@@ -1,0 +1,22 @@
+package io.quarkus.example;
+
+import javax.inject.Inject;
+import javax.security.auth.x500.X500Principal;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/x500")
+public class X500PrincipalEndpoint {
+    @Inject
+    X500Principal x500Principal;
+
+    @GET
+    @Path("/verifyInjectedPrincipal")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String verifyInjectedPrincipal() {
+        String name = x500Principal == null ? "anonymous" : x500Principal.getName();
+        return name;
+    }
+}

--- a/integration-tests/elytron-security/src/main/java/io/quarkus/example/X500PrincipalUtilUser.java
+++ b/integration-tests/elytron-security/src/main/java/io/quarkus/example/X500PrincipalUtilUser.java
@@ -1,0 +1,27 @@
+package io.quarkus.example;
+
+import java.security.Principal;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.security.auth.x500.X500Principal;
+
+import org.wildfly.security.x500.util.X500PrincipalUtil;
+
+/**
+ * Simple {@linkplain X500PrincipalUtil} user to validate it works in native image
+ */
+@ApplicationScoped
+public class X500PrincipalUtilUser {
+    @Produces
+    X500Principal dummyX500Principal() {
+        final Principal dummy = new Principal() {
+            @Override
+            public String getName() {
+                return "O=Fake X500Principal";
+            }
+        };
+        X500Principal principal = X500PrincipalUtil.asX500Principal(dummy, true);
+        return principal;
+    }
+}

--- a/integration-tests/elytron-security/src/main/resources/META-INF/microprofile-config.properties
+++ b/integration-tests/elytron-security/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,32 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.quarkus.example.rest.RestInterface/mp-rest/url=${test.url}
+# Disabled by default as it establishes external connections.
+# Uncomment when you want to test SSL support.
+#io.quarkus.example.rest.SslRestInterface/mp-rest/url=https://www.example.com/
+
+# used to test the client behavior when SSL is disabled
+# we probably won't be able to test SSL proper so it seems reasonable to set it globally
+quarkus.ssl.native=false
+
+quarkus.security.embedded.enabled=true
+quarkus.security.embedded.users.scott=jb0ss
+quarkus.security.embedded.roles.scott=Admin,admin,Tester,user
+
+quarkus.log.category.kafka.level=WARN
+quarkus.log.category.\"org.apache.kafka\".level=WARN
+quarkus.log.category.\"org.apache.zookeeper\".level=WARN

--- a/integration-tests/elytron-security/src/test/java/io/quarkus/example/test/X500PrincipalUtilITCase.java
+++ b/integration-tests/elytron-security/src/test/java/io/quarkus/example/test/X500PrincipalUtilITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.example.test;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class X500PrincipalUtilITCase extends X500PrincipalUtilTestCase {
+}

--- a/integration-tests/elytron-security/src/test/java/io/quarkus/example/test/X500PrincipalUtilTestCase.java
+++ b/integration-tests/elytron-security/src/test/java/io/quarkus/example/test/X500PrincipalUtilTestCase.java
@@ -1,0 +1,22 @@
+package io.quarkus.example.test;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class X500PrincipalUtilTestCase {
+
+    @Test
+    public void testVerifyPrincipal() {
+        RestAssured.when()
+                .get("/x500/verifyInjectedPrincipal")
+                .then()
+                .statusCode(200)
+                .body(is("O=Fake X500Principal"));
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -51,6 +51,7 @@
         <module>spring-di</module>
         <module>infinispan-cache-jpa</module>
         <module>infinispan-cache-jpa-stress</module>
+        <module>elytron-security</module>
         <!-- Camel tests are not working on Fedora + Bash
         see https://github.com/jbossas/protean-shamrock/issues/1130
         <module>camel-core</module>


### PR DESCRIPTION
Related to #1163 I have started an elytron-security extension integration set of tests focusing on the native image related issues to start. As part of this, I updated the Target_org_wildfly_security_x500_util_X500PrincipalUtil#asX500Principal(Principal, boolean) override to support the conversion functionality as it is used in the tests and verifies overriden method.