### PR TITLE
Issue 1934 extra entries filter in jar

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -16,6 +16,8 @@
 package io.quarkus.gradle.tasks;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.Input;
@@ -50,6 +52,8 @@ public class QuarkusBuild extends QuarkusTask {
     private boolean useStaticInit = true;
 
     private boolean uberJar = false;
+
+    private List<String> ignoredEntries = new ArrayList<>();
 
     public QuarkusBuild() {
         super("Quarkus builds a runner jar based on the build jar");
@@ -128,6 +132,18 @@ public class QuarkusBuild extends QuarkusTask {
         this.uberJar = uberJar;
     }
 
+    @Optional
+    @Input
+    public List<String> getIgnoredEntries() {
+        return ignoredEntries;
+    }
+
+    @Option(description = "When using the uber-jar option, this option can be used to "
+            + "specify one or more entries that should be excluded from the final jar", option = "ignored-entry")
+    public void setIgnoredEntries(List<String> ignoredEntries) {
+        this.ignoredEntries.addAll(ignoredEntries);
+    }
+
     @TaskAction
     public void buildQuarkus() {
         getLogger().lifecycle("building quarkus runner");
@@ -152,7 +168,8 @@ public class QuarkusBuild extends QuarkusTask {
                         .setLibDir(getLibDir().toPath())
                         .setFinalName(extension().finalName())
                         .setMainClass(getMainClass())
-                        .setUberJar(isUberJar()))
+                        .setUberJar(isUberJar())
+                        .setUserConfiguredIgnoredEntries(getIgnoredEntries()))
                 .setWorkDir(getProject().getBuildDir().toPath())
                 .build()) {
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -18,11 +18,11 @@
 package io.quarkus.maven;
 
 import java.io.File;
-import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -135,6 +135,25 @@ public class BuildMojo extends AbstractMojo {
     @Parameter(property = "uberJar", defaultValue = "false")
     private boolean uberJar;
 
+    /**
+     * When using the uberJar option, this array specifies entries that should
+     * be excluded from the final jar. The entries are relative to the root of
+     * the file. An example of this configuration could be:
+     * <code><pre>
+     * &#x3C;configuration&#x3E; 
+     *   &#x3C;uberJar&#x3E;true&#x3C;/uberJar&#x3E;
+     *   &#x3C;ignoredEntries&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.SF&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.DSA&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.SF&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.DSA&#x3C;/ignoredEntry&#x3E;
+     *   &#x3C;/ignoredEntries&#x3E; 
+     * &#x3C;/configuration&#x3E;
+     * </pre></code>
+     */
+    @Parameter(property = "ignoredEntries")
+    private String[] ignoredEntries;
+
     public BuildMojo() {
         MojoLogger.logSupplier = this::getLog;
     }
@@ -166,7 +185,9 @@ public class BuildMojo extends AbstractMojo {
                         .setLibDir(libDir.toPath())
                         .setFinalName(finalName)
                         .setMainClass(mainClass)
-                        .setUberJar(uberJar))
+                        .setUberJar(uberJar)
+                        .setUserConfiguredIgnoredEntries(
+                                this.ignoredEntries == null ? Collections.EMPTY_SET : Arrays.asList(this.ignoredEntries)))
                 .setWorkDir(buildDir.toPath())
                 .build()) {
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -209,3 +209,22 @@ The produced executable will be a 64 bit Linux executable, so depending on your 
 it may no longer be runnable.
 However, it's not an issue as we are going to copy it to a Docker container.
 
+== Building Uber-Jars
+
+Quarkus Gradle plugin supports the generation of Uber-Jars by specifying an `--uber-jar` argument as follows:
+
+[source,shell]
+----
+./gradlew quarkusBuild --uber-jar
+----
+
+When building an Uber-Jar you can specify entries that you want to exclude from the generated jar by using the `--ignored-entry` argument:
+
+[source,shell]
+----
+./gradlew quarkusBuild --uber-jar --ignored-entry=META-INF/file1.txt
+----
+
+The entries are relative to the root of the generated Uber-Jar. You can specify multiple entries by adding extra `--ignored-entry` arguments.
+
+

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -333,3 +333,65 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 <2> Use the {project-name} Maven plugin that will hook into the build process
 <3> Use a native profile and plugin to activate GraalVM compilation
 <4> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@SubstrateTest` will be run against the native executable. See the link:building-native-image-guide.html[Native executable guide] for more info.
+
+[[uber-jar-maven]]
+=== Uber-Jar Creation
+
+Quarkus Maven plugin supports the generation of Uber-Jars by specifying an `<uberJar>` configuration option in your `pom.xml`.
+
+[source,xml,subs=attributes+]
+----
+<build>
+    <plugins>
+        <plugin> 
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.version}</version>
+            <configuration>
+                <uberJar>true</uberJar> <1>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>build</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+----
+
+<1> Specifies that we want to build an Uber-Jar instead of a regular one. The regular jar will still be present in the `target` directory but it will be renamed to contain the `.original` suffix.
+
+When building an Uber-Jar you can specify entries that you want to exclude from the generated jar by using the `<ignoredEntries>` configuration option.
+
+[source,xml,subs=attributes+]
+----
+<build>
+    <plugins>
+        <plugin> 
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.version}</version>
+            <configuration>
+                <uberJar>true</uberJar>
+                <ignoredEntries>
+                    <ignoredEntry>META-INF/DEPENDENCIES.txt</ignoredEntry> <1>
+                </ignoredEntries>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>build</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+----
+
+<1> The entries are relative to the root of the generated Uber-Jar. You can specify multiple entries by adding extra `<ignoredEntry>` elements.
+
+


### PR DESCRIPTION
Related to #1934

Adds support to define a set of ignored entries in the final jar when building an uberJar. This commit adds support for this new configuration element in both, the maven and the gradle plugin.