### PR TITLE
Hibernate ORM teardown needs to happen before the datasources are destroyed

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -18,10 +18,13 @@ package io.quarkus.hibernate.orm.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
 import javax.inject.Singleton;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
@@ -41,7 +44,7 @@ public class JPAConfig {
 
     public JPAConfig() {
         this.jtaEnabled = new AtomicBoolean();
-        this.persistenceUnits = new HashMap<>();
+        this.persistenceUnits = new ConcurrentHashMap<>();
         this.defaultPersistenceUnitName = new AtomicReference<String>();
     }
 
@@ -82,8 +85,13 @@ public class JPAConfig {
         return jtaEnabled.get();
     }
 
-    @PreDestroy
-    void destroy() {
+    /**
+     * Need to shutdown all instances of Hibernate ORM before the actual destroy event,
+     * as it might need to use the datasources during shutdown.
+     *
+     * @param event ignored
+     */
+    void destroy(@BeforeDestroyed(ApplicationScoped.class) Object event) {
         for (LazyPersistenceUnit factory : persistenceUnits.values()) {
             try {
                 factory.close();
@@ -91,6 +99,10 @@ public class JPAConfig {
                 LOGGER.warn("Unable to close the EntityManagerFactory: " + factory, e);
             }
         }
+    }
+
+    @PreDestroy
+    void destroy() {
         persistenceUnits.clear();
     }
 


### PR DESCRIPTION
Fixes #1915 