### PR TITLE
Use the TCCL to load the OpenAPI extension classes

### DIFF
--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/SmallRyeOpenApiTemplate.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/SmallRyeOpenApiTemplate.java
@@ -43,7 +43,8 @@ public class SmallRyeOpenApiTemplate {
                 Config config = ConfigProvider.getConfig();
                 OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
 
-                OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig, Quarkus.class.getClassLoader());
+                OpenAPI readerModel = OpenApiProcessor.modelFromReader(openApiConfig,
+                        Thread.currentThread().getContextClassLoader());
 
                 OpenApiDocument document = createDocument(openApiConfig);
                 document.modelFromAnnotations(annotationModel);
@@ -64,6 +65,7 @@ public class SmallRyeOpenApiTemplate {
     }
 
     private OASFilter filter(OpenApiConfig openApiConfig) {
-        return OpenApiProcessor.getFilter(openApiConfig, Quarkus.class.getClassLoader());
+        return OpenApiProcessor.getFilter(openApiConfig,
+                Thread.currentThread().getContextClassLoader());
     }
 }


### PR DESCRIPTION
Otherwise, we end up with ClassNotFoundException in dev mode.

Fixes #1974.

Tested manually with the OP's case as it's only failing in dev mode.

(I confirmed with David that we should use the TCCL here)