### PR TITLE
Add Emitter support to Reactive Messaging

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,9 +51,9 @@
         <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>1.1.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>1.1.1</smallrye-jwt.version>
-        <smallrye-reactive-streams-operators.version>1.0.2</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.0.1</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>0.0.4</smallrye-reactive-messaging.version>
+        <smallrye-reactive-streams-operators.version>1.0.3</smallrye-reactive-streams-operators.version>
+        <smallrye-converter-api.version>1.0.3</smallrye-converter-api.version>
+        <smallrye-reactive-messaging.version>0.0.5</smallrye-reactive-messaging.version>
         <smallrye-rest-client.version>1.2.2</smallrye-rest-client.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         <javax.inject.version>1</javax.inject.version>
@@ -94,7 +94,7 @@
         <agroal.version>1.4</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
-        <rxjava.version>2.2.7</rxjava.version>
+        <rxjava.version>2.2.8</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
         <log4j.version>1.2.17</log4j.version>
@@ -127,7 +127,7 @@
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <test-containers.version>1.10.7</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <axle-client.version>0.0.2</axle-client.version>
+        <axle-client.version>0.0.3</axle-client.version>
         <kafka-clients.version>1.1.0</kafka-clients.version>
         <kafka2.version>1.1.0</kafka2.version>
         <debezium.version>0.9.2.Final</debezium.version>
@@ -1572,20 +1572,10 @@
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-streams-operators</artifactId>
                 <version>${smallrye-reactive-streams-operators.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-converter-api</artifactId>
+                <artifactId>smallrye-reactive-converter-api</artifactId>
                 <version>${smallrye-converter-api.version}</version>
             </dependency>
 

--- a/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/pom.xml
@@ -31,7 +31,7 @@
     <dependencies>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-converter-api</artifactId>
+            <artifactId>smallrye-reactive-converter-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-provider</artifactId>
             <exclusions>

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -51,7 +51,7 @@ import io.quarkus.smallrye.reactivemessaging.runtime.SmallRyeReactiveMessagingTe
  */
 public class SmallRyeReactiveMessagingProcessor {
 
-    private static final Logger LOGGER = Logger.getLogger("io.quarkus.scheduler.deployment.processor");
+    private static final Logger LOGGER = Logger.getLogger("io.quarkus.smallrye-reactive-messaging.deployment.processor");
 
     static final DotName NAME_INCOMING = DotName.createSimple(Incoming.class.getName());
     static final DotName NAME_OUTGOING = DotName.createSimple(Outgoing.class.getName());

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SimpleTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SimpleTest.java
@@ -19,10 +19,13 @@ public class SimpleTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(SimpleBean.class, StreamConsumer.class));
+                    .addClasses(SimpleBean.class, StreamConsumer.class, StreamEmitter.class));
 
     @Inject
     StreamConsumer streamConsumer;
+
+    @Inject
+    StreamEmitter streamEmitter;
 
     @Test
     public void testSimpleBean() {
@@ -42,5 +45,15 @@ public class SimpleTest {
         assertEquals("SmallRye", consumed.get(2));
         assertEquals("reactive", consumed.get(3));
         assertEquals("message", consumed.get(4));
+    }
+
+    @Test
+    public void testStreamEmitter() {
+        streamEmitter.run();
+        List<String> list = streamEmitter.list();
+        assertEquals(3, list.size());
+        assertEquals("a", list.get(0));
+        assertEquals("b", list.get(1));
+        assertEquals("c", list.get(2));
     }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/StreamConsumer.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/StreamConsumer.java
@@ -15,7 +15,7 @@ public class StreamConsumer {
 
     @Inject
     @Stream("source")
-    private Flowable<Message<String>> sourceStream;
+    Flowable<Message<String>> sourceStream;
 
     public List<String> consume() {
         return Flowable.fromPublisher(sourceStream)

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/StreamEmitter.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/StreamEmitter.java
@@ -1,0 +1,36 @@
+package io.quarkus.smallrye.reactivemessaging;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.annotations.Emitter;
+import io.smallrye.reactive.messaging.annotations.Stream;
+
+@ApplicationScoped
+public class StreamEmitter {
+
+    @Inject
+    @Stream("sink")
+    Emitter<String> emitter;
+
+    private List<String> list = new CopyOnWriteArrayList<>();
+
+    public void run() {
+        emitter.send("a").send("b").send("c").complete();
+    }
+
+    @Incoming("sink")
+    public void consume(String s) {
+        list.add(s);
+    }
+
+    public List<String> list() {
+        return list;
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/SmallRyeReactiveMessagingLifecycle.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/SmallRyeReactiveMessagingLifecycle.java
@@ -1,8 +1,5 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -17,12 +14,9 @@ public class SmallRyeReactiveMessagingLifecycle {
     MediatorManager mediatorManager;
 
     void onApplicationStart(@Observes StartupEvent event) {
-        CompletableFuture<Void> future = mediatorManager.initializeAndRun();
         try {
-            future.get();
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        } catch (InterruptedException e) {
+            mediatorManager.initializeAndRun();
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
This PR updates a few dependencies related to Reactive:

* SmallRye Reactive Utils (Axle) - 0.0.3
* RX Java 2 - 2.2.8
* SmallRye Reactive Streams Operators - 1.0.3
* SmallRye Reactive Messaging - 0.0.5

It also adds the support for the `Emitter` in Reactive Messaging.

An `Emitter` bridge a callback style API with Reactive Messaging. It allows the user to _feed_ a stream. 

For example, if you have an `Incoming` declared or configured:

```java

@Incoming("my-stream")
public void consume(String s) {
  ...
}
```

You can inject data in the stream using:

```java
@Inject @Stream("my-stream") Emitter<String> emitter;

// ...
emitter.send("hello");
```

Another example is when you have a websocket:

```java
@Inject @Stream("messages") Emitter<String> emitter;

@OnMessage
public void onMessage(String message) {
    LOG.info("Received {} on the web socket", message);
    emitter.send(message);
}
```

And you have configured the _outgoing_ message as follows:

```
mp.messaging.outgoing.messages.type=io.smallrye.reactive.messaging.kafka.Kafka
mp.messaging.outgoing.messages.topic=messages
mp.messaging.outgoing.messages.bootstrap.servers=localhost:9092
mp.messaging.outgoing.messages.key.serializer=org.apache.kafka.common.serialization.StringSerializer
mp.messaging.outgoing.messages.value.serializer=org.apache.kafka.common.serialization.StringSerializer
mp.messaging.outgoing.messages.acks=1
```