### PR TITLE
Reenable PrintAnalysisCallTree reports by default

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -650,10 +650,6 @@
                     <groupId>${project.groupId}</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
                     <version>${project.version}</version>
-                    <configuration>
-                        <!-- Disable PrintAnalysisCallTree reports for native image building by default -->
-                        <disableReports>true</disableReports>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
We disabled it because of a bug in GraalVM. The issue has now been
fixed.

https://github.com/oracle/graal/issues/845