### PR TITLE
Fix for #1797, ID-based invalidation of the bootstrap CP cache

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
@@ -44,12 +44,14 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
     private AppArtifactKey lastFindVersionsKey;
     private List<String> lastFindVersions;
     private long lastModified;
+    private int id = 1;
 
     protected void addProject(LocalProject project, long lastModified) {
         projects.put(project.getKey(), project);
         if(lastModified > this.lastModified) {
             this.lastModified = lastModified;
         }
+        id = 31 * id + (int) (lastModified ^ (lastModified >>> 32));
     }
 
     public LocalProject getProject(String groupId, String artifactId) {
@@ -62,6 +64,10 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
 
     public long getLastModified() {
         return lastModified;
+    }
+
+    public int getId() {
+        return id;
     }
 
     @Override


### PR DESCRIPTION
Fix for #1797 
This change also introduces the classpath cache format id.