### PR TITLE
Improve add-extension with error in case of multiple matches

### DIFF
--- a/devtools/common/src/main/java/io/quarkus/cli/commands/AddExtensions.java
+++ b/devtools/common/src/main/java/io/quarkus/cli/commands/AddExtensions.java
@@ -7,8 +7,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
@@ -18,6 +18,9 @@ import io.quarkus.dependencies.Extension;
 import io.quarkus.maven.utilities.MojoUtils;
 
 public class AddExtensions {
+    private static String OK = "\u2705";
+    private static String NOK = "\u274c";
+    private static String NOOP = "\uD83D\uDC4D";
     private Model model;
     private String pom;
     private ProjectWriter writer;
@@ -37,35 +40,48 @@ public class AddExtensions {
         List<Dependency> dependenciesFromBom = getDependenciesFromBom();
 
         for (String dependency : extensions) {
-            Optional<Extension> optional = MojoUtils.loadExtensions().stream()
+            List<Extension> matches = MojoUtils.loadExtensions().stream()
                     .filter(d -> {
                         boolean hasTag = d.labels().contains(dependency.trim().toLowerCase());
                         boolean machName = d.getName()
                                 .toLowerCase()
                                 .contains(dependency.trim().toLowerCase());
-                        return hasTag || machName;
+                        boolean matchArtifactId = d.getArtifactId()
+                                .toLowerCase()
+                                .contains(dependency.trim().toLowerCase());
+                        return hasTag || machName || matchArtifactId;
                     })
-                    .findAny();
+                    .collect(Collectors.toList());
 
-            if (optional.isPresent()) {
-                final Extension extension = optional.get();
+            if (matches.size() > 1) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(NOK)
+                        .append(" Multiple extensions matching '" + dependency + "'");
+
+                matches.stream()
+                        .forEach(extension -> sb.append(System.lineSeparator()).append("     * ")
+                                .append(extension.managementKey()));
+                sb.append(System.lineSeparator()).append("     Be more specific e.g using the exact name or the full gav.");
+                System.out.println(sb);
+            } else if (matches.size() == 1) {
+                final Extension extension = matches.get(0);
 
                 if (!MojoUtils.hasDependency(model, extension.getGroupId(), extension.getArtifactId())) {
-                    System.out.println("Adding extension " + extension.managementKey());
+                    System.out.println(OK + " Adding extension " + extension.managementKey());
                     model.addDependency(extension
                             .toDependency(containsBOM(model) &&
                                     isDefinedInBom(dependenciesFromBom, extension)));
                     updated = true;
                 } else {
-                    System.out.println("Skipping extension " + extension.managementKey() + ": already present");
+                    System.out.println(NOOP + " Skipping extension " + extension.managementKey() + ": already present");
                 }
             } else if (dependency.contains(":")) {
                 Dependency parsed = MojoUtils.parse(dependency);
-                System.out.println("Adding dependency " + parsed.getManagementKey());
+                System.out.println(OK + " Adding dependency " + parsed.getManagementKey());
                 model.addDependency(parsed);
                 updated = true;
             } else {
-                System.out.println("Cannot find a dependency matching '" + dependency + "'");
+                System.out.println(NOK + " Cannot find a dependency matching '" + dependency + "', maybe a typo?");
             }
         }
 

--- a/devtools/common/src/test/java/io/quarkus/cli/commands/AddExtensionsTest.java
+++ b/devtools/common/src/test/java/io/quarkus/cli/commands/AddExtensionsTest.java
@@ -15,6 +15,7 @@ import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.maven.utilities.MojoUtils;
 
 public class AddExtensionsTest {
+
     @Test
     public void addExtension() throws IOException {
         final File pom = new File("target/extensions-test", "pom.xml");
@@ -28,16 +29,45 @@ public class AddExtensionsTest {
 
         File pomFile = new File(pom.getAbsolutePath());
         new AddExtensions(new FileProjectWriter(pomFile.getParentFile()), pomFile.getName())
-                .addExtensions(new HashSet<>(asList("agroal", "arc", " hibernate-validator")));
+                .addExtensions(new HashSet<>(asList("jdbc-postgre", "agroal", "arc", " hibernate-validator")));
 
         Model model = MojoUtils.readPom(pom);
         hasDependency(model, "quarkus-agroal");
         hasDependency(model, "quarkus-arc");
         hasDependency(model, "quarkus-hibernate-validator");
+        hasDependency(model, "quarkus-jdbc-postgresql");
+    }
+
+    @Test
+    public void addDuplicatedExtension() throws IOException {
+        final File pom = new File("target/extensions-test", "pom.xml");
+
+        CreateProjectTest.delete(pom.getParentFile());
+        new CreateProject(new FileProjectWriter(pom.getParentFile()))
+                .groupId("org.acme")
+                .artifactId("add-extension-test")
+                .version("0.0.1-SNAPSHOT")
+                .doCreateProject(new HashMap<>());
+
+        File pomFile = new File(pom.getAbsolutePath());
+        new AddExtensions(new FileProjectWriter(pomFile.getParentFile()), pomFile.getName())
+                .addExtensions(new HashSet<>(asList("agroal", "jdbc", "non-exist-ent")));
+
+        Model model = MojoUtils.readPom(pom);
+        hasDependency(model, "quarkus-agroal");
+        doesNotHaveDependency(model, "quarkus-jdbc-postgresql");
+        doesNotHaveDependency(model, "quarkus-jdbc-h2");
     }
 
     private void hasDependency(final Model model, final String artifactId) {
         Assertions.assertTrue(model.getDependencies()
+                .stream()
+                .anyMatch(d -> d.getGroupId().equals(MojoUtils.getPluginGroupId()) &&
+                        d.getArtifactId().equals(artifactId)));
+    }
+
+    private void doesNotHaveDependency(final Model model, final String artifactId) {
+        Assertions.assertFalse(model.getDependencies()
                 .stream()
                 .anyMatch(d -> d.getGroupId().equals(MojoUtils.getPluginGroupId()) &&
                         d.getArtifactId().equals(artifactId)));

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -85,6 +85,25 @@ You can enable an extension using:
 
 Extensions are passed using a comma-separated list.
 
+The extension name is the GAV name of the extension: e.g. `io.quarkus:quarkus-agroal`.
+But you can pass a partial name and Quarkus will do its best to find the right extension.
+For example, `agroal`, `Agroal` or `agro`  will expand to `io.quarkus:quarkus-agroal`.
+If no extension is found or if more than one extensions match, you will see a red check mark  ❌ in the command result.
+
+[source,shell]
+----
+$ mvn quarkus:add-extensions -Dextensions=jdbc,agroal,non-exist-ent
+[...]
+❌ Multiple extensions matching 'jdbc'
+     * io.quarkus:quarkus-jdbc-h2
+     * io.quarkus:quarkus-jdbc-mariadb
+     * io.quarkus:quarkus-jdbc-postgresql
+     Be more specific e.g using the exact name or the full gav.
+✅ Adding extension io.quarkus:quarkus-agroal
+❌ Cannot find a dependency matching 'non-exist-ent', maybe a typo?
+[...]
+----
+
 == Development mode
 
 {project-name} comes with a built-in development mode.


### PR DESCRIPTION
I've done two things:

- make sure that if two extensions match the substring in add-extensions, we show the list instead of taking the random first choice
- use a bit of emoji to better expose what extension has been added, was already there or could not be added
- search artifact-id on top of the existing label and name search

```
$ mvn quarkus:add-extensions -Dextensions=secu,postgres,flyway,panache

[INFO] Scanning for projects...
[INFO]
[INFO] --------------------< com.redhat.maven:maven-test >---------------------
[INFO] Building maven-test 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:add-extensions (default-cli) @ maven-test ---
✅ Adding extension io.quarkus:quarkus-elytron-security
✅ Adding extension io.quarkus:quarkus-flyway
✅ Adding extension io.quarkus:quarkus-hibernate-orm-panache
❌ Multiple extensions matching 'postgres'
     * io.quarkus:quarkus-jdbc-postgresql
     * io.quarkus:quarkus-reactive-pg-client
     Be more specific e.g using the exact name or the full gav.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.198 s
[INFO] Finished at: 2019-05-09T09:43:39-04:00
[INFO] ------------------------------------------------------------------------

$ mvn quarkus:add-extensions -Dextensions=secu,jdbc-postgres,flyway,panache
[INFO] Scanning for projects...
[INFO]
[INFO] --------------------< com.redhat.maven:maven-test >---------------------
[INFO] Building maven-test 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:add-extensions (default-cli) @ maven-test ---
👍 Skipping extension io.quarkus:quarkus-elytron-security: already present
👍 Skipping extension io.quarkus:quarkus-flyway: already present
👍 Skipping extension io.quarkus:quarkus-hibernate-orm-panache: already present
✅ Adding extension io.quarkus:quarkus-jdbc-postgresql
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.218 s
[INFO] Finished at: 2019-05-09T09:43:56-04:00
[INFO] ------------------------------------------------------------------------
```