### PR TITLE
Register reflective classes from bean archive index by providing the index

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveHierarchyBuildItem.java
@@ -16,6 +16,7 @@
 
 package io.quarkus.deployment.builditem.substrate;
 
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Type;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -40,12 +41,22 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
 
     private final Type type;
+    private IndexView index;
 
     public ReflectiveHierarchyBuildItem(Type type) {
         this.type = type;
     }
 
+    public ReflectiveHierarchyBuildItem(Type type, IndexView index) {
+        this.type = type;
+        this.index = index;
+    }
+
     public Type getType() {
         return type;
+    }
+
+    public IndexView getIndex() {
+        return index;
     }
 }


### PR DESCRIPTION
register reflective classes from bean archive index by providing the index as part of the reflective class build item.

this is another change needed for https://github.com/quarkusio/quarkus/pull/2675 to make this work on native image as well. It simply does not take into account the bean archive items for generated classes. In addition int core-deployment we can't use arc build items so I added the index to reflective class build item instead. 

Wondering if better would be to use first the combined index and as fallback the one from build item (https://github.com/quarkusio/quarkus/compare/master...mswiderski:missing-reflective-classes?expand=1#diff-eb505e9693864a419f6cf2426bf540e2R117)

Obviously I'd like to have your opinion @gsmet @mkouba 