### PR TITLE
Add quarkus-caffeine as a dependency of quarkus-camel-core

### DIFF
--- a/extensions/camel/camel-core/deployment/pom.xml
+++ b/extensions/camel/camel-core/deployment/pom.xml
@@ -1,56 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <artifactId>quarkus-camel-core-parent</artifactId>
-    <groupId>io.quarkus</groupId>
-    <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
-
-  <artifactId>quarkus-camel-core-deployment</artifactId>
-  <name>Quarkus - Camel - Core - Deployment</name>
-
-  <dependencies>
-
-    <!-- quarkus -->
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-core-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-arc-deployment</artifactId>
-    </dependency>
-
-    <!-- camel -->
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-camel-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jaxb-deployment</artifactId>
-    </dependency>
-
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>io.quarkus</groupId>
-              <artifactId>quarkus-extension-processor</artifactId>
-              <version>${project.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-camel-core-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>quarkus-camel-core-deployment</artifactId>
+    <name>Quarkus - Camel - Core - Deployment</name>
+    <dependencies>
+        <!-- quarkus -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <!-- camel -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb-deployment</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/extensions/camel/camel-core/deployment/pom.xml
+++ b/extensions/camel/camel-core/deployment/pom.xml
@@ -30,6 +30,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-caffeine-deployment</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/camel/camel-core/runtime/pom.xml
+++ b/extensions/camel/camel-core/runtime/pom.xml
@@ -48,6 +48,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-caffeine</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/camel/camel-core/runtime/pom.xml
+++ b/extensions/camel/camel-core/runtime/pom.xml
@@ -44,7 +44,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/camel-aws-s3/pom.xml
+++ b/integration-tests/camel-aws-s3/pom.xml
@@ -38,11 +38,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-caffeine</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logging</artifactId>
             <version>1.1.0.Final</version>


### PR DESCRIPTION
This issue is hidden by the fact that the main Camel test is in the main IT. It was reported by a user trying to play with camel-core.

I had to reformat one of the pom but I did it in a separate commit.

Fixes #1670.