### PR TITLE
Make Netty EventLoopGroup instances injectable

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RuntimeBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RuntimeBeanBuildItem.java
@@ -1,0 +1,97 @@
+package io.quarkus.arc.deployment;
+
+import java.lang.annotation.Annotation;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.Dependent;
+
+import org.jboss.builder.item.MultiBuildItem;
+
+/**
+ * Represents a bean that can be easily produced through a template (or other runtime Supplier implementation)
+ */
+public final class RuntimeBeanBuildItem extends MultiBuildItem {
+
+    final String scope;
+    final String type;
+    final Supplier<Object> supplier;
+    final NavigableMap<String, NavigableMap<String, Object>> qualifiers;
+
+    RuntimeBeanBuildItem(String scope, String type, Supplier<Object> supplier,
+            NavigableMap<String, NavigableMap<String, Object>> qualifiers) {
+        this.scope = scope;
+        this.type = type;
+        this.supplier = supplier;
+        this.qualifiers = qualifiers;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Supplier<Object> getSupplier() {
+        return supplier;
+    }
+
+    public NavigableMap<String, NavigableMap<String, Object>> getQualifiers() {
+        return qualifiers;
+    }
+
+    public static Builder builder(String type, Supplier<Object> supplier) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(supplier);
+        return new Builder(type, supplier);
+    }
+
+    public static class Builder {
+
+        String scope = Dependent.class.getName();
+        final String type;
+        final Supplier<Object> supplier;
+        final NavigableMap<String, NavigableMap<String, Object>> qualifiers = new TreeMap<>();
+
+        public Builder(String type, Supplier<Object> supplier) {
+            this.type = type;
+            this.supplier = supplier;
+        }
+
+        public Builder setScope(String scope) {
+            this.scope = scope;
+            return this;
+        }
+
+        public Builder setScope(Class<? extends Annotation> type) {
+            this.scope = type.getName();
+            return this;
+        }
+
+        public Builder addQualifier(String type) {
+            qualifiers.put(type, new TreeMap<>());
+            return this;
+        }
+
+        public Builder addQualifier(String type, NavigableMap<String, Object> values) {
+            qualifiers.put(type, new TreeMap<>(values));
+            return this;
+        }
+
+        public Builder addQualifier(Class<? extends Annotation> type) {
+            return addQualifier(type.getName());
+        }
+
+        public Builder addQualifier(Class<? extends Annotation> type, NavigableMap<String, Object> values) {
+            return addQualifier(type.getName(), values);
+        }
+
+        public RuntimeBeanBuildItem build() {
+            return new RuntimeBeanBuildItem(scope, type, supplier, qualifiers);
+        }
+    }
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RuntimeBeanProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RuntimeBeanProcessor.java
@@ -1,0 +1,71 @@
+package io.quarkus.arc.deployment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import io.quarkus.arc.runtime.ArcDeploymentTemplate;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.util.HashUtil;
+import io.quarkus.gizmo.AnnotationCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+public class RuntimeBeanProcessor {
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void build(List<RuntimeBeanBuildItem> beans,
+            BuildProducer<GeneratedBeanBuildItem> generatedBean,
+            ArcDeploymentTemplate template) {
+        String beanName = "io.quarkus.arc.runtimebean.RuntimeBeanProducers";
+
+        ClassCreator c = new ClassCreator(new ClassOutput() {
+            @Override
+            public void write(String name, byte[] data) {
+                generatedBean.produce(new GeneratedBeanBuildItem(name, data));
+            }
+        }, beanName, null, Object.class.getName());
+
+        c.addAnnotation(ApplicationScoped.class);
+        Map<String, Supplier<Object>> map = new HashMap<>();
+        for (RuntimeBeanBuildItem b : beans) {
+            //deterministic name
+            //as we know the maps are sorted this will result in the same hash for the same bean
+            String name = b.type.replace(".", "_") + "_" + HashUtil.sha1(b.qualifiers.toString());
+            map.put(name, b.supplier);
+
+            MethodCreator producer = c.getMethodCreator("produce_" + name, b.type);
+            producer.addAnnotation(Produces.class);
+            producer.addAnnotation(b.scope);
+            for (Map.Entry<String, NavigableMap<String, Object>> i : b.qualifiers.entrySet()) {
+                AnnotationCreator builder = producer.addAnnotation(i.getKey());
+                for (Map.Entry<String, Object> j : i.getValue().entrySet()) {
+                    builder.addValue(i.getKey(), i.getValue());
+                }
+            }
+
+            ResultHandle staticMap = producer
+                    .readStaticField(FieldDescriptor.of(ArcDeploymentTemplate.class, "supplierMap", Map.class));
+            ResultHandle supplier = producer.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(Map.class, "get", Object.class, Object.class), staticMap, producer.load(name));
+            ResultHandle result = producer.invokeInterfaceMethod(MethodDescriptor.ofMethod(Supplier.class, "get", Object.class),
+                    supplier);
+            producer.returnValue(result);
+        }
+        c.close();
+        template.initSupplierBeans(map);
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcDeploymentTemplate.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcDeploymentTemplate.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -37,6 +38,11 @@ import io.quarkus.runtime.annotations.Template;
 @Template
 public class ArcDeploymentTemplate {
 
+    /**
+     * Used to hold the Supplier instances used for synthetic bean declarations.
+     */
+    public static volatile Map<String, Supplier<Object>> supplierMap;
+
     private static final Logger LOGGER = Logger.getLogger(ArcDeploymentTemplate.class.getName());
 
     public ArcContainer getContainer(ShutdownContext shutdown) throws Exception {
@@ -48,6 +54,10 @@ public class ArcDeploymentTemplate {
             }
         });
         return container;
+    }
+
+    public void initSupplierBeans(Map<String, Supplier<Object>> beans) {
+        supplierMap = beans;
     }
 
     public BeanContainer initBeanContainer(ArcContainer container, List<BeanContainerListener> listeners,

--- a/extensions/netty/deployment/pom.xml
+++ b/extensions/netty/deployment/pom.xml
@@ -37,6 +37,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-netty-runtime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -16,14 +16,23 @@
 
 package io.quarkus.netty.deployment;
 
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.logging.Logger;
 
+import io.netty.channel.EventLoopGroup;
+import io.quarkus.arc.deployment.RuntimeBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateConfigBuildItem;
+import io.quarkus.netty.BossGroup;
+import io.quarkus.netty.runtime.NettyTemplate;
 
 class NettyProcessor {
 
@@ -57,6 +66,23 @@ class NettyProcessor {
         }
         return builder //TODO: make configurable
                 .build();
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void createExecutors(BuildProducer<RuntimeBeanBuildItem> runtimeBeanBuildItemBuildProducer,
+            NettyTemplate template) {
+        //TODO: configuration
+        Supplier<Object> boss = template.createEventLoop(1);
+        Supplier<Object> worker = template.createEventLoop(0);
+
+        runtimeBeanBuildItemBuildProducer.produce(RuntimeBeanBuildItem.builder(EventLoopGroup.class.getName(), boss)
+                .setScope(ApplicationScoped.class)
+                .addQualifier(BossGroup.class)
+                .build());
+        runtimeBeanBuildItemBuildProducer.produce(RuntimeBeanBuildItem.builder(EventLoopGroup.class.getName(), worker)
+                .setScope(ApplicationScoped.class)
+                .build());
     }
 
 }

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -39,8 +39,16 @@
             <artifactId>netty-codec</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-runtime</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/BossGroup.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/BossGroup.java
@@ -1,0 +1,11 @@
+package io.quarkus.netty;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BossGroup {
+}

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyTemplate.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyTemplate.java
@@ -1,0 +1,30 @@
+package io.quarkus.netty.runtime;
+
+import java.util.function.Supplier;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.quarkus.runtime.annotations.Template;
+
+@Template
+public class NettyTemplate {
+
+    public Supplier<Object> createEventLoop(int nThreads) {
+        return new Supplier<Object>() {
+
+            volatile EventLoopGroup val;
+
+            @Override
+            public EventLoopGroup get() {
+                if (val == null) {
+                    synchronized (this) {
+                        if (val == null) {
+                            val = new NioEventLoopGroup(nThreads);
+                        }
+                    }
+                }
+                return val;
+            }
+        };
+    }
+}

--- a/integration-tests/vertx/src/main/java/io/quarkus/vertx/tests/NettyEventLoopResource.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/vertx/tests/NettyEventLoopResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.vertx.tests;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.netty.channel.EventLoopGroup;
+import io.quarkus.netty.BossGroup;
+
+@Path("/eventloop")
+public class NettyEventLoopResource {
+
+    @Inject
+    EventLoopGroup worker;
+
+    @Inject
+    @BossGroup
+    EventLoopGroup boss;
+
+    @GET
+    public String test() {
+        if (boss == null) {
+            throw new RuntimeException("Boss group null");
+        }
+        if (worker == null) {
+            throw new RuntimeException("worker group null");
+        }
+        return "passed";
+    }
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/NettyEventLoopGroupResourceTest.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/NettyEventLoopGroupResourceTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.runtime.tests;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class NettyEventLoopGroupResourceTest {
+
+    @Test
+    public void testInjection() {
+        RestAssured.when().get("/vertx-test/eventloop").then()
+                .body(containsString("passed"));
+    }
+}


### PR DESCRIPTION
This is very basic at the moment, but it also introduces a generic facility for template configured CDI beans. Basically you can just provide a Supplier that creates the bean instances, provide the scope and qualifiers, and Arc will generate a producer method for you.