### PR TITLE
Supports the implements configuration

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/ResolvedGradleArtifactDeps.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/ResolvedGradleArtifactDeps.java
@@ -67,7 +67,7 @@ public class ResolvedGradleArtifactDeps extends AppArtifactResolverBase {
     private List<AppDependency> extractDependencies(Project project) {
         Set<AppDependency> dependencies = new HashSet<>();
 
-        Configuration configuration = project.getConfigurations().getByName("compileOnly");
+        Configuration configuration = project.getConfigurations().getByName("compileClasspath");
         ResolutionResult resolutionResult = configuration.getIncoming().getResolutionResult();
         ResolvedComponentResult root = resolutionResult.getRoot();
 


### PR DESCRIPTION
With this change the Gradle Plugin will work when users choose the `implementation` configuration. Fixes #1533 