### PR TITLE
Upgrade JVM Docker base image

### DIFF
--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/${project_artifactId}-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
+FROM fabric8/java-alpine-openjdk8-jre
 ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar


### PR DESCRIPTION
JVM Dockerfile currently uses a deprecated `fabric8/java-jboss-openjdk8-jdk` which has throughput performance issues. One of the recommended base images to upgrade to `fabric8/java-alpine-openjdk8-jre` does not suffer from the same throughput performance issues, as described in #2079