### PR TITLE
Add hot reload context

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
@@ -11,7 +11,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
  * A build item that can be used to query the live reload state.
  *
  *
- * It can also be used to store context that that is persistent between hot reloads.
+ * It can also be used to store context information that is persistent between hot reloads.
  */
 public final class LiveReloadBuildItem extends SimpleBuildItem {
 
@@ -45,7 +45,7 @@ public final class LiveReloadBuildItem extends SimpleBuildItem {
     }
 
     /**
-     * If this is a live reload this set contains the set config resources that have changed
+     * If this is a live reload this set contains the config resources that have changed
      *
      */
     public Set<String> getChangedResources() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
@@ -1,0 +1,71 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A build item that can be used to query the live reload state.
+ *
+ *
+ * It can also be used to store context that that is persistent between hot reloads.
+ */
+public final class LiveReloadBuildItem extends SimpleBuildItem {
+
+    private final boolean liveReload;
+    private final Set<String> changedResources;
+    private final Map<Class<?>, Object> reloadContext;
+
+    /**
+     * This constructor should only be used if live reload is not possible
+     */
+    public LiveReloadBuildItem() {
+        liveReload = false;
+        changedResources = Collections.emptySet();
+        this.reloadContext = new ConcurrentHashMap<>();
+    }
+
+    public LiveReloadBuildItem(boolean liveReload, Set<String> changedResources, Map<Class<?>, Object> reloadContext) {
+        this.liveReload = liveReload;
+        this.changedResources = changedResources;
+        this.reloadContext = reloadContext;
+    }
+
+    /**
+     * If this is a reload of an app in the same JVM then this will return true. If it is the first
+     * time this app has started, or the app is not running in developer mode it will return false.
+     *
+     * @return <code>true</code> if this is a live reload
+     */
+    public boolean isLiveReload() {
+        return liveReload;
+    }
+
+    /**
+     * If this is a live reload this set contains the set config resources that have changed
+     *
+     */
+    public Set<String> getChangedResources() {
+        return changedResources;
+    }
+
+    /**
+     * Gets an object from live reload context that is persistent across restarts
+     *
+     * @return
+     */
+    public <T> T getContextObject(Class<T> type) {
+        return (T) reloadContext.get(type);
+    }
+
+    /**
+     * Sets an object into the live reload context that is persistent across restarts
+     *
+     */
+    public <T> void setContextObject(Class<T> type, T val) {
+        reloadContext.put(type, val);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
@@ -55,6 +55,7 @@ import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildIt
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -67,12 +68,6 @@ public class ApplicationArchiveBuildStep {
 
     // At least Jandex 2.1 is needed
     private static final int REQUIRED_INDEX_VERSION = 8;
-
-    /**
-     * When running in hot deployment mode we know that java archives will never change, there is no need
-     * to re-index them each time. We cache them here to reduce the hot reload time.
-     */
-    private static final Map<Path, Index> archiveCache = new HashMap<>();
 
     IndexDependencyConfiguration config;
 
@@ -89,21 +84,29 @@ public class ApplicationArchiveBuildStep {
     @BuildStep
     ApplicationArchivesBuildItem build(ArchiveRootBuildItem root, ApplicationIndexBuildItem appindex,
             List<AdditionalApplicationArchiveMarkerBuildItem> appMarkers,
-            List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchiveBuildItem) throws IOException {
+            List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchiveBuildItem,
+            LiveReloadBuildItem liveReloadContext) throws IOException {
 
         Set<String> markerFiles = new HashSet<>();
         for (AdditionalApplicationArchiveMarkerBuildItem i : appMarkers) {
             markerFiles.add(i.getFile());
         }
 
+        IndexCache indexCache = liveReloadContext.getContextObject(IndexCache.class);
+        if (indexCache == null) {
+            indexCache = new IndexCache();
+            liveReloadContext.setContextObject(IndexCache.class, indexCache);
+        }
+
         List<ApplicationArchive> applicationArchives = scanForOtherIndexes(Thread.currentThread().getContextClassLoader(),
-                markerFiles, root.getPath(), additionalApplicationArchiveBuildItem);
+                markerFiles, root.getPath(), additionalApplicationArchiveBuildItem, indexCache);
         return new ApplicationArchivesBuildItem(new ApplicationArchiveImpl(appindex.getIndex(), root.getPath(), null),
                 applicationArchives);
     }
 
     private List<ApplicationArchive> scanForOtherIndexes(ClassLoader classLoader, Set<String> applicationArchiveFiles,
-            Path appRoot, List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives) throws IOException {
+            Path appRoot, List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives, IndexCache indexCache)
+            throws IOException {
         Set<Path> dependenciesToIndex = new HashSet<>();
         //get paths that are included via index-dependencies
         dependenciesToIndex.addAll(getIndexDependencyPaths(classLoader));
@@ -119,7 +122,7 @@ public class ApplicationArchiveBuildStep {
             dependenciesToIndex.add(i.getPath());
         }
 
-        return indexPaths(dependenciesToIndex, classLoader);
+        return indexPaths(dependenciesToIndex, classLoader, indexCache);
     }
 
     public List<Path> getIndexDependencyPaths(ClassLoader classLoader) {
@@ -143,7 +146,8 @@ public class ApplicationArchiveBuildStep {
         }
     }
 
-    private static List<ApplicationArchive> indexPaths(Set<Path> dependenciesToIndex, ClassLoader classLoader)
+    private static List<ApplicationArchive> indexPaths(Set<Path> dependenciesToIndex, ClassLoader classLoader,
+            IndexCache indexCache)
             throws IOException {
         List<ApplicationArchive> ret = new ArrayList<>();
 
@@ -153,7 +157,7 @@ public class ApplicationArchiveBuildStep {
                 IndexView indexView = handleFilePath(dep);
                 ret.add(new ApplicationArchiveImpl(indexView, dep, null));
             } else {
-                IndexView index = handleJarPath(dep);
+                IndexView index = handleJarPath(dep, indexCache);
                 FileSystem fs = FileSystems.newFileSystem(dep, classLoader);
                 ret.add(new ApplicationArchiveImpl(index, fs.getRootDirectories().iterator().next(), fs));
             }
@@ -224,8 +228,8 @@ public class ApplicationArchiveBuildStep {
         return indexer.complete();
     }
 
-    private static Index handleJarPath(Path path) throws IOException {
-        return archiveCache.computeIfAbsent(path, new Function<Path, Index>() {
+    private static Index handleJarPath(Path path, IndexCache indexCache) throws IOException {
+        return indexCache.cache.computeIfAbsent(path, new Function<Path, Index>() {
             @Override
             public Index apply(Path path) {
                 try {
@@ -265,5 +269,15 @@ public class ApplicationArchiveBuildStep {
             }
         }
         return indexer.complete();
+    }
+
+    /**
+     * When running in hot deployment mode we know that java archives will never change, there is no need
+     * to re-index them each time. We cache them here to reduce the hot reload time.
+     */
+    private static final class IndexCache {
+
+        final Map<Path, Index> cache = new HashMap<>();
+
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/runner/RuntimeRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/RuntimeRunner.java
@@ -35,6 +35,7 @@ import io.quarkus.deployment.ClassOutput;
 import io.quarkus.deployment.QuarkusAugmentor;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.runtime.Application;
 import io.quarkus.runtime.LaunchMode;
 
@@ -52,12 +53,14 @@ public class RuntimeRunner implements Runnable, Closeable {
     private final List<Path> additionalArchives;
     private final List<Consumer<BuildChainBuilder>> chainCustomizers;
     private final LaunchMode launchMode;
+    private final LiveReloadBuildItem liveReloadState;
 
     public RuntimeRunner(Builder builder) {
         this.target = builder.target;
         this.additionalArchives = new ArrayList<>(builder.additionalArchives);
         this.chainCustomizers = new ArrayList<>(builder.chainCustomizers);
         this.launchMode = builder.launchMode;
+        this.liveReloadState = builder.liveReloadState;
         if (builder.classOutput == null) {
             List<Path> allPaths = new ArrayList<>();
             allPaths.add(target);
@@ -90,6 +93,9 @@ public class RuntimeRunner implements Runnable, Closeable {
             builder.setClassLoader(loader);
             builder.setOutput(classOutput);
             builder.setLaunchMode(launchMode);
+            if (liveReloadState != null) {
+                builder.setLiveReloadState(liveReloadState);
+            }
             for (Path i : additionalArchives) {
                 builder.addAdditionalApplicationArchive(i);
             }
@@ -156,6 +162,7 @@ public class RuntimeRunner implements Runnable, Closeable {
         private final List<Consumer<BuildChainBuilder>> chainCustomizers = new ArrayList<>();
         private ClassOutput classOutput;
         private TransformerTarget transformerTarget;
+        private LiveReloadBuildItem liveReloadState;
 
         public Builder setClassLoader(ClassLoader classLoader) {
             this.classLoader = classLoader;
@@ -214,6 +221,11 @@ public class RuntimeRunner implements Runnable, Closeable {
 
         public Builder setTransformerTarget(TransformerTarget transformerTarget) {
             this.transformerTarget = transformerTarget;
+            return this;
+        }
+
+        public Builder setLiveReloadState(LiveReloadBuildItem liveReloadState) {
+            this.liveReloadState = liveReloadState;
             return this;
         }
 

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.index.ClassPathArtifactResolver;
 import io.quarkus.deployment.index.ResolvedArtifact;
 import io.quarkus.deployment.util.FileUtil;
@@ -52,9 +53,6 @@ public class SwaggerUiProcessor {
 
     SmallRyeOpenApiConfig openapi;
 
-    private static String cachedOpenAPIPath;
-    private static String cachedDirectory;
-
     @Inject
     private LaunchModeBuildItem launch;
 
@@ -69,46 +67,43 @@ public class SwaggerUiProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     public void registerSwaggerUiServletExtension(SwaggerUiTemplate template,
             BuildProducer<ServletExtensionBuildItem> servletExtension,
-            BeanContainerBuildItem container) {
+            BeanContainerBuildItem container,
+            LiveReloadBuildItem liveReloadBuildItem) {
+
         if (launch.getLaunchMode().isDevOrTest()) {
-            if (cachedDirectory == null) {
-                Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            FileUtil.deleteDirectory(Paths.get(cachedDirectory));
-                        } catch (IOException e) {
-                            log.error("Failed to clean Swagger UI temp directory on shutdown", e);
-                        }
-                    }
-                }, "Swagger UI Shutdown Hook"));
-            }
-            if (cachedDirectory == null || !cachedOpenAPIPath.equals(openapi.path)) {
-                if (cachedDirectory != null) {
-                    try {
-                        FileUtil.deleteDirectory(Paths.get(cachedDirectory));
-                    } catch (IOException e) {
-                        log.error("Failed to clean Swagger UI temp directory on shutdown", e);
-                    }
-                    cachedDirectory = null;
-                    cachedOpenAPIPath = null;
+            CachedSwaggerUI cached = liveReloadBuildItem.getContextObject(CachedSwaggerUI.class);
+
+            boolean extractionNeeded = cached == null;
+            if (cached != null && !cached.cachedOpenAPIPath.equals(openapi.path)) {
+                try {
+                    FileUtil.deleteDirectory(Paths.get(cached.cachedDirectory));
+                } catch (IOException e) {
+                    log.error("Failed to clean Swagger UI temp directory on restart", e);
                 }
+                extractionNeeded = true;
             }
-            try {
-                ResolvedArtifact artifact = getSwaggerUiArtifact();
-                Path tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
-                extractSwaggerUi(artifact, tempDir);
-                updateApiUrl(tempDir.resolve("index.html"));
-                cachedDirectory = tempDir.toAbsolutePath().toString();
-                cachedOpenAPIPath = openapi.path;
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            if (extractionNeeded) {
+                if (cached == null) {
+                    cached = new CachedSwaggerUI();
+                    liveReloadBuildItem.setContextObject(CachedSwaggerUI.class, cached);
+                    Runtime.getRuntime().addShutdownHook(new Thread(cached, "Swagger UI Shutdown Hook"));
+                }
+                try {
+                    ResolvedArtifact artifact = getSwaggerUiArtifact();
+                    Path tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
+                    extractSwaggerUi(artifact, tempDir);
+                    updateApiUrl(tempDir.resolve("index.html"));
+                    cached.cachedDirectory = tempDir.toAbsolutePath().toString();
+                    cached.cachedOpenAPIPath = openapi.path;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
             servletExtension.produce(
                     new ServletExtensionBuildItem(
                             template.createSwaggerUiExtension(
                                     swaggerUiConfig.path,
-                                    cachedDirectory,
+                                    cached.cachedDirectory,
                                     container.getValue())));
         }
     }
@@ -152,5 +147,20 @@ public class SwaggerUiProcessor {
          */
         @ConfigItem(defaultValue = "/swagger-ui")
         String path;
+    }
+
+    private static final class CachedSwaggerUI implements Runnable {
+
+        String cachedOpenAPIPath;
+        String cachedDirectory;
+
+        @Override
+        public void run() {
+            try {
+                FileUtil.deleteDirectory(Paths.get(cachedDirectory));
+            } catch (IOException e) {
+                log.error("Failed to clean Swagger UI temp directory on shutdown", e);
+            }
+        }
     }
 }


### PR DESCRIPTION
This provides additional information about the hot reload state of the application, and provides a caching mechanism to avoid the need to stick things in statics.

This still needs to be expanded to include other extensions, e.g. this will allow hibernate/flyway to only initialize the DB if the SQL files have changed.