### PR TITLE
Initial work on enabling a shared executor pool

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ExecutorBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ExecutorBuildItem.java
@@ -16,20 +16,21 @@
 
 package io.quarkus.deployment.builditem;
 
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
+ * The main executor for blocking tasks
  */
 public final class ExecutorBuildItem extends SimpleBuildItem {
-    private final Executor executor;
+    private final ExecutorService executor;
 
-    public ExecutorBuildItem(final Executor executor) {
+    public ExecutorBuildItem(final ExecutorService executor) {
         this.executor = executor;
     }
 
-    public Executor getExecutorProxy() {
+    public ExecutorService getExecutorProxy() {
         return executor;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ThreadPoolSetup.java
@@ -20,24 +20,24 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.substrate.RuntimeInitializedClassBuildItem;
 import io.quarkus.runtime.ExecutorTemplate;
+import io.quarkus.runtime.ThreadPoolConfig;
 
 /**
+ *
  */
 public class ThreadPoolSetup {
 
     @BuildStep
     @Record(value = ExecutionTime.RUNTIME_INIT, optional = true)
-    public ExecutorBuildItem createExecutor(ExecutorTemplate setupTemplate, ShutdownContextBuildItem shutdownContextBuildItem) {
-        return new ExecutorBuildItem(setupTemplate.setupRunTime(shutdownContextBuildItem,
-                // build time default config constants - static method calls are not proxied
-                ExecutorTemplate.getIntConfigVal(ExecutorTemplate.CORE_POOL_SIZE, -1),
-                ExecutorTemplate.getIntConfigVal(ExecutorTemplate.MAX_POOL_SIZE, -1),
-                ExecutorTemplate.getIntConfigVal(ExecutorTemplate.QUEUE_SIZE, Integer.MAX_VALUE),
-                ExecutorTemplate.getFloatConfigVal(ExecutorTemplate.GROWTH_RESISTANCE, 0f),
-                ExecutorTemplate.getIntConfigVal(ExecutorTemplate.KEEP_ALIVE_MILLIS, 60_000)));
+    public ExecutorBuildItem createExecutor(ExecutorTemplate setupTemplate, ShutdownContextBuildItem shutdownContextBuildItem,
+            LaunchModeBuildItem launchModeBuildItem,
+            ThreadPoolConfig threadPoolConfig) {
+        return new ExecutorBuildItem(
+                setupTemplate.setupRunTime(shutdownContextBuildItem, threadPoolConfig, launchModeBuildItem.getLaunchMode()));
     }
 
     @BuildStep

--- a/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
@@ -1,0 +1,60 @@
+package io.quarkus.runtime;
+
+import java.time.Duration;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * The core thread pool config. This thread pool is responsible for running
+ * all blocking tasks.
+ */
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class ThreadPoolConfig {
+
+    /**
+     * The core thread pool size. This number of threads will always be kept alive.
+     */
+    @ConfigItem(defaultValue = "1")
+    public int coreThreads;
+
+    /**
+     * The maximum number of threads. If this is not specified or <= to zero then
+     * it will be automatically sized to 4 * the number of available processors
+     */
+    @ConfigItem(defaultValue = "0")
+    public int maxThreads;
+
+    /**
+     * The queue size. For most applications this should be unbounded
+     */
+    @ConfigItem(defaultValue = "0")
+    public int queueSize;
+
+    /**
+     * The executor growth resistance.
+     *
+     * A resistance factor applied after the core pool is full; values applied here will cause that fraction
+     * of submissions to create new threads when no idle thread is available. A value of {@code 0.0f} implies that
+     * threads beyond the core size should be created as aggressively as threads within it; a value of {@code 1.0f}
+     * implies that threads beyond the core size should never be created.
+     */
+    @ConfigItem(defaultValue = "0")
+    public float growthResistance;
+
+    /**
+     * The shutdown timeout in milliseconds. Defaults to 60s. If all pending work has not been completed by this time
+     * then additional threads will be spawned to attempt to finish any pending tasks, and the shutdown process will
+     * continue
+     */
+    @ConfigItem(defaultValue = "PT60S")
+    public Duration shutdownTimeout;
+
+    /**
+     * The amount of time in milliseconds a thread will stay alive with no work. Defaults to 1 second
+     */
+    @ConfigItem(defaultValue = "PT1S")
+    public Duration keepAliveTime;
+
+}

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -102,6 +102,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentConfigFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ObjectSubstitutionBuildItem;
@@ -151,8 +152,10 @@ public class UndertowBuildStep {
             ShutdownContextBuildItem shutdown,
             Consumer<UndertowBuildItem> undertowProducer,
             LaunchModeBuildItem launchMode,
+            ExecutorBuildItem executorBuildItem,
             HttpConfig config) throws Exception {
-        RuntimeValue<Undertow> ut = template.startUndertow(shutdown, servletDeploymentManagerBuildItem.getDeploymentManager(),
+        RuntimeValue<Undertow> ut = template.startUndertow(shutdown, executorBuildItem.getExecutorProxy(),
+                servletDeploymentManagerBuildItem.getDeploymentManager(),
                 config, wrappers.stream().map(HttpHandlerWrapperBuildItem::getValue).collect(Collectors.toList()),
                 launchMode.getLaunchMode());
         undertowProducer.accept(new UndertowBuildItem(ut));

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/HttpConfig.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/HttpConfig.java
@@ -60,13 +60,6 @@ public class HttpConfig {
     public String host;
 
     /**
-     * The number of worker threads used for blocking tasks, this will be automatically set to a reasonable value
-     * based on the number of CPU core if it is not provided
-     */
-    @ConfigItem
-    public OptionalInt workerThreads;
-
-    /**
      * The number if IO threads used to perform IO. This will be automatically set to a reasonable value based on
      * the number of CPU cores if it is not provided
      */

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentTemplate.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentTemplate.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
@@ -40,6 +42,8 @@ import javax.servlet.ServletException;
 
 import org.jboss.logging.Logger;
 import org.wildfly.common.net.Inet;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
 
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.runtime.BeanContainer;
@@ -266,19 +270,22 @@ public class UndertowDeploymentTemplate {
         info.getValue().addInitParameter(name, value);
     }
 
-    public RuntimeValue<Undertow> startUndertow(ShutdownContext shutdown, DeploymentManager manager, HttpConfig config,
+    public RuntimeValue<Undertow> startUndertow(ShutdownContext shutdown, ExecutorService executorService,
+            DeploymentManager manager, HttpConfig config,
             List<HandlerWrapper> wrappers, LaunchMode launchMode) throws Exception {
 
         if (undertow == null) {
             SSLContext context = config.ssl.toSSLContext();
-            doServerStart(config, launchMode, context);
+            doServerStart(config, launchMode, context, executorService);
 
             if (launchMode != LaunchMode.DEVELOPMENT) {
                 //in development mode undertow should not be shut down
                 shutdown.addShutdownTask(new Runnable() {
                     @Override
                     public void run() {
+                        XnioWorker worker = undertow.getWorker();
                         undertow.stop();
+                        worker.shutdown();
                         undertow = null;
                     }
                 });
@@ -327,7 +334,7 @@ public class UndertowDeploymentTemplate {
      * be no chance to use hot deployment to fix the error. In development mode we start Undertow early, so any error
      * on boot can be corrected via the hot deployment handler
      */
-    private static void doServerStart(HttpConfig config, LaunchMode launchMode, SSLContext sslContext)
+    private static void doServerStart(HttpConfig config, LaunchMode launchMode, SSLContext sslContext, ExecutorService executor)
             throws ServletException {
         if (undertow == null) {
             int port = config.determinePort(launchMode);
@@ -338,20 +345,22 @@ public class UndertowDeploymentTemplate {
                 rootHandler = i.wrap(rootHandler);
             }
 
+            XnioWorker.Builder workerBuilder = Xnio.getInstance().createWorkerBuilder()
+                    .setExternalExecutorService(executor);
+
             Undertow.Builder builder = Undertow.builder()
                     .addHttpListener(port, config.host)
                     .setHandler(rootHandler);
             if (config.ioThreads.isPresent()) {
-                builder.setIoThreads(config.ioThreads.getAsInt());
+                workerBuilder.setWorkerIoThreads(config.ioThreads.getAsInt());
             } else if (launchMode.isDevOrTest()) {
                 //we limit the number of IO and worker threads in development and testing mode
-                builder.setIoThreads(2);
+                workerBuilder.setWorkerIoThreads(2);
+            } else {
+                workerBuilder.setWorkerIoThreads(Runtime.getRuntime().availableProcessors() * 2);
             }
-            if (config.workerThreads.isPresent()) {
-                builder.setWorkerThreads(config.workerThreads.getAsInt());
-            } else if (launchMode.isDevOrTest()) {
-                builder.setWorkerThreads(6);
-            }
+            XnioWorker worker = workerBuilder.build();
+            builder.setWorker(worker);
             if (sslContext != null) {
                 log.debugf("Starting Undertow HTTPS listener on port %d", sslPort);
                 builder.addHttpsListener(sslPort, config.host, sslContext);


### PR DESCRIPTION
This changes Undertow to use a shared thread pool for blocking work, instead of the XNIO worker maintaining its own pool