### PR TITLE
Docs update to use same property name as project creator templates

### DIFF
--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -109,7 +109,7 @@ In the `pom.xml` file, the `native` profile contains:
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-failsafe-plugin</artifactId>
-    <version>${surefire.version}</version>
+    <version>${surefire-plugin.version}</version>
     <executions>
         <execution>
             <goals>

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -295,7 +295,7 @@ be set, as the default version does not support Junit 5:
 ----
 <plugin>
     <artifactId>maven-surefire-plugin</artifactId>
-    <version>${surefire.version}</version>
+    <version>${surefire-plugin.version}</version>
     <configuration>
        <systemProperties>
           <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -85,7 +85,7 @@ must be set, as the default version does not support Junit 5:
 ----
 <plugin>
     <artifactId>maven-surefire-plugin</artifactId>
-    <version>${surefire.version}</version>
+    <version>${surefire-plugin.version}</version>
     <configuration>
        <systemProperties>
           <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -308,7 +308,7 @@ If you have not used <<project-creation,project scaffolding>>, add the following
                 <plugin> <4>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${surefire.version}</version>
+                    <version>${surefire-plugin.version}</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Docs update to use same property name as project creator templates

Discussion in https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/surefire.20plugin.20version.20property/near/162419128