### PR TITLE
Fix Gradle builds with property files

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
@@ -22,9 +22,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.CopyOption;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -197,6 +202,17 @@ public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutc
         //lets default to appClassesDir for now
         if (configDir == null)
             configDir = appClassesDir;
+        else {
+            //if we use gradle we copy the configDir contents to appClassesDir
+            try {
+                if (!Files.isSameFile(configDir, appClassesDir)) {
+                    Files.walkFileTree(configDir,
+                            new CopyDirVisitor(configDir, appClassesDir, StandardCopyOption.REPLACE_EXISTING));
+                }
+            } catch (IOException e) {
+                throw new AppCreatorException("Failed while copying files from " + configDir + " to " + appClassesDir, e);
+            }
+        }
 
         transformedClassesDir = IoUtils
                 .mkdirs(transformedClassesDir == null ? outputDir.resolve("transformed-classes") : transformedClassesDir);
@@ -231,6 +247,7 @@ public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutc
         } catch (BootstrapDependencyProcessingException e) {
             throw new AppCreatorException("Failed to resolve application build classpath", e);
         }
+
         URLClassLoader runnerClassLoader = null;
         try {
             // we need to make sure all the deployment artifacts are on the class path
@@ -397,5 +414,32 @@ public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutc
                 .map("transformed-classes", (AugmentPhase t, String value) -> t.setTransformedClassesDir(Paths.get(value)))
                 .map("wiring-classes", (AugmentPhase t, String value) -> t.setWiringClassesDir(Paths.get(value)))
                 .map("config", (AugmentPhase t, String value) -> t.setConfigDir(Paths.get(value)));
+    }
+
+    public static class CopyDirVisitor extends SimpleFileVisitor<Path> {
+        private final Path fromPath;
+        private final Path toPath;
+        private final CopyOption copyOption;
+
+        public CopyDirVisitor(Path fromPath, Path toPath, CopyOption copyOption) {
+            this.fromPath = fromPath;
+            this.toPath = toPath;
+            this.copyOption = copyOption;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            Path targetPath = toPath.resolve(fromPath.relativize(dir));
+            if (!Files.exists(targetPath)) {
+                Files.createDirectory(targetPath);
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Files.copy(file, toPath.resolve(fromPath.relativize(file)), copyOption);
+            return FileVisitResult.CONTINUE;
+        }
     }
 }


### PR DESCRIPTION
Copies content of configDir into appClassesDir to make sure the property files are included when using Gradle.