### PR TITLE
reactive stream operators: add dep on context propagation runtime

### DIFF
--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
@@ -45,6 +45,10 @@
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-context-propagation-propagators-rxjava2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
otherwise the native compilation of an app using kafka fails with: https://gist.github.com/michalszynkiewicz/9920ab785e385933a34bc19bf3267ea1

The deployment modules have a dependency already