### PR TITLE
Improvement about ComponentsProviderGenerator

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.InterceptionType;
 import org.jboss.jandex.AnnotationInstance;
@@ -289,15 +288,26 @@ public class BeanInfo {
      * @return an ordered list of all interceptors associated with the bean
      */
     List<InterceptorInfo> getBoundInterceptors() {
+        if (lifecycleInterceptors.isEmpty() && interceptedMethods.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<InterceptorInfo> bound = new ArrayList<>();
         for (InterceptionInfo interception : lifecycleInterceptors.values()) {
-            bound.addAll(interception.interceptors);
+            for (InterceptorInfo interceptor : interception.interceptors) {
+                if (!bound.contains(interceptor)) {
+                    bound.add(interceptor);
+                }
+            }
         }
-        if (!interceptedMethods.isEmpty()) {
-            bound.addAll(
-                    interceptedMethods.values().stream().flatMap(ii -> ii.interceptors.stream()).collect(Collectors.toList()));
+        for (InterceptionInfo interception : interceptedMethods.values()) {
+            for (InterceptorInfo interceptor : interception.interceptors) {
+                if (!bound.contains(interceptor)) {
+                    bound.add(interceptor);
+                }
+            }
         }
-        return bound.isEmpty() ? Collections.emptyList() : bound.stream().distinct().sorted().collect(Collectors.toList());
+        Collections.sort(bound);
+        return bound;
     }
 
     public DisposerInfo getDisposer() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -229,12 +229,10 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                 paramTypes.add(Type.getDescriptor(InjectableReferenceProvider.class));
             }
         }
-        if (!bean.getInterceptedMethods().isEmpty()) {
-            for (InterceptorInfo interceptor : bean.getBoundInterceptors()) {
-                ResultHandle resultHandle = beanToResultHandle.get(interceptor);
-                params.add(resultHandle);
-                paramTypes.add(Type.getDescriptor(InjectableInterceptor.class));
-            }
+        for (InterceptorInfo interceptor : bean.getBoundInterceptors()) {
+            ResultHandle resultHandle = beanToResultHandle.get(interceptor);
+            params.add(resultHandle);
+            paramTypes.add(Type.getDescriptor(InjectableInterceptor.class));
         }
         // Foo_Bean bean2 = new Foo_Bean(bean2)
         ResultHandle beanInstance = getComponents.newInstance(

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.arc.test.interceptors.aroundconstruct;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Singleton;
+import javax.interceptor.AroundConstruct;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AroundConstructTest {
+
+    @Rule
+    public ArcTestContainer container = new ArcTestContainer(MyTransactional.class, SimpleBean.class,
+            SimpleInterceptor.class);
+
+    public static AtomicBoolean INTERCEPTOR_CALLED = new AtomicBoolean(false);
+
+    @Test
+    public void testInterception() {
+        ArcContainer arc = Arc.container();
+        SimpleBean simpleBean = arc.instance(SimpleBean.class).get();
+        Assert.assertTrue(INTERCEPTOR_CALLED.get());
+    }
+
+    @Singleton
+    @MyTransactional
+    static class SimpleBean {
+
+    }
+
+    @MyTransactional
+    @Interceptor
+    public static class SimpleInterceptor {
+
+        @AroundConstruct
+        void mySuperCoolAroundConstruct(InvocationContext ctx) throws Exception {
+            INTERCEPTOR_CALLED.set(true);
+            ctx.proceed();
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/MyTransactional.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/MyTransactional.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.arc.test.interceptors.aroundconstruct;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.interceptor.InterceptorBinding;
+
+@Target({ TYPE })
+@Retention(RUNTIME)
+@InterceptorBinding
+public @interface MyTransactional {
+
+}


### PR DESCRIPTION
`ComponentsProviderGenerator` was not enhancing beans that have only their constructor intercepted.

Fixes #1742 

https://github.com/quarkusio/quarkus/issues/1742
@mkouba please review