### PR TITLE
Fallback to LocalProject data if Maven does not provide metadata in quarkus:dev

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -250,7 +250,7 @@ public class DevMojo extends AbstractMojo {
                     String resourcePath = null;
 
                     if (mavenProject == null) {
-                        projectDirectory = localProject.getRawModel().getProjectDirectory().getPath();
+                        projectDirectory = localProject.getDir().toAbsolutePath().toString();
                         sourcePaths = Collections.singletonList(
                                 localProject.getSourcesSourcesDir().toAbsolutePath().toString());
                     } else {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -241,6 +241,10 @@ public class DevMojo extends AbstractMojo {
                     AppArtifact appArtifact = project.getAppArtifact();
                     MavenProject mavenProject = projectMap.get(String.format("%s:%s:%s",
                             appArtifact.getGroupId(), appArtifact.getArtifactId(), appArtifact.getVersion()));
+                    // no information about this project from Maven. Skip.
+                    if (mavenProject == null) {
+                        continue;
+                    }
                     String sourcePath = null;
                     String classesPath = null;
                     String resourcePath = null;


### PR DESCRIPTION
(closes #2549)

this PR **skips** the submodule if the `MavenProject` does not provide metadata about that submodule. This is a significant change from previous versions, where Quarkus tried to infer something from the POM, but it's also more consistent with the way the Maven build works