### PR TITLE
Second execution of BuildMojo may fail if the runner jar exists

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -325,8 +325,9 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
         });
 
         copyFiles(augmentOutcome.getAppClassesDir(), runnerZipFs, services);
-        if (Files.exists(augmentOutcome.getConfigDir()))
+        if (Files.exists(augmentOutcome.getConfigDir())) {
             copyFiles(augmentOutcome.getConfigDir(), runnerZipFs, services);
+        }
         copyFiles(augmentOutcome.getTransformedClassesDir(), runnerZipFs, services);
 
         generateManifest(runnerZipFs, classPath.toString());
@@ -356,6 +357,7 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
             try (InputStream is = Files.newInputStream(manifestPath)) {
                 manifest.read(is);
             }
+            Files.delete(manifestPath);
         }
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");


### PR DESCRIPTION
Fix for #1961