### PR TITLE
Fixes #2176: Add missing endpoint

### DIFF
--- a/docs/src/main/asciidoc/kafka-guide.adoc
+++ b/docs/src/main/asciidoc/kafka-guide.adoc
@@ -191,6 +191,12 @@ public class PriceResource {
     @Stream("my-data-stream") Publisher<Double> prices; // <1>
 
     @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+
+    @GET
     @Path("/stream")
     @Produces(MediaType.SERVER_SENT_EVENTS)             // <2>
     public Publisher<Double> stream() {                 // <3>


### PR DESCRIPTION
For some reason, the root endpoint needs to exist, otherwise the SSE connection is closed prematurely