### PR TITLE
Propagate tracing context in mp fault tolerance

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,7 +49,7 @@
         <smallrye-metrics.version>1.1.3</smallrye-metrics.version>
         <smallrye-open-api.version>1.1.1</smallrye-open-api.version>
         <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>
-        <smallrye-fault-tolerance.version>2.0.3</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>2.0.4</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>1.1.1</smallrye-jwt.version>
         <smallrye-reactive-streams-operators.version>1.0.3</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.3</smallrye-converter-api.version>

--- a/extensions/smallrye-opentracing/deployment/pom.xml
+++ b/extensions/smallrye-opentracing/deployment/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/RestService.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/RestService.java
@@ -4,6 +4,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.opentracing.Traced;
+
 @Path("/")
 public interface RestService {
 
@@ -18,4 +20,9 @@ public interface RestService {
     @GET
     @Path("/restClient")
     Response restClient();
+
+    @GET
+    @Traced(false)
+    @Path("/faultTolerance")
+    Response faultTolerance();
 }

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Service.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Service.java
@@ -1,13 +1,36 @@
 package io.quarkus.smallrye.opentracing.deployment;
 
-import javax.enterprise.context.ApplicationScoped;
+import java.time.temporal.ChronoUnit;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.opentracing.Traced;
+
+import io.opentracing.Tracer;
 
 @Traced
 @ApplicationScoped
 public class Service {
 
+    @Inject
+    private Tracer tracer;
+
     public void foo() {
+    }
+
+    @Fallback(fallbackMethod = "fallback")
+    @Timeout(value = 20L, unit = ChronoUnit.MILLIS)
+    @Retry(delay = 10L, maxRetries = 2)
+    public String faultTolerance() {
+        tracer.buildSpan("ft").start().finish();
+        throw new RuntimeException();
+    }
+
+    public String fallback() {
+        return "fallback";
     }
 }

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/TestResource.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/TestResource.java
@@ -36,4 +36,10 @@ public class TestResource implements RestService {
         client.hello();
         return Response.ok().build();
     }
+
+    @Override
+    public Response faultTolerance() {
+        String ret = service.faultTolerance();
+        return Response.ok(ret).build();
+    }
 }


### PR DESCRIPTION
Related to https://issues.jboss.org/browse/TRACING-469.

This fixes tracing propagation (span) in fault tolerance. For instance the following code would result in two (or more) traces prior to this change:

```java
  @Fallback(fallbackMethod = "fallback")
  @Timeout(value = 200L, unit = ChronoUnit.MILLIS)
  @Retry(delay = 100L, maxRetries = 5)
  public String failingService() {
    return resourceClient.hello();
  }
```

Signed-off-by: Pavol Loffay <ploffay@redhat.com>