### PR TITLE
JAX-RS body readers for Vert.x JsonObject and JsonArray

### DIFF
--- a/docs/src/main/asciidoc/using-vertx.adoc
+++ b/docs/src/main/asciidoc/using-vertx.adoc
@@ -290,10 +290,10 @@ Hello Quarkus! (Thu Mar 21 17:26:16 CET 2019)
 ...
 ----
 
-=== Using JSON results
+=== Using Vert.x JSON
 
 Vert.x API heavily relies on JSON, namely the `io.vertx.core.json.JsonObject` and `io.vertx.core.json.JsonArray` types.
-They are both supported as {project-name} web resource return types.
+They are both supported as {project-name} web resource request and response bodies.
 
 Consider these endpoints:
 
@@ -331,7 +331,7 @@ Then, navigate to http://localhost:8080/hello/Quarkus/array:
 ["Hello","Quarkus"]
 ----
 
-Needless to say, this works equally well when the JSON result is wrapped in a `CompletionStage` or a `Publisher`.
+Needless to say, this works equally well when the JSON content is a request body or is wrapped in a `CompletionStage` or `Publisher`.
 
 == Using Vert.x Clients
 

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonArrayReader.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonArrayReader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NoContentException;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * A body reader that allows to get a Vert.x {@link JsonArray} as JAX-RS request content.
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonArrayReader implements MessageBodyReader<JsonArray> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonArray.class;
+    }
+
+    @Override
+    public JsonArray readFrom(Class<JsonArray> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        byte[] bytes = getBytes(entityStream);
+        if (bytes.length == 0) {
+            throw new NoContentException("Cannot create JsonArray");
+        }
+        return new JsonArray(Buffer.buffer(bytes));
+    }
+
+    private static byte[] getBytes(InputStream entityStream) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int len;
+        while ((len = entityStream.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        return baos.toByteArray();
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonObjectReader.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/JsonObjectReader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NoContentException;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A body reader that allows to get a Vert.x {@link JsonObject} as JAX-RS request content.
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonObjectReader implements MessageBodyReader<JsonObject> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonObject.class;
+    }
+
+    @Override
+    public JsonObject readFrom(Class<JsonObject> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        byte[] bytes = getBytes(entityStream);
+        if (bytes.length == 0) {
+            throw new NoContentException("Cannot create JsonObject");
+        }
+        return new JsonObject(Buffer.buffer(bytes));
+    }
+
+    private static byte[] getBytes(InputStream entityStream) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int len;
+        while ((len = entityStream.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        return baos.toByteArray();
+    }
+}

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,2 +1,4 @@
 io.quarkus.vertx.runtime.JsonObjectWriter
 io.quarkus.vertx.runtime.JsonArrayWriter
+io.quarkus.vertx.runtime.JsonObjectReader
+io.quarkus.vertx.runtime.JsonArrayReader

--- a/integration-tests/vertx/src/main/java/io/quarkus/vertx/tests/JsonTestResource.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/vertx/tests/JsonTestResource.java
@@ -16,13 +16,14 @@
 
 package io.quarkus.vertx.tests;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.*;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -30,33 +31,49 @@ import io.vertx.core.json.JsonObject;
 /**
  * @author Thomas Ssegismont
  */
-@Path("/body-writers")
+@Path("/json-bodies")
 public class JsonTestResource {
 
     @GET
     @Path("/json/sync")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public JsonObject jsonSync() {
         return new JsonObject().put("Hello", "World");
     }
 
+    @POST
+    @Path("/json/sync")
+    @Consumes(APPLICATION_JSON)
+    @Produces(TEXT_PLAIN)
+    public String jsonSync(JsonObject jsonObject) {
+        return "Hello " + jsonObject.getString("Hello");
+    }
+
     @GET
     @Path("/array/sync")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public JsonArray arraySync() {
         return new JsonArray().add("Hello").add("World");
     }
 
+    @POST
+    @Path("/array/sync")
+    @Consumes(APPLICATION_JSON)
+    @Produces(TEXT_PLAIN)
+    public String arraySync(JsonArray jsonArray) {
+        return jsonArray.stream().map(String.class::cast).collect(Collectors.joining(" "));
+    }
+
     @GET
     @Path("/json/async")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public CompletionStage<JsonObject> jsonAsync() {
         return CompletableFuture.completedFuture(new JsonObject().put("Hello", "World"));
     }
 
     @GET
     @Path("/array/async")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public CompletionStage<JsonArray> arrayAsync() {
         return CompletableFuture.completedFuture(new JsonArray().add("Hello").add("World"));
     }

--- a/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonReaderIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonReaderIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime.tests;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class JsonReaderIT extends JsonReaderTest {
+
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonReaderTest.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonReaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.vertx.runtime.tests;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+@QuarkusTest
+public class JsonReaderTest {
+
+    @Test
+    public void testJson() {
+        String body = new JsonObject().put("Hello", "World").toString();
+        given().contentType(ContentType.JSON).body(body)
+                .post("/vertx-test/json-bodies/json/sync")
+                .then().statusCode(200).body(equalTo("Hello World"));
+    }
+
+    @Test
+    public void testEmptyJson() {
+        given().contentType(ContentType.JSON).body("")
+                .post("/vertx-test/json-bodies/json/sync")
+                .then().statusCode(400);
+    }
+
+    @Test
+    public void testArray() {
+        String body = new JsonArray().add("Hello").add("World").toString();
+        given().contentType(ContentType.JSON).body(body)
+                .post("/vertx-test/json-bodies/array/sync")
+                .then().statusCode(200).body(equalTo("Hello World"));
+    }
+
+    @Test
+    public void testEmptyArray() {
+        given().contentType(ContentType.JSON).body("")
+                .post("/vertx-test/json-bodies/array/sync")
+                .then().statusCode(400);
+    }
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonWriterTest.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/vertx/runtime/tests/JsonWriterTest.java
@@ -33,25 +33,25 @@ public class JsonWriterTest {
 
     @Test
     public void testJsonSync() {
-        RestAssured.when().get("/vertx-test/body-writers/json/sync").then()
+        RestAssured.when().get("/vertx-test/json-bodies/json/sync").then()
                 .statusCode(200).body("Hello", equalTo("World"));
     }
 
     @Test
     public void testArraySync() {
-        RestAssured.when().get("/vertx-test/body-writers/array/sync").then()
+        RestAssured.when().get("/vertx-test/json-bodies/array/sync").then()
                 .statusCode(200).body("", equalTo(Arrays.asList("Hello", "World")));
     }
 
     @Test
     public void testJsonAsync() {
-        RestAssured.when().get("/vertx-test/body-writers/json/async").then()
+        RestAssured.when().get("/vertx-test/json-bodies/json/async").then()
                 .statusCode(200).body("Hello", equalTo("World"));
     }
 
     @Test
     public void testArrayAsync() {
-        RestAssured.when().get("/vertx-test/body-writers/array/async").then()
+        RestAssured.when().get("/vertx-test/json-bodies/array/async").then()
                 .statusCode(200).body("", equalTo(Arrays.asList("Hello", "World")));
     }
 }


### PR DESCRIPTION
This allows to use Vert.x JsonObject and JsonArray as JAX-RS request content.

As many Vert.x client APIs take json content (e.g. Mongo client), this might be handy.