### PR TITLE
Customize log name for QuarkusUnitTest

### DIFF
--- a/core/test-extension/deployment/src/main/resources/application-periodic-file-log-rotating.properties
+++ b/core/test-extension/deployment/src/main/resources/application-periodic-file-log-rotating.properties
@@ -2,5 +2,5 @@ quarkus.log.level=ALL
 quarkus.log.file.enable=true
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
-quarkus.log.file.rotation.file-suffix=yyyy-MM-dd
+quarkus.log.file.rotation.file-suffix=.yyyy-MM-dd
 quarkus.root.dsa-key-location=/DSAPublicKey.encoded

--- a/core/test-extension/deployment/src/main/resources/application-periodic-size-file-log-rotating.properties
+++ b/core/test-extension/deployment/src/main/resources/application-periodic-size-file-log-rotating.properties
@@ -3,6 +3,6 @@ quarkus.log.file.enable=true
 quarkus.log.file.level=INFO
 quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
 quarkus.log.file.rotation.max-file-size=100
-quarkus.log.file.rotation.file-suffix=yyyy-MM-dd
+quarkus.log.file.rotation.file-suffix=.yyyy-MM-dd
 quarkus.log.file.rotation.rotate-on-boot=false
 quarkus.root.dsa-key-location=/DSAPublicKey.encoded

--- a/core/test-extension/deployment/src/test/java/logging/PeriodicRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/logging/PeriodicRotatingLoggingTest.java
@@ -24,7 +24,8 @@ public class PeriodicRotatingLoggingTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-periodic-file-log-rotating.properties", "application.properties"));
+                    .addAsResource("application-periodic-file-log-rotating.properties", "application.properties"))
+            .setLogFileName("PeriodicRotatingLoggingTest.log");
 
     @Test
     public void periodicRotatingConfigurationTest() {

--- a/core/test-extension/deployment/src/test/java/logging/PeriodicSizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/logging/PeriodicSizeRotatingLoggingTest.java
@@ -1,7 +1,6 @@
 package logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.util.Arrays;
 import java.util.logging.Formatter;
@@ -16,18 +15,17 @@ import org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
-@DisabledOnOs(WINDOWS)
 public class PeriodicSizeRotatingLoggingTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-periodic-size-file-log-rotating.properties", "application.properties"));
+                    .addAsResource("application-periodic-size-file-log-rotating.properties", "application.properties"))
+            .setLogFileName("PeriodicSizeRotatingLoggingTest.log");
 
     @Test
     public void periodicSizeRotatingConfigurationTest() {

--- a/core/test-extension/deployment/src/test/java/logging/SizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/logging/SizeRotatingLoggingTest.java
@@ -1,7 +1,6 @@
 package logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.util.Arrays;
 import java.util.logging.Formatter;
@@ -16,18 +15,17 @@ import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
-@DisabledOnOs(WINDOWS)
 public class SizeRotatingLoggingTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-size-file-log-rotating.properties", "application.properties"));
+                    .addAsResource("application-size-file-log-rotating.properties", "application.properties"))
+            .setLogFileName("SizeRotatingLoggingTest.log");
 
     @Test
     public void sizeRotatingConfigurationTest() {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
@@ -25,10 +25,18 @@ public class PropertyTestUtil {
         System.setProperty("quarkus.log.file.path", getLogFileLocation());
     }
 
+    public static void setLogFileProperty(String logFileName) {
+        System.setProperty("quarkus.log.file.path", getLogFileLocation(logFileName));
+    }
+
     public static String getLogFileLocation() {
+        return getLogFileLocation("quarkus.log");
+    }
+
+    private static String getLogFileLocation(String logFileName) {
         if (Files.isDirectory(Paths.get("build"))) {
-            return "build" + File.separator + "quarkus.log";
+            return "build" + File.separator + logFileName;
         }
-        return "target" + File.separator + "quarkus.log";
+        return "target" + File.separator + logFileName;
     }
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -81,6 +81,7 @@ public class QuarkusUnitTest
     private Consumer<Throwable> assertException;
     private Supplier<JavaArchive> archiveProducer;
     private Runnable afterUndeployListener;
+    private String logFileName;
 
     private final RestAssuredURLManager restAssuredURLManager;
 
@@ -114,6 +115,11 @@ public class QuarkusUnitTest
 
     public QuarkusUnitTest setArchiveProducer(Supplier<JavaArchive> archiveProducer) {
         this.archiveProducer = archiveProducer;
+        return this;
+    }
+
+    public QuarkusUnitTest setLogFileName(String logFileName) {
+        this.logFileName = logFileName;
         return this;
     }
 
@@ -178,7 +184,11 @@ public class QuarkusUnitTest
             throw new RuntimeException("QuarkusUnitTest does not have archive producer set");
         }
 
-        PropertyTestUtil.setLogFileProperty();
+        if (logFileName != null) {
+            PropertyTestUtil.setLogFileProperty(logFileName);
+        } else {
+            PropertyTestUtil.setLogFileProperty();
+        }
         ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
         if (store.get(TestResourceManager.class.getName()) == null) {
             TestResourceManager manager = new TestResourceManager(extensionContext.getRequiredTestClass());


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/2464

Possibility to customize log name for QuarkusUnitTest, doing so for `*Rotating*LoggingTest`

