### PR TITLE
Register substitutions with MainBytecodeRecorderBuildItems, Fixes #1663

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -195,6 +195,11 @@ class MainClassBuildStep {
         for (MainBytecodeRecorderBuildItem holder : mainMethod) {
             final BytecodeRecorderImpl recorder = holder.getBytecodeRecorder();
             if (!recorder.isEmpty()) {
+                // Register substitutions in all recorders
+                for (ObjectSubstitutionBuildItem sub : substitutions) {
+                    ObjectSubstitutionBuildItem.Holder holder1 = sub.holder;
+                    recorder.registerSubstitution(holder1.from, holder1.to, holder1.substitution);
+                }
                 for (BytecodeRecorderObjectLoaderBuildItem item : loaders) {
                     recorder.registerObjectLoader(item.getObjectLoader());
                 }

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/PublicKeyBuildItem.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/PublicKeyBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.extest.deployment;
+
+import java.security.interfaces.DSAPublicKey;
+
+import org.jboss.builder.item.SimpleBuildItem;
+
+final public class PublicKeyBuildItem extends SimpleBuildItem {
+    private DSAPublicKey publicKey;
+
+    public PublicKeyBuildItem(DSAPublicKey publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public DSAPublicKey getPublicKey() {
+        return publicKey;
+    }
+}

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -170,19 +170,19 @@ public final class TestProcessor {
     @BuildStep
     @Record(STATIC_INIT)
     PublicKeyBuildItem loadDSAPublicKey(TestTemplate template,
-                                        BuildProducer<ObjectSubstitutionBuildItem> substitutions) throws GeneralSecurityException {
+            BuildProducer<ObjectSubstitutionBuildItem> substitutions) throws GeneralSecurityException {
         String base64 = "MIIDQjCCAjUGByqGSM44BAEwggIoAoIBAQCPeTXZuarpv6vtiHrPSVG28y7FnjuvNxjo6sSWHz79NgbnQ1GpxBgzObg" +
-            "J58KuHFObp0dbhdARrbi0eYd1SYRpXKwOjxSzNggooi/6JxEKPWKpk0U0CaD+aWxGWPhL3SCBnDcJoBBXsZWtzQAjPbpUhLYpH51k" +
-            "jviDRIZ3l5zsBLQ0pqwudemYXeI9sCkvwRGMn/qdgYHnM423krcw17njSVkvaAmYchU5Feo9a4tGU8YzRY+AOzKkwuDycpAlbk4/i" +
-            "jsIOKHEUOThjBopo33fXqFD3ktm/wSQPtXPFiPhWNSHxgjpfyEc2B3KI8tuOAdl+CLjQr5ITAV2OTlgHNZnAh0AuvaWpoV499/e5/" +
-            "pnyXfHhe8ysjO65YDAvNVpXQKCAQAWplxYIEhQcE51AqOXVwQNNNo6NHjBVNTkpcAtJC7gT5bmHkvQkEq9rI837rHgnzGC0jyQQ8" +
-            "tkL4gAQWDt+coJsyB2p5wypifyRz6Rh5uixOdEvSCBVEy1W4AsNo0fqD7UielOD6BojjJCilx4xHjGjQUntxyaOrsLC+EsRGiWOef" +
-            "TznTbEBplqiuH9kxoJts+xy9LVZmDS7TtsC98kOmkltOlXVNb6/xF1PYZ9j897buHOSXC8iTgdzEpbaiH7B5HSPh++1/et1SEMWs" +
-            "iMt7lU92vAhErDR8C2jCXMiT+J67ai51LKSLZuovjntnhA6Y8UoELxoi34u1DFuHvF9veA4IBBQACggEAK6IeZShhydDUM5XsOJ/V" +
-            "AYPOgrnLr30AfKWLR39+FJBunVMWNPpvO5D9dU7B6nmSiLATpwhBDNEhyJ0ltmBGuFDBAkKkqE4l6l2iVh+C1TyYliv1P2LCJFNgr" +
-            "AJxyr+5Q5zM9hUgfbT66xnwCf/4aiO7nBlj4wOL3l9ABVllYifMZyKVYFGluXmo+jyyeAcCtzHi5SABbTOQJN0WXTlGtzxLFQ0QErD" +
-            "GhP1/A6z5lw5VHJn2aWMeTCaH+rJZpQfM8b2VWr7UEljqFgpSIHbrImuXcf2nP6uZLKFiDdAjDUyj0h2jXwwcdhwWXuhOEv8XIilkc" +
-            "9nMcPLqbdcQ4M5agg==";
+                "J58KuHFObp0dbhdARrbi0eYd1SYRpXKwOjxSzNggooi/6JxEKPWKpk0U0CaD+aWxGWPhL3SCBnDcJoBBXsZWtzQAjPbpUhLYpH51k" +
+                "jviDRIZ3l5zsBLQ0pqwudemYXeI9sCkvwRGMn/qdgYHnM423krcw17njSVkvaAmYchU5Feo9a4tGU8YzRY+AOzKkwuDycpAlbk4/i" +
+                "jsIOKHEUOThjBopo33fXqFD3ktm/wSQPtXPFiPhWNSHxgjpfyEc2B3KI8tuOAdl+CLjQr5ITAV2OTlgHNZnAh0AuvaWpoV499/e5/" +
+                "pnyXfHhe8ysjO65YDAvNVpXQKCAQAWplxYIEhQcE51AqOXVwQNNNo6NHjBVNTkpcAtJC7gT5bmHkvQkEq9rI837rHgnzGC0jyQQ8" +
+                "tkL4gAQWDt+coJsyB2p5wypifyRz6Rh5uixOdEvSCBVEy1W4AsNo0fqD7UielOD6BojjJCilx4xHjGjQUntxyaOrsLC+EsRGiWOef" +
+                "TznTbEBplqiuH9kxoJts+xy9LVZmDS7TtsC98kOmkltOlXVNb6/xF1PYZ9j897buHOSXC8iTgdzEpbaiH7B5HSPh++1/et1SEMWs" +
+                "iMt7lU92vAhErDR8C2jCXMiT+J67ai51LKSLZuovjntnhA6Y8UoELxoi34u1DFuHvF9veA4IBBQACggEAK6IeZShhydDUM5XsOJ/V" +
+                "AYPOgrnLr30AfKWLR39+FJBunVMWNPpvO5D9dU7B6nmSiLATpwhBDNEhyJ0ltmBGuFDBAkKkqE4l6l2iVh+C1TyYliv1P2LCJFNgr" +
+                "AJxyr+5Q5zM9hUgfbT66xnwCf/4aiO7nBlj4wOL3l9ABVllYifMZyKVYFGluXmo+jyyeAcCtzHi5SABbTOQJN0WXTlGtzxLFQ0QErD" +
+                "GhP1/A6z5lw5VHJn2aWMeTCaH+rJZpQfM8b2VWr7UEljqFgpSIHbrImuXcf2nP6uZLKFiDdAjDUyj0h2jXwwcdhwWXuhOEv8XIilkc" +
+                "9nMcPLqbdcQ4M5agg==";
         byte[] encoded = Base64.getDecoder().decode(base64);
         KeyFactory keyFactory = KeyFactory.getInstance("DSA");
         X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encoded);

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -3,10 +3,6 @@ package io.quarkus.extest.deployment;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.interfaces.DSAPublicKey;
@@ -16,9 +12,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
-import io.quarkus.deployment.builditem.ObjectSubstitutionBuildItem;
-import io.quarkus.extest.runtime.subst.DSAPublicKeyObjectSubstitution;
-import io.quarkus.extest.runtime.subst.KeyProxy;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -30,10 +23,10 @@ import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.ObjectSubstitutionBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.extest.runtime.IConfigConsumer;
 import io.quarkus.extest.runtime.ObjectOfValue;
@@ -43,6 +36,8 @@ import io.quarkus.extest.runtime.TestBuildAndRunTimeConfig;
 import io.quarkus.extest.runtime.TestBuildTimeConfig;
 import io.quarkus.extest.runtime.TestRunTimeConfig;
 import io.quarkus.extest.runtime.TestTemplate;
+import io.quarkus.extest.runtime.subst.DSAPublicKeyObjectSubstitution;
+import io.quarkus.extest.runtime.subst.KeyProxy;
 
 /**
  * A test extension deployment processor

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -1,11 +1,24 @@
 package io.quarkus.extest.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.interfaces.DSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import io.quarkus.deployment.builditem.ObjectSubstitutionBuildItem;
+import io.quarkus.extest.runtime.subst.DSAPublicKeyObjectSubstitution;
+import io.quarkus.extest.runtime.subst.KeyProxy;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -65,7 +78,7 @@ public final class TestProcessor {
      * Validate the expected BUILD_TIME configuration
      */
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(STATIC_INIT)
     void checkConfig() {
         // Deployment time configuration	
         if (!buildTimeConfig.btSBV.getValue().equals("StringBasedValue")) {
@@ -154,6 +167,40 @@ public final class TestProcessor {
         }
     }
 
+    @BuildStep
+    @Record(STATIC_INIT)
+    PublicKeyBuildItem loadDSAPublicKey(TestTemplate template,
+                                        BuildProducer<ObjectSubstitutionBuildItem> substitutions) throws GeneralSecurityException {
+        String base64 = "MIIDQjCCAjUGByqGSM44BAEwggIoAoIBAQCPeTXZuarpv6vtiHrPSVG28y7FnjuvNxjo6sSWHz79NgbnQ1GpxBgzObg" +
+            "J58KuHFObp0dbhdARrbi0eYd1SYRpXKwOjxSzNggooi/6JxEKPWKpk0U0CaD+aWxGWPhL3SCBnDcJoBBXsZWtzQAjPbpUhLYpH51k" +
+            "jviDRIZ3l5zsBLQ0pqwudemYXeI9sCkvwRGMn/qdgYHnM423krcw17njSVkvaAmYchU5Feo9a4tGU8YzRY+AOzKkwuDycpAlbk4/i" +
+            "jsIOKHEUOThjBopo33fXqFD3ktm/wSQPtXPFiPhWNSHxgjpfyEc2B3KI8tuOAdl+CLjQr5ITAV2OTlgHNZnAh0AuvaWpoV499/e5/" +
+            "pnyXfHhe8ysjO65YDAvNVpXQKCAQAWplxYIEhQcE51AqOXVwQNNNo6NHjBVNTkpcAtJC7gT5bmHkvQkEq9rI837rHgnzGC0jyQQ8" +
+            "tkL4gAQWDt+coJsyB2p5wypifyRz6Rh5uixOdEvSCBVEy1W4AsNo0fqD7UielOD6BojjJCilx4xHjGjQUntxyaOrsLC+EsRGiWOef" +
+            "TznTbEBplqiuH9kxoJts+xy9LVZmDS7TtsC98kOmkltOlXVNb6/xF1PYZ9j897buHOSXC8iTgdzEpbaiH7B5HSPh++1/et1SEMWs" +
+            "iMt7lU92vAhErDR8C2jCXMiT+J67ai51LKSLZuovjntnhA6Y8UoELxoi34u1DFuHvF9veA4IBBQACggEAK6IeZShhydDUM5XsOJ/V" +
+            "AYPOgrnLr30AfKWLR39+FJBunVMWNPpvO5D9dU7B6nmSiLATpwhBDNEhyJ0ltmBGuFDBAkKkqE4l6l2iVh+C1TyYliv1P2LCJFNgr" +
+            "AJxyr+5Q5zM9hUgfbT66xnwCf/4aiO7nBlj4wOL3l9ABVllYifMZyKVYFGluXmo+jyyeAcCtzHi5SABbTOQJN0WXTlGtzxLFQ0QErD" +
+            "GhP1/A6z5lw5VHJn2aWMeTCaH+rJZpQfM8b2VWr7UEljqFgpSIHbrImuXcf2nP6uZLKFiDdAjDUyj0h2jXwwcdhwWXuhOEv8XIilkc" +
+            "9nMcPLqbdcQ4M5agg==";
+        byte[] encoded = Base64.getDecoder().decode(base64);
+        KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encoded);
+        DSAPublicKey publicKey = (DSAPublicKey) keyFactory.generatePublic(publicKeySpec);
+        ObjectSubstitutionBuildItem.Holder<DSAPublicKey, KeyProxy> holder = new ObjectSubstitutionBuildItem.Holder(
+                DSAPublicKey.class, KeyProxy.class, DSAPublicKeyObjectSubstitution.class);
+        ObjectSubstitutionBuildItem keysub = new ObjectSubstitutionBuildItem(holder);
+        substitutions.produce(keysub);
+        log.infof("loadDSAPublicKey run");
+        return new PublicKeyBuildItem(publicKey);
+    }
+
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    void loadDSAPublicKeyProducer(TestTemplate template, PublicKeyBuildItem publicKey, BeanContainerBuildItem beanContainer) {
+        template.loadDSAPublicKeyProducer(publicKey.getPublicKey(), beanContainer.getValue());
+    }
+
     /**
      * Collect the beans with our custom bean defining annotation and configure them with the runtime config
      *
@@ -162,7 +209,7 @@ public final class TestProcessor {
      * @param testBeanProducer - producer for located Class<IConfigConsumer> bean types
      */
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(STATIC_INIT)
     void scanForBeans(TestTemplate template, BeanArchiveIndexBuildItem beanArchiveIndex,
             BuildProducer<TestBeanBuildItem> testBeanProducer) {
         IndexView indexView = beanArchiveIndex.getIndex();

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/TestTemplate.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/TestTemplate.java
@@ -1,5 +1,6 @@
 package io.quarkus.extest.runtime;
 
+import java.security.interfaces.DSAPublicKey;
 import java.util.Set;
 
 import org.jboss.logging.Logger;
@@ -31,6 +32,10 @@ public class TestTemplate {
         IConfigConsumer instance = beanContainer.instance(beanClass);
         instance.loadConfig(buildTimeConfig, runTimeConfig);
         log.infof("configureBeans, instance=%s\n", instance);
+    }
+
+    public void loadDSAPublicKeyProducer(DSAPublicKey publicKey, BeanContainer value) {
+        publicKey.getAlgorithm();
     }
 
     /**

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/subst/DSAPublicKeyObjectSubstitution.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/subst/DSAPublicKeyObjectSubstitution.java
@@ -1,0 +1,40 @@
+package io.quarkus.extest.runtime.subst;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.DSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+
+import io.quarkus.runtime.ObjectSubstitution;
+
+/**
+ * Example ObjectSubstitution for DSA public key substitution
+ * The DSA key provider is the SUN provider enabled by default in Graal
+ */
+public class DSAPublicKeyObjectSubstitution implements ObjectSubstitution<DSAPublicKey, KeyProxy> {
+    @Override
+    public KeyProxy serialize(DSAPublicKey obj) {
+        System.out.printf("DSAPublicKeyObjectSubstitution.serialize\n");
+        byte[] encoded = obj.getEncoded();
+        KeyProxy proxy = new KeyProxy();
+        proxy.setContent(encoded);
+        return proxy;
+    }
+
+    @Override
+    public DSAPublicKey deserialize(KeyProxy obj) {
+        System.out.printf("DSAPublicKeyObjectSubstitution.deserialize\n");
+        byte[] encoded = obj.getContent();
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encoded);
+        DSAPublicKey dsaPublicKey = null;
+        try {
+            KeyFactory kf = KeyFactory.getInstance("DSA");
+            dsaPublicKey = (DSAPublicKey) kf.generatePublic(publicKeySpec);
+
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            e.printStackTrace();
+        }
+        return dsaPublicKey;
+    }
+}

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/subst/KeyProxy.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/subst/KeyProxy.java
@@ -1,0 +1,14 @@
+package io.quarkus.extest.runtime.subst;
+
+public class KeyProxy {
+    private byte[] content;
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
+
+}


### PR DESCRIPTION
Fixes #1663 by adding substitution registration on MainBytecodeRecorderBuildItems in the MainClassBuildStep.