### PR TITLE
Update opentracing doc to describe using application.properties as alternative to env vars

### DIFF
--- a/docs/src/main/asciidoc/opentracing-guide.adoc
+++ b/docs/src/main/asciidoc/opentracing-guide.adoc
@@ -73,6 +73,26 @@ public class TracedResource {
 Notice that there is no tracing specific code included in the application. By default, requests sent to this
 endpoint will be traced without any code changes being required. It is also possible to enhance the tracing information. For more information on this, please see the https://github.com/eclipse/microprofile-opentracing/blob/master/spec/src/main/asciidoc/microprofile-opentracing.asciidoc[MicroProfile OpenTracing specification].
 
+=== Create the configuration
+
+There are two ways to configure the Jaeger tracer within the application.
+
+The first approach is by providing the properties within the `src/main/resources/application.properties` file:
+
+[source,shell]
+----
+quarkus.jaeger.service-name=myservice
+quarkus.jaeger.sampler-type=const
+quarkus.jaeger.sampler-param=1
+quarkus.jaeger.endpoint=http://localhost:14268/api/traces
+----
+
+The second approach is to supply the properties as https://www.jaegertracing.io/docs/latest/client-features/[environment variables]. These can be specified as `jvm.args` as shown in the following section.
+
+If the `quarkus.jaeger.service-name` property (or `JAEGER_SERVICE_NAME` environment variable) is not provided then a "no-op" tracer will be configured, resulting in no tracing data being reported to the backend.
+
+NOTE: Currently the tracer can only be configured to report spans directly to the collector via HTTP, using the `quarkus.jaeger.endpoint` property (or `JAEGER_ENDPOINT` environment variable). Support for using the Jaeger agent, via UDP, will be available in a future version.
+
 == Run the application
 
 The first step is to start the tracing system to collect and display the captured traces:
@@ -82,16 +102,19 @@ The first step is to start the tracing system to collect and display the capture
 docker run -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 -p 9411:9411 jaegertracing/all-in-one:latest
 ----
 
-Now we are ready to run our application. Use:
+Now we are ready to run our application. If using `application.properties` to configure the tracer:
 
 [source, text]
 ----
-./mvnw compile quarkus:dev -Djvm.args="-DJAEGER_SERVICE_NAME=myservice -DJAEGER_SAMPLER_TYPE=const -DJAEGER_SAMPLER_PARAM=1 -DJAEGER_ENDPOINT=http://localhost:14268/api/traces"
+mvn compile quarkus:dev
 ----
 
-The supplied `jvm.args` are used to configure the default OpenTracing tracer (Jaeger). If the `JAEGER_SERVICE_NAME` property is not provided then a "no-op" tracer will be configured, resulting in no tracing data being reported to the backend. The other properties are explained in the https://www.jaegertracing.io/docs/latest/client-features/[Tracer configuration via environment variables] section of the Jaeger documentation.
+or if configuring the tracer via environment variables:
 
-NOTE: Currently the tracer can only be configured to report spans directly to the collector via HTTP, using the `JAEGER_ENDPOINT` property. Support for using the Jaeger agent, via UDP, will be available in a future version.
+[source, text]
+----
+mvn compile quarkus:dev -Djvm.args="-DJAEGER_SERVICE_NAME=myservice -DJAEGER_SAMPLER_TYPE=const -DJAEGER_SAMPLER_PARAM=1 -DJAEGER_ENDPOINT=http://localhost:14268/api/traces"
+----
 
 Once both the application and tracing system are started, you can make a request to the provided endpoint:
 

--- a/docs/src/main/asciidoc/opentracing-guide.adoc
+++ b/docs/src/main/asciidoc/opentracing-guide.adoc
@@ -106,14 +106,14 @@ Now we are ready to run our application. If using `application.properties` to co
 
 [source, text]
 ----
-mvn compile quarkus:dev
+./mvnw compile quarkus:dev
 ----
 
 or if configuring the tracer via environment variables:
 
 [source, text]
 ----
-mvn compile quarkus:dev -Djvm.args="-DJAEGER_SERVICE_NAME=myservice -DJAEGER_SAMPLER_TYPE=const -DJAEGER_SAMPLER_PARAM=1 -DJAEGER_ENDPOINT=http://localhost:14268/api/traces"
+./mvnw compile quarkus:dev -Djvm.args="-DJAEGER_SERVICE_NAME=myservice -DJAEGER_SAMPLER_TYPE=const -DJAEGER_SAMPLER_PARAM=1 -DJAEGER_ENDPOINT=http://localhost:14268/api/traces"
 ----
 
 Once both the application and tracing system are started, you can make a request to the provided endpoint:


### PR DESCRIPTION
This PR accompanies quarkusio/quarkus-quickstarts#107.