### PR TITLE
Explicitly state that the guides are maintained in the main repository

### DIFF
--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 
 = {project-name} - Configuring Your Application

--- a/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
+++ b/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Application Initialization and Termination
 

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Building a Native Executable
 

--- a/docs/src/main/asciidoc/building-substrate-howto.adoc
+++ b/docs/src/main/asciidoc/building-substrate-howto.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Building a Custom SubstrateVM
 

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Contexts and Dependency Injection
 

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = Building {project-name} apps with {project-name} Command Line Interface (CLI)
 

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Writing Your Own Extension
 

--- a/docs/src/main/asciidoc/fault-tolerance-guide.adoc
+++ b/docs/src/main/asciidoc/fault-tolerance-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Fault Tolerance
 

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Creating Your First Application
 

--- a/docs/src/main/asciidoc/getting-started-knative-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-knative-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 :experimental:
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Testing Your Application
 

--- a/docs/src/main/asciidoc/gradle-config.adoc
+++ b/docs/src/main/asciidoc/gradle-config.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Gradle Plugin Repositories
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = Building {project-name} apps with Gradle
 

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - MicroProfile Health
 

--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using Hibernate ORM and JPA
 :config-file: application.properties

--- a/docs/src/main/asciidoc/hibernate-orm-panache-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Simplified Hibernate ORM with Panache
 :config-file: application.properties

--- a/docs/src/main/asciidoc/infinispan-client-guide.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Infinispan Client
 

--- a/docs/src/main/asciidoc/jwt-guide.adoc
+++ b/docs/src/main/asciidoc/jwt-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using JWT RBAC
 :extension-name: Smallrye JWT

--- a/docs/src/main/asciidoc/kafka-guide.adoc
+++ b/docs/src/main/asciidoc/kafka-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using Apache Kafka with Reactive Messaging
 

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using Kotlin
 

--- a/docs/src/main/asciidoc/kubernetes-guide.adoc
+++ b/docs/src/main/asciidoc/kubernetes-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Deploying on Kubernetes and OpenShift
 

--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Configuring Logging
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = Building {project-name} apps with Maven
 

--- a/docs/src/main/asciidoc/metrics-guide.adoc
+++ b/docs/src/main/asciidoc/metrics-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - MicroProfile Metrics
 

--- a/docs/src/main/asciidoc/native-and-ssl-guide.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = Quarkus - Using SSL With Native Executables
 

--- a/docs/src/main/asciidoc/opentracing-guide.adoc
+++ b/docs/src/main/asciidoc/opentracing-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using OpenTracing
 

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Measuring Performance
 

--- a/docs/src/main/asciidoc/rest-client-guide.adoc
+++ b/docs/src/main/asciidoc/rest-client-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using the REST Client
 

--- a/docs/src/main/asciidoc/rest-json-guide.adoc
+++ b/docs/src/main/asciidoc/rest-json-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = Quarkus - Writing JSON REST Services
 

--- a/docs/src/main/asciidoc/scheduled-guide.adoc
+++ b/docs/src/main/asciidoc/scheduled-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Scheduling Periodic Tasks
 

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using Security
 

--- a/docs/src/main/asciidoc/spring-di-guide.adoc
+++ b/docs/src/main/asciidoc/spring-di-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using our Spring Dependency Injection compatibility layer
 

--- a/docs/src/main/asciidoc/tooling.adoc
+++ b/docs/src/main/asciidoc/tooling.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using our Tooling
 

--- a/docs/src/main/asciidoc/transaction-guide.adoc
+++ b/docs/src/main/asciidoc/transaction-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = Using Transactions in Quarkus
 

--- a/docs/src/main/asciidoc/validation-guide.adoc
+++ b/docs/src/main/asciidoc/validation-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Validation with Hibernate Validator
 

--- a/docs/src/main/asciidoc/websocket-guide.adoc
+++ b/docs/src/main/asciidoc/websocket-guide.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Using WebSockets
 

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -1,3 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
 include::./attributes.adoc[]
 = {project-name} - Tips for writing native applications
 


### PR DESCRIPTION
OK, this is not the most glorious PR but maybe it will help reducing the number of people contributing fixes to the guides in the website project.