### PR TITLE
Add reportExceptionStackTraces to NativeImagePhase and tools.

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -118,6 +118,8 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
     private boolean addAllCharsets;
 
+    private boolean reportExceptionStackTraces;
+
     public NativeImagePhase setAddAllCharsets(boolean addAllCharsets) {
         this.addAllCharsets = addAllCharsets;
         return this;
@@ -272,6 +274,11 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
         return this;
     }
 
+    public NativeImagePhase setReportExceptionStackTraces(boolean reportExceptionStackTraces) {
+        this.reportExceptionStackTraces = reportExceptionStackTraces;
+        return this;
+    }
+
     @Override
     public void register(OutcomeProviderRegistration registration) throws AppCreatorException {
         registration.provides(NativeImageOutcome.class);
@@ -415,6 +422,9 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
             if (reportErrorsAtRuntime) {
                 command.add("-H:+ReportUnsupportedElementsAtRuntime");
+            }
+            if (reportExceptionStackTraces) {
+                command.add("-H:+ReportExceptionStackTraces");
             }
             if (debugSymbols) {
                 command.add("-g");
@@ -686,6 +696,9 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
                         break;
                     case "additional-build-args":
                         t.setAdditionalBuildArgs(Arrays.asList(value.split(",")));
+                        break;
+                    case "report-exception-stack-traces":
+                        t.setReportExceptionStackTraces(Boolean.parseBoolean(value));
                         break;
                     default:
                         return false;

--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -118,7 +118,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
     private boolean addAllCharsets;
 
-    private boolean reportExceptionStackTraces;
+    private boolean reportExceptionStackTraces = true;
 
     public NativeImagePhase setAddAllCharsets(boolean addAllCharsets) {
         this.addAllCharsets = addAllCharsets;

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -86,7 +86,7 @@ public class QuarkusNative extends QuarkusTask {
 
     private boolean addAllCharsets = false;
 
-    private boolean reportExceptionStackTraces = false;
+    private boolean reportExceptionStackTraces = true;
 
     public QuarkusNative() {
         super("Building a native image");

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -86,6 +86,8 @@ public class QuarkusNative extends QuarkusTask {
 
     private boolean addAllCharsets = false;
 
+    private boolean reportExceptionStackTraces = false;
+
     public QuarkusNative() {
         super("Building a native image");
     }
@@ -372,6 +374,17 @@ public class QuarkusNative extends QuarkusTask {
         this.additionalBuildArgs = additionalBuildArgs;
     }
 
+    @Optional
+    @Input
+    public boolean isReportExceptionStackTraces() {
+        return reportExceptionStackTraces;
+    }
+
+    @Option(description = "Show exception stack traces for exceptions during image building", option = "report-exception-stack-traces")
+    public void setReportExceptionStackTraces(boolean reportExceptionStackTraces) {
+        this.reportExceptionStackTraces = reportExceptionStackTraces;
+    }
+
     @TaskAction
     public void buildNative() {
         getLogger().lifecycle("building native image");
@@ -403,7 +416,8 @@ public class QuarkusNative extends QuarkusTask {
                         .setFullStackTraces(isFullStackTraces())
                         .setGraalvmHome(getGraalvmHome())
                         .setNativeImageXmx(getNativeImageXmx())
-                        .setReportErrorsAtRuntime(isReportErrorsAtRuntime()))
+                        .setReportErrorsAtRuntime(isReportErrorsAtRuntime())
+                        .setReportExceptionStackTraces(isReportExceptionStackTraces()))
 
                 .build()) {
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -135,6 +135,9 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean enableFallbackImages;
 
+    @Parameter(defaultValue = "false")
+    private boolean reportExceptionStackTraces;
+
     public NativeImageMojo() {
         MojoLogger.logSupplier = this::getLog;
     }
@@ -175,7 +178,8 @@ public class NativeImageMojo extends AbstractMojo {
                         .setFullStackTraces(fullStackTraces)
                         .setGraalvmHome(graalvmHome)
                         .setNativeImageXmx(nativeImageXmx)
-                        .setReportErrorsAtRuntime(reportErrorsAtRuntime))
+                        .setReportErrorsAtRuntime(reportErrorsAtRuntime)
+                        .setReportExceptionStackTraces(reportExceptionStackTraces))
 
                 .build()) {
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -135,7 +135,7 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean enableFallbackImages;
 
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "true")
     private boolean reportExceptionStackTraces;
 
     public NativeImageMojo() {


### PR DESCRIPTION
This enables the usage of
native-image -H:+ReportExceptionStackTraces

>  -H:±ReportExceptionStackTraces               Show exception stack traces for exceptions during image building.). Default: - (disabled).

This enables
`<reportExceptionStackTraces>true</reportExceptionStackTraces>` in the Maven Mojo
and the corresponding option of the Gradle plugin.