### PR TITLE
Fix REST client CI failure

### DIFF
--- a/integration-tests/main/src/main/resources/META-INF/microprofile-config.properties
+++ b/integration-tests/main/src/main/resources/META-INF/microprofile-config.properties
@@ -1,1 +1,0 @@
-org.eclipse.microprofile.rest.client.propagateHeaders=header-name

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -15,6 +15,7 @@
 #
 
 io.quarkus.example.rest.RestInterface/mp-rest/url=${test.url}
+org.eclipse.microprofile.rest.client.propagateHeaders=header-name
 # Disabled by default as it establishes external connections.
 # Uncomment when you want to test SSL support.
 #io.quarkus.example.rest.SslRestInterface/mp-rest/url=https://www.example.com/


### PR DESCRIPTION
I'm not sure the first commit is needed but we usually register the service file manually when it's required to be included in the native image.

The second commit is the one that fixes the issue as, apparently, we now don't include the `META-INF/microprofile-config.properties` file into the native image.