### PR TITLE
Fix urls in the Kubernetes guide

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-guide.adoc
+++ b/docs/src/main/asciidoc/kubernetes-guide.adoc
@@ -55,7 +55,7 @@ The application is now exposed as an internal service. If you are using `minikub
 
 [source,shell]
 ----
-curl $(minikube service quarkus-quickstart --url)/hello/greeting/quarkus
+curl $(minikube service quarkus-quickstart --url)/hello/quarkus
 ----
 
 == Deploying the application in OpenShift
@@ -77,7 +77,7 @@ oc expose service quarkus-quickstart
 
 # Get the route URL
 export URL="http://$(oc get route | grep quarkus-quickstart | awk '{print $2}')"
-curl $URL/hello/greeting/quarkus
+curl $URL/hello/quarkus
 ----
 
 Your application is accessible at the printed URL.


### PR DESCRIPTION
Applies fix from https://github.com/quarkusio/quarkusio.github.io/pull/142. 

It seems to be a left-over from the Application class removal.

Note that the URL was wrong twice:
* bare kubernetes
* openshift

IMPORTANT: Web site already updated.