### PR TITLE
fix: force Jackson transitive dependencies versions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -178,15 +178,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- RESTEasy dependencies, imported as a BOM -->
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-bom</artifactId>
-                <version>${resteasy.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Jackson dependencies, imported as a BOM -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
@@ -194,6 +185,24 @@
                 <version>${jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- The Jackson BOM imports version 2.9.0 and we want all the versions to be in sync. 
+                Especially, 2.9.1 adds an automatic module name. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+
+            <!-- RESTEasy dependencies, imported as a BOM -->
+            <!-- As RESTEasy also imports Jackson, we need to import its BOM after the Jackson BOM -->
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-bom</artifactId>
+                <version>${resteasy.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- JUnit 5 dependencies, imported as a BOM -->

--- a/extensions/smallrye-openapi/runtime/pom.xml
+++ b/extensions/smallrye-openapi/runtime/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>smallrye-open-api</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
@@ -59,10 +55,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-swagger-ui</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Force the version of all the Jackson dependencies that are inherited from smallrye-openapi.

I cannot find an other way than duplicating the jackson.version property as we need to use the dependencyManagement part of the pom. I add a comment to the Quarkus bom to avoid missing an update of the property in the two places.

Fixes #2789 