### PR TITLE
InjectionPoint.getMember() is currently supported

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -101,7 +101,7 @@ public class CounterBean {
 ** Type-safe resolution 
 ** Programmatic lookup via `javax.enterprise.inject.Instance`
 ** Client proxies
-** Injection point metadata footnote:[`InjectionPoint.getMember()` is currently not supported.]
+** Injection point metadata
 * Scopes and contexts
 ** `@Dependent`, `@ApplicationScoped`, `@Singleton`, `@RequestScoped` and `@SessionScoped`
 ** Custom scopes and contexts


### PR DESCRIPTION
Hello,

Right now documentation states that `InjectionPoint.getMember()` is not supported, but the code proves otherwise.

See `InjectionPointImpl` in `CurrentInjectionPointProvider`.

https://github.com/quarkusio/quarkus/blob/1b723f5a8942437bfa5cfa50f53e1f9a2307c3e0/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/CurrentInjectionPointProvider.java#L115-L118