### PR TITLE
package phase is useless

### DIFF
--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -160,7 +160,7 @@ To run Integration Tests on the native executable, make sure to have the proper 
 
 [source,shell]
 ----
-mvn package verify -Pnative
+mvn verify -Pnative
 ...
 [quarkus-quickstart-runner:50955]     universe:     391.96 ms
 [quarkus-quickstart-runner:50955]      (parse):     904.37 ms


### PR DESCRIPTION
`package` phase is before the `verify` phase in the default lifecycle thus its automatically called

https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html