### PR TITLE
Update to smallrye-jwt 1.1.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-open-api.version>1.1.1</smallrye-open-api.version>
         <smallrye-opentracing.version>1.2.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>1.1.0</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>1.1.0</smallrye-jwt.version>
+        <smallrye-jwt.version>1.1.1</smallrye-jwt.version>
         <smallrye-reactive-streams-operators.version>1.0.2</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.1</smallrye-converter-api.version>
         <smallrye-reactive-messaging.version>0.0.4</smallrye-reactive-messaging.version>


### PR DESCRIPTION
Motivation
----------
Update to smallrye-jwt 1.1.1

Modifications
-------------
Unfortunately the modifications which I applied to smallrye-jwt 1.1.1 are breaking for the Quarkus smallrye-jwt extension, however it also highlighted some duplication and divergence in the Quarkus extension compared to the smallrye-jwt:
The code removed from `SmallRyeJwtTemplate` is redundant as it is already available in [JWTCallerPrincipal](https://github.com/smallrye/smallrye-jwt/blob/master/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipal.java#L43).
The code in `ElytronJwtCallerPrincipal` is available either in [JWTCallerPrincipal](https://github.com/smallrye/smallrye-jwt/blob/master/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipal.java) or [DefaultJWTCallerPrincipal](https://github.com/smallrye/smallrye-jwt/blob/master/implementation/src/main/java/io/smallrye/jwt/auth/principal/DefaultJWTCallerPrincipal.java). I was not able to get ElytronJwtCallerPrincipal extending it since it diverged but the current modifications remove few methods which can be cleanly supported by  [JWTCallerPrincipal](https://github.com/smallrye/smallrye-jwt/blob/master/implementation/src/main/java/io/smallrye/jwt/auth/principal/JWTCallerPrincipal.java) and most of the remaining code will be gone after the synchronization with smallrye-jwt will be done

Most of the code in `MpJwtValidator` will also be eventually removed 

Result
------
The modifications in this PR is the first step toward a more compact Quarkus smalrye-jwt extension which will focus on Quarkus specific aspects better and will depend on the jose4j and the claim manipulation code centralized in smallrye-jwt which will be stressed by not only Quarkus but also Thorntail and possibly other projects.   

