### PR TITLE
propose default path based on the resource class name

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -245,7 +245,10 @@ public class CreateProjectMojo extends AbstractMojo {
                             .replace("_", ".") + ".HelloResource";
                     className = prompter.promptWithDefaultValue("Set the resource classname", defaultResourceName);
                     if (StringUtils.isBlank(path)) {
-                        path = prompter.promptWithDefaultValue("Set the resource path ", "/hello");
+                        String[] resourceClassName = StringUtils.splitByCharacterTypeCamelCase(
+                                className.substring(className.lastIndexOf(".")));
+                        path = prompter.promptWithDefaultValue("Set the resource path ",
+                                "/" + resourceClassName[1].toLowerCase());
                     }
                 } else {
                     className = null;

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -245,10 +245,7 @@ public class CreateProjectMojo extends AbstractMojo {
                             .replace("_", ".") + ".HelloResource";
                     className = prompter.promptWithDefaultValue("Set the resource classname", defaultResourceName);
                     if (StringUtils.isBlank(path)) {
-                        String[] resourceClassName = StringUtils.splitByCharacterTypeCamelCase(
-                                className.substring(className.lastIndexOf(".")));
-                        path = prompter.promptWithDefaultValue("Set the resource path ",
-                                "/" + resourceClassName[1].toLowerCase());
+                        path = prompter.promptWithDefaultValue("Set the resource path ", CreateUtils.getDerivedPath(className));
                     }
                 } else {
                     className = null;

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.maven;
+
+import org.apache.commons.lang3.StringUtils;
+
+public final class CreateUtils {
+
+    private CreateUtils() {
+        //Not to be constructed
+    }
+
+    public static String getDerivedPath(String className) {
+        String[] resourceClassName = StringUtils.splitByCharacterTypeCamelCase(
+                className.substring(className.lastIndexOf(".") + 1));
+        return "/" + resourceClassName[0].toLowerCase();
+    }
+}

--- a/devtools/maven/src/test/java/io/quarkus/maven/CreateUtilsTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/CreateUtilsTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.maven;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class CreateUtilsTest {
+
+    @Test
+    void testWithPackage() {
+        assertThat(CreateUtils.getDerivedPath("org.acme.ProductResource")).isEqualTo("/product");
+    }
+
+    @Test
+    void testWithDefaultPackage() {
+        assertThat(CreateUtils.getDerivedPath("ProductResource")).isEqualTo("/product");
+    }
+
+    @Test
+    void testWithoutCamelCase() {
+        assertThat(CreateUtils.getDerivedPath("org.acme.Product")).isEqualTo("/product");
+    }
+
+    @Test
+    void testWithoutCamelCaseAndPackage() {
+        assertThat(CreateUtils.getDerivedPath("Product")).isEqualTo("/product");
+    }
+
+}


### PR DESCRIPTION
Hi Folks,

I don't know if you are interested in this really small feature enhancement. At project creation time, if you also generate a REST Resource, instead of having the hardcoded path `/hello` you have one derived from your resource class name.

i.e
If you have your resource defined as `org.sebi.ProductResource` , the proposed path will be `/product` 
