### PR TITLE
Refactor how ORM with Panache generates bridge methods

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/deployment/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-panache-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/EntityField.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/EntityField.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.panache.deployment;
 
+import io.quarkus.panache.common.deployment.JavaBeanUtil;
+
 public class EntityField {
 
     final String name;

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheFieldAccessMethodVisitor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheFieldAccessMethodVisitor.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.quarkus.panache.common.deployment.JavaBeanUtil;
+
 class PanacheFieldAccessMethodVisitor extends MethodVisitor {
 
     private final String methodName;

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.panache.deployment;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -10,9 +11,13 @@ import java.util.function.BiFunction;
 import javax.persistence.Transient;
 
 import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -26,6 +31,7 @@ import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.common.deployment.JandexUtil;
 
 public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
 
@@ -53,10 +59,15 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
 
     private static final DotName DOTNAME_TRANSIENT = DotName.createSimple(Transient.class.getName());
     final Map<String, EntityModel> entities = new HashMap<>();
+    private ClassInfo panacheEntityBaseClassInfo;
+
+    public PanacheJpaEntityEnhancer(IndexView index) {
+        panacheEntityBaseClassInfo = index.getClassByName(PanacheResourceProcessor.DOTNAME_PANACHE_ENTITY_BASE);
+    }
 
     @Override
     public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
-        return new ModelEnhancingClassVisitor(className, outputClassVisitor, entities);
+        return new ModelEnhancingClassVisitor(className, outputClassVisitor, entities, panacheEntityBaseClassInfo);
     }
 
     static class ModelEnhancingClassVisitor extends ClassVisitor {
@@ -66,14 +77,16 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
         // set of name + "/" + descriptor (only for suspected accessor names)
         private Set<String> methods = new HashSet<>();
         private Map<String, EntityModel> entities;
+        private ClassInfo panacheEntityBaseClassInfo;
 
         public ModelEnhancingClassVisitor(String className, ClassVisitor outputClassVisitor,
-                Map<String, EntityModel> entities) {
+                Map<String, EntityModel> entities, ClassInfo panacheEntityBaseClassInfo) {
             super(Opcodes.ASM6, outputClassVisitor);
             thisClass = Type.getType("L" + className.replace('.', '/') + ";");
             this.entities = entities;
             EntityModel entityModel = entities.get(className);
             fields = entityModel != null ? entityModel.fields : null;
+            this.panacheEntityBaseClassInfo = panacheEntityBaseClassInfo;
         }
 
         @Override
@@ -121,198 +134,38 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
         public void visitEnd() {
             // FIXME: generate default constructor
 
-            generateMethod("findById",
-                    "(Ljava/lang/Object;)" + ENTITY_BASE_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/Object;)TT;",
-                    Opcodes.ARETURN, ENTITY_BASE_BINARY_NAME, "id");
-
-            // find Sort? Map|Object[]|Parameters?
-
-            generateMethod("find",
-                    "(Ljava/lang/String;[Ljava/lang/Object;)" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;[Ljava/lang/Object;)L" + QUERY_BINARY_NAME + "<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)L"
-                            + QUERY_BINARY_NAME + "<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;Ljava/util/Map;)" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE
-                            + ">(Ljava/lang/String;Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)L" + QUERY_BINARY_NAME
-                            + "<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map;)" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)L" + QUERY_BINARY_NAME + "<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")L" + QUERY_BINARY_NAME
-                            + "<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")L"
-                            + QUERY_BINARY_NAME + "<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            // list Sort? Map|Object[]|Parameters?
-
-            generateMethod("list",
-                    "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "[Ljava/lang/Object;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;Ljava/util/Map;)Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE
-                            + ">(Ljava/lang/String;Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map;)Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE
-                            + ")Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            // stream Sort? Map|Object[]|Parameters?
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "[Ljava/lang/Object;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;Ljava/util/Map;)Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE
-                            + ">(Ljava/lang/String;Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map;)Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + PARAMETERS_SIGNATURE
-                            + ")Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE
-                            + ")Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            // findAll Sort?
-
-            generateMethod("findAll",
-                    "()" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">()L" + QUERY_BINARY_NAME + "<TT;>;",
-                    Opcodes.ARETURN, null);
-
-            generateMethod("findAll",
-                    "(" + SORT_SIGNATURE + ")" + QUERY_SIGNATURE,
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(" + SORT_SIGNATURE + ")L" + QUERY_BINARY_NAME + "<TT;>;",
-                    Opcodes.ARETURN, null, "sort");
-
-            // listAll Sort?
-
-            generateMethod("listAll",
-                    "()Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">()Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null);
-
-            generateMethod("listAll",
-                    "(" + SORT_SIGNATURE + ")Ljava/util/List;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(" + SORT_SIGNATURE + ")Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "sort");
-
-            // streamAll Sort?
-
-            generateMethod("streamAll",
-                    "()Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">()Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null);
-
-            generateMethod("streamAll",
-                    "(" + SORT_SIGNATURE + ")Ljava/util/stream/Stream;",
-                    "<T:" + ENTITY_BASE_SIGNATURE + ">(" + SORT_SIGNATURE + ")Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "sort");
-
-            // count [String, Map|Object[]|Parameters?]?
-
-            generateMethod("count", "(Ljava/lang/String;[Ljava/lang/Object;)J", null, Opcodes.LRETURN, null, "query", "params");
-            generateMethod("count", "(Ljava/lang/String;Ljava/util/Map;)J", null, Opcodes.LRETURN, null, "query", "params");
-            generateMethod("count", "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")J", null, Opcodes.LRETURN, null, "query",
-                    "params");
-            generateMethod("count", "()J", null, Opcodes.LRETURN, null);
-
-            // delete [String, Map|Object[]|Parameters?]?
-
-            generateMethod("delete", "(Ljava/lang/String;[Ljava/lang/Object;)J", null, Opcodes.LRETURN, null, "query",
-                    "params");
-            generateMethod("delete", "(Ljava/lang/String;Ljava/util/Map;)J", null, Opcodes.LRETURN, null, "query", "params");
-            generateMethod("delete", "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")J", null, Opcodes.LRETURN, null, "query",
-                    "params");
-            generateMethod("deleteAll", "()J", null, Opcodes.LRETURN, null);
+            for (MethodInfo method : panacheEntityBaseClassInfo.methods()) {
+                AnnotationInstance bridge = method.annotation(JandexUtil.DOTNAME_GENERATE_BRIDGE);
+                if (bridge != null)
+                    generateMethod(method, bridge.value("targetReturnTypeErased"));
+            }
 
             generateAccessors();
 
             super.visitEnd();
         }
 
-        private void generateMethod(String name,
-                String descriptor,
-                String signature,
-                int returnOperation,
-                String castTo,
-                String... parameters) {
+        private void generateMethod(MethodInfo method, AnnotationValue targetReturnTypeErased) {
+            String descriptor = JandexUtil.getDescriptor(method, name -> null);
+            String signature = JandexUtil.getSignature(method, name -> null);
+            List<org.jboss.jandex.Type> parameters = method.parameters();
+            String castTo = null;
+            if (targetReturnTypeErased != null && targetReturnTypeErased.asBoolean()) {
+                castTo = method.returnType().name().toString('/');
+            }
+
             MethodVisitor mv = super.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
-                    name,
+                    method.name(),
                     descriptor,
                     signature,
                     null);
-            for (int i = 0; i < parameters.length; i++) {
-                mv.visitParameter(parameters[i], 0 /* modifiers */);
+            for (int i = 0; i < parameters.size(); i++) {
+                mv.visitParameter(method.parameterName(i), 0 /* modifiers */);
             }
             mv.visitCode();
             // inject Class
             mv.visitLdcInsn(thisClass);
-            for (int i = 0; i < parameters.length; i++) {
+            for (int i = 0; i < parameters.size(); i++) {
                 mv.visitIntInsn(Opcodes.ALOAD, i);
             }
             // inject Class
@@ -324,11 +177,12 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
             }
             mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                     JPA_OPERATIONS_BINARY_NAME,
-                    name,
+                    method.name(),
                     forwardingDescriptor, false);
             if (castTo != null)
                 mv.visitTypeInsn(Opcodes.CHECKCAST, castTo);
-            mv.visitInsn(returnOperation);
+            String returnTypeDescriptor = descriptor.substring(descriptor.lastIndexOf(")") + 1);
+            mv.visitInsn(JandexUtil.getReturnInstruction(returnTypeDescriptor));
             mv.visitMaxs(0, 0);
             mv.visitEnd();
         }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
@@ -59,7 +59,7 @@ public class PanacheJpaEntityEnhancer implements BiFunction<String, ClassVisitor
 
     private static final DotName DOTNAME_TRANSIENT = DotName.createSimple(Transient.class.getName());
     final Map<String, EntityModel> entities = new HashMap<>();
-    private ClassInfo panacheEntityBaseClassInfo;
+    private final ClassInfo panacheEntityBaseClassInfo;
 
     public PanacheJpaEntityEnhancer(IndexView index) {
         panacheEntityBaseClassInfo = index.getClassByName(PanacheResourceProcessor.DOTNAME_PANACHE_ENTITY_BASE);

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaRepositoryEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaRepositoryEnhancer.java
@@ -28,7 +28,7 @@ public class PanacheJpaRepositoryEnhancer implements BiFunction<String, ClassVis
 
     public final static String PANACHE_REPOSITORY_NAME = PanacheRepository.class.getName();
     public final static String PANACHE_REPOSITORY_BINARY_NAME = PANACHE_REPOSITORY_NAME.replace('.', '/');
-    private ClassInfo panacheRepositoryBaseClassInfo;
+    private final ClassInfo panacheRepositoryBaseClassInfo;
 
     public PanacheJpaRepositoryEnhancer(IndexView index) {
         panacheRepositoryBaseClassInfo = index.getClassByName(PanacheResourceProcessor.DOTNAME_PANACHE_REPOSITORY_BASE);

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaRepositoryEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaRepositoryEnhancer.java
@@ -1,13 +1,16 @@
 package io.quarkus.hibernate.orm.panache.deployment;
 
 import static io.quarkus.hibernate.orm.panache.deployment.PanacheJpaEntityEnhancer.JPA_OPERATIONS_BINARY_NAME;
-import static io.quarkus.hibernate.orm.panache.deployment.PanacheJpaEntityEnhancer.PARAMETERS_SIGNATURE;
-import static io.quarkus.hibernate.orm.panache.deployment.PanacheJpaEntityEnhancer.QUERY_BINARY_NAME;
-import static io.quarkus.hibernate.orm.panache.deployment.PanacheJpaEntityEnhancer.QUERY_SIGNATURE;
-import static io.quarkus.hibernate.orm.panache.deployment.PanacheJpaEntityEnhancer.SORT_SIGNATURE;
 
+import java.util.List;
 import java.util.function.BiFunction;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type.Kind;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -16,6 +19,7 @@ import org.objectweb.asm.signature.SignatureReader;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.quarkus.panache.common.deployment.JandexUtil;
 
 public class PanacheJpaRepositoryEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
 
@@ -24,10 +28,15 @@ public class PanacheJpaRepositoryEnhancer implements BiFunction<String, ClassVis
 
     public final static String PANACHE_REPOSITORY_NAME = PanacheRepository.class.getName();
     public final static String PANACHE_REPOSITORY_BINARY_NAME = PANACHE_REPOSITORY_NAME.replace('.', '/');
+    private ClassInfo panacheRepositoryBaseClassInfo;
+
+    public PanacheJpaRepositoryEnhancer(IndexView index) {
+        panacheRepositoryBaseClassInfo = index.getClassByName(PanacheResourceProcessor.DOTNAME_PANACHE_REPOSITORY_BASE);
+    }
 
     @Override
     public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
-        return new DaoEnhancingClassVisitor(className, outputClassVisitor);
+        return new DaoEnhancingClassVisitor(className, outputClassVisitor, panacheRepositoryBaseClassInfo);
     }
 
     static class DaoEnhancingClassVisitor extends ClassVisitor {
@@ -36,10 +45,13 @@ public class PanacheJpaRepositoryEnhancer implements BiFunction<String, ClassVis
         private String entitySignature;
         private String entityBinaryType;
         private String daoBinaryName;
+        private ClassInfo panacheRepositoryBaseClassInfo;
 
-        public DaoEnhancingClassVisitor(String className, ClassVisitor outputClassVisitor) {
+        public DaoEnhancingClassVisitor(String className, ClassVisitor outputClassVisitor,
+                ClassInfo panacheRepositoryBaseClassInfo) {
             super(Opcodes.ASM6, outputClassVisitor);
             daoBinaryName = className.replace('.', '/');
+            this.panacheRepositoryBaseClassInfo = panacheRepositoryBaseClassInfo;
         }
 
         @Override
@@ -84,189 +96,43 @@ public class PanacheJpaRepositoryEnhancer implements BiFunction<String, ClassVis
             mv.visitMaxs(0, 0);
             mv.visitEnd();
 
-            generateMethod("findById",
-                    "(Ljava/lang/Object;)" + entitySignature,
-                    null,
-                    Opcodes.ARETURN, entityBinaryType, "id");
-
-            // find String Sort? Map|Object[]|Parameters?
-
-            generateMethod("find",
-                    "(Ljava/lang/String;[Ljava/lang/Object;)" + QUERY_SIGNATURE,
-                    "(Ljava/lang/String;[Ljava/lang/Object;)L" + QUERY_BINARY_NAME + "<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)" + QUERY_SIGNATURE,
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)L" + QUERY_BINARY_NAME + "<" + entitySignature
-                            + ">;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;Ljava/util/Map;)" + QUERY_SIGNATURE,
-                    "(Ljava/lang/String;Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)L" + QUERY_BINARY_NAME + "<"
-                            + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map;)" + QUERY_SIGNATURE,
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)L"
-                            + QUERY_BINARY_NAME + "<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")" + QUERY_SIGNATURE,
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")L" + QUERY_BINARY_NAME + "<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("find",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")" + QUERY_SIGNATURE,
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")L" + QUERY_BINARY_NAME + "<"
-                            + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            // list String Sort? Map|Object[]|Parameters?
-
-            generateMethod("list",
-                    "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/List;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)Ljava/util/List;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "[Ljava/lang/Object;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;Ljava/util/Map;)Ljava/util/List;",
-                    "<T:" + entitySignature
-                            + ">(Ljava/lang/String;Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map;)Ljava/util/List;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/List;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("list",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")Ljava/util/List;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE
-                            + ")Ljava/util/List<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            // stream String Sort? Map|Object[]|Parameters?
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/stream/Stream;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;[Ljava/lang/Object;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "[Ljava/lang/Object;)Ljava/util/stream/Stream;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "[Ljava/lang/Object;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;Ljava/util/Map;)Ljava/util/stream/Stream;",
-                    "<T:" + entitySignature
-                            + ">(Ljava/lang/String;Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + "Ljava/util/Map;)Ljava/util/stream/Stream;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + SORT_SIGNATURE
-                            + "Ljava/util/Map<Ljava/lang/String;Ljava/lang/Object;>;)Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/stream/Stream;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "params");
-
-            generateMethod("stream",
-                    "(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE + ")Ljava/util/stream/Stream;",
-                    "<T:" + entitySignature + ">(Ljava/lang/String;" + SORT_SIGNATURE + PARAMETERS_SIGNATURE
-                            + ")Ljava/util/stream/Stream<TT;>;",
-                    Opcodes.ARETURN, null, "query", "sort", "params");
-
-            // findAll Sort?
-
-            generateMethod("findAll",
-                    "()" + QUERY_SIGNATURE,
-                    "()L" + QUERY_BINARY_NAME + "<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null);
-
-            generateMethod("findAll",
-                    "(" + SORT_SIGNATURE + ")" + QUERY_SIGNATURE,
-                    "(" + SORT_SIGNATURE + ")L" + QUERY_BINARY_NAME + "<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "sort");
-
-            // listAll Sort?
-
-            generateMethod("listAll",
-                    "()Ljava/util/List;",
-                    "()Ljava/util/List<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null);
-
-            generateMethod("listAll",
-                    "(" + SORT_SIGNATURE + ")Ljava/util/List;",
-                    "(" + SORT_SIGNATURE + ")Ljava/util/List<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "sort");
-
-            // streamAll Sort?
-
-            generateMethod("streamAll",
-                    "()Ljava/util/stream/Stream;",
-                    "()Ljava/util/stream/Stream<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null);
-
-            generateMethod("streamAll",
-                    "(" + SORT_SIGNATURE + ")Ljava/util/stream/Stream;",
-                    "(" + SORT_SIGNATURE + ")Ljava/util/stream/Stream<" + entitySignature + ">;",
-                    Opcodes.ARETURN, null, "sort");
-
-            // count [String, Map|Object[]|Parameters?]?
-
-            generateMethod("count", "(Ljava/lang/String;[Ljava/lang/Object;)J", null, Opcodes.LRETURN, null, "query", "params");
-            generateMethod("count", "(Ljava/lang/String;Ljava/util/Map;)J", null, Opcodes.LRETURN, null, "query", "params");
-            generateMethod("count", "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")J", null, Opcodes.LRETURN, null, "query",
-                    "params");
-            generateMethod("count", "()J", null, Opcodes.LRETURN, null);
-
-            // delete [String, Map|Object[]|Parameters?]?
-
-            generateMethod("delete", "(Ljava/lang/String;[Ljava/lang/Object;)J", null, Opcodes.LRETURN, null, "query",
-                    "params");
-            generateMethod("delete", "(Ljava/lang/String;Ljava/util/Map;)J", null, Opcodes.LRETURN, null, "query", "params");
-            generateMethod("delete", "(Ljava/lang/String;" + PARAMETERS_SIGNATURE + ")J", null, Opcodes.LRETURN, null, "query",
-                    "params");
-            generateMethod("deleteAll", "()J", null, Opcodes.LRETURN, null);
+            for (MethodInfo method : panacheRepositoryBaseClassInfo.methods()) {
+                AnnotationInstance bridge = method.annotation(JandexUtil.DOTNAME_GENERATE_BRIDGE);
+                if (bridge != null)
+                    generateMethod(method, bridge.value("targetReturnTypeErased"));
+            }
 
             super.visitEnd();
         }
 
-        private void generateMethod(String name, String descriptor, String signature, int returnOpCode, String castTo,
-                String... params) {
+        private void generateMethod(MethodInfo method, AnnotationValue targetReturnTypeErased) {
+            String descriptor = JandexUtil.getDescriptor(method, name -> name.equals("Entity") ? entitySignature : null);
+            String signature = JandexUtil.getSignature(method, name -> name.equals("Entity") ? entitySignature : null);
+            List<org.jboss.jandex.Type> parameters = method.parameters();
+
+            String castTo = null;
+            if (targetReturnTypeErased != null && targetReturnTypeErased.asBoolean()) {
+                org.jboss.jandex.Type type = method.returnType();
+                if (type.kind() == Kind.TYPE_VARIABLE) {
+                    if (type.asTypeVariable().identifier().equals("Entity"))
+                        castTo = entityBinaryType;
+                }
+                if (castTo == null)
+                    castTo = type.name().toString('/');
+            }
+
             MethodVisitor mv = super.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
-                    name,
+                    method.name(),
                     descriptor,
                     signature,
                     null);
-            for (int i = 0; i < params.length; i++) {
-                mv.visitParameter(params[i], 0 /* modifiers */);
+            for (int i = 0; i < parameters.size(); i++) {
+                mv.visitParameter(method.parameterName(i), 0 /* modifiers */);
             }
             mv.visitCode();
             // inject Class
             mv.visitLdcInsn(entityType);
-            for (int i = 0; i < params.length; i++) {
+            for (int i = 0; i < parameters.size(); i++) {
                 mv.visitIntInsn(Opcodes.ALOAD, i + 1);
             }
             // inject Class
@@ -278,11 +144,12 @@ public class PanacheJpaRepositoryEnhancer implements BiFunction<String, ClassVis
             }
             mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                     JPA_OPERATIONS_BINARY_NAME,
-                    name,
+                    method.name(),
                     forwardingDescriptor, false);
             if (castTo != null)
                 mv.visitTypeInsn(Opcodes.CHECKCAST, castTo);
-            mv.visitInsn(returnOpCode);
+            String returnTypeDescriptor = descriptor.substring(descriptor.lastIndexOf(")") + 1);
+            mv.visitInsn(JandexUtil.getReturnInstruction(returnTypeDescriptor));
             mv.visitMaxs(0, 0);
             mv.visitEnd();
         }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
@@ -44,9 +44,9 @@ import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 
 public final class PanacheResourceProcessor {
 
-    private static final DotName DOTNAME_PANACHE_REPOSITORY_BASE = DotName.createSimple(PanacheRepositoryBase.class.getName());
+    static final DotName DOTNAME_PANACHE_REPOSITORY_BASE = DotName.createSimple(PanacheRepositoryBase.class.getName());
     private static final DotName DOTNAME_PANACHE_REPOSITORY = DotName.createSimple(PanacheRepository.class.getName());
-    private static final DotName DOTNAME_PANACHE_ENTITY_BASE = DotName.createSimple(PanacheEntityBase.class.getName());
+    static final DotName DOTNAME_PANACHE_ENTITY_BASE = DotName.createSimple(PanacheEntityBase.class.getName());
     private static final DotName DOTNAME_PANACHE_ENTITY = DotName.createSimple(PanacheEntity.class.getName());
 
     private static final Set<DotName> UNREMOVABLE_BEANS = Collections.singleton(
@@ -82,7 +82,7 @@ public final class PanacheResourceProcessor {
             BuildProducer<BytecodeTransformerBuildItem> transformers,
             HibernateEnhancersRegisteredBuildItem hibernateMarker) throws Exception {
 
-        PanacheJpaRepositoryEnhancer daoEnhancer = new PanacheJpaRepositoryEnhancer();
+        PanacheJpaRepositoryEnhancer daoEnhancer = new PanacheJpaRepositoryEnhancer(index.getIndex());
         Set<String> daoClasses = new HashSet<>();
         for (ClassInfo classInfo : index.getIndex().getAllKnownImplementors(DOTNAME_PANACHE_REPOSITORY_BASE)) {
             // Skip PanacheRepository
@@ -97,7 +97,7 @@ public final class PanacheResourceProcessor {
             transformers.produce(new BytecodeTransformerBuildItem(daoClass, daoEnhancer));
         }
 
-        PanacheJpaEntityEnhancer modelEnhancer = new PanacheJpaEntityEnhancer();
+        PanacheJpaEntityEnhancer modelEnhancer = new PanacheJpaEntityEnhancer(index.getIndex());
         Set<String> modelClasses = new HashSet<>();
         // Note that we do this in two passes because for some reason Jandex does not give us subtypes
         // of PanacheEntity if we ask for subtypes of PanacheEntityBase

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -10,6 +10,7 @@ import javax.persistence.Transient;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.common.impl.GenerateBridge;
 
 /**
  * <p>
@@ -71,6 +72,7 @@ public abstract class PanacheEntityBase {
      * @param id the ID of the entity to find.
      * @return the entity found, or <code>null</code> if not found.
      */
+    @GenerateBridge(targetReturnTypeErased = true)
     public static <T extends PanacheEntityBase> T findById(Object id) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -87,6 +89,7 @@ public abstract class PanacheEntityBase {
      * @see #list(String, Object...)
      * @see #stream(String, Object...)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> find(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -104,6 +107,7 @@ public abstract class PanacheEntityBase {
      * @see #list(String, Sort, Object...)
      * @see #stream(String, Sort, Object...)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> find(String query, Sort sort, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -120,6 +124,7 @@ public abstract class PanacheEntityBase {
      * @see #list(String, Map)
      * @see #stream(String, Map)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> find(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -137,6 +142,7 @@ public abstract class PanacheEntityBase {
      * @see #list(String, Sort, Map)
      * @see #stream(String, Sort, Map)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> find(String query, Sort sort, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -153,6 +159,7 @@ public abstract class PanacheEntityBase {
      * @see #list(String, Parameters)
      * @see #stream(String, Parameters)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> find(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -170,6 +177,7 @@ public abstract class PanacheEntityBase {
      * @see #list(String, Sort, Parameters)
      * @see #stream(String, Sort, Parameters)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> find(String query, Sort sort, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -182,6 +190,7 @@ public abstract class PanacheEntityBase {
      * @see #listAll()
      * @see #streamAll()
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> findAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -195,6 +204,7 @@ public abstract class PanacheEntityBase {
      * @see #listAll(Sort)
      * @see #streamAll(Sort)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> PanacheQuery<T> findAll(Sort sort) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -212,6 +222,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Object...)
      * @see #stream(String, Object...)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> list(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -230,6 +241,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Sort, Object...)
      * @see #stream(String, Sort, Object...)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> list(String query, Sort sort, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -247,6 +259,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Map)
      * @see #stream(String, Map)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> list(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -265,6 +278,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Sort, Map)
      * @see #stream(String, Sort, Map)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> list(String query, Sort sort, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -282,6 +296,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Parameters)
      * @see #stream(String, Parameters)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> list(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -300,6 +315,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Sort, Parameters)
      * @see #stream(String, Sort, Parameters)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> list(String query, Sort sort, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -313,6 +329,7 @@ public abstract class PanacheEntityBase {
      * @see #findAll()
      * @see #streamAll()
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> listAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -327,6 +344,7 @@ public abstract class PanacheEntityBase {
      * @see #findAll(Sort)
      * @see #streamAll(Sort)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> List<T> listAll(Sort sort) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -344,6 +362,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Object...)
      * @see #list(String, Object...)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> stream(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -362,6 +381,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Sort, Object...)
      * @see #list(String, Sort, Object...)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> stream(String query, Sort sort, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -379,6 +399,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Map)
      * @see #list(String, Map)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> stream(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -397,6 +418,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Sort, Map)
      * @see #list(String, Sort, Map)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> stream(String query, Sort sort, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -414,6 +436,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Parameters)
      * @see #list(String, Parameters)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> stream(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -432,6 +455,7 @@ public abstract class PanacheEntityBase {
      * @see #find(String, Sort, Parameters)
      * @see #list(String, Sort, Parameters)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> stream(String query, Sort sort, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -445,6 +469,7 @@ public abstract class PanacheEntityBase {
      * @see #findAll()
      * @see #listAll()
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> streamAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -459,6 +484,7 @@ public abstract class PanacheEntityBase {
      * @see #findAll(Sort)
      * @see #listAll(Sort)
      */
+    @GenerateBridge
     public static <T extends PanacheEntityBase> Stream<T> streamAll(Sort sort) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -471,6 +497,7 @@ public abstract class PanacheEntityBase {
      * @see #count(String, Map)
      * @see #count(String, Parameters)
      */
+    @GenerateBridge
     public static long count() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -485,6 +512,7 @@ public abstract class PanacheEntityBase {
      * @see #count(String, Map)
      * @see #count(String, Parameters)
      */
+    @GenerateBridge
     public static long count(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -499,6 +527,7 @@ public abstract class PanacheEntityBase {
      * @see #count(String, Object...)
      * @see #count(String, Parameters)
      */
+    @GenerateBridge
     public static long count(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -513,6 +542,7 @@ public abstract class PanacheEntityBase {
      * @see #count(String, Object...)
      * @see #count(String, Map)
      */
+    @GenerateBridge
     public static long count(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -525,6 +555,7 @@ public abstract class PanacheEntityBase {
      * @see #delete(String, Map)
      * @see #delete(String, Parameters)
      */
+    @GenerateBridge
     public static long deleteAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -539,6 +570,7 @@ public abstract class PanacheEntityBase {
      * @see #delete(String, Map)
      * @see #delete(String, Parameters)
      */
+    @GenerateBridge
     public static long delete(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -553,6 +585,7 @@ public abstract class PanacheEntityBase {
      * @see #delete(String, Object...)
      * @see #delete(String, Parameters)
      */
+    @GenerateBridge
     public static long delete(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -567,6 +600,7 @@ public abstract class PanacheEntityBase {
      * @see #delete(String, Object...)
      * @see #delete(String, Map)
      */
+    @GenerateBridge
     public static long delete(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.common.impl.GenerateBridge;
 
 /**
  * <p>
@@ -71,6 +72,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @param id the ID of the entity to find.
      * @return the entity found, or <code>null</code> if not found.
      */
+    @GenerateBridge(targetReturnTypeErased = true)
     public default Entity findById(Id id) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -87,6 +89,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #list(String, Object...)
      * @see #stream(String, Object...)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> find(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -104,6 +107,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #list(String, Sort, Object...)
      * @see #stream(String, Sort, Object...)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> find(String query, Sort sort, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -120,6 +124,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #list(String, Map)
      * @see #stream(String, Map)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> find(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -137,6 +142,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #list(String, Sort, Map)
      * @see #stream(String, Sort, Map)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> find(String query, Sort sort, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -153,6 +159,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #list(String, Parameters)
      * @see #stream(String, Parameters)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> find(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -170,6 +177,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #list(String, Sort, Parameters)
      * @see #stream(String, Sort, Parameters)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> find(String query, Sort sort, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -182,6 +190,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #listAll()
      * @see #streamAll()
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> findAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -195,6 +204,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #listAll(Sort)
      * @see #streamAll(Sort)
      */
+    @GenerateBridge
     public default PanacheQuery<Entity> findAll(Sort sort) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -212,6 +222,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Object...)
      * @see #stream(String, Object...)
      */
+    @GenerateBridge
     public default List<Entity> list(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -230,6 +241,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Sort, Object...)
      * @see #stream(String, Sort, Object...)
      */
+    @GenerateBridge
     public default List<Entity> list(String query, Sort sort, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -247,6 +259,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Map)
      * @see #stream(String, Map)
      */
+    @GenerateBridge
     public default List<Entity> list(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -265,6 +278,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Sort, Map)
      * @see #stream(String, Sort, Map)
      */
+    @GenerateBridge
     public default List<Entity> list(String query, Sort sort, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -282,6 +296,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Parameters)
      * @see #stream(String, Parameters)
      */
+    @GenerateBridge
     public default List<Entity> list(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -300,6 +315,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Sort, Parameters)
      * @see #stream(String, Sort, Parameters)
      */
+    @GenerateBridge
     public default List<Entity> list(String query, Sort sort, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -313,6 +329,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #findAll()
      * @see #streamAll()
      */
+    @GenerateBridge
     public default List<Entity> listAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -327,6 +344,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #findAll(Sort)
      * @see #streamAll(Sort)
      */
+    @GenerateBridge
     public default List<Entity> listAll(Sort sort) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -344,6 +362,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Object...)
      * @see #list(String, Object...)
      */
+    @GenerateBridge
     public default Stream<Entity> stream(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -362,6 +381,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Sort, Object...)
      * @see #list(String, Sort, Object...)
      */
+    @GenerateBridge
     public default Stream<Entity> stream(String query, Sort sort, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -379,6 +399,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Map)
      * @see #list(String, Map)
      */
+    @GenerateBridge
     public default Stream<Entity> stream(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -397,6 +418,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Sort, Map)
      * @see #list(String, Sort, Map)
      */
+    @GenerateBridge
     public default Stream<Entity> stream(String query, Sort sort, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -414,6 +436,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Parameters)
      * @see #list(String, Parameters)
      */
+    @GenerateBridge
     public default Stream<Entity> stream(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -432,6 +455,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #find(String, Sort, Parameters)
      * @see #list(String, Sort, Parameters)
      */
+    @GenerateBridge
     public default Stream<Entity> stream(String query, Sort sort, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -445,6 +469,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #findAll()
      * @see #listAll()
      */
+    @GenerateBridge
     public default Stream<Entity> streamAll(Sort sort) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -459,6 +484,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #findAll(Sort)
      * @see #listAll(Sort)
      */
+    @GenerateBridge
     public default Stream<Entity> streamAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -471,6 +497,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #count(String, Map)
      * @see #count(String, Parameters)
      */
+    @GenerateBridge
     public default long count() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -485,6 +512,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #count(String, Map)
      * @see #count(String, Parameters)
      */
+    @GenerateBridge
     public default long count(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -499,6 +527,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #count(String, Object...)
      * @see #count(String, Parameters)
      */
+    @GenerateBridge
     public default long count(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -513,6 +542,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #count(String, Object...)
      * @see #count(String, Map)
      */
+    @GenerateBridge
     public default long count(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -525,6 +555,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #delete(String, Map)
      * @see #delete(String, Parameters)
      */
+    @GenerateBridge
     public default long deleteAll() {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -539,6 +570,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #delete(String, Map)
      * @see #delete(String, Parameters)
      */
+    @GenerateBridge
     public default long delete(String query, Object... params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -553,6 +585,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #delete(String, Object...)
      * @see #delete(String, Parameters)
      */
+    @GenerateBridge
     public default long delete(String query, Map<String, Object> params) {
         throw JpaOperations.implementationInjectionMissing();
     }
@@ -567,6 +600,7 @@ public interface PanacheRepositoryBase<Entity, Id> {
      * @see #delete(String, Object...)
      * @see #delete(String, Map)
      */
+    @GenerateBridge
     public default long delete(String query, Parameters params) {
         throw JpaOperations.implementationInjectionMissing();
     }

--- a/extensions/panache/panache-common/deployment/pom.xml
+++ b/extensions/panache/panache-common/deployment/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-panache-common-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-panache-common-deployment</artifactId>
+    <name>Quarkus - Panache - Common - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-panache-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JandexUtil.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JandexUtil.java
@@ -1,0 +1,162 @@
+package io.quarkus.panache.common.deployment;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.PrimitiveType.Primitive;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.panache.common.impl.GenerateBridge;
+
+public class JandexUtil {
+    public static final DotName DOTNAME_GENERATE_BRIDGE = DotName.createSimple(GenerateBridge.class.getName());
+
+    public static String getSignature(MethodInfo method, Function<String, String> typeArgMapper) {
+        List<Type> parameters = method.parameters();
+
+        StringBuilder signature = new StringBuilder("");
+        for (TypeVariable typeVariable : method.typeParameters()) {
+            if (signature.length() == 0)
+                signature.append("<");
+            else
+                signature.append(",");
+            signature.append(typeVariable.identifier()).append(":");
+            // FIXME: only use the first bound
+            toSignature(signature, typeVariable.bounds().get(0), typeArgMapper, false);
+        }
+        if (signature.length() > 0)
+            signature.append(">");
+        signature.append("(");
+        for (Type type : parameters) {
+            toSignature(signature, type, typeArgMapper, false);
+        }
+        signature.append(")");
+        toSignature(signature, method.returnType(), typeArgMapper, false);
+        return signature.toString();
+    }
+
+    public static String getDescriptor(MethodInfo method, Function<String, String> typeArgMapper) {
+        List<Type> parameters = method.parameters();
+
+        StringBuilder descriptor = new StringBuilder("(");
+        for (Type type : parameters) {
+            toSignature(descriptor, type, typeArgMapper, true);
+        }
+        descriptor.append(")");
+        toSignature(descriptor, method.returnType(), typeArgMapper, true);
+        return descriptor.toString();
+    }
+
+    static void toSignature(StringBuilder sb, Type type, Function<String, String> typeArgMapper, boolean erased) {
+        switch (type.kind()) {
+            case ARRAY:
+                ArrayType arrayType = type.asArrayType();
+                for (int i = 0; i < arrayType.dimensions(); i++)
+                    sb.append("[");
+                toSignature(sb, arrayType.component(), typeArgMapper, erased);
+                break;
+            case CLASS:
+                sb.append("L");
+                sb.append(type.asClassType().name().toString().replace('.', '/'));
+                sb.append(";");
+                break;
+            case PARAMETERIZED_TYPE:
+                ParameterizedType parameterizedType = type.asParameterizedType();
+                sb.append("L");
+                // FIXME: support owner type
+                sb.append(parameterizedType.name().toString().replace('.', '/'));
+                if (!erased && !parameterizedType.arguments().isEmpty()) {
+                    sb.append("<");
+                    List<Type> arguments = parameterizedType.arguments();
+                    for (int i = 0; i < arguments.size(); i++) {
+                        Type argType = arguments.get(i);
+                        toSignature(sb, argType, typeArgMapper, erased);
+                    }
+                    sb.append(">");
+                }
+                sb.append(";");
+                break;
+            case PRIMITIVE:
+                Primitive primitive = type.asPrimitiveType().primitive();
+                switch (primitive) {
+                    case BOOLEAN:
+                        sb.append('Z');
+                        break;
+                    case BYTE:
+                        sb.append('B');
+                        break;
+                    case CHAR:
+                        sb.append('C');
+                        break;
+                    case DOUBLE:
+                        sb.append('D');
+                        break;
+                    case FLOAT:
+                        sb.append('F');
+                        break;
+                    case INT:
+                        sb.append('I');
+                        break;
+                    case LONG:
+                        sb.append('J');
+                        break;
+                    case SHORT:
+                        sb.append('S');
+                        break;
+                }
+                break;
+            case TYPE_VARIABLE:
+                TypeVariable typeVariable = type.asTypeVariable();
+                String mappedSignature = typeArgMapper.apply(typeVariable.identifier());
+                if (mappedSignature != null)
+                    sb.append(mappedSignature);
+                else if (erased)
+                    toSignature(sb, typeVariable.bounds().get(0), typeArgMapper, erased);
+                else
+                    sb.append("T").append(typeVariable.identifier()).append(";");
+                break;
+            case UNRESOLVED_TYPE_VARIABLE:
+                // FIXME: ??
+                break;
+            case VOID:
+                sb.append("V");
+                break;
+            case WILDCARD_TYPE:
+                if (!erased) {
+                    sb.append("*");
+                }
+                break;
+            default:
+                break;
+
+        }
+    }
+
+    public static int getReturnInstruction(String typeDescriptor) {
+        switch (typeDescriptor) {
+            case "Z":
+            case "B":
+            case "C":
+            case "S":
+            case "I":
+                return Opcodes.IRETURN;
+            case "J":
+                return Opcodes.LRETURN;
+            case "F":
+                return Opcodes.FRETURN;
+            case "D":
+                return Opcodes.DRETURN;
+            case "V":
+                return Opcodes.RETURN;
+            default:
+                return Opcodes.ARETURN;
+        }
+    }
+
+}

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JavaBeanUtil.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JavaBeanUtil.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.orm.panache.deployment;
+package io.quarkus.panache.common.deployment;
 
 public class JavaBeanUtil {
 

--- a/extensions/panache/panache-common/pom.xml
+++ b/extensions/panache/panache-common/pom.xml
@@ -31,6 +31,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>runtime</module>
+        <module>deployment</module>
     </modules>
 
 

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/impl/GenerateBridge.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/impl/GenerateBridge.java
@@ -1,0 +1,20 @@
+package io.quarkus.panache.common.impl;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface GenerateBridge {
+
+    /**
+     * Set to true if the corresponding JpaOperations method returns Object
+     * but the bridge should return a more specific type.
+     */
+    boolean targetReturnTypeErased() default false;
+
+}


### PR DESCRIPTION
No more special cases: all methods annotated with `GenerateBridge` will be plugged in, like I had it in panache-rx.
Added the panache-common-deployment module to hold classes common to both jpa/rx implementations that have no place at runtime.