### PR TITLE
Add class name in ArC annotation processor error

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
@@ -89,7 +89,7 @@ class AnnotationLiteralProcessor {
                     value = method.defaultValue();
                 }
                 if (value == null) {
-                    throw new NullPointerException("Value not set for " + method);
+                    throw new NullPointerException("Value not set for " + method + " in " + method.declaringClass());
                 }
                 ResultHandle retValue = AnnotationLiteralGenerator.loadValue(bytecode, value, annotationClass, method);
                 constructorParams[iterator.previousIndex()] = retValue;


### PR DESCRIPTION
Hello @mkouba,

This is an addition to the problem we discussed today.

When you take a look at the stack trace:

```plain
Caused by: java.lang.NullPointerException: Value not set for java.lang.Class<? extends akka.actor.Actor> value()
    at io.quarkus.arc.processor.AnnotationLiteralProcessor.process(AnnotationLiteralProcessor.java:92)
    at io.quarkus.arc.processor.BeanGenerator.initConstructor(BeanGenerator.java:624)
```

And especially the message:

> Value not set for java.lang.Class<? extends akka.actor.Actor> value()

You may notice it's extremely hard to guess from which specific annotation class this error came from. It's because there is no class details included in a message.

This PR will address this inconvenience. After it's applied the message will be:

> Value not set for java.lang.Class<? extends akka.actor.Actor> value() in com.github.sarxos.abberwoult.annotation.ActorByClass

Example (from my experiment):

```plain
Caused by: java.lang.NullPointerException: Value not set for java.lang.Class<? extends akka.actor.Actor> value() in com.github.sarxos.abberwoult.annotation.ActorByClass
	at io.quarkus.arc.processor.AnnotationLiteralProcessor.process(AnnotationLiteralProcessor.java:92)
	at io.quarkus.arc.processor.BeanGenerator.initConstructor(BeanGenerator.java:624)
	at io.quarkus.arc.processor.BeanGenerator.createConstructor(BeanGenerator.java:513)
	at io.quarkus.arc.processor.BeanGenerator.generateProducerMethodBean(BeanGenerator.java:371)
	at io.quarkus.arc.processor.BeanGenerator.generate(BeanGenerator.java:124)
	at io.quarkus.arc.processor.BeanProcessor.process(BeanProcessor.java:186)
	at io.quarkus.arc.deployment.ArcAnnotationProcessor.build(ArcAnnotationProcessor.java:259)
```

It's a small addition but will make our everyday life a little bit easier when faced with this error again :)