### PR TITLE
Better error message when the health check has no name

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -45,7 +45,7 @@
         <microprofile-reactive-streams-operators.version>1.0</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.2.1</microprofile-rest-client.version>
         <smallrye-config.version>1.3.5</smallrye-config.version>
-        <smallrye-health.version>1.0.2</smallrye-health.version>
+        <smallrye-health.version>1.0.3</smallrye-health.version>
         <smallrye-metrics.version>1.1.3</smallrye-metrics.version>
         <smallrye-open-api.version>1.1.1</smallrye-open-api.version>
         <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>


### PR DESCRIPTION
Fixes #2072
- Update to SmallRye Health 1.0.3 that includes fix for NPE when name not specified on a Health Check