### PR TITLE
Ignore RESTEasy multipart classes for reflection registration

### DIFF
--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -101,6 +101,12 @@ public class ResteasyServerCommonProcessor {
             DotName.createSimple(Response.class.getName()),
             DotName.createSimple(AsyncResponse.class.getName()),
 
+            // RESTEasy
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartInput"),
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput"),
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartOutput"),
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput"),
+
             // Vert-x
             DotName.createSimple("io.vertx.core.json.JsonArray"),
             DotName.createSimple("io.vertx.core.json.JsonObject")));


### PR DESCRIPTION
Followup of https://stackoverflow.com/questions/56329008/how-to-create-a-jandex-index-for-resteasy-multipart-provider/56331021#56331021 .