### PR TITLE
Fixed commented highlighted points

### DIFF
--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -325,12 +325,12 @@ import static org.hamcrest.CoreMatchers.is;
 @QuarkusTest
 public class GreetingResourceTest {
 
-    @Test    // <1>
+    @Test    // (1)
     public void testHelloEndpoint() {
         given()
           .when().get("/hello")
           .then()
-             .statusCode(200)    // <2>
+             .statusCode(200)    // (2)
              .body(is("hello"));
     }
 


### PR DESCRIPTION
The commented highlighted points in the `GreetingResourceTest` file aren't rendered as comments so a copy/paste from web site to the IDE drives to a not buildable source.