### PR TITLE
Update to Hibernate Search 6.0.0.Alpha6

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -93,7 +93,7 @@
         <javax.el-impl.version>3.0.1.b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Alpha4</hibernate-validator.version>
         <hibernate-orm.version>5.4.2.Final</hibernate-orm.version>
-        <hibernate-search.version>6.0.0.Alpha5</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Alpha6</hibernate-search.version>
         <narayana.version>5.9.3.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.4</agroal.version>

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchConfigUtil.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchConfigUtil.java
@@ -15,6 +15,12 @@ public class HibernateSearchConfigUtil {
         propertyCollector.accept(configKey(configPath), value);
     }
 
+    public static void addConfig(BiConsumer<String, Object> propertyCollector, String configPath, Optional<?> value) {
+        if (value.isPresent()) {
+            propertyCollector.accept(configKey(configPath), value.get());
+        }
+    }
+
     public static <T> void addBackendConfig(BiConsumer<String, Object> propertyCollector, String backendName, String configPath,
             T value) {
         propertyCollector.accept(backendConfigKey(backendName, configPath), value);

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -24,6 +24,7 @@ import java.util.OptionalInt;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexLifecycleStrategyName;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexStatus;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -89,6 +90,12 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         DiscoveryConfig discovery;
 
         /**
+         * Configuration for the automatic indexing.
+         */
+        @ConfigItem
+        AutomaticIndexing automaticIndexing;
+
+        /**
          * The default configuration for the Elasticsearch indexes.
          */
         @ConfigItem
@@ -134,6 +141,29 @@ public class HibernateSearchElasticsearchRuntimeConfig {
          * The scheme that should be used for the new nodes discovered.
          */
         Optional<String> defaultScheme;
+    }
+
+    @ConfigGroup
+    public static class AutomaticIndexing {
+
+        /**
+         * The synchronization strategy to use when indexing automatically.
+         * <p>
+         * Defines the status for which you wait before considering the operation completed by Hibernate Search.
+         * <p>
+         * Can be either one of "queued", "committed" or "searchable".
+         * <p>
+         * Using "searchable" is recommend in unit tests.
+         */
+        Optional<HibernateOrmAutomaticIndexingSynchronizationStrategyName> synchronizationStrategy;
+
+        /**
+         * Whether to check if dirty properties are relevant to indexing before actually reindexing an entity.
+         * <p>
+         * When enabled, re-indexing of an entity is skipped if the only changes are on properties that are not used when
+         * indexing.
+         */
+        Optional<Boolean> enableDirtyCheck;
     }
 
     @ConfigGroup

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchTemplate.java
@@ -33,6 +33,7 @@ import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings
 import org.hibernate.search.engine.cfg.BackendSettings;
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateOrmIntegrationBooter;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.cfg.spi.HibernateOrmMapperSpiSettings;
 import org.hibernate.search.mapper.orm.cfg.spi.HibernateOrmPropertyHandleFactoryName;
 
@@ -99,6 +100,13 @@ public class HibernateSearchElasticsearchTemplate {
 
         @Override
         public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
+            addConfig(propertyCollector,
+                    HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
+                    runtimeConfig.elasticsearch.automaticIndexing.synchronizationStrategy);
+            addConfig(propertyCollector,
+                    HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK,
+                    runtimeConfig.elasticsearch.automaticIndexing.enableDirtyCheck);
+
             contributeBackendRuntimeProperties(propertyCollector, DEFAULT_BACKEND, runtimeConfig.elasticsearch);
 
             for (Entry<String, ElasticsearchBackendRuntimeConfig> backendEntry : runtimeConfig.additionalBackends.entrySet()) {
@@ -152,8 +160,6 @@ public class HibernateSearchElasticsearchTemplate {
                     ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
                     elasticsearchBackendConfig.indexDefaults.lifecycle.requiredStatusWaitTimeout, Optional::isPresent,
                     d -> d.get().toMillis());
-            addBackendDefaultIndexConfig(propertyCollector, backendName, ElasticsearchIndexSettings.REFRESH_AFTER_WRITE,
-                    runtimeConfig.elasticsearch.indexDefaults.refreshAfterWrite);
 
             for (Entry<String, ElasticsearchIndexConfig> indexConfigEntry : runtimeConfig.elasticsearch.indexes.entrySet()) {
                 String indexName = indexConfigEntry.getKey();
@@ -168,8 +174,6 @@ public class HibernateSearchElasticsearchTemplate {
                         ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
                         indexConfig.lifecycle.requiredStatusWaitTimeout, Optional::isPresent,
                         d -> d.get().toMillis());
-                addBackendIndexConfig(propertyCollector, backendName, indexName, ElasticsearchIndexSettings.REFRESH_AFTER_WRITE,
-                        indexConfig.refreshAfterWrite);
             }
         }
     }

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/test/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
@@ -39,10 +39,8 @@ public class HibernateSearchTestResource {
         SearchSession searchSession = Search.getSearchSession(entityManager);
 
         List<Person> person = searchSession.search(Person.class)
-                .asEntity()
                 .predicate(f -> f.match().onField("name").matching("john"))
                 .sort(f -> f.byField("name_sort"))
-                .toQuery()
                 .fetchHits();
 
         assertEquals(2, person.size());
@@ -50,10 +48,8 @@ public class HibernateSearchTestResource {
         assertEquals("John Irving", person.get(1).getName());
 
         person = searchSession.search(Person.class)
-                .asEntity()
                 .predicate(f -> f.nested().onObjectField("address").nest(f.match().onField("address.city").matching("london")))
                 .sort(f -> f.byField("name_sort"))
-                .toQuery()
                 .fetchHits();
 
         assertEquals(1, person.size());

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -26,5 +26,5 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis-configurer=io.quarkus.test.hibernate.search.elasticsearch.search.DefaultITAnalysisConfigurer
+quarkus.hibernate-search.elasticsearch.automatic-indexing.synchronization-strategy=searchable
 quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create-and-drop
-quarkus.hibernate-search.elasticsearch.index-defaults.refresh-after-write=true


### PR DESCRIPTION
It comes with some nice simplifications to the search DSL (and a few changes to the configuration).

Note: The quickstart is ready, I'm currently working on the guide.