### PR TITLE
ubi8 based container for native mode application

### DIFF
--- a/devtools/common/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-native.ftl
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/${project_artifactId}
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -233,13 +233,18 @@ The project generation has provided a `Dockerfile.native` in the `src/main/docke
 
 [source,dockerfile]
 ----
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
+
+[NOTE]
+====
+If your application requires libcrypt.so.2 you may consider `registry.fedoraproject.org/fedora-minimal:30` (or later) as a base image.
+====
 
 Then, if you didn't delete the generated native executable, you can build the docker image with:
 


### PR DESCRIPTION
ubi8 based container for native mode application

Size benefit:
```
docker images | grep minimal
registry.access.redhat.com/ubi8/ubi-minimal   latest               3bfa511b67f8        5 weeks ago         90MB
registry.fedoraproject.org/fedora-minimal     latest               f0c38118c459        3 months ago        105MB
```

@johnaohara do you see any performance drawbacks of using ubi8 image ?