### PR TITLE
Agroal - Allow to configure transaction isolation level #1122

### DIFF
--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -38,9 +39,11 @@ public class DefaultDataSourceConfigTest {
             int initialSize, Duration backgroundValidationInterval, Duration acquisitionTimeout, Duration leakDetectionInterval,
             Duration idleRemovalInterval) throws SQLException {
         AgroalConnectionPoolConfiguration configuration = dataSource.getConfiguration().connectionPoolConfiguration();
+        AgroalConnectionFactoryConfiguration agroalConnectionFactoryConfiguration = configuration
+                .connectionFactoryConfiguration();
 
-        assertEquals("jdbc:h2:tcp://localhost/mem:default", configuration.connectionFactoryConfiguration().jdbcUrl());
-        assertEquals(username, configuration.connectionFactoryConfiguration().principal().getName());
+        assertEquals("jdbc:h2:tcp://localhost/mem:default", agroalConnectionFactoryConfiguration.jdbcUrl());
+        assertEquals(username, agroalConnectionFactoryConfiguration.principal().getName());
         assertEquals(minSize, configuration.minSize());
         assertEquals(maxSize, configuration.maxSize());
         assertEquals(initialSize, configuration.initialSize());
@@ -48,6 +51,8 @@ public class DefaultDataSourceConfigTest {
         assertEquals(acquisitionTimeout, configuration.acquisitionTimeout());
         assertEquals(leakDetectionInterval, configuration.leakTimeout());
         assertEquals(idleRemovalInterval, configuration.reapTimeout());
+        assertEquals(AgroalConnectionFactoryConfiguration.TransactionIsolation.SERIALIZABLE,
+                agroalConnectionFactoryConfiguration.jdbcTransactionIsolation());
 
         try (Connection connection = dataSource.getConnection()) {
         }

--- a/extensions/agroal/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-default-datasource.properties
@@ -8,3 +8,4 @@ quarkus.datasource.background-validation-interval=PT53S
 quarkus.datasource.acquisition-timeout=PT54S
 quarkus.datasource.leak-detection-interval=PT55S
 quarkus.datasource.idle-removal-interval=PT56S
+quarkus.datasource.transaction-isolation-level=serializable

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceRuntimeConfig.java
@@ -85,4 +85,10 @@ public class DataSourceRuntimeConfig {
     @ConfigItem(defaultValue = "PT5M")
     public Optional<Duration> idleRemovalInterval;
 
+    /**
+     * The transaction isolation level.
+     */
+    @ConfigItem
+    public Optional<TransactionIsolationLevel> transactionIsolationLevel;
+
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/TransactionIsolationLevel.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/TransactionIsolationLevel.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.agroal.runtime;
+
+import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation;
+
+public enum TransactionIsolationLevel {
+    UNDEFINED(TransactionIsolation.UNDEFINED),
+    NONE(TransactionIsolation.NONE),
+    READ_UNCOMMITTED(TransactionIsolation.READ_UNCOMMITTED),
+    READ_COMMITTED(TransactionIsolation.READ_COMMITTED),
+    REPEATABLE_READ(TransactionIsolation.REPEATABLE_READ),
+    SERIALIZABLE(TransactionIsolation.SERIALIZABLE);
+
+    TransactionIsolation jdbcTransactionIsolationLevel;
+
+    TransactionIsolationLevel(TransactionIsolation jdbcTransactionIsolationLevel) {
+        this.jdbcTransactionIsolationLevel = jdbcTransactionIsolationLevel;
+    }
+
+    public static TransactionIsolationLevel of(String value) {
+        switch (value) {
+            case "none":
+                return NONE;
+            case "read-committed":
+                return READ_COMMITTED;
+            case "read-uncommitted":
+                return READ_UNCOMMITTED;
+            case "repeatable-read":
+                return REPEATABLE_READ;
+            case "serializable":
+                return SERIALIZABLE;
+            default:
+                return UNDEFINED;
+        }
+    }
+}


### PR DESCRIPTION
The PR adds the possibility to define database transaction isolation level using `quarkus.datasource.transaction-isolation` config property. 

@gsmet 