### PR TITLE
Remove {project-name} from page title

### DIFF
--- a/docs/src/main/asciidoc/ap4k.adoc
+++ b/docs/src/main/asciidoc/ap4k.adoc
@@ -1,4 +1,4 @@
-= {project-name} - Generating Kubernetes resources
+= Generating Kubernetes resources
 
 This guide covers generating Kubernetes resources based on sane defaults and user supplied configuration.
 


### PR DESCRIPTION
This is not being substituted properly for some reason on the live site. Drop it 
from the title, in common with the other guides.

This is a mirror of https://github.com/quarkusio/quarkusio.github.io/pull/202