### PR TITLE
More details about debug logging

### DIFF
--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -106,8 +106,12 @@ quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
 quarkus.log.console.level=DEBUG
 quarkus.log.console.color=false
+
+quarkus.log.category."io.quarkus".level=DEBUG
 ----
 
+NOTE: If you are adding these properties via command line make sure `"` is escaped.
+For example `-Dquarkus.log.category.\"io.quarkus\".level=DEBUG`.
 
 [#category-example]
 .File TRACE Logging Configuration


### PR DESCRIPTION
More details about debug logging

Topic discussed on Zulip - https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/debug-logging/near/161895822

`quarkus.log.console.level=DEBUG` is not enough to see debug log entries, `\"` note