### PR TITLE
Moves the logic that handles the registration for serialization of OpenAPI schema class to smallrye-openapi-extension

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,8 +31,16 @@ import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
@@ -42,6 +51,8 @@ import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentConfigFileBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyBuildItem;
 import io.quarkus.resteasy.deployment.ResteasyJaxrsConfig;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -66,6 +77,18 @@ public class SmallRyeOpenApiProcessor {
     private static final String WEB_INF_CLASSES_META_INF_OPENAPI_YML = "WEB-INF/classes/META-INF/openapi.yml";
     private static final String META_INF_OPENAPI_JSON = "META-INF/openapi.json";
     private static final String WEB_INF_CLASSES_META_INF_OPENAPI_JSON = "WEB-INF/classes/META-INF/openapi.json";
+
+    private static final DotName OPENAPI_SCHEMA = DotName.createSimple(Schema.class.getName());
+    private static final DotName OPENAPI_RESPONSE = DotName.createSimple(APIResponse.class.getName());
+    private static final DotName OPENAPI_RESPONSES = DotName.createSimple(APIResponses.class.getName());
+
+    private static final String OPENAPI_RESPONSE_CONTENT = "content";
+    private static final String OPENAPI_RESPONSE_SCHEMA = "schema";
+    private static final String OPENAPI_SCHEMA_NOT = "not";
+    private static final String OPENAPI_SCHEMA_ONE_OF = "oneOf";
+    private static final String OPENAPI_SCHEMA_ANY_OF = "anyOf";
+    private static final String OPENAPI_SCHEMA_ALL_OF = "allOf";
+    private static final String OPENAPI_SCHEMA_IMPLEMENTATION = "implementation";
 
     SmallRyeOpenApiConfig openapi;
 
@@ -95,6 +118,90 @@ public class SmallRyeOpenApiProcessor {
     List<AdditionalBeanBuildItem> beans() {
         return Arrays.asList(new AdditionalBeanBuildItem(OpenApiServlet.class),
                 new AdditionalBeanBuildItem(OpenApiDocumentProducer.class));
+    }
+
+    @BuildStep
+    public void registerOpenApiSchemaClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy, CombinedIndexBuildItem combinedIndexBuildItem) {
+        IndexView index = combinedIndexBuildItem.getIndex();
+
+        // Generate reflection declaration from MP OpenAPI Schema definition
+        // They are needed for serialization.
+        Collection<AnnotationInstance> schemaAnnotationInstances = index.getAnnotations(OPENAPI_SCHEMA);
+        for (AnnotationInstance schemaAnnotationInstance : schemaAnnotationInstances) {
+            AnnotationTarget typeTarget = schemaAnnotationInstance.target();
+            if (typeTarget.kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            reflectiveHierarchy
+                    .produce(new ReflectiveHierarchyBuildItem(Type.create(typeTarget.asClass().name(), Type.Kind.CLASS)));
+        }
+
+        // Generate reflection declaration from MP OpenAPI APIResponse schema definition
+        // They are needed for serialization
+        Collection<AnnotationInstance> apiResponseAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSE);
+        registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
+                apiResponseAnnotationInstances);
+
+        // Generate reflection declaration from MP OpenAPI APIResponses schema definition
+        // They are needed for serialization
+        Collection<AnnotationInstance> apiResponsesAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSES);
+        for (AnnotationInstance apiResponsesAnnotationInstance : apiResponsesAnnotationInstances) {
+            AnnotationValue apiResponsesAnnotationValue = apiResponsesAnnotationInstance.value();
+            if (apiResponsesAnnotationValue == null) {
+                continue;
+            }
+            registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
+                    Arrays.asList(apiResponsesAnnotationValue.asNestedArray()));
+        }
+    }
+
+    private void registerReflectionForApiResponseSchemaSerialization(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
+            Collection<AnnotationInstance> apiResponseAnnotationInstances) {
+        for (AnnotationInstance apiResponseAnnotationInstance : apiResponseAnnotationInstances) {
+            AnnotationInstance[] contents = apiResponseAnnotationInstance.value(OPENAPI_RESPONSE_CONTENT).asNestedArray();
+            if (contents == null) {
+                continue;
+            }
+            for (AnnotationInstance content : contents) {
+                AnnotationInstance schema = content.value(OPENAPI_RESPONSE_SCHEMA).asNested();
+                if (schema == null) {
+                    continue;
+                }
+
+                AnnotationValue schemaImplementationClass = schema.value(OPENAPI_SCHEMA_IMPLEMENTATION);
+                if (schemaImplementationClass != null) {
+                    reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaImplementationClass.asClass()));
+                }
+
+                AnnotationValue schemaNotClass = schema.value(OPENAPI_SCHEMA_NOT);
+                if (schemaNotClass != null) {
+                    reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, schemaNotClass.asString()));
+                }
+
+                AnnotationValue schemaOneOfClasses = schema.value(OPENAPI_SCHEMA_ONE_OF);
+                if (schemaOneOfClasses != null) {
+                    for (Type schemaOneOfClass : schemaOneOfClasses.asClassArray()) {
+                        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaOneOfClass));
+                    }
+                }
+
+                AnnotationValue schemaAnyOfClasses = schema.value(OPENAPI_SCHEMA_ANY_OF);
+                if (schemaAnyOfClasses != null) {
+                    for (Type schemaAnyOfClass : schemaAnyOfClasses.asClassArray()) {
+                        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaAnyOfClass));
+                    }
+                }
+
+                AnnotationValue schemaAllOfClasses = schema.value(OPENAPI_SCHEMA_ALL_OF);
+                if (schemaAllOfClasses != null) {
+                    for (Type schemaAllOfClass : schemaAllOfClasses.asClassArray()) {
+                        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaAllOfClass));
+                    }
+                }
+            }
+        }
     }
 
     @BuildStep


### PR DESCRIPTION
After merging of [1389](https://github.com/quarkusio/quarkus/pull/1389), @kenfinnigan came with a better idea of moving the said logic from `resteasy-extension` into `smallrye-openapi-extension`. This PR incorporates the proposed changes. 

cc @gsmet.