### PR TITLE
Remove now unnecessary @Inject on @ConfigProperty

### DIFF
--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -63,18 +63,17 @@ Edit the `org.acme.config.GreetingResource`, and introduce the 3 following confi
 
 [source,java]
 ----
-@Inject
 @ConfigProperty(name = "greeting.message")
 private String message;
 
-@Inject
 @ConfigProperty(name = "greeting.suffix", defaultValue="!")
 private String suffix;
 
-@Inject
 @ConfigProperty(name = "greeting.name")
 private Optional<String> name;
 ----
+
+NOTE: The `@Inject` annotation is not strictly necessary from members annotated with `@ConfigProperty`, a behavior which differs from https://microprofile.io/project/eclipse/microprofile-config[MicroProfile Config]
 
 If you do not provide a value for the first property, it will have a `null` value.
 The second property injects the given default value if the configuration file does not provide a value.

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -170,7 +170,6 @@ import javax.inject.Inject;
 @ApplicationScoped
 public class DatabaseConnectionHealthCheck implements HealthCheck {
     
-    @Inject
     @ConfigProperty(name = "database.up", defaultValue = "false")
     private boolean databaseUp;
     


### PR DESCRIPTION
#1554 made it redundant to have `@Inject` on a `@ConfigProperty` field

Follows up on: #1315

Quickstart PR: https://github.com/quarkusio/quarkus-quickstarts/pull/109