### PR TITLE
Some improvements regarding our use of Commons Beanutils

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -83,7 +83,7 @@
         <graal-sdk.version>1.0.0-rc14</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha3</gizmo.version>
         <jackson.version>2.9.8</jackson.version>
-        <commons-beanutils-core.version>1.8.3</commons-beanutils-core.version>
+        <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
@@ -564,8 +564,8 @@
 
             <dependency>
                 <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils-core</artifactId>
-                <version>${commons-beanutils-core.version}</version>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons-beanutils.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils-core</artifactId>
+            <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.invocation</groupId>

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.beanutils.PropertyUtils;
 import org.jboss.invocation.proxy.ProxyConfiguration;
 import org.jboss.invocation.proxy.ProxyFactory;
 import org.jboss.jandex.AnnotationValue;
@@ -549,80 +548,84 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 }
             }
             Set<String> handledProperties = new HashSet<>();
-            PropertyDescriptor[] desc = PropertyUtils.getPropertyDescriptors(param);
-            for (PropertyDescriptor i : desc) {
-                if (i.getReadMethod() != null && i.getWriteMethod() == null) {
-                    try {
-                        //read only prop, we may still be able to do stuff with it if it is a collection
-                        if (Collection.class.isAssignableFrom(i.getPropertyType())) {
-                            //special case, a collection with only a read method
-                            //we assume we can just add to the connection
-                            handledProperties.add(i.getName());
+            try (PropertyUtils introspection = new PropertyUtils()) {
+                PropertyDescriptor[] desc = introspection.getPropertyDescriptors(param);
+                for (PropertyDescriptor i : desc) {
+                    if (i.getReadMethod() != null && i.getWriteMethod() == null) {
+                        try {
+                            //read only prop, we may still be able to do stuff with it if it is a collection
+                            if (Collection.class.isAssignableFrom(i.getPropertyType())) {
+                                //special case, a collection with only a read method
+                                //we assume we can just add to the connection
+                                handledProperties.add(i.getName());
 
-                            Collection propertyValue = (Collection) PropertyUtils.getProperty(param, i.getName());
-                            if (!propertyValue.isEmpty()) {
-                                ResultHandle prop = method.invokeVirtualMethod(MethodDescriptor.ofMethod(i.getReadMethod()),
-                                        out);
-                                for (Object c : propertyValue) {
-                                    ResultHandle toAdd = loadObjectInstance(method, c, returnValueResults, Object.class);
-                                    method.invokeInterfaceMethod(COLLECTION_ADD, prop, toAdd);
+                                Collection propertyValue = (Collection) introspection.getProperty(param, i.getName());
+                                if (!propertyValue.isEmpty()) {
+                                    ResultHandle prop = method.invokeVirtualMethod(MethodDescriptor.ofMethod(i.getReadMethod()),
+                                            out);
+                                    for (Object c : propertyValue) {
+                                        ResultHandle toAdd = loadObjectInstance(method, c, returnValueResults, Object.class);
+                                        method.invokeInterfaceMethod(COLLECTION_ADD, prop, toAdd);
+                                    }
                                 }
-                            }
 
-                        } else if (Map.class.isAssignableFrom(i.getPropertyType())) {
-                            //special case, a map with only a read method
-                            //we assume we can just add to the map
+                            } else if (Map.class.isAssignableFrom(i.getPropertyType())) {
+                                //special case, a map with only a read method
+                                //we assume we can just add to the map
 
-                            handledProperties.add(i.getName());
-                            Map<Object, Object> propertyValue = (Map<Object, Object>) PropertyUtils.getProperty(param,
-                                    i.getName());
-                            if (!propertyValue.isEmpty()) {
-                                ResultHandle prop = method.invokeVirtualMethod(MethodDescriptor.ofMethod(i.getReadMethod()),
-                                        out);
-                                for (Map.Entry<Object, Object> entry : propertyValue.entrySet()) {
-                                    ResultHandle key = loadObjectInstance(method, entry.getKey(), returnValueResults,
-                                            Object.class);
-                                    ResultHandle val = entry.getValue() != null
-                                            ? loadObjectInstance(method, entry.getValue(), returnValueResults, Object.class)
-                                            : method.loadNull();
-                                    method.invokeInterfaceMethod(MAP_PUT, prop, key, val);
-                                }
-                            }
-                        }
-
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                } else if (i.getReadMethod() != null && i.getWriteMethod() != null) {
-                    try {
-                        handledProperties.add(i.getName());
-                        Object propertyValue = PropertyUtils.getProperty(param, i.getName());
-                        if (propertyValue == null) {
-                            //we just assume properties are null by default
-                            //TODO: is this a valid assumption? Should we check this by creating an instance?
-                            continue;
-                        }
-                        Class propertyType = i.getPropertyType();
-                        if (i.getReadMethod().getReturnType() != i.getWriteMethod().getParameterTypes()[0]) {
-                            //this is a weird situation where the reader and writer are different types
-                            //we iterate and try and find a valid setter method for the type we have
-                            //OpenAPI does some weird stuff like this
-
-                            for (Method m : param.getClass().getMethods()) {
-                                if (m.getName().equals(i.getWriteMethod().getName())) {
-                                    if (m.getParameterTypes().length > 0
-                                            && m.getParameterTypes()[0].isAssignableFrom(param.getClass())) {
-                                        propertyType = m.getParameterTypes()[0];
-                                        break;
+                                handledProperties.add(i.getName());
+                                Map<Object, Object> propertyValue = (Map<Object, Object>) introspection.getProperty(param,
+                                        i.getName());
+                                if (!propertyValue.isEmpty()) {
+                                    ResultHandle prop = method.invokeVirtualMethod(MethodDescriptor.ofMethod(i.getReadMethod()),
+                                            out);
+                                    for (Map.Entry<Object, Object> entry : propertyValue.entrySet()) {
+                                        ResultHandle key = loadObjectInstance(method, entry.getKey(), returnValueResults,
+                                                Object.class);
+                                        ResultHandle val = entry.getValue() != null
+                                                ? loadObjectInstance(method, entry.getValue(), returnValueResults, Object.class)
+                                                : method.loadNull();
+                                        method.invokeInterfaceMethod(MAP_PUT, prop, key, val);
                                     }
                                 }
                             }
+
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
                         }
-                        ResultHandle val = loadObjectInstance(method, propertyValue, returnValueResults, i.getPropertyType());
-                        method.invokeVirtualMethod(
-                                ofMethod(param.getClass(), i.getWriteMethod().getName(), void.class, propertyType), out, val);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
+                    } else if (i.getReadMethod() != null && i.getWriteMethod() != null) {
+                        try {
+                            handledProperties.add(i.getName());
+                            Object propertyValue = introspection.getProperty(param, i.getName());
+                            if (propertyValue == null) {
+                                //we just assume properties are null by default
+                                //TODO: is this a valid assumption? Should we check this by creating an instance?
+                                continue;
+                            }
+                            Class propertyType = i.getPropertyType();
+                            if (i.getReadMethod().getReturnType() != i.getWriteMethod().getParameterTypes()[0]) {
+                                //this is a weird situation where the reader and writer are different types
+                                //we iterate and try and find a valid setter method for the type we have
+                                //OpenAPI does some weird stuff like this
+
+                                for (Method m : param.getClass().getMethods()) {
+                                    if (m.getName().equals(i.getWriteMethod().getName())) {
+                                        if (m.getParameterTypes().length > 0
+                                                && m.getParameterTypes()[0].isAssignableFrom(param.getClass())) {
+                                            propertyType = m.getParameterTypes()[0];
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            ResultHandle val = loadObjectInstance(method, propertyValue, returnValueResults,
+                                    i.getPropertyType());
+                            method.invokeVirtualMethod(
+                                    ofMethod(param.getClass(), i.getWriteMethod().getName(), void.class, propertyType), out,
+                                    val);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
                     }
                 }
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
@@ -1,0 +1,95 @@
+package io.quarkus.deployment.recording;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.beanutils.PropertyUtilsBean;
+
+/**
+ * <p>
+ * Delegates to PropertyUtilsBean from Apache Commons Beanutils;
+ * must be closed to release any internal caches.
+ * </p>
+ *
+ * <p>
+ * This is inspired by org.apache.commons.beanutils.PropertyUtils, but
+ * only exposing the selected methods we use and to avoid allocating some objects
+ * which aren't necessary in our limited use cases; also bypasses the classloader
+ * scoped cache in favour of an explicit cache control on close, to keep things
+ * a bit lighter.
+ * </p>
+ *
+ * @see org.apache.commons.beanutils.PropertyUtils
+ * @see org.apache.commons.beanutils.PropertyUtilsBean
+ */
+final class PropertyUtils implements AutoCloseable {
+
+    /**
+     * Implementation note: the reference to PropertyUtilsBean is static so to avoid allocating multiple of those,
+     * yet we close its cache when this instance is closed.
+     * We're effectively assuming non current, singleton usage.
+     * Although if this is not respected, worse that could happen is some extra cache misses.
+     */
+    private static final PropertyUtilsBean propertyUtilsBean = new PropertyUtilsBean();
+
+    /**
+     * <p>
+     * Return the value of the specified property of the specified bean,
+     * no matter which property reference format is used, with no
+     * type conversions.
+     * </p>
+     *
+     * <p>
+     * For more details see <code>PropertyUtilsBean</code>.
+     * </p>
+     *
+     * @param bean Bean whose property is to be extracted
+     * @param name Possibly indexed and/or nested name of the property
+     *        to be extracted
+     * @return the property value
+     *
+     * @throws IllegalAccessException if the caller does not have
+     *         access to the property accessor method
+     * @throws IllegalArgumentException if <code>bean</code> or
+     *         <code>name</code> is null
+     * @throws InvocationTargetException if the property accessor method
+     *         throws an exception
+     * @throws NoSuchMethodException if an accessor method for this
+     *         property cannot be found
+     */
+    public Object getProperty(final Object bean, final String name)
+            throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        return propertyUtilsBean.getNestedProperty(bean, name);
+    }
+
+    /**
+     * <p>
+     * Retrieve the property descriptors for the specified bean,
+     * introspecting and caching them the first time a particular bean class
+     * is encountered.
+     * </p>
+     *
+     * <p>
+     * For more details see <code>PropertyUtilsBean</code>.
+     * </p>
+     *
+     * @param bean Bean for which property descriptors are requested
+     * @return the property descriptors
+     * @throws IllegalArgumentException if <code>bean</code> is null
+     */
+    public PropertyDescriptor[] getPropertyDescriptors(final Object bean) {
+        return propertyUtilsBean.getPropertyDescriptors(bean);
+    }
+
+    /**
+     * Clears all caches of PropertyUtilsBean and Introspector
+     *
+     * @see Introspector
+     * @see PropertyUtilsBean
+     */
+    public void close() {
+        propertyUtilsBean.clearDescriptors();
+    }
+
+}


### PR DESCRIPTION
Update common-beanutils to 1.9.3, changed GAV
    
The artifactId commons-beanutils-core no longer exists: it was folded into common-beanutils,
which in turn caused us to risk having duplicate classes on classpath - and of different versions.
    
This also alignes the dependency with Smallrye OpenAPI

Second commit: Improve decoupling from commons-beanutils, minimize object allocation during introspection

We possibly had a leak of resources during byte code generation; not bad as it was all via weak keys, but still with this alternative strategy we just clean it all up more aggressively, and allocate less intermediate unused helpers.

P.S. the change on BytecodeRecorderImpl looks large but it's trivial:  had to indent a large block so to wrap it all in the finally block to reset the cache.