### PR TITLE
Fire Initialized/BeforeDestroyed/Destroyed events for request context

### DIFF
--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/requestcontext/ContextObserver.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/requestcontext/ContextObserver.java
@@ -1,0 +1,34 @@
+package io.quarkus.arc.test.requestcontext;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.context.Destroyed;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class ContextObserver {
+
+    public static int initializedObserved = 0;
+    public static int beforeDestroyedObserved = 0;
+    public static int destroyedObserved = 0;
+
+    public static void reset() {
+        initializedObserved = 0;
+        beforeDestroyedObserved = 0;
+        destroyedObserved = 0;
+    }
+
+    public void observeContextInit(@Observes @Initialized(RequestScoped.class) Object event) {
+        initializedObserved++;
+    }
+
+    public void observeContextBeforeDestroyed(@Observes @BeforeDestroyed(RequestScoped.class) Object event) {
+        beforeDestroyedObserved++;
+    }
+
+    public void observeContextDestroyed(@Observes @Destroyed(RequestScoped.class) Object event) {
+        destroyedObserved++;
+    }
+}


### PR DESCRIPTION
If I am not mistaken then you can handle context activation manually, via interceptor and via controller bean. All of these should be incorporated and tested in this PR. Feedback and nagging are welcome ;-)