### PR TITLE
Mailer extension

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -159,6 +159,7 @@
         <!-- Used for integration tests, to make sure webjars work-->
         <bootstrap.version>3.1.0</bootstrap.version>
         <keycloak.version>6.0.1</keycloak.version>
+        <subethasmtp.version>3.1.7</subethasmtp.version>
     </properties>
 
     <dependencyManagement>
@@ -442,6 +443,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-reactive-pg-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-mailer</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -1094,6 +1100,11 @@
                 <version>${assertj.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.subethamail</groupId>
+                <artifactId>subethasmtp</artifactId>
+                <version>${subethasmtp.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>${json-smart.version}</version>
@@ -1585,6 +1596,11 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-axle-postgres-client</artifactId>
+                <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-axle-mail-client</artifactId>
                 <version>${axle-client.version}</version>
             </dependency>
             <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -849,6 +849,13 @@
                                             <exclude>jakarta.json.bind:jakarta.json.bind-api</exclude>
                                             <exclude>jakarta.json:jakarta.json-api</exclude>
                                         </excludes>
+                                        <includes>
+                                            <!--
+                                            Exception for the in-memory mail server (subethasmtp).
+                                            Only accepted in the test scope
+                                             -->
+                                            <include>javax.activation:activation:*:jar:test</include>
+                                        </includes>
                                     </bannedDependencies>
                                 </rules>
                             </configuration>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -849,13 +849,6 @@
                                             <exclude>jakarta.json.bind:jakarta.json.bind-api</exclude>
                                             <exclude>jakarta.json:jakarta.json-api</exclude>
                                         </excludes>
-                                        <includes>
-                                            <!--
-                                            Exception for the in-memory mail server (subethasmtp).
-                                            Only accepted in the test scope
-                                             -->
-                                            <include>javax.activation:activation:*:jar:test</include>
-                                        </includes>
                                     </bannedDependencies>
                                 </rules>
                             </configuration>

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -31,6 +31,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String JDBC_MSSQL = "jdbc-mssql";
     public static final String KEYCLOAK = "keycloak";
     public static final String KOTLIN = "kotlin";
+    public static final String MAILER = "mailer";
     public static final String NARAYANA_JTA = "narayana-jta";
     public static final String REACTIVE_PG_CLIENT = "reactive-pg-client";
     public static final String RESTEASY = "resteasy";

--- a/devtools/common/src/main/filtered/extensions.json
+++ b/devtools/common/src/main/filtered/extensions.json
@@ -450,6 +450,16 @@
     "guide": "https://quarkus.io/guides/using-vertx"
   },
   {
+    "name": "Mailer",
+    "labels": [
+      "mail",
+      "mailer"
+    ],
+    "groupId": "io.quarkus",
+    "artifactId": "quarkus-mailer",
+    "guide": "https://quarkus.io/guides/sending-emails"
+  },
+  {
     "name": "Reactive Postgres Client",
     "labels": [
       "eclipse-vert.x",

--- a/docs/src/main/asciidoc/sending-emails.adoc
+++ b/docs/src/main/asciidoc/sending-emails.adoc
@@ -23,7 +23,7 @@ To complete this guide, you need:
 == Architecture
 
 In this guide, we are going to see how you can send emails from a {project-name} application.
-It covers simple emails, attachments, inlined attachments, the reactive vs. imperative APIs...
+It covers simple emails, attachments, inlined attachments, the reactive and imperative APIs...
 
 == Creating the Maven Project
 
@@ -106,9 +106,19 @@ There are 2 APIs:
 * `io.quarkus.mailer.Mailer` provides the imperative (blocking and synchronous) API;
 * `io.quarkus.mailer.ReactiveMailer` provides the reactive (non-blocking and asynchronous) API
 
-NOTE: `Mailer` is implemented on top of `ReactiveMailer`
+NOTE: The two APIs are equivalent feature-wise. Actually the `Mailer` implementation is built on top of `ReactiveMailer` implementation.
 
 To send a simple email, proceed as follows:
+
+[source, java]
+----
+// Imperative API:
+mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body."));
+// Reactive API:
+CompletionStage<Void> stage = reactiveMailer.send(Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body."));
+----
+
+For example, you can use the `Mailer` in a JAX-RS endpoint as follows:
 
 [source, java]
 ----
@@ -126,6 +136,14 @@ public CompletionStage<Response> sendASimpleEmailAsync() {
             Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body"))
             .thenApply(x -> Response.accepted().build());
 }
+----
+
+With such a JAX-RS resource, you can check that everything is working with:
+
+[source, bash]
+----
+curl http://localhost:8080/simple
+curl http://localhost:8080/async
 ----
 
 You can create new `io.quarkus.mailer.Mail` instances from the constructor or from the `Mail.withText` and
@@ -157,12 +175,11 @@ public Response sendEmailWithAttachment() {
 ----
 
 Attachments can be created from raw bytes (as shown in the snippet) or files.
-When using a file, the content is read asynchronously.
 
 == Sending HTML emails with inlined attachments
 
 When sending HTML email, you can add inlined attachments.
-For example, you can send an image with your email, and this email will be displayed in the mail content.
+For example, you can send an image with your email, and this image will be displayed in the mail content.
 
 [source, java]
 ----
@@ -181,25 +198,30 @@ public Response sendingHTML() {
 ----
 
 Note the _content-id_ format and reference.
-When you create the inline attachment, the content-id must be structured as follows: `<id@domain>`.
-When referenced, for instance in the `src` attribute, use `cid:id@domain` (without the `<` and `>`).
+By spec, when you create the inline attachment, the content-id must be structured as follows: `<id@domain>`.
+If you don't wrap your content-id between `<>`, it is automatically wrapped for you.
+When you want to reference your attachment, for instance in the `src` attribute, use `cid:id@domain` (without the `<` and `>`).
 
 == Using the underlying Vert.x Mail Client
 
 The Quarkus Mailer is implemented on top of the https://vertx.io/docs/vertx-mail-client/java/[Vert.x Mail Client], providing an asynchronous and non-blocking way to send emails.
-You can inject the client directly:
+If you need fine control on how the mail is sent, for instance if you need to retrieve the message ids, you can inject the underlying client, and use it directly:
 
 [source, java]
 ----
 @Inject MailClient client;
 ----
 
-Are exposed:
+Three API flavors are exposed:
 
 * the Axle client (`io.vertx.axle.ext.mail.MailClient`), using `CompletionStage` and Reactive Streams `Publisher`
 * the RX Java 2 client (`io.vertx.reactivex.ext.mail.MailClient`)
 * the bare client (`io.vertx.ext.mail.MailClient`)
 
-The retrieved instance is configured using the configuration key presented above.
+Check the link:using-vertx.html[Using Vert.x guide] for further details about these different APIs and how to select the most suitable for you.
+
+The retrieved `MailClient` is configured using the configuration key presented above.
+You can also create your own instance, and pass your own configuration.
+
 
 

--- a/docs/src/main/asciidoc/sending-emails.adoc
+++ b/docs/src/main/asciidoc/sending-emails.adoc
@@ -66,26 +66,26 @@ The following table lists the properties that can be configured:
 [cols=*,options="header"]
 |===
 
-| Property | Type | Comment
+| Property | Type | Comment | Default
 
-| from | String | the default _from_ address, without, all emails will need an explicit value
-| mock | Boolean | if set to `true`, the emails are not sent, just printed on the console.
-| bounceAddress | String | the default bounce address
-| host | String | the SMTP server host name
-| port | Integer | the SMTP server port
-| username | String | the username
-| password | String | the password
-| ssl | Boolean | Enables or disables SSL
-| trustAll | Boolean | Set whether to trust all certificates
-| maxPoolSize | Integer | Set the maximum pool size
-| ownHostName | String | The hostname to be used for `HELO/EHLO` and the `Message-ID`
-| keepAlive | Boolean | Set if connection pool is enabled, default is `true`
-| disableEsmtp | Boolean | Set if ESMTP should be tried as first command (EHLO).
-| startTLS | `NONE`, `OPTIONAL`, `REQUIRED` | Set the TLS security mode
-| login | `DISABLED`, `OPTIONAL`, `REQUIRED` | Set the login mode for the connection
-| authMethods | space-separated list | Set the allowed auth methods
-| keyStore | String | Path of the key store
-| keyStorePassword | String | Key store password
+| from | String | the default _from_ address, without, all emails will need an explicit value |
+| mock | Boolean | if set to `true`, the emails are not sent, just printed on the console. | `false`
+| bounceAddress | String | the default bounce address |
+| host | String | the SMTP server host name | _mandatory_
+| port | Integer | the SMTP server port | `25`
+| username | String | the username |
+| password | String | the password |
+| ssl | Boolean | Enables or disables SSL | `false`
+| trustAll | Boolean | Set whether to trust all certificates | `false`
+| maxPoolSize | Integer | Configures the maximum number of open connections to the mail server | `10`
+| ownHostName | String | The hostname to be used for `HELO/EHLO` and the `Message-ID` |
+| keepAlive | Boolean | Set if connection pool is enabled. | `true`
+| disableEsmtp | Boolean | Disable ESMTP | `false`
+| startTLS | `NONE`, `OPTIONAL`, `REQUIRED` | Set the TLS security mode | `OPTIONAL`
+| login | `DISABLED`, `OPTIONAL`, `REQUIRED` | Set the login mode for the connection | `NONE`
+| authMethods | space-separated list | Set the allowed auth methods, accept all methods if not set |
+| keyStore | String | Path of the key store |
+| keyStorePassword | String | Key store password |
 |===
 
 == Sending simple emails
@@ -106,7 +106,7 @@ There are 2 APIs:
 * `io.quarkus.mailer.Mailer` provides the imperative (blocking and synchronous) API;
 * `io.quarkus.mailer.ReactiveMailer` provides the reactive (non-blocking and asynchronous) API
 
-NOTE: The two APIs are equivalent feature-wise. Actually the `Mailer` implementation is built on top of `ReactiveMailer` implementation.
+NOTE: The two APIs are equivalent feature-wise. Actually the `Mailer` implementation is built on top of the `ReactiveMailer` implementation.
 
 To send a simple email, proceed as follows:
 
@@ -222,6 +222,12 @@ Check the link:using-vertx.html[Using Vert.x guide] for further details about th
 
 The retrieved `MailClient` is configured using the configuration key presented above.
 You can also create your own instance, and pass your own configuration.
+
+
+== Conclusion
+
+This guide has shown how you can send emails from a Quarkus application.
+The _mailer_ extension works in JVM and native mode.
 
 
 

--- a/docs/src/main/asciidoc/sending-emails.adoc
+++ b/docs/src/main/asciidoc/sending-emails.adoc
@@ -1,0 +1,205 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+
+include::./attributes.adoc[]
+= {project-name} - Sending emails
+
+This guide demonstrates how your {project-name} application can send emails using an SMTP server.
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* less than 15 minutes
+* The SMTP hostname, port and credentials, and an email address
+* an IDE
+* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* Apache Maven 3.5.3+
+* GraalVM installed if you want to run in native mode.
+
+== Architecture
+
+In this guide, we are going to see how you can send emails from a {project-name} application.
+It covers simple emails, attachments, inlined attachments, the reactive vs. imperative APIs...
+
+== Creating the Maven Project
+
+Create a new project with the following command:
+
+[source, subs=attributes+]
+----
+mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=sending-email-quickstart \
+    -Dextensions="mailer"
+----
+
+If you already have an existing project, add the `mailer` extension:
+
+[source]
+----
+mvn quarkus:add-extensions -Dextensions="mailer"
+----
+
+== Configuring the mailer
+
+The {project-name} mailer is using SMTP. In the `src/main/resources/application.properties` file, you need to configure the host, port, username, password as well as the other configuration aspect.
+Note that the password can also be configured using system properties and environment variables.
+
+Here is an example using _sendgrid_:
+
+[source]
+----
+quarkus.mailer.from=test@quarkus.io
+quarkus.mailer.host=smtp.sendgrid.net
+quarkus.mailer.port=465
+quarkus.mailer.ssl=true
+quarkus.mailer.username=....
+quarkus.mailer.password=....
+----
+
+The following table lists the properties that can be configured:
+
+[cols=*,options="header"]
+|===
+
+| Property | Type | Comment
+
+| from | String | the default _from_ address, without, all emails will need an explicit value
+| mock | Boolean | if set to `true`, the emails are not sent, just printed on the console.
+| bounceAddress | String | the default bounce address
+| host | String | the SMTP server host name
+| port | Integer | the SMTP server port
+| username | String | the username
+| password | String | the password
+| ssl | Boolean | Enables or disables SSL
+| trustAll | Boolean | Set whether to trust all certificates
+| maxPoolSize | Integer | Set the maximum pool size
+| ownHostName | String | The hostname to be used for `HELO/EHLO` and the `Message-ID`
+| keepAlive | Boolean | Set if connection pool is enabled, default is `true`
+| disableEsmtp | Boolean | Set if ESMTP should be tried as first command (EHLO).
+| startTLS | `NONE`, `OPTIONAL`, `REQUIRED` | Set the TLS security mode
+| login | `DISABLED`, `OPTIONAL`, `REQUIRED` | Set the login mode for the connection
+| authMethods | space-separated list | Set the allowed auth methods
+| keyStore | String | Path of the key store
+| keyStorePassword | String | Key store password
+|===
+
+== Sending simple emails
+
+In a JAX-RS resource, or in a bean, you can inject the mailer as follows:
+
+[source, java]
+----
+@Inject
+Mailer mailer;
+
+@Inject
+ReactiveMailer reactiveMailer;
+----
+
+There are 2 APIs:
+
+* `io.quarkus.mailer.Mailer` provides the imperative (blocking and synchronous) API;
+* `io.quarkus.mailer.ReactiveMailer` provides the reactive (non-blocking and asynchronous) API
+
+NOTE: `Mailer` is implemented on top of `ReactiveMailer`
+
+To send a simple email, proceed as follows:
+
+[source, java]
+----
+@GET
+@Path("/simple")
+public Response sendASimpleEmail() {
+    mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body"));
+    return Response.accepted().build();
+}
+
+@GET
+@Path("/async")
+public CompletionStage<Response> sendASimpleEmailAsync() {
+    return reactiveMailer.send(
+            Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body"))
+            .thenApply(x -> Response.accepted().build());
+}
+----
+
+You can create new `io.quarkus.mailer.Mail` instances from the constructor or from the `Mail.withText` and
+`Mail.withHtml` helper methods. The `Mail` instance lets you add recipients (to, cc, or bcc), set the subject,
+headers, sender (from) address...
+
+You can also send several `Mail` objects in one call:
+
+[source, java]
+----
+mailer.send(mail1, mail2, mail3);
+----
+
+== Sending attachments
+
+To send attachment, just use the `addAttachment` methods on the `io.quarkus.mailer.Mail` instance:
+
+[source,java]
+----
+@GET
+@Path("/attachment")
+public Response sendEmailWithAttachment() {
+    mailer.send(Mail.withText("to@acme.org", "An email from quarkus with attachment",
+            "This is my body")
+            .addAttachment("my-file.txt",
+                "content of my file".getBytes(), "text/plain"));
+    return Response.accepted().build();
+}
+----
+
+Attachments can be created from raw bytes (as shown in the snippet) or files.
+When using a file, the content is read asynchronously.
+
+== Sending HTML emails with inlined attachments
+
+When sending HTML email, you can add inlined attachments.
+For example, you can send an image with your email, and this email will be displayed in the mail content.
+
+[source, java]
+----
+@GET
+@Path("/html")
+public Response sendingHTML() {
+    String body = "<strong>Hello!</strong>" + "\n" +
+        "<p>Here is an image for you: <img src=\"cid:my-image@quarkus.io\"/></p>" +
+        "<p>Regards</p>";
+    mailer.send(Mail.withHtml("to@acme.org", "An email in HTML", body)
+        .addInlineAttachment("quarkus-logo.png",
+            new File("quarkus-logo.png"),
+            "image/png", "<my-image@quarkus.io>"));
+    return Response.accepted().build();
+}
+----
+
+Note the _content-id_ format and reference.
+When you create the inline attachment, the content-id must be structured as follows: `<id@domain>`.
+When referenced, for instance in the `src` attribute, use `cid:id@domain` (without the `<` and `>`).
+
+== Using the underlying Vert.x Mail Client
+
+The Quarkus Mailer is implemented on top of the https://vertx.io/docs/vertx-mail-client/java/[Vert.x Mail Client], providing an asynchronous and non-blocking way to send emails.
+You can inject the client directly:
+
+[source, java]
+----
+@Inject MailClient client;
+----
+
+Are exposed:
+
+* the Axle client (`io.vertx.axle.ext.mail.MailClient`), using `CompletionStage` and Reactive Streams `Publisher`
+* the RX Java 2 client (`io.vertx.reactivex.ext.mail.MailClient`)
+* the bare client (`io.vertx.ext.mail.MailClient`)
+
+The retrieved instance is configured using the configuration key presented above.
+
+

--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-mailer-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-mailer-deployment</artifactId>
+
+    <name>Quarkus - Mailer - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mailer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerBuildItem.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerBuildItem.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.quarkus.mailer.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+import io.vertx.ext.mail.MailClient;
+
+public final class MailerBuildItem extends SimpleBuildItem {
+
+    private final RuntimeValue<MailClient> client;
+
+    public MailerBuildItem(RuntimeValue<MailClient> client) {
+        this.client = client;
+    }
+
+    public RuntimeValue<MailClient> getClient() {
+        return client;
+    }
+
+}

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
@@ -1,0 +1,60 @@
+package io.quarkus.mailer.deployment;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
+import io.quarkus.mailer.impl.*;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.vertx.deployment.VertxBuildItem;
+import io.vertx.ext.mail.MailClient;
+
+public class MailerProcessor {
+
+    @BuildStep
+    AdditionalBeanBuildItem registerClients() {
+        return AdditionalBeanBuildItem.unremovableOf(MailClientProducer.class);
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem registerMailers() {
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClasses(ReactiveMailerImpl.class, BlockingMailerImpl.class)
+                .build();
+    }
+
+    @BuildStep
+    void registerAuthClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        // We must register the auth provider used by the Vert.x mail clients
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true,
+                "io.vertx.ext.mail.impl.sasl.AuthDigestMD5",
+                "io.vertx.ext.mail.impl.sasl.AuthCramSHA256",
+                "io.vertx.ext.mail.impl.sasl.AuthCramSHA1",
+                "io.vertx.ext.mail.impl.sasl.AuthCramMD5",
+                "io.vertx.ext.mail.impl.sasl.AuthDigestMD5",
+                "io.vertx.ext.mail.impl.sasl.AuthPlain",
+                "io.vertx.ext.mail.impl.sasl.AuthLogin"));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    MailerBuildItem build(BuildProducer<FeatureBuildItem> feature, MailConfigTemplate template, VertxBuildItem vertx,
+            BeanContainerBuildItem beanContainer, LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown,
+            MailConfig config) {
+
+        feature.produce(new FeatureBuildItem(FeatureBuildItem.MAILER));
+
+        RuntimeValue<MailClient> client = template.configureTheClient(vertx.getVertx(), beanContainer.getValue(), config,
+                launchMode.getLaunchMode(), shutdown);
+
+        template.configureTheMailer(beanContainer.getValue(), config);
+
+        return new MailerBuildItem(client);
+    }
+}

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InjectionTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InjectionTest.java
@@ -14,8 +14,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.vertx.ext.mail.MailClient;
 
+@SuppressWarnings("WeakerAccess")
 public class InjectionTest {
 
+    @SuppressWarnings("unused")
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
@@ -53,7 +55,7 @@ public class InjectionTest {
         @Inject
         MailClient client;
 
-        public void verify() {
+        void verify() {
             Assertions.assertNotNull(client);
         }
     }
@@ -64,7 +66,7 @@ public class InjectionTest {
         @Inject
         io.vertx.axle.ext.mail.MailClient client;
 
-        public void verify() {
+        void verify() {
             Assertions.assertNotNull(client);
         }
     }
@@ -75,7 +77,7 @@ public class InjectionTest {
         @Inject
         io.vertx.reactivex.ext.mail.MailClient client;
 
-        public void verify() {
+        void verify() {
             Assertions.assertNotNull(client);
         }
     }
@@ -86,7 +88,7 @@ public class InjectionTest {
         @Inject
         ReactiveMailer mailer;
 
-        public CompletionStage<Void> verify() {
+        CompletionStage<Void> verify() {
             return mailer.send(Mail.withText("quarkus@quarkus.io", "test mailer", "reactive test!"));
         }
     }
@@ -97,7 +99,7 @@ public class InjectionTest {
         @Inject
         Mailer mailer;
 
-        public void verify() {
+        void verify() {
             mailer.send(Mail.withText("quarkus@quarkus.io", "test mailer", "blocking test!"));
         }
     }

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InjectionTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/InjectionTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.mailer;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.ext.mail.MailClient;
+
+public class InjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanUsingAxleMailClient.class, BeanUsingBareMailClient.class, BeanUsingRxClient.class)
+                    .addClasses(BeanUsingBlockingMailer.class, BeanUsingReactiveMailer.class)
+                    .addAsResource("mock-config.properties", "application.properties"));
+
+    @Inject
+    BeanUsingAxleMailClient beanUsingBare;
+
+    @Inject
+    BeanUsingBareMailClient beanUsingAxle;
+
+    @Inject
+    BeanUsingRxClient beanUsingRx;
+
+    @Inject
+    BeanUsingReactiveMailer beanUsingReactiveMailer;
+
+    @Inject
+    BeanUsingBlockingMailer beanUsingBlockingMailer;
+
+    @Test
+    public void testInjection() {
+        beanUsingAxle.verify();
+        beanUsingBare.verify();
+        beanUsingRx.verify();
+        beanUsingBlockingMailer.verify();
+        beanUsingReactiveMailer.verify().toCompletableFuture().join();
+    }
+
+    @ApplicationScoped
+    static class BeanUsingBareMailClient {
+
+        @Inject
+        MailClient client;
+
+        public void verify() {
+            Assertions.assertNotNull(client);
+        }
+    }
+
+    @ApplicationScoped
+    static class BeanUsingAxleMailClient {
+
+        @Inject
+        io.vertx.axle.ext.mail.MailClient client;
+
+        public void verify() {
+            Assertions.assertNotNull(client);
+        }
+    }
+
+    @ApplicationScoped
+    static class BeanUsingRxClient {
+
+        @Inject
+        io.vertx.reactivex.ext.mail.MailClient client;
+
+        public void verify() {
+            Assertions.assertNotNull(client);
+        }
+    }
+
+    @ApplicationScoped
+    static class BeanUsingReactiveMailer {
+
+        @Inject
+        ReactiveMailer mailer;
+
+        public CompletionStage<Void> verify() {
+            return mailer.send(Mail.withText("quarkus@quarkus.io", "test mailer", "reactive test!"));
+        }
+    }
+
+    @ApplicationScoped
+    static class BeanUsingBlockingMailer {
+
+        @Inject
+        Mailer mailer;
+
+        public void verify() {
+            mailer.send(Mail.withText("quarkus@quarkus.io", "test mailer", "blocking test!"));
+        }
+    }
+}

--- a/extensions/mailer/deployment/src/test/resources/mock-config.properties
+++ b/extensions/mailer/deployment/src/test/resources/mock-config.properties
@@ -1,0 +1,2 @@
+quarkus.mailer.mock=true
+quarkus.mailer.from=from@quarkus.io

--- a/extensions/mailer/deployment/src/test/resources/wiser-config.properties
+++ b/extensions/mailer/deployment/src/test/resources/wiser-config.properties
@@ -1,3 +1,0 @@
-quarkus.mailer.host=localhost
-quarkus.mailer.port=1587
-quarkus.mailer.from=from@quarkus.io

--- a/extensions/mailer/deployment/src/test/resources/wiser-config.properties
+++ b/extensions/mailer/deployment/src/test/resources/wiser-config.properties
@@ -1,0 +1,3 @@
+quarkus.mailer.host=localhost
+quarkus.mailer.port=1587
+quarkus.mailer.from=from@quarkus.io

--- a/extensions/mailer/pom.xml
+++ b/extensions/mailer/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-mailer-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Quarkus - Mailer</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+
+</project>

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-mailer-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-mailer</artifactId>
+
+    <name>Quarkus - Mailer - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-axle-mail-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.subethamail</groupId>
+            <artifactId>subethasmtp</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -53,6 +53,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
         </dependency>

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -53,13 +53,14 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Attachment.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Attachment.java
@@ -1,0 +1,176 @@
+package io.quarkus.mailer;
+
+import java.io.File;
+
+/**
+ * Defines an attachment.
+ * <p>
+ * Instances of this class are not thread-safe.
+ */
+public class Attachment {
+
+    /**
+     * Disposition for inline attachments.
+     */
+    public static final String DISPOSITION_INLINE = "inline";
+
+    /**
+     * Disposition for attachments.
+     */
+    public static final String DISPOSITION_ATTACHMENT = "attachment";
+
+    private String name;
+    private File file;
+    private String description;
+    private String disposition;
+    private byte[] data;
+    private String contentType;
+    private String contentId;
+
+    /**
+     * Creates a new {@link Attachment}. Disposition is set to {@code attachment}.
+     *
+     * @param name the name
+     * @param file the file
+     * @param contentType the content type
+     */
+    public Attachment(String name, File file, String contentType) {
+        this.name = name;
+        this.file = file;
+        this.contentType = contentType;
+        this.disposition = DISPOSITION_ATTACHMENT;
+    }
+
+    /**
+     * Creates a new {@link Attachment}. Disposition is set to {@code inline}.
+     *
+     * @param name the name
+     * @param file the file
+     * @param contentType the content type
+     * @param contentId the content id
+     */
+    public Attachment(String name, File file, String contentType, String contentId) {
+        this.name = name;
+        this.file = file;
+        this.contentId = contentId;
+        this.contentType = contentType;
+        this.disposition = DISPOSITION_INLINE;
+    }
+
+    /**
+     * Creates a new {@link Attachment}. Disposition is set to {@code attachment}.
+     *
+     * @param name the name
+     * @param data the data
+     * @param contentType the content type
+     */
+    public Attachment(String name, byte[] data, String contentType) {
+        this.name = name;
+        this.data = data;
+        this.contentType = contentType;
+        this.disposition = DISPOSITION_ATTACHMENT;
+    }
+
+    /**
+     * Creates a new {@link Attachment}. Disposition is set to {@code inline}.
+     *
+     * @param name the name
+     * @param data the data
+     * @param contentType the content type
+     * @param contentId the content id
+     */
+    public Attachment(String name, byte[] data, String contentType, String contentId) {
+        this.name = name;
+        this.data = data;
+        this.contentType = contentType;
+        this.contentId = contentId;
+        this.disposition = DISPOSITION_INLINE;
+    }
+
+    /**
+     * Creates a new {@link Attachment}.
+     *
+     * @param name the name
+     * @param data the data
+     * @param contentType the content type
+     * @param description the description
+     * @param disposition the disposition
+     */
+    public Attachment(String name, byte[] data, String contentType, String description, String disposition) {
+        this.name = name;
+        this.data = data;
+        this.contentType = contentType;
+        this.description = description;
+        this.disposition = disposition;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Attachment setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public Attachment setFile(File file) {
+        this.file = file;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Attachment setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getDisposition() {
+        return disposition;
+    }
+
+    public Attachment setDisposition(String disposition) {
+        this.disposition = disposition;
+        return this;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public Attachment setData(byte[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public Attachment setContentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public String getContentId() {
+        return contentId;
+    }
+
+    public Attachment setContentId(String contentId) {
+        this.contentId = contentId;
+        return this;
+    }
+
+    /**
+     * @return {@code true} if the disposition is set to {@code inline}.
+     */
+    public boolean isInlineAttachment() {
+        return DISPOSITION_INLINE.equalsIgnoreCase(disposition);
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Attachment.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Attachment.java
@@ -35,10 +35,10 @@ public class Attachment {
      * @param contentType the content type
      */
     public Attachment(String name, File file, String contentType) {
-        this.name = name;
-        this.file = file;
-        this.contentType = contentType;
-        this.disposition = DISPOSITION_ATTACHMENT;
+        setName(name)
+                .setFile(file)
+                .setContentType(contentType)
+                .setDisposition(DISPOSITION_ATTACHMENT);
     }
 
     /**
@@ -50,11 +50,11 @@ public class Attachment {
      * @param contentId the content id
      */
     public Attachment(String name, File file, String contentType, String contentId) {
-        this.name = name;
-        this.file = file;
-        this.contentId = contentId;
-        this.contentType = contentType;
-        this.disposition = DISPOSITION_INLINE;
+        setName(name)
+                .setFile(file)
+                .setContentType(contentType)
+                .setContentId(contentId)
+                .setDisposition(DISPOSITION_INLINE);
     }
 
     /**
@@ -65,10 +65,10 @@ public class Attachment {
      * @param contentType the content type
      */
     public Attachment(String name, byte[] data, String contentType) {
-        this.name = name;
-        this.data = data;
-        this.contentType = contentType;
-        this.disposition = DISPOSITION_ATTACHMENT;
+        setName(name)
+                .setData(data)
+                .setContentType(contentType)
+                .setDisposition(DISPOSITION_ATTACHMENT);
     }
 
     /**
@@ -80,11 +80,11 @@ public class Attachment {
      * @param contentId the content id
      */
     public Attachment(String name, byte[] data, String contentType, String contentId) {
-        this.name = name;
-        this.data = data;
-        this.contentType = contentType;
-        this.contentId = contentId;
-        this.disposition = DISPOSITION_INLINE;
+        setName(name)
+                .setData(data)
+                .setContentType(contentType)
+                .setContentId(contentId)
+                .setDisposition(DISPOSITION_INLINE);
     }
 
     /**
@@ -97,11 +97,11 @@ public class Attachment {
      * @param disposition the disposition
      */
     public Attachment(String name, byte[] data, String contentType, String description, String disposition) {
-        this.name = name;
-        this.data = data;
-        this.contentType = contentType;
-        this.description = description;
-        this.disposition = disposition;
+        setName(name)
+                .setData(data)
+                .setContentType(contentType)
+                .setDescription(description)
+                .setDisposition(disposition);
     }
 
     public String getName() {
@@ -163,7 +163,12 @@ public class Attachment {
     }
 
     public Attachment setContentId(String contentId) {
-        this.contentId = contentId;
+        if (contentId != null && !(contentId.startsWith("<") && contentId.endsWith(">"))) {
+            // Auto-wrap the content id between < and >.
+            this.contentId = "<" + contentId + ">";
+        } else {
+            this.contentId = contentId;
+        }
         return this;
     }
 

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mail.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mail.java
@@ -3,6 +3,8 @@ package io.quarkus.mailer;
 import java.io.File;
 import java.util.*;
 
+import org.reactivestreams.Publisher;
+
 /**
  * Represents an e-mail.
  * This class encapsulates the various attributes you want to set on an e-mail you are going to send (to, subject,
@@ -367,6 +369,19 @@ public class Mail {
     }
 
     /**
+     * Adds an attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param data the binary data to be attached
+     * @param contentType the content type.
+     * @return the current {@link Mail}
+     */
+    public Mail addAttachment(String name, Publisher<Byte> data, String contentType) {
+        this.attachments.add(new Attachment(name, data, contentType));
+        return this;
+    }
+
+    /**
      * Adds an inline attachment.
      *
      * @param name the name of the attachment, generally a file name.
@@ -382,6 +397,21 @@ public class Mail {
     }
 
     /**
+     * Adds an inline attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param data the binary data to be attached
+     * @param contentType the content type
+     * @param contentId the content id. It must follows the {@code <some-id@some-domain>} syntax. Then the HTML
+     *        content can reference this attachment using {@code src="cid:some-id@some-domain"}.
+     * @return the current {@link Mail}
+     */
+    public Mail addInlineAttachment(String name, Publisher<Byte> data, String contentType, String contentId) {
+        this.attachments.add(new Attachment(name, data, contentType, contentId));
+        return this;
+    }
+
+    /**
      * Adds an attachment.
      *
      * @param name the name of the attachment, generally a file name.
@@ -392,6 +422,21 @@ public class Mail {
      * @return the current {@link Mail}
      */
     public Mail addAttachment(String name, byte[] data, String contentType, String description, String disposition) {
+        this.attachments.add(new Attachment(name, data, contentType, description, disposition));
+        return this;
+    }
+
+    /**
+     * Adds an attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param data the binary data to be attached
+     * @param contentType the content type
+     * @param description the description of the attachment
+     * @param disposition the disposition of the attachment
+     * @return the current {@link Mail}
+     */
+    public Mail addAttachment(String name, Publisher<Byte> data, String contentType, String description, String disposition) {
         this.attachments.add(new Attachment(name, data, contentType, description, disposition));
         return this;
     }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mail.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mail.java
@@ -1,0 +1,416 @@
+package io.quarkus.mailer;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Represents an e-mail.
+ * This class encapsulates the various attributes you want to set on an e-mail you are going to send (to, subject,
+ * body...).
+ * <p>
+ * Instances are NOT thread-safe.
+ */
+public class Mail {
+
+    private List<String> bcc = new ArrayList<>();
+    private List<String> cc = new ArrayList<>();
+    private String from;
+    private String replyTo;
+    private String bounceAddress;
+    private String subject;
+    private String text;
+    private String html;
+    private List<String> to = new ArrayList<>();
+
+    private Map<String, List<String>> headers = new HashMap<>();
+    private List<Attachment> attachments = new ArrayList<>();
+
+    /**
+     * Creates a new instance of {@link Mail}.
+     */
+    public Mail() {
+        // empty
+    }
+
+    /**
+     * Creates a new instance of {@link Mail} that contains a "text" body.
+     * The returned instance can be modified.
+     *
+     * @param to the address of the recipient
+     * @param subject the subject
+     * @param text the body
+     * @return the new {@link Mail} instance.
+     */
+    public static Mail withText(String to, String subject, String text) {
+        return new Mail().addTo(to).setSubject(subject).setText(text);
+    }
+
+    /**
+     * Creates a new instance of {@link Mail} that contains a "html" body.
+     * The returned instance can be modified.
+     *
+     * @param to the address of the recipient
+     * @param subject the subject
+     * @param html the body
+     * @return the new {@link Mail} instance.
+     */
+    public static Mail withHtml(String to, String subject, String html) {
+        return new Mail().addTo(to).setSubject(subject).setHtml(html);
+    }
+
+    /**
+     * Adds BCC recipients.
+     *
+     * @param bcc the recipients, each item must be a valid email address.
+     * @return the current {@link Mail}
+     */
+    public Mail addBcc(String... bcc) {
+        if (bcc != null) {
+            Collections.addAll(this.bcc, bcc);
+        }
+        return this;
+    }
+
+    /**
+     * Adds CC recipients.
+     *
+     * @param cc the recipients, each item must be a valid email address.
+     * @return the current {@link Mail}
+     */
+    public Mail addCc(String... cc) {
+        if (cc != null) {
+            Collections.addAll(this.cc, cc);
+        }
+        return this;
+    }
+
+    /**
+     * Adds TO recipients.
+     *
+     * @param to the recipients, each item must be a valid email address.
+     * @return the current {@link Mail}
+     */
+    public Mail addTo(String... to) {
+        if (to != null) {
+            Collections.addAll(this.to, to);
+        }
+        return this;
+    }
+
+    /**
+     * @return the BCC recipients.
+     */
+    public List<String> getBcc() {
+        return bcc;
+    }
+
+    /**
+     * Sets the BCC recipients.
+     *
+     * @param bcc the list of recipients
+     * @return the current {@link Mail}
+     */
+    public Mail setBcc(List<String> bcc) {
+        if (bcc == null) {
+            this.bcc = new ArrayList<>();
+        } else {
+            this.bcc = bcc;
+        }
+        return this;
+    }
+
+    /**
+     * @return the CC recipients.
+     */
+    public List<String> getCc() {
+        return cc;
+    }
+
+    /**
+     * Sets the CC recipients.
+     *
+     * @param cc the list of recipients
+     * @return the current {@link Mail}
+     */
+    public Mail setCc(List<String> cc) {
+        if (cc == null) {
+            this.cc = new ArrayList<>();
+        } else {
+            this.cc = cc;
+        }
+        return this;
+    }
+
+    /**
+     * @return the sender address.
+     */
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * Sets the sender address. Notes that it's not accepted to send an email without a sender address.
+     * A default sender address can be configured in the application properties ( {@code quarkus.mailer.from} )
+     *
+     * @param from the sender address
+     * @return the current {@link Mail}
+     */
+    public Mail setFrom(String from) {
+        this.from = from;
+        return this;
+    }
+
+    /**
+     * @return the reply-to address.
+     */
+    public String getReplyTo() {
+        return replyTo;
+    }
+
+    /**
+     * Sets the reply-to address.
+     *
+     * @param replyTo the address to use as reply-to. Must be a valid email address.
+     * @return the current {@link Mail}
+     */
+    public Mail setReplyTo(String replyTo) {
+        this.replyTo = replyTo;
+        return this;
+    }
+
+    /**
+     * @return the bounce address.
+     */
+    public String getBounceAddress() {
+        return bounceAddress;
+    }
+
+    /**
+     * Sets the bounce address.
+     * A default sender address can be configured in the application properties ( {@code quarkus.mailer.bounceAddress} )
+     *
+     * @param bounceAddress the bounce address, must be a valid email address.
+     * @return the current {@link Mail}
+     */
+    public Mail setBounceAddress(String bounceAddress) {
+        this.bounceAddress = bounceAddress;
+        return this;
+    }
+
+    /**
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the email subject.
+     *
+     * @param subject the subject
+     * @return the current {@link Mail}
+     */
+    public Mail setSubject(String subject) {
+        this.subject = subject;
+        return this;
+    }
+
+    /**
+     * @return the text content of the email
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Sets the body of the email as plain text.
+     *
+     * @param text the content
+     * @return the current {@link Mail}
+     */
+    public Mail setText(String text) {
+        this.text = text;
+        return this;
+    }
+
+    /**
+     * @return the HTML content of the email
+     */
+    public String getHtml() {
+        return html;
+    }
+
+    /**
+     * Sets the body of the email as HTML.
+     *
+     * @param html the content
+     * @return the current {@link Mail}
+     */
+    public Mail setHtml(String html) {
+        this.html = html;
+        return this;
+    }
+
+    /**
+     * @return the TO recipients.
+     */
+    public List<String> getTo() {
+        return to;
+    }
+
+    /**
+     * Sets the TO recipients.
+     *
+     * @param to the list of recipients
+     * @return the current {@link Mail}
+     */
+    public Mail setTo(List<String> to) {
+        if (to == null) {
+            this.to = new ArrayList<>();
+        } else {
+            this.to = to;
+        }
+        return this;
+    }
+
+    /**
+     * @return the current set of headers.
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Adds a header value. If this header already has a value, the value is appended.
+     *
+     * @param key the header name, must not be {@code null}
+     * @param values the header values, must not be {@code null}
+     * @return the current {@link Mail}
+     */
+    public Mail addHeader(String key, String... values) {
+        if (key == null || values == null) {
+            throw new IllegalArgumentException("Cannot add header, key and value must not be null");
+        }
+        List<String> content = this.headers.computeIfAbsent(key, k -> new ArrayList<>());
+        Collections.addAll(content, values);
+        return this;
+    }
+
+    /**
+     * Removes a header.
+     *
+     * @param key the header name, must not be {@code null}.
+     * @return the current {@link Mail}
+     */
+    public Mail removeHeader(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("Cannot remove header, key must not be null");
+        }
+        headers.remove(key);
+        return this;
+    }
+
+    /**
+     * Sets the list of headers.
+     *
+     * @param headers the headers
+     * @return the current {@link Mail}
+     */
+    public Mail setHeaders(Map<String, List<String>> headers) {
+        if (headers == null) {
+            this.headers = new HashMap<>();
+        } else {
+            this.headers = headers;
+        }
+        return this;
+    }
+
+    /**
+     * Adds an inline attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param file the file to be attached. Note that the file will be read asynchronously.
+     * @param contentType the content type
+     * @param contentId the content id. It must follows the {@code <some-id@some-domain>} syntax. Then the HTML
+     *        content can reference this attachment using {@code src="cid:some-id@some-domain"}.
+     * @return the current {@link Mail}
+     */
+    public Mail addInlineAttachment(String name, File file, String contentType, String contentId) {
+        this.attachments.add(new Attachment(name, file, contentType, contentId));
+        return this;
+    }
+
+    /**
+     * Adds an attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param file the file to be attached. Note that the file will be read asynchronously.
+     * @param contentType the content type.
+     * @return the current {@link Mail}
+     */
+    public Mail addAttachment(String name, File file, String contentType) {
+        this.attachments.add(new Attachment(name, file, contentType));
+        return this;
+    }
+
+    /**
+     * Adds an attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param data the binary data to be attached
+     * @param contentType the content type.
+     * @return the current {@link Mail}
+     */
+    public Mail addAttachment(String name, byte[] data, String contentType) {
+        this.attachments.add(new Attachment(name, data, contentType));
+        return this;
+    }
+
+    /**
+     * Adds an inline attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param data the binary data to be attached
+     * @param contentType the content type
+     * @param contentId the content id. It must follows the {@code <some-id@some-domain>} syntax. Then the HTML
+     *        content can reference this attachment using {@code src="cid:some-id@some-domain"}.
+     * @return the current {@link Mail}
+     */
+    public Mail addInlineAttachment(String name, byte[] data, String contentType, String contentId) {
+        this.attachments.add(new Attachment(name, data, contentType, contentId));
+        return this;
+    }
+
+    /**
+     * Adds an attachment.
+     *
+     * @param name the name of the attachment, generally a file name.
+     * @param data the binary data to be attached
+     * @param contentType the content type
+     * @param description the description of the attachment
+     * @param disposition the disposition of the attachment
+     * @return the current {@link Mail}
+     */
+    public Mail addAttachment(String name, byte[] data, String contentType, String description, String disposition) {
+        this.attachments.add(new Attachment(name, data, contentType, description, disposition));
+        return this;
+    }
+
+    /**
+     * @return the list of attachments
+     */
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    /**
+     * Sets the attachment list.
+     *
+     * @param attachments the attachments.
+     * @return the current {@link Mail}
+     */
+    public Mail setAttachments(List<Attachment> attachments) {
+        this.attachments = attachments;
+        return this;
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mailer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Mailer.java
@@ -1,0 +1,17 @@
+package io.quarkus.mailer;
+
+/**
+ * A mailer to send email.
+ *
+ * @see ReactiveMailer
+ */
+public interface Mailer {
+
+    /**
+     * Sends the given mails.
+     *
+     * @param mails the mails, must not be {@code null}.
+     */
+    void send(Mail... mails);
+
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/ReactiveMailer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/ReactiveMailer.java
@@ -1,0 +1,18 @@
+package io.quarkus.mailer;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A mailer to send email asynchronously.
+ */
+public interface ReactiveMailer {
+
+    /**
+     * Sends the passed emails.
+     *
+     * @param mails the emails to send, must not be {@code null}
+     * @return a {@link CompletionStage} indicating when the mails have been sent. The {@link CompletionStage} may be
+     *         completed with a failure if the emails cannot be sent.
+     */
+    CompletionStage<Void> send(Mail... mails);
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/BlockingMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/BlockingMailerImpl.java
@@ -1,0 +1,23 @@
+package io.quarkus.mailer.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.Mailer;
+import io.quarkus.mailer.ReactiveMailer;
+
+/**
+ * Implementation of {@link Mailer} relying on the {@link ReactiveMailer} and waiting for completion.
+ */
+@ApplicationScoped
+public class BlockingMailerImpl implements Mailer {
+
+    @Inject
+    ReactiveMailer mailer;
+
+    @Override
+    public void send(Mail... mails) {
+        mailer.send(mails).toCompletableFuture().join();
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailClientProducer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailClientProducer.java
@@ -1,0 +1,43 @@
+package io.quarkus.mailer.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import io.vertx.ext.mail.MailClient;
+
+/**
+ * Beans producing the Vert.x Mail clients.
+ */
+@ApplicationScoped
+public class MailClientProducer {
+
+    private volatile io.vertx.axle.ext.mail.MailClient axleMailClient;
+    private volatile io.vertx.reactivex.ext.mail.MailClient rxMailClient;
+    private volatile MailClient client;
+
+    void initialize(MailClient client) {
+        this.client = client;
+        this.axleMailClient = io.vertx.axle.ext.mail.MailClient.newInstance(client);
+        this.rxMailClient = io.vertx.reactivex.ext.mail.MailClient.newInstance(client);
+    }
+
+    @Singleton
+    @Produces
+    public MailClient mailClient() {
+        return client;
+    }
+
+    @Singleton
+    @Produces
+    public io.vertx.axle.ext.mail.MailClient axleMailClient() {
+        return axleMailClient;
+    }
+
+    @Singleton
+    @Produces
+    public io.vertx.reactivex.ext.mail.MailClient rxMailClient() {
+        return rxMailClient;
+    }
+
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfig.java
@@ -1,0 +1,129 @@
+package io.quarkus.mailer.impl;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "mailer", phase = ConfigPhase.RUN_TIME)
+public class MailConfig {
+
+    /**
+     * Configure the default `from` attribute.
+     * It's the sender email address.
+     */
+    @ConfigItem
+    public Optional<String> from;
+
+    /**
+     * Enables the mock mode, not sending emails.
+     * The content of the emails is printed on the console.
+     */
+    @ConfigItem
+    public Optional<Boolean> mock;
+
+    /**
+     * Configures the default bounce email address.
+     */
+    @ConfigItem
+    public Optional<String> bounceAddress;
+
+    /**
+     * The SMTP host name.
+     */
+    @ConfigItem(defaultValue = "localhost")
+    public String host;
+
+    /**
+     * The SMTP port.
+     */
+    @ConfigItem
+    public OptionalInt port;
+
+    /**
+     * The username.
+     */
+    @ConfigItem
+    public Optional<String> username;
+
+    /**
+     * The password.
+     */
+    @ConfigItem
+    public Optional<String> password;
+
+    /**
+     * Enables or disables the SSL on connect.
+     */
+    @ConfigItem
+    public Optional<Boolean> ssl;
+
+    /**
+     * Set whether to trust all certificates on ssl connect the option is also
+     * applied to {@code STARTTLS} operation
+     */
+    @ConfigItem
+    public Optional<Boolean> trustAll;
+
+    /**
+     * The pool maximum size.
+     */
+    @ConfigItem
+    public OptionalInt maxPoolSize;
+
+    /**
+     * The hostname to be used for HELO/EHLO and the Message-ID
+     */
+    @ConfigItem
+    public Optional<String> ownHostName;
+
+    /**
+     * Set if connection pool is enabled, {@code true} by default.
+     * <p>
+     * If the connection pooling is disabled, the max number of sockets is enforced nevertheless
+     * <p>
+     */
+    @ConfigItem
+    public Optional<Boolean> keepAlive;
+
+    /**
+     * Set if ESMTP should be tried as first command (EHLO).
+     */
+    @ConfigItem
+    public Optional<Boolean> disableEsmtp;
+
+    /**
+     * Set the TLS security mode for the connection.
+     * Either {@code NONE}, {@code OPTIONAL} or {@code REQUIRED}.
+     */
+    @ConfigItem
+    public Optional<String> startTLS;
+
+    /**
+     * Set the login mode for the connection.
+     * Either {@code DISABLED}, @{code OPTIONAL} or {@code REQUIRED}
+     */
+    @ConfigItem
+    public Optional<String> login;
+
+    /**
+     * Set the allowed auth methods.
+     * If defined, only these methods will be used, if the server supports them.
+     */
+    @ConfigItem
+    public Optional<String> authMethods;
+
+    /**
+     * Set the key store.
+     */
+    @ConfigItem
+    public Optional<String> keyStore;
+
+    /**
+     * Set the key store password.
+     */
+    @ConfigItem
+    public Optional<String> keyStorePassword;
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfig.java
@@ -20,9 +20,11 @@ public class MailConfig {
     /**
      * Enables the mock mode, not sending emails.
      * The content of the emails is printed on the console.
+     *
+     * Disabled by default.
      */
     @ConfigItem
-    public Optional<Boolean> mock;
+    public boolean mock;
 
     /**
      * Configures the default bounce email address.
@@ -56,16 +58,17 @@ public class MailConfig {
 
     /**
      * Enables or disables the SSL on connect.
+     * {@code false} by default.
      */
     @ConfigItem
-    public Optional<Boolean> ssl;
+    public boolean ssl;
 
     /**
      * Set whether to trust all certificates on ssl connect the option is also
-     * applied to {@code STARTTLS} operation
+     * applied to {@code STARTTLS} operation. {@code false} by default.
      */
     @ConfigItem
-    public Optional<Boolean> trustAll;
+    public boolean trustAll;
 
     /**
      * The pool maximum size.
@@ -82,17 +85,18 @@ public class MailConfig {
     /**
      * Set if connection pool is enabled, {@code true} by default.
      * <p>
-     * If the connection pooling is disabled, the max number of sockets is enforced nevertheless
+     * If the connection pooling is disabled, the max number of sockets is enforced nevertheless.
      * <p>
      */
-    @ConfigItem
-    public Optional<Boolean> keepAlive;
+    @ConfigItem(defaultValue = "true")
+    public boolean keepAlive;
 
     /**
      * Set if ESMTP should be tried as first command (EHLO).
+     * {@code false} by default.
      */
     @ConfigItem
-    public Optional<Boolean> disableEsmtp;
+    public boolean disableEsmtp;
 
     /**
      * Set the TLS security mode for the connection.

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfig.java
@@ -20,7 +20,7 @@ public class MailConfig {
     /**
      * Enables the mock mode, not sending emails.
      * The content of the emails is printed on the console.
-     *
+     * <p>
      * Disabled by default.
      */
     @ConfigItem
@@ -71,7 +71,8 @@ public class MailConfig {
     public boolean trustAll;
 
     /**
-     * The pool maximum size.
+     * Configures the maximum allowed number of open connections to the mail server
+     * If not set the default is {@code 10}.
      */
     @ConfigItem
     public OptionalInt maxPoolSize;
@@ -92,8 +93,9 @@ public class MailConfig {
     public boolean keepAlive;
 
     /**
-     * Set if ESMTP should be tried as first command (EHLO).
-     * {@code false} by default.
+     * Disable ESMTP. {@code false} by default.
+     * The RFC-1869 states that clients should always attempt {@code EHLO} as first command to determine if ESMTP
+     * is supported, if this returns an error code, {@code HELO} is tried to use the <em>regular</em> SMTP command.
      */
     @ConfigItem
     public boolean disableEsmtp;

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfigTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfigTemplate.java
@@ -49,9 +49,9 @@ public class MailConfigTemplate {
     private io.vertx.ext.mail.MailConfig toVertxMailConfig(MailConfig config) {
         io.vertx.ext.mail.MailConfig cfg = new io.vertx.ext.mail.MailConfig();
         config.authMethods.ifPresent(cfg::setAuthMethods);
-        config.disableEsmtp.ifPresent(cfg::setDisableEsmtp);
+        cfg.setDisableEsmtp(config.disableEsmtp);
         cfg.setHostname(config.host);
-        config.keepAlive.ifPresent(cfg::setKeepAlive);
+        cfg.setKeepAlive(config.keepAlive);
         config.keyStore.ifPresent(cfg::setKeyStore);
         config.keyStorePassword.ifPresent(cfg::setKeyStorePassword);
         config.login.ifPresent(s -> cfg.setLogin(LoginOption.valueOf(s.toUpperCase())));
@@ -60,9 +60,9 @@ public class MailConfigTemplate {
         config.username.ifPresent(cfg::setUsername);
         config.password.ifPresent(cfg::setPassword);
         config.port.ifPresent(cfg::setPort);
-        config.ssl.ifPresent(cfg::setSsl);
+        cfg.setSsl(config.ssl);
         config.startTLS.ifPresent(s -> cfg.setStarttls(StartTLSOptions.valueOf(s.toUpperCase())));
-        config.trustAll.ifPresent(cfg::setTrustAll);
+        cfg.setTrustAll(config.trustAll);
         return cfg;
     }
 

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfigTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/MailConfigTemplate.java
@@ -1,0 +1,74 @@
+package io.quarkus.mailer.impl;
+
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Template;
+import io.vertx.core.Vertx;
+import io.vertx.ext.mail.LoginOption;
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.StartTLSOptions;
+
+@Template
+public class MailConfigTemplate {
+
+    private static volatile MailClient client;
+
+    public RuntimeValue<MailClient> configureTheClient(RuntimeValue<Vertx> vertx, BeanContainer container,
+            MailConfig config, LaunchMode launchMode, ShutdownContext shutdown) {
+
+        initialize(vertx.getValue(), config);
+
+        MailClientProducer producer = container.instance(MailClientProducer.class);
+        producer.initialize(client);
+
+        if (!launchMode.isDevOrTest()) {
+            shutdown.addShutdownTask(this::close);
+        }
+        return new RuntimeValue<>(client);
+    }
+
+    public RuntimeValue<ReactiveMailerImpl> configureTheMailer(BeanContainer container, MailConfig config) {
+
+        ReactiveMailerImpl mailer = container.instance(ReactiveMailerImpl.class);
+        mailer.configure(config.from, config.bounceAddress, config.mock);
+
+        return new RuntimeValue<>(mailer);
+    }
+
+    void initialize(Vertx vertx, MailConfig config) {
+        if (client != null) {
+            // Already configured
+            return;
+        }
+        io.vertx.ext.mail.MailConfig cfg = toVertxMailConfig(config);
+        client = MailClient.createNonShared(vertx, cfg);
+    }
+
+    private io.vertx.ext.mail.MailConfig toVertxMailConfig(MailConfig config) {
+        io.vertx.ext.mail.MailConfig cfg = new io.vertx.ext.mail.MailConfig();
+        config.authMethods.ifPresent(cfg::setAuthMethods);
+        config.disableEsmtp.ifPresent(cfg::setDisableEsmtp);
+        cfg.setHostname(config.host);
+        config.keepAlive.ifPresent(cfg::setKeepAlive);
+        config.keyStore.ifPresent(cfg::setKeyStore);
+        config.keyStorePassword.ifPresent(cfg::setKeyStorePassword);
+        config.login.ifPresent(s -> cfg.setLogin(LoginOption.valueOf(s.toUpperCase())));
+        config.maxPoolSize.ifPresent(cfg::setMaxPoolSize);
+        config.ownHostName.ifPresent(cfg::setOwnHostname);
+        config.username.ifPresent(cfg::setUsername);
+        config.password.ifPresent(cfg::setPassword);
+        config.port.ifPresent(cfg::setPort);
+        config.ssl.ifPresent(cfg::setSsl);
+        config.startTLS.ifPresent(s -> cfg.setStarttls(StartTLSOptions.valueOf(s.toUpperCase())));
+        config.trustAll.ifPresent(cfg::setTrustAll);
+        return cfg;
+    }
+
+    void close() {
+        if (client != null) {
+            client.close();
+        }
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/ReactiveMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/ReactiveMailerImpl.java
@@ -177,9 +177,9 @@ public class ReactiveMailerImpl implements ReactiveMailer {
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    void configure(Optional<String> from, Optional<String> bounceAddress, Optional<Boolean> mock) {
+    void configure(Optional<String> from, Optional<String> bounceAddress, boolean mock) {
         this.from = from.orElse(null);
         this.bounceAddress = bounceAddress.orElse(null);
-        this.mock = mock.orElse(false);
+        this.mock = mock;
     }
 }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/ReactiveMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/impl/ReactiveMailerImpl.java
@@ -1,0 +1,169 @@
+package io.quarkus.mailer.impl;
+
+import static java.util.Arrays.stream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.mailer.Attachment;
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.ReactiveMailer;
+import io.vertx.axle.core.Vertx;
+import io.vertx.axle.ext.mail.MailClient;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.mail.MailAttachment;
+import io.vertx.ext.mail.MailMessage;
+
+@ApplicationScoped
+public class ReactiveMailerImpl implements ReactiveMailer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("quarkus-mailer");
+
+    @Inject
+    MailClient client;
+
+    @Inject
+    Vertx vertx;
+
+    /**
+     * Default from value.
+     */
+    private String from;
+
+    /**
+     * Default bounce address.
+     */
+    private String bounceAddress;
+
+    /**
+     * If {@code true}, mails are not sent to the server, the body is printed in the console.
+     */
+    private boolean mock;
+
+    @Override
+    public CompletionStage<Void> send(Mail... mails) {
+        if (mails == null) {
+            throw new IllegalArgumentException("The `mails` parameter must not be `null`");
+        }
+
+        return allOf(
+                stream(mails)
+                        .map(mail -> toMailMessage(mail).thenCompose(this::send))
+                        .collect(Collectors.toList()));
+    }
+
+    private CompletionStage<Void> send(MailMessage message) {
+        if (mock) {
+            LOGGER.info("Sending email {} from {} to {}, body is: \n{}",
+                    message.getSubject(), message.getFrom(), message.getTo(),
+                    message.getHtml() == null ? message.getText() : message.getHtml());
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return client.sendMail(message)
+                    .thenAccept(x -> {
+                    }); // Discard result.
+        }
+    }
+
+    private CompletionStage<MailMessage> toMailMessage(Mail mail) {
+        MailMessage message = new MailMessage();
+
+        if (mail.getBounceAddress() != null) {
+            message.setBounceAddress(mail.getBounceAddress());
+        } else {
+            message.setBounceAddress(this.bounceAddress);
+        }
+
+        if (mail.getFrom() != null) {
+            message.setFrom(mail.getFrom());
+        } else {
+            message.setFrom(this.from);
+        }
+
+        message.setTo(mail.getTo());
+        message.setCc(mail.getCc());
+        message.setBcc(mail.getBcc());
+        message.setSubject(mail.getSubject());
+        message.setText(mail.getText());
+        message.setHtml(mail.getHtml());
+        message.setHeaders(toMultimap(mail.getHeaders()));
+
+        List<CompletionStage<?>> stages = new ArrayList<>();
+        List<MailAttachment> attachments = new CopyOnWriteArrayList<>();
+        List<MailAttachment> inline = new CopyOnWriteArrayList<>();
+        for (Attachment attachment : mail.getAttachments()) {
+            if (attachment.isInlineAttachment()) {
+                stages.add(toMailAttachment(attachment).thenAccept(inline::add));
+            } else {
+                stages.add(toMailAttachment(attachment).thenAccept(attachments::add));
+            }
+        }
+
+        return allOf(stages).thenApply(x -> {
+            message.setAttachment(attachments);
+            message.setInlineAttachment(inline);
+            return message;
+        });
+    }
+
+    private MultiMap toMultimap(Map<String, List<String>> headers) {
+        MultiMap mm = MultiMap.caseInsensitiveMultiMap();
+        headers.forEach(mm::add);
+        return mm;
+    }
+
+    private CompletionStage<MailAttachment> toMailAttachment(Attachment attachment) {
+        MailAttachment attach = new MailAttachment();
+        attach.setName(attachment.getName());
+        attach.setContentId(attachment.getContentId());
+        attach.setDescription(attachment.getDescription());
+        attach.setDisposition(attachment.getDisposition());
+        attach.setContentType(attachment.getContentType());
+
+        if ((attachment.getFile() == null && attachment.getData() == null) // No content
+                || (attachment.getFile() != null && attachment.getData() != null)) // Too much content
+        {
+
+            throw new IllegalArgumentException("An attachment must contain either a file or a raw data");
+        }
+
+        if (attachment.getData() != null) {
+            attach.setData(Buffer.buffer(attachment.getData()));
+            return CompletableFuture.completedFuture(attach);
+        } else {
+            // File, must be read asynchronously
+            CompletionStage<io.vertx.axle.core.buffer.Buffer> stage = vertx.fileSystem()
+                    .readFile(attachment.getFile().getAbsolutePath());
+
+            return stage.thenApply(b -> attach.setData(b.getDelegate()));
+        }
+
+    }
+
+    private static CompletionStage<Void> allOf(List<CompletionStage<?>> stages) {
+        CompletableFuture<?>[] array = stages.stream()
+                .map(CompletionStage::toCompletableFuture)
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(array);
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    void configure(Optional<String> from, Optional<String> bounceAddress, Optional<Boolean> mock) {
+        this.from = from.orElse(null);
+        this.bounceAddress = bounceAddress.orElse(null);
+        this.mock = mock.orElse(false);
+    }
+}

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/AttachmentTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/AttachmentTest.java
@@ -1,0 +1,272 @@
+package io.quarkus.mailer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import io.quarkus.mailer.impl.ReactiveMailerImpl;
+import io.vertx.axle.core.Vertx;
+import io.vertx.core.file.OpenOptions;
+
+class AttachmentTest {
+
+    private static final File LOREM = new File("src/test/resources/lorem-ipsum.txt");
+    private static final String BEGINNING = "Sed ut perspiciatis unde omnis iste natus error sit";
+    private static final String DESCRIPTION = "my lorem ipsum";
+    private static Vertx vertx;
+
+    @BeforeAll
+    static void init() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void closing() {
+        vertx.close().toCompletableFuture().join();
+    }
+
+    @Test
+    void testAttachmentCreationFromFile() {
+        Attachment attachment = new Attachment("lorem.txt", LOREM, "text/plain");
+        assertThat(attachment.getFile()).isFile();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(attachment.getContentId()).isNull();
+        assertThat(attachment.getDescription()).isNull();
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNull();
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).startsWith(BEGINNING);
+    }
+
+    @Test
+    void testInlineAttachmentCreationFromFile() {
+        Attachment attachment = new Attachment("lorem.txt", LOREM, "text/plain", "my-file");
+        assertThat(attachment.getFile()).isFile();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_INLINE);
+        assertThat(attachment.getContentId()).isEqualTo("<my-file>");
+        assertThat(attachment.getDescription()).isNull();
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNull();
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).startsWith(BEGINNING);
+    }
+
+    @Test
+    void testAttachmentCreationFromStream() {
+        Publisher<Byte> publisher = vertx.fileSystem().open(LOREM.getAbsolutePath(), new OpenOptions().setRead(true))
+                .thenApply(af -> af.toPublisherBuilder().flatMapIterable(buffer -> () -> new Iterator<Byte>() {
+                    private int index = 0;
+                    private byte[] bytes = buffer.getBytes();
+
+                    @Override
+                    public boolean hasNext() {
+                        return bytes.length > index;
+                    }
+
+                    @Override
+                    public Byte next() {
+                        if (!hasNext()) {
+                            throw new NoSuchElementException();
+                        }
+                        return bytes[index++];
+                    }
+                }).buildRs())
+                .toCompletableFuture()
+                .join();
+
+        Attachment attachment = new Attachment("lorem.txt", publisher, "text/plain");
+        assertThat(attachment.getFile()).isNull();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(attachment.getContentId()).isNull();
+        assertThat(attachment.getDescription()).isNull();
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNotNull().isEqualTo(publisher);
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).startsWith(BEGINNING);
+    }
+
+    @Test
+    void testInlineAttachmentCreationFromStream() {
+        Publisher<Byte> publisher = vertx.fileSystem().open(LOREM.getAbsolutePath(), new OpenOptions().setRead(true))
+                .thenApply(af -> af.toPublisherBuilder().flatMapIterable(buffer -> () -> new Iterator<Byte>() {
+                    private int index = 0;
+                    private byte[] bytes = buffer.getBytes();
+
+                    @Override
+                    public boolean hasNext() {
+                        return bytes.length > index;
+                    }
+
+                    @Override
+                    public Byte next() {
+                        if (!hasNext()) {
+                            throw new NoSuchElementException();
+                        }
+                        return bytes[index++];
+                    }
+                }).buildRs())
+                .toCompletableFuture()
+                .join();
+
+        Attachment attachment = new Attachment("lorem.txt", publisher, "text/plain", "<my-id>");
+        assertThat(attachment.getFile()).isNull();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_INLINE);
+        assertThat(attachment.getContentId()).isEqualTo("<my-id>");
+        assertThat(attachment.getDescription()).isNull();
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNotNull().isEqualTo(publisher);
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).startsWith(BEGINNING);
+    }
+
+    @Test
+    void testAttachmentCreationWithDescription() {
+        Publisher<Byte> publisher = vertx.fileSystem().open(LOREM.getAbsolutePath(), new OpenOptions().setRead(true))
+                .thenApply(af -> af.toPublisherBuilder().flatMapIterable(buffer -> () -> new Iterator<Byte>() {
+                    private int index = 0;
+                    private byte[] bytes = buffer.getBytes();
+
+                    @Override
+                    public boolean hasNext() {
+                        return bytes.length > index;
+                    }
+
+                    @Override
+                    public Byte next() {
+                        if (!hasNext()) {
+                            throw new NoSuchElementException();
+                        }
+                        return bytes[index++];
+                    }
+                }).buildRs())
+                .toCompletableFuture()
+                .join();
+
+        Attachment attachment = new Attachment("lorem.txt", publisher, "text/plain",
+                DESCRIPTION, Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(attachment.getFile()).isNull();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(attachment.getContentId()).isNull();
+        assertThat(attachment.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNotNull().isEqualTo(publisher);
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).startsWith(BEGINNING);
+    }
+
+    @Test
+    void testInlineAttachmentCreationWithDescription() {
+        Publisher<Byte> publisher = vertx.fileSystem().open(LOREM.getAbsolutePath(), new OpenOptions().setRead(true))
+                .thenApply(af -> af.toPublisherBuilder().flatMapIterable(buffer -> () -> new Iterator<Byte>() {
+                    private int index = 0;
+                    private byte[] bytes = buffer.getBytes();
+
+                    @Override
+                    public boolean hasNext() {
+                        return bytes.length > index;
+                    }
+
+                    @Override
+                    public Byte next() {
+                        if (!hasNext()) {
+                            throw new NoSuchElementException();
+                        }
+                        return bytes[index++];
+                    }
+                }).buildRs())
+                .toCompletableFuture()
+                .join();
+
+        Attachment attachment = new Attachment("lorem.txt", publisher, "text/plain",
+                DESCRIPTION, Attachment.DISPOSITION_INLINE);
+        assertThat(attachment.getFile()).isNull();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_INLINE);
+        assertThat(attachment.getContentId()).isNull();
+        assertThat(attachment.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNotNull().isEqualTo(publisher);
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).startsWith(BEGINNING);
+    }
+
+    @Test
+    void testAttachmentCreationWithByteArray() {
+        String payload = UUID.randomUUID().toString();
+        byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
+
+        Attachment attachment = new Attachment("lorem.txt", bytes, "text/plain",
+                DESCRIPTION, Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(attachment.getFile()).isNull();
+        assertThat(attachment.getName()).isEqualTo("lorem.txt");
+        assertThat(attachment.getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(attachment.getContentId()).isNull();
+        assertThat(attachment.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(attachment.getContentType()).isEqualTo("text/plain");
+        assertThat(attachment.getData()).isNotNull();
+
+        String content = ReactiveMailerImpl.getAttachmentStream(vertx, attachment)
+                .thenApply(buffer -> buffer.toString("UTF-8"))
+                .toCompletableFuture().join();
+        assertThat(content).isEqualTo(payload);
+    }
+
+    @Test
+    void testCreationWithEmptyContent() {
+        Attachment attachment1 = new Attachment("attachment-1", (byte[]) null, "text/plain");
+        Attachment attachment2 = new Attachment("attachment-2", new byte[0], "text/plain");
+        Attachment attachment3 = new Attachment("attachment-3", ReactiveStreams.<Byte> empty().buildRs(), "text/plain");
+
+        assertThat(ReactiveStreams.fromPublisher(attachment1.getData()).findFirst().run().toCompletableFuture().join())
+                .isEmpty();
+        assertThat(ReactiveStreams.fromPublisher(attachment2.getData()).findFirst().run().toCompletableFuture().join())
+                .isEmpty();
+        assertThat(ReactiveStreams.fromPublisher(attachment3.getData()).findFirst().run().toCompletableFuture().join())
+                .isEmpty();
+    }
+
+    @Test
+    void testCreationFromMissingFile() {
+        File missing = new File("missing");
+        Attachment attachment = new Attachment("missing", missing, "text/plain");
+        Assertions.assertThrows(ExecutionException.class, () -> {
+            ReactiveMailerImpl.getAttachmentStream(vertx, attachment).toCompletableFuture().get();
+        });
+    }
+
+}

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/MailTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/MailTest.java
@@ -1,0 +1,184 @@
+package io.quarkus.mailer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.File;
+import java.util.*;
+
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.axle.core.Vertx;
+
+class MailTest {
+
+    private static final File LOREM = new File("src/test/resources/lorem-ipsum.txt");
+    private static final String BEGINNING = "Sed ut perspiciatis unde omnis iste natus error sit";
+    private static final String DESCRIPTION = "my lorem ipsum";
+    private static final String TO_ADDRESS = "quarkus@quarkus.io";
+    private static final String TEXT_PLAIN = "text/plain";
+    private static Vertx vertx;
+
+    @BeforeAll
+    static void init() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void closing() {
+        vertx.close().toCompletableFuture().join();
+    }
+
+    @Test
+    void testSimpleTextEmail() {
+        Mail mail = new Mail().addTo(TO_ADDRESS).setSubject("test").setText(BEGINNING)
+                .setFrom("from@quarkus.io")
+                .setReplyTo("reply-to@quarkus.io")
+                .setBounceAddress("bounce@quarkus.io");
+        assertThat(mail.getTo()).containsExactly(TO_ADDRESS);
+        assertThat(mail.getSubject()).isEqualTo("test");
+        assertThat(mail.getText()).isEqualTo(BEGINNING);
+        assertThat(mail.getHtml()).isNull();
+        assertThat(mail.getFrom()).isEqualTo("from@quarkus.io");
+        assertThat(mail.getReplyTo()).isEqualTo("reply-to@quarkus.io");
+        assertThat(mail.getBounceAddress()).isEqualTo("bounce@quarkus.io");
+    }
+
+    @Test
+    void testSimpleHTMLEmail() {
+        Mail mail = new Mail().addTo(TO_ADDRESS).setSubject("test").setHtml(BEGINNING);
+        assertThat(mail.getTo()).containsExactly(TO_ADDRESS);
+        assertThat(mail.getSubject()).isEqualTo("test");
+        assertThat(mail.getText()).isNull();
+        assertThat(mail.getHtml()).isEqualTo(BEGINNING);
+    }
+
+    @Test
+    void testMailWithMultipleReceivers() {
+        Mail mail = new Mail()
+                .addTo("to1@quarkus.io", "to2@quarkus.io")
+                .addCc("cc1@quarkus.io", "cc2@quarkus.io")
+                .addBcc("bcc1@quarkus.io", "bcc2@quarkus.io");
+
+        assertThat(mail.getTo()).containsExactly("to1@quarkus.io", "to2@quarkus.io");
+        assertThat(mail.getCc()).containsExactly("cc1@quarkus.io", "cc2@quarkus.io");
+        assertThat(mail.getBcc()).containsExactly("bcc1@quarkus.io", "bcc2@quarkus.io");
+    }
+
+    @Test
+    void testMailWithMultipleReceiversSet() {
+        Mail mail = new Mail()
+                .setTo(Arrays.asList("to1@quarkus.io", "to2@quarkus.io"))
+                .setCc(Arrays.asList("cc1@quarkus.io", "cc2@quarkus.io"))
+                .setBcc(Arrays.asList("bcc1@quarkus.io", "bcc2@quarkus.io"));
+
+        assertThat(mail.getTo()).containsExactly("to1@quarkus.io", "to2@quarkus.io");
+        assertThat(mail.getCc()).containsExactly("cc1@quarkus.io", "cc2@quarkus.io");
+        assertThat(mail.getBcc()).containsExactly("bcc1@quarkus.io", "bcc2@quarkus.io");
+    }
+
+    @Test
+    void testMailWithReceiversSetWithNull() {
+        Mail mail = new Mail()
+                .setTo(null)
+                .setCc(null)
+                .setBcc(null);
+
+        assertThat(mail.getTo()).isEmpty();
+        assertThat(mail.getCc()).isEmpty();
+        assertThat(mail.getBcc()).isEmpty();
+    }
+
+    @Test
+    void testMailWithAttachments() {
+        Mail mail1 = new Mail().addAttachment("some-name-1", LOREM, TEXT_PLAIN);
+        assertThat(mail1.getAttachments()).hasSize(1);
+        assertThat(mail1.getAttachments().get(0).getName()).isEqualTo("some-name-1");
+        assertThat(mail1.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail1.getAttachments().get(0).getFile()).isFile();
+        assertThat(mail1.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+
+        Mail mail2 = new Mail().addAttachment("some-name-2", BEGINNING.getBytes(), TEXT_PLAIN);
+        assertThat(mail2.getAttachments()).hasSize(1);
+        assertThat(mail2.getAttachments().get(0).getName()).isEqualTo("some-name-2");
+        assertThat(mail2.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail2.getAttachments().get(0).getData()).isNotNull();
+        assertThat(mail2.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+
+        Mail mail3 = new Mail().addAttachment("some-name-3",
+                ReactiveStreams.of(0, 1, 2).map(Integer::byteValue).buildRs(), TEXT_PLAIN);
+        assertThat(mail3.getAttachments()).hasSize(1);
+        assertThat(mail3.getAttachments().get(0).getName()).isEqualTo("some-name-3");
+        assertThat(mail3.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail3.getAttachments().get(0).getData()).isNotNull();
+        assertThat(mail3.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+
+        Mail mail4 = new Mail().addAttachment("some-name-4",
+                ReactiveStreams.of(0, 1, 2).map(Integer::byteValue).buildRs(), TEXT_PLAIN,
+                DESCRIPTION, Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(mail4.getAttachments()).hasSize(1);
+        assertThat(mail4.getAttachments().get(0).getName()).isEqualTo("some-name-4");
+        assertThat(mail4.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail4.getAttachments().get(0).getData()).isNotNull();
+        assertThat(mail4.getAttachments().get(0).getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(mail4.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+
+        Mail mail5 = new Mail().addAttachment("some-name-5", BEGINNING.getBytes(), TEXT_PLAIN,
+                DESCRIPTION, Attachment.DISPOSITION_ATTACHMENT);
+        assertThat(mail5.getAttachments()).hasSize(1);
+        assertThat(mail5.getAttachments().get(0).getName()).isEqualTo("some-name-5");
+        assertThat(mail5.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail5.getAttachments().get(0).getData()).isNotNull();
+        assertThat(mail5.getAttachments().get(0).getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(mail5.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
+    }
+
+    @Test
+    void testMailWithInlineAttachments() {
+        Mail mail1 = new Mail().addInlineAttachment("name-1", LOREM, TEXT_PLAIN, "cid-1");
+        assertThat(mail1.getAttachments()).hasSize(1);
+        assertThat(mail1.getAttachments().get(0).getName()).isEqualTo("name-1");
+        assertThat(mail1.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail1.getAttachments().get(0).getFile()).isFile();
+        assertThat(mail1.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_INLINE);
+        assertThat(mail1.getAttachments().get(0).getContentId()).isEqualTo("<cid-1>");
+
+        Mail mail2 = new Mail().addInlineAttachment("name-2", BEGINNING.getBytes(), TEXT_PLAIN, "cid-2");
+        assertThat(mail2.getAttachments()).hasSize(1);
+        assertThat(mail2.getAttachments().get(0).getName()).isEqualTo("name-2");
+        assertThat(mail2.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail2.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_INLINE);
+        assertThat(mail2.getAttachments().get(0).getContentId()).isEqualTo("<cid-2>");
+
+        Mail mail3 = new Mail().addInlineAttachment("name-3",
+                ReactiveStreams.of(0, 1, 2).map(Integer::byteValue).buildRs(), TEXT_PLAIN, "cid-3");
+        assertThat(mail3.getAttachments()).hasSize(1);
+        assertThat(mail3.getAttachments().get(0).getName()).isEqualTo("name-3");
+        assertThat(mail3.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
+        assertThat(mail3.getAttachments().get(0).getData()).isNotNull();
+        assertThat(mail3.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_INLINE);
+        assertThat(mail3.getAttachments().get(0).getContentId()).isEqualTo("<cid-3>");
+    }
+
+    @Test
+    void testHeaders() {
+        Mail mail = new Mail()
+                .addHeader("foo", "bar").addHeader("multiple", "a", "b", "c");
+        assertThat(mail.getHeaders()).hasSize(2).contains(entry("foo", Collections.singletonList("bar")),
+                entry("multiple", Arrays.asList("a", "b", "c")));
+
+        mail.removeHeader("foo");
+        assertThat(mail.getHeaders()).hasSize(1).containsKeys("multiple");
+
+        Map<String, List<String>> headers = Collections.singletonMap("X-header", Collections.singletonList("foo"));
+        mail.setHeaders(headers);
+        assertThat(mail.getHeaders()).hasSize(1).containsKeys("X-header");
+
+        mail.setHeaders(null);
+        assertThat(mail.getHeaders()).isEmpty();
+    }
+
+}

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
@@ -1,0 +1,242 @@
+package io.quarkus.mailer.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+import javax.mail.BodyPart;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.subethamail.wiser.Wiser;
+import org.subethamail.wiser.WiserMessage;
+
+import io.quarkus.mailer.Mail;
+import io.vertx.axle.core.Vertx;
+import io.vertx.axle.ext.mail.MailClient;
+import io.vertx.ext.mail.MailConfig;
+
+class MailerImplTest {
+
+    private static final String FROM = "test@test.org";
+    private static final String TO = "foo@quarkus.io";
+    private static final String TEXT_CONTENT_TYPE = "text/plain";
+
+    private static Wiser wiser;
+    private static Vertx vertx;
+    private ReactiveMailerImpl mailer;
+
+    @BeforeAll
+    static void startWiser() {
+        wiser = new Wiser();
+        wiser.setPort(1537);
+        wiser.start();
+
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void stopWiser() {
+        wiser.stop();
+        vertx.close();
+    }
+
+    @BeforeEach
+    void init() {
+        mailer = new ReactiveMailerImpl();
+        mailer.configure(Optional.of(FROM), Optional.empty(), Optional.of(false));
+        mailer.vertx = vertx;
+        mailer.client = MailClient.createShared(mailer.vertx,
+                new MailConfig().setPort(1537));
+
+        wiser.getMessages().clear();
+    }
+
+    @Test
+    void testTextMail() throws MessagingException, IOException {
+        String content = UUID.randomUUID().toString();
+        mailer.send(Mail.withText(TO, "Test", content)).toCompletableFuture().join();
+        assertThat(wiser.getMessages()).hasSize(1);
+        WiserMessage actual = wiser.getMessages().get(0);
+        assertThat(getContent(actual)).contains(content);
+        MimeMessage msg = actual.getMimeMessage();
+        List<String> types = getContentTypesFromMimeMultipart((MimeMultipart) actual.getMimeMessage().getContent());
+        assertThat(types).containsExactly(TEXT_CONTENT_TYPE);
+        assertThat(msg.getSubject()).isEqualTo("Test");
+        assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
+        assertThat(msg.getAllRecipients()).hasSize(1).contains(new InternetAddress(TO));
+    }
+
+    @Test
+    void testHTMLMail() throws MessagingException, IOException {
+        String content = UUID.randomUUID().toString();
+        mailer.send(Mail.withHtml(TO, "Test", "<h1>" + content + "</h1>")).toCompletableFuture().join();
+        assertThat(wiser.getMessages()).hasSize(1);
+        WiserMessage actual = wiser.getMessages().get(0);
+        assertThat(getContent(actual)).contains("<h1>" + content + "</h1>");
+        List<String> types = getContentTypesFromMimeMultipart((MimeMultipart) actual.getMimeMessage().getContent());
+        assertThat(types).containsExactly("text/html");
+        MimeMessage msg = actual.getMimeMessage();
+        assertThat(msg.getSubject()).isEqualTo("Test");
+        assertThat(msg.getContentType()).startsWith("multipart/");
+        assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
+        assertThat(msg.getAllRecipients()).hasSize(1).contains(new InternetAddress(TO));
+    }
+
+    @Test
+    void testWithSeveralMails() {
+        Mail mail1 = Mail.withText(TO, "Mail 1", "Mail 1").addCc("cc@quarkus.io").addBcc("bcc@quarkus.io");
+        Mail mail2 = Mail.withHtml(TO, "Mail 2", "<strong>Mail 2</strong>").addCc("cc2@quarkus.io").addBcc("bcc2@quarkus.io");
+        mailer.send(mail1, mail2).toCompletableFuture().join();
+        assertThat(wiser.getMessages()).hasSize(6);
+    }
+
+    @Test
+    void testHeaders() throws MessagingException {
+        mailer.send(Mail.withText(TO, "Test", "testHeaders")
+                .addHeader("X-header", "value")
+                .addHeader("X-header-2", "value1", "value2"))
+                .toCompletableFuture().join();
+        assertThat(wiser.getMessages()).hasSize(1);
+        WiserMessage actual = wiser.getMessages().get(0);
+        MimeMessage msg = actual.getMimeMessage();
+        assertThat(msg.getSubject()).isEqualTo("Test");
+        assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
+        assertThat(msg.getHeader("X-header")).hasSize(1).contains("value");
+        assertThat(msg.getHeader("X-header-2")).hasSize(2).contains("value1", "value2");
+    }
+
+    @Test
+    void testAttachment() throws MessagingException, IOException {
+        String payload = UUID.randomUUID().toString();
+        mailer.send(Mail.withText(TO, "Test", "testAttachment")
+                .addAttachment("my-file.txt", payload.getBytes(), TEXT_CONTENT_TYPE)).toCompletableFuture().join();
+        assertThat(wiser.getMessages()).hasSize(1);
+        WiserMessage actual = wiser.getMessages().get(0);
+        assertThat(getContent(actual)).contains("testAttachment");
+        MimeMessage msg = actual.getMimeMessage();
+        assertThat(msg.getSubject()).isEqualTo("Test");
+        assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
+        String value = getAttachment("my-file.txt", (MimeMultipart) actual.getMimeMessage().getContent());
+        assertThat(value).isEqualTo(payload);
+    }
+
+    @Test
+    void testInlineAttachment() throws MessagingException, IOException {
+        String cid = "<" + UUID.randomUUID().toString() + "@acme>";
+        mailer.send(Mail.withHtml(TO, "Test", "testInlineAttachment")
+                .addInlineAttachment("inline.txt", "my inlined text".getBytes(), TEXT_CONTENT_TYPE, cid)).toCompletableFuture()
+                .join();
+        assertThat(wiser.getMessages()).hasSize(1);
+        WiserMessage actual = wiser.getMessages().get(0);
+        assertThat(getContent(actual)).contains("testInlineAttachment");
+        MimeMessage msg = actual.getMimeMessage();
+        assertThat(msg.getSubject()).isEqualTo("Test");
+        assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
+
+        String value = getInlineAttachment(cid, (MimeMultipart) actual.getMimeMessage().getContent());
+        assertThat(value).isEqualTo("my inlined text");
+    }
+
+    @Test
+    void testAttachments() throws MessagingException, IOException {
+        mailer.send(Mail.withText(TO, "Test", "Simple Test")
+                .addAttachment("some-data.txt", "Hello".getBytes(), TEXT_CONTENT_TYPE)
+                .addAttachment("some-data-2.txt", "Hello 2".getBytes(), TEXT_CONTENT_TYPE)).toCompletableFuture().join();
+        assertThat(wiser.getMessages()).hasSize(1);
+        WiserMessage actual = wiser.getMessages().get(0);
+        assertThat(getContent(actual)).contains("Simple Test");
+        MimeMessage msg = actual.getMimeMessage();
+        assertThat(msg.getSubject()).isEqualTo("Test");
+        assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
+        String value = getAttachment("some-data.txt", (MimeMultipart) actual.getMimeMessage().getContent());
+        assertThat(value).isEqualTo("Hello");
+        value = getAttachment("some-data-2.txt", (MimeMultipart) actual.getMimeMessage().getContent());
+        assertThat(value).isEqualTo("Hello 2");
+    }
+
+    private String getContent(WiserMessage msg) {
+        try {
+            return getTextFromMimeMultipart((MimeMultipart) msg.getMimeMessage().getContent());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String getAttachment(String name, MimeMultipart multipart) throws IOException, MessagingException {
+        for (int i = 0; i < multipart.getCount(); i++) {
+            BodyPart bodyPart = multipart.getBodyPart(i);
+            if (bodyPart.getFileName() != null && bodyPart.getFileName().equalsIgnoreCase(name)) {
+                assertThat(bodyPart.getContentType()).startsWith(TEXT_CONTENT_TYPE);
+                return read(bodyPart);
+            }
+        }
+        return null;
+    }
+
+    private String getInlineAttachment(String cid, MimeMultipart multipart) throws IOException, MessagingException {
+        for (int i = 0; i < multipart.getCount(); i++) {
+            BodyPart bodyPart = multipart.getBodyPart(i);
+            if (bodyPart.getContent() instanceof MimeMultipart) {
+                for (int j = 0; j < ((MimeMultipart) bodyPart.getContent()).getCount(); j++) {
+                    BodyPart nested = ((MimeMultipart) bodyPart.getContent()).getBodyPart(j);
+                    if (nested.getHeader("Content-ID") != null && nested.getHeader("Content-ID")[0].equalsIgnoreCase(cid)) {
+                        assertThat(nested.getDisposition()).isEqualTo("inline");
+                        assertThat(nested.getContentType()).startsWith(TEXT_CONTENT_TYPE);
+                        return read(nested);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private String read(BodyPart part) throws IOException, MessagingException {
+        try (InputStream is = part.getInputStream()) {
+            Scanner s = new Scanner(is).useDelimiter("\\A");
+            return s.hasNext() ? s.next() : "";
+        }
+    }
+
+    private String getTextFromMimeMultipart(
+            MimeMultipart mimeMultipart) throws MessagingException, IOException {
+        StringBuilder result = new StringBuilder();
+        int count = mimeMultipart.getCount();
+        for (int i = 0; i < count; i++) {
+            BodyPart bodyPart = mimeMultipart.getBodyPart(i);
+            if (bodyPart.isMimeType(TEXT_CONTENT_TYPE)) {
+                result.append("\n").append(bodyPart.getContent());
+                break; // without break same text appears twice in my tests
+            } else if (bodyPart.isMimeType("text/html")) {
+                result.append("\n").append(bodyPart.getContent());
+            } else if (bodyPart.getContent() instanceof MimeMultipart) {
+                result.append(getTextFromMimeMultipart((MimeMultipart) bodyPart.getContent()));
+            }
+        }
+        return result.toString();
+    }
+
+    private List<String> getContentTypesFromMimeMultipart(
+            MimeMultipart mimeMultipart) throws MessagingException, IOException {
+        List<String> types = new ArrayList<>();
+        int count = mimeMultipart.getCount();
+        for (int i = 0; i < count; i++) {
+            BodyPart bodyPart = mimeMultipart.getBodyPart(i);
+            if (bodyPart.getContent() instanceof MimeMultipart) {
+                types.addAll(getContentTypesFromMimeMultipart((MimeMultipart) bodyPart.getContent()));
+            } else {
+                types.add(bodyPart.getContentType());
+            }
+        }
+        return types;
+    }
+
+}

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
@@ -54,7 +54,7 @@ class MailerImplTest {
     @BeforeEach
     void init() {
         mailer = new ReactiveMailerImpl();
-        mailer.configure(Optional.of(FROM), Optional.empty(), Optional.of(false));
+        mailer.configure(Optional.of(FROM), Optional.empty(), false);
         mailer.vertx = vertx;
         mailer.client = MailClient.createShared(mailer.vertx,
                 new MailConfig().setPort(wiser.getServer().getPort()));

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
@@ -37,7 +37,7 @@ class MailerImplTest {
     @BeforeAll
     static void startWiser() {
         wiser = new Wiser();
-        wiser.setPort(1537);
+        wiser.setPort(0);
         wiser.start();
 
         vertx = Vertx.vertx();
@@ -55,7 +55,7 @@ class MailerImplTest {
         mailer.configure(Optional.of(FROM), Optional.empty(), Optional.of(false));
         mailer.vertx = vertx;
         mailer.client = MailClient.createShared(mailer.vertx,
-                new MailConfig().setPort(1537));
+                new MailConfig().setPort(wiser.getServer().getPort()));
 
         wiser.getMessages().clear();
     }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/impl/MailerImplTest.java
@@ -131,7 +131,7 @@ class MailerImplTest {
 
     @Test
     void testInlineAttachment() throws MessagingException, IOException {
-        String cid = "<" + UUID.randomUUID().toString() + "@acme>";
+        String cid = UUID.randomUUID().toString() + "@acme";
         mailer.send(Mail.withHtml(TO, "Test", "testInlineAttachment")
                 .addInlineAttachment("inline.txt", "my inlined text".getBytes(), TEXT_CONTENT_TYPE, cid)).toCompletableFuture()
                 .join();
@@ -142,7 +142,7 @@ class MailerImplTest {
         assertThat(msg.getSubject()).isEqualTo("Test");
         assertThat(msg.getFrom()[0].toString()).isEqualTo(FROM);
 
-        String value = getInlineAttachment(cid, (MimeMultipart) actual.getMimeMessage().getContent());
+        String value = getInlineAttachment("<" + cid + ">", (MimeMultipart) actual.getMimeMessage().getContent());
         assertThat(value).isEqualTo("my inlined text");
     }
 

--- a/extensions/mailer/runtime/src/test/resources/lorem-ipsum.txt
+++ b/extensions/mailer/runtime/src/test/resources/lorem-ipsum.txt
@@ -1,0 +1,20 @@
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
+totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta
+sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui
+dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora
+incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum
+exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem
+vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui
+dolorem eum fugiat quo voluptas nulla pariatur?
+
+But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born
+and I will give you a complete account of the system, and expound the actual teachings of the great explorer
+ of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself,
+ because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter
+ consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain
+  pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can
+   procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical
+    exercise, except to obtain some advantage from it? But who has any right to find fault with a man who
+    chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no
+    resultant pleasure?

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -68,6 +68,7 @@
         <module>smallrye-reactive-messaging</module>
         <module>smallrye-reactive-messaging-kafka</module>
         <module>reactive-pg-client</module>
+        <module>mailer</module>
 
         <!-- Data access and validation -->
         <module>narayana-jta</module>


### PR DESCRIPTION
Implementation of an extension to send emails.

The extension is based on an asynchronous and non-blocking mail client (Vert.x Mail client), so does not use `javax.mail`. 

The extension exposed:
* an imperative API (`Mailer`)
* a reactive API (`ReactiveMailer`)
* the underlying Vert.x Mail Client

It supports:

* sending text emails
* sending attachments
* sending HTML images with inline attachments

The extension contains tests and documentation. 

Of course, it works in native mode too. 