### PR TITLE
Add better error handing out of the box for web requests

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -461,7 +461,8 @@ public class UndertowBuildStep {
                     (Class<? extends ServletContainerInitializer>) context.classProxy(sci.sciClass), handlesTypes);
         }
 
-        return new ServletDeploymentManagerBuildItem(template.bootServletContainer(deployment, bc.getValue()));
+        return new ServletDeploymentManagerBuildItem(
+                template.bootServletContainer(deployment, bc.getValue(), launchMode.getLaunchMode()));
 
     }
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
@@ -1,0 +1,157 @@
+package io.quarkus.undertow.runtime;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class QuarkusErrorServlet extends HttpServlet {
+
+    public static final String SHOW_STACK = "show-stack";
+
+    private static final String HTML_TEMPLATE = "" +
+            "<!doctype html>\n" +
+            "<html lang=\"en\">\n" +
+            "<head>\n" +
+            "    <title>Internal Server Error</title>\n" +
+            "    <meta charset=\"utf-8\">\n" +
+            "    <style>%2$s</style>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "" +
+            "<header>\n" +
+            "    <h1 class=\"container\">Internal Server Error</h1>\n" +
+            "    <div class=\"exception-message\">\n" +
+            "        <h2 class=\"container\">%1$s</h2>\n" +
+            "    </div>\n" +
+            "</header>\n" +
+            "" +
+            "<div class=\"container\">\n" +
+            "    <div class=\"trace\">\n" +
+            "        <pre>%3$s</pre>\n" +
+            "    </div>\n" +
+            "</div>\n" +
+            "" +
+            "</body>\n" +
+            "</html>\n";
+
+    private static final String ERROR_CSS = "\n" +
+            "html, body {\n" +
+            "    margin: 0;\n" +
+            "    padding: 0;\n" +
+            "    font-family: Helvetica, Arial, sans-serif;\n" +
+            "    font-size: 14px;\n" +
+            "    line-height: 1.4;\n" +
+            "}\n" +
+            "\n" +
+            "html {\n" +
+            "    overflow-y: scroll;\n" +
+            "}\n" +
+            "\n" +
+            "body {\n" +
+            "    background: #f9f9f9;\n" +
+            "}\n" +
+            "\n" +
+            ".container {\n" +
+            "    width: 80%;\n" +
+            "    margin: 0 auto;\n" +
+            "}\n" +
+            "\n" +
+            "header {\n" +
+            "    background: #ad1c1c;\n" +
+            "}\n" +
+            "\n" +
+            ".exception-message {\n" +
+            "    background: #be2828;\n" +
+            "}\n" +
+            "\n" +
+            "h1, h2 {\n" +
+            "    margin: 0;\n" +
+            "    padding: 0;\n" +
+            "    font-weight: normal;\n" +
+            "}\n" +
+            "\n" +
+            "h1 {\n" +
+            "    font-size: 22px;\n" +
+            "    color: #fff;\n" +
+            "    padding: 10px 0;\n" +
+            "}\n" +
+            "\n" +
+            "h2 {\n" +
+            "    font-size: 18px;\n" +
+            "    color: rgba(255, 255, 255, 0.85);\n" +
+            "    padding: 20px 0;\n" +
+            "}\n" +
+            "\n" +
+            ".trace {\n" +
+            "    background: #fff;\n" +
+            "    padding: 15px;\n" +
+            "    margin: 15px auto;\n" +
+            "    overflow-y: scroll;\n" +
+            "    border: 1px solid #ececec;\n" +
+            "}\n" +
+            "\n" +
+            "pre {\n" +
+            "    white-space: pre;\n" +
+            "    font-family: Consolas, Monaco, Menlo, \"Ubuntu Mono\", \"Liberation Mono\", monospace;\n" +
+            "    font-size: 12px;\n" +
+            "    line-height: 1.5;\n" +
+            "}\n";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String details = "";
+        String stack = "";
+        Object uuid = req.getAttribute(QuarkusExceptionHandler.ERROR_ID);
+        Throwable exception = (Throwable) req.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+        if (Boolean.parseBoolean(getInitParameter(SHOW_STACK))) {
+            details = generateHeaderMessage(exception, uuid == null ? null : uuid.toString());
+            stack = generateStackTrace(exception);
+
+        } else if (uuid != null) {
+            details = "Error id " + uuid;
+        }
+
+        resp.setContentType("text/html");
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        resp.getWriter().write(String.format(HTML_TEMPLATE, details, ERROR_CSS, stack));
+    }
+
+    private static String generateStackTrace(final Throwable exception) {
+        StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+
+        return escapeHtml(stringWriter.toString().trim());
+    }
+
+    private static String generateHeaderMessage(final Throwable exception, String uuid) {
+        return escapeHtml(String.format("Error handling %s, %s: %s", uuid, exception.getClass().getName(),
+                extractFirstLine(exception.getMessage())));
+    }
+
+    private static String extractFirstLine(final String message) {
+        if (null == message) {
+            return "";
+        }
+
+        String[] lines = message.split("\\r?\\n");
+        return lines[0].trim();
+    }
+
+    private static String escapeHtml(final String bodyText) {
+        if (bodyText == null) {
+            return "null";
+        }
+
+        return bodyText
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusExceptionHandler.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusExceptionHandler.java
@@ -1,0 +1,71 @@
+package io.quarkus.undertow.runtime;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+
+import io.undertow.UndertowLogger;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.ExceptionLog;
+import io.undertow.servlet.api.ExceptionHandler;
+
+public class QuarkusExceptionHandler implements ExceptionHandler {
+
+    /**
+     * The servlet request attribute that contains the error ID. This can be accessed from a customer error page.
+     */
+    public static final String ERROR_ID = "quarkus.error.id";
+
+    /**
+     * we don't want to generate a new UUID each time as it is slowish. Instead we just generate one based one
+     * and then use a counter.
+     */
+    private static final String BASE_ID = UUID.randomUUID().toString() + "-";
+
+    private static final AtomicLong ERROR_COUNT = new AtomicLong();
+
+    @Override
+    public boolean handleThrowable(HttpServerExchange exchange, ServletRequest request, ServletResponse response, Throwable t) {
+        String uid = BASE_ID + ERROR_COUNT.incrementAndGet();
+        request.setAttribute(ERROR_ID, uid);
+        ExceptionLog log = t.getClass().getAnnotation(ExceptionLog.class);
+        if (log != null) {
+            Logger.Level level = log.value();
+            Logger.Level stackTraceLevel = log.stackTraceLevel();
+            String category = log.category();
+            handleCustomLog(exchange, t, level, stackTraceLevel, category, uid);
+        } else if (t instanceof IOException) {
+            //we log IOExceptions at a lower level
+            //because they can be easily caused by malicious remote clients in at attempt to DOS the server by filling the logs
+            UndertowLogger.REQUEST_IO_LOGGER.debugf(t, "Exception handling request %s to %s", uid, exchange.getRequestURI());
+        } else {
+            UndertowLogger.REQUEST_IO_LOGGER.errorf(t, "Exception handling request %s to %s", uid, exchange.getRequestURI());
+        }
+        return false;
+    }
+
+    private void handleCustomLog(HttpServerExchange exchange, Throwable t, Logger.Level level, Logger.Level stackTraceLevel,
+            String category, String uid) {
+        BasicLogger logger = UndertowLogger.REQUEST_LOGGER;
+        if (!category.isEmpty()) {
+            logger = Logger.getLogger(category);
+        }
+        boolean stackTrace = true;
+        if (stackTraceLevel.ordinal() > level.ordinal()) {
+            if (!logger.isEnabled(stackTraceLevel)) {
+                stackTrace = false;
+            }
+        }
+        if (stackTrace) {
+            logger.logf(level, t, "Exception handling request %s to %s", uid, exchange.getRequestURI());
+        } else {
+            logger.logf(level, "Exception handling request %s to %s: %s", uid, exchange.getRequestURI(), t.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This will generate a UUID for failed web requests, so the
error message the user sees can be cross referenced with the
corresponding log message