### PR TITLE
Override the Jandex version used by jandex-maven-plugin in build-parent

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -788,6 +788,15 @@
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
                     <version>1.0.5</version>
+                    <dependencies>
+                        <!-- For now we need to override and hardcode the jandex version -->
+                        <!-- See also https://github.com/wildfly/jandex-maven-plugin/pull/13 -->
+                        <dependency>
+                            <groupId>org.jboss</groupId>
+                            <artifactId>jandex</artifactId>
+                            <version>2.1.1.Final</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
- resolves #1920

Unfortunately we cannot re-use the version from BOM.