### PR TITLE
Only register the contributed providers if we use all the built-in ones

### DIFF
--- a/extensions/smallrye-rest-client/deployment/src/main/java/io/quarkus/smallrye/restclient/deployment/SmallRyeRestClientProcessor.java
+++ b/extensions/smallrye-rest-client/deployment/src/main/java/io/quarkus/smallrye/restclient/deployment/SmallRyeRestClientProcessor.java
@@ -235,7 +235,7 @@ class SmallRyeRestClientProcessor {
             CombinedIndexBuildItem combinedIndexBuildItem,
             SmallRyeRestClientTemplate smallRyeRestClientTemplate) {
         smallRyeRestClientTemplate.initializeResteasyProviderFactory(jaxrsProvidersToRegisterBuildItem.useBuiltIn(),
-                jaxrsProvidersToRegisterBuildItem.getProviders());
+                jaxrsProvidersToRegisterBuildItem.getProviders(), jaxrsProvidersToRegisterBuildItem.getContributedProviders());
 
         // register the providers for reflection
         for (String providerToRegister : jaxrsProvidersToRegisterBuildItem.getProviders()) {

--- a/extensions/smallrye-rest-client/runtime/src/main/java/io/quarkus/smallrye/restclient/runtime/SmallRyeRestClientTemplate.java
+++ b/extensions/smallrye-rest-client/runtime/src/main/java/io/quarkus/smallrye/restclient/runtime/SmallRyeRestClientTemplate.java
@@ -39,7 +39,8 @@ public class SmallRyeRestClientTemplate {
         RestClientBuilderImpl.SSL_ENABLED = sslEnabled;
     }
 
-    public void initializeResteasyProviderFactory(boolean useBuiltIn, Set<String> providersToRegister) {
+    public void initializeResteasyProviderFactory(boolean useBuiltIn, Set<String> providersToRegister,
+            Set<String> contributedProviders) {
         ResteasyProviderFactory clientProviderFactory = new ResteasyProviderFactoryImpl(null, true) {
             @Override
             public RuntimeType getRuntimeType() {
@@ -55,8 +56,15 @@ public class SmallRyeRestClientTemplate {
 
         if (useBuiltIn) {
             RegisterBuiltin.register(clientProviderFactory);
+            registerProviders(clientProviderFactory, contributedProviders);
+        } else {
+            registerProviders(clientProviderFactory, providersToRegister);
         }
 
+        RestClientBuilderImpl.PROVIDER_FACTORY = clientProviderFactory;
+    }
+
+    private static void registerProviders(ResteasyProviderFactory clientProviderFactory, Set<String> providersToRegister) {
         for (String providerToRegister : providersToRegister) {
             try {
                 clientProviderFactory
@@ -65,7 +73,5 @@ public class SmallRyeRestClientTemplate {
                 throw new RuntimeException("Unable to find class for provider " + providerToRegister, e);
             }
         }
-
-        RestClientBuilderImpl.PROVIDER_FACTORY = clientProviderFactory;
     }
 }


### PR DESCRIPTION
Fixes #2647

The logic should have been similar to what we do for the RESTEasy server but apparently it was not properly taken care of.