### PR TITLE
Use Maven equivalent BOM import syntax that in Gradle guide

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -42,20 +42,21 @@ Here is a complete sample file for a simple REST project:
 ----
 plugins {
     id 'java'
-    id 'io.quarkus.' version '{quarkus-version}' <1>
+    id 'io.quarkus' version '{quarkus-version}' // <1>
 }
 
 repositories {
     mavenCentral()
 }
 
-dependencies { <2>
-    implementation 'io.quarkus:quarkus-resteasy:{quarkus-version}'
+dependencies { // <2>
+    implementation enforcedPlatform('io.quarkus:quarkus-bom:{quarkus-version}')
+    implementation 'io.quarkus:quarkus-resteasy'
 }
 ----
 
 <1> The {project-name} plugin needs to be applied.
-<2> This dependency is needed for a REST application similar to the getting started example.
+<2> We include the {project-name} BOM using Gradle's link:https://docs.gradle.org/5.4.1/userguide/managing_transitive_dependencies.html#sec:bom_import[relevant syntax] and add RESTEasy dependency since we are developing a REST application similar to the getting started example.
 {project-name} also need this dependency for running tests, to provide this we use the `implementation` configuration.
 
 Here's the same build script, using the Gradle Kotlin DSL:
@@ -72,7 +73,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.quarkus:quarkus-resteasy:{quarkus-version}")
+    implementation(enforcedPlatform("io.quarkus:quarkus-bom:{quarkus-version}"))
+    implementation("io.quarkus:quarkus-resteasy")
 }
 ----
 


### PR DESCRIPTION
Note the use of `enforcedPlatform` which forces Gradle to mimic Maven's
BOM import behavior. If regular `platform` were to be used instead, then
different rules would be followed to determine dependency versions