### PR TITLE
Default to maven central unless settings.xml is configured with different repos

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
@@ -206,6 +206,9 @@ public class MavenRepoInitializer {
                 addProfileRepos(profilesMap.get(profileName), remotes);
             }
         }
+        if(remotes.isEmpty()) {
+            remotes.add(new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2/").build());
+        }
         return remotes;
     }
 


### PR DESCRIPTION
Fix for #1918, unless there are repositories configured in the settings.xml, fallback to maven central as the default one.