### PR TITLE
feat(#1302): Introduce a CDI bean which encapsulates the command-line arguments

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/Application.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Application.java
@@ -16,6 +16,8 @@
 
 package io.quarkus.runtime;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
@@ -50,6 +52,7 @@ public abstract class Application {
     private final Condition stateCond = stateLock.newCondition();
 
     private int state = ST_INITIAL;
+    private String[] commandLineParameters;
     private volatile boolean shutdownRequested;
     private static volatile Application currentApplication;
 
@@ -97,6 +100,7 @@ public abstract class Application {
             stateLock.unlock();
         }
         try {
+            this.commandLineParameters = args;
             doStart(args);
         } catch (Throwable t) {
             stateLock.lock();
@@ -180,6 +184,10 @@ public abstract class Application {
 
     public static Application currentApplication() {
         return currentApplication;
+    }
+
+    public List<String> getCommandLineParameters() {
+        return Arrays.asList(commandLineParameters);
     }
 
     protected abstract void doStop();

--- a/devtools/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -53,6 +54,57 @@ public class JarRunnerIT extends MojoTestBase {
         String logs = FileUtils.readFileToString(output, "UTF-8");
 
         assertThatOutputWorksCorrectly(logs);
+
+        process.destroy();
+    }
+
+    @Test
+    public void testCommandLineArgsInjection() throws MavenInvocationException, IOException {
+        File testDir = initProject("projects/classic", "projects/project-classic-injected-cli-args");
+        File source = new File(testDir, "src/main/java/org/acme/InjectedCliArgsResource.java");
+        String injectedCliArgsResource = "package org.acme;\n" +
+                "\n" +
+                "import javax.ws.rs.GET;\n" +
+                "import javax.ws.rs.Path;\n" +
+                "import java.util.List;\n" +
+                "import javax.ws.rs.Produces;\n" +
+                "import javax.inject.Inject;\n" +
+                "import io.quarkus.arc.runtime.Parameters;\n" +
+                "import javax.ws.rs.core.MediaType;\n" +
+                "\n" +
+                "@Path(\"/args\")\n" +
+                "public class InjectedCliArgsResource {\n" +
+                "    @Inject @Parameters List<String> params;\n" +
+                "    @GET\n" +
+                "    @Produces(MediaType.APPLICATION_JSON)\n" +
+                "    public String params() {\n" +
+                "        return params.toString();\n" +
+                "    }\n" +
+                "}\n";
+        FileUtils.write(source, injectedCliArgsResource, Charset.forName("UTF-8"));
+
+        RunningInvoker running = new RunningInvoker(testDir, false);
+        MavenProcessInvocationResult result = running.execute(Arrays.asList("package", "-DskipTests"), Collections.emptyMap());
+        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        running.stop();
+
+        Path jar = testDir.toPath().toAbsolutePath().resolve(Paths.get("target/acme-1.0-SNAPSHOT-runner.jar"));
+        List<String> commands = new ArrayList<>();
+        commands.add(JavaBinFinder.findBin());
+        commands.add("-jar");
+        commands.add(jar.toString());
+        commands.add("arg1");
+        commands.add("arg2");
+        ProcessBuilder processBuilder = new ProcessBuilder(commands.toArray(new String[0]));
+        Process process = processBuilder.start();
+
+        await()
+                .pollDelay(1, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES).until(() -> getHttpResponse("/app/args", 200));
+
+        String args = getHttpResponse("/app/args");
+        assertThat(args).contains("arg1");
+        assertThat(args).contains("arg2");
 
         process.destroy();
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/CommandLineBeanBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/CommandLineBeanBuildStep.java
@@ -1,0 +1,14 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.arc.runtime.CommandLineParametersProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+
+/**
+ * Command line parameters bean related build steps.
+ */
+public class CommandLineBeanBuildStep {
+    @BuildStep
+    AdditionalBeanBuildItem bean() {
+        return new AdditionalBeanBuildItem(CommandLineParametersProducer.class);
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/CommandLineParametersProducer.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/CommandLineParametersProducer.java
@@ -1,0 +1,29 @@
+package io.quarkus.arc.runtime;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.runtime.Application;
+
+@Unremovable
+@ApplicationScoped
+public class CommandLineParametersProducer {
+
+    @Parameters
+    @Produces
+    @Dependent
+    List<String> produceParameters() {
+        Application application = Application.currentApplication();
+        if (application == null) {
+            // TODO investigate dev mode
+            return Collections.emptyList();
+        }
+
+        return application.getCommandLineParameters();
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/Parameters.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/Parameters.java
@@ -1,0 +1,14 @@
+package io.quarkus.arc.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD })
+public @interface Parameters {
+}


### PR DESCRIPTION
Introduces a CDI bean for CLI Args that can be injected as : 
```
@Inject @Parameters List<String> params
``` 
When running via `io.quarkus.runner.GeneratedMain`. 

TODO: dev mode behaviour? In this PR, the bean is an empty list when running in dev mode. 
 
Fixes #1302 

@mkouba WDYT? 