### PR TITLE
MariaDB tests had been broken

### DIFF
--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -29,6 +29,11 @@
     <artifactId>quarkus-integration-test-jpa-mariadb</artifactId>
     <name>Quarkus - Integration Tests - JPA - MariaDB</name>
     <description>Module that contains JPA related tests running with the MariaDB database</description>
+
+    <properties>
+        <mariadb.url>jdbc:mariadb://localhost:3306/hibernate_orm_test</mariadb.url>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/jpa-mariadb/src/main/resources/application.properties
+++ b/integration-tests/jpa-mariadb/src/main/resources/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-quarkus.datasource.url=${mariadb.url:}
+quarkus.datasource.url=${mariadb.url}
 quarkus.datasource.driver=org.mariadb.jdbc.Driver
 quarkus.datasource.username=hibernate_orm_test
 quarkus.datasource.password=hibernate_orm_test


### PR DESCRIPTION

The integration tests of this module aren't run by default, so it was broken and nobody noticed:

Restoring.