### PR TITLE
No longer enable the JBoss Nexus repository

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -41,11 +41,6 @@ plugins {
 
 repositories {
     mavenCentral()
-
-    // this is temporary, all dependencies should be in central soon
-    maven {
-        url = 'http://repository.jboss.org/nexus/content/groups/public'
-    }
 }
 
 dependencies { <2>
@@ -68,9 +63,6 @@ plugins {
 
 repositories {
     mavenCentral()
-
-    // this is temporary, all dependencies should be in central soon
-    maven(url = uri("http://repository.jboss.org/nexus/content/groups/public"))
 }
 
 dependencies {

--- a/pom.xml
+++ b/pom.xml
@@ -87,17 +87,7 @@
             <name>Maven Repository Switchboard</name>
             <url>http://repo.maven.apache.org/maven2</url>
         </repository>
-        <repository>
-            <id>jboss</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+   </repositories>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION

We no longer require the JBoss Nexus repository in the main project, so let's make this permanent.

Technically it's still creeping in via:

- maven compiler plugin defined in the jboss-parent - but this limits the scope to our build plugins - see https://issues.apache.org/jira/browse/MCOMPILER-320
- some of the "independent projects" still declare it - see #1685

But these have very limited scope, so removing the main one already would be a good step to avoid regressions such as introducing a dependency which would require this repo to be enabled for end users.