### PR TITLE
Enhance the testing guide to highlight how the test port is configured

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -136,8 +136,17 @@ the test is run.
 === Controlling the test port
 
 While Quarkus will listen on port `8080` by default, when running tests it defaults to `8081`. This allows you to run
-tests while having the application running in parallel. This can be configured via the `quarkus.http.test-port`
-config property in `application.properties`.
+tests while having the application running in parallel.
+
+[TIP]
+.Changing the test port
+====
+You can configure the port used by tests by configuring `quarkus.http.test-port` in your `application.properties`:
+[source]
+----
+quarkus.http.test-port=8083
+----
+====
 
 Quarkus also provides Restassured integration that updates the default port used by Restassured before the tests are run,
 so no additional configuration should be required.


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/1627.

Mostly cosmetic to highlight the content.