### PR TITLE
Expose all flavors (core, axle, rx) of Vert.x EventBus

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxProducer.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxProducer.java
@@ -37,8 +37,8 @@ public class VertxProducer {
 
     private volatile VertxConfiguration conf;
     private volatile Vertx vertx;
-    private io.vertx.axle.core.Vertx axle;
-    private io.vertx.reactivex.core.Vertx rx;
+    private volatile io.vertx.axle.core.Vertx axle;
+    private volatile io.vertx.reactivex.core.Vertx rx;
 
     private void createCompanions(Vertx instance) {
         this.vertx = instance == null ? Vertx.vertx() : instance;
@@ -244,6 +244,24 @@ public class VertxProducer {
             initialize();
         }
         return this.vertx.eventBus();
+    }
+
+    @Singleton
+    @Produces
+    public synchronized io.vertx.axle.core.eventbus.EventBus axleEventbus() {
+        if (vertx == null) {
+            initialize();
+        }
+        return this.axle.eventBus();
+    }
+
+    @Singleton
+    @Produces
+    public synchronized io.vertx.reactivex.core.eventbus.EventBus rxRventbus() {
+        if (vertx == null) {
+            initialize();
+        }
+        return this.rx.eventBus();
     }
 
     void configure(VertxConfiguration config) {

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -8,41 +8,56 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class VertxProducerTest {
 
-    @Test
-    public void shouldNotFailWithoutConfig() {
-        VertxProducer producer = new VertxProducer();
-        producer.configure(null);
+    private VertxProducer producer;
 
-        assertThat(producer.vertx(), is(notNullValue()));
-        assertFalse(producer.vertx().isClustered());
-        assertThat(producer.eventbus(), is(notNullValue()));
+    @Before
+    public void setUp() throws Exception {
+        producer = new VertxProducer();
+    }
 
+    @After
+    public void tearDown() throws Exception {
         producer.destroy();
     }
 
     @Test
+    public void shouldNotFailWithoutConfig() {
+        producer.configure(null);
+        verifyProducer();
+    }
+
+    private void verifyProducer() {
+        assertThat(producer.vertx(), is(notNullValue()));
+        assertFalse(producer.vertx().isClustered());
+        assertThat(producer.eventbus(), is(notNullValue()));
+
+        assertThat(producer.axle(), is(notNullValue()));
+        assertFalse(producer.axle().isClustered());
+        assertThat(producer.axleEventbus(), is(notNullValue()));
+
+        assertThat(producer.rx(), is(notNullValue()));
+        assertFalse(producer.rx().isClustered());
+        assertThat(producer.rxRventbus(), is(notNullValue()));
+    }
+
+    @Test
     public void shouldNotFailWithDefaultConfig() {
-        VertxProducer producer = new VertxProducer();
         VertxConfiguration configuration = createDefaultConfiguration();
         configuration.workerPoolSize = 10;
         configuration.warningExceptionTime = Duration.ofSeconds(1);
         configuration.internalBlockingPoolSize = 5;
         producer.configure(configuration);
-
-        assertThat(producer.vertx(), is(notNullValue()));
-        assertFalse(producer.vertx().isClustered());
-        assertThat(producer.eventbus(), is(notNullValue()));
-
-        producer.destroy();
+        verifyProducer();
     }
 
     @Test
     public void shouldEnableClustering() {
-        VertxProducer producer = new VertxProducer();
         VertxConfiguration configuration = createDefaultConfiguration();
         ClusterConfiguration cc = configuration.cluster;
         cc.clustered = true;
@@ -63,8 +78,6 @@ public class VertxProducerTest {
         } catch (IllegalStateException e) {
             assertTrue(e.getMessage().contains("No ClusterManagerFactory"));
         }
-
-        producer.destroy();
     }
 
     private VertxConfiguration createDefaultConfiguration() {


### PR DESCRIPTION
The VertxProducer exposed all flavors of Vert.x instance, but a single (core) EventBus.