### PR TITLE
fix m2e war launcher lifcycle

### DIFF
--- a/war-launcher/launcher/pom.xml
+++ b/war-launcher/launcher/pom.xml
@@ -111,4 +111,44 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>only-eclipse</id>
+            <activation>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>1.0.0</version>
+                            <configuration>
+                                <lifecycleMappingMetadata>
+                                    <pluginExecutions>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-dependency-plugin</artifactId>
+                                                <versionRange>${maven-dependency-plugin.version}</versionRange>
+                                                <goals>
+                                                    <goal>copy-dependencies</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                    </pluginExecutions>
+                                </lifecycleMappingMetadata>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Maven intégration in eclipse produce an error:
“Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187.”
This error is due to copy dependcies goal which is not take account by m2e so I propose to ignore this goal until m2e provide the feature on their connector 