### PR TITLE
Making sure the right RocksDB native binary is added for container build

### DIFF
--- a/extensions/kafka-streams/deployment/pom.xml
+++ b/extensions/kafka-streams/deployment/pom.xml
@@ -20,6 +20,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kafka-client-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-streams</artifactId>
         </dependency>
 


### PR DESCRIPTION
Fix #2663.

@gsmet, @cescoffier, a small follow-up to the Kafka Streams work. The wrong native binary for RocksDB ended up being added to the application image when doing a build targeting containers but running on macOS.