### PR TITLE
Introduce an Hibernate Search + Elasticsearch extension

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Maven Build'
     inputs:
       goals: 'install'
-      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dnative-image.xmx=6g -Dnative -Dno-format'
+      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dtest-elasticsearch -Dnative-image.xmx=6g -Dnative -Dno-format'
 
 - job: Windows_Build
   timeoutInMinutes: 60

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ pr:
 
 jobs:
 - job: Build_Native_Linux
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   pool:
     vmImage: 'Ubuntu 16.04'
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,6 +92,7 @@
         <javax.el-impl.version>3.0.1.b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Alpha4</hibernate-validator.version>
         <hibernate-orm.version>5.4.2.Final</hibernate-orm.version>
+        <hibernate-search.version>6.0.0.Alpha3</hibernate-search.version>
         <narayana.version>5.9.3.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.4</agroal.version>
@@ -256,12 +257,32 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-elytron-security</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-flyway</artifactId>
+                <version>${project.version}</version>
+             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-orm-panache</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -381,16 +402,6 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-hibernate-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-elasticsearch-rest-client</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -402,11 +413,6 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-vertx-web</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-hibernate-orm-panache</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -1463,6 +1469,23 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${hibernate-orm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+                <version>${hibernate-search.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm</artifactId>
+                <version>${hibernate-search.version}</version>
+                <exclusions>
+                    <!-- the right version will come with Hibernate ORM -->
+                    <exclusion>
+                        <groupId>org.hibernate.common</groupId>
+                        <artifactId>hibernate-commons-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.web</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -86,6 +86,7 @@
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
+        <commons-codec.version>1.11</commons-codec.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <classmate.version>1.3.4</classmate.version>
         <javax.el-impl.version>3.0.1.b11</javax.el-impl.version>
@@ -96,6 +97,7 @@
         <agroal.version>1.4</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
+        <elasticsearch-rest-client.version>6.7.0</elasticsearch-rest-client.version>
         <rxjava.version>2.2.8</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
@@ -384,6 +386,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -596,6 +603,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
@@ -1471,6 +1483,16 @@
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
                 <version>${mssql-jdbc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${elasticsearch-rest-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+                <version>${elasticsearch-rest-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,13 +92,13 @@
         <javax.el-impl.version>3.0.1.b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Alpha4</hibernate-validator.version>
         <hibernate-orm.version>5.4.2.Final</hibernate-orm.version>
-        <hibernate-search.version>6.0.0.Alpha4</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Alpha5</hibernate-search.version>
         <narayana.version>5.9.3.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.4</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
-        <elasticsearch-rest-client.version>6.7.0</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.0.0</elasticsearch-rest-client.version>
         <rxjava.version>2.2.8</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -126,6 +126,7 @@
         <junit4.version>4.12</junit4.version>
         <junit.jupiter.version>5.4.1</junit.jupiter.version>
         <assertj.version>3.12.1</assertj.version>
+        <json-smart.version>2.3</json-smart.version>
         <infinispan.version>10.0.0.Beta2</infinispan.version>
         <caffeine.version>2.6.2</caffeine.version>
         <netty.version>4.1.34.Final</netty.version>
@@ -1087,6 +1088,11 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,7 +92,7 @@
         <javax.el-impl.version>3.0.1.b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Alpha4</hibernate-validator.version>
         <hibernate-orm.version>5.4.2.Final</hibernate-orm.version>
-        <hibernate-search.version>6.0.0.Alpha3</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Alpha4</hibernate-search.version>
         <narayana.version>5.9.3.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.4</agroal.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -30,6 +30,10 @@
     <packaging>pom</packaging>
 
     <properties>
+        <!-- Maven plugin versions -->
+        <elasticsearch-maven-plugin.version>6.11</elasticsearch-maven-plugin.version>
+        <elasticsearch-server.version>6.7.0</elasticsearch-server.version>
+
         <!-- These properties are not in the bom as we don't want to enforce the version -->
         <spring.version>5.1.4.RELEASE</spring.version>
 
@@ -524,6 +528,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-vertx</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -878,6 +892,14 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.alexcojocaru</groupId>
+                    <artifactId>elasticsearch-maven-plugin</artifactId>
+                    <version>${elasticsearch-maven-plugin.version}</version>
+                    <configuration>
+                        <version>${elasticsearch-server.version}</version>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -527,6 +527,16 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-hibernate-search-elasticsearch-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-elasticsearch-rest-client</artifactId>
                 <version>${project.version}</version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -31,8 +31,8 @@
 
     <properties>
         <!-- Maven plugin versions -->
-        <elasticsearch-maven-plugin.version>6.11</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>6.7.0</elasticsearch-server.version>
+        <elasticsearch-maven-plugin.version>6.12</elasticsearch-maven-plugin.version>
+        <elasticsearch-server.version>7.0.0</elasticsearch-server.version>
 
         <!-- These properties are not in the bom as we don't want to enforce the version -->
         <spring.version>5.1.4.RELEASE</spring.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -21,6 +21,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String FLYWAY = "flyway";
     public static final String HIBERNATE_ORM = "hibernate-orm";
     public static final String HIBERNATE_VALIDATOR = "hibernate-validator";
+    public static final String HIBERNATE_SEARCH_ELASTICSEARCH = "hibernate-search-elasticsearch";
     public static final String INFINISPAN_CLIENT = "infinispan-client";
     public static final String JAEGER = "jaeger";
     public static final String JDBC_H2 = "jdbc-h2";

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -17,6 +17,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String CAMEL_NETTY4_HTTP = "camel-netty4-http";
     public static final String CAMEL_SALESFORCE = "camel-salesforce";
     public static final String CDI = "cdi";
+    public static final String ELASTICSEARCH_REST_CLIENT = "elasticsearch-rest-client";
     public static final String FLYWAY = "flyway";
     public static final String HIBERNATE_ORM = "hibernate-orm";
     public static final String HIBERNATE_VALIDATOR = "hibernate-validator";

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_net_ssl_SSLContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_net_ssl_SSLContext.java
@@ -6,10 +6,8 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.Provider;
 import java.security.SecureRandom;
-import java.util.Objects;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -25,10 +23,8 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 import io.quarkus.runtime.ssl.SslContextConfiguration;
-import sun.security.jca.GetInstance;
 
 @TargetClass(className = "javax.net.ssl.SSLContext")
-@SuppressWarnings("restriction")
 public final class Target_javax_net_ssl_SSLContext {
 
     @Alias
@@ -51,47 +47,50 @@ public final class Target_javax_net_ssl_SSLContext {
         return defaultContext;
     }
 
-    @Substitute
-    public static Target_javax_net_ssl_SSLContext getInstance(String protocol)
-            throws NoSuchAlgorithmException {
-        Objects.requireNonNull(protocol, "null protocol name");
-
-        if (!SslContextConfiguration.isSslNativeEnabled()) {
-            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
-        }
-
-        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol);
-        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
-                protocol);
-    }
-
-    @Substitute
-    public static Target_javax_net_ssl_SSLContext getInstance(String protocol, String provider)
-            throws NoSuchAlgorithmException, NoSuchProviderException {
-        Objects.requireNonNull(protocol, "null protocol name");
-
-        if (!SslContextConfiguration.isSslNativeEnabled()) {
-            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
-        }
-
-        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol, provider);
-        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
-                protocol);
-    }
-
-    @Substitute
-    public static Target_javax_net_ssl_SSLContext getInstance(String protocol, Provider provider)
-            throws NoSuchAlgorithmException {
-        Objects.requireNonNull(protocol, "null protocol name");
-
-        if (!SslContextConfiguration.isSslNativeEnabled()) {
-            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
-        }
-
-        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol, provider);
-        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
-                protocol);
-    }
+    //    TODO sun.security.jca.GetInstance is not accessible in JDK 11. We cannot add an export
+    //    as we still compile with a JDK 8 target. So for now, we will have to leave with this
+    //    and only override getDefault().
+    //    @Substitute
+    //    public static Target_javax_net_ssl_SSLContext getInstance(String protocol)
+    //            throws NoSuchAlgorithmException {
+    //        Objects.requireNonNull(protocol, "null protocol name");
+    //
+    //        if (!SslContextConfiguration.isSslNativeEnabled()) {
+    //            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
+    //        }
+    //
+    //        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol);
+    //        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
+    //                protocol);
+    //    }
+    //
+    //    @Substitute
+    //    public static Target_javax_net_ssl_SSLContext getInstance(String protocol, String provider)
+    //            throws NoSuchAlgorithmException, NoSuchProviderException {
+    //        Objects.requireNonNull(protocol, "null protocol name");
+    //
+    //        if (!SslContextConfiguration.isSslNativeEnabled()) {
+    //            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
+    //        }
+    //
+    //        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol, provider);
+    //        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
+    //                protocol);
+    //    }
+    //
+    //    @Substitute
+    //    public static Target_javax_net_ssl_SSLContext getInstance(String protocol, Provider provider)
+    //            throws NoSuchAlgorithmException {
+    //        Objects.requireNonNull(protocol, "null protocol name");
+    //
+    //        if (!SslContextConfiguration.isSslNativeEnabled()) {
+    //            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
+    //        }
+    //
+    //        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol, provider);
+    //        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
+    //                protocol);
+    //    }
 
     private static class DisabledSSLContext extends SSLContext {
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_net_ssl_SSLContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_net_ssl_SSLContext.java
@@ -1,0 +1,183 @@
+package io.quarkus.runtime.graal;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.util.Objects;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLContextSpi;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.runtime.ssl.SslContextConfiguration;
+import sun.security.jca.GetInstance;
+
+@TargetClass(className = "javax.net.ssl.SSLContext")
+@SuppressWarnings("restriction")
+public final class Target_javax_net_ssl_SSLContext {
+
+    @Alias
+    private static SSLContext defaultContext;
+
+    @Alias
+    protected Target_javax_net_ssl_SSLContext(SSLContextSpi contextSpi, Provider provider, String protocol) {
+    }
+
+    @Substitute
+    public static synchronized SSLContext getDefault()
+            throws NoSuchAlgorithmException {
+        if (defaultContext == null) {
+            if (SslContextConfiguration.isSslNativeEnabled()) {
+                defaultContext = SSLContext.getInstance("Default");
+            } else {
+                defaultContext = new DisabledSSLContext();
+            }
+        }
+        return defaultContext;
+    }
+
+    @Substitute
+    public static Target_javax_net_ssl_SSLContext getInstance(String protocol)
+            throws NoSuchAlgorithmException {
+        Objects.requireNonNull(protocol, "null protocol name");
+
+        if (!SslContextConfiguration.isSslNativeEnabled()) {
+            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
+        }
+
+        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol);
+        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
+                protocol);
+    }
+
+    @Substitute
+    public static Target_javax_net_ssl_SSLContext getInstance(String protocol, String provider)
+            throws NoSuchAlgorithmException, NoSuchProviderException {
+        Objects.requireNonNull(protocol, "null protocol name");
+
+        if (!SslContextConfiguration.isSslNativeEnabled()) {
+            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
+        }
+
+        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol, provider);
+        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
+                protocol);
+    }
+
+    @Substitute
+    public static Target_javax_net_ssl_SSLContext getInstance(String protocol, Provider provider)
+            throws NoSuchAlgorithmException {
+        Objects.requireNonNull(protocol, "null protocol name");
+
+        if (!SslContextConfiguration.isSslNativeEnabled()) {
+            return (Target_javax_net_ssl_SSLContext) (Object) getDefault();
+        }
+
+        GetInstance.Instance instance = GetInstance.getInstance("SSLContext", SSLContextSpi.class, protocol, provider);
+        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
+                protocol);
+    }
+
+    private static class DisabledSSLContext extends SSLContext {
+
+        protected DisabledSSLContext() {
+            super(new DisabledSSLContextSpi(), new Provider("DISABLED", 1, "DISABLED") {
+            }, "DISABLED");
+        }
+    }
+
+    private static class DisabledSSLContextSpi extends SSLContextSpi {
+
+        @Override
+        protected void engineInit(KeyManager[] keyManagers, TrustManager[] trustManagers, SecureRandom secureRandom)
+                throws KeyManagementException {
+        }
+
+        @Override
+        protected SSLSocketFactory engineGetSocketFactory() {
+            return new SSLSocketFactory() {
+                @Override
+                public String[] getDefaultCipherSuites() {
+                    return new String[0];
+                }
+
+                @Override
+                public String[] getSupportedCipherSuites() {
+                    return new String[0];
+                }
+
+                @Override
+                public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(String s, int i, InetAddress inetAddress, int i1)
+                        throws IOException, UnknownHostException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1)
+                        throws IOException {
+                    throw sslSupportDisabledException();
+                }
+            };
+        }
+
+        @Override
+        protected SSLServerSocketFactory engineGetServerSocketFactory() {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLEngine engineCreateSSLEngine() {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLEngine engineCreateSSLEngine(String s, int i) {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLSessionContext engineGetServerSessionContext() {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLSessionContext engineGetClientSessionContext() {
+            throw sslSupportDisabledException();
+        }
+
+        private RuntimeException sslSupportDisabledException() {
+            return new IllegalStateException(
+                    "Native SSL support is disabled: you have set quarkus.ssl.native to false in your configuration.");
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/ssl/SslContextConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ssl/SslContextConfiguration.java
@@ -1,0 +1,14 @@
+package io.quarkus.runtime.ssl;
+
+public class SslContextConfiguration {
+
+    private static boolean sslNativeEnabled;
+
+    public static void setSslNativeEnabled(boolean sslNativeEnabled) {
+        SslContextConfiguration.sslNativeEnabled = sslNativeEnabled;
+    }
+
+    public static boolean isSslNativeEnabled() {
+        return sslNativeEnabled;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/ssl/SslContextConfigurationTemplate.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ssl/SslContextConfigurationTemplate.java
@@ -1,0 +1,11 @@
+package io.quarkus.runtime.ssl;
+
+import io.quarkus.runtime.annotations.Template;
+
+@Template
+public class SslContextConfigurationTemplate {
+
+    public void setSslNativeEnabled(boolean sslNativeEnabled) {
+        SslContextConfiguration.setSslNativeEnabled(sslNativeEnabled);
+    }
+}

--- a/extensions/elasticsearch-rest-client/deployment/pom.xml
+++ b/extensions/elasticsearch-rest-client/deployment/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-elasticsearch-rest-client-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
+    <name>Quarkus - Elasticsearch REST client - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/deployment/ElasticsearchRestClientProcessor.java
+++ b/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/deployment/ElasticsearchRestClientProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.elasticsearch.restclient.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
+
+class ElasticsearchRestClientProcessor {
+
+    @BuildStep
+    public void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport) throws Exception {
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
+                org.apache.commons.logging.impl.LogFactoryImpl.class.getName(),
+                org.apache.commons.logging.impl.Jdk14Logger.class.getName()));
+
+        // Indicates that this extension would like the SSL support to be enabled
+        extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.ELASTICSEARCH_REST_CLIENT));
+    }
+}

--- a/extensions/elasticsearch-rest-client/pom.xml
+++ b/extensions/elasticsearch-rest-client/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-elasticsearch-rest-client-parent</artifactId>
+    <name>Quarkus - Elasticsearch client</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/elasticsearch-rest-client/runtime/pom.xml
+++ b/extensions/elasticsearch-rest-client/runtime/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-elasticsearch-rest-client-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+    <name>Quarkus - Elasticsearch REST client - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.substratevm</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/elasticsearch-rest-client/runtime/src/main/java/io/quarkus/elasticsearch/restclient/runtime/graal/Substitute_RestClient.java
+++ b/extensions/elasticsearch-rest-client/runtime/src/main/java/io/quarkus/elasticsearch/restclient/runtime/graal/Substitute_RestClient.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.elasticsearch.restclient.runtime.graal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.http.HttpHost;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.auth.AuthScheme;
+import org.apache.http.client.AuthCache;
+import org.apache.http.conn.SchemePortResolver;
+import org.apache.http.conn.UnsupportedSchemeException;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.conn.DefaultSchemePortResolver;
+import org.apache.http.util.Args;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.RestClient;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * {@link BasicAuthCache} used in the {@link RestClient} is using
+ * serialization which is not supported by GraalVM.
+ * <p>
+ * We substitute it with an implementation which does not use serialization.
+ */
+@TargetClass(className = "org.elasticsearch.client.RestClient")
+final class Substitute_RestClient {
+
+    @Alias
+    private ConcurrentMap<HttpHost, DeadHostState> blacklist;
+
+    @Alias
+    private volatile NodeTuple<List<Node>> nodeTuple;
+
+    @Substitute
+    public synchronized void setNodes(Collection<Node> nodes) {
+        if (nodes == null || nodes.isEmpty()) {
+            throw new IllegalArgumentException("nodes must not be null or empty");
+        }
+        AuthCache authCache = new NoSerializationBasicAuthCache();
+
+        Map<HttpHost, Node> nodesByHost = new LinkedHashMap<>();
+        for (Node node : nodes) {
+            Objects.requireNonNull(node, "node cannot be null");
+            // TODO should we throw an IAE if we have two nodes with the same host?
+            nodesByHost.put(node.getHost(), node);
+            authCache.put(node.getHost(), new BasicScheme());
+        }
+        this.nodeTuple = new NodeTuple<>(Collections.unmodifiableList(new ArrayList<>(nodesByHost.values())),
+                authCache);
+        this.blacklist.clear();
+    }
+
+    @TargetClass(className = "org.elasticsearch.client.DeadHostState")
+    final static class DeadHostState {
+    }
+
+    @TargetClass(className = "org.elasticsearch.client.RestClient", innerClass = "NodeTuple")
+    final static class NodeTuple<T> {
+
+        @Alias
+        NodeTuple(final T nodes, final AuthCache authCache) {
+        }
+    }
+
+    @Contract(threading = ThreadingBehavior.SAFE)
+    private static final class NoSerializationBasicAuthCache implements AuthCache {
+
+        private final Map<HttpHost, AuthScheme> map;
+        private final SchemePortResolver schemePortResolver;
+
+        public NoSerializationBasicAuthCache(final SchemePortResolver schemePortResolver) {
+            this.map = new ConcurrentHashMap<>();
+            this.schemePortResolver = schemePortResolver != null ? schemePortResolver
+                    : DefaultSchemePortResolver.INSTANCE;
+        }
+
+        public NoSerializationBasicAuthCache() {
+            this(null);
+        }
+
+        protected HttpHost getKey(final HttpHost host) {
+            if (host.getPort() <= 0) {
+                final int port;
+                try {
+                    port = schemePortResolver.resolve(host);
+                } catch (final UnsupportedSchemeException ignore) {
+                    return host;
+                }
+                return new HttpHost(host.getHostName(), port, host.getSchemeName());
+            } else {
+                return host;
+            }
+        }
+
+        @Override
+        public void put(final HttpHost host, final AuthScheme authScheme) {
+            Args.notNull(host, "HTTP host");
+            if (authScheme == null) {
+                return;
+            }
+            this.map.put(getKey(host), authScheme);
+        }
+
+        @Override
+        public AuthScheme get(final HttpHost host) {
+            Args.notNull(host, "HTTP host");
+            return this.map.get(getKey(host));
+        }
+
+        @Override
+        public void remove(final HttpHost host) {
+            Args.notNull(host, "HTTP host");
+            this.map.remove(getKey(host));
+        }
+
+        @Override
+        public void clear() {
+            this.map.clear();
+        }
+
+        @Override
+        public String toString() {
+            return this.map.toString();
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/HibernateOrmIntegrationBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/HibernateOrmIntegrationBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.deployment.integration;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class HibernateOrmIntegrationBuildItem extends MultiBuildItem {
+
+    private final String name;
+
+    public HibernateOrmIntegrationBuildItem(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name cannot be null");
+        }
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append(HibernateOrmIntegrationBuildItem.class.getSimpleName())
+                .append(" [").append(name).append("]")
+                .toString();
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/HibernateOrmIntegrationRuntimeConfiguredBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/HibernateOrmIntegrationRuntimeConfiguredBuildItem.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.deployment.integration;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class HibernateOrmIntegrationRuntimeConfiguredBuildItem extends MultiBuildItem {
+
+    private final String name;
+
+    public HibernateOrmIntegrationRuntimeConfiguredBuildItem(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name cannot be null");
+        }
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append(HibernateOrmIntegrationRuntimeConfiguredBuildItem.class.getSimpleName())
+                .append(" [").append(name).append("]")
+                .toString();
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -35,12 +35,14 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
 import org.hibernate.jpa.internal.util.PersistenceUtilHelper;
+import org.hibernate.service.internal.ProvidedService;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder;
 import io.quarkus.hibernate.orm.runtime.boot.registry.PreconfiguredServiceRegistryBuilder;
+import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrations;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedState;
 
 /**
@@ -162,15 +164,19 @@ final class FastBootHibernatePersistenceProvider implements PersistenceProvider 
             final MetadataImplementor metadata = recordedState.getMetadata();
 
             final BuildTimeSettings buildTimeSettings = recordedState.getBuildTimeSettings();
+            final IntegrationSettings integrationSettings = recordedState.getIntegrationSettings();
             // TODO:
             final Object validatorFactory = null;
             // TODO:
             final Object cdiBeanManager = null;
 
-            RuntimeSettings.Builder runtimeSettingsBuilder = new RuntimeSettings.Builder(buildTimeSettings);
+            RuntimeSettings.Builder runtimeSettingsBuilder = new RuntimeSettings.Builder(buildTimeSettings,
+                    integrationSettings);
 
             // Inject the datasource
             injectDataSource(persistenceUnitName, runtimeSettingsBuilder);
+
+            HibernateOrmIntegrations.contributeRuntimeProperties((k, v) -> runtimeSettingsBuilder.put(k, v));
 
             RuntimeSettings runtimeSettings = runtimeSettingsBuilder.build();
 
@@ -196,9 +202,12 @@ final class FastBootHibernatePersistenceProvider implements PersistenceProvider 
         runtimeSettings.getSettings().forEach((key, value) -> {
             serviceRegistryBuilder.applySetting(key, value);
         });
+
+        for (ProvidedService<?> providedService : rs.getProvidedServices()) {
+            serviceRegistryBuilder.addService(providedService);
+        }
+
         // TODO serviceRegistryBuilder.addInitiator( )
-        // TODO serviceRegistryBuilder.applyIntegrator( )
-        // TODO serviceregistryBuilder.addService( )
 
         StandardServiceRegistryImpl standardServiceRegistry = serviceRegistryBuilder.buildNewServiceRegistry();
         return standardServiceRegistry;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmTemplate.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmTemplate.java
@@ -17,10 +17,13 @@
 package io.quarkus.hibernate.orm.runtime;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.boot.archive.scan.spi.Scanner;
+import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
+import org.hibernate.service.spi.ServiceContributor;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.runtime.BeanContainer;
@@ -75,11 +78,13 @@ public class HibernateOrmTemplate {
     }
 
     public BeanContainerListener initMetadata(List<ParsedPersistenceXmlDescriptor> parsedPersistenceXmlDescriptors,
-            Scanner scanner) {
+            Scanner scanner, Collection<Class<? extends Integrator>> additionalIntegrators,
+            Collection<Class<? extends ServiceContributor>> additionalServiceContributors) {
         return new BeanContainerListener() {
             @Override
             public void created(BeanContainer beanContainer) {
-                PersistenceUnitsHolder.initializeJpa(parsedPersistenceXmlDescriptors, scanner);
+                PersistenceUnitsHolder.initializeJpa(parsedPersistenceXmlDescriptors, scanner, additionalIntegrators,
+                        additionalServiceContributors);
             }
         };
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/IntegrationSettings.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/IntegrationSettings.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.orm.runtime;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IntegrationSettings {
+
+    private final Map<String, Object> settings;
+
+    private IntegrationSettings(Map<String, Object> settings) {
+        this.settings = Collections.unmodifiableMap(new HashMap<>(settings));
+    }
+
+    public Map<String, Object> getSettings() {
+        return settings;
+    }
+
+    public static class Builder {
+
+        private final Map<String, Object> settings = new HashMap<>();
+
+        public Builder() {
+        }
+
+        public void put(String key, Object value) {
+            settings.put(key, value);
+        }
+
+        public IntegrationSettings build() {
+            return new IntegrationSettings(settings);
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitsHolder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitsHolder.java
@@ -16,6 +16,7 @@
 
 package io.quarkus.hibernate.orm.runtime;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,8 +25,10 @@ import java.util.stream.Collectors;
 import javax.persistence.PersistenceException;
 
 import org.hibernate.boot.archive.scan.spi.Scanner;
+import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
+import org.hibernate.service.spi.ServiceContributor;
 
 import io.quarkus.hibernate.orm.runtime.boot.FastBootMetadataBuilder;
 import io.quarkus.hibernate.orm.runtime.boot.LightPersistenceXmlDescriptor;
@@ -54,9 +57,11 @@ public final class PersistenceUnitsHolder {
      * @param scanner
      */
     static void initializeJpa(List<ParsedPersistenceXmlDescriptor> parsedPersistenceXmlDescriptors,
-            Scanner scanner) {
+            Scanner scanner, Collection<Class<? extends Integrator>> additionalIntegrators,
+            Collection<Class<? extends ServiceContributor>> additionalServiceContributors) {
         final List<PersistenceUnitDescriptor> units = convertPersistenceUnits(parsedPersistenceXmlDescriptors);
-        final Map<String, RecordedState> metadata = constructMetadataAdvance(units, scanner);
+        final Map<String, RecordedState> metadata = constructMetadataAdvance(units, scanner, additionalIntegrators,
+                additionalServiceContributors);
 
         persistenceUnits = new PersistenceUnits(units, metadata);
     }
@@ -86,11 +91,13 @@ public final class PersistenceUnitsHolder {
     }
 
     private static Map<String, RecordedState> constructMetadataAdvance(
-            final List<PersistenceUnitDescriptor> parsedPersistenceXmlDescriptors, Scanner scanner) {
+            final List<PersistenceUnitDescriptor> parsedPersistenceXmlDescriptors, Scanner scanner,
+            Collection<Class<? extends Integrator>> additionalIntegrators,
+            Collection<Class<? extends ServiceContributor>> additionalServiceContributors) {
         Map<String, RecordedState> recordedStates = new HashMap<>();
 
         for (PersistenceUnitDescriptor unit : parsedPersistenceXmlDescriptors) {
-            RecordedState m = createMetadata(unit, scanner);
+            RecordedState m = createMetadata(unit, scanner, additionalIntegrators);
             Object previous = recordedStates.put(unitName(unit), m);
             if (previous != null) {
                 throw new IllegalStateException("Duplicate persistence unit name: " + unit.getName());
@@ -114,8 +121,9 @@ public final class PersistenceUnitsHolder {
         return name;
     }
 
-    private static RecordedState createMetadata(PersistenceUnitDescriptor unit, Scanner scanner) {
-        FastBootMetadataBuilder fastBootMetadataBuilder = new FastBootMetadataBuilder(unit, scanner);
+    private static RecordedState createMetadata(PersistenceUnitDescriptor unit, Scanner scanner,
+            Collection<Class<? extends Integrator>> additionalIntegrators) {
+        FastBootMetadataBuilder fastBootMetadataBuilder = new FastBootMetadataBuilder(unit, scanner, additionalIntegrators);
         return fastBootMetadataBuilder.build();
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/RuntimeSettings.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/RuntimeSettings.java
@@ -33,8 +33,9 @@ public class RuntimeSettings {
 
         private final Map<String, Object> settings;
 
-        public Builder(BuildTimeSettings buildTimeSettings) {
+        public Builder(BuildTimeSettings buildTimeSettings, IntegrationSettings integrationSettings) {
             this.settings = new HashMap<>(buildTimeSettings.getSettings());
+            this.settings.putAll(integrationSettings.getSettings());
         }
 
         public void put(String key, Object value) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/MirroringIntegratorService.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/MirroringIntegratorService.java
@@ -16,7 +16,7 @@
 
 package io.quarkus.hibernate.orm.runtime.boot.registry;
 
-import java.util.LinkedHashSet;
+import java.util.Collection;
 
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.integrator.spi.IntegratorService;
@@ -35,10 +35,10 @@ import org.hibernate.integrator.spi.IntegratorService;
  */
 final class MirroringIntegratorService implements IntegratorService {
 
-    private final LinkedHashSet<Integrator> integrators = new LinkedHashSet<Integrator>();
+    private final Collection<Integrator> integrators;
 
-    void addIntegrator(Integrator integrator) {
-        integrators.add(integrator);
+    MirroringIntegratorService(Collection<Integrator> integrators) {
+        this.integrators = integrators;
     }
 
     @Override

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -19,6 +19,7 @@ package io.quarkus.hibernate.orm.runtime.boot.registry;
 import static org.hibernate.internal.HEMLogging.messageLogger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilder
 import org.hibernate.service.Service;
 import org.hibernate.service.internal.ProvidedService;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
+import org.hibernate.service.spi.ServiceContributor;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractorInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
@@ -79,11 +81,12 @@ public class PreconfiguredServiceRegistryBuilder {
     private final Map configurationValues = new HashMap();
     private final List<StandardServiceInitiator> initiators;
     private final List<ProvidedService> providedServices = new ArrayList<ProvidedService>();
-    private final MirroringIntegratorService integrators = new MirroringIntegratorService();
+    private final Collection<Integrator> integrators;
     private final StandardServiceRegistryImpl destroyedRegistry;
 
     public PreconfiguredServiceRegistryBuilder(RecordedState rs) {
         this.initiators = buildQuarkusServiceInitiatorList(rs);
+        this.integrators = rs.getIntegrators();
         this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata().getMetadataBuildingOptions()
                 .getServiceRegistry();
     }
@@ -93,18 +96,13 @@ public class PreconfiguredServiceRegistryBuilder {
         return this;
     }
 
-    public PreconfiguredServiceRegistryBuilder applyIntegrator(Integrator integrator) {
-        integrators.addIntegrator(integrator);
-        return this;
-    }
-
     public PreconfiguredServiceRegistryBuilder addInitiator(StandardServiceInitiator initiator) {
         initiators.add(initiator);
         return this;
     }
 
-    public PreconfiguredServiceRegistryBuilder addService(final Class serviceRole, final Service service) {
-        providedServices.add(new ProvidedService(serviceRole, service));
+    public PreconfiguredServiceRegistryBuilder addService(ProvidedService providedService) {
+        providedServices.add(providedService);
         return this;
     }
 
@@ -146,7 +144,7 @@ public class PreconfiguredServiceRegistryBuilder {
         return new BootstrapServiceRegistryImpl(true,
                 FlatClassLoaderService.INSTANCE,
                 strategySelector, // new MirroringStrategySelector(),
-                integrators);
+                new MirroringIntegratorService(integrators));
     }
 
     /**

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/integration/HibernateOrmIntegrationListener.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/integration/HibernateOrmIntegrationListener.java
@@ -1,0 +1,16 @@
+package io.quarkus.hibernate.orm.runtime.integration;
+
+import java.util.function.BiConsumer;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.spi.BootstrapContext;
+
+public interface HibernateOrmIntegrationListener {
+
+    void contributeBootProperties(BiConsumer<String, Object> propertyCollector);
+
+    void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
+            BiConsumer<String, Object> propertyCollector);
+
+    void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector);
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/integration/HibernateOrmIntegrations.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/integration/HibernateOrmIntegrations.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.runtime.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.spi.BootstrapContext;
+
+public class HibernateOrmIntegrations {
+
+    private static final List<HibernateOrmIntegrationListener> LISTENERS = new ArrayList<>();
+
+    public static void registerListener(HibernateOrmIntegrationListener listener) {
+        LISTENERS.add(listener);
+    }
+
+    public static void contributeBootProperties(BiConsumer<String, Object> propertyCollector) {
+        for (HibernateOrmIntegrationListener listener : LISTENERS) {
+            listener.contributeBootProperties(propertyCollector);
+        }
+    }
+
+    public static void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
+            BiConsumer<String, Object> propertyCollector) {
+        for (HibernateOrmIntegrationListener listener : LISTENERS) {
+            ClassLoaderService cls = bootstrapContext.getServiceRegistry().getService(ClassLoaderService.class);
+            listener.onMetadataInitialized(metadata, bootstrapContext, propertyCollector);
+        }
+    }
+
+    public static void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
+        for (HibernateOrmIntegrationListener listener : LISTENERS) {
+            listener.contributeRuntimeProperties(propertyCollector);
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
@@ -385,6 +385,10 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
         }
     }
 
+    public List<ProvidedService> getProvidedServices() {
+        return providedServices;
+    }
+
     /**
      * Temporarily exposed since Configuration is still around and much code still
      * uses Configuration. This allows code to configure the builder and access that

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedState.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedState.java
@@ -16,11 +16,16 @@
 
 package io.quarkus.hibernate.orm.runtime.recording;
 
+import java.util.Collection;
+
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.service.internal.ProvidedService;
 
 import io.quarkus.hibernate.orm.runtime.BuildTimeSettings;
+import io.quarkus.hibernate.orm.runtime.IntegrationSettings;
 
 public final class RecordedState {
 
@@ -28,13 +33,20 @@ public final class RecordedState {
     private final MetadataImplementor metadata;
     private final JtaPlatform jtaPlatform;
     private final BuildTimeSettings settings;
+    private final Collection<Integrator> integrators;
+    private final Collection<ProvidedService> providedServices;
+    private final IntegrationSettings integrationSettings;
 
     public RecordedState(Dialect dialect, JtaPlatform jtaPlatform, MetadataImplementor metadata,
-            BuildTimeSettings settings) {
+            BuildTimeSettings settings, Collection<Integrator> integrators,
+            Collection<ProvidedService> providedServices, IntegrationSettings integrationSettings) {
         this.dialect = dialect;
         this.jtaPlatform = jtaPlatform;
         this.metadata = metadata;
         this.settings = settings;
+        this.integrators = integrators;
+        this.providedServices = providedServices;
+        this.integrationSettings = integrationSettings;
     }
 
     public Dialect getDialect() {
@@ -47,6 +59,18 @@ public final class RecordedState {
 
     public BuildTimeSettings getBuildTimeSettings() {
         return settings;
+    }
+
+    public Collection<Integrator> getIntegrators() {
+        return integrators;
+    }
+
+    public Collection<ProvidedService> getProvidedServices() {
+        return providedServices;
+    }
+
+    public IntegrationSettings getIntegrationSettings() {
+        return integrationSettings;
     }
 
     public JtaPlatform getJtaPlatform() {

--- a/extensions/hibernate-search-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/deployment/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-hibernate-search-elasticsearch-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-search-elasticsearch-deployment</artifactId>
+    <name>Quarkus - Hibernate Search - Elasticsearch - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/hibernate-search-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/deployment/pom.xml
@@ -46,10 +46,20 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.search.elasticsearch;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.AbstractCompositeAnalysisDefinition;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.AnalysisDefinition;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.AnalysisDefinitionJsonAdapterFactory;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.AnalyzerDefinition;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.AnalyzerDefinitionJsonAdapterFactory;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.CharFilterDefinition;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.NormalizerDefinition;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.NormalizerDefinitionJsonAdapterFactory;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.TokenFilterDefinition;
+import org.hibernate.search.backend.elasticsearch.analysis.model.impl.esnative.TokenizerDefinition;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.AbstractTypeMapping;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.AbstractTypeMappingJsonAdapterFactory;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DynamicType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.ElasticsearchFormatJsonAdapter;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.ElasticsearchRoutingTypeJsonAdapter;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMappingJsonAdapterFactory;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RootTypeMapping;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RootTypeMappingJsonAdapterFactory;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RoutingType;
+import org.hibernate.search.backend.elasticsearch.index.settings.impl.esnative.Analysis;
+import org.hibernate.search.backend.elasticsearch.index.settings.impl.esnative.IndexSettings;
+import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeMapping;
+import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeMapping;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+import org.jboss.jandex.DotName;
+
+class HibernateSearchClasses {
+
+    static final List<DotName> FIELD_ANNOTATIONS = Arrays.asList(
+            DotName.createSimple(DocumentId.class.getName()),
+            DotName.createSimple(GenericField.class.getName()),
+            DotName.createSimple(FullTextField.class.getName()),
+            DotName.createSimple(KeywordField.class.getName()),
+            DotName.createSimple(IndexedEmbedded.class.getName()));
+
+    static final DotName PROPERTY_BRIDGE_DECLARATION_ANNOTATION = DotName
+            .createSimple(PropertyBridgeMapping.class.getName());
+
+    static final DotName TYPE_BRIDGE_DECLARATION_ANNOTATION = DotName
+            .createSimple(TypeBridgeMapping.class.getName());
+
+    static final List<DotName> SCHEMA_MAPPING_CLASSES = Arrays.asList(
+            DotName.createSimple(AbstractTypeMapping.class.getName()),
+            DotName.createSimple(AbstractTypeMappingJsonAdapterFactory.class.getName()),
+            DotName.createSimple(DataType.class.getName()),
+            DotName.createSimple(DynamicType.class.getName()),
+            DotName.createSimple(ElasticsearchFormatJsonAdapter.class.getName()),
+            DotName.createSimple(ElasticsearchRoutingTypeJsonAdapter.class.getName()),
+            DotName.createSimple(PropertyMapping.class.getName()),
+            DotName.createSimple(PropertyMappingJsonAdapterFactory.class.getName()),
+            DotName.createSimple(RootTypeMapping.class.getName()),
+            DotName.createSimple(RootTypeMappingJsonAdapterFactory.class.getName()),
+            DotName.createSimple(RoutingType.class.getName()),
+            DotName.createSimple(IndexSettings.class.getName()),
+            DotName.createSimple(Analysis.class.getName()),
+            DotName.createSimple(AnalysisDefinition.class.getName()),
+            DotName.createSimple(AbstractCompositeAnalysisDefinition.class.getName()),
+            DotName.createSimple(AnalyzerDefinition.class.getName()),
+            DotName.createSimple(AnalyzerDefinitionJsonAdapterFactory.class.getName()),
+            DotName.createSimple(NormalizerDefinition.class.getName()),
+            DotName.createSimple(NormalizerDefinitionJsonAdapterFactory.class.getName()),
+            DotName.createSimple(TokenizerDefinition.class.getName()),
+            DotName.createSimple(TokenFilterDefinition.class.getName()),
+            DotName.createSimple(CharFilterDefinition.class.getName()),
+            DotName.createSimple(AnalysisDefinitionJsonAdapterFactory.class.getName()));
+
+    static final DotName INDEXED = DotName.createSimple(Indexed.class.getName());
+}

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.search.elasticsearch;
+
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.FIELD_ANNOTATIONS;
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.INDEXED;
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.PROPERTY_BRIDGE_DECLARATION_ANNOTATION;
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.SCHEMA_MAPPING_CLASSES;
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.TYPE_BRIDGE_DECLARATION_ANNOTATION;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.UnresolvedTypeVariable;
+import org.jboss.jandex.VoidType;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationBuildItem;
+import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
+import io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfig;
+import io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+import io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchElasticsearchTemplate;
+
+class HibernateSearchElasticsearchProcessor {
+
+    private static final String HIBERNATE_SEARCH_ELASTICSEARCH = "Hibernate Search Elasticsearch";
+
+    HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig;
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    public void build(HibernateSearchElasticsearchTemplate template,
+            CombinedIndexBuildItem combinedIndexBuildItem,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
+            BuildProducer<HibernateOrmIntegrationBuildItem> integrations,
+            BuildProducer<FeatureBuildItem> feature) throws Exception {
+        feature.produce(new FeatureBuildItem(FeatureBuildItem.HIBERNATE_SEARCH_ELASTICSEARCH));
+
+        checkConfig(buildTimeConfig);
+
+        IndexView index = combinedIndexBuildItem.getIndex();
+
+        if (index.getAnnotations(INDEXED).isEmpty()) {
+            // we don't have any indexed entity, we can bail out
+            return;
+        }
+
+        // Register the Hibernate Search integration
+        integrations.produce(new HibernateOrmIntegrationBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH));
+
+        // Register the required reflection declarations
+        registerReflection(index, reflectiveClass, reflectiveHierarchy);
+
+        // Register the Hibernate Search integration listener
+        template.registerHibernateSearchIntegration(buildTimeConfig);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setRuntimeConfig(HibernateSearchElasticsearchTemplate template,
+            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
+            BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeConfigured) {
+        template.setRuntimeConfig(runtimeConfig);
+
+        runtimeConfigured.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH));
+    }
+
+    private static void checkConfig(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
+        if (buildTimeConfig.defaultBackend.isPresent()) {
+            if (buildTimeConfig.elasticsearch.dialect.isPresent()) {
+                throw new ConfigurationError(
+                        "quarkus.hibernate-search.elasticsearch.default-backend cannot be used in conjunction with a default backend configuration.");
+            }
+            if (!buildTimeConfig.additionalBackends.containsKey(buildTimeConfig.defaultBackend.get())) {
+                throw new ConfigurationError(
+                        "The default backend defined does not exist: " + buildTimeConfig.defaultBackend.get());
+            }
+        }
+    }
+
+    private void registerReflection(IndexView index, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
+        Set<DotName> reflectiveClassCollector = new HashSet<>();
+        Set<DotName> reflectiveTypeCollector = new HashSet<>();
+
+        if (buildTimeConfig.elasticsearch.analysisConfigurer.isPresent()) {
+            reflectiveClass.produce(
+                    new ReflectiveClassBuildItem(true, false, buildTimeConfig.elasticsearch.analysisConfigurer.get()));
+        }
+
+        for (DotName fieldAnnotation : FIELD_ANNOTATIONS) {
+            for (AnnotationInstance fieldAnnotationInstance : index.getAnnotations(fieldAnnotation)) {
+                AnnotationTarget annotationTarget = fieldAnnotationInstance.target();
+                if (annotationTarget.kind() == Kind.FIELD) {
+                    FieldInfo fieldInfo = annotationTarget.asField();
+                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, fieldInfo.declaringClass());
+                    addReflectiveType(index, reflectiveTypeCollector, fieldInfo.type());
+                } else if (annotationTarget.kind() == Kind.METHOD) {
+                    MethodInfo methodInfo = annotationTarget.asMethod();
+                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, methodInfo.declaringClass());
+                    addReflectiveType(index, reflectiveTypeCollector, methodInfo.returnType());
+                }
+            }
+        }
+
+        Set<Type> reflectiveHierarchyCollector = new HashSet<>();
+
+        for (AnnotationInstance propertyBridgeMappingInstance : index.getAnnotations(PROPERTY_BRIDGE_DECLARATION_ANNOTATION)) {
+            for (AnnotationInstance propertyBridgeInstance : index.getAnnotations(propertyBridgeMappingInstance.name())) {
+                AnnotationTarget annotationTarget = propertyBridgeInstance.target();
+                if (annotationTarget.kind() == Kind.FIELD) {
+                    FieldInfo fieldInfo = annotationTarget.asField();
+                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, fieldInfo.declaringClass());
+                    reflectiveHierarchyCollector.add(fieldInfo.type());
+                } else if (annotationTarget.kind() == Kind.METHOD) {
+                    MethodInfo methodInfo = annotationTarget.asMethod();
+                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, methodInfo.declaringClass());
+                    reflectiveHierarchyCollector.add(methodInfo.returnType());
+                }
+            }
+        }
+
+        for (AnnotationInstance typeBridgeMappingInstance : index.getAnnotations(TYPE_BRIDGE_DECLARATION_ANNOTATION)) {
+            for (AnnotationInstance typeBridgeInstance : index.getAnnotations(typeBridgeMappingInstance.name())) {
+                addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector,
+                        typeBridgeInstance.target().asClass());
+            }
+        }
+
+        String[] reflectiveClasses = Stream
+                .of(reflectiveClassCollector.stream(), reflectiveTypeCollector.stream(), SCHEMA_MAPPING_CLASSES.stream())
+                .flatMap(Function.identity()).map(c -> c.toString()).toArray(String[]::new);
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, reflectiveClasses));
+
+        for (Type reflectiveHierarchyType : reflectiveHierarchyCollector) {
+            reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(reflectiveHierarchyType));
+        }
+    }
+
+    private static void addReflectiveClass(IndexView index, Set<DotName> reflectiveClassCollector,
+            Set<DotName> reflectiveTypeCollector, ClassInfo classInfo) {
+        if (skipClass(classInfo.name(), reflectiveClassCollector)) {
+            return;
+        }
+
+        reflectiveClassCollector.add(classInfo.name());
+
+        for (ClassInfo subclass : index.getAllKnownSubclasses(classInfo.name())) {
+            reflectiveClassCollector.add(subclass.name());
+        }
+        for (ClassInfo implementor : index.getAllKnownImplementors(classInfo.name())) {
+            reflectiveClassCollector.add(implementor.name());
+        }
+
+        Type superClassType = classInfo.superClassType();
+        while (superClassType != null && !superClassType.name().toString().equals("java.lang.Object")) {
+            if (superClassType instanceof ClassType) {
+                superClassType = index.getClassByName(superClassType.name()).superClassType();
+            } else if (superClassType instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = superClassType.asParameterizedType();
+                for (Type typeArgument : parameterizedType.arguments()) {
+                    addReflectiveType(index, reflectiveTypeCollector, typeArgument);
+                }
+                superClassType = parameterizedType.owner();
+            }
+        }
+    }
+
+    private static void addReflectiveType(IndexView index, Set<DotName> reflectiveTypeCollector, Type type) {
+        if (type instanceof VoidType || type instanceof PrimitiveType || type instanceof UnresolvedTypeVariable) {
+            return;
+        } else if (type instanceof ClassType) {
+            if (skipClass(type.name(), reflectiveTypeCollector)) {
+                return;
+            }
+
+            reflectiveTypeCollector.add(type.name());
+        } else if (type instanceof ArrayType) {
+            addReflectiveType(index, reflectiveTypeCollector, type.asArrayType().component());
+        } else if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = type.asParameterizedType();
+            addReflectiveType(index, reflectiveTypeCollector, parameterizedType.owner());
+            for (Type typeArgument : parameterizedType.arguments()) {
+                addReflectiveType(index, reflectiveTypeCollector, typeArgument);
+            }
+        }
+    }
+
+    private static boolean skipClass(DotName name, Set<DotName> processedClasses) {
+        return name.toString().startsWith("java.") || processedClasses.contains(name);
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -105,7 +105,7 @@ class HibernateSearchElasticsearchProcessor {
 
     private static void checkConfig(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
         if (buildTimeConfig.defaultBackend.isPresent()) {
-            if (buildTimeConfig.elasticsearch.dialect.isPresent()) {
+            if (buildTimeConfig.elasticsearch.version.isPresent()) {
                 throw new ConfigurationError(
                         "quarkus.hibernate-search.elasticsearch.default-backend cannot be used in conjunction with a default backend configuration.");
             }

--- a/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/IndexedEntity.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/IndexedEntity.java
@@ -1,0 +1,13 @@
+package io.quarkus.hibernate.search.elasticsearch.test;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+/**
+ * This particular entity is not a valid entity as it is not marked with @Entity.
+ * <p>
+ * It is done this way just for the sake of testing the extension bootstrap.
+ */
+@Indexed
+public class IndexedEntity {
+
+}

--- a/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/NoConfigIndexedEntityTest.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/NoConfigIndexedEntityTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.search.elasticsearch.test;
+
+import java.sql.SQLException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoConfigIndexedEntityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(IndexedEntity.class))
+            .setExpectedException(ConfigurationError.class);
+
+    @Test
+    public void testNoConfig() throws SQLException {
+        // an exception should be thrown
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/NoConfigNoIndexedEntityTest.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/NoConfigNoIndexedEntityTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.hibernate.search.elasticsearch.test;
+
+import java.sql.SQLException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoConfigNoIndexedEntityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class));
+
+    @Test
+    public void testNoConfig() throws SQLException {
+        // we should be able to start the application, even with no configuration at all nor indexed entities
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-search-elasticsearch-parent</artifactId>
+    <name>Quarkus - Hibernate Search - Elasticsearch</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/hibernate-search-elasticsearch/runtime/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/runtime/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-hibernate-search-elasticsearch-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
+    <name>Quarkus - Hibernate Search - Elasticsearch - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.substratevm</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchConfigUtil.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchConfigUtil.java
@@ -1,0 +1,66 @@
+package io.quarkus.hibernate.search.elasticsearch.runtime;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.EngineSettings;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+
+public class HibernateSearchConfigUtil {
+
+    public static <T> void addConfig(BiConsumer<String, Object> propertyCollector, String configPath, T value) {
+        propertyCollector.accept(configKey(configPath), value);
+    }
+
+    public static <T> void addBackendConfig(BiConsumer<String, Object> propertyCollector, String backendName, String configPath,
+            T value) {
+        propertyCollector.accept(backendConfigKey(backendName, configPath), value);
+    }
+
+    public static void addBackendConfig(BiConsumer<String, Object> propertyCollector, String backendName, String configPath,
+            Optional<?> value) {
+        addBackendConfig(propertyCollector, backendName, configPath, value, Optional::isPresent, Optional::get);
+    }
+
+    public static void addBackendConfig(BiConsumer<String, Object> propertyCollector, String backendName, String configPath,
+            OptionalInt value) {
+        addBackendConfig(propertyCollector, backendName, configPath, value, OptionalInt::isPresent, OptionalInt::getAsInt);
+    }
+
+    public static <T> void addBackendConfig(BiConsumer<String, Object> propertyCollector, String backendName, String configPath,
+            T value,
+            Function<T, Boolean> shouldBeAdded, Function<T, ?> getValue) {
+        if (shouldBeAdded.apply(value)) {
+            propertyCollector.accept(backendConfigKey(backendName, configPath), getValue.apply(value));
+        }
+    }
+
+    public static void addBackendDefaultIndexConfig(BiConsumer<String, Object> propertyCollector, String backendName,
+            String configPath, Optional<?> value) {
+        addBackendDefaultIndexConfig(propertyCollector, backendName, configPath, value, Optional::isPresent, Optional::get);
+    }
+
+    public static void addBackendDefaultIndexConfig(BiConsumer<String, Object> propertyCollector, String backendName,
+            String configPath, OptionalInt value) {
+        addBackendDefaultIndexConfig(propertyCollector, backendName, configPath, value, OptionalInt::isPresent,
+                OptionalInt::getAsInt);
+    }
+
+    public static <T> void addBackendDefaultIndexConfig(BiConsumer<String, Object> propertyCollector, String backendName,
+            String configPath, T value,
+            Function<T, Boolean> shouldBeAdded, Function<T, ?> getValue) {
+        addBackendConfig(propertyCollector, backendName, BackendSettings.INDEX_DEFAULTS + "." + configPath, value,
+                shouldBeAdded, getValue);
+    }
+
+    private static String configKey(String configPath) {
+        return HibernateOrmMapperSettings.PREFIX + configPath;
+    }
+
+    private static String backendConfigKey(String backendName, String configPath) {
+        return configKey(EngineSettings.BACKENDS + "." + backendName + "." + configPath);
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchConfigUtil.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchConfigUtil.java
@@ -56,6 +56,24 @@ public class HibernateSearchConfigUtil {
                 shouldBeAdded, getValue);
     }
 
+    public static void addBackendIndexConfig(BiConsumer<String, Object> propertyCollector, String backendName,
+            String indexName, String configPath, Optional<?> value) {
+        addBackendIndexConfig(propertyCollector, backendName, indexName, configPath, value, Optional::isPresent, Optional::get);
+    }
+
+    public static void addBackendIndexConfig(BiConsumer<String, Object> propertyCollector, String backendName,
+            String indexName, String configPath, OptionalInt value) {
+        addBackendIndexConfig(propertyCollector, backendName, indexName, configPath, value, OptionalInt::isPresent,
+                OptionalInt::getAsInt);
+    }
+
+    public static <T> void addBackendIndexConfig(BiConsumer<String, Object> propertyCollector, String backendName,
+            String indexName, String configPath, T value,
+            Function<T, Boolean> shouldBeAdded, Function<T, ?> getValue) {
+        addBackendConfig(propertyCollector, backendName, BackendSettings.INDEXES + "." + indexName + "." + configPath, value,
+                shouldBeAdded, getValue);
+    }
+
     private static String configKey(String configPath) {
         return HibernateOrmMapperSettings.PREFIX + configPath;
     }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -19,7 +19,7 @@ package io.quarkus.hibernate.search.elasticsearch.runtime;
 import java.util.Map;
 import java.util.Optional;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchDialectName;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchVersion;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -49,12 +49,19 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
     @ConfigGroup
     public static class ElasticsearchBackendBuildTimeConfig {
         /**
-         * The dialect used to converse with the Elasticsearch cluster.
+         * The version of Elasticsearch used in the cluster.
          * <p>
          * As the schema is generated without a connection to the server, this item is mandatory.
+         * <p>
+         * It doesn't have to be the exact version (it can be 7 or 7.1 for instance) but it has to be sufficiently precise to
+         * choose a model dialect (the one used to generate the schema) compatible with the protocol dialect (the one used to
+         * communicate with Elasticsearch).
+         * <p>
+         * There's no rule of thumb here as it depends on the schema incompatibilities introduced by Elasticsearch versions. In
+         * any case, if there is a problem, you will have an error when Hibernate Search tries to connect to the cluster.
          */
         @ConfigItem
-        public Optional<ElasticsearchDialectName> dialect;
+        public Optional<ElasticsearchVersion> version;
 
         /**
          * The class or the name of the bean used to configure full text analysis (e.g. analyzers, normalizers).

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.search.elasticsearch.runtime;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchDialectName;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "hibernate-search", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class HibernateSearchElasticsearchBuildTimeConfig {
+
+    /**
+     * Configuration of the default backend.
+     */
+    public ElasticsearchBackendBuildTimeConfig elasticsearch;
+
+    /**
+     * If not using the default backend configuration, the name of the default backend that is part of the
+     * {@link #additionalBackends}.
+     */
+    public Optional<String> defaultBackend;
+
+    /**
+     * Configuration of optional additional backends.
+     */
+    @ConfigItem(name = "elasticsearch.backends")
+    public Map<String, ElasticsearchBackendBuildTimeConfig> additionalBackends;
+
+    @ConfigGroup
+    public static class ElasticsearchBackendBuildTimeConfig {
+        /**
+         * The dialect used to converse with the Elasticsearch cluster.
+         * <p>
+         * As the schema is generated without a connection to the server, this item is mandatory.
+         */
+        @ConfigItem
+        public Optional<ElasticsearchDialectName> dialect;
+
+        /**
+         * The class or the name of the bean used to configure full text analysis (e.g. analyzers, normalizers).
+         */
+        @ConfigItem
+        public Optional<Class<?>> analysisConfigurer;
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.search.elasticsearch.runtime;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexLifecycleStrategyName;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexStatus;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "hibernate-search", phase = ConfigPhase.RUN_TIME)
+public class HibernateSearchElasticsearchRuntimeConfig {
+
+    /**
+     * Configuration of the default backend.
+     */
+    ElasticsearchBackendRuntimeConfig elasticsearch;
+
+    /**
+     * Configuration of optional additional backends.
+     */
+    @ConfigItem(name = "elasticsearch.backends")
+    Map<String, ElasticsearchBackendRuntimeConfig> additionalBackends;
+
+    @ConfigGroup
+    public static class ElasticsearchBackendRuntimeConfig {
+        /**
+         * The list of hosts of the Elasticsearch servers.
+         */
+        @ConfigItem
+        List<String> hosts;
+
+        /**
+         * The username used for authentication.
+         */
+        @ConfigItem
+        Optional<String> username;
+
+        /**
+         * The password used for authentication.
+         */
+        @ConfigItem
+        Optional<String> password;
+
+        /**
+         * The connection timeout.
+         */
+        @ConfigItem
+        Optional<Duration> connectionTimeout;
+
+        /**
+         * The maximum number of connections to all the Elasticsearch servers.
+         */
+        @ConfigItem
+        OptionalInt maxConnections;
+
+        /**
+         * The maximum number of connections per Elasticsearch server.
+         */
+        @ConfigItem
+        OptionalInt maxConnectionsPerRoute;
+
+        /**
+         * Configuration for the automatic discovery of new Elasticsearch nodes.
+         */
+        @ConfigItem
+        DiscoveryConfig discovery;
+
+        /**
+         * The default configuration for the Elasticsearch indexes.
+         */
+        @ConfigItem
+        ElasticsearchIndexConfig indexDefaults;
+
+        /**
+         * Per-index specific configuration.
+         */
+        @ConfigItem
+        Map<String, ElasticsearchIndexConfig> indexes;
+    }
+
+    @ConfigGroup
+    public static class ElasticsearchIndexConfig {
+        /**
+         * Configuration for the lifecyle of the indexes.
+         */
+        @ConfigItem
+        LifecycleConfig lifecycle;
+
+        /**
+         * Defines if the indexes should be refreshed after writes.
+         */
+        @ConfigItem
+        Optional<Boolean> refreshAfterWrite;
+    }
+
+    @ConfigGroup
+    public static class DiscoveryConfig {
+
+        /**
+         * Defines if automatic discovery is enabled.
+         */
+        @ConfigItem
+        Optional<Boolean> enabled;
+
+        /**
+         * Refresh interval of the node list.
+         */
+        Optional<Duration> refreshInterval;
+
+        /**
+         * The scheme that should be used for the new nodes discovered.
+         */
+        Optional<String> defaultScheme;
+    }
+
+    @ConfigGroup
+    public static class LifecycleConfig {
+
+        /**
+         * The strategy used for index lifecycle.
+         * <p>
+         * Must be one of: none, validate, update, create, drop-and-create or drop-and-create-and-drop.
+         */
+        @ConfigItem
+        Optional<ElasticsearchIndexLifecycleStrategyName> strategy;
+
+        /**
+         * The minimal cluster status required.
+         * <p>
+         * Must be one of: green, yellow, red.
+         */
+        @ConfigItem
+        Optional<ElasticsearchIndexStatus> requiredStatus;
+
+        /**
+         * How long we should wait for the status before failing the bootstrap.
+         */
+        @ConfigItem
+        Optional<Duration> requiredStatusWaitTimeout;
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
@@ -74,7 +74,7 @@ public class HibernateSearchElasticsearchTemplate {
             if (buildTimeConfig.defaultBackend.isPresent()) {
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
                         buildTimeConfig.defaultBackend.get());
-            } else if (buildTimeConfig.elasticsearch.dialect.isPresent()) {
+            } else if (buildTimeConfig.elasticsearch.version.isPresent()) {
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
                         HibernateSearchElasticsearchTemplate.DEFAULT_BACKEND);
             }
@@ -108,8 +108,8 @@ public class HibernateSearchElasticsearchTemplate {
                 ElasticsearchBackendBuildTimeConfig elasticsearchBackendConfig) {
             addBackendConfig(propertyCollector, backendName, BackendSettings.TYPE,
                     ElasticsearchBackendSettings.TYPE_NAME);
-            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DIALECT,
-                    elasticsearchBackendConfig.dialect);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.VERSION,
+                    elasticsearchBackendConfig.version);
             addBackendConfig(propertyCollector, backendName,
                     ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
                     elasticsearchBackendConfig.analysisConfigurer,

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.hibernate.search.elasticsearch.runtime;
+
+import static io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchConfigUtil.addBackendConfig;
+import static io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchConfigUtil.addBackendDefaultIndexConfig;
+import static io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchConfigUtil.addConfig;
+
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.EngineSettings;
+import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateOrmIntegrationBooter;
+import org.hibernate.search.mapper.orm.cfg.spi.HibernateOrmMapperSpiSettings;
+import org.hibernate.search.mapper.orm.cfg.spi.HibernateOrmPropertyHandleFactoryName;
+
+import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationListener;
+import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrations;
+import io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfig.ElasticsearchBackendBuildTimeConfig;
+import io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig.ElasticsearchBackendRuntimeConfig;
+import io.quarkus.runtime.annotations.Template;
+
+@Template
+public class HibernateSearchElasticsearchTemplate {
+
+    public static final String DEFAULT_BACKEND = "_quarkus_";
+
+    private static HibernateSearchElasticsearchRuntimeConfig runtimeConfig;
+
+    public void registerHibernateSearchIntegration(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
+        HibernateOrmIntegrations.registerListener(new HibernateSearchIntegrationListener(buildTimeConfig));
+    }
+
+    public void setRuntimeConfig(HibernateSearchElasticsearchRuntimeConfig runtimeConfig) {
+        HibernateSearchElasticsearchTemplate.runtimeConfig = runtimeConfig;
+    }
+
+    private static final class HibernateSearchIntegrationListener implements HibernateOrmIntegrationListener {
+
+        private HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig;
+
+        private HibernateSearchIntegrationListener(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
+            this.buildTimeConfig = buildTimeConfig;
+        }
+
+        @Override
+        public void contributeBootProperties(BiConsumer<String, Object> propertyCollector) {
+            addConfig(propertyCollector, HibernateOrmMapperSpiSettings.Radicals.PROPERTY_HANDLE_FACTORY,
+                    HibernateOrmPropertyHandleFactoryName.JAVA_LANG_REFLECT);
+
+            if (buildTimeConfig.defaultBackend.isPresent()) {
+                addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
+                        buildTimeConfig.defaultBackend.get());
+            } else if (buildTimeConfig.elasticsearch.dialect.isPresent()) {
+                addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
+                        HibernateSearchElasticsearchTemplate.DEFAULT_BACKEND);
+            }
+
+            contributeBackendBuildTimeProperties(propertyCollector, HibernateSearchElasticsearchTemplate.DEFAULT_BACKEND,
+                    buildTimeConfig.elasticsearch);
+
+            for (Entry<String, ElasticsearchBackendBuildTimeConfig> backendEntry : buildTimeConfig.additionalBackends
+                    .entrySet()) {
+                contributeBackendBuildTimeProperties(propertyCollector, backendEntry.getKey(), backendEntry.getValue());
+            }
+        }
+
+        @Override
+        public void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
+                BiConsumer<String, Object> propertyCollector) {
+            HibernateOrmIntegrationBooter booter = HibernateOrmIntegrationBooter.create(metadata, bootstrapContext);
+            booter.preBoot(propertyCollector);
+        }
+
+        @Override
+        public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
+            contributeBackendRuntimeProperties(propertyCollector, DEFAULT_BACKEND, runtimeConfig.elasticsearch);
+
+            for (Entry<String, ElasticsearchBackendRuntimeConfig> backendEntry : runtimeConfig.additionalBackends.entrySet()) {
+                contributeBackendRuntimeProperties(propertyCollector, backendEntry.getKey(), backendEntry.getValue());
+            }
+        }
+
+        private void contributeBackendBuildTimeProperties(BiConsumer<String, Object> propertyCollector, String backendName,
+                ElasticsearchBackendBuildTimeConfig elasticsearchBackendConfig) {
+            addBackendConfig(propertyCollector, backendName, BackendSettings.TYPE,
+                    ElasticsearchBackendSettings.TYPE_NAME);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DIALECT,
+                    elasticsearchBackendConfig.dialect);
+            addBackendConfig(propertyCollector, backendName,
+                    ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+                    elasticsearchBackendConfig.analysisConfigurer,
+                    Optional::isPresent, c -> c.get().getName());
+        }
+
+        private void contributeBackendRuntimeProperties(BiConsumer<String, Object> propertyCollector, String backendName,
+                ElasticsearchBackendRuntimeConfig elasticsearchBackendConfig) {
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.HOSTS,
+                    elasticsearchBackendConfig.hosts,
+                    v -> (!v.isEmpty() && !(v.size() == 1 && v.get(0).isEmpty())), Function.identity());
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.USERNAME,
+                    elasticsearchBackendConfig.username);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.PASSWORD,
+                    elasticsearchBackendConfig.password);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.CONNECTION_TIMEOUT,
+                    elasticsearchBackendConfig.connectionTimeout,
+                    Optional::isPresent, d -> d.get().toMillis());
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.MAX_CONNECTIONS,
+                    elasticsearchBackendConfig.maxConnections);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.MAX_CONNECTIONS_PER_ROUTE,
+                    elasticsearchBackendConfig.maxConnectionsPerRoute);
+
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DISCOVERY_ENABLED,
+                    elasticsearchBackendConfig.discovery.enabled);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DISCOVERY_REFRESH_INTERVAL,
+                    elasticsearchBackendConfig.discovery.refreshInterval,
+                    Optional::isPresent, d -> d.get().getSeconds());
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DISCOVERY_SCHEME,
+                    elasticsearchBackendConfig.discovery.defaultScheme);
+
+            addBackendDefaultIndexConfig(propertyCollector, backendName, ElasticsearchIndexSettings.LIFECYCLE_STRATEGY,
+                    elasticsearchBackendConfig.indexDefaults.lifecycle.strategy);
+            addBackendDefaultIndexConfig(propertyCollector, backendName,
+                    ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS,
+                    elasticsearchBackendConfig.indexDefaults.lifecycle.requiredStatus);
+            addBackendDefaultIndexConfig(propertyCollector, backendName,
+                    ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
+                    elasticsearchBackendConfig.indexDefaults.lifecycle.requiredStatusWaitTimeout, Optional::isPresent,
+                    d -> d.get().toMillis());
+
+            addBackendDefaultIndexConfig(propertyCollector, backendName, ElasticsearchIndexSettings.REFRESH_AFTER_WRITE,
+                    runtimeConfig.elasticsearch.indexDefaults.refreshAfterWrite);
+
+            // TODO: manage the specific per-index configuration: let's wait for Alpha4 as it is totally different now
+            // TODO: test the per-backend configuration: let's wait for Alpha4 as it is totally different now
+        }
+    }
+}

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
@@ -72,9 +72,11 @@ public class HibernateSearchElasticsearchTemplate {
                     HibernateOrmPropertyHandleFactoryName.JAVA_LANG_REFLECT);
 
             if (buildTimeConfig.defaultBackend.isPresent()) {
+                // we have a named default backend
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
                         buildTimeConfig.defaultBackend.get());
             } else if (buildTimeConfig.elasticsearch.version.isPresent()) {
+                // we use the default backend configuration
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
                         HibernateSearchElasticsearchTemplate.DEFAULT_BACKEND);
             }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/graal/Substitute_HibernateOrmIntegrationBooterImpl.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/graal/Substitute_HibernateOrmIntegrationBooterImpl.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.search.elasticsearch.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Force two phase-boot so that bootstrap code can be DCEd.
+ */
+@TargetClass(className = "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateOrmIntegrationBooterImpl")
+final class Substitute_HibernateOrmIntegrationBooterImpl {
+
+    @Substitute
+    private HibernateOrmIntegrationPartialBuildState doBootFirstPhase() {
+        throw new IllegalStateException("Partial build state should have been generated during the static init phase.");
+    }
+
+    @TargetClass(className = "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateOrmIntegrationBooterImpl", innerClass = "HibernateOrmIntegrationPartialBuildState")
+    final static class HibernateOrmIntegrationPartialBuildState {
+
+    }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -76,6 +76,7 @@
         <module>hibernate-orm</module>
         <module>hibernate-validator</module>
         <module>panache</module>
+        <module>elasticsearch-rest-client</module>
         <module>kafka-client</module>
 
         <!-- Spring -->

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -76,6 +76,7 @@
         <module>hibernate-orm</module>
         <module>hibernate-validator</module>
         <module>panache</module>
+        <module>hibernate-search-elasticsearch</module>
         <module>elasticsearch-rest-client</module>
         <module>kafka-client</module>
 

--- a/integration-tests/hibernate-search-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-elasticsearch/pom.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-hibernate-search-elasticsearch</artifactId>
+    <name>Quarkus - Integration Tests - Hibernate Search + Elasticsearch</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-elasticsearch</id>
+            <activation>
+                <property>
+                    <name>test-elasticsearch</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.alexcojocaru</groupId>
+                        <artifactId>elasticsearch-maven-plugin</artifactId>
+                        <version>${elasticsearch-maven-plugin.version}</version>
+                        <configuration>
+                            <!-- Use the same server version as the client -->
+                            <version>${elasticsearch-server.version}</version>
+                            <timeout>90</timeout>
+                            <pathConf>${project.build.directory}/test-classes/elasticsearch-maven-plugin/configuration/</pathConf>
+                            <pathInitScript>${project.build.directory}/test-classes/elasticsearch-maven-plugin/init/init.script</pathInitScript>
+                            <autoCreateIndex>true</autoCreateIndex>
+                        </configuration>
+                        <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
+                        <executions>
+                            <execution>
+                                <id>start-elasticsearch</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>runforked</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop-elasticsearch</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <!-- Requires Protean Graal fork to work, will fail otherwise
+                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
+                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
+                                    -->
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
+                                    <debugBuildProcess>false</debugBuildProcess>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/hibernate-search-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-elasticsearch/pom.xml
@@ -35,13 +35,27 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-elasticsearch-rest-client</artifactId>
+            <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -116,10 +130,7 @@
                     <plugin>
                         <groupId>com.github.alexcojocaru</groupId>
                         <artifactId>elasticsearch-maven-plugin</artifactId>
-                        <version>${elasticsearch-maven-plugin.version}</version>
                         <configuration>
-                            <!-- Use the same server version as the client -->
-                            <version>${elasticsearch-server.version}</version>
                             <timeout>90</timeout>
                             <pathConf>${project.build.directory}/test-classes/elasticsearch-maven-plugin/configuration/</pathConf>
                             <pathInitScript>${project.build.directory}/test-classes/elasticsearch-maven-plugin/init/init.script</pathInitScript>

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/elasticsearch/ElasticsearchClientTestResource.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/elasticsearch/ElasticsearchClientTestResource.java
@@ -1,0 +1,143 @@
+package io.quarkus.test.elasticsearch;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.sniff.Sniffer;
+
+@Path("/test/elasticsearch-client")
+public class ElasticsearchClientTestResource {
+
+    @GET
+    @Path("/connection")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testConnection() throws IOException, NoSuchAlgorithmException {
+        try (RestClient restClient = createRestClient()) {
+            Response response = restClient.performRequest(new Request("GET", "/"));
+
+            checkStatus(response, 200);
+
+            return "OK";
+        }
+    }
+
+    @GET
+    @Path("/full-cycle")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testFullCycle() throws IOException {
+        try (RestClient restClient = createRestClient()) {
+            try {
+                restClient.performRequest(new Request("DELETE", "/books"));
+            } catch (Exception e) {
+                // ignore
+            }
+
+            // create schema
+            Request createIndex = new Request("PUT", "/books");
+            createIndex.setJsonEntity(
+                    "{ " +
+                            "    \"settings\" : { " +
+                            "        \"number_of_shards\" : 1 " +
+                            "    }, " +
+                            "    \"mappings\" : { " +
+                            "        \"_doc\" : { " +
+                            "            \"properties\" : { " +
+                            "                \"title\" : { \"type\" : \"text\" }, " +
+                            "                \"author\" : { \"type\" : \"text\" } " +
+                            "            } " +
+                            "        } " +
+                            "    } " +
+                            "}");
+
+            Response response = restClient.performRequest(createIndex);
+            checkStatus(response, 200);
+
+            // index documents
+            Request indexDocument = new Request("POST", "/books/_doc/1");
+            indexDocument.setJsonEntity(
+                    "{" +
+                            "    \"title\": \"4 3 2 1\"," +
+                            "    \"author\": \"Auster\"" +
+                            "}");
+            response = restClient.performRequest(indexDocument);
+            checkStatus(response, 201);
+
+            indexDocument = new Request("POST", "/books/_doc/2");
+            indexDocument.setJsonEntity(
+                    "{" +
+                            "    \"title\": \"Avenue of mysteries\"," +
+                            "    \"author\": \"Irving\"" +
+                            "}");
+            response = restClient.performRequest(indexDocument);
+            checkStatus(response, 201);
+
+            restClient.performRequest(new Request("POST", "/books/_flush"));
+
+            // search
+            Request searchRequest = new Request("POST", "/books/_search");
+            searchRequest.setJsonEntity("{" +
+                    "    \"query\": { " +
+                    "        \"query_string\": {" +
+                    "            \"query\": \"Irving\"" +
+                    "        } " +
+                    "    } " +
+                    "}");
+            response = restClient.performRequest(searchRequest);
+            checkStatus(response, 200);
+            checkContent(response, "mysteries");
+
+            return "OK";
+        }
+    }
+
+    @GET
+    @Path("/sniffer")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testSniffer() throws IOException, InterruptedException {
+        try (RestClient restClient = createRestClient()) {
+            Sniffer sniffer = Sniffer.builder(restClient).setSniffIntervalMillis(5).build();
+
+            // Wait for a few iterations of the sniffer
+            Thread.sleep(20);
+
+            sniffer.close();
+
+            return "OK";
+        }
+    }
+
+    private static RestClient createRestClient() {
+        return RestClient.builder(new HttpHost("localhost", 9200)).build();
+    }
+
+    private static void checkStatus(Response response, int status) {
+        if (response.getStatusLine().getStatusCode() != status) {
+            throw new IllegalStateException("Status should have been " + status + " but is: "
+                    + response.getStatusLine().getStatusCode() + " - " + response.getStatusLine().getReasonPhrase());
+        }
+    }
+
+    private static void checkContent(Response response, String token) throws IOException {
+        String content = getContent(response);
+        if (!content.contains(token)) {
+            throw new IllegalStateException("Content should contain " + token + " but is: " + content);
+        }
+    }
+
+    private static String getContent(Response response) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        response.getEntity().writeTo(baos);
+        return new String(baos.toByteArray(), StandardCharsets.UTF_8);
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/client/ElasticsearchClientTestResource.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/client/ElasticsearchClientTestResource.java
@@ -51,12 +51,10 @@ public class ElasticsearchClientTestResource {
                             "        \"number_of_shards\" : 1 " +
                             "    }, " +
                             "    \"mappings\" : { " +
-                            "        \"_doc\" : { " +
                             "            \"properties\" : { " +
                             "                \"title\" : { \"type\" : \"text\" }, " +
                             "                \"author\" : { \"type\" : \"text\" } " +
                             "            } " +
-                            "        } " +
                             "    } " +
                             "}");
 
@@ -64,7 +62,7 @@ public class ElasticsearchClientTestResource {
             checkStatus(response, 200);
 
             // index documents
-            Request indexDocument = new Request("POST", "/books/_doc/1");
+            Request indexDocument = new Request("POST", "/books/_doc/1?refresh=true");
             indexDocument.setJsonEntity(
                     "{" +
                             "    \"title\": \"4 3 2 1\"," +
@@ -73,7 +71,7 @@ public class ElasticsearchClientTestResource {
             response = restClient.performRequest(indexDocument);
             checkStatus(response, 201);
 
-            indexDocument = new Request("POST", "/books/_doc/2");
+            indexDocument = new Request("POST", "/books/_doc/2?refresh=true");
             indexDocument.setJsonEntity(
                     "{" +
                             "    \"title\": \"Avenue of mysteries\"," +
@@ -82,13 +80,11 @@ public class ElasticsearchClientTestResource {
             response = restClient.performRequest(indexDocument);
             checkStatus(response, 201);
 
-            restClient.performRequest(new Request("POST", "/books/_flush"));
-
             // search
             Request searchRequest = new Request("POST", "/books/_search");
             searchRequest.setJsonEntity("{" +
                     "    \"query\": { " +
-                    "        \"query_string\": {" +
+                    "        \"simple_query_string\": {" +
                     "            \"query\": \"Irving\"" +
                     "        } " +
                     "    } " +

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/client/ElasticsearchClientTestResource.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/client/ElasticsearchClientTestResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.elasticsearch;
+package io.quarkus.test.hibernate.search.elasticsearch.client;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/Address.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/Address.java
@@ -1,0 +1,54 @@
+package io.quarkus.test.hibernate.search.elasticsearch.search;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "addressSeq")
+    private Long id;
+
+    @FullTextField(analyzer = "standard")
+    private String city;
+
+    @OneToMany(mappedBy = "address")
+    private List<Person> person;
+
+    public Address() {
+    }
+
+    public Address(String city) {
+        this.city = city;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String name) {
+        this.city = name;
+    }
+
+    public void describeFully(StringBuilder sb) {
+        sb.append("Address with id=").append(id).append(", city='").append(city).append("'");
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/DefaultITAnalysisConfigurer.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/DefaultITAnalysisConfigurer.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.hibernate.search.elasticsearch.search;
+
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
+import org.hibernate.search.backend.elasticsearch.analysis.model.dsl.ElasticsearchAnalysisDefinitionContainerContext;
+
+public class DefaultITAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
+
+    @Override
+    public void configure(ElasticsearchAnalysisDefinitionContainerContext context) {
+        context.analyzer("standard").type("standard");
+        context.normalizer("lowercase").custom().withTokenFilters("lowercase");
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
@@ -1,0 +1,83 @@
+package io.quarkus.test.hibernate.search.elasticsearch.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
+@Path("/test/hibernate-search")
+public class HibernateSearchTestResource {
+
+    @Inject
+    EntityManager entityManager;
+
+    @PUT
+    @Path("/init-data")
+    @Transactional
+    public void initData() {
+        createPerson("John Irving", "Burlington");
+        createPerson("David Lodge", "London");
+        createPerson("Paul Auster", "New York");
+        createPerson("John Grisham", "Oxford");
+    }
+
+    @GET
+    @Path("/search")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testSearch() {
+        SearchSession searchSession = Search.getSearchSession(entityManager);
+
+        List<Person> person = searchSession.search(Person.class)
+                .asEntity()
+                .predicate(f -> f.match().onField("name").matching("john"))
+                .sort(f -> f.byField("name_sort"))
+                .toQuery()
+                .fetchHits();
+
+        assertEquals(2, person.size());
+        assertEquals("John Grisham", person.get(0).getName());
+        assertEquals("John Irving", person.get(1).getName());
+
+        person = searchSession.search(Person.class)
+                .asEntity()
+                .predicate(f -> f.nested().onObjectField("address").nest(f.match().onField("address.city").matching("london")))
+                .sort(f -> f.byField("name_sort"))
+                .toQuery()
+                .fetchHits();
+
+        assertEquals(1, person.size());
+        assertEquals("David Lodge", person.get(0).getName());
+
+        return "OK";
+    }
+
+    @PUT
+    @Path("/mass-indexer")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testMassIndexer() throws InterruptedException {
+        SearchSession searchSession = Search.getSearchSession(entityManager);
+
+        searchSession.createIndexer().startAndWait();
+
+        return "OK";
+    }
+
+    private void createPerson(String name, String city) {
+        Address address = new Address(city);
+        entityManager.persist(address);
+
+        Person person = new Person(name, address);
+        entityManager.persist(person);
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/Person.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/Person.java
@@ -1,0 +1,71 @@
+package io.quarkus.test.hibernate.search.elasticsearch.search;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class Person {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "personSeq")
+    private Long id;
+
+    @FullTextField(analyzer = "standard")
+    @KeywordField(name = "name_sort", normalizer = "lowercase", sortable = Sortable.YES)
+    private String name;
+
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @IndexedEmbedded(storage = ObjectFieldStorage.NESTED)
+    private Address address;
+
+    public Person() {
+    }
+
+    public Person(String name, Address address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public void describeFully(StringBuilder sb) {
+        sb.append("Person with id=").append(id).append(", name='").append(name).append("', address { ");
+        getAddress().describeFully(sb);
+        sb.append(" }");
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/META-INF/beans.xml
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#quarkus.ssl.native = false

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -24,7 +24,7 @@ quarkus.datasource.min-size=2
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search.elasticsearch.dialect=6
+quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis-configurer=io.quarkus.test.hibernate.search.elasticsearch.search.DefaultITAnalysisConfigurer
 quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create-and-drop
 quarkus.hibernate-search.elasticsearch.index-defaults.refresh-after-write=true

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -15,3 +15,16 @@
 #
 
 #quarkus.ssl.native = false
+
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.max-size=8
+quarkus.datasource.min-size=2
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.hibernate-search.elasticsearch.dialect=6
+quarkus.hibernate-search.elasticsearch.analysis-configurer=io.quarkus.test.hibernate.search.elasticsearch.search.DefaultITAnalysisConfigurer
+quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create-and-drop
+quarkus.hibernate-search.elasticsearch.index-defaults.refresh-after-write=true

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-#quarkus.ssl.native = false
+quarkus.ssl.native = false
 
 quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.datasource.driver=org.h2.Driver

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/elasticsearch/test/ElasticsearchClientTest.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/elasticsearch/test/ElasticsearchClientTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.test.elasticsearch.test;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class ElasticsearchClientTest {
+
+    @Test
+    public void testConnection() throws Exception {
+        RestAssured.when().get("/test/elasticsearch-client/connection").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testFullCycle() throws Exception {
+        RestAssured.when().get("/test/elasticsearch-client/full-cycle").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testSniffer() throws Exception {
+        RestAssured.when().get("/test/elasticsearch-client/sniffer").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/elasticsearch/test/ElasticsearchClientTestInGraalIT.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/elasticsearch/test/ElasticsearchClientTestInGraalIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.test.elasticsearch.test;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class ElasticsearchClientTestInGraalIT extends ElasticsearchClientTest {
+
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/ElasticsearchClientInGraalIT.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/ElasticsearchClientInGraalIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.test.hibernate.search.elasticsearch;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class ElasticsearchClientInGraalIT extends ElasticsearchClientTest {
+
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/ElasticsearchClientTest.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/ElasticsearchClientTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.test.hibernate.search.elasticsearch;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class ElasticsearchClientTest {
+
+    @Test
+    public void testConnection() throws Exception {
+        RestAssured.when().get("/test/elasticsearch-client/connection").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testFullCycle() throws Exception {
+        RestAssured.when().get("/test/elasticsearch-client/full-cycle").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+
+    @Test
+    public void testSniffer() throws Exception {
+        RestAssured.when().get("/test/elasticsearch-client/sniffer").then()
+                .statusCode(200)
+                .body(is("OK"));
+    }
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/HibernateSearchInGraalIT.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/HibernateSearchInGraalIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.test.hibernate.search.elasticsearch;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class HibernateSearchInGraalIT extends HibernateSearchTest {
+
+}

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/HibernateSearchTest.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/HibernateSearchTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.test.elasticsearch.test;
+package io.quarkus.test.hibernate.search.elasticsearch;
 
 import static org.hamcrest.Matchers.is;
 
@@ -24,25 +24,18 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-public class ElasticsearchClientTest {
+public class HibernateSearchTest {
 
     @Test
-    public void testConnection() throws Exception {
-        RestAssured.when().get("/test/elasticsearch-client/connection").then()
+    public void testSearch() throws Exception {
+        RestAssured.when().put("/test/hibernate-search/init-data").then()
+                .statusCode(204);
+
+        RestAssured.when().get("/test/hibernate-search/search").then()
                 .statusCode(200)
                 .body(is("OK"));
-    }
 
-    @Test
-    public void testFullCycle() throws Exception {
-        RestAssured.when().get("/test/elasticsearch-client/full-cycle").then()
-                .statusCode(200)
-                .body(is("OK"));
-    }
-
-    @Test
-    public void testSniffer() throws Exception {
-        RestAssured.when().get("/test/elasticsearch-client/sniffer").then()
+        RestAssured.when().put("/test/hibernate-search/mass-indexer").then()
                 .statusCode(200)
                 .body(is("OK"));
     }

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/TestResources.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/test/hibernate/search/elasticsearch/TestResources.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package io.quarkus.test.elasticsearch.test;
+package io.quarkus.test.hibernate.search.elasticsearch;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@SubstrateTest
-public class ElasticsearchClientTestInGraalIT extends ElasticsearchClientTest {
-
+@QuarkusTestResource(H2DatabaseTestResource.class)
+public class TestResources {
 }

--- a/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/elasticsearch.yml
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/elasticsearch.yml
@@ -1,0 +1,66 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please consult the documentation for further information on configuration options:
+# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+#
+# ----------------------------------- Memory -----------------------------------
+#
+# Lock the memory on startup:
+#
+bootstrap.memory_lock: true
+#
+# Make sure that the heap size is set to about half the memory available
+# on the system and that the owner of the process is allowed to use this
+# limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
+# ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
+network.host: _local_
+#
+# Set a custom port for HTTP:
+#
+http.port: 9200
+#
+# For more information, consult the network module documentation.
+#
+# --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
+#discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
+#
+discovery.zen.minimum_master_nodes: 1
+#
+# For more information, consult the zen discovery module documentation.
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+#gateway.recover_after_nodes: 3
+#
+# For more information, consult the gateway module documentation.
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Require explicit names when deleting indices:
+#
+#action.destructive_requires_name: true
+#
+# Disable starting multiple nodes on a single system:
+#
+node.max_local_storage_nodes: 1

--- a/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/elasticsearch.yml
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/elasticsearch.yml
@@ -10,6 +10,32 @@
 # Please consult the documentation for further information on configuration options:
 # https://www.elastic.co/guide/en/elasticsearch/reference/index.html
 #
+# ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
+#
+#cluster.name: my-application
+#
+# ------------------------------------ Node ------------------------------------
+#
+# Use a descriptive name for the node:
+#
+#node.name: node-1
+#
+# Add custom attributes to the node:
+#
+#node.attr.rack: r1
+#
+# ----------------------------------- Paths ------------------------------------
+#
+# Path to directory where to store the data (separate multiple locations by comma):
+#
+#path.data: /path/to/data
+#
+# Path to log files:
+#
+#path.logs: /path/to/logs
+#
 # ----------------------------------- Memory -----------------------------------
 #
 # Lock the memory on startup:
@@ -36,16 +62,16 @@ http.port: 9200
 #
 # --------------------------------- Discovery ----------------------------------
 #
-# Pass an initial list of hosts to perform discovery when new node is started:
+# Pass an initial list of hosts to perform discovery when this node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-#discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#discovery.seed_hosts: ["host1", "host2"]
 #
-# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
+# Bootstrap the cluster using an initial set of master-eligible nodes:
 #
-discovery.zen.minimum_master_nodes: 1
+#cluster.initial_master_nodes: ["node-1", "node-2"]
 #
-# For more information, consult the zen discovery module documentation.
+# For more information, consult the discovery and cluster formation module documentation.
 #
 # ---------------------------------- Gateway -----------------------------------
 #

--- a/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/jvm.options
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/jvm.options
@@ -1,0 +1,105 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+# For Hibernate Search, we don't need as much as the default 2g
+# Let's keep it low, so that we'll be able to run tests
+# on memory-constrained CI slaves
+-Xms256m
+-Xmx256m
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+#${heap.dump.path}
+
+# specify an alternative path for JVM fatal error logs
+#${error.file}
+
+## JDK 8 GC logging
+
+#8:-XX:+PrintGCDetails
+#8:-XX:+PrintGCDateStamps
+#8:-XX:+PrintTenuringDistribution
+#8:-XX:+PrintGCApplicationStoppedTime
+#8:-Xloggc:${loggc}
+#8:-XX:+UseGCLogFileRotation
+#8:-XX:NumberOfGCLogFiles=32
+#8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+#9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+#9-:-Djava.locale.providers=COMPAT

--- a/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/jvm.options
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/jvm.options
@@ -40,6 +40,23 @@
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
 
+## G1GC Configuration
+# NOTE: G1GC is only supported on JDK version 10 or later.
+# To use G1GC uncomment the lines below.
+# 10-:-XX:-UseConcMarkSweepGC
+# 10-:-XX:-UseCMSInitiatingOccupancyOnly
+# 10-:-XX:+UseG1GC
+# 10-:-XX:InitiatingHeapOccupancyPercent=75
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
 ## optimizations
 
 # pre-touch memory pages used by the JVM during initialization
@@ -82,24 +99,27 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
-#${heap.dump.path}
+-XX:HeapDumpPath=data
 
 # specify an alternative path for JVM fatal error logs
-#${error.file}
+-XX:ErrorFile=logs/hs_err_pid%p.log
 
 ## JDK 8 GC logging
 
-#8:-XX:+PrintGCDetails
-#8:-XX:+PrintGCDateStamps
-#8:-XX:+PrintTenuringDistribution
-#8:-XX:+PrintGCApplicationStoppedTime
-#8:-Xloggc:${loggc}
-#8:-XX:+UseGCLogFileRotation
-#8:-XX:NumberOfGCLogFiles=32
-#8:-XX:GCLogFileSize=64m
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-#9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
-#9-:-Djava.locale.providers=COMPAT
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/log4j2.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/configuration/log4j2.properties
@@ -1,0 +1,36 @@
+status = error
+appenders = console
+loggers = action, metadata, cluster, settings, deprecation, slow_search, slow_indexing
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = info
+
+# do not log metadata too much as we generate a log of noise
+logger.metadata.name = org.elasticsearch.cluster.metadata
+logger.metadata.level = warn
+
+logger.cluster.name = org.elasticsearch.cluster.routing.allocation
+logger.cluster.level = warn
+
+logger.settings.name = org.elasticsearch.common.settings
+logger.settings.level = warn
+
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = warn
+
+# Warn us about using inefficient Search operations
+logger.slow_search.name = index.search.slowlog
+logger.slow_search.level = trace
+
+# Warn us about using inefficient indexing actions
+logger.slow_indexing.name = index.indexing.slowlog
+logger.slow_indexing.level = trace
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/init/init.script
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/resources/elasticsearch-maven-plugin/init/init.script
@@ -1,0 +1,6 @@
+PUT:_template/lightweight_index:{ "template" : "*", "order": -9999, "settings" : { "number_of_shards" : 1, "number_of_replicas" : 0 } }
+PUT:_template/slowlogs_search_level:{ "template" : "*", "order": -9999, "settings" : { "index.search.slowlog.level": "debug" } }
+PUT:_template/slowlogs_indexing_level:{ "template" : "*", "order": -9999, "settings" : { "index.indexing.slowlog.level": "debug" } }
+PUT:_template/slowlogs_search_threshold_query:{ "template" : "*", "order": -9999, "settings" : { "index.search.slowlog.threshold.query.warn": "5s", "index.search.slowlog.threshold.query.info": "500ms", "index.search.slowlog.threshold.query.debug": "100ms", "index.search.slowlog.threshold.query.trace": "10ms" } }
+PUT:_template/slowlogs_search_threshold_fetch:{ "template" : "*", "order": -9999, "settings" : { "index.search.slowlog.threshold.fetch.warn": "1s", "index.search.slowlog.threshold.fetch.info": "200ms", "index.search.slowlog.threshold.fetch.debug": "100ms", "index.search.slowlog.threshold.fetch.trace": "10ms" } }
+PUT:_template/slowlogs_indexing_threshold_index:{ "template" : "*", "order": -9999, "settings" : { "index.indexing.slowlog.threshold.index.warn": "2s", "index.indexing.slowlog.threshold.index.info": "500ms", "index.indexing.slowlog.threshold.index.debug": "100ms", "index.indexing.slowlog.threshold.index.trace": "10ms" } }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -48,6 +48,7 @@
         <module>jpa-h2</module>
         <module>jpa-mssql</module>
         <module>hibernate-orm-panache</module>
+        <module>hibernate-search-elasticsearch</module>
         <module>vertx</module>
         <module>spring-di</module>
         <module>infinispan-cache-jpa</module>


### PR DESCRIPTION
So here it is, finally, after months of rebasing and renaming :).

It is based on Hibernate Search 6 Alpha, where @yrodiere did the work of reorganizing the bootstrap specifically for our requirements (thanks @yrodiere!). We also tried to stabilize the query DSL as much as possible.

It only supports the Elasticsearch backend, the Lucene backend is not supported (for 2 reasons: it's still pretty much in flux in Search 6 and dealing with the crazy low level things of Lucene + GraalVM was not the top priority).

We will upgrade to Search 6 Alpha5 soon where we did a few configuration changes but let's get this one in first.

I'll get a quickstart + documentation ready.