### PR TITLE
 Validate @ConfigProperty injection points at runtime 

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigurationSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigurationSetup.java
@@ -116,8 +116,10 @@ public class ConfigurationSetup {
             "getImplicitConverter", Converter.class, Class.class);
     private static final MethodDescriptor CPR_SET_INSTANCE = MethodDescriptor.ofMethod(ConfigProviderResolver.class,
             "setInstance", void.class, ConfigProviderResolver.class);
-    private static final MethodDescriptor SCPR_CONSTRUCT = MethodDescriptor
-            .ofConstructor(SimpleConfigurationProviderResolver.class, Config.class);
+    private static final MethodDescriptor CPR_REGISTER_CONFIG = MethodDescriptor.ofMethod(ConfigProviderResolver.class,
+            "registerConfig", void.class, Config.class, ClassLoader.class);
+    private static final MethodDescriptor CPR_INSTANCE = MethodDescriptor.ofMethod(ConfigProviderResolver.class,
+            "instance", ConfigProviderResolver.class);
     private static final MethodDescriptor SRCB_BUILD = MethodDescriptor.ofMethod(SmallRyeConfigBuilder.class, "build",
             Config.class);
     private static final MethodDescriptor SRCB_WITH_CONVERTER = MethodDescriptor.ofMethod(SmallRyeConfigBuilder.class,
@@ -506,8 +508,13 @@ public class ConfigurationSetup {
                 // Build the config
 
                 final ResultHandle config = carc.checkCast(carc.invokeVirtualMethod(SRCB_BUILD, builder), SmallRyeConfig.class);
-                final ResultHandle providerResolver = carc.newInstance(SCPR_CONSTRUCT, config);
-                carc.invokeStaticMethod(CPR_SET_INSTANCE, providerResolver);
+
+                // ConfigProviderResolver.setInstance(new SimpleConfigurationProviderResolver())
+                carc.invokeStaticMethod(CPR_SET_INSTANCE,
+                        carc.newInstance(MethodDescriptor.ofConstructor(SimpleConfigurationProviderResolver.class)));
+                // Note that we need to to set the current Config because of ConfigProvider.INSTANCE
+                // ConfigProviderResolver.instance().registerConfig(config, null) 
+                carc.invokeVirtualMethod(CPR_REGISTER_CONFIG, carc.invokeStaticMethod(CPR_INSTANCE), config, carc.loadNull());
 
                 // create the config root
                 carc.writeStaticField(RUN_TIME_CONFIG_FIELD,

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigurationSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigurationSetup.java
@@ -120,6 +120,8 @@ public class ConfigurationSetup {
             "registerConfig", void.class, Config.class, ClassLoader.class);
     private static final MethodDescriptor CPR_INSTANCE = MethodDescriptor.ofMethod(ConfigProviderResolver.class,
             "instance", ConfigProviderResolver.class);
+    private static final MethodDescriptor SCPR_CONSTRUCT = MethodDescriptor
+            .ofConstructor(SimpleConfigurationProviderResolver.class);
     private static final MethodDescriptor SRCB_BUILD = MethodDescriptor.ofMethod(SmallRyeConfigBuilder.class, "build",
             Config.class);
     private static final MethodDescriptor SRCB_WITH_CONVERTER = MethodDescriptor.ofMethod(SmallRyeConfigBuilder.class,
@@ -509,11 +511,10 @@ public class ConfigurationSetup {
 
                 final ResultHandle config = carc.checkCast(carc.invokeVirtualMethod(SRCB_BUILD, builder), SmallRyeConfig.class);
 
-                // ConfigProviderResolver.setInstance(new SimpleConfigurationProviderResolver())
-                carc.invokeStaticMethod(CPR_SET_INSTANCE,
-                        carc.newInstance(MethodDescriptor.ofConstructor(SimpleConfigurationProviderResolver.class)));
-                // Note that we need to to set the current Config because of ConfigProvider.INSTANCE
-                // ConfigProviderResolver.instance().registerConfig(config, null) 
+                // IMPL NOTE: we do invoke ConfigProviderResolver.setInstance() in RUNTIME_INIT when an app starts, but ConfigProvider only obtains the
+                // resolver once when initializing ConfigProvider.INSTANCE. That is why we store the current Config as a static field on the
+                // SimpleConfigurationProviderResolver
+                carc.invokeStaticMethod(CPR_SET_INSTANCE, carc.newInstance(SCPR_CONSTRUCT));
                 carc.invokeVirtualMethod(CPR_REGISTER_CONFIG, carc.invokeStaticMethod(CPR_INSTANCE), config, carc.loadNull());
 
                 // create the config root

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/SimpleConfigurationProviderResolver.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/SimpleConfigurationProviderResolver.java
@@ -1,7 +1,5 @@
 package io.quarkus.runtime.configuration;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -13,10 +11,11 @@ import io.smallrye.config.SmallRyeConfigBuilder;
  */
 public class SimpleConfigurationProviderResolver extends ConfigProviderResolver {
 
-    private static final AtomicReference<Config> CONFIG = new AtomicReference<>();
+    // We use a shared config 
+    private static volatile Config config;
 
     public Config getConfig() {
-        return CONFIG.get();
+        return config;
     }
 
     public Config getConfig(final ClassLoader loader) {
@@ -28,10 +27,10 @@ public class SimpleConfigurationProviderResolver extends ConfigProviderResolver 
     }
 
     public void registerConfig(final Config config, final ClassLoader classLoader) {
-        CONFIG.set(config);
+        SimpleConfigurationProviderResolver.config = config;
     }
 
     public void releaseConfig(final Config config) {
-        CONFIG.set(null);
+        SimpleConfigurationProviderResolver.config = null;
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/SimpleConfigurationProviderResolver.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/SimpleConfigurationProviderResolver.java
@@ -1,5 +1,7 @@
 package io.quarkus.runtime.configuration;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -10,14 +12,11 @@ import io.smallrye.config.SmallRyeConfigBuilder;
  * A simple configuration provider.
  */
 public class SimpleConfigurationProviderResolver extends ConfigProviderResolver {
-    private final Config config;
 
-    public SimpleConfigurationProviderResolver(final Config config) {
-        this.config = config;
-    }
+    private static final AtomicReference<Config> CONFIG = new AtomicReference<>();
 
     public Config getConfig() {
-        return config;
+        return CONFIG.get();
     }
 
     public Config getConfig(final ClassLoader loader) {
@@ -29,10 +28,10 @@ public class SimpleConfigurationProviderResolver extends ConfigProviderResolver 
     }
 
     public void registerConfig(final Config config, final ClassLoader classLoader) {
-        // ignore
+        CONFIG.set(config);
     }
 
     public void releaseConfig(final Config config) {
-        // ignore
+        CONFIG.set(null);
     }
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -1,9 +1,12 @@
 package io.quarkus.arc.deployment;
 
+import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -15,16 +18,18 @@ import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanDeploymentValidator;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InjectionPointInfo;
+import io.quarkus.arc.runtime.ConfigDeploymentTemplate;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
 import io.smallrye.config.inject.ConfigProducer;
 
 /**
- * 
+ * MicroProfile Config related build steps.
  */
 public class ConfigBuildStep {
 
-    private static final DotName CONFIG_ANNOTATION = DotName.createSimple(ConfigProperty.class.getName());
+    private static final DotName CONFIG_PROPERTY_NAME = DotName.createSimple(ConfigProperty.class.getName());
 
     @BuildStep
     AdditionalBeanBuildItem bean() {
@@ -32,18 +37,90 @@ public class ConfigBuildStep {
     }
 
     @BuildStep
-    BeanDeploymentValidatorBuildItem beanDeploymentValidator() {
-        return new BeanDeploymentValidatorBuildItem(new ConfigBeanDeploymentValidator());
+    BeanDeploymentValidatorBuildItem collectMandatoryConfigProperties(BuildProducer<ConfigPropertyBuildItem> configProperties) {
+
+        return new BeanDeploymentValidatorBuildItem(new BeanDeploymentValidator() {
+
+            @Override
+            public void validate(ValidationContext validationContext) {
+                ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+
+                for (InjectionPointInfo injectionPoint : validationContext.get(Key.INJECTION_POINTS)) {
+                    if (injectionPoint.hasDefaultedQualifier()) {
+                        // Defaulted qualifier means no @ConfigProperty
+                        continue;
+                    }
+                    if (DotNames.OPTIONAL.equals(injectionPoint.getRequiredType().name())) {
+                        // Never validate Optional values
+                        continue;
+                    }
+                    AnnotationInstance configProperty = injectionPoint.getRequiredQualifiers().stream()
+                            .filter(a -> a.name().equals(CONFIG_PROPERTY_NAME))
+                            .findFirst().orElse(null);
+                    if (configProperty != null) {
+                        AnnotationValue defaultValue = configProperty.value("defaultValue");
+                        if (defaultValue != null && !ConfigProperty.UNCONFIGURED_VALUE.equals(defaultValue.asString())) {
+                            // No need to validate properties with default values
+                            continue;
+                        }
+                        String propertyName = configProperty.value("name").asString();
+                        Class<?> propertyType;
+
+                        if (injectionPoint.getRequiredType().kind() == Type.Kind.PRIMITIVE) {
+                            switch (injectionPoint.getRequiredType().asPrimitiveType().primitive()) {
+                                case BOOLEAN:
+                                    propertyType = Boolean.TYPE;
+                                    break;
+                                case BYTE:
+                                    propertyType = Byte.TYPE;
+                                    break;
+                                case CHAR:
+                                    propertyType = Character.TYPE;
+                                    break;
+                                case DOUBLE:
+                                    propertyType = Double.TYPE;
+                                    break;
+                                case INT:
+                                    propertyType = Integer.TYPE;
+                                    break;
+                                case FLOAT:
+                                    propertyType = Float.TYPE;
+                                    break;
+                                case LONG:
+                                    propertyType = Long.TYPE;
+                                    break;
+                                case SHORT:
+                                    propertyType = Short.TYPE;
+                                    break;
+                                default:
+                                    throw new IllegalArgumentException(
+                                            "Not a supported primitive type: "
+                                                    + injectionPoint.getRequiredType().asPrimitiveType().primitive());
+                            }
+                        } else {
+                            try {
+                                propertyType = tccl.loadClass(injectionPoint.getRequiredType().name().toString());
+                            } catch (ClassNotFoundException e) {
+                                throw new IllegalStateException("Unable to load the config property type: " + injectionPoint,
+                                        e);
+                            }
+                        }
+                        configProperties.produce(new ConfigPropertyBuildItem(propertyName, propertyType));
+                    }
+                }
+            }
+        });
     }
 
     /**
-     * Uses {@link AnnotationsTransformer} to automatically add {@code @Inject} to all fields that have
-     * {@code @ConfigProperty} on them, but are missing {@code @Inject}.
+     * Uses {@link AnnotationsTransformer} to automatically add {@code @Inject} to all fields that have {@code @ConfigProperty}
+     * on them, but are missing
+     * {@code @Inject}.
      *
      * @author Matej Novotny
      */
     @BuildStep
-    public void build(BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer) throws Exception {
+    void annotationTransformer(BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer) throws Exception {
         annotationsTransformer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
             @Override
             public boolean appliesTo(AnnotationTarget.Kind kind) {
@@ -52,91 +129,22 @@ public class ConfigBuildStep {
 
             @Override
             public void transform(TransformationContext transformationContext) {
-                if (transformationContext.getTarget().asField().hasAnnotation(CONFIG_ANNOTATION)
+                if (transformationContext.getTarget().asField().hasAnnotation(CONFIG_PROPERTY_NAME)
                         && !transformationContext.getTarget().asField().hasAnnotation(DotNames.INJECT)) {
                     transformationContext.transform().add(Inject.class).done();
-
                 }
             }
         }));
     }
 
-    static class ConfigBeanDeploymentValidator implements BeanDeploymentValidator {
-
-        private static final DotName CONFIG_PROPERTY_NAME = DotName.createSimple(ConfigProperty.class.getName());
-
-        @Override
-        public void validate(ValidationContext validationContext) {
-
-            Config config = ConfigProvider.getConfig();
-            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-
-            for (InjectionPointInfo injectionPoint : validationContext.get(Key.INJECTION_POINTS)) {
-                if (injectionPoint.hasDefaultedQualifier()) {
-                    continue;
-                }
-                AnnotationInstance configProperty = injectionPoint.getRequiredQualifiers()
-                        .stream()
-                        .filter(a -> a.name()
-                                .equals(CONFIG_PROPERTY_NAME))
-                        .findFirst()
-                        .orElse(null);
-                if (configProperty != null) {
-                    if (DotNames.OPTIONAL.equals(injectionPoint.getRequiredType().name())) {
-                        continue;
-                    }
-                    String key = configProperty.value("name").asString();
-                    // TODO: collection types
-                    Class<?> type;
-                    try {
-                        if (injectionPoint.getRequiredType().kind() == Type.Kind.PRIMITIVE) {
-                            switch (injectionPoint.getRequiredType().asPrimitiveType().primitive()) {
-                                case BOOLEAN:
-                                    type = Boolean.TYPE;
-                                    break;
-                                case BYTE:
-                                    type = Byte.TYPE;
-                                    break;
-                                case CHAR:
-                                    type = Character.TYPE;
-                                    break;
-                                case DOUBLE:
-                                    type = Double.TYPE;
-                                    break;
-                                case INT:
-                                    type = Integer.TYPE;
-                                    break;
-                                case FLOAT:
-                                    type = Float.TYPE;
-                                    break;
-                                case LONG:
-                                    type = Long.TYPE;
-                                    break;
-                                case SHORT:
-                                    type = Short.TYPE;
-                                    break;
-                                default:
-                                    throw new IllegalArgumentException("Not a supported primitive type: "
-                                            + injectionPoint.getRequiredType().asPrimitiveType().primitive());
-                            }
-
-                        } else {
-                            type = tccl.loadClass(injectionPoint.getRequiredType().name().toString());
-                        }
-                        if (!config.getOptionalValue(key, type).isPresent()) {
-                            AnnotationValue defaultValue = configProperty.value("defaultValue");
-                            if (defaultValue == null || ConfigProperty.UNCONFIGURED_VALUE.equals(defaultValue.asString())) {
-                                validationContext
-                                        .addDeploymentProblem(new IllegalStateException("No config value exists for: " + key));
-                            }
-                        }
-                    } catch (ClassNotFoundException e) {
-                        throw new IllegalStateException("Unable to verify config injection point: " + injectionPoint, e);
-                    }
-                }
-            }
-        }
-
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    void validateConfigProperties(ConfigDeploymentTemplate template, List<ConfigPropertyBuildItem> configProperties,
+            BeanContainerBuildItem beanContainer) {
+        // IMPL NOTE: we do depend on BeanContainerBuildItem to make sure that the BeanDeploymentValidator finished its processing
+        template.validateConfigProperties(
+                configProperties.stream().collect(
+                        Collectors.toMap(ConfigPropertyBuildItem::getPropertyName, ConfigPropertyBuildItem::getPropertyType)));
     }
 
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigPropertyBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigPropertyBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.arc.deployment;
+
+import org.jboss.builder.item.MultiBuildItem;
+
+/**
+ * TODO
+ */
+public final class ConfigPropertyBuildItem extends MultiBuildItem {
+
+    private final String propertyName;
+
+    private final Class<?> propertyType;
+
+    public ConfigPropertyBuildItem(String propertyName, Class<?> propertyType) {
+        this.propertyName = propertyName;
+        this.propertyType = propertyType;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public Class<?> getPropertyType() {
+        return propertyType;
+    }
+
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigPropertyBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigPropertyBuildItem.java
@@ -3,7 +3,7 @@ package io.quarkus.arc.deployment;
 import org.jboss.builder.item.MultiBuildItem;
 
 /**
- * TODO
+ * Represents a mandatory config property that needs to be validated at runtime.
  */
 public final class ConfigPropertyBuildItem extends MultiBuildItem {
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainer.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainer.java
@@ -16,7 +16,6 @@
 
 package io.quarkus.arc.runtime;
 
-import java.io.Closeable;
 import java.lang.annotation.Annotation;
 
 import io.quarkus.arc.ManagedContext;

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigDeploymentTemplate.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigDeploymentTemplate.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.arc.runtime;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.runtime.annotations.Template;
+
+/**
+ * @author Martin Kouba
+ */
+@Template
+public class ConfigDeploymentTemplate {
+
+    public void validateConfigProperties(Map<String, Class<?>> properties) {
+        Config config = ConfigProvider.getConfig();
+        for (Entry<String, Class<?>> entry : properties.entrySet()) {
+            Class<?> propertyType = entry.getValue();
+            // Copy SmallRye logic - for collections, we only check if the property config exists without trying to convert it
+            if (Collection.class.isAssignableFrom(propertyType)) {
+                propertyType = String.class;
+            }
+            if (!config.getOptionalValue(entry.getKey(), propertyType).isPresent()) {
+                throw new DeploymentException("No config value of type " + entry.getValue() + " exists for: " + entry.getKey());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
@dmlloyd David pls review the config part. Basically we need to re-set the `Config` instead of `ConfigProviderResolver` because the `ConfigProvider` caches the `ConfigProviderResolver` instance - as a result, the config stays the same between test runs.