### PR TITLE
Unclutter dev mode logging

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -22,12 +22,14 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.locks.LockSupport;
+import java.util.logging.Handler;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.runner.RuntimeRunner;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.Timing;
+import io.quarkus.runtime.logging.InitialConfigurator;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
 /**
@@ -112,6 +114,11 @@ public class DevModeMain {
         } catch (Throwable t) {
             deploymentProblem = t;
             log.error("Failed to start quarkus", t);
+
+            // if the log handler is not activated, activate it with a default configuration to flush the messages
+            if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
+                InitialConfigurator.DELAYED_HANDLER.setHandlers(new Handler[] { InitialConfigurator.createDefaultHandler() });
+            }
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InitialConfigurator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InitialConfigurator.java
@@ -16,23 +16,23 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
 
     public static final DelayedHandler DELAYED_HANDLER = new DelayedHandler();
 
+    @Override
     public Level getMinimumLevelOf(final String loggerName) {
         return Level.ALL;
     }
 
+    @Override
     public Level getLevelOf(final String loggerName) {
         return loggerName.isEmpty() ? Level.ALL : null;
     }
 
+    @Override
     public Handler[] getHandlersOf(final String loggerName) {
         if (loggerName.isEmpty()) {
-            if (ImageInfo.inImageBuildtimeCode() || System.getProperty("quarkus-internal.devMode") != null) {
-                final ConsoleHandler handler = new ConsoleHandler(new PatternFormatter(
-                        "%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
-                handler.setLevel(Level.INFO);
+            if (ImageInfo.inImageBuildtimeCode()) {
                 // we can't set a cleanup filter without the build items ready
                 return new Handler[] {
-                        handler
+                        createDefaultHandler()
                 };
             } else {
                 return new Handler[] { DELAYED_HANDLER };
@@ -40,5 +40,11 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
         } else {
             return NO_HANDLERS;
         }
+    }
+
+    public static ConsoleHandler createDefaultHandler() {
+        ConsoleHandler handler = new ConsoleHandler(new PatternFormatter("%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
+        handler.setLevel(Level.INFO);
+        return handler;
     }
 }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -64,7 +64,7 @@ public class QuarkusDev extends QuarkusTask {
 
     private boolean preventnoverify = false;
 
-    private static final String RESOURCES_PROP = "quarkus.undertow.resources";
+    private static final String RESOURCES_PROP = "quarkus-internal.undertow.resources";
 
     public QuarkusDev() {
         super("Creates a native image");

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -186,8 +186,6 @@ public class QuarkusDev extends QuarkusTask {
             if (getJvmArgs() != null) {
                 args.addAll(Arrays.asList(getJvmArgs().split(" ")));
             }
-            //Add env to enable quarkus dev mode logging
-            args.add("-Dquarkus-internal.devMode");
 
             for (File f : extension.resourcesDir()) {
                 File servletRes = new File(f, "META-INF/resources");

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -190,7 +190,7 @@ public class DevMojo extends AbstractMojo {
         try {
             List<String> args = new ArrayList<>();
             String javaTool = findJavaTool();
-            getLog().info("Using javaTool: " + javaTool);
+            getLog().debug("Using javaTool: " + javaTool);
             args.add(javaTool);
             if (debug == null) {
                 // debug mode not specified
@@ -237,7 +237,7 @@ public class DevMojo extends AbstractMojo {
                 File servletRes = new File(f, "META-INF/resources");
                 if (servletRes.exists()) {
                     args.add("-D" + RESOURCES_PROP + "=" + servletRes.getAbsolutePath());
-                    getLog().info("Using servlet resources " + servletRes.getAbsolutePath());
+                    getLog().debug("Using servlet resources: " + servletRes.getAbsolutePath());
                     break;
                 }
             }
@@ -388,7 +388,7 @@ public class DevMojo extends AbstractMojo {
             Toolchain toolchain = getToolchainManager().getToolchainFromBuildContext("jdk", getSession());
             if (toolchain != null) {
                 java = toolchain.findTool("java");
-                getLog().info("JVM from toolchain: " + java);
+                getLog().debug("JVM from toolchain: " + java);
             }
         }
         if (java == null) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -229,8 +229,6 @@ public class DevMojo extends AbstractMojo {
                     args.add("-D" + i.getKey() + "=" + i.getValue());
                 }
             }
-            //Add env to enable quarkus dev mode logging
-            args.add("-Dquarkus-internal.devMode");
 
             for (Resource r : project.getBuild().getResources()) {
                 File f = new File(r.getDirectory());

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -72,7 +72,7 @@ import io.quarkus.maven.utilities.MojoUtils;
 @Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DevMojo extends AbstractMojo {
 
-    private static final String RESOURCES_PROP = "quarkus.undertow.resources";
+    private static final String RESOURCES_PROP = "quarkus-internal.undertow.resources";
 
     /**
      * The directory for compiled classes.

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentTemplate.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentTemplate.java
@@ -89,7 +89,7 @@ public class UndertowDeploymentTemplate {
             currentRoot.handleRequest(exchange);
         }
     };
-    private static final String RESOURCES_PROP = "quarkus.undertow.resources";
+    private static final String RESOURCES_PROP = "quarkus-internal.undertow.resources";
 
     private static volatile Undertow undertow;
     private static final List<HandlerWrapper> hotDeploymentWrappers = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
- Change `quarkus.undertow.resources` to `quarkus-internal.undertow.resources` to avoid an unrecognized config log message
- Remove some newly added log messages (some debug messages were moved to info by mistake AFAICS)
- Restore log cleanup filters and colors by reverting https://github.com/quarkusio/quarkus/pull/1375 and fixing it in a different way

Fixes #1764 
Fixes #1803 
Also fixes https://github.com/quarkusio/quarkus/issues/1393 as it was introduced by https://github.com/quarkusio/quarkus/pull/1375