### PR TITLE
Include smallrye-axle-web-client to BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1455,6 +1455,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-axle-web-client</artifactId>
+                <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-rx-java2</artifactId>
                 <version>${vertx.version}</version>


### PR DESCRIPTION
Include smallrye-axle-web-client to BOM

This artifact is used in QS, we should have it in the BOM for better user experience and maintenance of QS. Also mentioned in our docs.

There are more smallrye axle/reactive artifacts - https://repo.maven.apache.org/maven2/io/smallrye/reactive/ Probably for discussion how to handle them in BOM for Q