### PR TITLE
Improve the java executable location logic, #241

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -70,6 +70,7 @@
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
         <maven-core.version>3.5.4</maven-core.version>
         <maven-resolver.version>1.1.1</maven-resolver.version>
+        <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <guava.version>27.0.1-jre</guava.version>
         <plexus-utils.version>3.0.24</plexus-utils.version>
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
@@ -939,6 +940,17 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-settings-builder</artifactId>
                 <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-toolchain</artifactId>
+                <version>${maven-toolchain.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-classworlds</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -46,6 +46,10 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-toolchain</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -152,8 +152,8 @@ public class DevMojo extends AbstractMojo {
         }
         if (!found) {
             getLog().warn("The quarkus-maven-plugin build goal was not configured for this project, " +
-                                  "skipping quarkus:dev as this is assumed to be a support library. If you want to run quarkus dev" +
-                                  " on this project make sure the quarkus-maven-plugin is configured with a build goal.");
+                    "skipping quarkus:dev as this is assumed to be a support library. If you want to run quarkus dev" +
+                    " on this project make sure the quarkus-maven-plugin is configured with a build goal.");
             return;
         }
 
@@ -173,7 +173,7 @@ public class DevMojo extends AbstractMojo {
             if (debug == null) {
                 // debug mode not specified
                 // make sure 5005 is not used, we don't want to just fail if something else is using it
-                try (Socket socket = new Socket(InetAddress.getByAddress(new byte[]{127, 0, 0, 1}), 5005)) {
+                try (Socket socket = new Socket(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), 5005)) {
                     getLog().error("Port 5005 in use, not starting in debug mode");
                 } catch (IOException e) {
                     args.add("-Xdebug");
@@ -253,7 +253,7 @@ public class DevMojo extends AbstractMojo {
                 path = new File(jarPath);
             } else if (classFile.getProtocol().equals("file")) {
                 String filePath = classFile.getPath().substring(0,
-                                                                classFile.getPath().lastIndexOf(DevModeMain.class.getName().replace('.', '/')));
+                        classFile.getPath().lastIndexOf(DevModeMain.class.getName().replace('.', '/')));
                 path = new File(filePath);
             } else {
                 throw new MojoFailureException("Unsupported DevModeMain artifact URL:" + classFile);

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -152,8 +152,8 @@ public class DevMojo extends AbstractMojo {
         }
         if (!found) {
             getLog().warn("The quarkus-maven-plugin build goal was not configured for this project, " +
-                    "skipping quarkus:dev as this is assumed to be a support library. If you want to run quarkus dev" +
-                    " on this project make sure the quarkus-maven-plugin is configured with a build goal.");
+                                  "skipping quarkus:dev as this is assumed to be a support library. If you want to run quarkus dev" +
+                                  " on this project make sure the quarkus-maven-plugin is configured with a build goal.");
             return;
         }
 
@@ -173,7 +173,7 @@ public class DevMojo extends AbstractMojo {
             if (debug == null) {
                 // debug mode not specified
                 // make sure 5005 is not used, we don't want to just fail if something else is using it
-                try (Socket socket = new Socket(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), 5005)) {
+                try (Socket socket = new Socket(InetAddress.getByAddress(new byte[]{127, 0, 0, 1}), 5005)) {
                     getLog().error("Port 5005 in use, not starting in debug mode");
                 } catch (IOException e) {
                     args.add("-Xdebug");
@@ -253,7 +253,7 @@ public class DevMojo extends AbstractMojo {
                 path = new File(jarPath);
             } else if (classFile.getProtocol().equals("file")) {
                 String filePath = classFile.getPath().substring(0,
-                        classFile.getPath().lastIndexOf(DevModeMain.class.getName().replace('.', '/')));
+                                                                classFile.getPath().lastIndexOf(DevModeMain.class.getName().replace('.', '/')));
                 path = new File(filePath);
             } else {
                 throw new MojoFailureException("Unsupported DevModeMain artifact URL:" + classFile);
@@ -328,6 +328,7 @@ public class DevMojo extends AbstractMojo {
      * 1. maven-toolchains plugin configuration
      * 2. java.home location
      * 3. java[.exe] on the system path
+     *
      * @return the java command to use
      */
     protected String findJavaTool() {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -174,7 +174,7 @@ public class DevMojo extends AbstractMojo {
         try {
             List<String> args = new ArrayList<>();
             String javaTool = findJavaTool();
-            getLog().info("Using javaTool: " + javaTool);
+            getLog().debug("Using javaTool: " + javaTool);
             args.add(javaTool);
             if (debug == null) {
                 // debug mode not specified
@@ -332,12 +332,13 @@ public class DevMojo extends AbstractMojo {
     protected String findJavaTool() {
         String java = null;
 
+        // See if a toolchain is configured
         if (getToolchainManager() != null) {
             Toolchain toolchain = getToolchainManager().getToolchainFromBuildContext("jdk", getSession());
             if (toolchain != null) {
                 java = toolchain.findTool("java");
             }
-            getLog().debug("JVM from toolchain: " + java);
+            getLog().info("JVM from toolchain: " + java);
         }
         if (java == null) {
             // use the same JVM as the one used to run Maven (the "java.home" one)
@@ -346,7 +347,30 @@ public class DevMojo extends AbstractMojo {
             getLog().debug("Checking: " + javaCheck.getAbsolutePath());
             if (!javaCheck.canExecute()) {
                 getLog().debug(javaCheck.getAbsolutePath() + " is not executable");
-                java = "java";
+
+                java = null;
+                // Try executable extensions if windows
+                if (OS.determineOS() == OS.WINDOWS && System.getenv().containsKey("PATHEXT")) {
+                    String extpath = System.getenv("PATHEXT");
+                    String[] exts = extpath.split(";");
+                    for (String ext : exts) {
+                        File winExe = new File(javaCheck.getAbsolutePath() + ext);
+                        getLog().debug("Checking: " + winExe.getAbsolutePath());
+                        if (winExe.canExecute()) {
+                            java = winExe.getAbsolutePath();
+                            getLog().debug("Executable: " + winExe.getAbsolutePath());
+                            break;
+                        }
+                    }
+                }
+                // Fallback to java on the path
+                if (java == null) {
+                    if (OS.determineOS() == OS.WINDOWS) {
+                        java = "java.exe";
+                    } else {
+                        java = "java";
+                    }
+                }
             }
         }
         getLog().debug("findJavaTool, selected JVM: " + java);
@@ -364,6 +388,46 @@ public class DevMojo extends AbstractMojo {
         }
         classPathManifest.append(" ");
         classPath.append(" ");
+    }
+
+    /**
+     * Enum to classify the os.name system property
+     */
+    static enum OS {
+        WINDOWS, LINUX, MAC, OTHER;
+
+        private String version;
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        static OS determineOS() {
+            OS os = OS.OTHER;
+            String osName = System.getProperty("os.name");
+            osName = osName.toLowerCase();
+            if (osName.contains("windows")) {
+                os = OS.WINDOWS;
+            } else if (osName.contains("linux")
+                    || osName.contains("freebsd")
+                    || osName.contains("unix")
+                    || osName.contains("sunos")
+                    || osName.contains("solaris")
+                    || osName.contains("aix")) {
+                os = OS.LINUX;
+            } else if (osName.contains("mac os")) {
+                os = OS.MAC;
+            } else {
+                os = OS.OTHER;
+            }
+
+            os.setVersion(System.getProperty("os.version"));
+            return os;
+        }
     }
 
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -34,10 +34,6 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import io.quarkus.dev.ClassLoaderCompiler;
-import io.quarkus.dev.DevModeMain;
-import io.quarkus.maven.components.MavenVersionEnforcer;
-import io.quarkus.maven.utilities.MojoUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
@@ -54,6 +50,11 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
+
+import io.quarkus.dev.ClassLoaderCompiler;
+import io.quarkus.dev.DevModeMain;
+import io.quarkus.maven.components.MavenVersionEnforcer;
+import io.quarkus.maven.utilities.MojoUtils;
 
 /**
  * The dev mojo, that runs a quarkus app in a forked process


### PR DESCRIPTION
Here is an initial update the the DevMojo logic for locating the java binary to address #241 . It allows for use of the maven toolchains as well as fallback to java.home and then the path. I have tested it on osx and windows.