### PR TITLE
Add a dependency on the Reactive Streams Operators implementation in Reactive Messaging

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging/deployment/pom.xml
@@ -27,7 +27,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-runtime</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Fix #1495.

As proposed in the issue, add a dependency on the Quarkus SmallRye Reactive Streams Operators module in the SmallRye Reactive Messaging module to the user do not have to declare it explicitly.