### PR TITLE
Fix for #1415, Map<String,String> in config root is not working

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/AccessorFinder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/AccessorFinder.java
@@ -66,7 +66,7 @@ public final class AccessorFinder {
         final String fieldType = primitive ? rawFieldType : DescriptorUtils.getTypeStringFromDescriptorFormat(rawFieldType);
         final String publicType = primitive ? fieldType : JLO;
         methodDescriptor = MethodDescriptor.ofMethod(accessorName, "put_" + fieldDescriptor.getName(), void.class,
-                                                     publicType, String.class, String.class);
+                publicType, String.class, String.class);
         return methodDescriptor;
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/AccessorFinder.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/AccessorFinder.java
@@ -52,6 +52,24 @@ public final class AccessorFinder {
         return methodDescriptor;
     }
 
+    /**
+     *
+     * @param fieldDescriptor
+     * @return
+     */
+    public synchronized MethodDescriptor getMapPutFor(FieldDescriptor fieldDescriptor) {
+        MethodDescriptor methodDescriptor;
+        final String declaringClass = fieldDescriptor.getDeclaringClass();
+        final String accessorName = declaringClass + "$$accessor";
+        final String rawFieldType = fieldDescriptor.getType();
+        final boolean primitive = isPrimitive(rawFieldType);
+        final String fieldType = primitive ? rawFieldType : DescriptorUtils.getTypeStringFromDescriptorFormat(rawFieldType);
+        final String publicType = primitive ? fieldType : JLO;
+        methodDescriptor = MethodDescriptor.ofMethod(accessorName, "put_" + fieldDescriptor.getName(), void.class,
+                                                     publicType, String.class, String.class);
+        return methodDescriptor;
+    }
+
     public synchronized MethodDescriptor getConstructorFor(MethodDescriptor ctor) {
         MethodDescriptor methodDescriptor = ctors.get(ctor);
         if (methodDescriptor != null)

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
@@ -282,8 +282,9 @@ public class ConfigDefinition extends CompoundConfigType {
         } else {
             // treat as a plain object, hope for the best
             // TODO, REVISIT THIS
-            final ObjectConfigType leaf = new ObjectConfigType(NO_CONTAINING_NAME, mct, true, "", valueClass);
-            //container.getConfigDefinition().getLeafPatterns().addPattern(subKey, leaf);
+            //final ObjectConfigType leaf = new ObjectConfigType(NO_CONTAINING_NAME, mct, true, "", valueClass);
+            final MapValueConfigType leaf = new MapValueConfigType(containingName, mct, true, valueClass);
+            container.getConfigDefinition().getLeafPatterns().addPattern(subKey, leaf);
         }
         return mct;
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/GroupConfigType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/GroupConfigType.java
@@ -61,7 +61,8 @@ public class GroupConfigType extends CompoundConfigType {
                 }
                 field.setAccessible(true);
                 final FieldDescriptor descr = FieldDescriptor.of(field);
-                FieldInfo fieldInfo = new FieldInfo(field, accessorFinder.getSetterFor(descr), accessorFinder.getGetterFor(descr));
+                FieldInfo fieldInfo = new FieldInfo(field, accessorFinder.getSetterFor(descr),
+                        accessorFinder.getGetterFor(descr));
                 fieldInfos.put(field.getName(), fieldInfo);
                 if (Map.class.isAssignableFrom(field.getType())) {
                     MethodDescriptor putMethod = accessorFinder.getMapPutFor(descr);
@@ -105,6 +106,7 @@ public class GroupConfigType extends CompoundConfigType {
     public ConfigType getField(String name) {
         return fields.get(name);
     }
+
     public FieldInfo getFieldInfo(String name) {
         return fieldInfos.get(name);
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/GroupConfigType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/GroupConfigType.java
@@ -61,8 +61,12 @@ public class GroupConfigType extends CompoundConfigType {
                 }
                 field.setAccessible(true);
                 final FieldDescriptor descr = FieldDescriptor.of(field);
-                fieldInfos.put(field.getName(),
-                        new FieldInfo(field, accessorFinder.getSetterFor(descr), accessorFinder.getGetterFor(descr)));
+                FieldInfo fieldInfo = new FieldInfo(field, accessorFinder.getSetterFor(descr), accessorFinder.getGetterFor(descr));
+                fieldInfos.put(field.getName(), fieldInfo);
+                if (Map.class.isAssignableFrom(field.getType())) {
+                    MethodDescriptor putMethod = accessorFinder.getMapPutFor(descr);
+                    fieldInfo.setPutMap(putMethod);
+                }
             }
         }
     }
@@ -100,6 +104,9 @@ public class GroupConfigType extends CompoundConfigType {
 
     public ConfigType getField(String name) {
         return fields.get(name);
+    }
+    public FieldInfo getFieldInfo(String name) {
+        return fieldInfos.get(name);
     }
 
     public void addField(ConfigType node) {
@@ -264,6 +271,7 @@ public class GroupConfigType extends CompoundConfigType {
         private final Field field;
         private final MethodDescriptor setter;
         private final MethodDescriptor getter;
+        private MethodDescriptor putMap;
 
         public FieldInfo(final Field field, final MethodDescriptor setter, final MethodDescriptor getter) {
             this.field = field;
@@ -281,6 +289,14 @@ public class GroupConfigType extends CompoundConfigType {
 
         public MethodDescriptor getGetter() {
             return getter;
+        }
+
+        public MethodDescriptor getPutMap() {
+            return putMap;
+        }
+
+        public void setPutMap(MethodDescriptor putMap) {
+            this.putMap = putMap;
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/MapValueConfigType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/MapValueConfigType.java
@@ -17,7 +17,7 @@ public class MapValueConfigType extends LeafConfigType {
     final Class<?> expectedType;
 
     public MapValueConfigType(final String containingName, final CompoundConfigType container, final boolean consumeSegment,
-                            final Class<?> expectedType) {
+            final Class<?> expectedType) {
         super(containingName, container, consumeSegment);
         this.expectedType = expectedType;
     }
@@ -64,7 +64,8 @@ public class MapValueConfigType extends LeafConfigType {
     }
 
     @Override
-    void generateAcceptConfigurationValueIntoGroup(BytecodeCreator body, ResultHandle enclosing, MethodDescriptor setter, ResultHandle name, ResultHandle config) {
+    void generateAcceptConfigurationValueIntoGroup(BytecodeCreator body, ResultHandle enclosing, MethodDescriptor setter,
+            ResultHandle name, ResultHandle config) {
         // Expect to be in a MapConfigType contained in a GroupConfigType
         final MapConfigType mapContainer = getContainer(MapConfigType.class);
         final GroupConfigType container = mapContainer.getContainer(GroupConfigType.class);
@@ -86,7 +87,8 @@ public class MapValueConfigType extends LeafConfigType {
     }
 
     @Override
-    void generateGetDefaultValueIntoEnclosingGroup(BytecodeCreator body, ResultHandle enclosing, MethodDescriptor setter, ResultHandle config) {
+    void generateGetDefaultValueIntoEnclosingGroup(BytecodeCreator body, ResultHandle enclosing, MethodDescriptor setter,
+            ResultHandle config) {
         // noop
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/MapValueConfigType.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/MapValueConfigType.java
@@ -1,0 +1,97 @@
+package io.quarkus.deployment.configuration;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import io.quarkus.deployment.AccessorFinder;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.runtime.configuration.NameIterator;
+import io.smallrye.config.SmallRyeConfig;
+
+/**
+ * Handle Map<String,String> leaf values
+ */
+public class MapValueConfigType extends LeafConfigType {
+    final Class<?> expectedType;
+
+    public MapValueConfigType(final String containingName, final CompoundConfigType container, final boolean consumeSegment,
+                            final Class<?> expectedType) {
+        super(containingName, container, consumeSegment);
+        this.expectedType = expectedType;
+    }
+
+    @Override
+    public Class<?> getItemClass() {
+        return expectedType;
+    }
+
+    @Override
+    public void acceptConfigurationValue(NameIterator name, SmallRyeConfig config) {
+        // Expect to be in a MapConfigType contained in a GroupConfigType
+        final MapConfigType mapContainer = getContainer(MapConfigType.class);
+        final GroupConfigType container = mapContainer.getContainer(GroupConfigType.class);
+        if (isConsumeSegment())
+            name.previous();
+        container.acceptConfigurationValueIntoLeaf(this, name, config);
+        // the iterator is not used after this point
+        // if (isConsumeSegment()) name.next();
+    }
+
+    @Override
+    public void generateAcceptConfigurationValue(BytecodeCreator body, ResultHandle name, ResultHandle config) {
+        // Expect to be in a MapConfigType contained in a GroupConfigType
+        final MapConfigType mapContainer = getContainer(MapConfigType.class);
+        if (isConsumeSegment())
+            body.invokeVirtualMethod(NI_PREV_METHOD, name);
+        mapContainer.generateAcceptConfigurationValueIntoLeaf(body, this, name, config);
+        // the iterator is not used after this point
+        // if (isConsumeSegment()) body.invokeVirtualMethod(NI_NEXT_METHOD, name);
+    }
+
+    @Override
+    void acceptConfigurationValueIntoGroup(Object enclosing, Field field, NameIterator name, SmallRyeConfig config) {
+        try {
+            Map map = (Map) field.get(enclosing);
+            String value = config.getValue(name.toString(), String.class);
+            String key = name.getNextSegment();
+            map.put(key, value);
+        } catch (IllegalAccessException e) {
+            throw toError(e);
+        }
+
+    }
+
+    @Override
+    void generateAcceptConfigurationValueIntoGroup(BytecodeCreator body, ResultHandle enclosing, MethodDescriptor setter, ResultHandle name, ResultHandle config) {
+        // Expect to be in a MapConfigType contained in a GroupConfigType
+        final MapConfigType mapContainer = getContainer(MapConfigType.class);
+        final GroupConfigType container = mapContainer.getContainer(GroupConfigType.class);
+        // config.getValue(name.toString(), String.class)
+        final ResultHandle value = body.checkCast(body.invokeVirtualMethod(
+                SRC_GET_VALUE,
+                config,
+                body.invokeVirtualMethod(
+                        OBJ_TO_STRING_METHOD,
+                        name),
+                body.loadClass(String.class)), String.class);
+        final ResultHandle key = body.invokeVirtualMethod(NI_GET_NEXT_SEGMENT, name);
+        body.invokeStaticMethod(setter, enclosing, key, value);
+    }
+
+    @Override
+    void getDefaultValueIntoEnclosingGroup(Object enclosing, SmallRyeConfig config, Field field) {
+        // noop
+    }
+
+    @Override
+    void generateGetDefaultValueIntoEnclosingGroup(BytecodeCreator body, ResultHandle enclosing, MethodDescriptor setter, ResultHandle config) {
+        // noop
+    }
+
+    @Override
+    public ResultHandle writeInitialization(BytecodeCreator body, AccessorFinder accessorFinder, ResultHandle smallRyeConfig) {
+        return null;
+    }
+}

--- a/core/test-extension/deployment/src/test/resources/application.properties
+++ b/core/test-extension/deployment/src/test/resources/application.properties
@@ -50,7 +50,19 @@ quarkus.rt.all-values.opt-double-value=3.1415926535897932384
 quarkus.rt.all-values.optional-long-value=12345678941
 quarkus.rt.all-values.nested-config-map.key1.nested-value=value1
 quarkus.rt.all-values.nested-config-map.key1.oov=value1.1+value1.2
+quarkus.rt.all-values.nested-config-map.key1.long-primitive=100
+quarkus.rt.all-values.nested-config-map.key1.long-list=100,101,102
 quarkus.rt.all-values.nested-config-map.key2.nested-value=value2
 quarkus.rt.all-values.nested-config-map.key2.oov=value2.1+value2.2
+quarkus.rt.all-values.nested-config-map.key2.long-primitive=200
+quarkus.rt.all-values.nested-config-map.key2.long-list=200,201,202
 quarkus.rt.all-values.string-list=value1,value2
 quarkus.rt.all-values.long-list=1,2,3
+# A nested map of properties
+quarkus.rt.all-values.string-map.key1=value1
+quarkus.rt.all-values.string-map.key2=value2
+quarkus.rt.all-values.string-map.key3=value3
+# A root map of properties
+quarkus.rt.string-map.key1=value1
+quarkus.rt.string-map.key2=value2
+quarkus.rt.string-map.key3=value3

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/AllValuesConfig.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/AllValuesConfig.java
@@ -44,6 +44,9 @@ public class AllValuesConfig {
     /** A map of config group objects */
     @ConfigItem
     public Map<String, NestedConfig> nestedConfigMap;
+    /** A map of properties */
+    @ConfigItem
+    public Map<String, String> stringMap;
     /** A List of string values */
     @ConfigItem
     public List<String> stringList;
@@ -55,13 +58,19 @@ public class AllValuesConfig {
     public String toString() {
         return "AllValuesConfig{" +
                 "longPrimitive=" + longPrimitive +
+                ", doublePrimitive=" + doublePrimitive +
                 ", longValue=" + longValue +
                 ", optLongValue=" + optLongValue +
+                ", optDoubleValue=" + optDoubleValue +
                 ", optionalLongValue=" + optionalLongValue +
                 ", oov=" + oov +
                 ", oovWithDefault=" + oovWithDefault +
                 ", ovo=" + ovo +
                 ", ovoWithDefault=" + ovoWithDefault +
+                ", nestedConfigMap=" + nestedConfigMap +
+                ", stringMap=" + stringMap +
+                ", stringList=" + stringList +
+                ", longList=" + longList +
                 '}';
     }
 }

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/NestedConfig.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/NestedConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.extest.runtime;
 
+import java.util.List;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -11,5 +13,11 @@ public class NestedConfig {
     /** A nested ObjectOfValue value */
     @ConfigItem
     public ObjectOfValue oov;
+    /** A nested long primitive */
+    @ConfigItem
+    public long longPrimitive;
+    /** A nested long list */
+    @ConfigItem
+    public List<Long> longList;
 
 }

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/TestRunTimeConfig.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/TestRunTimeConfig.java
@@ -1,11 +1,16 @@
 package io.quarkus.extest.runtime;
 
+import java.util.Map;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 @ConfigRoot(name = "rt", phase = ConfigPhase.RUN_TIME)
 public class TestRunTimeConfig {
+    /** A map of properties */
+    @ConfigItem
+    public Map<String, String> stringMap;
     /** A run time object */
     @ConfigItem
     public String rtStringOpt;
@@ -22,6 +27,7 @@ public class TestRunTimeConfig {
                 "rtStringOpt='" + rtStringOpt + '\'' +
                 ", rtStringOptWithDefault='" + rtStringOptWithDefault + '\'' +
                 ", allValues=" + allValues +
+                ", stringMap=" + stringMap +
                 '}';
     }
 }


### PR DESCRIPTION
This is what I found to work, but I'm not sure it is the cleanest way to do this. There is a duality of the Map type as a container and leaf that perhaps could be handled better.