### PR TITLE
use 'plugins' instead of 'apply plugin' in gradle-it

### DIFF
--- a/devtools/gradle-it/build.gradle
+++ b/devtools/gradle-it/build.gradle
@@ -1,30 +1,10 @@
-apply plugin: 'java'
-apply plugin: 'io.quarkus'
+plugins {
+    id 'java'
+    id 'io.quarkus' version '999-SNAPSHOT'
+}
 
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
-
-buildscript {
-    repositories {
-        maven { url '../gradle/target/dependencies/' }
-        mavenCentral()
-    }
-    dependencies {
-        classpath fileTree(dir: '../gradle/build/libs', include: 'quarkus-gradle-plugin-*.jar')
-
-        classpath 'io.quarkus:quarkus-bootstrap-core:999-SNAPSHOT'
-        classpath 'io.quarkus:quarkus-devtools-common:999-SNAPSHOT'
-        classpath 'io.quarkus:quarkus-devtools-common-core:999-SNAPSHOT'
-        classpath 'io.quarkus:quarkus-development-mode:999-SNAPSHOT'
-        classpath 'io.quarkus:quarkus-creator:999-SNAPSHOT'
-    }
-}
-
-repositories {
-    //Needs latest from local snapshots too:
-    mavenLocal()
-    mavenCentral()
-}
 
 test {
     useJUnitPlatform()

--- a/devtools/gradle-it/settings.gradle
+++ b/devtools/gradle-it/settings.gradle
@@ -1,8 +1,5 @@
 pluginManagement {
     repositories {
-        // TODO ideally this, like build.gradle, should just read from ../gradle instead of mavenLocal(), but it's not clear how
-        // classpath fileTree(dir: '../gradle/build/libs', include: 'quarkus-gradle-plugin-*.jar')
-        // classpath fileTree(dir: '../gradle/target/dependencies/compile', include: '*.jar')
         mavenLocal()
 
         // target/dependencies is missing quarkus-gradle-plugin's dependencies; we need latest transitive dependencies from local SNAPSHOTs too:

--- a/devtools/gradle-it/settings.gradle
+++ b/devtools/gradle-it/settings.gradle
@@ -1,8 +1,7 @@
 pluginManagement {
     repositories {
-        mavenLocal()
-
-        // target/dependencies is missing quarkus-gradle-plugin's dependencies; we need latest transitive dependencies from local SNAPSHOTs too:
+        maven { url '../gradle/target/quarkus-gradle-plugin-999-SNAPSHOT/quarkus-gradle-plugin-999-SNAPSHOT/' }
+        maven { url '../gradle/target/dependencies/' }
         mavenCentral()
     }
     resolutionStrategy {

--- a/devtools/gradle-it/settings.gradle
+++ b/devtools/gradle-it/settings.gradle
@@ -4,6 +4,9 @@ pluginManagement {
         // classpath fileTree(dir: '../gradle/build/libs', include: 'quarkus-gradle-plugin-*.jar')
         // classpath fileTree(dir: '../gradle/target/dependencies/compile', include: '*.jar')
         mavenLocal()
+
+        // target/dependencies is missing quarkus-gradle-plugin's dependencies; we need latest transitive dependencies from local SNAPSHOTs too:
+        mavenCentral()
     }
     resolutionStrategy {
         eachPlugin {

--- a/devtools/gradle-it/settings.gradle
+++ b/devtools/gradle-it/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        // TODO ideally this, like build.gradle, should just read from ../gradle instead of mavenLocal(), but it's not clear how
+        // classpath fileTree(dir: '../gradle/build/libs', include: 'quarkus-gradle-plugin-*.jar')
+        // classpath fileTree(dir: '../gradle/target/dependencies/compile', include: '*.jar')
+        mavenLocal()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == 'io.quarkus') {
+                useModule("io.quarkus:quarkus-gradle-plugin:${requested.version}")
+            }
+        }
+    }
+}

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -145,6 +145,25 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/copy.xml</descriptor>
+                    </descriptors>
+                    <attach>false</attach>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-repo</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/devtools/gradle/src/assembly/copy.xml
+++ b/devtools/gradle/src/assembly/copy.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly>
+    <id>repo</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <files>
+        <file>
+            <source>${basedir}/build/libs/${project.artifactId}-${project.version}.jar</source>
+            <outputDirectory>io/quarkus/quarkus-gradle-plugin/999-SNAPSHOT/</outputDirectory>
+        </file>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory>io/quarkus/quarkus-gradle-plugin/999-SNAPSHOT/</outputDirectory>
+            <destName>quarkus-gradle-plugin-999-SNAPSHOT.pom</destName>
+        </file>
+    </files>
+</assembly>


### PR DESCRIPTION
related to https://github.com/quarkusio/quarkus/issues/1623

just for consistency with the Quick Start and our doc on https://quarkus.io/guides/gradle-tooling and https://quarkus.io/guides/gradle-config.html

FTR: This change does not actually fix the currently broken Gradle IT.