### PR TITLE
Generate missing no-args constructor for normal scoped bean class

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/NoArgsConstructorProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/NoArgsConstructorProcessor.java
@@ -1,0 +1,154 @@
+package io.quarkus.arc.deployment;
+
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import javax.enterprise.context.NormalScope;
+import javax.inject.Inject;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.logging.Logger;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.arc.processor.BeanDeploymentValidator;
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.arc.processor.InjectionTargetInfo;
+import io.quarkus.arc.processor.InjectionTargetInfo.TargetKind;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+
+public class NoArgsConstructorProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(NoArgsConstructorProcessor.class);
+
+    // Copied from java.lang.Class
+    // https://github.com/wildfly/jandex/issues/60
+    private static final int ANNOTATION = 0x00002000;
+
+    @Inject
+    BeanArchiveIndexBuildItem beanArchiveIndex;
+
+    @Inject
+    CombinedIndexBuildItem combinedIndex;
+
+    @Inject
+    BuildProducer<BytecodeTransformerBuildItem> transformers;
+
+    @Inject
+    BuildProducer<BeanDeploymentValidatorBuildItem> validators;
+
+    @BuildStep
+    public void addMissingConstructors() throws Exception {
+        Set<ClassInfo> targetClasses = new HashSet<>();
+        Set<DotName> normalScopes = initNormalScopes();
+
+        for (DotName normalScope : normalScopes) {
+            collectTargetClasses(targetClasses, normalScope);
+        }
+        for (Iterator<ClassInfo> iterator = targetClasses.iterator(); iterator.hasNext();) {
+            ClassInfo targetClass = iterator.next();
+            if (targetClass.hasNoArgsConstructor()) {
+                // Skip all classes with no-args constructors
+                iterator.remove();
+            }
+        }
+
+        if (targetClasses.isEmpty()) {
+            return;
+        }
+
+        Set<DotName> transformedClasses = new HashSet<>();
+        for (ClassInfo targetClass : targetClasses) {
+            String superClassName;
+            if (targetClass.superName() == null) {
+                // Bean class extends java.lang.Object
+                superClassName = "java/lang/Object";
+            } else {
+                ClassInfo superClass = combinedIndex.getIndex().getClassByName(targetClass.superName());
+                if (superClass != null && superClass.hasNoArgsConstructor()) {
+                    // Bean class extends a class with no-args constructor
+                    superClassName = superClass.name().toString().replace('.', '/');
+                } else {
+                    superClassName = null;
+                }
+            }
+
+            if (superClassName != null) {
+                transformedClasses.add(targetClass.name());
+                LOGGER.debugf("Adding no-args constructor to %s", targetClass);
+                transformers.produce(new BytecodeTransformerBuildItem(targetClass.name().toString(),
+                        new BiFunction<String, ClassVisitor, ClassVisitor>() {
+                            @Override
+                            public ClassVisitor apply(String className, ClassVisitor classVisitor) {
+                                ClassVisitor cv = new ClassVisitor(Opcodes.ASM6, classVisitor) {
+
+                                    @Override
+                                    public void visit(int version, int access, String name, String signature, String superName,
+                                            String[] interfaces) {
+                                        super.visit(version, access, name, signature, superName, interfaces);
+                                        MethodVisitor mv = visitMethod(Modifier.PUBLIC, "<init>", "()V", null,
+                                                null);
+                                        mv.visitCode();
+                                        mv.visitVarInsn(Opcodes.ALOAD, 0);
+                                        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, superClassName, "<init>", "()V", false);
+                                        // NOTE: it seems that we do not need to handle final fields?
+                                        mv.visitInsn(Opcodes.RETURN);
+                                        mv.visitMaxs(1, 1);
+                                        mv.visitEnd();
+                                    }
+                                };
+                                return cv;
+                            }
+                        }));
+            }
+        }
+
+        if (!transformedClasses.isEmpty()) {
+            // Skip validation for the transformed classes
+            validators.produce(new BeanDeploymentValidatorBuildItem(new BeanDeploymentValidator() {
+
+                @Override
+                public boolean skipValidation(InjectionTargetInfo target, ValidationRule rule) {
+                    return ValidationRule.NO_ARGS_CONSTRUCTOR.equals(rule) && target.kind() == TargetKind.BEAN
+                            && transformedClasses.contains(target.asBean().getBeanClass());
+                }
+            }));
+        }
+    }
+
+    private Set<DotName> initNormalScopes() {
+        Set<DotName> normalScopes = new HashSet<>();
+        normalScopes.add(BuiltinScope.APPLICATION.getName());
+        normalScopes.add(BuiltinScope.REQUEST.getName());
+        combinedIndex.getIndex().getAnnotations(DotName.createSimple(NormalScope.class.getName())).stream()
+                .filter(NoArgsConstructorProcessor::isTargetAnnotation)
+                .map(AnnotationInstance::name)
+                .forEach(normalScopes::add);
+        return normalScopes;
+    }
+
+    private void collectTargetClasses(Set<ClassInfo> targetClasses, DotName normalScope) {
+        for (AnnotationInstance annotationInstance : beanArchiveIndex.getIndex()
+                .getAnnotations(normalScope)) {
+            if (annotationInstance.target().kind() == Kind.CLASS) {
+                targetClasses.add(annotationInstance.target().asClass());
+            }
+        }
+    }
+
+    private static boolean isTargetAnnotation(AnnotationInstance annotationInstance) {
+        return annotationInstance.target().kind() == Kind.CLASS
+                && ((annotationInstance.target().asClass().flags() & ANNOTATION) != 0);
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/noargsconstructor/AddMissingNoargsConstructorTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/noargsconstructor/AddMissingNoargsConstructorTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.arc.test.noargsconstructor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AddMissingNoargsConstructorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AddMissingNoargsConstructorTest.class, MyBean.class));
+
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void testConstructorWasAdded() {
+        assertNotNull(bean.getBeanManager());
+        assertEquals("ok", bean.getFoo());
+        assertEquals(true, bean.isVal());
+    }
+
+    @ApplicationScoped
+    static class MyBean extends BaseBean {
+
+        String foo;
+
+        final boolean val;
+
+        // The absence of a no-args constructor should normally result in deployment exception
+
+        // No need for @Inject
+        MyBean(BeanManager beanManager) {
+            super.beanManager = beanManager;
+            this.val = true;
+        }
+
+        BeanManager getBeanManager() {
+            return beanManager;
+        }
+
+        String getFoo() {
+            return foo;
+        }
+
+        boolean isVal() {
+            return val;
+        }
+
+        @PostConstruct
+        void init() {
+            foo = "ok";
+        }
+
+    }
+
+    static class BaseBean {
+
+        BeanManager beanManager;
+
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/noargsconstructor/FailedToAddMissingNoargsConstructorTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/noargsconstructor/FailedToAddMissingNoargsConstructorTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.arc.test.noargsconstructor;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FailedToAddMissingNoargsConstructorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FailedToAddMissingNoargsConstructorTest.class, MyBean.class))
+            .setExpectedException(DeploymentException.class);
+
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void testConstructorWasNotAdded() {
+        Assertions.fail();
+    }
+
+    @ApplicationScoped
+    static class MyBean extends BaseBean {
+
+        String foo;
+
+        MyBean(BeanManager beanManager) {
+            super(beanManager);
+        }
+
+    }
+
+    static class BaseBean {
+
+        BeanManager beanManager;
+
+        public BaseBean(BeanManager beanManager) {
+            this.beanManager = beanManager;
+        }
+
+        BeanManager getBeanManager() {
+            return beanManager;
+        }
+
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -249,7 +249,7 @@ public class BeanDeployment {
         long start = System.currentTimeMillis();
         // Validate the bean deployment
         List<Throwable> errors = new ArrayList<>();
-        validateBeans(errors);
+        validateBeans(errors, validators);
         ValidationContextImpl validationContext = new ValidationContextImpl(buildContext);
         for (BeanDeploymentValidator validator : validators) {
             validator.validate(validationContext);
@@ -467,7 +467,7 @@ public class BeanDeployment {
         }
     }
 
-    private void validateBeans(List<Throwable> errors) {
+    private void validateBeans(List<Throwable> errors, List<BeanDeploymentValidator> validators) {
         Map<String, List<BeanInfo>> namedBeans = new HashMap<>();
 
         for (BeanInfo bean : beans) {
@@ -479,7 +479,7 @@ public class BeanDeployment {
                 }
                 named.add(bean);
             }
-            bean.validate(errors);
+            bean.validate(errors, validators);
         }
 
         if (!namedBeans.isEmpty()) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeploymentValidator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeploymentValidator.java
@@ -16,10 +16,11 @@
 
 package io.quarkus.arc.processor;
 
+import java.util.List;
 import javax.enterprise.inject.spi.DeploymentException;
 
 /**
- * Makes it possible to validate the bean deployment.
+ * Makes it possible to validate the bean deployment and also to skip some validation rules for specific components.
  *
  * @author Martin Kouba
  */
@@ -34,11 +35,37 @@ public interface BeanDeploymentValidator extends BuildExtension {
      * @see Key#OBSERVERS
      * @see DeploymentException
      */
-    void validate(ValidationContext validationContext);
+    default void validate(ValidationContext validationContext) {
+    }
+
+    /**
+     * 
+     * @param target
+     * @param rule
+     * @return {@code true} if the given validation rule should be skipped for the specified target
+     */
+    default boolean skipValidation(InjectionTargetInfo target, ValidationRule rule) {
+        return false;
+    }
 
     interface ValidationContext extends BuildContext {
 
         void addDeploymentProblem(Throwable t);
+
+    }
+
+    public enum ValidationRule {
+
+        NO_ARGS_CONSTRUCTOR;
+
+        boolean skipFor(List<BeanDeploymentValidator> validators, InjectionTargetInfo target) {
+            for (BeanDeploymentValidator validator : validators) {
+                if (validator.skipValidation(target, this)) {
+                    return true;
+                }
+            }
+            return false;
+        }
 
     }
 


### PR DESCRIPTION
- but only if the bean class extends java.lang.Object or a class that
has no-args constructor
- also make it possible to skip some validation rules for specific
components
- resolves #2469