### PR TITLE
Disable native build for camel components

### DIFF
--- a/integration-tests/camel-aws-s3/pom.xml
+++ b/integration-tests/camel-aws-s3/pom.xml
@@ -144,7 +144,7 @@
             <id>native-image</id>
             <activation>
                 <property>
-                    <name>native</name>
+                    <name>native-camel</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/camel-core/pom.xml
+++ b/integration-tests/camel-core/pom.xml
@@ -122,7 +122,7 @@
             <id>native-image</id>
             <activation>
                 <property>
-                    <name>native</name>
+                    <name>native-camel</name>
                 </property>
             </activation>
             <build>

--- a/integration-tests/camel-salesforce/pom.xml
+++ b/integration-tests/camel-salesforce/pom.xml
@@ -133,7 +133,7 @@
             <id>native-image</id>
             <activation>
                 <property>
-                    <name>native</name>
+                    <name>native-camel</name>
                 </property>
             </activation>
             <build>


### PR DESCRIPTION
This is because they take a LOT of time on the CI. They will be run in a nightly build.