### PR TITLE
Injection of @ConfigProperty double produces java.lang.ClassNotFoundException: double

### DIFF
--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.extest.deployment;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -13,9 +14,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
-import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
-import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -23,7 +22,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
-import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.extest.runtime.IConfigConsumer;
 import io.quarkus.extest.runtime.ObjectOfValue;
 import io.quarkus.extest.runtime.ObjectValueOf;
@@ -32,7 +30,6 @@ import io.quarkus.extest.runtime.TestBuildAndRunTimeConfig;
 import io.quarkus.extest.runtime.TestBuildTimeConfig;
 import io.quarkus.extest.runtime.TestRunTimeConfig;
 import io.quarkus.extest.runtime.TestTemplate;
-import io.quarkus.runtime.RuntimeValue;
 
 /**
  * A test extension deployment processor
@@ -197,6 +194,32 @@ public final class TestProcessor {
             Class<IConfigConsumer> beanClass = testBeanBuildItem.getConfigConsumer();
             template.configureBeans(beanContainer.getValue(), beanClass, buildAndRunTimeConfig, runTimeConfig);
         }
+    }
+
+    /**
+     * Test for https://github.com/quarkusio/quarkus/issues/1633
+     * 
+     * @param template - runtime template
+     */
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    void referencePrimitiveTypeClasses(TestTemplate template) {
+        HashSet<Class<?>> allPrimitiveTypes = new HashSet<>();
+        allPrimitiveTypes.add(byte.class);
+        allPrimitiveTypes.add(char.class);
+        allPrimitiveTypes.add(short.class);
+        allPrimitiveTypes.add(int.class);
+        allPrimitiveTypes.add(long.class);
+        allPrimitiveTypes.add(float.class);
+        allPrimitiveTypes.add(double.class);
+        allPrimitiveTypes.add(byte[].class);
+        allPrimitiveTypes.add(char[].class);
+        allPrimitiveTypes.add(short[].class);
+        allPrimitiveTypes.add(int[].class);
+        allPrimitiveTypes.add(long[].class);
+        allPrimitiveTypes.add(float[].class);
+        allPrimitiveTypes.add(double[].class);
+        template.validateTypes(allPrimitiveTypes);
     }
 
     @BuildStep

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/TestTemplate.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/TestTemplate.java
@@ -1,5 +1,7 @@
 package io.quarkus.extest.runtime;
 
+import java.util.Set;
+
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.runtime.BeanContainer;
@@ -15,12 +17,12 @@ public class TestTemplate {
     /**
      * Instantiate the given class in the given BeanContainer and passes the TestBuildAndRunTimeConfig and TestRunTimeConfig to
      * it
-     * 
-     * @see IConfigConsumer#loadConfig(TestBuildAndRunTimeConfig, TestRunTimeConfig)
+     *
      * @param beanContainer - CDI container
      * @param beanClass - IConfigConsumer
      * @param buildTimeConfig - the extension TestBuildAndRunTimeConfig
      * @param runTimeConfig - the extension TestRunTimeConfig
+     * @see IConfigConsumer#loadConfig(TestBuildAndRunTimeConfig, TestRunTimeConfig)
      */
     public void configureBeans(BeanContainer beanContainer, Class<IConfigConsumer> beanClass,
             TestBuildAndRunTimeConfig buildTimeConfig,
@@ -29,5 +31,16 @@ public class TestTemplate {
         IConfigConsumer instance = beanContainer.instance(beanClass);
         instance.loadConfig(buildTimeConfig, runTimeConfig);
         log.infof("configureBeans, instance=%s\n", instance);
+    }
+
+    /**
+     * Access the primitive class types at runtime to validate the build step generated deploy method
+     * 
+     * @param typesSet
+     */
+    public void validateTypes(Set<Class<?>> typesSet) {
+        for (Class<?> type : typesSet) {
+            log.infof("Checking type: %s", type.getName());
+        }
     }
 }


### PR DESCRIPTION
Fixes #1633.

There was a path into the BytecodeRecorderImpl#loadObjectInstance where a method parameter was a Class of primitive type that was not being excluded from the Class#forName code generation. Added a similar usecase to the test-extension to verify future regressions.
