### PR TITLE
Make the bootstrap plugin more consistent with the code base

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -71,7 +71,7 @@
 
             <dependency>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-core</artifactId>
+                <artifactId>quarkus-bootstrap-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -688,7 +688,7 @@
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus.bootstrap</groupId>
-                    <artifactId>bootstrap-maven-plugin</artifactId>
+                    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                     <version>${project.version}</version>
                     <executions>
                         <execution>

--- a/core/creator/pom.xml
+++ b/core/creator/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-core</artifactId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -81,13 +81,13 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
             "META-INF/LICENSE.txt",
             "META-INF/NOTICE.txt",
             "META-INF/README",
-            "META-INF/quarkus-config-roots.list",
             "META-INF/DEPENDENCIES",
             "META-INF/beans.xml",
+            "META-INF/quarkus-config-roots.list",
             "META-INF/quarkus-javadoc.properties",
-            "LICENSE",
-            "quarkus/quarkus-extension.properties",
-            "quarkus/quarkus-deployment-dependency.graph")));
+            "META-INF/quarkus-extension.properties",
+            "META-INF/quarkus-deployment-dependency.graph",
+            "LICENSE")));
 
     private Path outputDir;
     private Path libDir;

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-core</artifactId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -111,7 +111,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -59,7 +59,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -23,7 +23,7 @@
         <!-- Compile -->
         <dependency>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-core</artifactId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -107,10 +107,10 @@ public class AppModelGradleResolver implements AppModelResolver {
             final File f = a.getFile();
             final Dependency dep;
             if (f.isDirectory()) {
-                dep = processQuarkusDir(a, f.toPath().resolve(BootstrapConstants.QUARKUS));
+                dep = processQuarkusDir(a, f.toPath().resolve(BootstrapConstants.META_INF));
             } else {
                 try (FileSystem artifactFs = FileSystems.newFileSystem(f.toPath(), null)) {
-                    dep = processQuarkusDir(a, artifactFs.getPath(BootstrapConstants.QUARKUS));
+                    dep = processQuarkusDir(a, artifactFs.getPath(BootstrapConstants.META_INF));
                 } catch (IOException e) {
                     throw new GradleException("Failed to process " + f, e);
                 }

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-core</artifactId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -65,7 +65,7 @@ Your extension project should be setup as a multi-module project with two submod
 2. A runtime submodule that contains the runtime behavior that will provide the extension behavior in the native executable or runtime JVM.
 
 Your runtime artifact should depend on `io.quarkus:quarkus-core`, and possibly the runtime artifacts of other Quarkus
-modules if you want to use functionality provided by them. You will also need to include the `io.quarkus.bootstrap:bootstrap-maven-plugin`
+modules if you want to use functionality provided by them. You will also need to include the `io.quarkus.bootstrap:quarkus-bootstrap-maven-plugin`
 to generate the Quarkus extension descriptor included into the runtime artifact, if you are using the Quarkus parent pom it will automatically inherit the correct configuration.
 
 NOTE: By convention the deployment time artifact has the `-deployment` suffix, and the runtime artifact
@@ -85,7 +85,7 @@ has no suffix (and is what the end user adds to their project).
     <plugins>
         <plugin>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-maven-plugin</artifactId>
+            <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
         </plugin>
     </plugins>
 </build>

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -76,7 +76,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/amazon-lambda/runtime/pom.xml
+++ b/extensions/amazon-lambda/runtime/pom.xml
@@ -37,7 +37,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/arc/runtime/pom.xml
+++ b/extensions/arc/runtime/pom.xml
@@ -44,7 +44,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus.bootstrap</groupId>
-        <artifactId>bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/caffeine/runtime/pom.xml
+++ b/extensions/caffeine/runtime/pom.xml
@@ -43,7 +43,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/camel/camel-aws-s3/runtime/pom.xml
+++ b/extensions/camel/camel-aws-s3/runtime/pom.xml
@@ -61,7 +61,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/camel/camel-core/runtime/pom.xml
+++ b/extensions/camel/camel-core/runtime/pom.xml
@@ -48,7 +48,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/camel/camel-infinispan/runtime/pom.xml
+++ b/extensions/camel/camel-infinispan/runtime/pom.xml
@@ -49,7 +49,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/camel/camel-netty4-http/runtime/pom.xml
+++ b/extensions/camel/camel-netty4-http/runtime/pom.xml
@@ -41,7 +41,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/camel/camel-salesforce/runtime/pom.xml
+++ b/extensions/camel/camel-salesforce/runtime/pom.xml
@@ -41,7 +41,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -64,7 +64,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -98,7 +98,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -83,7 +83,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -75,7 +75,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -57,7 +57,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -48,7 +48,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/pom.xml
@@ -53,7 +53,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jdbc/jdbc-mariadb/jdbc-mariadb-runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/jdbc-mariadb-runtime/pom.xml
@@ -43,7 +43,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jdbc/jdbc-mssql/jdbc-mssql-runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/jdbc-mssql-runtime/pom.xml
@@ -91,7 +91,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jdbc/jdbc-postgresql/jdbc-postgresql-runtime/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/jdbc-postgresql-runtime/pom.xml
@@ -43,7 +43,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jsonb/runtime/pom.xml
+++ b/extensions/jsonb/runtime/pom.xml
@@ -36,7 +36,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jsonp/runtime/pom.xml
+++ b/extensions/jsonp/runtime/pom.xml
@@ -28,7 +28,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -36,7 +36,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -17,7 +17,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/kubernetes/runtime/pom.xml
+++ b/extensions/kubernetes/runtime/pom.xml
@@ -17,7 +17,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -60,7 +60,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -61,7 +61,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -51,7 +51,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
@@ -47,7 +47,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/pom.xml
@@ -39,7 +39,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -48,7 +48,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-jsonb/runtime/pom.xml
@@ -52,7 +52,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/resteasy/runtime/pom.xml
+++ b/extensions/resteasy/runtime/pom.xml
@@ -68,7 +68,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/scheduler/runtime/pom.xml
+++ b/extensions/scheduler/runtime/pom.xml
@@ -58,7 +58,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus.bootstrap</groupId>
-        <artifactId>bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -56,7 +56,7 @@
     <plugins>
         <plugin>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-maven-plugin</artifactId>
+            <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
         </plugin>
         <plugin>
             <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-health/runtime/pom.xml
+++ b/extensions/smallrye-health/runtime/pom.xml
@@ -57,7 +57,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-jwt/runtime/pom.xml
+++ b/extensions/smallrye-jwt/runtime/pom.xml
@@ -68,7 +68,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-metrics/runtime/pom.xml
+++ b/extensions/smallrye-metrics/runtime/pom.xml
@@ -61,7 +61,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-openapi/runtime/pom.xml
+++ b/extensions/smallrye-openapi/runtime/pom.xml
@@ -66,7 +66,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus.bootstrap</groupId>
-        <artifactId>bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -77,7 +77,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -61,7 +61,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -38,7 +38,7 @@
       <plugins>
          <plugin>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-maven-plugin</artifactId>
+            <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
          </plugin>
          <plugin>
            <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/smallrye-rest-client/runtime/pom.xml
+++ b/extensions/smallrye-rest-client/runtime/pom.xml
@@ -64,7 +64,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/spring-di/runtime/pom.xml
+++ b/extensions/spring-di/runtime/pom.xml
@@ -33,7 +33,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/extensions/swagger-ui/runtime/pom.xml
+++ b/extensions/swagger-ui/runtime/pom.xml
@@ -36,7 +36,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -52,7 +52,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -59,7 +59,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -59,7 +59,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -81,7 +81,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus.bootstrap</groupId>
-                <artifactId>bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -14,7 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -19,15 +19,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>bootstrap-parent</artifactId>
+        <artifactId>quarkus-bootstrap-parent</artifactId>
         <groupId>io.quarkus.bootstrap</groupId>
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>bootstrap-core</artifactId>
-    <name>Quarkus Bootstrap Core</name>
+    <artifactId>quarkus-bootstrap-core</artifactId>
+    <name>Quarkus - Bootstrap - Core</name>
 
     <dependencies>
         <dependency>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -28,7 +28,7 @@ public interface BootstrapConstants {
 
     String DESCRIPTOR_PATH = DESCRIPTOR_FILE_NAME;
 
-    String QUARKUS = "quarkus";
+    String META_INF = "META-INF";
 
     String PROP_DEPLOYMENT_ARTIFACT = "deployment-artifact";
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
@@ -75,10 +75,10 @@ public class DeploymentInjectingDependencyVisitor implements DependencyVisitor {
         final Path path = resolve(artifact);
         try {
             if (Files.isDirectory(path)) {
-                processChildren = !processQuarkusDir(path.resolve(BootstrapConstants.QUARKUS));
+                processChildren = !processMetaInfDir(path.resolve(BootstrapConstants.META_INF));
             } else {
                 try (FileSystem artifactFs = ZipUtils.newFileSystem(path)) {
-                    processChildren = !processQuarkusDir(artifactFs.getPath(BootstrapConstants.QUARKUS));
+                    processChildren = !processMetaInfDir(artifactFs.getPath(BootstrapConstants.META_INF));
                 }
             }
         } catch (Throwable t) {
@@ -87,14 +87,14 @@ public class DeploymentInjectingDependencyVisitor implements DependencyVisitor {
         return processChildren;
     }
 
-    private boolean processQuarkusDir(Path quarkusDir) throws BootstrapDependencyProcessingException {
-        if (Files.exists(quarkusDir)) {
-            Path p = quarkusDir.resolve(BootstrapConstants.DEPLOYMENT_DEPENDENCY_GRAPH);
+    private boolean processMetaInfDir(Path metaInfDir) throws BootstrapDependencyProcessingException {
+        if (Files.exists(metaInfDir)) {
+            Path p = metaInfDir.resolve(BootstrapConstants.DEPLOYMENT_DEPENDENCY_GRAPH);
             if (Files.exists(p)) {
                 processDeploymentDependencyGraph(p);
                 return true;
             }
-            p = quarkusDir.resolve(BootstrapConstants.DESCRIPTOR_PATH);
+            p = metaInfDir.resolve(BootstrapConstants.DESCRIPTOR_PATH);
             if (Files.exists(p)) {
                 processPlatformArtifact(p);
                 return true;

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/SimpleReplacedDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/SimpleReplacedDependencyTestCase.java
@@ -37,7 +37,7 @@ public class SimpleReplacedDependencyTestCase extends CollectDependenciesBase {
                 extension,
                 newJar().addFile(
                         PropsBuilder.init(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT, deployment.toString()).build(),
-                        BootstrapConstants.QUARKUS, BootstrapConstants.DESCRIPTOR_PATH)
+                        BootstrapConstants.META_INF, BootstrapConstants.DESCRIPTOR_PATH)
                 .getPath(),
                 true);
 

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -21,13 +21,13 @@
 
   <parent>
     <groupId>io.quarkus.bootstrap</groupId>
-    <artifactId>bootstrap-parent</artifactId>
+    <artifactId>quarkus-bootstrap-parent</artifactId>
     <version>999-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>bootstrap-maven-plugin</artifactId>
-  <name>Quarkus Bootstrap Maven plugin</name>
+  <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+  <name>Quarkus - Bootstrap - Maven plugin</name>
   <packaging>maven-plugin</packaging>
 
   <properties>
@@ -54,7 +54,7 @@
 
     <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>bootstrap-core</artifactId>
+        <artifactId>quarkus-bootstrap-core</artifactId>
     </dependency>
 
     <dependency>

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2018 Red Hat, Inc.
+  ~ Copyright 2019 Red Hat, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -13,65 +13,52 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>io.quarkus.bootstrap</groupId>
-    <artifactId>quarkus-bootstrap-parent</artifactId>
-    <version>999-SNAPSHOT</version>
-    <relativePath>../</relativePath>
-  </parent>
-
-  <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-  <name>Quarkus - Bootstrap - Maven plugin</name>
-  <packaging>maven-plugin</packaging>
-
-  <properties>
-    <version.maven-plugin-plugin>3.5.2</version.maven-plugin-plugin>
-  </properties>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <version>${version.maven-plugin-plugin}</version>
-        <executions>
-          <execution>
-            <id>default-descriptor</id>
-            <phase>process-classes</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
-  <dependencies>
-
-    <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>quarkus-bootstrap-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven.plugin-tools</groupId>
-      <artifactId>maven-plugin-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-    </dependency>
-
-  </dependencies>
-
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.bootstrap</groupId>
+        <artifactId>quarkus-bootstrap-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+    <name>Quarkus - Bootstrap - Maven plugin</name>
+    <packaging>maven-plugin</packaging>
+    <properties>
+        <version.maven-plugin-plugin>3.5.2</version.maven-plugin-plugin>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -26,7 +26,6 @@ import java.util.Properties;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -43,6 +42,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.resolver.maven.DependencyGraphParser;
 
@@ -94,7 +94,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         final Properties props = new Properties();
         props.setProperty(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT, deployment);
 
-        final Path output = outputDirectory.toPath().resolve(BootstrapConstants.QUARKUS);
+        final Path output = outputDirectory.toPath().resolve(BootstrapConstants.META_INF);
         try {
             Files.createDirectories(output);
             try (BufferedWriter writer = Files.newBufferedWriter(output.resolve(BootstrapConstants.DESCRIPTOR_FILE_NAME))) {

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -25,8 +25,8 @@
     <version>31</version>
   </parent>
   <groupId>io.quarkus.bootstrap</groupId>
-  <artifactId>bootstrap-parent</artifactId>
-  <name>Quarkus Bootstrap Parent</name>
+  <artifactId>quarkus-bootstrap-parent</artifactId>
+  <name>Quarkus - Bootstrap - Parent</name>
   <packaging>pom</packaging>
   <version>999-SNAPSHOT</version>
 
@@ -61,12 +61,12 @@
     <dependencies>
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>bootstrap-core</artifactId>
+        <artifactId>quarkus-bootstrap-core</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -13,166 +13,155 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>org.jboss</groupId>
-    <artifactId>jboss-parent</artifactId>
-    <version>31</version>
-  </parent>
-  <groupId>io.quarkus.bootstrap</groupId>
-  <artifactId>quarkus-bootstrap-parent</artifactId>
-  <name>Quarkus - Bootstrap - Parent</name>
-  <packaging>pom</packaging>
-  <version>999-SNAPSHOT</version>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <distribution>repo</distribution>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-    </license>
-  </licenses>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <!-- Versions -->
-    <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-    <junit.version>4.12</junit.version>
-    <maven-core.version>3.5.4</maven-core.version>
-    <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
-    <maven-resolver.version>1.1.1</maven-resolver.version>
-
-    <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-  </properties>
-
-  <modules>
-    <module>core</module>
-    <module>maven-plugin</module>
-  </modules>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>quarkus-bootstrap-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>${maven-core.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven-core.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven-core.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-resolver-provider</artifactId>
-            <version>${maven-core.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-settings-builder</artifactId>
-            <version>${maven-core.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>${maven-plugin-annotations.version}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.apache.maven</groupId>
-                  <artifactId>maven-artifact</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-connector-basic</artifactId>
-            <version>${maven-resolver.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-file</artifactId>
-            <version>${maven-resolver.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-transport-http</artifactId>
-            <version>${maven-resolver.version}</version>
-         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>${jboss-logging.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-            <version>${junit.version}</version>
-        </dependency>
-    </dependencies>
-  </dependencyManagement>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <quiet>true</quiet>
-            <doclint>none</doclint>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <configuration>
-                <rules>
-                  <bannedDependencies>
-                    <excludes>
-                      <!-- Use javax.annotation-api -->
-                      <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
-                      <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
-                    </excludes>
-                  </bannedDependencies>
-                </rules>
-              </configuration>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>31</version>
+    </parent>
+    <groupId>io.quarkus.bootstrap</groupId>
+    <artifactId>quarkus-bootstrap-parent</artifactId>
+    <name>Quarkus - Bootstrap - Parent</name>
+    <packaging>pom</packaging>
+    <version>999-SNAPSHOT</version>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Versions -->
+        <jboss-logging.version>3.3.2.Final</jboss-logging.version>
+        <junit.version>4.12</junit.version>
+        <maven-core.version>3.5.4</maven-core.version>
+        <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
+        <maven-resolver.version>1.1.1</maven-resolver.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+    </properties>
+    <modules>
+        <module>core</module>
+        <module>maven-plugin</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-bootstrap-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-resolver-provider</artifactId>
+                <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-settings-builder</artifactId>
+                <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>${maven-plugin-annotations.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-artifact</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-connector-basic</artifactId>
+                <version>${maven-resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-transport-file</artifactId>
+                <version>${maven-resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-transport-http</artifactId>
+                <version>${maven-resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss-logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <scope>test</scope>
+                <version>${junit.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <quiet>true</quiet>
+                        <doclint>none</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>enforce</id>
+                            <configuration>
+                                <rules>
+                                    <bannedDependencies>
+                                        <excludes>
+                                            <!-- Use javax.annotation-api -->
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
+                                        </excludes>
+                                    </bannedDependencies>
+                                </rules>
+                            </configuration>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
     <profiles>
         <profile>
             <id>release</id>
@@ -215,12 +204,17 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <!-- ## IMPORTANT ## In your ~/.m2/settings.xml you
-                            need to add and edit the following profile: <profile> <id>release</id> <properties>
-                            <gpg.useagent>false</gpg.useagent> <gpg.executable>/usr/local/Cellar/gnupg@1.4/1.4.23_1/bin/gpg1</gpg.executable>
-                            <- use gpg1 on Mac OS X <gpg.homedir>~/.gnupg</gpg.homedir> <- Update to
-                            your own directory <gpg.passphrase>******</gpg.passphrase> <- Add your passphrase
-                            </properties> </profile> -->
+                        <!-- ## IMPORTANT ## In your ~/.m2/settings.xml you 
+                            need to add and edit the following profile:
+                            <profile>
+                                <id>release</id>
+                                <properties> 
+                                    <gpg.useagent>false</gpg.useagent>
+                                    <gpg.executable>/usr/local/Cellar/gnupg@1.4/1.4.23_1/bin/gpg1</gpg.executable> <- use gpg1 on Mac OS X
+                                    <gpg.homedir>~/.gnupg</gpg.homedir> <- Update to your own directory <gpg.passphrase>******</gpg.passphrase> <- Add your passphrase
+                                </properties>
+                            </profile>
+                        -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
@@ -237,5 +231,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/integration-tests/class-transformer/runtime/pom.xml
+++ b/integration-tests/class-transformer/runtime/pom.xml
@@ -33,7 +33,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus.bootstrap</groupId>
-        <artifactId>bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus.bootstrap</groupId>
-            <artifactId>bootstrap-core</artifactId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
 * rename it to `quarkus-bootstrap-maven-plugin`
 * reformat pom.xml (in a separate commit)
 * move the descriptors to `META-INF/` instead of having a `quarkus/` directory at the root.