### PR TITLE
Add documentation on the ServiceStartBuildItem and how it relates to startup events

### DIFF
--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -153,11 +153,12 @@ public final class TestProcessor {
      * @param template - runtime template
      * @param shutdownContextBuildItem - ShutdownContext information
      * @param serviceBuildItem - previously created RuntimeXmlConfigService container
+     * @return ServiceStartBuildItem - build item indicating the RuntimeXmlConfigService startuup
      * @throws IOException - on failure
      */
     @BuildStep
     @Record(RUNTIME_INIT)
-    void startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem,
+    ServiceStartBuildItem startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem,
             RuntimeServiceBuildItem serviceBuildItem) throws IOException {
         if (serviceBuildItem != null) {
             log.info("Registering service start");
@@ -165,6 +166,7 @@ public final class TestProcessor {
         } else {
             log.info("No RuntimeServiceBuildItem seen, check config.xml");
         }
+        return new ServiceStartBuildItem("RuntimeXmlConfigService");
     }
 
     /**

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -800,15 +800,15 @@ A common purpose for an extension is to integrate a non-CDI aware service into t
             log.infof("Have XmlConfig, loading");
             XmlConfig config = (XmlConfig) unmarshaller.unmarshal(is);
             log.infof("Loaded XmlConfig, creating service");
-            RuntimeValue<RuntimeXmlConfigService> service = template.initRuntimeService(config); <1>
-            serviceBuildItem = new RuntimeServiceBuildItem(service); <3>
+            RuntimeValue<RuntimeXmlConfigService> service = template.initRuntimeService(config); //<1>
+            serviceBuildItem = new RuntimeServiceBuildItem(service); //<3>
         }
         return serviceBuildItem;
     }
 
 // TestTemplate#initRuntimeService
     public RuntimeValue<RuntimeXmlConfigService> initRuntimeService(XmlConfig config) {
-        RuntimeXmlConfigService service = new RuntimeXmlConfigService(config); <2>
+        RuntimeXmlConfigService service = new RuntimeXmlConfigService(config); //<2>
         return new RuntimeValue<>(service);
     }
 
@@ -838,23 +838,23 @@ Now that you have recorded the creation of a service during the build phase, you
 // TestProcessor#startRuntimeService
     @BuildStep
     @Record(RUNTIME_INIT)
-    ServiceStartBuildItem startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem <1>,
-            RuntimeServiceBuildItem serviceBuildItem <2>) throws IOException {
+    ServiceStartBuildItem startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem , // <1>
+            RuntimeServiceBuildItem serviceBuildItem) throws IOException { // <2>
         if (serviceBuildItem != null) {
             log.info("Registering service start");
-            template.startRuntimeService(shutdownContextBuildItem, serviceBuildItem.getService()); <3>
+            template.startRuntimeService(shutdownContextBuildItem, serviceBuildItem.getService()); // <3>
         } else {
             log.info("No RuntimeServiceBuildItem seen, check config.xml");
         }
-        return new ServiceStartBuildItem("RuntimeXmlConfigService"); <4>
+        return new ServiceStartBuildItem("RuntimeXmlConfigService"); //<4>
     }
 
 // TestTemplate#startRuntimeService
     public void startRuntimeService(ShutdownContext shutdownContext, RuntimeValue<RuntimeXmlConfigService> runtimeValue)
             throws IOException {
         RuntimeXmlConfigService service = runtimeValue.getValue();
-        service.startService(); <5>
-        shutdownContext.addShutdownTask(service::stopService); <6>
+        service.startService(); //<5>
+        shutdownContext.addShutdownTask(service::stopService); //<6>
     }
 ----
 <1> We consume a ShutdownContextBuildItem to register the service shutdown.
@@ -919,7 +919,7 @@ we saw the production of a `ServiceStartBuildItem` in the previous section, and 
     ServiceStartBuildItem startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem,
             RuntimeServiceBuildItem serviceBuildItem) throws IOException {
 ...
-        return new ServiceStartBuildItem("RuntimeXmlConfigService"); <1>
+        return new ServiceStartBuildItem("RuntimeXmlConfigService"); //<1>
     }
 ----
 <1> Produce a `ServiceStartBuildItem` to indicate that this is a service starting step that needs to run before the `StartupEvent` is sent.
@@ -938,12 +938,12 @@ public final class MyExtProcessor {
 
     @BuildStep
     void registerNativeImageReources() {
-        resource.produce(new SubstrateResourceBuildItem("/security/runtime.keys")); <1>
+        resource.produce(new SubstrateResourceBuildItem("/security/runtime.keys")); //<1>
 
         resource.produce(new SubstrateResourceBuildItem(
-                "META-INF/services/" + io.quarkus.SomeService.class.getName())); <2>
+                "META-INF/services/" + io.quarkus.SomeService.class.getName())); //<2>
 
-        resourceBundle.produce(new SubstrateResourceBuildItem("javax.xml.bind.Messages")); <3>
+        resourceBundle.produce(new SubstrateResourceBuildItem("javax.xml.bind.Messages")); //<3>
     }
 }
 ----
@@ -984,7 +984,7 @@ import io.quarkus.runtime.ObjectSubstitution;
 public class DSAPublicKeyObjectSubstitution implements ObjectSubstitution<DSAPublicKey, KeyProxy> {
     private static final Logger log = Logger.getLogger("DSAPublicKeyObjectSubstitution");
     @Override
-    public KeyProxy serialize(DSAPublicKey obj) { <1>
+    public KeyProxy serialize(DSAPublicKey obj) { //<1>
         log.info("DSAPublicKeyObjectSubstitution.serialize");
         byte[] encoded = obj.getEncoded();
         KeyProxy proxy = new KeyProxy();
@@ -993,7 +993,7 @@ public class DSAPublicKeyObjectSubstitution implements ObjectSubstitution<DSAPub
     }
 
     @Override
-    public DSAPublicKey deserialize(KeyProxy obj) { <1>
+    public DSAPublicKey deserialize(KeyProxy obj) { //<2>
         log.info("DSAPublicKeyObjectSubstitution.deserialize");
         byte[] encoded = obj.getContent();
         X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(encoded);

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -838,29 +838,91 @@ Now that you have recorded the creation of a service during the build phase, you
 // TestProcessor#startRuntimeService
     @BuildStep
     @Record(RUNTIME_INIT)
-    void startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem <1>, RuntimeServiceBuildItem serviceBuildItem <2>) throws IOException {
-        log.info("Registering service start");
-        template.startRuntimeService(shutdownContextBuildItem, serviceBuildItem.getService()); <3>
+    ServiceStartBuildItem startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem <1>,
+            RuntimeServiceBuildItem serviceBuildItem <2>) throws IOException {
+        if (serviceBuildItem != null) {
+            log.info("Registering service start");
+            template.startRuntimeService(shutdownContextBuildItem, serviceBuildItem.getService()); <3>
+        } else {
+            log.info("No RuntimeServiceBuildItem seen, check config.xml");
+        }
+        return new ServiceStartBuildItem("RuntimeXmlConfigService"); <4>
     }
 
 // TestTemplate#startRuntimeService
     public void startRuntimeService(ShutdownContext shutdownContext, RuntimeValue<RuntimeXmlConfigService> runtimeValue)
             throws IOException {
         RuntimeXmlConfigService service = runtimeValue.getValue();
-        service.startService(); <4>
-        shutdownContext.addShutdownTask(service::stopService); <5>
+        service.startService(); <5>
+        shutdownContext.addShutdownTask(service::stopService); <6>
     }
 ----
 <1> We consume a ShutdownContextBuildItem to register the service shutdown.
 <2> We consume the previously initialized service captured in `RuntimeServiceBuildItem`.
 <3> Call the runtime template to record the service start invocation.
-<4> Runtime template retrieves the service instance reference and calls its `startService` method.
-<5> Runtime template registers an invocation of the service instance `stopService` method with the {project-name} `ShutdownContext`.
+<4> Produce a `ServiceStartBuildItem` to indicate the startup of a service. See <<Startup and Shutdown Events>> for details.
+<5> Runtime template retrieves the service instance reference and calls its `startService` method.
+<6> Runtime template registers an invocation of the service instance `stopService` method with the {project-name} `ShutdownContext`.
 
 The code for the `RuntimeXmlConfigService` can be viewed here:
 {quarkus-blob-url}/core/test-extension/runtime/src/main/java/io/quarkus/extest/runtime/RuntimeXmlConfigService.java[RuntimeXmlConfigService.java]
 
 The testcase for validating that the `RuntimeXmlConfigService` has started can be found in the `testRuntimeXmlConfigService` test of `ConfiguredBeanTest` and `NativeImageIT`.
+
+=== Startup and Shutdown Events
+The {project-name} container supports startup and shutdown lifecycle events to notify components of the container startup
+and shutdown. There are CDI events fired that components can observe are illustrated in this example:
+
+.Observing Container Startup
+[source,java]
+----
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+puclic class SomeBean {
+    /**
+     * Called when the runtime has started
+     * @param event
+     */
+    void onStart(@Observes StartupEvent event) { // <1>
+        System.out.printf("onStart, event=%s\n", event);
+    }
+
+    /**
+     * Called when the runtime is shutting down
+     * @param event
+    */
+    void onStop(@Observes ShutdownEvent event) { // <2>
+        System.out.printf("onStop, event=%s\n", event);
+    }
+}
+----
+<1> Observe a `StartupEvent` to be notified the runtime has started.
+<2> Observe a 'ShutdownEvent` to be notified when the runtime is going to shutdown.
+
+What is the relevance of startup and shutdown events for extension authors? We have already seen the use of a `ShutdownContext`
+to register a callback to perform shutdown tasks in the <<Starting a Service>> section. These shutdown tasks would be called
+after a `ShutdownEvent` had been sent.
+
+A `StartupEvent` is fired after all `io.quarkus.deployment.builditem.ServiceStartBuildItem` producers have been consumed.
+The implication of this is that if an extension has services that application components would expect to have been
+started when they observe a `StartupEvent`, the build steps that invoke the runtime code to start those services needs
+to produce a `ServiceStartBuildItem` to ensure that the runtime code is run before the `StartupEvent` is sent. Recall that
+we saw the production of a `ServiceStartBuildItem` in the previous section, and it is repeated here for clarity:
+
+.Example of Producing a ServiceStartBuildItem
+[source,java]
+----
+// TestProcessor#startRuntimeService
+    @BuildStep
+    @Record(RUNTIME_INIT)
+    ServiceStartBuildItem startRuntimeService(TestTemplate template, ShutdownContextBuildItem shutdownContextBuildItem,
+            RuntimeServiceBuildItem serviceBuildItem) throws IOException {
+...
+        return new ServiceStartBuildItem("RuntimeXmlConfigService"); <1>
+    }
+----
+<1> Produce a `ServiceStartBuildItem` to indicate that this is a service starting step that needs to run before the `StartupEvent` is sent.
 
 === Register Resources for Use in Native Image
 Not all configuration or resources can be consumed at build time. If you have classpath resources that the runtime needs to access, you need to inform the build phase that these resources need to be copied into the native image. This is done by producing one or more `SubstrateResourceBuildItem` or `SubstrateResourceBundleBuildItem` in the case of resource bundles. Examples of this are shown in this sample `registerNativeImageReources` build step:


### PR DESCRIPTION
This addresses some missing documentation about how extensions that create services need to produce a ServiceStartBuildItem to ensure that code is run before a StartupEvent is generated.