### PR TITLE
add useJUnitPlatform to build.gradle

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -22,6 +22,7 @@ jar {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
     }


### PR DESCRIPTION
so that the (existing) QuarkusPluginTest unit test actually really runs.

FYI the POM here is <packaging>pom, so it's Gradle (not Maven) which
actually builds the quarkus-gradle-plugin sources, and runs its test.

This has nothing to do with the (new) ../gradle-it integration test.