### PR TITLE
Fix #1701: mark `isPersistent()` method transient

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -41,9 +41,13 @@ public class IndexingUtil {
         for (DotName annotationName : beanInfo.annotations().keySet()) {
             if (!additionalIndex.contains(annotationName) && quarkusIndex.getClassByName(annotationName) == null) {
                 try (InputStream annotationStream = IoUtil.readClass(classLoader, annotationName.toString())) {
-                    log.debugf("Index annotation: %s", annotationName);
-                    indexer.index(annotationStream);
-                    additionalIndex.add(annotationName);
+                    if (annotationStream == null) {
+                        log.debugf("Could not index annotation: %s (missing class or dependency)", annotationName);
+                    } else {
+                        log.debugf("Index annotation: %s", annotationName);
+                        indexer.index(annotationStream);
+                        additionalIndex.add(annotationName);
+                    }
                 } catch (IOException e) {
                     throw new IllegalStateException("Failed to index: " + beanClass, e);
                 }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
@@ -13,7 +13,9 @@ import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -47,6 +49,9 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
     public final static String JPA_OPERATIONS_BINARY_NAME = JPA_OPERATIONS_NAME.replace('.', '/');
     public final static String JPA_OPERATIONS_SIGNATURE = "L" + JPA_OPERATIONS_BINARY_NAME + ";";
 
+    private static final String JAXB_TRANSIENT_BINARY_NAME = "javax/xml/bind/annotation/XmlTransient";
+    private static final String JAXB_TRANSIENT_SIGNATURE = "L" + JAXB_TRANSIENT_BINARY_NAME + ";";
+
     private static final DotName DOTNAME_TRANSIENT = DotName.createSimple(Transient.class.getName());
     final Map<String, EntityModel> entities = new HashMap<>();
 
@@ -70,6 +75,32 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
             this.entities = entities;
             EntityModel entityModel = entities.get(className);
             fields = entityModel != null ? entityModel.fields : null;
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+            FieldVisitor superVisitor = super.visitField(access, name, descriptor, signature, value);
+            if (fields == null || !fields.containsKey(name))
+                return superVisitor;
+            // if we have a mapped field, let's add some annotations
+            return new FieldVisitor(Opcodes.ASM6, superVisitor) {
+                private Set<String> descriptors = new HashSet<>();
+
+                @Override
+                public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                    descriptors.add(descriptor);
+                    return super.visitAnnotation(descriptor, visible);
+                }
+
+                @Override
+                public void visitEnd() {
+                    // add the @JaxbTransient property to the field so that Jackson prefers the generated getter
+                    // jsonb will already use the getter so we're good
+                    if (!descriptors.contains(JAXB_TRANSIENT_SIGNATURE))
+                        super.visitAnnotation(JAXB_TRANSIENT_SIGNATURE, true);
+                    super.visitEnd();
+                }
+            };
         }
 
         @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -45,6 +45,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-panache-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.Transient;
 
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
@@ -57,6 +58,7 @@ public abstract class PanacheEntityBase {
      *
      * @return true if this entity is persistent in the database.
      */
+    @JsonbTransient
     public boolean isPersistent() {
         return JpaOperations.isPersistent(this);
     }

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -43,6 +43,18 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Person.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Person.java
@@ -24,9 +24,13 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.Transient;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
+@XmlRootElement
 @Entity(name = "Person2")
 public class Person extends PanacheEntity {
 
@@ -40,7 +44,23 @@ public class Person extends PanacheEntity {
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     public List<Dog> dogs = new ArrayList<>();
 
+    // note that this annotation is automatically added for mapped fields, which is not the case here
+    // so we do it manually to emulate a mapped field situation
+    @XmlTransient
+    @Transient
+    public int serialisationTrick;
+
     public static List<Dog> findOrdered() {
         return find("ORDER BY name").list();
+    }
+
+    // For JAXB: both getter and setter are required
+    // Here we make sure the field is not used by Hibernate, but the accessor is used by jaxb and jsonb
+    public int getSerialisationTrick() {
+        return ++serialisationTrick;
+    }
+
+    public void setSerialisationTrick(int serialisationTrick) {
+        this.serialisationTrick = serialisationTrick;
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -28,6 +28,8 @@ import javax.persistence.NonUniqueResultException;
 import javax.transaction.Transactional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.junit.jupiter.api.Assertions;
@@ -750,5 +752,25 @@ public class TestEndpoint {
         Assertions.assertEquals(0, Person.count());
 
         return "OK";
+    }
+
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @GET
+    @Path("ignored-properties")
+    public Person ignoredProperties() throws NoSuchMethodException, SecurityException {
+        Person.class.getMethod("$$_hibernate_read_id");
+        Person.class.getMethod("$$_hibernate_read_name");
+        try {
+            Person.class.getMethod("$$_hibernate_read_persistent");
+            Assertions.fail();
+        } catch (NoSuchMethodException e) {
+        }
+
+        // no need to persist it, we can fake it
+        Person person = new Person();
+        person.id = 666l;
+        person.name = "Eddie";
+        person.status = Status.DECEASED;
+        return person;
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -25,6 +25,7 @@ import io.quarkus.it.panache.Person;
 import io.quarkus.test.junit.DisabledOnSubstrate;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 /**
  * Test various Panache operations running in Quarkus
@@ -41,6 +42,18 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/model1").then().body(is("OK"));
         RestAssured.when().get("/test/model2").then().body(is("OK"));
         RestAssured.when().get("/test/model3").then().body(is("OK"));
+    }
+
+    @Test
+    public void testPanacheSerialisation() {
+        RestAssured.given().accept(ContentType.JSON)
+                .when().get("/test/ignored-properties")
+                .then()
+                .body(is("{\"id\":666,\"dogs\":[],\"name\":\"Eddie\",\"serialisationTrick\":1,\"status\":\"DECEASED\"}"));
+        RestAssured.given().accept(ContentType.XML)
+                .when().get("/test/ignored-properties")
+                .then().body(is(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><person><id>666</id><name>Eddie</name><serialisationTrick>1</serialisationTrick><status>DECEASED</status></person>"));
     }
 
     @DisabledOnSubstrate


### PR DESCRIPTION
for isTransient():
- hibernate does not care, since it the class is not annotated
- jaxb ignores it since it has no setter
- for jsonb I generate an override in subtypes marked @JsonbTransient to avoid depending on jsonb

for mapped public fields:
- for jaxb: add the @XmlTransient annotation to the field to make it use the accessors
- for jsonb: nothing needed since it will ignore it and use the accessors