### PR TITLE
Generate reflection declaration from MP OpenAPI schema definition

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyScanningProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyScanningProcessor.java
@@ -49,6 +49,7 @@ import javax.ws.rs.ext.Providers;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -98,7 +99,6 @@ import io.quarkus.undertow.deployment.ServletInitParamBuildItem;
  * @author Stuart Douglas
  */
 public class ResteasyScanningProcessor {
-
     private static final String JAVAX_WS_RS_APPLICATION = Application.class.getName();
     private static final String JAX_RS_FILTER_NAME = JAVAX_WS_RS_APPLICATION;
     private static final String JAX_RS_SERVLET_NAME = JAVAX_WS_RS_APPLICATION;
@@ -137,6 +137,14 @@ public class ResteasyScanningProcessor {
 
     private static final DotName JSONB_ANNOTATION = DotName.createSimple("javax.json.bind.annotation.JsonbAnnotation");
 
+    private static final DotName OPENAPI_SCHEMA = DotName
+            .createSimple("org.eclipse.microprofile.openapi.annotations.media.Schema");
+    private static final DotName OPENAPI_RESPONSE = DotName
+            .createSimple("org.eclipse.microprofile.openapi.annotations.responses.APIResponse");
+
+    private static final DotName OPENAPI_RESPONSES = DotName
+            .createSimple("org.eclipse.microprofile.openapi.annotations.responses.APIResponses");
+
     private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(Arrays.asList(
             // javax.json
             DotName.createSimple("javax.json.JsonObject"),
@@ -174,6 +182,14 @@ public class ResteasyScanningProcessor {
             new ProviderDiscoverer(PUT, true, false)
     };
     private static final DotName SINGLETON_SCOPE = DotName.createSimple(Singleton.class.getName());
+
+    private static final String OPENAPI_RESPONSE_CONTENT = "content";
+    private static final String OPENAPI_RESPONSE_SCHEMA = "schema";
+    private static final String OPENAPI_SCHEMA_NOT = "not";
+    private static final String OPENAPI_SCHEMA_ONE_OF = "oneOf";
+    private static final String OPENAPI_SCHEMA_ANY_OF = "anyOf";
+    private static final String OPENAPI_SCHEMA_ALL_OF = "allOf";
+    private static final String OPENAPI_SCHEMA_IMPLEMENTATION = "implementation";
 
     /**
      * JAX-RS configuration.
@@ -537,9 +553,87 @@ public class ResteasyScanningProcessor {
             }
         }
 
+        // Generate reflection declaration from MP OpenAPI Schema definition
+        // They are needed for serialization.
+        Collection<AnnotationInstance> schemaAnnotationInstances = index.getAnnotations(OPENAPI_SCHEMA);
+        for (AnnotationInstance schemaAnnotationInstance : schemaAnnotationInstances) {
+            AnnotationTarget typeTarget = schemaAnnotationInstance.target();
+            if (typeTarget.kind() != Kind.CLASS) {
+                continue;
+            }
+            reflectiveHierarchy
+                    .produce(new ReflectiveHierarchyBuildItem(Type.create(typeTarget.asClass().name(), Type.Kind.CLASS)));
+        }
+
+        // Generate reflection declaration from MP OpenAPI APIResponse schema definition
+        // They are needed for serialization
+        Collection<AnnotationInstance> apiResponseAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSE);
+        registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
+                apiResponseAnnotationInstances);
+
+        // Generate reflection declaration from MP OpenAPI APIResponses schema definition
+        // They are needed for serialization
+        Collection<AnnotationInstance> apiResponsesAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSES);
+        for (AnnotationInstance apiResponsesAnnotationInstance : apiResponsesAnnotationInstances) {
+            AnnotationValue apiResponsesAnnotationValue = apiResponsesAnnotationInstance.value();
+            if (apiResponsesAnnotationValue == null) {
+                continue;
+            }
+            registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
+                    Arrays.asList(apiResponsesAnnotationValue.asNestedArray()));
+        }
+
         // In the case of a constraint violation, these elements might be returned as entities and will be serialized
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, ViolationReport.class.getName()));
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, ResteasyConstraintViolation.class.getName()));
+    }
+
+    private void registerReflectionForApiResponseSchemaSerialization(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
+            Collection<AnnotationInstance> apiResponseAnnotationInstances) {
+        for (AnnotationInstance apiResponseAnnotationInstance : apiResponseAnnotationInstances) {
+            AnnotationInstance[] contents = apiResponseAnnotationInstance.value(OPENAPI_RESPONSE_CONTENT).asNestedArray();
+            if (contents == null) {
+                continue;
+            }
+            for (AnnotationInstance content : contents) {
+                AnnotationInstance schema = content.value(OPENAPI_RESPONSE_SCHEMA).asNested();
+                if (schema == null) {
+                    continue;
+                }
+
+                AnnotationValue schemaImplementationClass = schema.value(OPENAPI_SCHEMA_IMPLEMENTATION);
+                if (schemaImplementationClass != null) {
+                    reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaImplementationClass.asClass()));
+                }
+
+                AnnotationValue schemaNotClass = schema.value(OPENAPI_SCHEMA_NOT);
+                if (schemaNotClass != null) {
+                    reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, schemaNotClass.asString()));
+                }
+
+                AnnotationValue schemaOneOfClasses = schema.value(OPENAPI_SCHEMA_ONE_OF);
+                if (schemaOneOfClasses != null) {
+                    for (Type schemaOneOfClass : schemaOneOfClasses.asClassArray()) {
+                        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaOneOfClass));
+                    }
+                }
+
+                AnnotationValue schemaAnyOfClasses = schema.value(OPENAPI_SCHEMA_ANY_OF);
+                if (schemaAnyOfClasses != null) {
+                    for (Type schemaAnyOfClass : schemaAnyOfClasses.asClassArray()) {
+                        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaAnyOfClass));
+                    }
+                }
+
+                AnnotationValue schemaAllOfClasses = schema.value(OPENAPI_SCHEMA_ALL_OF);
+                if (schemaAllOfClasses != null) {
+                    for (Type schemaAllOfClass : schemaAllOfClasses.asClassArray()) {
+                        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaAllOfClass));
+                    }
+                }
+            }
+        }
     }
 
     private static void categorizeProviders(Set<String> availableProviders, MediaTypeMap<String> categorizedReaders,

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RootResource.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RootResource.java
@@ -10,5 +10,4 @@ public class RootResource {
     public String root() {
         return "Root Resource";
     }
-
 }

--- a/integration-tests/main/src/main/java/io/quarkus/example/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/example/rest/TestResource.java
@@ -42,6 +42,12 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.reactivex.Single;
 
@@ -168,6 +174,45 @@ public class TestResource {
         MyEntity entity = new MyEntity();
         entity.setName("my entity name");
         entity.setValue("my entity value");
+        return Response.ok(entity).build();
+    }
+
+    @GET
+    @Path("/openapi/responses")
+    @Produces("application/json")
+    @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class)))
+    public Response openApiResponse() {
+        MyOpenApiEntityV1 entity = new MyOpenApiEntityV1();
+        entity.setName("my openapi entity name");
+        return Response.ok(entity).build();
+    }
+
+    @GET
+    @Path("/openapi/responses/{version}")
+    @Produces("application/json")
+    @APIResponses({
+            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class))),
+            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV2.class)))
+    })
+    public Response openApiResponses(@PathParam("version") String version) {
+        if ("v1".equals(version)) {
+            MyOpenApiEntityV1 entityV1 = new MyOpenApiEntityV1();
+            entityV1.setName("my openapi entity version one name");
+            return Response.ok(entityV1).build();
+        }
+
+        MyOpenApiEntityV2 entityV2 = new MyOpenApiEntityV2();
+        entityV2.setName("my openapi entity version two name");
+        entityV2.setValue(version);
+        return Response.ok(entityV2).build();
+    }
+
+    @GET
+    @Path("/openapi/schema")
+    @Produces("application/json")
+    public Response openApiSchemaResponses() {
+        MyOpenApiSchemaEntity entity = new MyOpenApiSchemaEntity();
+        entity.setName("my openapi schema");
         return Response.ok(entity).build();
     }
 
@@ -324,4 +369,51 @@ public class TestResource {
             this.value = value;
         }
     }
+
+    public static class MyOpenApiEntityV1 {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class MyOpenApiEntityV2 {
+        private String value;
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @Schema()
+    public static class MyOpenApiSchemaEntity {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
 }

--- a/integration-tests/main/src/test/java/io/quarkus/example/test/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/example/test/JaxRSTestCase.java
@@ -135,4 +135,29 @@ public class JaxRSTestCase {
                 .body("name", is("my entity name"),
                         "value", is("my entity value"));
     }
+
+    @Test
+    public void testOpenApiSchemaResponse() {
+        RestAssured.when().get("/test/openapi/responses").then()
+                .body("name", is("my openapi entity name"));
+    }
+
+    @Test
+    public void testOpenApiSchemaResponsesV1() {
+        RestAssured.when().get("/test/openapi/responses/v1").then()
+                .body("name", is("my openapi entity version one name"));
+    }
+
+    @Test
+    public void testOpenApiSchemaResponseV2() {
+        RestAssured.when().get("/test/openapi/responses/v2").then()
+                .body("name", is("my openapi entity version two name"));
+    }
+
+    @Test
+    public void testOpenApiSchema() {
+        RestAssured.when().get("/test/openapi/schema").then()
+                .body("name", is("my openapi schema"));
+    }
+
 }


### PR DESCRIPTION
Fixes #745.

The main idea is to scan for SCHEMA annotation and mark them as ReflectiveHierarchy
-Scan APIResponse annotation for schema declaration and mark the results ( `implementation , not, oneOf, anyOf, allOf values`) for reflection.
-Scan APIResponses annotation and do as above.