### PR TITLE
Fix for 2114 - Missing AWS events classes in jandex when building Lambda

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -31,9 +31,11 @@ import io.quarkus.deployment.recording.RecorderContext;
 
 @SuppressWarnings("unchecked")
 public final class AmazonLambdaProcessor {
+    public static final String AWS_LAMBDA_EVENTS_ARCHIVE_MARKERS = "com/amazonaws/services/lambda/runtime/events";
+
     private static final DotName REQUEST_HANDLER = DotName.createSimple(RequestHandler.class.getName());
 
-    @BuildStep
+    @BuildStep(applicationArchiveMarkers = { AWS_LAMBDA_EVENTS_ARCHIVE_MARKERS })
     List<AmazonLambdaClassNameBuildItem> discover(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClasses) {
         List<AmazonLambdaClassNameBuildItem> ret = new ArrayList<>();
@@ -52,6 +54,7 @@ public final class AmazonLambdaProcessor {
                             && method.parameters().size() == 2
                             && !method.parameters().get(0).name().equals(DotName.createSimple(Object.class.getName()))) {
                         reflectiveClasses.produce(new ReflectiveHierarchyBuildItem(method.parameters().get(0)));
+                        reflectiveClasses.produce(new ReflectiveHierarchyBuildItem(method.returnType()));
                         done = true;
                         break;
                     }

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaTemplate.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaTemplate.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
@@ -23,7 +24,7 @@ public class AmazonLambdaTemplate {
             BeanContainer beanContainer) {
         RequestHandler handler = beanContainer.instance(handlerClass);
 
-        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         AtomicBoolean running = new AtomicBoolean(true);
         ObjectReader objectReader = mapper.readerFor(handlerType.getValue());
         context.addShutdownTask(new Runnable() {


### PR DESCRIPTION
This is a fix for #2114