### PR TITLE
Fixing minor typo

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -424,7 +424,7 @@ public final class HibernateOrmProcessor {
                                 c -> {
                                     throw new ConfigurationError(
                                             "Unable to find file referenced in '" + HIBERNATE_ORM_CONFIG_PREFIX
-                                                    + ".sql-load-script-source="
+                                                    + "sql-load-script-source="
                                                     + c + "'. Remove property or add file to your path.");
                                 });
 


### PR DESCRIPTION
When you set `quarkus.hibernate-orm.sql-load-script` in your application.properties to a file that can not be found, the current exception reads "{trim} in 'quarkus.hibernate-orm..sql-load-script-source=import.sql'. Remove property or add file to your path."

There are two .'s in the property name.  This makes it so there is only one.