### PR TITLE
Issue #1578 Adding json schema validator

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -707,6 +707,27 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${rest-assured.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                    </exclusion>
+                    <!-- We have this dependencies from elsewhere up the chain. -->
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- https://github.com/quarkusio/quarkus/issues/1991 -->
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <dependency>
                 <groupId>io.debezium</groupId>


### PR DESCRIPTION
Adding a very basic pom to test this change.

RestAssured json schema validator is now listed as a managed dependency
for use in projects when you use the BOM.