### PR TITLE
Do not try to mark Vert-x JSON types for reflection

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyScanningProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyScanningProcessor.java
@@ -123,9 +123,14 @@ public class ResteasyScanningProcessor {
             // javax.json
             DotName.createSimple("javax.json.JsonObject"),
             DotName.createSimple("javax.json.JsonArray"),
+
             // JAX-RS
             DotName.createSimple(Response.class.getName()),
-            DotName.createSimple(AsyncResponse.class.getName())));
+            DotName.createSimple(AsyncResponse.class.getName()),
+
+            // Vert-x
+            DotName.createSimple("io.vertx.core.json.JsonArray"),
+            DotName.createSimple("io.vertx.core.json.JsonObject")));
 
     private static final DotName[] METHOD_ANNOTATIONS = {
             GET,
@@ -420,7 +425,7 @@ public class ResteasyScanningProcessor {
 
     /**
      * Indicates that JAXB support should be enabled
-     * 
+     *
      * @return
      */
     @BuildStep


### PR DESCRIPTION
This is a follow-up of https://github.com/quarkusio/quarkus/pull/1826 . These types are managed by specific readers/writers so they shouldn't be marked for reflection.