### PR TITLE
[fixes #2564] - CORS related properties should be optional otherwise they are set as an empty string

### DIFF
--- a/extensions/keycloak/deployment/src/main/java/io/quarkus/keycloak/KeycloakAdapterProcessor.java
+++ b/extensions/keycloak/deployment/src/main/java/io/quarkus/keycloak/KeycloakAdapterProcessor.java
@@ -74,9 +74,9 @@ public class KeycloakAdapterProcessor {
         config.setUseResourceRoleMappings(keycloakConfig.useResourceRoleMappings);
         config.setCors(keycloakConfig.cors);
         config.setCorsMaxAge(keycloakConfig.corsMaxAge);
-        config.setCorsAllowedHeaders(keycloakConfig.corsAllowedHeaders);
-        config.setCorsAllowedMethods(keycloakConfig.corsAllowedMethods);
-        config.setCorsExposedHeaders(keycloakConfig.corsExposedHeaders);
+        config.setCorsAllowedHeaders(keycloakConfig.corsAllowedHeaders.orElse(null));
+        config.setCorsAllowedMethods(keycloakConfig.corsAllowedMethods.orElse(null));
+        config.setCorsExposedHeaders(keycloakConfig.corsExposedHeaders.orElse(null));
         config.setBearerOnly(keycloakConfig.bearerOnly);
         config.setAutodetectBearerOnly(keycloakConfig.autodetectBearerOnly);
         config.setPublicClient(keycloakConfig.publicClient);

--- a/extensions/keycloak/deployment/src/main/java/io/quarkus/keycloak/KeycloakConfig.java
+++ b/extensions/keycloak/deployment/src/main/java/io/quarkus/keycloak/KeycloakConfig.java
@@ -93,21 +93,21 @@ public final class KeycloakConfig {
      * string
      */
     @ConfigItem(name = "cors-allowed-headers")
-    String corsAllowedHeaders;
+    Optional<String> corsAllowedHeaders;
 
     /**
      * If CORS is enabled, this sets the value of the Access-Control-Allow-Methods header. This should be a comma-separated
      * string
      */
     @ConfigItem(name = "cors-allowed-methods")
-    String corsAllowedMethods;
+    Optional<String> corsAllowedMethods;
 
     /**
      * If CORS is enabled, this sets the value of the Access-Control-Expose-Headers header. This should be a comma-separated
      * string
      */
     @ConfigItem(name = "cors-exposed-headers")
-    String corsExposedHeaders;
+    Optional<String> corsExposedHeaders;
 
     /**
      * This should be set to true for services. If enabled the adapter will not attempt to authenticate users,


### PR DESCRIPTION
Fixes #2564 