### PR TITLE
Minor cleanup after the bootstrap PR

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -675,6 +675,7 @@
                             <goals>
                                 <goal>extension-descriptor</goal>
                             </goals>
+                            <phase>compile</phase>
                             <configuration>
                                 <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
                             </configuration>

--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -233,9 +233,6 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
         final List<AppDependency> appDeps = curateOutcome.getEffectiveModel().getUserDependencies();
         for (AppDependency appDep : appDeps) {
             final AppArtifact depArtifact = appDep.getArtifact();
-            if (depArtifact.getArtifactId().equals("svm") && depArtifact.getGroupId().equals("com.oracle.substratevm")) {
-                throw new IllegalStateException("Dependency on com.oracle.substratevm:svm");
-            }
             final Path resolvedDep = depResolver.resolve(depArtifact);
             if (uberJar) {
                 try (FileSystem artifactFs = ZipUtils.newFileSystem(resolvedDep)) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
@@ -226,7 +226,7 @@ public class BootstrapClassLoaderFactory {
                         writer.newLine();
                     }
                 }
-                debug("Deployment classloader cached for ", localProject.getAppArtifact());
+                debug("Deployment classloader cached for %s", localProject.getAppArtifact());
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
- configured the phase bootstrap-maven-plugin extension-descriptor goal to avoid an error on mvn clean (reported by @kenfinnigan)
- don't throw an exception in case SVM appears among the dependencies;
- bootstrap logging formatting fix.