### PR TITLE
Add the ability to keep beans from application classes

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -275,3 +275,17 @@ An unused bean:
 * is not directly eligible for injection into any `javax.enterprise.inject.Instance` or `javax.inject.Provider` injection point
  
 The extensions can eliminate possible false positives by producing `UnremovableBeanBuildItem`.
+
+Another possibility is to have `quarkus.arc.remove-unused-beans=true` but also set `quarkus.arc.keep-application-beans=true`. In this case beans defined by the application
+will not be removed even if they meet all the criteria set out in the list above.
+This could be useful in cases where bean discovery is needed, like when using
+
+[source,java]
+----
+@Inject
+BeanManager beanManager;
+
+...
+
+beanManager.getBeans(SomeService.class)
+----

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -27,4 +27,11 @@ public class ArcConfig {
     @ConfigItem(defaultValue = "true")
     public boolean removeUnusedBeans;
 
+    /**
+     * If removeUnusedBeans is set to true and this property is also set to true, then beans defined by the application
+     * will not be removed even if they meet all the removal criteria mentioned above
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean keepApplicationBeans;
+
 }

--- a/integration-tests/arc-keep-app-classes/pom.xml
+++ b/integration-tests/arc-keep-app-classes/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>arc-keep-app-classes</artifactId>
+    <name>Quarkus - Integration Tests - Arc - Keep App Classes</name>
+    <description>Arc integration test for quarkus.arc.keepApplicationBeans</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
+                                    <disableReports>true</disableReports>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    
+</project>

--- a/integration-tests/arc-keep-app-classes/src/main/java/io/quarkus/arc/app/classes/tests/SomeOtherService.java
+++ b/integration-tests/arc-keep-app-classes/src/main/java/io/quarkus/arc/app/classes/tests/SomeOtherService.java
@@ -1,0 +1,16 @@
+package io.quarkus.arc.app.classes.tests;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+
+@ApplicationScoped
+@Alternative
+@Priority(10)
+public class SomeOtherService extends SomeService {
+
+    @Override
+    public String execute() {
+        return "someOther";
+    }
+}

--- a/integration-tests/arc-keep-app-classes/src/main/java/io/quarkus/arc/app/classes/tests/SomeService.java
+++ b/integration-tests/arc-keep-app-classes/src/main/java/io/quarkus/arc/app/classes/tests/SomeService.java
@@ -1,0 +1,11 @@
+package io.quarkus.arc.app.classes.tests;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SomeService {
+
+    public String execute() {
+        return "some";
+    }
+}

--- a/integration-tests/arc-keep-app-classes/src/main/java/io/quarkus/arc/app/classes/tests/TestResource.java
+++ b/integration-tests/arc-keep-app-classes/src/main/java/io/quarkus/arc/app/classes/tests/TestResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.app.classes.tests;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/classes")
+public class TestResource {
+
+    @Inject
+    BeanManager beanManager;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public int numberOfServices() {
+        return beanManager.getBeans(SomeService.class).size();
+    }
+}

--- a/integration-tests/arc-keep-app-classes/src/main/resources/application.properties
+++ b/integration-tests/arc-keep-app-classes/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.arc.keep-application-beans=true

--- a/integration-tests/arc-keep-app-classes/src/test/java/io/quarkus/arc/app/classes/tests/AppClassesNotRemovedTest.java
+++ b/integration-tests/arc-keep-app-classes/src/test/java/io/quarkus/arc/app/classes/tests/AppClassesNotRemovedTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.arc.app.classes.tests;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class AppClassesNotRemovedTest {
+
+    @Test
+    public void testInjection() {
+        RestAssured.when().get("/classes").then()
+                .body(containsString("2"));
+    }
+}

--- a/integration-tests/arc-keep-app-classes/src/test/java/io/quarkus/arc/app/classes/tests/AppClassesNotRemovedTestIT.java
+++ b/integration-tests/arc-keep-app-classes/src/test/java/io/quarkus/arc/app/classes/tests/AppClassesNotRemovedTestIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.arc.app.classes.tests;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class AppClassesNotRemovedTestIT extends AppClassesNotRemovedTest {
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -55,5 +55,6 @@
         <module>elytron-security</module>
         <module>camel-core</module>
         <module>camel-salesforce</module>
+        <module>arc-keep-app-classes</module>
     </modules>
 </project>


### PR DESCRIPTION
This provides a useful middle-ground between removing all unused beans and removing none.

It could be useful in cases such when one wants to use `@Inject BeanManager beanManager` and get all the beans of a specific type. 