### PR TITLE
Make OpenAPI servlet serve UTF-8 encoded content

### DIFF
--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiServlet.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiServlet.java
@@ -68,8 +68,9 @@ public class OpenApiServlet extends HttpServlet {
         String oai = getCachedOaiString(format);
 
         addCorsResponseHeaders(resp);
-        resp.addHeader("Content-Type", format.getMimeType());
-        resp.getOutputStream().print(oai);
+        resp.setHeader("Content-Type", format.getMimeType());
+        resp.setCharacterEncoding("UTF-8");
+        resp.getWriter().print(oai);
     }
 
     void setOpenApiDocument(OpenApiDocument document) {


### PR DESCRIPTION
Fixes #1935