### PR TITLE
Add quarkus-core-deployment in BOM POM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -185,6 +185,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-core-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-arc</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Hello, 

This manages `quarkus-core-deployment` artifact via BOM POM.

Right now users are unable to skip version when defining dependency. Take a look at the example in: https://quarkus.io/guides/extension-authors-guide#maven-setup

```xml
<dependency>
  <groupId>io.quarkus</groupId>
  <artifactId>quarkus-core-deployment</artifactId>
</dependency>
```

It will yield error when this dependency is not managed manually. This PR is to address this problem.

