### PR TITLE
Update warning messages to reference quarkus application properties

### DIFF
--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentTemplate.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentTemplate.java
@@ -51,10 +51,10 @@ public class JaegerDeploymentTemplate {
         Optional<String> endpoint = mpconfig.getOptionalValue(JAEGER_ENDPOINT, String.class);
         if (!jaeger.serviceName.isPresent() && !serviceName.isPresent()) {
             log.warn(
-                    "Jaeger service name has not been defined (e.g. JAEGER_SERVICE_NAME environment variable or system properties)");
+                    "Jaeger service name has not been defined, either as 'quarkus.jaeger.service-name' application property or JAEGER_SERVICE_NAME environment variable/system property");
         } else if (!jaeger.endpoint.isPresent() && !endpoint.isPresent()) {
             log.warn(
-                    "Jaeger collector endpoint has not been defined (e.g. JAEGER_ENDPOINT environment variable or system properties)");
+                    "Jaeger collector endpoint has not been defined, either as 'quarkus.jaeger.endpoint' application property or JAEGER_SERVICE_NAME environment variable/system property");
             // Return true for now, so we can reproduce issue with UdpSender
             return true;
         } else {


### PR DESCRIPTION
Warning message must reference quarkus application properties before environment properties

Fixes #1596