### PR TITLE
Handle baseUri value of @RegisterRestClient

### DIFF
--- a/extensions/smallrye-rest-client/deployment/src/main/java/io/quarkus/smallrye/restclient/deployment/SmallRyeRestClientProcessor.java
+++ b/extensions/smallrye-rest-client/deployment/src/main/java/io/quarkus/smallrye/restclient/deployment/SmallRyeRestClientProcessor.java
@@ -35,9 +35,11 @@ import org.apache.commons.logging.impl.LogFactoryImpl;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
 import org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -79,6 +81,7 @@ import io.smallrye.restclient.RestClientProxy;
 class SmallRyeRestClientProcessor {
 
     private static final DotName REST_CLIENT = DotName.createSimple(RestClient.class.getName());
+    private static final DotName REGISTER_REST_CLIENT = DotName.createSimple(RegisterRestClient.class.getName());
 
     private static final DotName PATH = DotName.createSimple(Path.class.getName());
 
@@ -209,10 +212,12 @@ class SmallRyeRestClientProcessor {
                     configurator.scope(BuiltinScope.SINGLETON.getInfo());
                     configurator.addQualifier(REST_CLIENT);
                     configurator.creator(m -> {
-                        // return new RestClientBase(proxyType).create();
+                        // return new RestClientBase(proxyType, baseUri).create();
                         ResultHandle interfaceHandle = m.loadClass(entry.getKey().toString());
+                        ResultHandle baseUriHandle = m.load(getBaseUri(entry.getValue()));
                         ResultHandle baseHandle = m.newInstance(
-                                MethodDescriptor.ofConstructor(RestClientBase.class, Class.class), interfaceHandle);
+                                MethodDescriptor.ofConstructor(RestClientBase.class, Class.class, String.class),
+                                interfaceHandle, baseUriHandle);
                         ResultHandle ret = m.invokeVirtualMethod(
                                 MethodDescriptor.ofMethod(RestClientBase.class, "create", Object.class), baseHandle);
                         m.returnValue(ret);
@@ -226,6 +231,20 @@ class SmallRyeRestClientProcessor {
         extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.SMALLRYE_REST_CLIENT));
 
         smallRyeRestClientTemplate.setSslEnabled(sslNativeConfig.isEnabled());
+    }
+
+    private String getBaseUri(ClassInfo classInfo) {
+        AnnotationInstance instance = classInfo.classAnnotation(REGISTER_REST_CLIENT);
+        if (instance == null) {
+            return "";
+        }
+
+        AnnotationValue value = instance.value("baseUri");
+        if (value == null) {
+            return "";
+        }
+
+        return value.asString();
     }
 
     @BuildStep

--- a/extensions/smallrye-rest-client/runtime/src/main/java/io/quarkus/smallrye/restclient/runtime/RestClientBase.java
+++ b/extensions/smallrye-rest-client/runtime/src/main/java/io/quarkus/smallrye/restclient/runtime/RestClientBase.java
@@ -28,11 +28,13 @@ public class RestClientBase {
     public static final String REST_URL_FORMAT = "%s/mp-rest/url";
 
     private final Class<?> proxyType;
+    private final String baseUriFromAnnotation;
 
     private final Config config;
 
-    public RestClientBase(Class<?> proxyType) {
+    public RestClientBase(Class<?> proxyType, String baseUriFromAnnotation) {
         this.proxyType = proxyType;
+        this.baseUriFromAnnotation = baseUriFromAnnotation;
         this.config = ConfigProvider.getConfig();
     }
 
@@ -53,7 +55,10 @@ public class RestClientBase {
     }
 
     private String getBaseUrl() {
-        String property = String.format(REST_URL_FORMAT, proxyType.getName());
-        return config.getValue(property, String.class);
+        if ((baseUriFromAnnotation == null) || baseUriFromAnnotation.isEmpty()) {
+            String property = String.format(REST_URL_FORMAT, proxyType.getName());
+            return config.getValue(property, String.class);
+        }
+        return baseUriFromAnnotation;
     }
 }


### PR DESCRIPTION
Fixes: #2687

I didn't add a test for this because it would have to contain either: 
* The URL where the application is deployed (which currently is always `http://localhost:8081`, but in all other tests is read via a system property)
* The URL of an external service

as the value of `baseUri` of `@RegisterRestClient`.

I of course manually tested with the scenario outlined in #2687, but if someone would like a test, I'm glad to add it - just let me know which one of the scenarios explained above you would prefer.