### PR TITLE
Duplicated project.build.sourceEncoding changed to project.reporting.outputEncoding

### DIFF
--- a/devtools/common/src/main/resources/templates/basic-rest/java/pom-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/java/pom-template.ftl
@@ -7,7 +7,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom-template.ftl
@@ -7,7 +7,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 


### PR DESCRIPTION
POM templates - duplicated project.build.sourceEncoding changed to project.reporting.outputEncoding

