### PR TITLE
opentracing, jaeger, xnio, debezium, log4j2, assertj, junit-jupiter minor version updates

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,23 +32,23 @@
         <jandex.version>2.1.1.Final</jandex.version>
         <resteasy.version>4.0.0.Beta8</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>
-        <opentracing-jaxrs.version>0.3.1</opentracing-jaxrs.version>
+        <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>
         <opentracing-web-servlet-filter.version>0.2.3</opentracing-web-servlet-filter.version>
         <opentracing-tracerresolver.version>0.1.5</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
-        <jaeger.version>0.33.1</jaeger.version>
+        <jaeger.version>0.34.0</jaeger.version>
         <undertow.version>2.0.19.Final</undertow.version>
-        <xnio.version>3.6.5.Final</xnio.version>
+        <xnio.version>3.7.0.Final</xnio.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.3</microprofile-config-api.version>
-        <microprofile-opentracing-api.version>1.2.1</microprofile-opentracing-api.version>
+        <microprofile-opentracing-api.version>1.3.1</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.2.1</microprofile-rest-client.version>
         <smallrye-config.version>1.3.5</smallrye-config.version>
         <smallrye-health.version>1.0.2</smallrye-health.version>
         <smallrye-metrics.version>1.1.3</smallrye-metrics.version>
         <smallrye-open-api.version>1.1.1</smallrye-open-api.version>
-        <smallrye-opentracing.version>1.2.1</smallrye-opentracing.version>
+        <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>1.1.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>1.1.0</smallrye-jwt.version>
         <smallrye-reactive-streams-operators.version>1.0.2</smallrye-reactive-streams-operators.version>
@@ -97,7 +97,7 @@
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
         <log4j.version>1.2.17</log4j.version>
-        <log4j2.version>2.0</log4j2.version>
+        <log4j2.version>2.11.2</log4j2.version>
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-jboss-logging.version>1.1.0.Final</slf4j-jboss-logging.version>
         <wildfly-common.version>1.5.0.Final-format-001</wildfly-common.version>
@@ -118,8 +118,8 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <rest-assured.version>3.3.0</rest-assured.version>
         <junit4.version>4.12</junit4.version>
-        <junit.jupiter.version>5.3.2</junit.jupiter.version>
-        <assertj.version>3.11.1</assertj.version>
+        <junit.jupiter.version>5.4.0</junit.jupiter.version>
+        <assertj.version>3.12.1</assertj.version>
         <infinispan.version>10.0.0.Beta2</infinispan.version>
         <caffeine.version>2.6.2</caffeine.version>
         <netty.version>4.1.34.Final</netty.version>
@@ -129,7 +129,7 @@
         <axle-client.version>0.0.1</axle-client.version>
         <kafka-clients.version>1.1.0</kafka-clients.version>
         <kafka2.version>1.1.0</kafka2.version>
-        <debezium.version>0.8.3.Final</debezium.version>
+        <debezium.version>0.9.2.Final</debezium.version>
         <zookeeper.version>3.4.10</zookeeper.version>
         <scala.version>2.12.2</scala.version>
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>


### PR DESCRIPTION
opentracing, jaeger, xnio, debezium, log4j2, assertj, junit-jupiter minor version updates

I tried locally both `mvn clean install` and `mvn clean install -Dnative`, no issues hit.