### PR TITLE
Allow beans in a default package

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
@@ -25,6 +25,33 @@ abstract class AbstractGenerator {
 
     static final String DEFAULT_PACKAGE = Arc.class.getPackage().getName() + ".generator";
 
+    /**
+     * Create a generated bean name from a bean package. When bean is located
+     * in a default package (i.e. a classpath root), the target package name
+     * is empty string. This need to be taken into account when creating
+     * generated bean name because it is later used to build class file path
+     * and we do not want it to start from a slash because it will point root
+     * directory instead of a relative one. This method will address this
+     * problem.<br>
+     * <br>
+     * Example generated bean names (without quotes):
+     * <ol>
+     * <li>a <i>"io/quarcus/foo/FooService_Bean"</i>, when in io.quarcus.foo package,</li>
+     * <li>a <i>"BarService_Bean"</i>, when in default package.</li>
+     * </ol>
+     *
+     * @param baseName a bean name (class name)
+     * @param targetPackage a package where bean is located
+     * @return Generated name
+     */
+    static String generatedNameFromTarget(String targetPackage, String baseName, String suffix) {
+        if (targetPackage == null || targetPackage.isEmpty()) {
+            return baseName + suffix;
+        } else {
+            return targetPackage.replace('.', '/') + "/" + baseName + suffix;
+        }
+    }
+
     protected String getBaseName(BeanInfo bean, String beanClassName) {
         String name = Types.getSimpleName(beanClassName);
         return name.substring(0, name.lastIndexOf(BeanGenerator.BEAN_SUFFIX));

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -148,7 +148,7 @@ public class BeanGenerator extends AbstractGenerator {
         ClassInfo providerClass = bean.getDeployment().getIndex().getClassByName(providerType.name());
         String providerTypeName = providerClass.name().toString();
         String targetPackage = getPackageName(bean);
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + BEAN_SUFFIX;
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);
 
         boolean isApplicationClass = applicationClassPredicate.test(bean.getImplClazz().name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
@@ -247,7 +247,7 @@ public class BeanGenerator extends AbstractGenerator {
         ClassInfo providerClass = bean.getDeployment().getIndex().getClassByName(providerType.name());
         String providerTypeName = providerClass.name().toString();
         String targetPackage = DotNames.packageName(providerType.name());
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + BEAN_SUFFIX;
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);
 
         boolean isApplicationClass = applicationClassPredicate.test(beanClass.name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
@@ -337,7 +337,7 @@ public class BeanGenerator extends AbstractGenerator {
                 + Hashes.sha1(sigBuilder.toString());
         String providerTypeName = providerType.name().toString();
         String targetPackage = DotNames.packageName(declaringClass.name());
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + BEAN_SUFFIX;
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);
 
         boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
@@ -415,7 +415,7 @@ public class BeanGenerator extends AbstractGenerator {
         String baseName = declaringClassBase + PRODUCER_FIELD_SUFFIX + "_" + producerField.name();
         String providerTypeName = providerType.name().toString();
         String targetPackage = DotNames.packageName(declaringClass.name());
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + BEAN_SUFFIX;
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);
 
         boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -77,7 +77,7 @@ public class ClientProxyGenerator extends AbstractGenerator {
         String providerTypeName = providerClass.name().toString();
         String baseName = getBaseName(bean, beanClassName);
         String targetPackage = getPackageName(bean);
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + CLIENT_PROXY_SUFFIX;
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, CLIENT_PROXY_SUFFIX);
 
         // Foo_ClientProxy extends Foo implements ClientProxy
         List<String> interfaces = new ArrayList<>();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -80,7 +80,7 @@ public class InterceptorGenerator extends BeanGenerator {
         ClassInfo providerClass = interceptor.getDeployment().getIndex().getClassByName(providerType.name());
         String providerTypeName = providerClass.name().toString();
         String targetPackage = DotNames.packageName(providerType.name());
-        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + BEAN_SUFFIX;
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);
 
         boolean isApplicationClass = applicationClassPredicate.test(interceptor.getBeanClass());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -98,9 +98,16 @@ public class ObserverGenerator extends AbstractGenerator {
         for (org.jboss.jandex.Type paramType : observer.getObserverMethod().parameters()) {
             sigBuilder.append(paramType.name().toString());
         }
-        String baseName = declaringClassBase + OBSERVER_SUFFIX + "_" + observer.getObserverMethod().name() + "_"
-                + Hashes.sha1(sigBuilder.toString());
-        String generatedName = DotNames.packageName(declaringClass.name()).replace('.', '/') + "/" + baseName;
+
+        String baseName = declaringClassBase + OBSERVER_SUFFIX
+                + "_" + observer.getObserverMethod().name()
+                + "_" + Hashes.sha1(sigBuilder.toString());
+
+        // No suffix added at the end of generated name because it's already
+        // included in a baseName, e.g. Foo_Observer_fooMethod_hash
+
+        String targetPackage = DotNames.packageName(declaringClass.name());
+        String generatedName = generatedNameFromTarget(targetPackage, baseName, "");
 
         boolean isApplicationClass = applicationClassPredicate.test(observer.getObserverMethod().declaringClass().name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,


### PR DESCRIPTION
Hello @mkouba,

This is PR against `FileNotFoundException` when beans are located in a default package. Having them in a default package is a bad practice, but it should still be allowed since, from a Java perspective, default package does not differ in any way when compared to a non-default one.

Example stack trace before the fix:

```plain
java.lang.RuntimeException: java.io.FileNotFoundException: /SomeRefFactoryX_Bean.class (Permission denied)
    at io.quarkus.runner.RuntimeRunner.run(RuntimeRunner.java:134)
    at io.quarkus.test.junit.QuarkusTestExtension.doJavaStart(QuarkusTestExtension.java:196)
    at io.quarkus.test.junit.QuarkusTestExtension.beforeAll(QuarkusTestExtension.java:80)
    ...
Caused by: java.io.FileNotFoundException: /SomeRefFactoryX_Bean.class (Permission denied)
    at java.io.FileOutputStream.open0(Native Method)
    at java.io.FileOutputStream.open(FileOutputStream.java:270)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
    at io.quarkus.test.junit.QuarkusTestExtension$2.writeClass(QuarkusTestExtension.java:107)
    at io.quarkus.deployment.QuarkusAugmentor.run(QuarkusAugmentor.java:114)
    at io.quarkus.runner.RuntimeRunner.run(RuntimeRunner.java:99)
    ... 39 more
```

After this PR is applied, the problem is fixed.