### PR TITLE
Move ImageIO and Java2D substitutions to quarkus-core

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/ImageIOSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/ImageIOSubstitutions.java
@@ -1,4 +1,4 @@
-package io.quarkus.resteasy.common.runtime.graal;
+package io.quarkus.runtime.graal;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
@@ -29,155 +29,139 @@ final class Target_javax_imageio_ImageIO {
     @Substitute
     public static ImageInputStream createImageInputStream(Object input)
             throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static ImageOutputStream createImageOutputStream(Object output)
             throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static String[] getReaderFormatNames() {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static String[] getReaderMIMETypes() {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static String[] getReaderFileSuffixes() {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageReader> getImageReaders(Object input) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageReader> getImageReadersByFormatName(String formatName) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageReader> getImageReadersBySuffix(String fileSuffix) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageReader> getImageReadersByMIMEType(String MIMEType) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static String[] getWriterFormatNames() {
-
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
-    /**
-     * Returns an array of {@code String}s listing all of the
-     * MIME types understood by the current set of registered
-     * writers.
-     *
-     * @return an array of {@code String}s.
-     */
     @Substitute
     public static String[] getWriterMIMETypes() {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
-    /**
-     * Returns an array of {@code String}s listing all of the
-     * file suffixes associated with the formats understood
-     * by the current set of registered writers.
-     *
-     * @return an array of {@code String}s.
-     * @since 1.6
-     */
     @Substitute
     public static String[] getWriterFileSuffixes() {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageWriter> getImageWritersByFormatName(String formatName) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageWriter> getImageWritersBySuffix(String fileSuffix) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageWriter> getImageWritersByMIMEType(String MIMEType) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static ImageWriter getImageWriter(ImageReader reader) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static ImageReader getImageReader(ImageWriter writer) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageWriter> getImageWriters(ImageTypeSpecifier type, String formatName) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static Iterator<ImageTranscoder> getImageTranscoders(ImageReader reader, ImageWriter writer) {
-        throw new RuntimeException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static BufferedImage read(File input) throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static BufferedImage read(InputStream input) throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static BufferedImage read(URL input) throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static BufferedImage read(ImageInputStream stream)
             throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static boolean write(RenderedImage im,
             String formatName,
             ImageOutputStream output) throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static boolean write(RenderedImage im,
             String formatName,
             File output) throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static boolean write(RenderedImage im,
             String formatName,
             OutputStream output) throws IOException {
-        throw new IOException("Not Implemented yet on substrate");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutions.java
@@ -1,4 +1,4 @@
-package io.quarkus.resteasy.common.runtime.graal;
+package io.quarkus.runtime.graal;
 
 import java.awt.color.ICC_Profile;
 
@@ -10,38 +10,28 @@ final class Target_sun_java2d_cmm_lcms_LCMS {
 
     @Substitute
     private long loadProfileNative(byte[] data, Object ref) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     private int getProfileSizeNative(long ptr) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     private void getProfileDataNative(long ptr, byte[] data) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     static byte[] getTagNative(long profileID, int signature) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
-    /**
-     * Writes supplied data as a tag into the profile.
-     * Destroys old profile, if new one was successfully
-     * created.
-     * <p>
-     * Returns valid pointer to new profile.
-     * <p>
-     * Throws CMMException if operation fails, preserve old profile from
-     * destruction.
-     */
     @Substitute
     private void setTagDataNative(long ptr, int tagSignature,
             byte[] data) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
@@ -50,29 +40,28 @@ final class Target_sun_java2d_cmm_lcms_LCMS {
             int inFormatter, boolean isInIntPacked,
             int outFormatter, boolean isOutIntPacked,
             Object disposerRef) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static void initLCMS(Class<?> Trans, Class<?> IL, Class<?> Pf) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static synchronized LCMSProfile getProfileID(ICC_Profile profile) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @Substitute
     public static void colorConvert(LCMSTransform trans,
             LCMSImageLayout src,
             LCMSImageLayout dest) {
-        throw new RuntimeException("Not Implemented");
+        throw new UnsupportedOperationException("Not implemented yet for GraalVM native images");
     }
 
     @TargetClass(className = "sun.java2d.cmm.lcms.LCMSProfile")
     static final class LCMSProfile {
-
     }
 
     @TargetClass(className = "sun.java2d.cmm.lcms.LCMSImageLayout")
@@ -81,7 +70,6 @@ final class Target_sun_java2d_cmm_lcms_LCMS {
 
     @TargetClass(className = "sun.java2d.cmm.lcms.LCMSTransform")
     static final class LCMSTransform {
-
     }
 
 }


### PR DESCRIPTION
They were in the resteasy-common module but they are also useful for
Camel and probably others.

JDK related substitutions should probably always be in the core module.

Fixes #1671.