### PR TITLE
Update vertx to version 3.6.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -106,7 +106,7 @@
         <wildfly-elytron.version>2.0.0.Alpha1</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Alpha4</jboss-threads.version>
-        <vertx.version>3.6.2</vertx.version>
+        <vertx.version>3.6.3</vertx.version>
         <httpclient.version>4.5.7</httpclient.version>
         <httpcore.version>4.4.11</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -127,7 +127,7 @@
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <test-containers.version>1.10.7</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <axle-client.version>0.0.1</axle-client.version>
+        <axle-client.version>0.0.2</axle-client.version>
         <kafka-clients.version>1.1.0</kafka-clients.version>
         <kafka2.version>1.1.0</kafka2.version>
         <debezium.version>0.9.2.Final</debezium.version>


### PR DESCRIPTION
Updates the Vert.x version to 3.6.3 as well as the related Vert.x Axle clients. This fixes #1524.