### PR TITLE
MP Config TCK - fix a regression caused by #2629

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Maven Build'
     inputs:
       goals: 'install'
-      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dtest-elasticsearch -Dnative-image.xmx=6g -Dnative -Dno-format'
+      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dtest-elasticsearch -Dnative-image.xmx=6g -Dnative -Dno-format -Dtcks'
 
 - job: Windows_Build
   timeoutInMinutes: 60

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Maven Build'
     inputs:
       goals: 'install'
-      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dtest-elasticsearch -Dnative-image.xmx=6g -Dnative -Dno-format -Dtcks'
+      options: '-B --settings azure-mvn-settings.xml -Dnative-image.docker-build -Dtest-postgresql -Dtest-elasticsearch -Dnative-image.xmx=6g -Dnative -Dno-format'
 
 - job: Windows_Build
   timeoutInMinutes: 60
@@ -73,3 +73,25 @@ jobs:
       jdkVersionOption: '1.11'
       goals: 'install'
       options: '-B --settings azure-mvn-settings.xml -Dno-native -Dno-format'
+
+- job: Run_TCKs
+  timeoutInMinutes: 45
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  variables:
+    imageName: 'quarkus:$(build.buildId)'
+
+  steps:
+
+  - task: Maven@3
+    displayName: 'Maven Install'
+    inputs:
+      goals: 'install'
+      options: '-B --settings azure-mvn-settings.xml -Dno-native -Dno-format -DskipTests -Dtcks'
+
+  - task: Maven@3
+    displayName: 'Maven Verify'
+    inputs:
+      goals: 'verify'
+      mavenPomFile: 'tcks/pom.xml'

--- a/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/ConfigApplicationArchiveProcessor.java
+++ b/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/ConfigApplicationArchiveProcessor.java
@@ -1,0 +1,44 @@
+package io.quarkus.tck.config;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Arquillian automatically adds the test class to a test deployment. However, some MP Config tests do add the test class to a
+ * library jar too. As a result, we get ambiguous dependency when trying to instantiate the test class. Unfortunately, we can't
+ * use an ApplicationArchiveProcessor to remove the test class added by Arquillian because it's applied
+ * before the test class is added. Therefore, we deciced to remove the test class from any library jar.
+ */
+public class ConfigApplicationArchiveProcessor implements ApplicationArchiveProcessor {
+
+    private static final ArchivePath PATH_LIBRARY = ArchivePaths.create("WEB-INF/lib");
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        if (applicationArchive instanceof WebArchive) {
+            WebArchive war = applicationArchive.as(WebArchive.class);
+            Node libNode = war.get(PATH_LIBRARY);
+            if (libNode != null) {
+                for (Node child : libNode.getChildren()) {
+                    Asset childAsset = child.getAsset();
+                    if (childAsset instanceof ArchiveAsset) {
+                        ArchiveAsset archiveAsset = (ArchiveAsset) childAsset;
+                        if (archiveAsset.getArchive() instanceof JavaArchive) {
+                            JavaArchive libArchive = (JavaArchive) archiveAsset.getArchive();
+                            libArchive.deleteClass(testClass.getName());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/ConfigExtension.java
+++ b/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/ConfigExtension.java
@@ -1,0 +1,13 @@
+package io.quarkus.tck.config;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class ConfigExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ApplicationArchiveProcessor.class, ConfigApplicationArchiveProcessor.class);
+    }
+
+}

--- a/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/Dummy.java
+++ b/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/Dummy.java
@@ -1,6 +1,0 @@
-package io.quarkus.tck.config;
-
-// We need this class so that target/test-classes is added to the class path?
-public class Dummy {
-
-}

--- a/tcks/microprofile-config/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/tcks/microprofile-config/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.quarkus.tck.config.ConfigExtension


### PR DESCRIPTION
Could we also enable the `tcks` profile for CI?