### PR TITLE
Support cleanup of deleted classes during live reload

### DIFF
--- a/devtools/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -219,16 +219,81 @@ public class DevMojoIT extends MojoTestBase {
                 .atMost(1, TimeUnit.MINUTES).until(() -> getHttpResponse("/app/foo").contains("bar"));
     }
 
+    @Test
+    public void testThatClassFileAreCleanedUp() throws MavenInvocationException, IOException {
+        testDir = initProject("projects/classic", "projects/project-class-file-deletion");
+
+        File source = new File(testDir, "src/main/java/org/acme/ClassDeletionResource.java");
+        String classDeletionResource = "package org.acme;\n" +
+                "\n" +
+                "import javax.ws.rs.GET;\n" +
+                "import javax.ws.rs.Path;\n" +
+                "import javax.ws.rs.Produces;\n" +
+                "import javax.ws.rs.core.MediaType;\n" +
+                "\n" +
+                "@Path(\"/deletion\")\n" +
+                "public class ClassDeletionResource {\n" +
+                "    public static class InnerClass {} \n" +
+                "    @GET\n" +
+                "    @Produces(MediaType.TEXT_PLAIN)\n" +
+                "    public String toDelete() {\n" +
+                "        return Hello.message();\n" +
+                "    }\n" +
+                "}\n " +
+                "class Hello {\n" +
+                "    public static String message() {\n" +
+                "        return \"to be deleted\";\n" +
+                "    }\n" +
+                "}";
+        FileUtils.write(source, classDeletionResource, Charset.forName("UTF-8"));
+
+        runAndCheck();
+        // Wait until source file is compiled
+        await()
+                .pollDelay(1, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> getHttpResponse("/app/deletion").contains("to be deleted"));
+
+        // Remove InnerClass
+        filter(source, ImmutableMap.of("public static class InnerClass {}", ""));
+
+        File helloClassFile = new File(testDir, "target/classes/org/acme/Hello.class");
+        File innerClassFile = new File(testDir, "target/classes/org/acme/ClassDeletionResource$InnerClass.class");
+        File classDeletionResourceClassFile = new File(testDir, "target/classes/org/acme/ClassDeletionResource.class");
+
+        // Make sure that other class files have not been deleted.
+        await()
+                .pollDelay(1, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> getHttpResponse("/app/hello/package", 200));
+
+        // Verify that only ClassDeletionResource$InnerClass.class to be deleted
+        assertThat(innerClassFile).doesNotExist();
+        assertThat(helloClassFile).exists();
+        assertThat(classDeletionResourceClassFile).exists();
+
+        // Delete source file
+        source.delete();
+
+        // Wait until we get "404 Not Found" because ClassDeletionResource.class have been deleted.
+        await()
+                .pollDelay(1, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> getHttpResponse("/app/deletion", 404));
+
+        // Make sure that class files for the deleted source file have also been deleted
+        assertThat(helloClassFile).doesNotExist();
+        assertThat(classDeletionResourceClassFile).doesNotExist();
+    }
+
     private void runAndCheck(String... options) throws FileNotFoundException, MavenInvocationException {
         assertThat(testDir).isDirectory();
         running = new RunningInvoker(testDir, false);
         final List<String> args = new ArrayList<>(2 + options.length);
         args.add("compile");
         args.add("quarkus:dev");
-        if (options.length > 0) {
-            for (String s : options) {
-                args.add(s);
-            }
+        for (String option : options) {
+            args.add(option);
         }
         running.execute(args, Collections.emptyMap());
 


### PR DESCRIPTION
PR [#1872](https://github.com/quarkusio/quarkus/pull/1872) added support to cleanup deleted config files during live reload. This is a followup PR to enable cleanup of deleted source files (classes). 

See #1772 and #1963 

@gsmet @Sanne @stuartwdouglas 