### PR TITLE
Generate default constructor for RESTEasy classes if needed

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ConstructorInjectionResource.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ConstructorInjectionResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/ctor")
+public class ConstructorInjectionResource {
+
+    final Service service;
+
+    public ConstructorInjectionResource(Service service) {
+        this.service = service;
+    }
+
+    @GET
+    public String val() {
+        return service.execute();
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ConstructorInjectionResourceTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ConstructorInjectionResourceTestCase.java
@@ -1,0 +1,23 @@
+package io.quarkus.resteasy.test;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ConstructorInjectionResourceTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConstructorInjectionResource.class, Service.class));
+
+    @Test
+    public void testConstructorInjectionResource() {
+        RestAssured.when().get("/ctor").then().body(Matchers.is("service"));
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/Service.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/Service.java
@@ -1,0 +1,11 @@
+package io.quarkus.resteasy.test;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Service {
+
+    String execute() {
+        return "service";
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/Someservice.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/Someservice.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.rest;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Someservice {
+
+    public String name() {
+        return "some";
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceWithConstructorInjection.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceWithConstructorInjection.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/testCtor")
+public class TestResourceWithConstructorInjection {
+
+    final Someservice service;
+
+    public TestResourceWithConstructorInjection(Someservice service) {
+        this.service = service;
+    }
+
+    @GET
+    @Path("/service")
+    public String service() {
+        return service.name();
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceWithTwoConstructors.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceWithTwoConstructors.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.rest;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/testCtor2")
+public class TestResourceWithTwoConstructors {
+
+    Someservice service;
+
+    public TestResourceWithTwoConstructors() {
+    }
+
+    @Inject
+    public TestResourceWithTwoConstructors(Someservice service) {
+        this.service = service;
+    }
+
+    @GET
+    @Path("/service")
+    public String service() {
+        return service.name();
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestResteasyConstructorsTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestResteasyConstructorsTestCase.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class TestResteasyConstructorsTestCase {
+
+    @Test
+    public void testWithoutDefaultConstructor() {
+        RestAssured.when().get("/testCtor/service").then().body(is("some"));
+    }
+
+    @Test
+    public void testWithDefaultConstructor() {
+        RestAssured.when().get("/testCtor2/service").then().body(is("some"));
+    }
+}


### PR DESCRIPTION
This allows users to use constructor injection in their RESTEasy resources.
For a complete background on why this is a proper solution, see:
https://issues.jboss.org/browse/RESTEASY-2183

Fixes: #1314