### PR TITLE
ProcessBuilder for determining UID and GID in linux docker build was …

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -524,7 +524,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
             ProcessBuilder idPB = new ProcessBuilder().command("id", option);
             idPB.redirectError(new File("/dev/null"));
-            idPB.redirectOutput(new File("/dev/null"));
+            idPB.redirectInput(new File("/dev/null"));
 
             process = idPB.start();
             try (InputStream inputStream = process.getInputStream()) {


### PR DESCRIPTION
…redirecting the wrong stream to /dev/null