### PR TITLE
remove un-used (and "dangerous") mavenLocal from build.gradle

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 repositories {
-        mavenLocal()
     mavenCentral()
 }
 

--- a/devtools/gradle/gradle.properties
+++ b/devtools/gradle/gradle.properties
@@ -1,1 +1,0 @@
-projectName = quarkus-gradle-plugin


### PR DESCRIPTION
This "isolates" this build better.  Also makes it clearer; easier to understand - so the Quarkus dependencies are copied by mvn in the POM, and the Gradle build then picks them out via fileTree, not as a Maven dependencies (so no need for mavenLocal).