### PR TITLE
*Rotating*LoggingTest disabled on Windows, file locking issue

### DIFF
--- a/core/test-extension/deployment/src/test/java/logging/PeriodicSizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/logging/PeriodicSizeRotatingLoggingTest.java
@@ -1,6 +1,7 @@
 package logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.util.Arrays;
 import java.util.logging.Formatter;
@@ -15,11 +16,13 @@ import org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(WINDOWS)
 public class PeriodicSizeRotatingLoggingTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/core/test-extension/deployment/src/test/java/logging/SizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/logging/SizeRotatingLoggingTest.java
@@ -1,6 +1,7 @@
 package logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.util.Arrays;
 import java.util.logging.Formatter;
@@ -15,11 +16,13 @@ import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
+@DisabledOnOs(WINDOWS)
 public class SizeRotatingLoggingTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()


### PR DESCRIPTION
`*Rotating*LoggingTest` disabled on Windows, file locking issue
The issue is tracked in https://github.com/quarkusio/quarkus/issues/2464

There are 3 tests for rotating logs, keeping `PeriodicRotatingLoggingTest` enabled.
The first test for rotating logs works, second and third got stuck due to locked file.