### PR TITLE
fix: #2203 Update proxy settings of each remote repositories if applicable

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
@@ -179,15 +179,8 @@ public class MavenRepoInitializer {
 
         final org.apache.maven.settings.Proxy proxy = settings.getActiveProxy();
         if (proxy != null) {
-            Authentication auth = null;
-            if(proxy.getUsername() != null) {
-                auth = new AuthenticationBuilder()
-                        .addUsername(proxy.getUsername())
-                        .addPassword(proxy.getPassword())
-                        .build();
-            }
             session.setProxySelector(new DefaultProxySelector()
-                    .add(new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), auth), proxy.getNonProxyHosts()));
+                    .add(toAetherProxy(proxy), proxy.getNonProxyHosts()));
         }
 
         final List<Mirror> mirrors = settings.getMirrors();
@@ -231,6 +224,8 @@ public class MavenRepoInitializer {
 
     public static List<RemoteRepository> getRemoteRepos(Settings settings) throws AppModelResolverException {
         final List<RemoteRepository> remotes = new ArrayList<>();
+
+        final Proxy proxy = toAetherProxy(settings.getActiveProxy());
 
         final int profilesTotal = settings.getProfiles().size();
         if(profilesTotal > 0) {
@@ -281,7 +276,7 @@ public class MavenRepoInitializer {
                 }
             });
             for(org.apache.maven.model.Profile modelProfile : modelProfiles) {
-                addProfileRepos(modelProfile, remotes);
+                addProfileRepos(modelProfile, remotes, proxy);
             }
         }
 
@@ -291,7 +286,7 @@ public class MavenRepoInitializer {
             for (String profileName : activeProfiles) {
                 final Profile profile = getProfile(profileName, settings);
                 if(profile != null) {
-                    addProfileRepos(profile, remotes);
+                    addProfileRepos(profile, remotes, proxy);
                 }
             }
         }
@@ -300,10 +295,30 @@ public class MavenRepoInitializer {
             remotes.add(new RemoteRepository.Builder(DEFAULT_REMOTE_REPO_ID, "default", DEFAULT_REMOTE_REPO_URL)
                     .setReleasePolicy(new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
                     .setSnapshotPolicy(new RepositoryPolicy(false, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                    .setProxy(proxy)
                     .build());
         }
 
         return remotes;
+    }
+
+    /**
+     * Convert a {@link org.apache.maven.settings.Proxy} to a {@link Proxy}.
+     * @param proxy Maven proxy settings, may be {@code null}.
+     * @return Aether repository proxy or {@code null} if given {@link org.apache.maven.settings.Proxy} is {@code null}.
+     */
+    private static Proxy toAetherProxy(org.apache.maven.settings.Proxy proxy) {
+        if (proxy == null) {
+            return null;
+        }
+        Authentication auth = null;
+        if (proxy.getUsername() != null) {
+            auth = new AuthenticationBuilder()
+                    .addUsername(proxy.getUsername())
+                    .addPassword(proxy.getPassword())
+                    .build();
+        }
+        return new Proxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), auth);
     }
 
     private static Profile getProfile(String name, Settings settings) throws AppModelResolverException {
@@ -324,7 +339,7 @@ public class MavenRepoInitializer {
         log.warn(buf.toString());
     }
 
-    private static void addProfileRepos(final org.apache.maven.model.Profile profile, final List<RemoteRepository> all) {
+    private static void addProfileRepos(final org.apache.maven.model.Profile profile, final List<RemoteRepository> all, final Proxy proxy) {
         final List<org.apache.maven.model.Repository> repositories = profile.getRepositories();
         for (org.apache.maven.model.Repository repo : repositories) {
             final RemoteRepository.Builder repoBuilder = new RemoteRepository.Builder(repo.getId(), repo.getLayout(), repo.getUrl());
@@ -336,11 +351,12 @@ public class MavenRepoInitializer {
             if (policy != null) {
                 repoBuilder.setSnapshotPolicy(toAetherRepoPolicy(policy));
             }
+            repoBuilder.setProxy(proxy);
             all.add(repoBuilder.build());
         }
     }
 
-    private static void addProfileRepos(final Profile profile, final List<RemoteRepository> all) {
+    private static void addProfileRepos(final Profile profile, final List<RemoteRepository> all, final Proxy proxy) {
         final List<Repository> repositories = profile.getRepositories();
         for (Repository repo : repositories) {
             final RemoteRepository.Builder repoBuilder = new RemoteRepository.Builder(repo.getId(), repo.getLayout(), repo.getUrl());
@@ -352,6 +368,7 @@ public class MavenRepoInitializer {
             if (policy != null) {
                 repoBuilder.setSnapshotPolicy(toAetherRepoPolicy(policy));
             }
+            repoBuilder.setProxy(proxy);
             all.add(repoBuilder.build());
         }
     }


### PR DESCRIPTION
See: #2203

Aether artifact resolver (used by Quarkus to download "custom dependencies") use proxy configuration defined on each remote repository.
See: https://github.com/apache/maven-resolver/blob/maven-resolver-1.1.1/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java#L132

We need to configure proxy for each remote repositories (from repoSession)