### PR TITLE
checks return code on dev mode

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -355,7 +355,10 @@ public class DevMojo extends AbstractMojo {
                 }
             }, "Development Mode Shutdown Hook"));
             try {
-                p.waitFor();
+                int ret = p.waitFor();
+                if (ret != 0) {
+                    throw new MojoFailureException("JVM exited with error code: " + String.valueOf(ret));
+                }
             } catch (Exception e) {
                 p.destroy();
                 throw e;


### PR DESCRIPTION
Fixes #480 

It checks the return code on running `mvn quarkus:dev` like this:

```
$ ./mvnw quarkus:dev -Djvm.args="-sfsjfj"
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------------< org.acme:getting-started >----------------------
[INFO] Building getting-started 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:dev (default-cli) @ getting-started ---
Unrecognized option: -sfsjfj
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```