### PR TITLE
fix npe in dev mode when source is missing in recompilation diagnostic

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/JavaCompilationProvider.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/JavaCompilationProvider.java
@@ -49,7 +49,7 @@ public class JavaCompilationProvider implements CompilationProvider {
 
             for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
                 System.out.format("%s, line %d in %s", diagnostic.getMessage(null), diagnostic.getLineNumber(),
-                        diagnostic.getSource().getName());
+                        diagnostic.getSource() == null ? "[unknown source]" : diagnostic.getSource().getName());
             }
         } catch (IOException e) {
             throw new RuntimeException("Cannot close file manager", e);


### PR DESCRIPTION
Hi

I have found a NPE bug in dev-mode that occurs when recompiling. It happens when the "source" is null on a diagnostic.

I have created a small project that reproduces the error when using the Apache TinkerPop Gremlin Core dependency : https://github.com/devauxbr/quarkus-npe-dev-mode

Playing with the debugger, I have found that the diagnostic causing this error is warning about incompatible supported source from the [GremlinDslProcessor](https://github.com/apache/tinkerpop/blob/master/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/dsl/GremlinDslProcessor.java)

Once fixed with this pull request, the full warning message is : 
`
Supported source version 'RELEASE_8' from annotation processor 'org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDslProcessor' less than -source '11', line -1 in [unknown source]2019-03-17 15:35:41,316 INFO  [com.bde.qua.tes.AppLifecycleBean] (XNIO-1 task-1) The application is stopping... {}
`

My environment : 
Mac OSX Mojave
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)
graalvm-ce-1.0.0-rc13