### PR TITLE
feat: align console log to file log

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -39,7 +39,7 @@ public class ConsoleConfig {
     /**
      * The console log level
      */
-    @ConfigItem(defaultValue = "INFO")
+    @ConfigItem(defaultValue = "ALL")
     Level level;
 
     /**

--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -22,7 +22,7 @@ Console logging is enabled by default.  To configure or disable it, the followin
 |Property Name|Default|Description
 |quarkus.log.console.enable|true|Determine whether console logging is enabled.
 |quarkus.log.console.format|%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n|The format pattern to use for logging to the console; see <<format_string>>.
-|quarkus.log.console.level|INFO|The minimum log level to display to the console.
+|quarkus.log.console.level|ALL|The minimum log level to display to the console.
 |quarkus.log.console.color|true|Allow color rendering to be used on the console, if it is supported by the terminal.
 |===
 


### PR DESCRIPTION
This fixes #2488 .

I propose to align console and file log default configuration to log at ALL level.

IMHO, it's even mode important for console logs as it's used while developing, and the DEBUG level is more interesting at developement time than runtime.