### PR TITLE
Add amazon-lambda missing entry

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -405,6 +405,12 @@
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-lambda</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <!-- Quarkus test dependencies -->
 


### PR DESCRIPTION
Adding the amazon-lambda dependencyManagement entry. When installing the extension the build fails because of the missing version definition.