### PR TITLE
PathTestHelper should accept default Gradle build paths now

### DIFF
--- a/devtools/gradle-it/build.gradle
+++ b/devtools/gradle-it/build.gradle
@@ -15,6 +15,10 @@ repositories {
      mavenCentral()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     // quarkus-resteasy, quarkus-junit5, rest are copied in pom.xml
     compileOnly fileTree(dir: 'target/dependencies/compile', include: '*.jar')

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -24,8 +24,10 @@ import java.nio.file.Paths;
 
 public final class PathTestHelper {
 
-    private static final String TEST_CLASSES_FRAGMENT = File.separator + "test-classes";
-    private static final String CLASSES_FRAGMENT = File.separator + "classes";
+    private static final String TEST_CLASSES_FRAGMENT_MAVEN = File.separator + "test-classes";
+    private static final String CLASSES_FRAGMENT_MAVEN = File.separator + "classes";
+    private static final String TEST_CLASSES_FRAGMENT_GRADLE = "classes" + File.separator + "java" + File.separator + "test";
+    private static final String CLASSES_FRAGMENT_GRADLE = "classes" + File.separator + "java" + File.separator + "main";
 
     private PathTestHelper() {
     }
@@ -36,12 +38,14 @@ public final class PathTestHelper {
 
         try {
             Path path = Paths.get(resource.toURI());
-            if (!path.toString().contains(TEST_CLASSES_FRAGMENT)) {
-                throw new RuntimeException(
-                        "The test class " + testClass + " is not located in the " + TEST_CLASSES_FRAGMENT + " directory.");
+            if (path.toString().contains(TEST_CLASSES_FRAGMENT_MAVEN) ||
+                    path.toString().contains(TEST_CLASSES_FRAGMENT_GRADLE)) {
+                return path.getRoot().resolve(path.subpath(0, path.getNameCount() - Paths.get(classFileName).getNameCount()));
             }
+            throw new RuntimeException(
+                    "The test class " + testClass + " is not located in the " + TEST_CLASSES_FRAGMENT_MAVEN +
+                            " nor in " + TEST_CLASSES_FRAGMENT_GRADLE + " directory.");
 
-            return path.getRoot().resolve(path.subpath(0, path.getNameCount() - Paths.get(classFileName).getNameCount()));
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
@@ -49,6 +53,14 @@ public final class PathTestHelper {
     }
 
     public static Path getAppClassLocation(Class<?> testClass) {
-        return Paths.get(getTestClassesLocation(testClass).toString().replace(TEST_CLASSES_FRAGMENT, CLASSES_FRAGMENT));
+        String testClassPath = getTestClassesLocation(testClass).toString();
+        //maven
+        if (testClassPath.contains(TEST_CLASSES_FRAGMENT_MAVEN))
+            return Paths.get(getTestClassesLocation(testClass).toString()
+                    .replace(TEST_CLASSES_FRAGMENT_MAVEN, CLASSES_FRAGMENT_MAVEN));
+        //gradle
+        else
+            return Paths.get(getTestClassesLocation(testClass).toString()
+                    .replace(TEST_CLASSES_FRAGMENT_GRADLE, CLASSES_FRAGMENT_GRADLE));
     }
 }


### PR DESCRIPTION
This fixes #1532 
PathTestHelper is very hard coded to the `default` Maven/Gradle folders ATM. Developers can change the test target folders as they choose which would break tests for both.