### PR TITLE
Ensure the Maven Wrapper is created in the proper directory

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -44,7 +46,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
 import org.fusesource.jansi.Ansi;
 
 import io.quarkus.SourceType;
@@ -97,6 +101,9 @@ public class CreateProjectMojo extends AbstractMojo {
     @Component
     private BuildPluginManager pluginManager;
 
+    @Component
+    private ProjectBuilder projectBuilder;
+
     @Override
     public void execute() throws MojoExecutionException {
         // We detect the Maven version during the project generation to indicate the user immediately that the installed
@@ -146,12 +153,13 @@ public class CreateProjectMojo extends AbstractMojo {
                     .sourceType(determineSourceType(extensions))
                     .doCreateProject(context);
 
+            File createdPomFile = new File(projectRoot, "pom.xml");
             if (success) {
-                new AddExtensions(new File(projectRoot, "pom.xml"))
+                new AddExtensions(createdPomFile)
                         .addExtensions(extensions);
             }
 
-            createMavenWrapper();
+            createMavenWrapper(createdPomFile);
         } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
@@ -160,8 +168,20 @@ public class CreateProjectMojo extends AbstractMojo {
         }
     }
 
-    private void createMavenWrapper() {
+    private void createMavenWrapper(File createdPomFile) {
         try {
+            // we need to modify the maven environment used by the wrapper plugin since the project could have been
+            // created in a directory other than the current
+            MavenProject newProject = projectBuilder.build(
+                    createdPomFile, new DefaultProjectBuildingRequest(session.getProjectBuildingRequest())).getProject();
+
+            MavenExecutionRequest newExecutionRequest = DefaultMavenExecutionRequest.copy(session.getRequest());
+            newExecutionRequest.setBaseDirectory(createdPomFile.getParentFile());
+
+            MavenSession newSession = new MavenSession(session.getContainer(), session.getRepositorySession(),
+                    newExecutionRequest, session.getResult());
+            newSession.setCurrentProject(newProject);
+
             executeMojo(
                     plugin(
                             groupId("io.takari"),
@@ -171,8 +191,8 @@ public class CreateProjectMojo extends AbstractMojo {
                     configuration(
                             element(name("maven"), MojoUtils.getProposedMavenVersion())),
                     executionEnvironment(
-                            project,
-                            session,
+                            newProject,
+                            newSession,
                             pluginManager));
         } catch (Exception e) {
             // no reason to fail if the wrapper could not be created


### PR DESCRIPTION
When a project is created via the maven plugin, ensure that the maven
wrapper always ends up in the same directory as the generated pom file

Fixes: #1657