### PR TITLE
Upgrade JBoss LogManager to 1.0.2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -139,7 +139,7 @@
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>3.1.5</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
-        <jboss-logmanager.version>1.0.1</jboss-logmanager.version>
+        <jboss-logmanager.version>1.0.2</jboss-logmanager.version>
         <jetty.version>9.4.14.v20181114</jetty.version>
     </properties>
 


### PR DESCRIPTION
- Fixes problem with handler error reporting
- Makes the SVM dep provided