### PR TITLE
Modifies File logging guide so that it corresponds with default behavior

### DIFF
--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -28,7 +28,7 @@ Console logging is enabled by default.  To configure or disable it, the followin
 
 === File configuration
 
-Logging to a file is also supported and enabled by default.  To configure or disable this behavior, use the following configuration properties:
+Logging to a file is also supported but not enabled by default.  To configure or enable this behavior, use the following configuration properties:
 
 [cols="<m,<m,<2",options="header"]
 |===


### PR DESCRIPTION
While going through file [logging guide](https://quarkus.io/guides/logging-guide), I noticed this phrase `Logging to a file is also supported and enabled by default.` But  the table shows a `false` default value which corresponds to the `FileConfig` value in the code. 