### PR TITLE
remove Maven plugin from Gradle example

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -36,12 +36,8 @@ Here is a complete sample file for a simple rest project:
 [source,groovy,subs=attributes+]
 ----
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'io.quarkus.gradle.plugin' <1>
 
-
-group = 'org.acme'
-version = '1.0-SNAPSHOT'
 
 buildscript { <2>
 


### PR DESCRIPTION
The Gradle maven plugin is only used in projects which need to re-use Gradle built artifacts in Maven projects.

This will not be the case in a typical Gradle built Quarkus project.