### PR TITLE
Removes TODO comments about needing proper assertion

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PrimitiveInjectionUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PrimitiveInjectionUnitTest.java
@@ -114,9 +114,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
-
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -137,8 +135,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -159,8 +156,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -182,8 +178,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -204,8 +199,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -226,8 +220,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -248,8 +241,7 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -270,7 +262,6 @@ public class PrimitiveInjectionUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 }

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RequiredClaimsUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RequiredClaimsUnitTest.java
@@ -113,9 +113,7 @@ public class RequiredClaimsUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
-
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -137,8 +135,7 @@ public class RequiredClaimsUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -160,8 +157,7 @@ public class RequiredClaimsUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -183,8 +179,7 @@ public class RequiredClaimsUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -206,8 +201,7 @@ public class RequiredClaimsUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 
     /**
@@ -229,7 +223,6 @@ public class RequiredClaimsUnitTest {
         String replyString = response.body().asString();
         JsonReader jsonReader = Json.createReader(new StringReader(replyString));
         JsonObject reply = jsonReader.readObject();
-        // TODO add proper assertion
-        //System.out.println(reply.toString());
+        Assertions.assertTrue(reply.getBoolean("pass"), reply.getString("msg"));
     }
 }

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RolesAllowedUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RolesAllowedUnitTest.java
@@ -86,8 +86,7 @@ public class RolesAllowedUnitTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+        Assertions.assertEquals("Not authorized", replyString);
     }
 
     /**
@@ -124,8 +123,7 @@ public class RolesAllowedUnitTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+        Assertions.assertEquals("Access forbidden: role not allowed", replyString);
     }
 
     /**
@@ -135,6 +133,7 @@ public class RolesAllowedUnitTest {
      */
     @Test()
     public void checkIsUserInRole() throws Exception {
+
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -142,8 +141,7 @@ public class RolesAllowedUnitTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+        Assertions.assertEquals("jdoe@example.com", replyString);
     }
 
     /**
@@ -161,8 +159,8 @@ public class RolesAllowedUnitTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+
+        Assertions.assertEquals("", replyString);
     }
 
     /**
@@ -172,17 +170,17 @@ public class RolesAllowedUnitTest {
      */
     @Test()
     public void echoNeedsToken2Role() throws Exception {
+        String input = "hello";
         String token2 = TokenUtils.generateTokenString("/Token2.json");
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token2)
                 .when()
-                .queryParam("input", "hello")
+                .queryParam("input", input)
                 .get("/endp/echoNeedsToken2Role").andReturn();
 
         Assertions.assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+        Assertions.assertEquals(input + ", user=jdoe2@example.com", replyString);
     }
 
     /**
@@ -201,8 +199,7 @@ public class RolesAllowedUnitTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+        Assertions.assertEquals("Access forbidden: role not allowed", replyString);
     }
 
     /**
@@ -238,8 +235,7 @@ public class RolesAllowedUnitTest {
 
         Assertions.assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode());
         String replyString = response.body().asString();
-        // TODO add proper assertion
-        //System.out.println(replyString);
+        Assertions.assertEquals("jdoe@example.com", replyString);
     }
 
     /**

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TokenRealmUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TokenRealmUnitTest.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.wildfly.security.auth.principal.NamePrincipal;
 import org.wildfly.security.auth.realm.token.TokenSecurityRealm;
@@ -60,9 +61,8 @@ public class TokenRealmUnitTest {
         RealmIdentity identity = tokenRealm.getRealmIdentity(tokenEvidence);
         assertNotNull(identity);
         assertTrue(identity.exists());
-        AuthorizationIdentity authz = identity.getAuthorizationIdentity();
-        // TODO add proper assertion
-        //System.out.println(authz.getAttributes().keySet());
+        AuthorizationIdentity authorizationIdentity = identity.getAuthorizationIdentity();
+        Assertions.assertNotNull(authorizationIdentity);
     }
 
     @Test
@@ -117,8 +117,7 @@ public class TokenRealmUnitTest {
         String jwt = TokenUtils.generateTokenString("/Token1.json", pk1Priv, "testTokenRealm");
         BearerTokenEvidence tokenEvidence = new BearerTokenEvidence(jwt);
         SecurityIdentity securityIdentity = securityDomain.authenticate(tokenEvidence);
-        // TODO add proper assertion
-        //System.out.println(securityIdentity.getAttributes().keySet());
+        Assertions.assertNotNull(securityIdentity);
     }
 
     private Principal mpJwtLogic(Attributes claims) {


### PR DESCRIPTION
I have found some TODO comments about adding `add proper assertion` in tests. This concerns the following files: `PrimitiveInjectionUnitTest, RequiredClaimsUnitTest, RolesAllowedUnitTest and TokenRealmUnitTest`. I have added some assertions for the missing cases.