### PR TITLE
Improve the dependencies between gradle tasks

### DIFF
--- a/devtools/gradle-it/pom.xml
+++ b/devtools/gradle-it/pom.xml
@@ -81,7 +81,7 @@
                         <configuration>
                             <executable>${gradle.executable}</executable>
                             <arguments>
-                                <argument>quarkusBuild</argument>
+                                <argument>build</argument>
                                 <argument>-S</argument>
                             </arguments>
                             <skip>${skip.gradle.build}</skip>

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -18,6 +18,10 @@ package io.quarkus.gradle;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.util.GradleVersion;
 
 import io.quarkus.gradle.tasks.QuarkusAddExtension;
@@ -34,20 +38,32 @@ public class QuarkusPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         verifyGradleVersion();
-        //register extension
+        // register extension
         project.getExtensions().create("quarkus", QuarkusPluginExtension.class, project);
 
-        registerListExtensions(project);
+        registerTasks(project);
     }
 
-    private void registerListExtensions(Project project) {
-        project.getTasks().create("listExtensions", QuarkusListExtensions.class);
-        project.getTasks().create("addExtension", QuarkusAddExtension.class);
-        project.getTasks().create("quarkusDev", QuarkusDev.class).dependsOn("build");
-        project.getTasks().create("quarkusBuild", QuarkusBuild.class).dependsOn("build");
-        project.getTasks()
-                .create("quarkusNative", QuarkusNative.class)
-                .dependsOn("quarkusBuild");
+    private void registerTasks(Project project) {
+        TaskContainer tasks = project.getTasks();
+        tasks.create("listExtensions", QuarkusListExtensions.class);
+        tasks.create("addExtension", QuarkusAddExtension.class);
+
+        Task quarkusBuild = tasks.create("quarkusBuild", QuarkusBuild.class);
+        Task quarkusDev = tasks.create("quarkusDev", QuarkusDev.class);
+
+        project.getPlugins().withType(
+                BasePlugin.class,
+                basePlugin -> tasks.getByName(BasePlugin.ASSEMBLE_TASK_NAME).dependsOn(quarkusBuild));
+        project.getPlugins().withType(
+                JavaPlugin.class,
+                javaPlugin -> {
+                    Task classesTask = tasks.getByName(JavaPlugin.CLASSES_TASK_NAME);
+                    quarkusDev.dependsOn(classesTask);
+                    quarkusBuild.dependsOn(classesTask);
+                });
+
+        tasks.create("quarkusNative", QuarkusNative.class).dependsOn(quarkusBuild);
     }
 
     private void verifyGradleVersion() {

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public class QuarkusPluginTest {
 
     @Test
-    public void quarkusTest() {
+    public void shouldCreateTasks() {
         Project project = ProjectBuilder.builder().build();
         project.getPluginManager().apply("io.quarkus.gradle.plugin");
 
@@ -24,4 +24,26 @@ public class QuarkusPluginTest {
         assertNotNull(tasks.getByName("addExtension"));
     }
 
+    @Test
+    public void shouldMakeAssembleDependOnQuarkusBuild() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply("io.quarkus.gradle.plugin");
+        project.getPluginManager().apply("base");
+
+        TaskContainer tasks = project.getTasks();
+
+        assertTrue(tasks.getByName("assemble").getDependsOn().contains(tasks.getByName("quarkusBuild")));
+    }
+
+    @Test
+    public void shouldMakeQuarkusDevAndQuarkusBuildDependOnClassesTask() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply("io.quarkus.gradle.plugin");
+        project.getPluginManager().apply("java");
+
+        TaskContainer tasks = project.getTasks();
+
+        assertTrue(tasks.getByName("quarkusBuild").getDependsOn().contains(tasks.getByName("classes")));
+        assertTrue(tasks.getByName("quarkusDev").getDependsOn().contains(tasks.getByName("classes")));
+    }
 }


### PR DESCRIPTION
- `assemble` is the standard gradle lifecycle task used to build the artifact (i.e. the jar in the case of a classical Java project). So `assemble` now depends on `quarkusBuild`, which produces the runner jar
- `classes` is the standard lifecycle task which produces the classes (and copies the resources). Since that's what `quarkusBuild` and `quarkusDev` need as input (as far as I understand), they now depend on the `classes` task, instead of depending on the `build` task
- The `build` task is the standard gradle lifecycle task to run a complete build, including the production of the jar artifact, the compilation and execution of the tests, the static code analysis checks such as PMD, CheckStyle, etc. It's the top-level task, and nothing should normally depend on the `build` task. The `quarkusDev` and `quarkusBuild` tasks which depended on `build` now don't depend on it anymore, since all they should need is the output of the `classes` task.

So now `./gradlew assemble` produces the runner jar as expected by a gradle user. So does `./gradlew build` of course, since `build` depends on `assemble`.

`./gradlew quarkusDev` and  `./gradlew quarkusBuild` won't compile and run all the tests and static code analysis checks, since that's not what these tasks are supposed to do.

fix #1442