### PR TITLE
Switch to GraalVM 1.0.0-rc13

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -76,7 +76,7 @@
         <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal
            is not available in Maven fast enough: -->
-        <graal-sdk.version>1.0.0-rc12</graal-sdk.version>
+        <graal-sdk.version>1.0.0-rc13</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha2</gizmo.version>
         <jackson.version>2.9.8</jackson.version>
         <commons-beanutils-core.version>1.8.3</commons-beanutils-core.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -39,7 +39,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>1.0.0-rc12</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>1.0.0-rc13</graal-sdk.version-for-documentation>
         <rest-assured.version>3.3.0</rest-assured.version>
 
         <!-- Enable APT by default for Eclipse -->

--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -278,7 +278,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
             //TODO: use an 'official' image
             String image;
             if (dockerBuild.toLowerCase().equals("true")) {
-                image = "swd847/centos-graal-native-image-rc12";
+                image = "swd847/centos-graal-native-image-rc13";
             } else {
                 //allow the use of a custom image
                 image = dockerBuild;
@@ -466,8 +466,8 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
     private boolean isThisGraalVMRCObsolete() {
         final String vmName = System.getProperty("java.vm.name");
         log.info("Running Quarkus native-image plugin on " + vmName);
-        if (vmName.contains("-rc9") || vmName.contains("-rc10") || vmName.contains("-rc11")) {
-            log.error("Out of date RC build of GraalVM detected! Please upgrade to RC12");
+        if (vmName.contains("-rc9") || vmName.contains("-rc10") || vmName.contains("-rc11") || vmName.contains("-rc12")) {
+            log.error("Out of date RC build of GraalVM detected! Please upgrade to RC13");
             return true;
         }
         return false;

--- a/docker/centos-graal-maven/Dockerfile
+++ b/docker/centos-graal-maven/Dockerfile
@@ -1,4 +1,4 @@
-FROM swd847/centos-graal-rc12
+FROM swd847/centos-graal-rc13
 
 ARG MAVEN_VERSION=3.3.9
 ARG USER_HOME_DIR="/root"

--- a/docker/centos-graal-native-image/Dockerfile
+++ b/docker/centos-graal-native-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM swd847/centos-graal-rc12
+FROM swd847/centos-graal-rc13
 
 VOLUME /project
 WORKDIR /project

--- a/docker/centos-graal/Dockerfile
+++ b/docker/centos-graal/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:latest
 
 ARG GRAAL_VERSION
-ENV GRAAL_VERSION=${GRAAL_VERSION:-1.0.0-rc12}
+ENV GRAAL_VERSION=${GRAAL_VERSION:-1.0.0-rc13}
 ENV GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-linux-amd64.tar.gz
 
 ENV JAVA_HOME=/opt/graalvm


### PR DESCRIPTION

I'm going to need requiring rc13 soon.. 

N.B. While I tested the full build with `-Dnative`, Docker images like `swd847/centos-graal-native-image-rc13` don't exist yet. @stuartwdouglas please?