### PR TITLE
Provide Dockerfile files for both JVM and Native modes

### DIFF
--- a/devtools/common/src/main/java/io/quarkus/BasicRest.java
+++ b/devtools/common/src/main/java/io/quarkus/BasicRest.java
@@ -44,7 +44,7 @@ public class BasicRest extends QuarkusTemplate {
             createClasses();
         }
         createIndexPage();
-        createDockerFile();
+        createDockerFiles();
         createDockerIgnore();
         createApplicationConfig();
     }
@@ -161,10 +161,11 @@ public class BasicRest extends QuarkusTemplate {
 
     }
 
-    private void createDockerFile() throws IOException {
+    private void createDockerFiles() throws IOException {
         File dockerRoot = new File(projectRoot, "src/main/docker");
-        File docker = new File(mkdirs(dockerRoot), "Dockerfile");
-        generate("templates/dockerfile.ftl", context, docker, "docker file");
+        generate("templates/dockerfile-native.ftl", context, new File(mkdirs(dockerRoot), "Dockerfile.native"),
+                "native docker file");
+        generate("templates/dockerfile-jvm.ftl", context, new File(mkdirs(dockerRoot), "Dockerfile.jvm"), "jvm docker file");
     }
 
     private void createDockerIgnore() throws IOException {

--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -1,0 +1,21 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/${project_artifactId}-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/${project_artifactId}-jvm
+#
+###
+FROM fabric8/java-jboss-openjdk8-jdk
+ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/devtools/common/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-native.ftl
@@ -1,11 +1,13 @@
 ####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
 # Before building the docker image run:
 #
 # mvn package -Pnative -Dnative-image.docker-build=true
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile -t quarkus/${project_artifactId} .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/${project_artifactId} .
 #
 # Then run the container using:
 #

--- a/devtools/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -69,7 +69,8 @@ public class CreateProjectMojoIT extends MojoTestBase {
                 .read();
         assertThat(config).contains("key = value");
 
-        assertThat(new File(testDir, "src/main/docker/Dockerfile")).isFile();
+        assertThat(new File(testDir, "src/main/docker/Dockerfile.native")).isFile();
+        assertThat(new File(testDir, "src/main/docker/Dockerfile.jvm")).isFile();
 
         Model model = load(testDir);
         final DependencyManagement dependencyManagement = model.getDependencyManagement();

--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -42,7 +42,7 @@ It generates:
 
 * the Maven structure
 * a landing page accessible on `http://localhost:8080`
-* an example of `Dockerfile`
+* example `Dockerfile` files for both `native` and `jvm` modes
 * the application configuration file
 * an `org.acme.config.GreetingResource` resource
 * an associated test

--- a/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
+++ b/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
@@ -44,7 +44,7 @@ It generates:
 
 * the Maven structure
 * a landing page accessible on `http://localhost:8080`
-* an example of `Dockerfile`
+* example `Dockerfile` files for both `native` and `jvm` modes
 * the application configuration file
 * an `org.acme.events.GreetingResource` resource
 * an associated test

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -194,7 +194,7 @@ we will instruct the Maven build to produce an executable from inside a Docker c
 
 The produced executable will be a 64 bit Linux executable, so depending on your operating system it may no longer be runnable.
 However, it's not an issue as we are going to copy it to a Docker container.
-The project generation has provided a `Dockerfile` in the `src/main/docker` directory with the following content:
+The project generation has provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
 
 [source,dockerfile]
 ----
@@ -210,7 +210,7 @@ Then, if you didn't delete the generated native executable, you can build the do
 
 [source,shell]
 ----
-docker build -f src/main/docker/Dockerfile -t quarkus-quickstart/quickstart .
+docker build -f src/main/docker/Dockerfile.native -t quarkus-quickstart/quickstart .
 ----
 
 And finally, run it with:

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -67,7 +67,7 @@ It generates:
 * an `org.acme.quickstart.GreetingResource` resource exposed on `/hello`
 * an associated unit test
 * a landing page that is accessible on `http://localhost:8080` after starting the application
-* an example of `Dockerfile`
+* example `Dockerfile` files for both `native` and `jvm` modes
 * the application configuration file
 
 Once generated, look at the `pom.xml`.

--- a/docs/src/main/asciidoc/scheduled-guide.adoc
+++ b/docs/src/main/asciidoc/scheduled-guide.adoc
@@ -49,7 +49,7 @@ It generates:
 
 * the Maven structure
 * a landing page accessible on `http://localhost:8080`
-* an example of `Dockerfile`
+* example `Dockerfile` files for both `native` and `jvm` modes
 * the application configuration file
 * an `org.acme.scheduling.CountResource` resource
 * an associated test


### PR DESCRIPTION
Fixes: #1118

This is also sort of necessary if an AP4K guide (part of #1300) is to make sense and not confuse users

Supersedes #1173
