### PR TITLE
rm skip.gradle.build=true for Java 11 (re. #1405)

### DIFF
--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -228,14 +228,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>java8</id>
-            <activation>
-                <jdk>[8,)</jdk>
-            </activation>
-            <properties>
-                <skip.gradle.build>true</skip.gradle.build>
-            </properties>
-        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
see #1405

I don't understand why the Gradle plugin should be hard-coded and forcibly only built on Java 8.

As far as I can tell (just from running the "IT" from #1405), the build does at least run (even though the built `getting-started-runner.jar` then fails to start, but that is another problem, I think, or is it known to be broken running on Java 11?).

@stalep 