### PR TITLE
Explain @ConfigGroup and @ConfigRoot in more details

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -28,6 +28,11 @@ import io.quarkus.runtime.configuration.MemorySize;
 public class FileConfig {
 
     /**
+     * Default file name where logs should be stored.
+     */
+    public static final String DEFAULT_LOG_FILE_NAME = "quarkus.log";
+
+    /**
      * If file logging should be enabled
      */
     @ConfigItem
@@ -40,15 +45,15 @@ public class FileConfig {
     String format;
 
     /**
-     * The file log level
+     * The level of logs to be written into the file.
      */
     @ConfigItem(defaultValue = "ALL")
     Level level;
 
     /**
-     * The file logging log level
+     * The name of the file in which logs will be written.
      */
-    @ConfigItem(defaultValue = "quarkus.log")
+    @ConfigItem(defaultValue = DEFAULT_LOG_FILE_NAME)
     File path;
 
     /**

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -482,7 +482,7 @@ import java.util.logging.Level;
 public class FileConfig {
 
     /**
-     * Enable file logging.
+     * Enable logging to a file.
      */
     @ConfigItem(defaultValue = "true")
     boolean enable;
@@ -494,15 +494,15 @@ public class FileConfig {
     String format;
 
     /**
-     * The file log level.
+     * The level of logs to be written into the file.
      */
     @ConfigItem(defaultValue = "ALL")
     Level level;
 
     /**
-     * The file logging log level.
+     * The name of the file in which logs will be written.
      */
-    @ConfigItem(defaultValue = "quarkus.log")
+    @ConfigItem(defaultValue = "application.log")
     File path;
 
 }
@@ -531,19 +531,36 @@ public class LoggingProcessor {
     LogConfiguration config;
 }
 ----
+
+A configuration property name can be split into segments. For example, a property name like
+`quarkus.log.file.enable` can be split into the following segments:
+
+* `quarkus` - a namespace claimed by {project-name} which is a prefix for all `@ConfigRoot` classes,
+* `log` - a name segment which corresponds to the `LogConfiguration` class annotated with `@ConfigRoot`,
+* `file` - a name segment which corresponds to the `file` field in this class,
+* `enabled` - a name segment which corresponds to `enable` field in `FileConfig` class annotated with `@ConfigGroup`.
+
 <1> The `FileConfig` class is annotated with `@ConfigGroup` to indicate that this is an aggregate
 configuration object containing a collection of configurable properties, rather than being a simple configuration
 key type.
-<2> The `@ConfigRoot` annotation indicates that this object is a configuration root group, whose property names will have a parent only of `quarkus.`.  In this case the properties within the group will begin with `quarkus.log.*`.
-<3> Here the `LoggingProcessor` injects a `LogConfiguration` instance automatically by detecting the `@ConfigRoot` annotation.
+<2> The `@ConfigRoot` annotation indicates that this object is a configuration root group, in this case one which
+corresponds to a `log` segment. A class name is used to link configuration root group with the segment from a
+property name. The `Configuration` part is stripped off from a `LogConfiguration` class name and the remaining `Log`
+is lowercased to become a `log`. Since all `@ConfigRoot` annotated classes uses `quarkus` as a prefix, this finally
+becomes `quarkus.log` and represents the properties which names begin with `quarkus.log.*`.
+<3> Here the `LoggingProcessor` injects a `LogConfiguration` instance automatically by detecting the `@ConfigRoot`
+annotation.
 
-A corresponding `application.properties` file for the `File` values could be:
+A corresponding `application.properties` for the above example could be:
+
 [source%nowrap,properties]
 ----
 quarkus.log.file.enable=true
 quarkus.log.file.level=DEBUG
 quarkus.log.file.path=/tmp/debug.log
 ----
+
+Since `format` is not defined in these properties, the default value from `@ConfigItem` will be used instead.
 
 === Bytecode Recording
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import io.quarkus.runtime.logging.FileConfig;
+
 public class PropertyTestUtil {
 
     public static void setLogFileProperty() {
@@ -30,7 +32,7 @@ public class PropertyTestUtil {
     }
 
     public static String getLogFileLocation() {
-        return getLogFileLocation("quarkus.log");
+        return getLogFileLocation(FileConfig.DEFAULT_LOG_FILE_NAME);
     }
 
     private static String getLogFileLocation(String logFileName) {


### PR DESCRIPTION
Hello.

This commit is in regards to our discussion on Zulip. See https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Extensions for more details.

My concern was in regards to the following statement from the "2.4.6. Configuration Example" in Extensions tutorial here https://quarkus.io/guides/extension-authors-guide.

> 2. The @ConfigRoot annotation indicates that this object is a configuration root group, whose property names will have a parent only of quarkus.. In this case the properties within the group will begin with quarkus.log.*.

Where the code sample looks like this:

```java
@ConfigRoot(phase = ConfigPhase.RUN_TIME)
public class LogConfiguration {

    // ...

    /**
     * Configuration properties for the logging file handler.
     */
    FileConfig file;
}
```

And where point 2 states:

> ... indicates that this object is a configuration root group, whose property names will have a parent only of quarkus.. In this case the properties within the group will begin with quarkus.log.*.

But where is this indication? How this class is linked to `quarkus.log.*`? Is there some declaration missing?

----

This PR is to (hopefully) make this paragraph more clear and to document details you guys provided to me in the Zulip chat, since these details are not explained anywhere else.