### PR TITLE
dev mode logger messages are swallowed and not written to console

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InitialConfigurator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InitialConfigurator.java
@@ -26,7 +26,7 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
 
     public Handler[] getHandlersOf(final String loggerName) {
         if (loggerName.isEmpty()) {
-            if (ImageInfo.inImageBuildtimeCode()) {
+            if (ImageInfo.inImageBuildtimeCode() || System.getProperty("quarkus.devMode") != null) {
                 final ConsoleHandler handler = new ConsoleHandler(new PatternFormatter(
                         "%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
                 handler.setLevel(Level.INFO);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -176,6 +176,8 @@ public class QuarkusDev extends QuarkusTask {
             if (getJvmArgs() != null) {
                 args.addAll(Arrays.asList(getJvmArgs().split(" ")));
             }
+            //Add env to enable quarkus dev mode logging
+            args.add("-Dquarkus.devMode");
 
             for (File f : extension.resourcesDir()) {
                 File servletRes = new File(f, "META-INF/resources");

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -184,6 +184,8 @@ public class DevMojo extends AbstractMojo {
                     args.add("-D" + i.getKey() + "=" + i.getValue());
                 }
             }
+            //Add env to enable quarkus dev mode logging
+            args.add("-Dquarkus.devMode");
 
             for (Resource r : project.getBuild().getResources()) {
                 File f = new File(r.getDirectory());


### PR DESCRIPTION
@stuartwdouglas @dmlloyd all dev mode messages were being handled by a org.jboss.logmanager.handlers.DelayedHandler and were not being written to console.  I thought about creating a new EmbeddedConfigurator for dev mode, but decided to pass "-Dquarkus.devMode" to the devMode process, and test for that env variable, and re-use io.quarkus.runtime.logging.InitialConfigurator