### PR TITLE
Add some additional cleanup filters

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -151,6 +151,7 @@ public class SmallRyeFaultToleranceProcessor {
     public void logCleanup(BuildProducer<LogCleanupFilterBuildItem> logCleanupFilter) {
         logCleanupFilter.produce(new LogCleanupFilterBuildItem("io.smallrye.faulttolerance.HystrixInitializer",
                 "### Init Hystrix ###",
+                "### Reset Hystrix ###",
                 // no need to log the strategy if it is the default
                 "Hystrix concurrency strategy used: DefaultHystrixConcurrencyStrategy"));
         logCleanupFilter.produce(new LogCleanupFilterBuildItem("io.smallrye.faulttolerance.DefaultHystrixConcurrencyStrategy",
@@ -159,6 +160,8 @@ public class SmallRyeFaultToleranceProcessor {
         logCleanupFilter.produce(new LogCleanupFilterBuildItem("com.netflix.config.sources.URLConfigurationSource",
                 "No URLs will be polled as dynamic configuration sources.",
                 "To enable URLs as dynamic configuration sources"));
+        logCleanupFilter.produce(new LogCleanupFilterBuildItem("com.netflix.config.DynamicPropertyFactory",
+                "DynamicPropertyFactory is initialized with configuration sources"));
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -42,6 +42,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
+import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.smallrye.metrics.runtime.SmallRyeMetricsServlet;
@@ -151,4 +152,9 @@ public class SmallRyeMetricsProcessor {
         metrics.registerVendorMetrics(shutdown);
     }
 
+    @BuildStep
+    public void logCleanup(BuildProducer<LogCleanupFilterBuildItem> logCleanupFilter) {
+        logCleanupFilter.produce(new LogCleanupFilterBuildItem("io.smallrye.metrics.MetricsRegistryImpl",
+                "Register metric ["));
+    }
 }


### PR DESCRIPTION
OK, not the most interesting PR in the world but I noticed some messages that could be avoided.

I will start to compile them and create issues upstream as some really don't scale. The one for each metric registered for instance really doesn't scale for a large application using metrics.