### PR TITLE
Remove warning on no endpoint specified, as UDPSender is now working

### DIFF
--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentTemplate.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentTemplate.java
@@ -16,7 +16,6 @@
 
 package io.quarkus.jaeger.runtime;
 
-import static io.jaegertracing.Configuration.JAEGER_ENDPOINT;
 import static io.jaegertracing.Configuration.JAEGER_SERVICE_NAME;
 
 import java.util.Optional;
@@ -50,15 +49,9 @@ public class JaegerDeploymentTemplate {
     private boolean isValidConfig(JaegerConfig jaeger) {
         Config mpconfig = ConfigProvider.getConfig();
         Optional<String> serviceName = mpconfig.getOptionalValue(JAEGER_SERVICE_NAME, String.class);
-        Optional<String> endpoint = mpconfig.getOptionalValue(JAEGER_ENDPOINT, String.class);
         if (!jaeger.serviceName.isPresent() && !serviceName.isPresent()) {
             log.warn(
                     "Jaeger service name has not been defined, either as 'quarkus.jaeger.service-name' application property or JAEGER_SERVICE_NAME environment variable/system property");
-        } else if (!jaeger.endpoint.isPresent() && !endpoint.isPresent()) {
-            log.warn(
-                    "Jaeger collector endpoint has not been defined, either as 'quarkus.jaeger.endpoint' application property or JAEGER_SERVICE_NAME environment variable/system property");
-            // Return true for now, so we can reproduce issue with UdpSender
-            return true;
         } else {
             return true;
         }


### PR DESCRIPTION
On retesting the UDPSender issue, with the latest version of graalvm (1.0.0-rc16), it appears the core dump no longer occurs.

To avoid the core dump using the default UDPSender, a warning message was output to direct the user to specific a HTTP endpoint, and therefore use the HTTPSender. This PR removes that warning message.

Resolves #484