### PR TITLE
Fix install when using uberjar

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarOutcome.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarOutcome.java
@@ -28,4 +28,6 @@ public interface RunnerJarOutcome {
     Path getRunnerJar();
 
     Path getLibDir();
+
+    Path getOriginalJar();
 }

--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -96,6 +96,7 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
     private Path outputDir;
     private Path libDir;
     private Path runnerJar;
+    private Path originalJar;
 
     private String finalName;
 
@@ -174,6 +175,11 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
     }
 
     @Override
+    public Path getOriginalJar() {
+        return originalJar;
+    }
+
+    @Override
     public void register(OutcomeProviderRegistration registration) throws AppCreatorException {
         registration.provides(RunnerJarOutcome.class);
     }
@@ -212,12 +218,14 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
         // this greatly aids tools (such as s2i) that look for a single jar in the output directory to work OOTB
         if (uberJar) {
             try {
-                Path originalFile = outputDir.resolve(finalName + ".jar.original");
-                Files.deleteIfExists(originalFile);
-                Files.move(outputDir.resolve(finalName + ".jar"), originalFile);
+                originalJar = outputDir.resolve(finalName + ".jar.original");
+                Files.deleteIfExists(originalJar);
+                Files.move(outputDir.resolve(finalName + ".jar"), originalJar);
             } catch (IOException e) {
                 throw new AppCreatorException("Unable to build uberjar", e);
             }
+        } else {
+            originalJar = outputDir.resolve(finalName + ".jar");
         }
 
         ctx.pushOutcome(RunnerJarOutcome.class, this);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -417,6 +417,7 @@ public class QuarkusNative extends QuarkusTask {
                 }
             }).pushOutcome(RunnerJarOutcome.class, new RunnerJarOutcome() {
                 final Path runnerJar = getProject().getBuildDir().toPath().resolve(extension().finalName() + "-runner.jar");
+                final Path originalJar = getProject().getBuildDir().toPath().resolve(extension().finalName() + ".jar");
 
                 @Override
                 public Path getRunnerJar() {
@@ -426,6 +427,11 @@ public class QuarkusNative extends QuarkusTask {
                 @Override
                 public Path getLibDir() {
                     return runnerJar.getParent().resolve("lib");
+                }
+
+                @Override
+                public Path getOriginalJar() {
+                    return originalJar;
                 }
             }).resolveOutcome(NativeImageOutcome.class);
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -202,6 +202,7 @@ public class NativeImageMojo extends AbstractMojo {
                     })
                     .pushOutcome(RunnerJarOutcome.class, new RunnerJarOutcome() {
                         final Path runnerJar = buildDir.toPath().resolve(finalName + "-runner.jar");
+                        final Path originalJar = buildDir.toPath().resolve(finalName + ".jar");
 
                         @Override
                         public Path getRunnerJar() {
@@ -211,6 +212,11 @@ public class NativeImageMojo extends AbstractMojo {
                         @Override
                         public Path getLibDir() {
                             return runnerJar.getParent().resolve("lib");
+                        }
+
+                        @Override
+                        public Path getOriginalJar() {
+                            return originalJar;
                         }
                     })
                     // resolve the outcome of the native image phase


### PR DESCRIPTION
`mvn clean install` will currently fail when using uberjar,
unless the project is set to also install the sources or javadocs (which
is why the main build does not fail).

This changes the build so that the original artifact is always installed,
and when using an uberjar the uberjar is installed with the classifier 'runner'.