### PR TITLE
JAX-RS body writers for Vert.x JsonObject and JsonArray

### DIFF
--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>quarkus-core-runtime</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-runtime</artifactId>
         </dependency>

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonArrayWriter.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonArrayWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import io.vertx.core.json.JsonArray;
+
+/**
+ * A body writer that allows to return a Vert.x {@link JsonArray} as JAX-RS response content.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonArrayWriter implements MessageBodyWriter<JsonArray> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonArray.class;
+    }
+
+    @Override
+    public void writeTo(JsonArray jsonArray, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write(jsonArray.toBuffer().getBytes());
+        entityStream.flush();
+        entityStream.close();
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonObjectWriter.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonObjectWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A body writer that allows to return a Vert.x {@link JsonObject} as JAX-RS response content.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonObjectWriter implements MessageBodyWriter<JsonObject> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonObject.class;
+    }
+
+    @Override
+    public void writeTo(JsonObject jsonObject, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write(jsonObject.toBuffer().getBytes());
+        entityStream.flush();
+        entityStream.close();
+    }
+}

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,0 +1,2 @@
+io.quarkus.vertx.runtime.JsonObjectWriter
+io.quarkus.vertx.runtime.JsonArrayWriter

--- a/integration-tests/vertx/src/main/java/io/quarkus/vertx/tests/JsonTestResource.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/vertx/tests/JsonTestResource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.tests;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author Thomas Ssegismont
+ */
+@Path("/body-writers")
+public class JsonTestResource {
+
+    @GET
+    @Path("/json/sync")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject jsonSync() {
+        return new JsonObject().put("Hello", "World");
+    }
+
+    @GET
+    @Path("/array/sync")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonArray arraySync() {
+        return new JsonArray().add("Hello").add("World");
+    }
+
+    @GET
+    @Path("/json/async")
+    @Produces(MediaType.APPLICATION_JSON)
+    public CompletionStage<JsonObject> jsonAsync() {
+        return CompletableFuture.completedFuture(new JsonObject().put("Hello", "World"));
+    }
+
+    @GET
+    @Path("/array/async")
+    @Produces(MediaType.APPLICATION_JSON)
+    public CompletionStage<JsonArray> arrayAsync() {
+        return CompletableFuture.completedFuture(new JsonArray().add("Hello").add("World"));
+    }
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonWriterIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonWriterIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime.tests;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+/**
+ * @author Thomas Segismont
+ */
+@SubstrateTest
+public class JsonWriterIT extends JsonWriterTest {
+
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonWriterTest.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime.tests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * @author Thomas Segismont
+ */
+@QuarkusTest
+public class JsonWriterTest {
+
+    @Test
+    public void testJsonSync() {
+        RestAssured.when().get("/vertx-test/body-writers/json/sync").then()
+                .statusCode(200).body("Hello", equalTo("World"));
+    }
+
+    @Test
+    public void testArraySync() {
+        RestAssured.when().get("/vertx-test/body-writers/array/sync").then()
+                .statusCode(200).body("", equalTo(Arrays.asList("Hello", "World")));
+    }
+
+    @Test
+    public void testJsonAsync() {
+        RestAssured.when().get("/vertx-test/body-writers/json/async").then()
+                .statusCode(200).body("Hello", equalTo("World"));
+    }
+
+    @Test
+    public void testArrayAsync() {
+        RestAssured.when().get("/vertx-test/body-writers/array/async").then()
+                .statusCode(200).body("", equalTo(Arrays.asList("Hello", "World")));
+    }
+}


### PR DESCRIPTION
This allows to use Vert.x JsonObject and JsonArray as JAX-RS response content.

As many Vert.x client APIs return json content (e.g. Mongo client), this might be handy.