### PR TITLE
Let SmallRye Metrics interceptors do the metric registration

### DIFF
--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -19,20 +19,19 @@ package io.quarkus.smallrye.metrics.deployment;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.util.Arrays;
 import java.util.Collection;
 
-import javax.interceptor.Interceptor;
-
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationTarget;
-import org.jboss.jandex.AnnotationTarget.Kind;
-import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
-import org.jboss.jandex.IndexView;
-import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -59,6 +58,12 @@ import io.smallrye.metrics.interceptors.TimedInterceptor;
 public class SmallRyeMetricsProcessor {
 
     SmallRyeMetricsConfig metrics;
+
+    private static final Collection<DotName> metricsAnnotations = Arrays.asList(
+            DotName.createSimple(Gauge.class.getName()),
+            DotName.createSimple(Counted.class.getName()),
+            DotName.createSimple(Timed.class.getName()),
+            DotName.createSimple(Metered.class.getName()));
 
     @ConfigRoot(name = "smallrye-metrics")
     static final class SmallRyeMetricsConfig {
@@ -92,44 +97,44 @@ public class SmallRyeMetricsProcessor {
     }
 
     @BuildStep
+    void annotationTransformers(BuildProducer<AnnotationsTransformerBuildItem> transformers) {
+        // attach @MetricsBinding to each class that contains any metric annotations
+        transformers.produce(new AnnotationsTransformerBuildItem(ctx -> {
+            if (ctx.isClass()) {
+                // skip classes in package io.smallrye.metrics.interceptors
+                if (ctx.getTarget().asClass().name().toString()
+                        .startsWith(io.smallrye.metrics.interceptors.MetricsInterceptor.class.getPackage().getName())) {
+                    return;
+                }
+                for (DotName annotationName : ctx.getTarget().asClass().annotations().keySet()) {
+                    if (metricsAnnotations.contains(annotationName)) {
+                        ctx.transform().add(AnnotationInstance.create(DotName.createSimple(MetricsBinding.class.getName()),
+                                ctx.getTarget(), new AnnotationValue[0]))
+                                .done();
+                        return;
+                    }
+                }
+            }
+        }));
+    }
+
+    @BuildStep
     @Record(STATIC_INIT)
     public void build(BeanContainerBuildItem beanContainerBuildItem,
             SmallRyeMetricsTemplate metrics,
             ShutdownContextBuildItem shutdown,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BeanArchiveIndexBuildItem beanArchiveIndex,
-            BuildProducer<FeatureBuildItem> feature) throws Exception {
+            BuildProducer<FeatureBuildItem> feature) {
 
         feature.produce(new FeatureBuildItem(FeatureBuildItem.SMALLRYE_METRICS));
 
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, Counted.class.getName()));
+        for (DotName metricsAnnotation : metricsAnnotations) {
+            reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, metricsAnnotation.toString()));
+        }
         reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, MetricsBinding.class.getName()));
 
         metrics.createRegistries(beanContainerBuildItem.getValue());
-
-        IndexView index = beanArchiveIndex.getIndex();
-        Collection<AnnotationInstance> annos = index.getAnnotations(DotName.createSimple(Counted.class.getName()));
-
-        for (AnnotationInstance anno : annos) {
-            AnnotationTarget target = anno.target();
-
-            // We need to exclude metrics interceptors
-            if (Kind.CLASS.equals(target.kind())
-                    && target.asClass().classAnnotations().stream()
-                            .anyMatch(a -> a.name().equals(DotName.createSimple(Interceptor.class.getName())))) {
-                continue;
-            }
-
-            MethodInfo methodInfo = target.asMethod();
-            String name = methodInfo.name();
-            if (anno.value("name") != null) {
-                name = anno.value("name").asString();
-            }
-            ClassInfo classInfo = methodInfo.declaringClass();
-
-            metrics.registerCounted(classInfo.name().toString(),
-                    name, shutdown);
-        }
     }
 
     @BuildStep

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -20,7 +20,8 @@ import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
@@ -57,13 +58,11 @@ import io.smallrye.metrics.interceptors.TimedInterceptor;
 
 public class SmallRyeMetricsProcessor {
 
-    SmallRyeMetricsConfig metrics;
-
-    private static final Collection<DotName> metricsAnnotations = Arrays.asList(
+    private static final Set<DotName> metricsAnnotations = new HashSet<>(Arrays.asList(
             DotName.createSimple(Gauge.class.getName()),
             DotName.createSimple(Counted.class.getName()),
             DotName.createSimple(Timed.class.getName()),
-            DotName.createSimple(Metered.class.getName()));
+            DotName.createSimple(Metered.class.getName())));
 
     @ConfigRoot(name = "smallrye-metrics")
     static final class SmallRyeMetricsConfig {
@@ -74,6 +73,8 @@ public class SmallRyeMetricsProcessor {
         @ConfigItem(defaultValue = "/metrics")
         String path;
     }
+
+    SmallRyeMetricsConfig metrics;
 
     @BuildStep
     ServletBuildItem createServlet() {

--- a/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsTemplate.java
+++ b/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsTemplate.java
@@ -32,7 +32,6 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Template;
 import io.smallrye.metrics.MetricRegistries;
-import io.smallrye.metrics.app.CounterImpl;
 
 @Template
 public class SmallRyeMetricsTemplate {
@@ -41,31 +40,6 @@ public class SmallRyeMetricsTemplate {
     private static final String MEMORY_HEAP_USAGE = "memory.heap.usage";
     private static final String MEMORY_NON_HEAP_USAGE = "memory.nonHeap.usage";
     private static final String THREAD_COUNT = "thread.count";
-
-    /*
-     * public <E extends Member & AnnotatedElement> void registerCounted(Class<?> topClass, E element) {
-     * MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
-     * //registry.register(name, new CounterImpl());
-     * MetricResolver resolver = new MetricResolver();
-     * MetricResolver.Of<Counted> of = resolver.counted(topClass, element);
-     * Metadata meta = new Metadata(of.metricName(), MetricType.COUNTER);
-     * //registry.register(meta, new CounterImpl());
-     * }
-     */
-    public void registerCounted(String topClassName, String elementName, ShutdownContext shutdown) {
-        MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.APPLICATION);
-
-        String name = MetricRegistry.name(topClassName, elementName);
-        Metadata meta = new Metadata(name, MetricType.COUNTER);
-        log.debugf("Register: %s", name);
-        registry.register(meta, new CounterImpl());
-        shutdown.addShutdownTask(new Runnable() {
-            @Override
-            public void run() {
-                registry.remove(name);
-            }
-        });
-    }
 
     public void registerBaseMetrics(ShutdownContext shutdown) {
         MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.BASE);

--- a/integration-tests/main/src/main/java/io/quarkus/example/metrics/MetricsResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/example/metrics/MetricsResource.java
@@ -16,17 +16,71 @@
 
 package io.quarkus.example.metrics;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 
 @Path("/metricsresource")
 public class MetricsResource {
 
+    @Inject
+    @Metric(name = "histogram")
+    Histogram histogram;
+
     @GET
+    @Path("/counter")
     @Counted(monotonic = true, name = "a_counted_resource")
-    public String getTest() {
+    public String counter() {
+        return "TEST";
+    }
+
+    @GET
+    @Path("/gauge")
+    @Gauge(name = "gauge", unit = MetricUnits.NONE)
+    public Long gauge() {
+        return 42L;
+    }
+
+    @GET
+    @Path("/meter")
+    @Metered(name = "meter")
+    public String meter() {
+        return "OK";
+    }
+
+    @GET
+    @Path("/timer")
+    @Timed(name = "timer_metric")
+    public String timer() {
+        return "OK";
+    }
+
+    @GET
+    @Path("/histogram")
+    public String histogram() {
+        histogram.update(42);
+        return "OK";
+    }
+
+    @GET
+    @Path("/counter-absolute")
+    @Counted(monotonic = true, name = "counter_absolute", absolute = true)
+    public String counterAbsoluteName() {
+        return "TEST";
+    }
+
+    @GET
+    @Path("/counter-with-tags")
+    @Counted(monotonic = true, name = "counter_with_tags", tags = "foo=bar")
+    public String counterWithTags() {
         return "TEST";
     }
 


### PR DESCRIPTION
Fixes #1009 and #1303

This change lets interceptors in SmallRye Metrics do the registration of metrics, so we don't anymore attempt to duplicate that logic in Quarkus. This also enables support for all remaining metrics that were not supported (Meter, Timer), fixes processing of metric tags and the `absolute` attribute.
Includes tests for all things that this resolves.

I realize this is not the best solution given the Quarkus philosophy, because this way metrics (from annotations) will NOT be initialized at build time, but at least this should be correct for the time being. Eagerly initializing metrics at Quarkus' side will require a lot of duplication of logic from SmallRye Metrics and will be very brittle with regard to changes in Metrics which can easily break everything.
So I would suggest we use this for now as the temporary solution until a more proper solution is found, which might require substantial changes in SmallRye as well... I will continue to research how to do it properly.

@rsvoboda @kenfinnigan 