### PR TITLE
Improves unit tests coverage regarding Hibernate ORM's handling of import.sql imports #558 

### DIFF
--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -65,6 +65,21 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/DefaultSqlLoadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/DefaultSqlLoadScriptTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.orm.sql_load_scirpt;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DefaultSqlLoadScriptTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application.properties")
+                    .addClasses(SqlLoadScriptTestResource.class, MyEntity.class));
+
+    @Test
+    public void testDefaultSqlLoadScriptTest() {
+        String name = "default sql load script entity";
+        RestAssured.when().get("/orm-sql-load-script/1").then().body(Matchers.is(name));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/ImportSqlLoadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/ImportSqlLoadScriptTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.orm.sql_load_scirpt;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ImportSqlLoadScriptTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application-import-load-script-test.properties", "application.properties")
+                    .addAsResource("import.sql"));
+
+    @Test
+    public void testImportSqlLoadScriptTest() {
+        String name = "import.sql load script entity";
+        RestAssured.when().get("/orm-sql-load-script/2").then().body(Matchers.is(name));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/MyEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/MyEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.orm.sql_load_scirpt;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class MyEntity {
+    private long id;
+    private String name;
+
+    public MyEntity() {
+    }
+
+    public MyEntity(String name) {
+        this.name = name;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "myEntitySeq")
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/SqlLoadScriptFileAbsentTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/SqlLoadScriptFileAbsentTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.orm.sql_load_scirpt;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SqlLoadScriptFileAbsentTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(ConfigurationError.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class)
+                    .addAsResource("application-other-load-script-test.properties", "application.properties"));
+
+    @Test
+    public void testSqlLoadScriptFileAbsentTest() {
+        // should not be called, deployment exception should happen first:
+        // it's illegal to have Hibernate sql-load-script configuration property set
+        // to an absent file
+        Assertions.fail();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/SqlLoadScriptPresentTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/SqlLoadScriptPresentTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.orm.sql_load_scirpt;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class SqlLoadScriptPresentTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application-other-load-script-test.properties", "application.properties")
+                    .addAsResource("load-script-test.sql"));
+
+    @Test
+    public void testSqlLoadScriptPresentTest() {
+        String name = "other-load-script sql load script entity";
+        RestAssured.when().get("/orm-sql-load-script/3").then().body(Matchers.is(name));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/SqlLoadScriptTestResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_scirpt/SqlLoadScriptTestResource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.orm.sql_load_scirpt;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+@Path("/orm-sql-load-script")
+public class SqlLoadScriptTestResource {
+
+    @Inject
+    EntityManager em;
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getName(@PathParam("id") long id) {
+        MyEntity entity = em.find(MyEntity.class, id);
+        if (entity != null) {
+            return entity.getName();
+        }
+
+        return null;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-import-load-script-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-import-load-script-test.properties
@@ -4,3 +4,4 @@ quarkus.datasource.driver=org.h2.Driver
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=import.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-other-load-script-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-other-load-script-test.properties
@@ -4,3 +4,4 @@ quarkus.datasource.driver=org.h2.Driver
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=load-script-test.sql

--- a/extensions/hibernate-orm/deployment/src/test/resources/import.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import.sql
@@ -1,0 +1,2 @@
+INSERT INTO MyEntity(id, name) VALUES(1, 'default sql load script entity');
+INSERT INTO MyEntity(id, name) VALUES(2, 'import.sql load script entity');

--- a/extensions/hibernate-orm/deployment/src/test/resources/load-script-test.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/load-script-test.sql
@@ -1,0 +1,1 @@
+INSERT INTO MyEntity(id, name) VALUES(3, 'other-load-script sql load script entity');


### PR DESCRIPTION
Four test cases are covered:

- No load script is specified (defaults to `import.sql`)
-`import.sql` is specified as a load script file and it is present 
- a different sql file is specified as a load script and is present
- a different sql file is specified as a load script but it is absent

@Sanne @emmanuelbernard @gsmet 