### PR TITLE
Rename the Gradle plugin to io.quarkus

### DIFF
--- a/devtools/gradle-it/build.gradle
+++ b/devtools/gradle-it/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-apply plugin: 'io.quarkus.gradle.plugin'
+apply plugin: 'io.quarkus'
 
 buildscript {
     repositories {

--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -1,23 +1,18 @@
 plugins {
-    id 'java'
+    id 'com.gradle.build-scan' version '2.2.1'
+    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'java-gradle-plugin'
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
+    jcenter()
 }
 
 dependencies {
-    compile localGroovy()
-    compile gradleApi()
     compile fileTree(dir: 'target/dependencies/compile', include: '*.jar')
-    testCompile gradleTestKit()
     testCompile fileTree(dir: 'target/dependencies/test', include: '*.jar')
-}
-
-jar {
-    manifest {
-        attributes 'Implementation-Version': (version ? version : 'unknown')
-    }
 }
 
 test {
@@ -42,3 +37,23 @@ artifacts {
     archives javadocJar
 }
 
+gradlePlugin {
+    plugins {
+        simplePlugin {
+            id = 'io.quarkus'
+            implementationClass = 'io.quarkus.gradle.QuarkusPlugin'
+            displayName = 'Quarkus Plugin'
+            description = 'Builds a Quarkus application, and provides helpers to launch dev-mode, the Quarkus CLI, building of native images'
+        }
+    }
+}
+
+buildScan {
+    //See also: https://docs.gradle.com/build-scan-plugin/
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service';
+    termsOfServiceAgree = 'yes'
+}
+
+//To publish properly in the future:
+//name='quarkus-gradle-plugin'
+//groupId='io.quarkus'

--- a/devtools/gradle/src/main/resources/META-INF/gradle-plugins/io.quarkus.gradle.plugin.properties
+++ b/devtools/gradle/src/main/resources/META-INF/gradle-plugins/io.quarkus.gradle.plugin.properties
@@ -1,1 +1,0 @@
-implementation-class=io.quarkus.gradle.QuarkusPlugin

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -12,9 +12,9 @@ public class QuarkusPluginTest {
     @Test
     public void shouldCreateTasks() {
         Project project = ProjectBuilder.builder().build();
-        project.getPluginManager().apply("io.quarkus.gradle.plugin");
+        project.getPluginManager().apply("io.quarkus");
 
-        assertTrue(project.getPluginManager().hasPlugin("io.quarkus.gradle.plugin"));
+        assertTrue(project.getPluginManager().hasPlugin("io.quarkus"));
 
         TaskContainer tasks = project.getTasks();
         assertNotNull(tasks.getByName("quarkusBuild"));
@@ -27,7 +27,7 @@ public class QuarkusPluginTest {
     @Test
     public void shouldMakeAssembleDependOnQuarkusBuild() {
         Project project = ProjectBuilder.builder().build();
-        project.getPluginManager().apply("io.quarkus.gradle.plugin");
+        project.getPluginManager().apply("io.quarkus");
         project.getPluginManager().apply("base");
 
         TaskContainer tasks = project.getTasks();
@@ -38,7 +38,7 @@ public class QuarkusPluginTest {
     @Test
     public void shouldMakeQuarkusDevAndQuarkusBuildDependOnClassesTask() {
         Project project = ProjectBuilder.builder().build();
-        project.getPluginManager().apply("io.quarkus.gradle.plugin");
+        project.getPluginManager().apply("io.quarkus");
         project.getPluginManager().apply("java");
 
         TaskContainer tasks = project.getTasks();

--- a/docs/src/main/asciidoc/gradle-config.adoc
+++ b/docs/src/main/asciidoc/gradle-config.adoc
@@ -13,7 +13,7 @@ pluginManagement {
     }
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.id == 'io.quarkus.gradle.plugin') {
+            if (requested.id.id == 'io.quarkus') {
                 useModule("io.quarkus:quarkus-gradle-plugin:${requested.version}")
             }
         }
@@ -31,7 +31,7 @@ pluginManagement {
     }
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.id == "io.quarkus.gradle.plugin") {
+            if (requested.id.id == "io.quarkus") {
                 useModule("io.quarkus:quarkus-gradle-plugin:${requested.version}")
             }
         }

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -12,7 +12,7 @@ luckily setting up a {project-name} project with Gradle is very simple. You only
 ----
 plugins {
     id 'java'
-    id 'io.quarkus.gradle.plugin' version '{quarkus-version}'
+    id 'io.quarkus' version '{quarkus-version}'
 }
 ----
 
@@ -22,7 +22,7 @@ or, if you use the Gradle Kotlin DSL:
 ----
 plugins {
     java
-    id("io.quarkus.gradle.plugin") version "{quarkus-version}"
+    id("io.quarkus") version "{quarkus-version}"
 }
 ----
 
@@ -36,7 +36,7 @@ Here is a complete sample file for a simple REST project:
 ----
 plugins {
     id 'java'
-    id 'io.quarkus.gradle.plugin' version '{quarkus-version}' <1>
+    id 'io.quarkus.' version '{quarkus-version}' <1>
 }
 
 repositories {
@@ -58,7 +58,7 @@ Here's the same build script, using the Gradle Kotlin DSL:
 ----
 plugins {
     java
-    id("io.quarkus.gradle.plugin") version "{quarkus-version}"
+    id("io.quarkus") version "{quarkus-version}"
 }
 
 repositories {


### PR DESCRIPTION

while at it, flipped the build to use the `java-gradle-plugin` which simplifies creation (and validation!) of the plugin metadata, and enabled the build scanner - also useful to identify further issues.