### PR TITLE
System property name change quarkus-project-discovery -> quarkus-ws-discovery

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
@@ -47,8 +47,8 @@ public class BootstrapClassLoaderFactory {
     private static final String BOOTSTRAP = "bootstrap";
     private static final String DEPLOYMENT_CP = "deployment.cp";
 
-    public static final String PROP_CP_CACHE = "quarkus-cp-cache";
-    public static final String PROP_PROJECT_DISCOVERY = "quarkus-project-discovery";
+    public static final String PROP_CP_CACHE = "quarkus-classpath-cache";
+    public static final String PROP_WS_DISCOVERY = "quarkus-workspace-discovery";
     public static final String PROP_OFFLINE = "quarkus-bootstrap-offline";
 
     private static final int CP_CACHE_FORMAT_ID = 1;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -94,7 +94,7 @@ public class QuarkusTestExtension
                     .setParent(getClass().getClassLoader())
                     .setOffline(PropertyUtils.getBooleanOrNull(BootstrapClassLoaderFactory.PROP_OFFLINE))
                     .setLocalProjectsDiscovery(
-                            PropertyUtils.getBoolean(BootstrapClassLoaderFactory.PROP_PROJECT_DISCOVERY, true))
+                            PropertyUtils.getBoolean(BootstrapClassLoaderFactory.PROP_WS_DISCOVERY, true))
                     .setEnableClasspathCache(PropertyUtils.getBoolean(BootstrapClassLoaderFactory.PROP_CP_CACHE, true))
                     .newDeploymentClassLoader();
         } catch (BootstrapException e) {


### PR DESCRIPTION
This is a minor change, it's very unlikely users have started using it and it didn't exist in the previous release.
I'll document the properties introduced in bootstrap after this has been merged.