### PR TITLE
add .apt_generated_tests/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,5 @@ graph-output.dot
 ObjectStore
 .gradle
 build
-
-
 docker/distroless/bazel-*
+/.apt_generated_tests/


### PR DESCRIPTION
This is generated by the M2E APT Eclipse plugin.