### PR TITLE
Disable Fallback native images by default 

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -87,6 +87,8 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
     private boolean enableIsolates;
 
+    private boolean enableFallbackImages;
+
     private String graalvmHome;
 
     private boolean enableServer;
@@ -172,6 +174,11 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
     public NativeImagePhase setEnableIsolates(boolean enableIsolates) {
         this.enableIsolates = enableIsolates;
+        return this;
+    }
+
+    public NativeImagePhase setEnableFallbackImages(boolean enableFallbackImages) {
+        this.enableFallbackImages = enableFallbackImages;
         return this;
     }
 
@@ -396,6 +403,14 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
             command.add(runnerJarName);
             //https://github.com/oracle/graal/issues/660
             command.add("-J-Djava.util.concurrent.ForkJoinPool.common.parallelism=1");
+            if (enableFallbackImages) {
+                command.add("-H:FallbackThreshold=5");
+            } else {
+                //Default: be strict as those fallback images aren't very useful
+                //and tend to cover up real problems.
+                command.add("-H:FallbackThreshold=0");
+            }
+
             if (reportErrorsAtRuntime) {
                 command.add("-H:+ReportUnsupportedElementsAtRuntime");
             }
@@ -632,6 +647,9 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
                         break;
                     case "enable-isolates":
                         t.setEnableIsolates(Boolean.parseBoolean(value));
+                        break;
+                    case "enable-fallback-images":
+                        t.setEnableFallbackImages(Boolean.parseBoolean(value));
                         break;
                     case "graalvm-home":
                         t.setGraalvmHome(value);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -76,6 +76,8 @@ public class QuarkusNative extends QuarkusTask {
 
     private boolean enableVMInspection = false;
 
+    private boolean enableFallbackImages = false;
+
     private boolean fullStackTraces = true;
 
     private boolean disableReports;
@@ -147,6 +149,19 @@ public class QuarkusNative extends QuarkusTask {
     @Input
     public boolean isEnableHttpUrlHandler() {
         return enableHttpUrlHandler;
+    }
+
+    @Optional
+    @Input
+    private boolean isEnableFallbackImages() {
+        return enableFallbackImages;
+    }
+
+    @Option(description = "Enable the GraalVM native image compiler to generate Fallback Images in case of compilation error. "
+            +
+            "Careful: these are not as efficient as normal native images.", option = "enable-fallback-images")
+    public void setEnableFallbackImages(boolean enableFallbackImages) {
+        this.enableFallbackImages = enableFallbackImages;
     }
 
     @Option(description = "Specify if http url handler is enabled", option = "enable-http-url-handler")
@@ -384,6 +399,7 @@ public class QuarkusNative extends QuarkusTask {
                         .setEnableRetainedHeapReporting(isEnableRetainedHeapReporting())
                         .setEnableServer(isEnableServer())
                         .setEnableVMInspection(isEnableVMInspection())
+                        .setEnableFallbackImages(isEnableFallbackImages())
                         .setFullStackTraces(isFullStackTraces())
                         .setGraalvmHome(getGraalvmHome())
                         .setNativeImageXmx(getNativeImageXmx())

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -129,6 +129,9 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean addAllCharsets;
 
+    @Parameter(defaultValue = "false")
+    private boolean enableFallbackImages;
+
     public NativeImageMojo() {
         MojoLogger.logSupplier = this::getLog;
     }
@@ -158,6 +161,7 @@ public class NativeImageMojo extends AbstractMojo {
                         .setDumpProxies(dumpProxies)
                         .setEnableAllSecurityServices(enableAllSecurityServices)
                         .setEnableCodeSizeReporting(enableCodeSizeReporting)
+                        .setEnableFallbackImages(enableFallbackImages)
                         .setEnableHttpsUrlHandler(enableHttpsUrlHandler)
                         .setEnableHttpUrlHandler(enableHttpUrlHandler)
                         .setEnableIsolates(enableIsolates)


### PR DESCRIPTION

switch the GraalVM default so to disable "Fallback images" by default.

These fallback images are odd, tricky things; I described them on the mailing list.