### PR TITLE
Fix number of thread in javadoc

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
@@ -23,7 +23,7 @@ public class ThreadPoolConfig {
 
     /**
      * The maximum number of threads. If this is not specified then
-     * it will be automatically sized to 4 * the number of available processors
+     * it will be automatically sized to 8 * the number of available processors
      */
     @ConfigItem
     public OptionalInt maxThreads;


### PR DESCRIPTION
According to the below code, default maxThreads is 8 * the number of available processors.

https://github.com/quarkusio/quarkus/blob/master/core/runtime/src/main/java/io/quarkus/runtime/ExecutorTemplate.java#L168
```
builder.setMaximumPoolSize(threadPoolConfig.maxThreads.orElse(8 * cpus));
```