### PR TITLE
Extension guide - runtime module annotation processor config

### DIFF
--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -66,8 +66,9 @@ Your extension project should be setup as a multi-module project with two submod
 2. A runtime submodule that contains the runtime behavior that will provide the extension behavior in the native executable or runtime JVM.
 
 Your runtime artifact should depend on `io.quarkus:quarkus-core`, and possibly the runtime artifacts of other Quarkus
-modules if you want to use functionality provided by them. You will also need to include the `io.quarkus:quarkus-bootstrap-maven-plugin`
-to generate the Quarkus extension descriptor included into the runtime artifact, if you are using the Quarkus parent pom it will automatically inherit the correct configuration.
+modules if you want to use functionality provided by them. 
+You will also need to include the `io.quarkus:quarkus-bootstrap-maven-plugin` to generate the Quarkus extension descriptor included into the runtime artifact, if you are using the Quarkus parent pom it will automatically inherit the correct configuration.
+Futhermore, you'll need to configure the `maven-compiler-plugin` to detect the `quarkus-extension-processor` annotation processor.
 
 NOTE: By convention the deployment time artifact has the `-deployment` suffix, and the runtime artifact
 has no suffix (and is what the end user adds to their project).
@@ -99,9 +100,23 @@ has no suffix (and is what the end user adds to their project).
                </execution>
            </executions>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-extension-processor</artifactId>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
     </plugins>
 </build>
 ----
+
+NOTE: The above `maven-compiler-plugin` configuration requires version 3.5+.
 
 [WARNING]
 ====
@@ -139,9 +154,6 @@ You will also need to configure the `maven-compiler-plugin` to detect the `quark
     </plugins>
 </build>
 ----
-
-NOTE: The above `maven-compiler-plugin` configuration requires version 3.5+.
-
 
 == Build Step Processors
 


### PR DESCRIPTION
As @dmlloyd suggested: "simply always include it, otherwise you could get a hard-to-debug surprise".