### PR TITLE
Introduce ApplicationConfig

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
@@ -56,6 +56,7 @@ import io.quarkus.creator.config.reader.MappedPropertiesHandler;
 import io.quarkus.creator.config.reader.PropertiesHandler;
 import io.quarkus.creator.outcome.OutcomeProviderRegistration;
 import io.quarkus.creator.phase.curate.CurateOutcome;
+import io.quarkus.deployment.ApplicationInfoUtil;
 import io.quarkus.deployment.ClassOutput;
 import io.quarkus.deployment.QuarkusAugmentor;
 import io.quarkus.deployment.QuarkusClassWriter;
@@ -74,6 +75,8 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutcome {
 
     private static final Logger log = Logger.getLogger(AugmentPhase.class);
+    private static final String APPLICATION_INFO_PROPERTIES = "application-info.properties";
+    private static final String META_INF = "META-INF";
 
     private Path outputDir;
     private Path appClassesDir;
@@ -182,11 +185,14 @@ public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutc
             } catch (IOException e) {
                 throw new AppCreatorException("Failed to unzip " + appJar, e);
             }
-            final Path metaInf = appClassesDir.resolve("META-INF");
+            final Path metaInf = appClassesDir.resolve(META_INF);
             IoUtils.recursiveDelete(metaInf.resolve("maven"));
             IoUtils.recursiveDelete(metaInf.resolve("INDEX.LIST"));
             IoUtils.recursiveDelete(metaInf.resolve("MANIFEST.MF"));
+            IoUtils.recursiveDelete(metaInf.resolve(APPLICATION_INFO_PROPERTIES));
         }
+
+        ApplicationInfoUtil.writeApplicationInfoProperties(appState.getAppArtifact(), appClassesDir);
 
         //lets default to appClassesDir for now
         if (configDir == null)

--- a/core/deployment/src/main/java/io/quarkus/deployment/ApplicationConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ApplicationConfig.java
@@ -1,0 +1,23 @@
+package io.quarkus.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public class ApplicationConfig {
+
+    /**
+     * The name of the application.
+     * If not set, defaults to the name of the project.
+     */
+    @ConfigItem
+    public String name;
+
+    /**
+     * The version of the application.
+     * If not set, defaults to the version of the project
+     */
+    @ConfigItem
+    public String version;
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/ApplicationInfoUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ApplicationInfoUtil.java
@@ -1,0 +1,32 @@
+package io.quarkus.deployment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+
+public final class ApplicationInfoUtil {
+
+    public static final String APPLICATION_INFO_PROPERTIES = "application-info.properties";
+    public static final String META_INF = "META-INF";
+
+    private ApplicationInfoUtil() {
+    }
+
+    // these properties are used as default values for ApplicationInfoBuildItem
+    public static void writeApplicationInfoProperties(AppArtifact appArtifact, Path appClassesDir) {
+        Properties properties = new Properties();
+        properties.setProperty("artifactId", appArtifact.getArtifactId());
+        properties.setProperty("version", appArtifact.getVersion());
+        try {
+            appClassesDir.resolve(META_INF).toFile().mkdir();
+            File file = appClassesDir.resolve(META_INF).resolve(APPLICATION_INFO_PROPERTIES).toFile();
+            properties.store(new FileOutputStream(file), "Generated file; do not edit manually");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.deployment.builditem;
+
+import org.jboss.builder.item.SimpleBuildItem;
+
+public final class ApplicationInfoBuildItem extends SimpleBuildItem {
+
+    private final String name;
+    private final String version;
+
+    public ApplicationInfoBuildItem(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ApplicationInfoBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ApplicationInfoBuildStep.java
@@ -1,0 +1,66 @@
+package io.quarkus.deployment.steps;
+
+import static io.quarkus.deployment.ApplicationInfoUtil.APPLICATION_INFO_PROPERTIES;
+import static io.quarkus.deployment.ApplicationInfoUtil.META_INF;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import io.quarkus.deployment.ApplicationConfig;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
+
+public class ApplicationInfoBuildStep {
+
+    private static final String PROPERTIES_FILE_TO_READ = META_INF + File.separator + APPLICATION_INFO_PROPERTIES;
+
+    private static final String ARTIFACT_ID_KEY = "artifactId";
+    private static final String VERSION_KEY = "version";
+    private static final String UNSET_VALUE = "unset";
+
+    @BuildStep
+    public ApplicationInfoBuildItem create(ApplicationConfig applicationConfig) {
+        final String userConfiguredName = applicationConfig.name;
+        final String userConfiguredVersion = applicationConfig.version;
+
+        final Properties applicationInfoProperties = getApplicationInfoProperties();
+
+        return new ApplicationInfoBuildItem(
+                useIfNotEmpty(userConfiguredName, applicationInfoProperties.getProperty(ARTIFACT_ID_KEY, UNSET_VALUE)),
+                useIfNotEmpty(userConfiguredVersion, applicationInfoProperties.getProperty(VERSION_KEY, UNSET_VALUE)));
+    }
+
+    private Properties getApplicationInfoProperties() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = ApplicationInfoBuildStep.class.getClassLoader();
+        }
+        try {
+            final Properties p = new Properties();
+            // work around #1477
+            final Enumeration<URL> resources = cl == null ? ClassLoader.getSystemResources(PROPERTIES_FILE_TO_READ)
+                    : cl.getResources(PROPERTIES_FILE_TO_READ);
+            if (resources.hasMoreElements()) {
+                final URL url = resources.nextElement();
+                try (InputStream is = url.openStream()) {
+                    try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+                        p.load(isr);
+                    }
+                }
+            }
+            return p;
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read application-info.properties", e);
+        }
+    }
+
+    private String useIfNotEmpty(String value, String defaultValue) {
+        return (value != null) && !value.isEmpty() ? value : defaultValue;
+    }
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -43,6 +43,7 @@ import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.deployment.ApplicationInfoUtil;
 import io.quarkus.dev.ClassLoaderCompiler;
 import io.quarkus.dev.DevModeMain;
 import io.quarkus.gradle.QuarkusPluginExtension;
@@ -267,6 +268,7 @@ public class QuarkusDev extends QuarkusTask {
             }
 
             extension.outputDirectory().mkdirs();
+            ApplicationInfoUtil.writeApplicationInfoProperties(appModel.getAppArtifact(), extension.outputDirectory().toPath());
 
             args.add("-Dquarkus-internal.runner.classes=" + extension.outputDirectory().getAbsolutePath());
             args.add("-Dquarkus-internal.runner.sources=" + getSourceDir().getAbsolutePath());

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -58,6 +58,7 @@ import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.deployment.ApplicationInfoUtil;
 import io.quarkus.dev.ClassLoaderCompiler;
 import io.quarkus.dev.DevModeMain;
 import io.quarkus.maven.components.MavenVersionEnforcer;
@@ -327,6 +328,7 @@ public class DevMojo extends AbstractMojo {
             }
 
             outputDirectory.mkdirs();
+            ApplicationInfoUtil.writeApplicationInfoProperties(appModel.getAppArtifact(), outputDirectory.toPath());
 
             args.add("-Dquarkus-internal.runner.classes=" + outputDirectory.getAbsolutePath());
             args.add("-Dquarkus-internal.runner.sources=" + sourceDir.getAbsolutePath());


### PR DESCRIPTION
This allows users to set a desired name for the applications
(using quarkus.application.name) or version.
The idea came from:

https://github.com/quarkusio/quarkus/pull/1300#discussion_r268617341

and this configuration is meant to be used by extensions that for some
reason need this information (like the planned kubernetes extension, where we need to inject something like `ApplicationConfig` in the processor)

**Implementation notes**:

I am not really sure if this is the simplest solution - it kind of seems like I went overboard...

The idea is to inject an `ApplicationInfoBuildItem` that has the default values, use that in `ConfigurationSetup#initializeConfiguration` to create a new `ConfigSource` with the default values.
This new source has a lower ordinal that the `application.properties` source and thus if values are set there (or in any of the sources with even higher ordinal), those values will be used.

If there is a simpler solution for creating the `ApplicationConfig` and populating it from with the values from the build, I'd love to hear it and implement it :)