### PR TITLE
Swagger UI Docs

### DIFF
--- a/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
@@ -275,9 +275,12 @@ When building APIs, developers want to test them quickly. https://swagger.io/too
 permitting to visualize and interact with your APIs.
 The UI is automatically generated from your OpenAPI specification.
 
-The Quarkus `smallrye-openapi` extension comes with a `swagger-ui` extension embedding a properly configured Swagger UI page.
+To enable the Swagger UI just need to add the `quarkus-swagger-ui` extension to your Quarkus application:
+----
+./mvnw quarkus:add-extension -Dextensions="quarkus-swagger-ui"
+----
 
-NOTE: Swagger UI is only available when Quarkus is started in dev or test mode.
+NOTE: Swagger UI is only available when Quarkus is started in dev or test mode. The Swagger UI extension was introduced in quarkus v 0.14.0 and is not present in older versions.
 
 By default, Swagger UI is accessible at `/swagger-ui`.
 


### PR DESCRIPTION
I had some trouble enabling the swagger ui and had to dive into the PR to figure out that there is a seperate extension that needed to be installed https://github.com/quarkusio/quarkus/pull/1573#issuecomment-478029052. I added some clarification to the docs detaling that:

1) there is a separate extension for swagger-ui 

and 

2) it is only available as of quarkus 0.14.0

Thanks for the good work folks, really enjoying building on quarkus.