### PR TITLE
Force org.jboss.logmanager.LogManager in Docker image

### DIFF
--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -15,7 +15,7 @@
 #
 ###
 FROM fabric8/java-alpine-openjdk8-jre
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 ENTRYPOINT [ "/deployments/run-java.sh" ]


### PR DESCRIPTION
Force org.jboss.logmanager.LogManager in Docker image

"Reasonable" fix for https://github.com/quarkusio/quarkus/issues/2145

The underlying issue is #2152