### PR TITLE
When starting native image, use argument for log file location

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
@@ -59,8 +59,7 @@ public class NativeImageLauncher implements Closeable {
         args.add(path);
         args.add("-Dquarkus.http.port=" + port);
         args.add("-Dtest.url=" + TestHTTPResourceManager.getUri());
-        //args.add("-Dquarkus.log.file.path=target/quarkus.log");
-        PropertyTestUtil.setLogFileProperty();
+        args.add("-Dquarkus.log.file.path=" + PropertyTestUtil.getLogFileLocation());
 
         System.out.println("Executing " + args);
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
@@ -22,9 +22,13 @@ import java.nio.file.Paths;
 public class PropertyTestUtil {
 
     public static void setLogFileProperty() {
+        System.setProperty("quarkus.log.file.path", getLogFileLocation());
+    }
+
+    public static String getLogFileLocation() {
         if (Files.isDirectory(Paths.get("build"))) {
-            System.setProperty("quarkus.log.file.path", "build" + File.separator + "quarkus.log");
-        } else
-            System.setProperty("quarkus.log.file.path", "target" + File.separator + "quarkus.log");
+            return "build" + File.separator + "quarkus.log";
+        }
+        return "target" + File.separator + "quarkus.log";
     }
 }


### PR DESCRIPTION
Do not make sense to use System.properties when creating a new process, added back the `quarkus.log.file.path` argument.