### PR TITLE
Fix source code and properties in JWT guide

### DIFF
--- a/docs/src/main/asciidoc/jwt-guide.adoc
+++ b/docs/src/main/asciidoc/jwt-guide.adoc
@@ -339,6 +339,7 @@ import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Map;
 
 import org.eclipse.microprofile.jwt.Claims;
@@ -404,19 +405,14 @@ public class TokenUtils {
         JSONObject jwtContent = parser.parse(content, JSONObject.class);
         long currentTimeInSecs = currentTimeInSecs();
         long exp = currentTimeInSecs + 300;
+        // If exp was passed in, use it
+        if (timeClaims.containsKey(Claims.exp.name())) {
+            exp = timeClaims.get(Claims.exp.name());
+        }
+        System.out.printf("Setting exp: %d / %s\n", exp, new Date(1000*exp));
         long iat = currentTimeInSecs;
         long authTime = currentTimeInSecs;
-        boolean expWasInput = false;
-        // Check for an input exp to override the default of now + 300 seconds
-        if (timeClaims != null && timeClaims.containsKey(Claims.exp.name())) {
-            exp = timeClaims.get(Claims.exp.name());
-            expWasInput = true;
-        }
-        // iat and auth_time should be before any input exp value
-        if (expWasInput) {
-            iat = exp - 5;
-            authTime = exp - 5;
-        }
+        jwtContent.put(Claims.exp.name(), exp);
         jwtContent.put(Claims.iat.name(), iat);
         jwtContent.put(Claims.auth_time.name(), authTime);
         // Return the token time values if requested
@@ -429,6 +425,10 @@ public class TokenUtils {
         // Create RSA-signer with the private key
         JWSSigner signer = new RSASSASigner(pk);
         JWTClaimsSet claimsSet = JWTClaimsSet.parse(jwtContent);
+        for (String claim : claimsSet.getClaims().keySet()) {
+            Object claimValue = claimsSet.getClaim(claim);
+            System.out.printf("\tAdded claim: %s, value: %s\n", claim, claimValue);
+        }
         JWSAlgorithm alg = JWSAlgorithm.RS256;
         JWSHeader jwtHeader = new JWSHeader.Builder(alg)
                 .keyID(kid)

--- a/docs/src/main/asciidoc/jwt-guide.adoc
+++ b/docs/src/main/asciidoc/jwt-guide.adoc
@@ -280,7 +280,7 @@ In the <<Configuration>> section we introduce the `application.properties` file 
 .application.properties for TokenSecuredResource
 [source, properties]
 ----
-mp.jwt.verify.publickey.location=publicKey.pem #<1>
+mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem #<1>
 mp.jwt.verify.issuer=https://quarkus.io/using-jwt-rbac #<2>
 
 quarkus.smalllrye-jwt.auth-mechanism=MP-JWT # <3>


### PR DESCRIPTION
While going through the (very good!) JWT Guide at https://quarkus.io/guides/jwt-guide I recognized two mismatches between the source code in the guide and the source code in the GitHub repository, that this pull request should fix.

1. The location of the `publicKey.pem` file in `application.properties` is wrong (missing folder)
2. The `TokenUtils` source code misses some lines leading to invalid JWTs (also the console output in the guide does not match the output that the TokenUtils source in the guide produces)

(There are also wrong property names in the `application.properties` that are already addressed in #1776.)




