### PR TITLE
chore: remove jQuery from Kafka example

### DIFF
--- a/docs/src/main/asciidoc/kafka-guide.adoc
+++ b/docs/src/main/asciidoc/kafka-guide.adoc
@@ -264,7 +264,6 @@ Create the `src/main/resources/META-INF/resources/prices.html` file, with the fo
     </div>
 </div>
 </body>
-<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script>
     var source = new EventSource("/prices/stream");
     source.onmessage = function (event) {


### PR DESCRIPTION
JQuery doesn't seem to be used anywhere, since the example uses plain JS