### PR TITLE
refactor: minor cleanups to remove unused imports

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -16,7 +16,6 @@
 
 package io.quarkus.deployment.recording;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterSupport.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConverterSupport.java
@@ -12,8 +12,6 @@ import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.Converter;
 import org.jboss.logging.Logger;
 
-import io.smallrye.config.SmallRyeConfigBuilder;
-
 /**
  * This small utility class is a tool which helps populating SmallRye {@link ConfigBuilder} with
  * {@link Converter} implementations loaded from {@link ServiceLoader}.

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -18,7 +18,6 @@ package io.quarkus.runtime.logging;
 
 import java.io.File;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.logging.Level;
 
 import io.quarkus.runtime.annotations.ConfigGroup;

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConverterTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConverterTestCase.java
@@ -11,10 +11,6 @@ import org.junit.Test;
 import org.wildfly.common.net.CidrAddress;
 import org.wildfly.common.net.Inet;
 
-import io.quarkus.runtime.configuration.CidrAddressConverter;
-import io.quarkus.runtime.configuration.InetAddressConverter;
-import io.quarkus.runtime.configuration.InetSocketAddressConverter;
-
 /**
  */
 public class ConverterTestCase {

--- a/devtools/aesh/src/main/java/io/quarkus/cli/commands/CreateProjectCommand.java
+++ b/devtools/aesh/src/main/java/io/quarkus/cli/commands/CreateProjectCommand.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
-import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Option;

--- a/devtools/aesh/src/main/java/io/quarkus/cli/commands/ListExtensionsCommand.java
+++ b/devtools/aesh/src/main/java/io/quarkus/cli/commands/ListExtensionsCommand.java
@@ -5,8 +5,6 @@ import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
 import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.command.option.Argument;
-import org.aesh.command.option.Arguments;
 import org.aesh.command.option.Option;
 
 import io.quarkus.dependencies.Extension;

--- a/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskContainer;

--- a/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
@@ -23,8 +23,6 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/devtools/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -10,7 +10,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/extensions/keycloak/runtime/src/main/java/io/quarkus/keycloak/QuarkusDeploymentContext.java
+++ b/extensions/keycloak/runtime/src/main/java/io/quarkus/keycloak/QuarkusDeploymentContext.java
@@ -17,7 +17,6 @@ package io.quarkus.keycloak;
 
 import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.KeycloakDeployment;
-import org.keycloak.representations.adapters.config.AdapterConfig;
 
 /**
  * An extension to Keycloak default {@code AdapterDeploymentContext} so that any additional requirement on how

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/NoConfigTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/NoConfigTest.java
@@ -5,7 +5,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class NoConfigTest {

--- a/independent-projects/bootstrap/maven-plugin/src/test/java/io/quarkus/maven/BuildTreeMojoTest.java
+++ b/independent-projects/bootstrap/maven-plugin/src/test/java/io/quarkus/maven/BuildTreeMojoTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.maven;
 
-import io.quarkus.maven.BuildTreeMojo;
-
 public class BuildTreeMojoTest extends TreeMojoTestBase {
 
     @Override

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.it.panache.Person;
 import io.quarkus.test.junit.DisabledOnSubstrate;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;


### PR DESCRIPTION
When going through the codebase I noticed some unused imports. 
This PR propose a minor cleanups to remove them. 