### PR TITLE
NativeImageMojo - Check the pom first

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -148,14 +148,14 @@ public class NativeImageMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
-        if (!buildDir.isDirectory() || !new File(buildDir, "lib").isDirectory()) {
-            throw new MojoFailureException("Unable to find the required build output. " +
-                    "Please ensure that the 'build' goal has been properly configured for the project - since it is a prerequisite of the 'native-image' goal");
-        }
-
         if (project.getPackaging().equals("pom")) {
             getLog().info("Type of the artifact is POM, skipping native-image goal");
             return;
+        }
+
+        if (!buildDir.isDirectory() || !new File(buildDir, "lib").isDirectory()) {
+            throw new MojoFailureException("Unable to find the required build output. " +
+                    "Please ensure that the 'build' goal has been properly configured for the project - since it is a prerequisite of the 'native-image' goal");
         }
 
         try (AppCreator appCreator = AppCreator.builder()


### PR DESCRIPTION
NativeImageMojo - do pom check first

Otherwise MojoFailureException saying "Unable to find the required build output" will be thrown for multimodule projects with root pom.xml having packaging set to pom.