### PR TITLE
Search for a native image for gradle builds if the maven search fails

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
@@ -81,9 +81,18 @@ public class NativeImageLauncher implements Closeable {
             URL[] urls = ((URLClassLoader) cl).getURLs();
             for (URL url : urls) {
                 if (url.getProtocol().equals("file") && url.getPath().endsWith("test-classes/")) {
-                    //we have the test classes dir
+                    //we have the maven test classes dir
                     File testClasses = new File(url.getPath());
                     for (File file : testClasses.getParentFile().listFiles()) {
+                        if (file.getName().endsWith("-runner")) {
+                            logGuessedPath(file.getAbsolutePath());
+                            return file.getAbsolutePath();
+                        }
+                    }
+                } else if (url.getProtocol().equals("file") && url.getPath().endsWith("test/")) {
+                    //we have the gradle test classes dir, build/classes/java/test
+                    File testClasses = new File(url.getPath());
+                    for (File file : testClasses.getParentFile().getParentFile().getParentFile().listFiles()) {
                         if (file.getName().endsWith("-runner")) {
                             logGuessedPath(file.getAbsolutePath());
                             return file.getAbsolutePath();


### PR DESCRIPTION
With this change we can correctly run SubstrateTests with Gradle. - there is a difference between Gradle and Maven regarding tests however. Gradle will by default try to run everything it can in the `src/test/java`folder. The common way of splitting up integration tests in Gradle is to put the integration tests in a different folder, eg: `src/integTest/java`.
In the current state (with this fix), if a user tries to run the quickstarts with gradle (with a correct build file) either the QuarkusTest or SubstrateTest will fail. Depending on what he have built. - just a fyi for further discussions :)