### PR TITLE
If buildDir is null, use the default

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -90,6 +90,8 @@ public class QuarkusDev extends QuarkusTask {
     @InputDirectory
     @Optional
     public File getBuildDir() {
+        if (buildDir == null)
+            buildDir = getProject().getBuildDir();
         return buildDir;
     }
 


### PR DESCRIPTION
This fixes dev-mode for Gradle