### PR TITLE
Make the default datasource application scoped

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -195,7 +194,7 @@ class AgroalProcessor {
         if (agroalBuildTimeConfig.defaultDataSource.driver.isPresent()) {
             MethodCreator defaultDataSourceMethodCreator = classCreator.getMethodCreator("createDefaultDataSource",
                     AgroalDataSource.class);
-            defaultDataSourceMethodCreator.addAnnotation(Singleton.class);
+            defaultDataSourceMethodCreator.addAnnotation(ApplicationScoped.class);
             defaultDataSourceMethodCreator.addAnnotation(Produces.class);
             defaultDataSourceMethodCreator.addAnnotation(Default.class);
 


### PR DESCRIPTION
It was already the case for the additional named datasources.

Per discussion with Martin.

Fixes #2270