### PR TITLE
Fix bad user prompt

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -237,7 +237,7 @@ public class CreateProjectMojo extends AbstractMojo {
             }
 
             if (StringUtils.isBlank(projectVersion)) {
-                projectVersion = prompter.promptWithDefaultValue("Set the Quarkus version",
+                projectVersion = prompter.promptWithDefaultValue("Set the project version",
                         "1.0-SNAPSHOT");
             }
 


### PR DESCRIPTION
Fix #1725.  it's the project version that is set. The Quarkus version cannot be overridden in the interactive move.