### PR TITLE
Extend CompilerContext to provide more details on the build

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
@@ -129,10 +129,14 @@ public class ClassLoaderCompiler {
                             + "'. It is advised that this module be compiled before launching dev mode");
                     continue;
                 }
-                i.getSourcePaths().forEach(s -> {
-                    this.compilationContexts.put(s,
+                i.getSourcePaths().forEach(sourcePath -> {
+                    this.compilationContexts.put(sourcePath,
                             new CompilationProvider.Context(
-                                    classPathElements, new File(i.getClassesPath())));
+                                    i.getName(),
+                                    classPathElements,
+                                    new File(i.getProjectDirectory()),
+                                    new File(sourcePath),
+                                    new File(i.getClassesPath())));
                 });
             }
         }

--- a/core/devmode/src/main/java/io/quarkus/dev/CompilationProvider.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/CompilationProvider.java
@@ -10,16 +10,41 @@ public interface CompilationProvider {
     void compile(Set<File> files, Context context);
 
     class Context {
+
+        private final String name;
         private final Set<File> classpath;
+        private final File projectDirectory;
+        private final File sourceDirectory;
         private final File outputDirectory;
 
-        public Context(Set<File> classpath, File outputDirectory) {
+        public Context(
+                String name,
+                Set<File> classpath,
+                File projectDirectory,
+                File sourceDirectory,
+                File outputDirectory) {
+
+            this.name = name;
             this.classpath = classpath;
+            this.projectDirectory = projectDirectory;
+            this.sourceDirectory = sourceDirectory;
             this.outputDirectory = outputDirectory;
+        }
+
+        public String getName() {
+            return name;
         }
 
         public Set<File> getClasspath() {
             return classpath;
+        }
+
+        public File getProjectDirectory() {
+            return projectDirectory;
+        }
+
+        public File getSourceDirectory() {
+            return sourceDirectory;
         }
 
         public File getOutputDirectory() {

--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
@@ -32,13 +32,21 @@ public class DevModeContext implements Serializable {
     }
 
     public static class ModuleInfo implements Serializable {
+
         private final String name;
+        private final String projectDirectory;
         private final List<String> sourcePaths;
         private final String classesPath;
         private final String resourcePath;
 
-        public ModuleInfo(String name, List<String> sourcePaths, String classesPath, String resourcePath) {
+        public ModuleInfo(
+                String name,
+                String projectDirectory,
+                List<String> sourcePaths,
+                String classesPath,
+                String resourcePath) {
             this.name = name;
+            this.projectDirectory = projectDirectory;
             this.sourcePaths = sourcePaths;
             this.classesPath = classesPath;
             this.resourcePath = resourcePath;
@@ -46,6 +54,10 @@ public class DevModeContext implements Serializable {
 
         public String getName() {
             return name;
+        }
+
+        public String getProjectDirectory() {
+            return projectDirectory;
         }
 
         public List<String> getSourcePaths() {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -44,6 +44,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.tasks.Input;
@@ -154,7 +155,8 @@ public class QuarkusDev extends QuarkusTask {
     @TaskAction
     public void startDev() {
 
-        QuarkusPluginExtension extension = (QuarkusPluginExtension) getProject().getExtensions().findByName("quarkus");
+        Project project = getProject();
+        QuarkusPluginExtension extension = (QuarkusPluginExtension) project.getExtensions().findByName("quarkus");
 
         if (!getSourceDir().isDirectory()) {
             throw new GradleException("The `src/main/java` directory is required, please create it.");
@@ -250,9 +252,12 @@ public class QuarkusDev extends QuarkusTask {
                 resources.append(file.getAbsolutePath());
                 res = file.getAbsolutePath();
             }
-            DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(getProject().getName(),
+            DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(
+                    project.getName(),
+                    project.getProjectDir().getAbsolutePath(),
                     Collections.singletonList(getSourceDir().getAbsolutePath()),
-                    extension.outputDirectory().getAbsolutePath(), res);
+                    extension.outputDirectory().getAbsolutePath(),
+                    res);
             context.getModules().add(moduleInfo);
 
             try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(tempFile))) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -259,8 +259,12 @@ public class DevMojo extends AbstractMojo {
                     if (Files.isDirectory(resourcesSourcesDir)) {
                         resourcePath = resourcesSourcesDir.toAbsolutePath().toString();
                     }
-                    DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(project.getArtifactId(), sourcePaths,
-                            classesPath, resourcePath);
+                    DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(
+                            project.getArtifactId(),
+                            mavenProject.getBasedir().getPath(),
+                            sourcePaths,
+                            classesPath,
+                            resourcePath);
                     devModeContext.getModules().add(moduleInfo);
                 }
 


### PR DESCRIPTION
Attempt at #2373. Added:
- ~~groupId~~
- ~~artifactId (renamed `name`)~~
- ~~version~~
- projectDirectory
- sourceDirectory

I also tried to make it work with Gradle and it seems to work with https://github.com/quarkusio/quarkus-quickstarts/tree/master/getting-started ~~although groupId and version are empty or `unspecified`, but I guess that's just how Gradle works. If this is too Maven-specific, I can remove the GAV part, and~~ just add `projectDirectory` and `sourceDirectory` (those would be still helpful)

