### PR TITLE
fix: avoid private members in application beans

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -61,7 +61,8 @@ You can then happily inject your `EntityManager`:
 --
 @ApplicationScoped
 public class SantaClausService {
-    @Inject private EntityManager em; <1>
+    @Inject
+    EntityManager em; <1>
 
     @Transactional <2>
     public void createGift(String giftDescription) {


### PR DESCRIPTION
This fixes the following warning during build: 
```
[INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:
        - @Inject field SantaClausService#em
```

Also in https://github.com/quarkusio/quarkusio.github.io/pull/115