### PR TITLE
CDI.current() should throw ISE if no container is available

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcCDIProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcCDIProvider.java
@@ -37,6 +37,9 @@ public class ArcCDIProvider implements CDIProvider {
 
     @Override
     public CDI<Object> getCDI() {
+        if (Arc.container() == null) {
+            throw new IllegalStateException("No CDI container is available");
+        }
         return arcCDI;
     }
 


### PR DESCRIPTION
- resolves #2710