### PR TITLE
Fix distroless link

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -87,6 +87,7 @@
                         <quarkus-tree-url>${quarkus-base-url}/tree/master</quarkus-tree-url>
                         <!-- Quarkus URL to issues -->
                         <quarkus-issues-url>${quarkus-base-url}/issues</quarkus-issues-url>
+                        <quarkus-images-url>https://github.com/quarkusio/quarkus-images/tree</quarkus-images-url>
 
                         <!-- === Quickstart settings === -->
                         <!-- Quickstart repository base URL -->

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -36,6 +36,7 @@ complete list of externalized variables for use is given in the following table:
 |\{quarkus-blob-url}|{quarkus-blob-url}| {project-name} URL to master blob source tree; used for referencing source files.
 |\{quarkus-tree-url}|{quarkus-tree-url}| {project-name} URL to master source tree root; used for referencing directories.
 |\{quarkus-issues-url}|{quarkus-issues-url}| {project-name} URL to the issues page.
+|\{quarkus-images-url}|{quarkus-images-url}| {project-name} URL to set of container images delivered for Quarkus.
 
 |\{quarkus-chat-url}|{quarkus-chat-url} | URL of our chat.
 |\{quarkus-mailing-list-subscription-email}|{quarkus-mailing-list-subscription-email} | Email used to subscribe to our mailing list.

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -242,7 +242,7 @@ And finally, run it with:
 docker run -i --rm -p 8080:8080 quarkus-quickstart/quickstart
 ----
 
-NOTE: Interested by tiny Docker images, check the {quarkus-images-url}/graalvm-1.0.0-rc14/distroless[distroless] version.
+NOTE: Interested by tiny Docker images, check the {quarkus-images-url}/graalvm-{graalvm-version}/distroless[distroless] version.
 
 == What's next?
 

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -242,7 +242,7 @@ And finally, run it with:
 docker run -i --rm -p 8080:8080 quarkus-quickstart/quickstart
 ----
 
-NOTE: Interested by tiny Docker images, check the {quarkus-tree-url}/docker/distroless[distroless] version.
+NOTE: Interested by tiny Docker images, check the {quarkus-images-url}/graalvm-1.0.0-rc14/distroless[distroless] version.
 
 == What's next?
 


### PR DESCRIPTION
Apply changes from https://github.com/quarkusio/quarkusio.github.io/pull/145 to the quarkus repository

So it won't be lost during the release.