### PR TITLE
Improve support to infinispan marshallers

### DIFF
--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -38,6 +38,11 @@ import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.commons.util.Util;
+import org.infinispan.protostream.BaseMarshaller;
+import org.infinispan.protostream.EnumMarshaller;
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.MessageMarshaller;
+import org.infinispan.protostream.RawProtobufMarshaller;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
@@ -208,8 +213,11 @@ class InfinispanClientProcessor {
 
     private static final Set<DotName> UNREMOVABLE_BEANS = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
-                    DotName.createSimple("org.infinispan.protostream.MessageMarshaller"),
-                    DotName.createSimple("org.infinispan.protostream.FileDescriptorSource"))));
+                    DotName.createSimple(BaseMarshaller.class.getName()),
+                    DotName.createSimple(EnumMarshaller.class.getName()),
+                    DotName.createSimple(MessageMarshaller.class.getName()),
+                    DotName.createSimple(RawProtobufMarshaller.class.getName()),
+                    DotName.createSimple(FileDescriptorSource.class.getName()))));
 
     @BuildStep
     UnremovableBeanBuildItem ensureBeanLookupAvailable() {

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
@@ -149,7 +150,7 @@ class InfinispanClientProcessor {
         // Add any user project listeners to allow reflection in native code
         Index index = applicationIndexBuildItem.getIndex();
         List<AnnotationInstance> listenerInstances = index.getAnnotations(
-                DotName.createSimple("org.infinispan.client.hotrod.annotation.ClientListener"));
+                DotName.createSimple(ClientListener.class.getName()));
         for (AnnotationInstance instance : listenerInstances) {
             AnnotationTarget target = instance.target();
             if (target.kind() == AnnotationTarget.Kind.CLASS) {

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -29,6 +29,7 @@ import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Util;
 import org.infinispan.counter.api.CounterManager;
+import org.infinispan.protostream.BaseMarshaller;
 import org.infinispan.protostream.FileDescriptorSource;
 import org.infinispan.protostream.MessageMarshaller;
 import org.infinispan.protostream.SerializationContext;
@@ -183,10 +184,10 @@ public class InfinispanClientProducer {
             throw new RuntimeException(e);
         }
 
-        Set<Bean<MessageMarshaller>> beans = (Set) beanManager.getBeans(MessageMarshaller.class);
-        for (Bean<MessageMarshaller> bean : beans) {
-            CreationalContext<MessageMarshaller> ctx = beanManager.createCreationalContext(bean);
-            MessageMarshaller messageMarshaller = (MessageMarshaller) beanManager.getReference(bean, MessageMarshaller.class,
+        Set<Bean<BaseMarshaller>> beans = (Set) beanManager.getBeans(BaseMarshaller.class);
+        for (Bean<BaseMarshaller> bean : beans) {
+            CreationalContext<BaseMarshaller> ctx = beanManager.createCreationalContext(bean);
+            BaseMarshaller messageMarshaller = (BaseMarshaller) beanManager.getReference(bean, BaseMarshaller.class,
                     ctx);
             serializationContext.registerMarshaller(messageMarshaller);
         }

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/Book.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/Book.java
@@ -11,12 +11,18 @@ public class Book {
     private final String description;
     private final int publicationYear;
     private final Set<Author> authors;
+    private final Type bookType;
 
-    public Book(String title, String description, int publicationYear, Set<Author> authors) {
+    enum Type {
+        FANTASY, PROGRAMMING
+    }
+
+    public Book(String title, String description, int publicationYear, Set<Author> authors, Type bookType) {
         this.title = Objects.requireNonNull(title);
         this.description = Objects.requireNonNull(description);
         this.publicationYear = publicationYear;
         this.authors = Objects.requireNonNull(authors);
+        this.bookType = bookType;
     }
 
     public String getTitle() {
@@ -35,6 +41,10 @@ public class Book {
         return authors;
     }
 
+    public Type getBookType() {
+        return bookType;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -45,11 +55,12 @@ public class Book {
         return publicationYear == book.publicationYear &&
                 title.equals(book.title) &&
                 description.equals(book.description) &&
-                authors.equals(book.authors);
+                authors.equals(book.authors) &&
+                bookType.equals(book.bookType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, description, publicationYear, authors);
+        return Objects.hash(title, description, publicationYear, authors, bookType);
     }
 }

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/BookMarshaller.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/BookMarshaller.java
@@ -27,6 +27,7 @@ public class BookMarshaller implements MessageMarshaller<Book> {
         writer.writeString("description", book.getDescription());
         writer.writeInt("publicationYear", book.getPublicationYear());
         writer.writeCollection("authors", book.getAuthors(), Author.class);
+        writer.writeEnum("bookType", book.getBookType());
     }
 
     @Override
@@ -35,6 +36,7 @@ public class BookMarshaller implements MessageMarshaller<Book> {
         String description = reader.readString("description");
         int publicationYear = reader.readInt("publicationYear");
         Set<Author> authors = reader.readCollection("authors", new HashSet<>(), Author.class);
-        return new Book(title, description, publicationYear, authors);
+        Book.Type bookType = reader.readEnum("bookType", Book.Type.class);
+        return new Book(title, description, publicationYear, authors, bookType);
     }
 }

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/BookTypeMarshaller.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/BookTypeMarshaller.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.infinispan.client;
+
+import org.infinispan.protostream.EnumMarshaller;
+
+/**
+ * @author Katia Aresti, karesti@redhat.com
+ */
+public class BookTypeMarshaller implements EnumMarshaller<Book.Type> {
+
+    @Override
+    public Class<Book.Type> getJavaClass() {
+        return Book.Type.class;
+    }
+
+    @Override
+    public String getTypeName() {
+        return "book_sample.Book.Type";
+    }
+
+    @Override
+    public Book.Type decode(int enumValue) {
+        switch (enumValue) {
+            case 0:
+                return Book.Type.FANTASY;
+            case 1:
+                return Book.Type.PROGRAMMING;
+        }
+        return null;  // unknown value
+    }
+
+    @Override
+    public int encode(Book.Type bookType) {
+        switch (bookType) {
+            case FANTASY:
+                return 0;
+            case PROGRAMMING:
+                return 1;
+            default:
+                throw new IllegalArgumentException("Unexpected Book.Type value : " + bookType);
+        }
+    }
+}

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/MarshallerConfiguration.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/MarshallerConfiguration.java
@@ -3,16 +3,23 @@ package io.quarkus.it.infinispan.client;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
+import org.infinispan.protostream.BaseMarshaller;
 import org.infinispan.protostream.FileDescriptorSource;
 import org.infinispan.protostream.MessageMarshaller;
 
 /**
  * Handles configuration of marshalling code for marshalling
- * 
+ *
  * @author William Burns
  */
 @ApplicationScoped
 public class MarshallerConfiguration {
+
+    @Produces
+    BaseMarshaller bookTypeMarshaller() {
+        return new BookTypeMarshaller();
+    }
+
     @Produces
     MessageMarshaller bookMarshaller() {
         return new BookMarshaller();

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/TestServlet.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/TestServlet.java
@@ -117,9 +117,9 @@ public class TestServlet {
         log.info("Added continuous query listener");
 
         cache.put("book1", new Book("Game of Thrones", "Lots of people perish", 2010,
-                Collections.singleton(new Author("George", "Martin"))));
+                Collections.singleton(new Author("George", "Martin")), Book.Type.FANTASY));
         cache.put("book2", new Book("Game of Thrones Path 2", "They win?", 2023,
-                Collections.singleton(new Author("Son", "Martin"))));
+                Collections.singleton(new Author("Son", "Martin")), Book.Type.FANTASY));
 
         log.info("Inserted values");
 
@@ -253,7 +253,7 @@ public class TestServlet {
         long nearCacheInvalidations = stats.getNearCacheInvalidations();
 
         Book nearCacheBook = new Book("Near Cache Book", "Just here to test", 2010,
-                Collections.emptySet());
+                Collections.emptySet(), Book.Type.PROGRAMMING);
 
         String id = "nearcache";
         cache.put(id, nearCacheBook);
@@ -287,7 +287,7 @@ public class TestServlet {
             return "second retrieved book doesn't match";
         }
 
-        nearCacheBook = new Book("Near Cache Book", "Just here to test", 2011, Collections.emptySet());
+        nearCacheBook = new Book("Near Cache Book", "Just here to test", 2011, Collections.emptySet(), Book.Type.PROGRAMMING);
 
         cache.put(id, nearCacheBook);
 
@@ -316,7 +316,7 @@ public class TestServlet {
     @Consumes(MediaType.TEXT_PLAIN)
     public Response createItem(String value, @PathParam("id") String id) {
         ensureStart();
-        Book book = new Book(id, value, 2019, Collections.emptySet());
+        Book book = new Book(id, value, 2019, Collections.emptySet(), Book.Type.PROGRAMMING);
         Book previous = cache.putIfAbsent(id, book);
         if (previous == null) {
             //status code 201

--- a/integration-tests/infinispan-client/src/main/resources/META-INF/library.proto
+++ b/integration-tests/infinispan-client/src/main/resources/META-INF/library.proto
@@ -6,6 +6,13 @@ message Book {
   required int32 publicationYear = 3; // no native Date type available in Protobuf
 
   repeated Author authors = 4;
+
+  enum Type {
+    FANTASY = 0;
+    PROGRAMMING = 1;
+  }
+
+  required Type bookType = 5;
 }
 
 message Author {


### PR DESCRIPTION
I noticed `infinispan-client` extension doesn't allow usage of `EnumMarshaller`, so what I basically did is use `BaseMarshaller` as the look up type to register all the marshallers and allow all types of marshallers to be added to the context.

There is another issue I hadn't been able to solve by myself, currently a user can't do this 
```
@Produces
BookMarshaller bookMarshaller() {
    return new BookMarshaller();
}
```
in the case of the example the only way to register `BookMarshaller` is to change the return type to `MessageMarshaller` . I think for users would be more intuitive to be able to return their own types because in the end `BookMarshaller` implements `MessageMarshaller` . If we consider I can just raise an issue and merge this PR's changes as is.