### PR TITLE
Update to Vert.x 3.7.0 and other reactive bits

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,9 +51,9 @@
         <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>2.0.4</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>1.1.4</smallrye-jwt.version>
-        <smallrye-reactive-streams-operators.version>1.0.3</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.0.3</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>0.0.8</smallrye-reactive-messaging.version>
+        <smallrye-reactive-streams-operators.version>1.0.4</smallrye-reactive-streams-operators.version>
+        <smallrye-converter-api.version>1.0.4</smallrye-converter-api.version>
+        <smallrye-reactive-messaging.version>0.0.9</smallrye-reactive-messaging.version>
         <smallrye-rest-client.version>1.2.2</smallrye-rest-client.version>
         <swagger-ui.version>3.20.9</swagger-ui.version>
         <javax.activation.version>1.1.1</javax.activation.version>
@@ -111,7 +111,7 @@
         <wildfly-elytron.version>2.0.0.Alpha4</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Beta4</jboss-threads.version>
-        <vertx.version>3.6.3</vertx.version>
+        <vertx.version>3.7.0</vertx.version>
         <httpclient.version>4.5.7</httpclient.version>
         <httpcore.version>4.4.11</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>
@@ -131,13 +131,13 @@
         <caffeine.version>2.6.2</caffeine.version>
         <netty.version>4.1.34.Final</netty.version>
         <reactive-streams.version>1.0.2</reactive-streams.version>
-        <test-containers.version>1.10.7</test-containers.version>
+        <test-containers.version>1.11.2</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <axle-client.version>0.0.4</axle-client.version>
-        <reactive-pg-client.version>0.11.2</reactive-pg-client.version>
-        <kafka-clients.version>1.1.0</kafka-clients.version>
-        <kafka2.version>1.1.0</kafka2.version>
-        <debezium.version>0.9.2.Final</debezium.version>
+        <axle-client.version>0.0.5</axle-client.version>
+        <reactive-pg-client.version>0.11.3</reactive-pg-client.version>
+        <kafka-clients.version>2.1.0</kafka-clients.version>
+        <kafka2.version>2.1.0</kafka2.version>
+        <debezium.version>0.9.5.Final</debezium.version>
         <zookeeper.version>3.4.10</zookeeper.version>
         <scala.version>2.12.2</scala.version>
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -46,7 +46,7 @@
         <graal-sdk.version-for-documentation>1.0.0-rc16</graal-sdk.version-for-documentation>
         <rest-assured.version>3.3.0</rest-assured.version>
         <axle-client.version>0.0.4</axle-client.version>
-        <vertx.version>3.6.3</vertx.version>
+        <vertx.version>3.7.0</vertx.version>
 
         <!-- Enable APT by default for Eclipse -->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>


### PR DESCRIPTION
Bump versions:

* Vert.x -> 3.7.0
* SmallRye Reactive Utils -> 0.0.5
* SmallRye Reactive Streams Operators -> 1.0.4
* SmallRye Reactive Messaging -> 0.0.9
* Test Container -> 1.11.2
* Kafka ->  2.1.0
* Debezium -> 0.9.5