### PR TITLE
Allow to register JAX-RS endpoints generated by extensions - register…

### DIFF
--- a/extensions/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-common/deployment/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>quarkus-resteasy-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>resteasy-context-propagation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
         </dependency>


### PR DESCRIPTION
… providers

@gsmet here is a follow up PR based on the comment https://github.com/quarkusio/quarkus/pull/2420#discussion_r285567725
is this what you had in mind?

to be able to use `BeanArchiveIndexBuildItem` I had to add arc-deployment dependency.