### PR TITLE
Add all system properties to args for dev mode.

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -225,9 +225,7 @@ public class DevMojo extends AbstractMojo {
             }
             //we don't want to just copy every system property, as a lot of them are set by the JVM
             for (Map.Entry<Object, Object> i : System.getProperties().entrySet()) {
-                if (i.getKey().toString().startsWith("quarkus.")) {
-                    args.add("-D" + i.getKey() + "=" + i.getValue());
-                }
+                args.add("-D" + i.getKey() + "=" + i.getValue());
             }
 
             for (Resource r : project.getBuild().getResources()) {


### PR DESCRIPTION
User input VM argument is ignored in development mode because it only takes argument starts with **quarkus.**