### PR TITLE
Add a note about configuring gradle build using locally built Quarkus version

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -32,6 +32,28 @@ plugins {
 }
 ----
 
+=== Gradle configuration for a local SNAPSHOT version of Quarkus
+
+This paragraph is relevant for those who want to use a locally built version of Quarkus, instead of an official release. It appears the configuration described above will not work in this case due to an issue in Gradle. There is a workaround though that looks a bit more verbose but nevertheless works for both locally built and offically released versions.
+
+[source,groovy,subs=attributes+]
+----
+buildscript {
+    repositories {
+        mavenLocal()
+    }
+    dependencies {
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkus-version}"
+    }
+}
+
+plugins {
+    id 'java'
+}
+
+apply plugin: 'io.quarkus'
+----
+
 [[project-creation]]
 == Creating a new project
 


### PR DESCRIPTION
Fix for #2432 