### PR TITLE
Add support to multiple sourceDirectories (Maven)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/devmode/HotReplacementContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/devmode/HotReplacementContext.java
@@ -7,7 +7,7 @@ public interface HotReplacementContext {
 
     Path getClassesDir();
 
-    Path getSourcesDir();
+    List<Path> getSourcesDir();
 
     List<Path> getResourcesDir();
 

--- a/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
@@ -40,7 +40,7 @@ import org.jboss.logging.Logger;
 
 /**
  * Class that handles compilation of source files
- *
+ * 
  * @author Stuart Douglas
  */
 public class ClassLoaderCompiler {
@@ -123,14 +123,17 @@ public class ClassLoaderCompiler {
             }
         }
         for (DevModeContext.ModuleInfo i : context.getModules()) {
-            if (i.getSourcePath() != null) {
+            if (!i.getSourcePaths().isEmpty()) {
                 if (i.getClassesPath() == null) {
                     log.warn("No classes directory found for module '" + i.getName()
                             + "'. It is advised that this module be compiled before launching dev mode");
                     continue;
                 }
-                this.compilationContexts.put(i.getSourcePath(),
-                        new CompilationProvider.Context(classPathElements, new File(i.getClassesPath())));
+                i.getSourcePaths().forEach(s -> {
+                    this.compilationContexts.put(s,
+                            new CompilationProvider.Context(
+                                    classPathElements, new File(i.getClassesPath())));
+                });
             }
         }
         this.allHandledExtensions = new HashSet<>();

--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
@@ -33,13 +33,13 @@ public class DevModeContext implements Serializable {
 
     public static class ModuleInfo implements Serializable {
         private final String name;
-        private final String sourcePath;
+        private final List<String> sourcePaths;
         private final String classesPath;
         private final String resourcePath;
 
-        public ModuleInfo(String name, String sourcePath, String classesPath, String resourcePath) {
+        public ModuleInfo(String name, List<String> sourcePaths, String classesPath, String resourcePath) {
             this.name = name;
-            this.sourcePath = sourcePath;
+            this.sourcePaths = sourcePaths;
             this.classesPath = classesPath;
             this.resourcePath = resourcePath;
         }
@@ -48,8 +48,8 @@ public class DevModeContext implements Serializable {
             return name;
         }
 
-        public String getSourcePath() {
-            return sourcePath;
+        public List<String> getSourcePaths() {
+            return sourcePaths;
         }
 
         public String getClassesPath() {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -32,6 +32,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -250,7 +251,7 @@ public class QuarkusDev extends QuarkusTask {
                 res = file.getAbsolutePath();
             }
             DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(getProject().getName(),
-                    getSourceDir().getAbsolutePath(),
+                    Collections.singletonList(getSourceDir().getAbsolutePath()),
                     extension.outputDirectory().getAbsolutePath(), res);
             context.getModules().add(moduleInfo);
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -31,12 +31,14 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -55,6 +57,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 
+import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
@@ -231,16 +234,23 @@ public class DevMojo extends AbstractMojo {
             }
 
             final AppModel appModel;
+            Map<String, MavenProject> projectMap = session.getProjectMap();
             try {
                 final LocalProject localProject = LocalProject.loadWorkspace(outputDirectory.toPath());
                 for (LocalProject project : localProject.getSelfWithLocalDeps()) {
+                    AppArtifact appArtifact = project.getAppArtifact();
+                    MavenProject mavenProject = projectMap.get(String.format("%s:%s:%s",
+                            appArtifact.getGroupId(), appArtifact.getArtifactId(), appArtifact.getVersion()));
                     String sourcePath = null;
                     String classesPath = null;
                     String resourcePath = null;
-                    Path javaSourcesDir = project.getSourcesSourcesDir();
-                    if (Files.isDirectory(javaSourcesDir)) {
-                        sourcePath = javaSourcesDir.toAbsolutePath().toString();
-                    }
+
+                    List<String> sourcePaths = mavenProject.getCompileSourceRoots().stream()
+                            .map(Paths::get)
+                            .filter(Files::isDirectory)
+                            .map(src -> src.toAbsolutePath().toString())
+                            .collect(Collectors.toList());
+
                     Path classesDir = project.getClassesDir();
                     if (Files.isDirectory(classesDir)) {
                         classesPath = classesDir.toAbsolutePath().toString();
@@ -249,7 +259,7 @@ public class DevMojo extends AbstractMojo {
                     if (Files.isDirectory(resourcesSourcesDir)) {
                         resourcePath = resourcesSourcesDir.toAbsolutePath().toString();
                     }
-                    DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(project.getArtifactId(), sourcePath,
+                    DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(project.getArtifactId(), sourcePaths,
                             classesPath, resourcePath);
                     devModeContext.getModules().add(moduleInfo);
                 }

--- a/extensions/undertow-websockets/deployment/src/main/java/io/quarkus/undertow/websockets/deployment/HotReplacementWebsocketEndpoint.java
+++ b/extensions/undertow-websockets/deployment/src/main/java/io/quarkus/undertow/websockets/deployment/HotReplacementWebsocketEndpoint.java
@@ -115,11 +115,13 @@ public class HotReplacementWebsocketEndpoint {
                         !m.resources.isEmpty()) {
                     if (hrc.getSourcesDir() != null) {
                         for (Map.Entry<String, byte[]> i : m.srcFiles.entrySet()) {
-                            Path path = hrc.getSourcesDir().resolve(i.getKey());
-                            Files.createDirectories(path.getParent());
-                            try (FileOutputStream out = new FileOutputStream(
-                                    path.toFile())) {
-                                out.write(i.getValue());
+                            for (Path sourcesDir : hrc.getSourcesDir()) {
+                                Path path = sourcesDir.resolve(i.getKey());
+                                Files.createDirectories(path.getParent());
+                                try (FileOutputStream out = new FileOutputStream(
+                                        path.toFile())) {
+                                    out.write(i.getValue());
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
My first take at #2370. In order to verify I have created this repository https://github.com/evacchi/quarkus-multiple-source-directories with a build helper plugin, adding `src/main/extras` as another source directory. The PR patches up Quarkus so that **all** the declared source directories are picked up from the Maven Mojo. Not yet working with Gradle, looking for directions to write proper tests 

```xml
      <plugin>
          <groupId>org.codehaus.mojo</groupId>
          <artifactId>build-helper-maven-plugin</artifactId>
          <executions>
              <execution>
                  <phase>generate-sources</phase>
                  <goals>
                      <goal>add-source</goal>
                  </goals>
                  <configuration>
                      <sources>
                          <source>src/main/extras</source>
                      </sources>
                  </configuration>
              </execution>
          </executions>
      </plugin>
```

caveat, because this is bound to `generate-sources` and `quarkus:dev` is not bound to any phase, you will always have to write `mvn compile quarkus:dev` or at least `mvn generate-sources quarkus:dev` for this to work properly, because the plugins that configure the extra source directories must be executed before `quarkus:dev`. This might be surprising for users, so we need to decide whether this is good enough or we should  take a better approach; e.g. adding explicit parameters to the DevMojo
