### PR TITLE
Add log darkening factor

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -146,7 +146,7 @@
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>3.1.6</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
-        <jboss-logmanager.version>1.0.2</jboss-logmanager.version>
+        <jboss-logmanager.version>1.0.3</jboss-logmanager.version>
         <jetty.version>9.4.15.v20190215</jetty.version>
         <flyway.version>5.2.4</flyway.version>
         <yasson.version>1.0.3</yasson.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -110,4 +110,10 @@ public final class LoggingResourceProcessor {
                 Level.class,
                 LevelConverter.class);
     }
+
+    // This is specifically to help out with presentations, to allow an env var to always override this value
+    @BuildStep
+    void setUpDarkeningDefault(Consumer<RunTimeConfigurationDefaultBuildItem> rtcConsumer) {
+        rtcConsumer.accept(new RunTimeConfigurationDefaultBuildItem("quarkus.log.console.darken", "0"));
+    }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -48,4 +48,9 @@ public class ConsoleConfig {
     @ConfigItem(defaultValue = "true")
     boolean color;
 
+    /**
+     * Specify how much the colors should be darkened
+     */
+    @ConfigItem(defaultValue = "0")
+    int darken;
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupTemplate.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupTemplate.java
@@ -52,7 +52,7 @@ public class LoggingSetupTemplate {
         if (config.console.enable) {
             final PatternFormatter formatter;
             if (config.console.color && System.console() != null) {
-                formatter = new ColorPatternFormatter(config.console.format);
+                formatter = new ColorPatternFormatter(config.console.darken, config.console.format);
             } else {
                 formatter = new PatternFormatter(config.console.format);
             }


### PR DESCRIPTION
Configure via `quarkus.log.console.darken=<factor>` where the factor should be a small integer (2 seems to work well for bright backgrounds).