### PR TITLE
Call start() on Thread

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorTemplate.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorTemplate.java
@@ -76,7 +76,7 @@ public class ExecutorTemplate {
                                 //JVM alive
                                 Thread t = new Thread(i, "Shutdown thread");
                                 t.setDaemon(true);
-                                t.run();
+                                t.start();
                             }
                         }
                         return;


### PR DESCRIPTION
Call `.start()` on Thread instead of `.run()`