### PR TITLE
add support for GraalVM RuntimeReflection's 'finalIsWritable' parameter

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveClassBuildItem.java
@@ -16,6 +16,8 @@
 
 package io.quarkus.deployment.builditem.substrate;
 
+import static java.util.Arrays.stream;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +43,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this(constructors, methods, fields, false, className);
     }
 
-    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
+    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
             Class<?>... className) {
         List<String> names = new ArrayList<>();
         for (Class<?> i : className) {
@@ -65,7 +67,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this(constructors, methods, fields, false, className);
     }
 
-    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
+    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
             String... className) {
         for (String i : className) {
             if (i == null) {
@@ -97,5 +99,64 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     public boolean isFinalWritable() {
         return finalIsWritable;
+    }
+
+    public static Builder builder(Class<?>... className) {
+        String[] classNameStrings = stream(className)
+                .map(aClass -> {
+                    if (aClass == null) {
+                        throw new NullPointerException();
+                    }
+                    return aClass.getName();
+                })
+                .toArray(String[]::new);
+
+        return new Builder()
+                .className(classNameStrings);
+    }
+
+    public static Builder builder(String... className) {
+        return new Builder()
+                .className(className);
+    }
+
+    public static class Builder {
+        private String[] className;
+        private boolean constructors = true;
+        private boolean methods;
+        private boolean fields;
+        private boolean finalIsWritable;
+
+        private Builder() {
+        }
+
+        public Builder className(String[] className) {
+            this.className = className;
+            return this;
+        }
+
+        public Builder constructors(boolean constructors) {
+            this.constructors = constructors;
+            return this;
+        }
+
+        public Builder methods(boolean methods) {
+            this.methods = methods;
+            return this;
+        }
+
+        public Builder fields(boolean fields) {
+            this.fields = fields;
+            return this;
+        }
+
+        public Builder finalIsWritable(boolean finalIsWritable) {
+            this.finalIsWritable = finalIsWritable;
+            return this;
+        }
+
+        public ReflectiveClassBuildItem build() {
+            return new ReflectiveClassBuildItem(constructors, methods, fields, finalIsWritable, className);
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveClassBuildItem.java
@@ -31,12 +31,18 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final boolean methods;
     private final boolean fields;
     private final boolean constructors;
+    private final boolean finalIsWritable;
 
     public ReflectiveClassBuildItem(boolean methods, boolean fields, Class<?>... className) {
         this(true, methods, fields, className);
     }
 
     public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, Class<?>... className) {
+        this(constructors, methods, fields, false, className);
+    }
+
+    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
+            Class<?>... className) {
         List<String> names = new ArrayList<>();
         for (Class<?> i : className) {
             if (i == null) {
@@ -48,14 +54,19 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.methods = methods;
         this.fields = fields;
         this.constructors = constructors;
+        this.finalIsWritable = finalIsWritable;
     }
 
     public ReflectiveClassBuildItem(boolean methods, boolean fields, String... className) {
         this(true, methods, fields, className);
-
     }
 
     public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, String... className) {
+        this(constructors, methods, fields, false, className);
+    }
+
+    public ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
+            String... className) {
         for (String i : className) {
             if (i == null) {
                 throw new NullPointerException();
@@ -65,6 +76,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.methods = methods;
         this.fields = fields;
         this.constructors = constructors;
+        this.finalIsWritable = finalIsWritable;
     }
 
     public List<String> getClassNames() {
@@ -81,5 +93,9 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
 
     public boolean isConstructors() {
         return constructors;
+    }
+
+    public boolean isFinalWritable() {
+        return finalIsWritable;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveClassBuildItem.java
@@ -33,7 +33,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
     private final boolean methods;
     private final boolean fields;
     private final boolean constructors;
-    private final boolean finalIsWritable;
+    private final boolean finalFieldsWritable;
 
     public ReflectiveClassBuildItem(boolean methods, boolean fields, Class<?>... className) {
         this(true, methods, fields, className);
@@ -43,7 +43,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this(constructors, methods, fields, false, className);
     }
 
-    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
+    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
             Class<?>... className) {
         List<String> names = new ArrayList<>();
         for (Class<?> i : className) {
@@ -56,7 +56,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.methods = methods;
         this.fields = fields;
         this.constructors = constructors;
-        this.finalIsWritable = finalIsWritable;
+        this.finalFieldsWritable = finalFieldsWritable;
     }
 
     public ReflectiveClassBuildItem(boolean methods, boolean fields, String... className) {
@@ -67,7 +67,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this(constructors, methods, fields, false, className);
     }
 
-    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable,
+    private ReflectiveClassBuildItem(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable,
             String... className) {
         for (String i : className) {
             if (i == null) {
@@ -78,7 +78,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         this.methods = methods;
         this.fields = fields;
         this.constructors = constructors;
-        this.finalIsWritable = finalIsWritable;
+        this.finalFieldsWritable = finalFieldsWritable;
     }
 
     public List<String> getClassNames() {
@@ -97,8 +97,8 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         return constructors;
     }
 
-    public boolean isFinalWritable() {
-        return finalIsWritable;
+    public boolean areFinalFieldsWritable() {
+        return finalFieldsWritable;
     }
 
     public static Builder builder(Class<?>... className) {
@@ -125,7 +125,7 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         private boolean constructors = true;
         private boolean methods;
         private boolean fields;
-        private boolean finalIsWritable;
+        private boolean finalFieldsWritable;
 
         private Builder() {
         }
@@ -150,13 +150,13 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
             return this;
         }
 
-        public Builder finalIsWritable(boolean finalIsWritable) {
-            this.finalIsWritable = finalIsWritable;
+        public Builder finalFieldsWritable(boolean finalFieldsWritable) {
+            this.finalFieldsWritable = finalFieldsWritable;
             return this;
         }
 
         public ReflectiveClassBuildItem build() {
-            return new ReflectiveClassBuildItem(constructors, methods, fields, finalIsWritable, className);
+            return new ReflectiveClassBuildItem(constructors, methods, fields, finalFieldsWritable, className);
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/SubstrateAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/SubstrateAutoFeatureStep.java
@@ -273,7 +273,8 @@ public class SubstrateAutoFeatureStep {
             if (entry.getValue().fields) {
                 tc.invokeStaticMethod(
                         ofMethod("org/graalvm/nativeimage/RuntimeReflection", "register", void.class,
-                                boolean.class, Field[].class), tc.load(entry.getValue().finalIsWritable), fields);
+                                boolean.class, Field[].class),
+                        tc.load(entry.getValue().finalIsWritable), fields);
             } else if (!entry.getValue().fieldSet.isEmpty()) {
                 ResultHandle farray = tc.newArray(Field.class, tc.load(1));
                 for (String field : entry.getValue().fieldSet) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/SubstrateAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/SubstrateAutoFeatureStep.java
@@ -192,7 +192,7 @@ public class SubstrateAutoFeatureStep {
 
         final Map<String, ReflectionInfo> reflectiveClasses = new LinkedHashMap<>();
         for (ReflectiveClassBuildItem i : reflectiveClassBuildItems) {
-            addReflectiveClass(reflectiveClasses, i.isConstructors(), i.isMethods(), i.isFields(), i.isFinalWritable(),
+            addReflectiveClass(reflectiveClasses, i.isConstructors(), i.isMethods(), i.isFields(), i.areFinalFieldsWritable(),
                     i.getClassNames().toArray(new String[0]));
         }
         for (ReflectiveFieldBuildItem i : reflectiveFields) {
@@ -274,7 +274,7 @@ public class SubstrateAutoFeatureStep {
                 tc.invokeStaticMethod(
                         ofMethod("org/graalvm/nativeimage/RuntimeReflection", "register", void.class,
                                 boolean.class, Field[].class),
-                        tc.load(entry.getValue().finalIsWritable), fields);
+                        tc.load(entry.getValue().finalFieldsWritable), fields);
             } else if (!entry.getValue().fieldSet.isEmpty()) {
                 ResultHandle farray = tc.newArray(Field.class, tc.load(1));
                 for (String field : entry.getValue().fieldSet) {
@@ -314,12 +314,12 @@ public class SubstrateAutoFeatureStep {
     }
 
     public void addReflectiveClass(Map<String, ReflectionInfo> reflectiveClasses, boolean constructors, boolean method,
-            boolean fields, boolean finalIsWritable,
+            boolean fields, boolean finalFieldsWritable,
             String... className) {
         for (String cl : className) {
             ReflectionInfo existing = reflectiveClasses.get(cl);
             if (existing == null) {
-                reflectiveClasses.put(cl, new ReflectionInfo(constructors, method, fields, finalIsWritable));
+                reflectiveClasses.put(cl, new ReflectionInfo(constructors, method, fields, finalFieldsWritable));
             } else {
                 if (constructors) {
                     existing.constructors = true;
@@ -347,16 +347,16 @@ public class SubstrateAutoFeatureStep {
         boolean constructors;
         boolean methods;
         boolean fields;
-        boolean finalIsWritable;
+        boolean finalFieldsWritable;
         Set<String> fieldSet = new HashSet<>();
         Set<ReflectiveMethodBuildItem> methodSet = new HashSet<>();
         Set<ReflectiveMethodBuildItem> ctorSet = new HashSet<>();
 
-        private ReflectionInfo(boolean constructors, boolean methods, boolean fields, boolean finalIsWritable) {
+        private ReflectionInfo(boolean constructors, boolean methods, boolean fields, boolean finalFieldsWritable) {
             this.methods = methods;
             this.fields = fields;
             this.constructors = constructors;
-            this.finalIsWritable = finalIsWritable;
+            this.finalFieldsWritable = finalFieldsWritable;
         }
     }
 }

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -48,10 +48,7 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateResourceBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateResourceBundleBuildItem;
-import io.quarkus.extest.runtime.IConfigConsumer;
-import io.quarkus.extest.runtime.RuntimeXmlConfigService;
-import io.quarkus.extest.runtime.TestAnnotation;
-import io.quarkus.extest.runtime.TestTemplate;
+import io.quarkus.extest.runtime.*;
 import io.quarkus.extest.runtime.beans.CommandServlet;
 import io.quarkus.extest.runtime.beans.PublicKeyProducer;
 import io.quarkus.extest.runtime.config.ObjectOfValue;
@@ -426,5 +423,16 @@ public final class TestProcessor {
             classes.produce(new ReflectiveClassBuildItem(true, true, className));
             log.debugf("Register SUN.provider class: %s", className);
         }
+    }
+
+    @BuildStep
+    void registerFinalFieldReflectionObject(BuildProducer<ReflectiveClassBuildItem> classes) {
+        ReflectiveClassBuildItem finalField = ReflectiveClassBuildItem
+                .builder(FinalFieldReflectionObject.class.getName())
+                .methods(true)
+                .fields(true)
+                .finalIsWritable(true)
+                .build();
+        classes.produce(finalField);
     }
 }

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -431,7 +431,7 @@ public final class TestProcessor {
                 .builder(FinalFieldReflectionObject.class.getName())
                 .methods(true)
                 .fields(true)
-                .finalIsWritable(true)
+                .finalFieldsWritable(true)
                 .build();
         classes.produce(finalField);
     }

--- a/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/FinalFieldReflectionObject.java
+++ b/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/FinalFieldReflectionObject.java
@@ -1,0 +1,17 @@
+package io.quarkus.extest.runtime;
+
+public class FinalFieldReflectionObject {
+    private final String value;
+
+    public FinalFieldReflectionObject() {
+        this.value = null;
+    }
+
+    public FinalFieldReflectionObject(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/integration-tests/test-extension/src/main/java/io/quarkus/example/FinalFieldReflectionTestEndpoint.java
+++ b/integration-tests/test-extension/src/main/java/io/quarkus/example/FinalFieldReflectionTestEndpoint.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.example;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.quarkus.extest.runtime.FinalFieldReflectionObject;
+
+/**
+ * Final field reflection functionality test
+ */
+@WebServlet(name = "FinalFieldReflectionTestEndpoint", urlPatterns = "/core/reflection/final")
+public class FinalFieldReflectionTestEndpoint extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        reflectiveSetterInvoke(resp);
+        resp.getWriter().write("OK");
+    }
+
+    private void reflectiveSetterInvoke(HttpServletResponse resp) throws IOException {
+        try {
+            FinalFieldReflectionObject nominalInstance = new FinalFieldReflectionObject();
+            Field field = nominalInstance.getClass().getDeclaredField("value");
+            field.setAccessible(true);
+            field.set(nominalInstance, "OK");
+
+            Method getValue = nominalInstance.getClass().getMethod("getValue");
+            Object value = getValue.invoke(nominalInstance);
+            if (!"OK".equals(value)) {
+                final PrintWriter writer = resp.getWriter();
+                writer.write(format("field incorrectly set, expecting 'OK', got '%s'", value));
+                writer.append("\n\t");
+            }
+        } catch (Exception e) {
+            reportException(e, resp);
+        }
+    }
+
+    private void reportException(final Exception e, final HttpServletResponse resp) throws IOException {
+        reportException(null, e, resp);
+    }
+
+    private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {
+        final PrintWriter writer = resp.getWriter();
+        if (errorMessage != null) {
+            writer.write(errorMessage);
+            writer.write(" ");
+        }
+        writer.write(e.toString());
+        writer.append("\n\t");
+        e.printStackTrace(writer);
+        writer.append("\n\t");
+    }
+
+}

--- a/integration-tests/test-extension/src/test/java/io/quarkus/extest/test/FinalFieldReflectionInGraalITCase.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/extest/test/FinalFieldReflectionInGraalITCase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.extest.test;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.SubstrateTest;
+import io.restassured.RestAssured;
+
+@SubstrateTest
+public class FinalFieldReflectionInGraalITCase {
+
+    @Test
+    public void testFieldAndGetterReflectionOnEntityFromServlet() throws Exception {
+        RestAssured.when().get("/core/reflection/final").then()
+                .body(is("OK"));
+    }
+
+}


### PR DESCRIPTION
# Rationale

I'm a heavy user of [JanusGraph database](https://janusgraph.org/) integrated with the [TinkerPop](http://tinkerpop.apache.org/) [gremlin-driver](http://tinkerpop.apache.org/docs/current/reference/#gremlin-java). The driver makes heavy use of reflections in order to deserialize requests and response from JanusGraph DB. It relies on a shaded version of [Kryo](https://github.com/EsotericSoftware/kryo) for the plumbing.

Since the announcement of Quarkus a few weeks ago, I've been working on a POC on my spare time for creating a quarkus extension for the gremlin-driver, registering necessary classes for reflection, etc. 

Today I am stuck as I discovered that in order to deserialize a [RelationIdentifier](https://github.com/JanusGraph/janusgraph/blob/master/janusgraph-core/src/main/java/org/janusgraph/graphdb/relations/RelationIdentifier.java) instance, Kryo needs to set final fields. Therefore it faces the dreadful SubstrateVM error `java.lang.IllegalAccessException: Cannot set final field: org.janusgraph.graphdb.relations.RelationIdentifier.inVertexId. Enable by specifying "allowWrite" for this field in the reflection configuration.`

# Solution

The [SubstrateVM reflection guide](https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md#manual-configuration) states that 

> In order to write a field that is declared final, the `allowWrite` attribute must be specified for that field

Problem is : this statement refers to the manual configuration based on a JSON file, and Quarkus does not rely on this file, but automatically generates a [Feature](https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Feature.java) instead. This generated Feature registers classes for reflection via the [RuntimeReflection](https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/RuntimeReflection.java) static utility methods.

I've been digging through this API and figured that the `register(Field... fields)` method has an overloaded version which accepts a `finalIsWritable` boolean parameter, which has the exact same effect as the `allowWrite` attribute stated above

# Implementation

This PR adds a new optional `finalIsWritable` boolean parameter to the existing Quarkus `ReflectiveClassBuildItem` constructors with a default value of `false`, and uses its value when calling the `register(boolean finalIsWritable, Field... fields)` in the generated `Feature`.

It successfully resolves the previous `IllegalAccessException` at native runtime when I produces a `new ReflectiveClassBuildItem(true, true, true, true, RelationIdentifier.class.getName())` in my POC extension.

If required, I can create and submit a small showcase project along this PR that would demonstrate the whole thing (my POC extension is far from being finalized though...)