### PR TITLE
build: bump jandex-maven-plugin from 1.0.5 to 1.0.6

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -878,16 +878,7 @@
                 <plugin>
                     <groupId>org.jboss.jandex</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
-                    <version>1.0.5</version>
-                    <dependencies>
-                        <!-- For now we need to override and hardcode the jandex version -->
-                        <!-- See also https://github.com/wildfly/jandex-maven-plugin/pull/13 -->
-                        <dependency>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jandex</artifactId>
-                            <version>2.1.1.Final</version>
-                        </dependency>
-                    </dependencies>
+                    <version>1.0.6</version>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
This uses Jandex 2.1.1.Final already