### PR TITLE
Fix CNFE when using reactive messaging without an explicit dependency on Vert.x

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -22,6 +22,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -23,6 +23,10 @@
          <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
       </dependency>
       <dependency>
+         <groupId>io.quarkus</groupId>
+         <artifactId>quarkus-vertx</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.smallrye.reactive</groupId>
          <artifactId>smallrye-reactive-messaging-provider</artifactId>
          <exclusions>


### PR DESCRIPTION
Fix #2548

* Missing dependency in the reactive messaging extension
* Missing dependency in the kafka connector (require during the native build)