### PR TITLE
Arc - correct circular dependency check to detect self-injection as w…

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -272,9 +272,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
     private boolean isDependency(BeanInfo bean, Map<BeanInfo, List<BeanInfo>> beanToInjections) {
         for (Iterator<Entry<BeanInfo, List<BeanInfo>>> iterator = beanToInjections.entrySet().iterator(); iterator.hasNext();) {
             Entry<BeanInfo, List<BeanInfo>> entry = iterator.next();
-            if (entry.getKey().equals(bean)) {
-                continue;
-            } else if (entry.getValue().contains(bean)) {
+            if (entry.getValue().contains(bean)) {
                 return true;
             }
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/CircularInjectionNotSupportedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/CircularInjectionNotSupportedTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.arc.test.injection.erroneous;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class CircularInjectionNotSupportedTest {
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(new TestRule() {
+        @Override
+        public Statement apply(Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        base.evaluate();
+                    } catch (IllegalStateException e) {
+                        // expected failure on ISE due to circular dependency
+                    }
+                }
+            };
+        }
+    }).around(new ArcTestContainer(Foo.class, AbstractServiceImpl.class, ActualServiceImpl.class));
+
+    @Test
+    public void testExceptionThrown() {
+        // throws exception during deployment
+    }
+
+    static abstract class AbstractServiceImpl {
+        @Inject
+        protected Foo foo;
+    }
+
+    @ApplicationScoped
+    static class ActualServiceImpl extends AbstractServiceImpl implements Foo {
+
+        @Override
+        public void ping() {
+        }
+    }
+
+    interface Foo {
+        void ping();
+    }
+
+}


### PR DESCRIPTION
…ell, added test.

Resolves #2609 

Since self-injection is a special case of circular dependency, I have changed it so that we now throw a proper ISE on detecting one.