### PR TITLE
fix typo of min-size/max-size datasource properties in integration tests config

### DIFF
--- a/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
@@ -16,8 +16,8 @@
 
 quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.driver=org.h2.Driver
-quarkus.datasource.maxSize=8
-quarkus.datasource.minSize=2
+quarkus.datasource.max-size=8
+quarkus.datasource.min-size=2
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/integration-tests/infinispan-cache-jpa/src/main/resources/application.properties
+++ b/integration-tests/infinispan-cache-jpa/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.driver=org.h2.Driver
-quarkus.datasource.maxSize=8
-quarkus.datasource.minSize=2
+quarkus.datasource.max-size=8
+quarkus.datasource.min-size=2
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.cache."com.example.EntityA".memory.object-count=200


### PR DESCRIPTION
While checking out some integration tests I noticed this warning
<img width="710" alt="Screenshot 2019-04-06 at 13 12 20" src="https://user-images.githubusercontent.com/10106536/55669028-ae949580-5872-11e9-9068-773b08cb4b68.png">. It is because of a typo in the provided datasource pool size properties: `quarkus.datasource.max-size` and `quarkus.datasource.min-size`. 
