### PR TITLE
Add javax.xml.bind.helpers.Messages resource

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -138,6 +138,7 @@ class JaxbProcessor {
                 .produce(new RuntimeInitializedClassBuildItem("com.sun.xml.internal.bind.v2.runtime.reflect.opt.Injector"));
 
         addResourceBundle("javax.xml.bind.Messages");
+        addResourceBundle("javax.xml.bind.helpers.Messages");
         addResourceBundle("com.sun.org.apache.xml.internal.serializer.utils.SerializerMessages");
         addResourceBundle("com.sun.org.apache.xml.internal.res.XMLErrorResources");
         substrateProps


### PR DESCRIPTION
It's useful when you have errors as the error message are coming from the resource bundle.
fix #2250