### PR TITLE
Fix for #1376

### DIFF
--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/example/panache/Address.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/example/panache/Address.java
@@ -25,6 +25,9 @@ public class Address extends PanacheEntity {
 
     public String street;
 
+    public Address() {
+    }
+
     public Address(String street) {
         this.street = street;
     }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/example/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/example/panache/TestEndpoint.java
@@ -29,6 +29,7 @@ import javax.transaction.Transactional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
@@ -698,5 +699,56 @@ public class TestEndpoint {
             throws NoSuchMethodException, SecurityException {
         Method method = klass.getMethod(name, params);
         Assertions.assertEquals(returnType, method.getReturnType());
+    }
+
+    @GET
+    @Path("model1")
+    @Transactional
+    public String testModel1() {
+        Assertions.assertEquals(0, Person.count());
+
+        Person person = makeSavedPerson();
+        SelfDirtinessTracker trackingPerson = (SelfDirtinessTracker) person;
+
+        String[] dirtyAttributes = trackingPerson.$$_hibernate_getDirtyAttributes();
+        Assertions.assertEquals(0, dirtyAttributes.length);
+
+        person.name = "1";
+
+        dirtyAttributes = trackingPerson.$$_hibernate_getDirtyAttributes();
+        Assertions.assertEquals(1, dirtyAttributes.length);
+
+        Assertions.assertEquals(1, Person.count());
+        return "OK";
+    }
+
+    @GET
+    @Path("model2")
+    @Transactional
+    public String testModel2() {
+        Assertions.assertEquals(1, Person.count());
+
+        Person person = Person.findAll().firstResult();
+        Assertions.assertEquals("1", person.name);
+
+        person.name = "2";
+        return "OK";
+    }
+
+    @GET
+    @Path("model3")
+    @Transactional
+    public String testModel3() {
+        Assertions.assertEquals(1, Person.count());
+
+        Person person = Person.findAll().firstResult();
+        Assertions.assertEquals("2", person.name);
+
+        Dog.deleteAll();
+        Person.deleteAll();
+        Address.deleteAll();
+        Assertions.assertEquals(0, Person.count());
+
+        return "OK";
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/example/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/example/panache/TestEndpoint.java
@@ -272,7 +272,6 @@ public class TestEndpoint {
         Dog dog = new Dog("octave", "dalmatian");
         dog.owner = person;
         dog.persist();
-        person.dogs.add(dog);
 
         return person;
     }
@@ -555,7 +554,6 @@ public class TestEndpoint {
         Dog dog = new Dog("octave", "dalmatian");
         dog.owner = person;
         dogDao.persist(dog);
-        person.dogs.add(dog);
 
         return person;
     }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/example/test/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/example/test/PanacheFunctionalityTest.java
@@ -34,6 +34,10 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/model-dao").then().body(is("OK"));
         RestAssured.when().get("/test/model").then().body(is("OK"));
         RestAssured.when().get("/test/accessors").then().body(is("OK"));
+
+        RestAssured.when().get("/test/model1").then().body(is("OK"));
+        RestAssured.when().get("/test/model2").then().body(is("OK"));
+        RestAssured.when().get("/test/model3").then().body(is("OK"));
     }
 
 }


### PR DESCRIPTION
Generate calls to Hibernare read/write methods in the generated accessors because the Hibernate enhancer does not actually use the `byte[]` class we're passing it for reflection.