### PR TITLE
Fix typo in extension guide

### DIFF
--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -468,7 +468,7 @@ public class LogConfiguration {
     /**
      * Configuration properties for the logging file handler.
      */
-    File file;
+    FileConfig file;
 }
 
 public class LoggingProcessor {


### PR DESCRIPTION
As reported here:
https://github.com/quarkusio/quarkusio.github.io/pull/182/files .