### PR TITLE
Introduce test Mock stereotype

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -305,9 +305,11 @@ public class TestStereotypeTestCase {
 
 == Mock Support
 
-Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism. To use this simply override the bean
-you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations
-on the bean. For example if I have the following service:
+Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism.
+To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean. 
+Alternatively, a convenient `io.quarkus.test.Mock` stereotype annotation could be used.
+This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`. 
+For example if I have the following service:
 
 [source,java]
 ----
@@ -323,12 +325,10 @@ public class ExternalService {
 
 I could mock it with the following class in `src/test/java`:
 
-
 [source,java]
 ----
-@Alternative()
-@Priority(1)
-@ApplicationScoped
+@Mock
+@ApplicationScoped <1>
 public class MockExternalService extends ExternalService {
 
     @Override
@@ -337,6 +337,7 @@ public class MockExternalService extends ExternalService {
     }
 }
 ----
+<1> Overrides the `@Dependent` scope declared on the `@Mock` stereotype.
 
 It is important that the alternative be present in the `src/test/java` directory rather than `src/main/java`, as otherwise
 it will take effect all the time, not just when testing.

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -424,6 +424,7 @@ public class BeanDeployment {
             if (stereotypeClass != null) {
 
                 boolean isAlternative = false;
+                Integer alternativePriority = null;
                 List<ScopeInfo> scopes = new ArrayList<>();
                 List<AnnotationInstance> bindings = new ArrayList<>();
                 boolean isNamed = false;
@@ -441,6 +442,8 @@ public class BeanDeployment {
                                     "Stereotype must not declare @Named with a non-empty value: " + stereotypeClass);
                         }
                         isNamed = true;
+                    } else if (DotNames.PRIORITY.equals(annotation.name())) {
+                        alternativePriority = annotation.value().asInt();
                     } else {
                         final ScopeInfo scope = getScope(annotation.name(), customContexts);
                         if (scope != null) {
@@ -449,7 +452,8 @@ public class BeanDeployment {
                     }
                 }
                 final ScopeInfo scope = getValidScope(scopes, stereotypeClass);
-                stereotypes.put(stereotypeName, new StereotypeInfo(scope, bindings, isAlternative, isNamed, stereotypeClass));
+                stereotypes.put(stereotypeName, new StereotypeInfo(scope, bindings, isAlternative, alternativePriority,
+                        isNamed, stereotypeClass));
             }
         }
         //if an additional bean defining annotation has a default scope we register it as a stereotype
@@ -457,7 +461,7 @@ public class BeanDeployment {
             for (BeanDefiningAnnotation i : additionalBeanDefiningAnnotations) {
                 if (i.getDefaultScope() != null) {
                     ScopeInfo scope = getScope(i.getDefaultScope(), customContexts);
-                    stereotypes.put(i.getAnnotation(), new StereotypeInfo(scope, Collections.emptyList(), false, false,
+                    stereotypes.put(i.getAnnotation(), new StereotypeInfo(scope, Collections.emptyList(), false, null, false,
                             index.getClassByName(i.getAnnotation())));
                 }
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -112,6 +112,9 @@ final class Beans {
         if (name == null) {
             name = initStereotypeName(stereotypes, beanClass);
         }
+        if (isAlternative && alternativePriority == null) {
+            alternativePriority = initStereotypeAlternativePriority(stereotypes);
+        }
 
         BeanInfo bean = new BeanInfo(beanClass, beanDeployment, scope, types, qualifiers,
                 Injection.forBean(beanClass, null, beanDeployment, transformer), null, null,
@@ -194,6 +197,9 @@ final class Beans {
                         .filter(a -> a.name().equals(DotNames.PRIORITY)).findAny()
                         .map(a -> a.value().asInt()).orElse(null);
             }
+            if (alternativePriority == null) {
+                alternativePriority = initStereotypeAlternativePriority(stereotypes);
+            }
         }
 
         BeanInfo bean = new BeanInfo(producerMethod, beanDeployment, scope, types, qualifiers,
@@ -268,6 +274,9 @@ final class Beans {
                         .filter(a -> a.name().equals(DotNames.PRIORITY)).findAny()
                         .map(a -> a.value().asInt()).orElse(null);
             }
+            if (alternativePriority == null) {
+                alternativePriority = initStereotypeAlternativePriority(stereotypes);
+            }
         }
 
         BeanInfo bean = new BeanInfo(producerField, beanDeployment, scope, types, qualifiers, Collections.emptyList(),
@@ -302,6 +311,18 @@ final class Beans {
             }
         }
         return false;
+    }
+
+    private static Integer initStereotypeAlternativePriority(List<StereotypeInfo> stereotypes) {
+        if (stereotypes.isEmpty()) {
+            return null;
+        }
+        for (StereotypeInfo stereotype : stereotypes) {
+            if (stereotype.getAlternativePriority() != null) {
+                return stereotype.getAlternativePriority();
+            }
+        }
+        return null;
     }
 
     private static String initStereotypeName(List<StereotypeInfo> stereotypes, AnnotationTarget target) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
@@ -23,20 +23,19 @@ import org.jboss.jandex.ClassInfo;
 public class StereotypeInfo {
 
     private final ScopeInfo defaultScope;
-
     private final List<AnnotationInstance> interceptorBindings;
-
-    private final boolean isAlternative;
-
+    private final boolean alternative;
+    private final Integer alternativePriority;
     private final boolean isNamed;
-
     private final ClassInfo target;
 
-    public StereotypeInfo(ScopeInfo defaultScope, List<AnnotationInstance> interceptorBindings, boolean isAlternative,
+    public StereotypeInfo(ScopeInfo defaultScope, List<AnnotationInstance> interceptorBindings, boolean alternative,
+            Integer alternativePriority,
             boolean isNamed, ClassInfo target) {
         this.defaultScope = defaultScope;
         this.interceptorBindings = interceptorBindings;
-        this.isAlternative = isAlternative;
+        this.alternative = alternative;
+        this.alternativePriority = alternativePriority;
         this.isNamed = isNamed;
         this.target = target;
     }
@@ -50,7 +49,11 @@ public class StereotypeInfo {
     }
 
     public boolean isAlternative() {
-        return isAlternative;
+        return alternative;
+    }
+
+    public Integer getAlternativePriority() {
+        return alternativePriority;
     }
 
     public boolean isNamed() {

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -55,6 +55,13 @@
             <artifactId>javax.persistence-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeTest.java
@@ -20,13 +20,10 @@ import static org.junit.Assert.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.UUID;
-import javax.annotation.PostConstruct;
 import javax.annotation.Priority;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Alternative;
@@ -37,40 +34,61 @@ import org.junit.Test;
 public class StereotypeAlternativeTest {
 
     @Rule
-    public ArcTestContainer container = new ArcTestContainer(BeAlternative.class, NonAternative.class, IamAlternative.class);
+    public ArcTestContainer container = new ArcTestContainer(BeAlternative.class, BeAlternativeWithPriority.class,
+            NonAlternative.class, IamAlternative.class, NotAtAllAlternative.class, IamAlternativeWithPriority.class);
 
     @Test
     public void testStereotype() {
-        assertEquals("OK", Arc.container().instance(NonAternative.class).get().getId());
+        assertEquals("OK", Arc.container().instance(NonAlternative.class).get().getId());
+        assertEquals("OK", Arc.container().instance(NotAtAllAlternative.class).get().getId());
     }
 
     @Alternative
-    @Documented
     @Stereotype
     @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
     @Retention(RetentionPolicy.RUNTIME)
     public @interface BeAlternative {
     }
 
+    @Priority(1)
+    @Alternative
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface BeAlternativeWithPriority {
+    }
+
     @Dependent
-    static class NonAternative {
-
-        private String id;
-
-        @PostConstruct
-        void init() {
-            id = UUID.randomUUID().toString();
-        }
+    static class NonAlternative {
 
         public String getId() {
-            return id;
+            return "NOK";
         }
 
     }
 
     @Priority(1)
     @BeAlternative
-    static class IamAlternative extends NonAternative {
+    static class IamAlternative extends NonAlternative {
+
+        @Override
+        public String getId() {
+            return "OK";
+        }
+
+    }
+
+    @Dependent
+    static class NotAtAllAlternative {
+
+        public String getId() {
+            return "NOK";
+        }
+
+    }
+
+    @BeAlternativeWithPriority
+    static class IamAlternativeWithPriority extends NotAtAllAlternative {
 
         @Override
         public String getId() {

--- a/test-framework/common/src/main/java/io/quarkus/test/Mock.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/Mock.java
@@ -1,0 +1,27 @@
+package io.quarkus.test;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+
+/**
+ * The built-in stereotype intended for use with mock beans injected in tests.
+ */
+@Priority(1)
+@Dependent
+@Alternative
+@Stereotype
+@Target({ TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface Mock {
+
+}


### PR DESCRIPTION
- also make it possible to specify priority on a stereotype annotation

This PR extends the mock support so that it's possible to replace:
```java
@Priority(1)
@Alternative
@Dependent
class MyMockBean {
}
```
with:
```java
@Mock
class MyMockBean {
}
```

The priority and scope could be overriden.