### PR TITLE
Fix JAX-RS ParamConverterProvider integration

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyScanningProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyScanningProcessor.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
-import javax.net.ssl.TrustManager;
 import javax.servlet.DispatcherType;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Consumes;
@@ -41,8 +40,6 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
@@ -70,6 +67,8 @@ import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -231,12 +230,15 @@ public class ResteasyScanningProcessor {
     }
 
     @BuildStep
-    void scanForProviders(BuildProducer<ResteasyJaxrsProviderBuildItem> providers, CombinedIndexBuildItem indexBuildItem) {
+    void scanForProviders(BuildProducer<ResteasyJaxrsProviderBuildItem> providers, CombinedIndexBuildItem indexBuildItem,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
         for (AnnotationInstance i : indexBuildItem.getIndex().getAnnotations(PROVIDER)) {
             if (i.target().kind() == AnnotationTarget.Kind.CLASS) {
                 providers.produce(new ResteasyJaxrsProviderBuildItem(i.target().asClass().name().toString()));
             }
         }
+        // Providers should never be removed
+        unremovableBeans.produce(new UnremovableBeanBuildItem(new BeanClassAnnotationExclusion(PROVIDER)));
     }
 
     @BuildStep

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusConstructorInjector.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusConstructorInjector.java
@@ -45,7 +45,16 @@ public class QuarkusConstructorInjector implements ConstructorInjector {
 
     @Override
     public CompletionStage<Object> construct(boolean unwrapAsync) {
-        return this.delegate.construct(unwrapAsync);
+        if (QuarkusInjectorFactory.CONTAINER == null) {
+            return this.delegate.construct(unwrapAsync);
+        }
+        if (factory == null) {
+            factory = QuarkusInjectorFactory.CONTAINER.instanceFactory(this.ctor.getDeclaringClass());
+        }
+        if (factory == null) {
+            return delegate.construct(unwrapAsync);
+        }
+        return CompletableFuture.completedFuture(factory.create().get());
     }
 
     @Override

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusInjectorFactory.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusInjectorFactory.java
@@ -46,7 +46,7 @@ public class QuarkusInjectorFactory extends InjectorFactoryImpl {
     @Override
     public ConstructorInjector createConstructor(Constructor constructor, ResteasyProviderFactory providerFactory) {
         log.debugf("Create constructor: %s", constructor);
-        return super.createConstructor(constructor, providerFactory);
+        return new QuarkusConstructorInjector(constructor, super.createConstructor(constructor, providerFactory));
     }
 
     @Override


### PR DESCRIPTION
- make JAX-RS providers unremovable
- use QuarkusInjectorFactory also for components outside HTTP request
- resolves #1392