### PR TITLE
Adds runtime select option for building native image on container

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -68,6 +68,10 @@ public class QuarkusNative extends QuarkusTask {
 
     private String nativeImageXmx;
 
+    private String containerRuntime = "docker";
+
+    private String containerRuntimeOptions;
+
     private String dockerBuild;
 
     private boolean enableVMInspection = false;
@@ -276,8 +280,32 @@ public class QuarkusNative extends QuarkusTask {
 
     @Optional
     @Input
+    public String getContainerRuntime() {
+        return containerRuntime;
+    }
+
+    @Optional
+    @Input
+    public String getContainerRuntimeOptions() {
+        return containerRuntimeOptions;
+    }
+
+    @Optional
+    @Input
     public String getDockerBuild() {
         return dockerBuild;
+    }
+
+    @Option(description = "Container runtime", option = "container-runtime")
+    @Optional
+    public void setContainerRuntime(String containerRuntime) {
+        this.containerRuntime = containerRuntime;
+    }
+
+    @Option(description = "Container runtime options", option = "container-runtime-options")
+    @Optional
+    public void setContainerRuntimeOptions(String containerRuntimeOptions) {
+        this.containerRuntimeOptions = containerRuntimeOptions;
     }
 
     @Option(description = "Docker build", option = "docker-build")
@@ -343,6 +371,8 @@ public class QuarkusNative extends QuarkusTask {
                         .setDebugBuildProcess(isDebugBuildProcess())
                         .setDebugSymbols(isDebugSymbols())
                         .setDisableReports(isDisableReports())
+                        .setContainerRuntime(getContainerRuntime())
+                        .setContainerRuntimeOptions(getContainerRuntimeOptions())
                         .setDockerBuild(getDockerBuild())
                         .setDumpProxies(isDumpProxies())
                         .setEnableAllSecurityServices(isEnableAllSecurityServices())

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -108,6 +108,12 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "${native-image.docker-build}")
     private String dockerBuild;
 
+    @Parameter(defaultValue = "${native-image.container-runtime}")
+    private String containerRuntime;
+
+    @Parameter(defaultValue = "${native-image.container-runtime-options}")
+    private String containerRuntimeOptions;
+
     @Parameter(defaultValue = "false")
     private boolean enableVMInspection;
 
@@ -147,6 +153,8 @@ public class NativeImageMojo extends AbstractMojo {
                         .setDebugSymbols(debugSymbols)
                         .setDisableReports(disableReports)
                         .setDockerBuild(dockerBuild)
+                        .setContainerRuntime(containerRuntime)
+                        .setContainerRuntimeOptions(containerRuntimeOptions)
                         .setDumpProxies(dumpProxies)
                         .setEnableAllSecurityServices(enableAllSecurityServices)
                         .setEnableCodeSizeReporting(enableCodeSizeReporting)

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -10,7 +10,7 @@ include::./attributes.adoc[]
 This guide covers:
 
 * Compiling the application to a native executable
-* The packaging of the application in a Docker container
+* The packaging of the application in a container
 
 This guide takes as input the application developed in the link:getting-started-guide.html[Getting Started Guide].
 
@@ -189,26 +189,33 @@ that does not call your HTTP endpoints, it's probably not a good idea to run the
 If you share your test class between JVM and native execusions like we advise above, you can mark certain tests
 with the `@DisabledOnSubstrate` annotation in order to only run them on the JVM.
 
-== Producing a Docker container
+== Producing a container
 
-IMPORTANT: Before going further, be sure to have a working Docker environment.
+IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment.
 
-You can run the application in a Docker container using the JAR produced by the Quarkus Maven Plugin.
-However, in this guide we focus on creating a Docker image using the produced native executable.
+You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
+However, in this guide we focus on creating a container image using the produced native executable.
 
 image:containerization-process.png[Containerization Process]
 
 By default, the native executable is tailored for your operating system (Linux, macOS, Windows etc).
-Because the Docker container may not use the same _executable_ format as the one produced by your operating system,
-we will instruct the Maven build to produce an executable from inside a Docker container:
+Because the container may not use the same _executable_ format as the one produced by your operating system,
+we will instruct the Maven build to produce an executable from inside a container:
 
 [source,shell]
 ----
-./mvnw package -Pnative -Dnative-image.docker-build=true
+./mvnw package -Pnative -Dnative-image.container-runtime=docker
+----
+
+Or if you'd like to use podman:
+
+[source,shell]
+----
+./mvnw package -Pnative -Dnative-image.container-runtime=podman
 ----
 
 The produced executable will be a 64 bit Linux executable, so depending on your operating system it may no longer be runnable.
-However, it's not an issue as we are going to copy it to a Docker container.
+However, it's not an issue as we are going to copy it to a container.
 The project generation has provided a `Dockerfile.native` in the `src/main/docker` directory with the following content:
 
 [source,dockerfile]


### PR DESCRIPTION
I'd like to use another container runtime like this:

```bash
/gradlew quarkusNative --container-runtime=podman --container-runtime-options="--security-opt=label=disable"
```