### PR TITLE
Avoid wrapping runtime exceptions between interceptors in some cases

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Reflections.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Reflections.java
@@ -109,8 +109,13 @@ public final class Reflections {
                 method.setAccessible(true);
             }
             return method.invoke(instance, args);
-        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException
-                | InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
+            Throwable t = e.getTargetException();
+            if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+            }
+            throw new RuntimeException("Cannot invoke method: " + clazz.getName() + "#" + name + " on " + instance, e);
+        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
             throw new RuntimeException("Cannot invoke method: " + clazz.getName() + "#" + name + " on " + instance, e);
         }
     }

--- a/integration-tests/main/src/main/java/io/quarkus/example/metrics/MetricsResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/example/metrics/MetricsResource.java
@@ -18,6 +18,7 @@ package io.quarkus.example.metrics;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 
 import org.eclipse.microprofile.metrics.Histogram;
@@ -82,6 +83,13 @@ public class MetricsResource {
     @Counted(monotonic = true, name = "counter_with_tags", tags = "foo=bar")
     public String counterWithTags() {
         return "TEST";
+    }
+
+    @GET
+    @Path("/counter-throwing-not-found-exception")
+    @Counted(monotonic = true, name = "counter_404")
+    public String counterWithTagsThrowingNotFound() {
+        throw new NotFoundException();
     }
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/example/test/MetricsTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/example/test/MetricsTestCase.java
@@ -138,6 +138,15 @@ public class MetricsTestCase {
                 .body(containsString("vendor:memory_max_non_heap_bytes "));
     }
 
+    /**
+     * A REST method with metrics is throwing a NotFoundException, so the client should receive 404.
+     */
+    @Test
+    public void testEndpointWithMetricsThrowingException() {
+        RestAssured.when().get("/metricsresource/counter-throwing-not-found-exception").then()
+                .statusCode(404);
+    }
+
     private void assertMetricExactValue(String name, String val) {
         RestAssured.when().get("/metrics").then()
                 .body(containsString(name + " " + val));


### PR DESCRIPTION
Fixes #1668 