### PR TITLE
Skip build and native-image goals when the artifact is POM

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -169,6 +169,12 @@ public class BuildMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+
+        if (project.getPackaging().equals("pom")) {
+            getLog().info("Type of the artifact is POM, skipping build goal");
+            return;
+        }
+
         final Artifact projectArtifact = project.getArtifact();
         final AppArtifact appArtifact = new AppArtifact(projectArtifact.getGroupId(), projectArtifact.getArtifactId(),
                 projectArtifact.getClassifier(), projectArtifact.getArtifactHandler().getExtension(),

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -150,6 +150,11 @@ public class NativeImageMojo extends AbstractMojo {
                     "Please ensure that the 'build' goal has been properly configured for the project - since it is a prerequisite of the 'native-image' goal");
         }
 
+        if (project.getPackaging().equals("pom")) {
+            getLog().info("Type of the artifact is POM, skipping native-image goal");
+            return;
+        }
+
         try (AppCreator appCreator = AppCreator.builder()
                 // configure the build phase we want the app to go through
                 .addPhase(new NativeImagePhase()


### PR DESCRIPTION
Skip build and native-image goals when the artifact is POM

Enables use-case when users have multi-module maven projects and root pom.xml file defines common stuff like quarkus-maven-plugin, native profile and common dependencies.

