### PR TITLE
Move the title of guides to the top

### DIFF
--- a/docs/src/main/asciidoc/ap4k.adoc
+++ b/docs/src/main/asciidoc/ap4k.adoc
@@ -3,10 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Generating Kubernetes resources
 
 include::./attributes.adoc[]
-
-= {project-name} - Generating Kubernetes resources
 
 This guide covers generating Kubernetes resources based on sane defaults and user supplied configuration.
 

--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -3,10 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Configuring Your Application
 
 include::./attributes.adoc[]
-
-= {project-name} - Configuring Your Application
 
 Hardcoded values in your code is a _no go_ (even if we all did it at some point ;-)).
 In this guide, we learn how to configure your application.

--- a/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
+++ b/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Application Initialization and Termination
 
 include::./attributes.adoc[]
-= {project-name} - Application Initialization and Termination
 
 You often need to execute custom actions when the application starts and clean up everything when the application stops.
 This guide explains how to:

--- a/docs/src/main/asciidoc/async-message-passing.adoc
+++ b/docs/src/main/asciidoc/async-message-passing.adoc
@@ -1,5 +1,11 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Asynchronous messages between beans
+
 include::./attributes.adoc[]
-= {project-name} - Asynchronous messages between beans
 
 {project-name} allows different beans to interact using asynchronous messages, enforcing loose-coupling.
 The messages are sent to _virtual addresses_.

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Building a Native Executable
 
 include::./attributes.adoc[]
-= {project-name} - Building a Native Executable
 
 This guide covers:
 

--- a/docs/src/main/asciidoc/building-substrate-howto.adoc
+++ b/docs/src/main/asciidoc/building-substrate-howto.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Building a Custom SubstrateVM
 
 include::./attributes.adoc[]
-= {project-name} - Building a Custom SubstrateVM
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Contexts and Dependency Injection
 
 include::./attributes.adoc[]
-= {project-name} - Contexts and Dependency Injection
 :numbered:
 :sectnums:
 :sectnumlevels: 4

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Building Quarkus apps with Quarkus Command Line Interface (CLI)
 
 include::./attributes.adoc[]
-= Building {project-name} apps with {project-name} Command Line Interface (CLI)
 
 == Installing the CLI
 

--- a/docs/src/main/asciidoc/context-propagation-guide.adoc
+++ b/docs/src/main/asciidoc/context-propagation-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Context Propagation in Quarkus
 
 include::./attributes.adoc[]
-= Context Propagation in Quarkus
 
 Traditional blocking code uses link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ThreadLocal.html[`ThreadLocal`]
  variables to store contextual objects in order to avoid

--- a/docs/src/main/asciidoc/datasource-guide.adoc
+++ b/docs/src/main/asciidoc/datasource-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Datasources
 
 include::./attributes.adoc[]
-= {project-name} - Datasources
 
 Many projects that use data require connections to a database.
 The main way of obtaining connections to a database is to use a datasource.

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -3,8 +3,8 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-
 = {project-name} - Writing Your Own Extension
+
 :numbered:
 :sectnums:
 :sectnumlevels: 4

--- a/docs/src/main/asciidoc/faq.adoc
+++ b/docs/src/main/asciidoc/faq.adoc
@@ -1,5 +1,6 @@
+= Quarkus - Frequently Asked Questions
+
 include::./attributes.adoc[]
-= {project-name} - Frequently Asked Questions
 
 :toc: macro
 :toclevels: 4

--- a/docs/src/main/asciidoc/fault-tolerance-guide.adoc
+++ b/docs/src/main/asciidoc/fault-tolerance-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Fault Tolerance
 
 include::./attributes.adoc[]
-= {project-name} - Fault Tolerance
 
 One of the challenges brought by the distributed nature of microservices is that communication with external systems is
 inherently unreliable. This increases demand on resiliency of applications. To simplify making more resilient

--- a/docs/src/main/asciidoc/flyway-guide.adoc
+++ b/docs/src/main/asciidoc/flyway-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using Flyway
 
 include::./attributes.adoc[]
-= {project-name} - Using Flyway
 :migrations-path: src/main/resources/db/migration
 :config-file: application.properties
 

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Creating Your First Application
 
 include::./attributes.adoc[]
-= {project-name} - Creating Your First Application
 
 :toc: macro
 :toclevels: 4

--- a/docs/src/main/asciidoc/getting-started-knative-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-knative-guide.adoc
@@ -3,11 +3,11 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Deploying Knative Application to Kubernetes or OpenShift
 
 include::./attributes.adoc[]
 :experimental:
 
-= {project-name} - Deploying Knative Application to Kubernetes or OpenShift
 
 This guide covers:
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Testing Your Application
 
 include::./attributes.adoc[]
-= {project-name} - Testing Your Application
 
 :toc: macro
 :toclevels: 4

--- a/docs/src/main/asciidoc/gradle-config.adoc
+++ b/docs/src/main/asciidoc/gradle-config.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Gradle Plugin Repositories
 
 include::./attributes.adoc[]
-= {project-name} - Gradle Plugin Repositories
 
 // tag::repositories[]
 {project-name} Gradle plugin is not yet published to the https://plugins.gradle.org/[Gradle Plugin Portal],

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Building Quarkus apps with Gradle
 
 include::./attributes.adoc[]
-= Building {project-name} apps with Gradle
 
 == Gradle configuration
 

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - MicroProfile Health
 
 include::./attributes.adoc[]
-= {project-name} - MicroProfile Health
 
 This guide demonstrates how your {project-name} application can utilize the MicroProfile 
 Health specification through the SmallRye Health extension.

--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using Hibernate ORM and JPA
 
 include::./attributes.adoc[]
-= {project-name} - Using Hibernate ORM and JPA
 :config-file: application.properties
 
 Hibernate ORM is the de facto JPA implementation and offers you the full breath of an Object Relational Mapper.

--- a/docs/src/main/asciidoc/hibernate-orm-panache-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Simplified Hibernate ORM with Panache
 
 include::./attributes.adoc[]
-= {project-name} - Simplified Hibernate ORM with Panache
 :config-file: application.properties
 
 Hibernate ORM is the de facto JPA implementation and offers you the full breadth of an Object Relational Mapper.

--- a/docs/src/main/asciidoc/hibernate-search-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Hibernate Search guide
 
 include::./attributes.adoc[]
-= Quarkus - Hibernate Search guide
 
 You have a Hibernate ORM-based application? You want to provide a full-featured full-text search to your users? You're at the right place.
 

--- a/docs/src/main/asciidoc/infinispan-client-guide.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Infinispan Client
 
 include::./attributes.adoc[]
-= {project-name} - Infinispan Client
 
 Infinispan is an in memory data grid that allows running in a server outside of application processes. This extension
 provides functionality to allow the client that can connect to said server when running in {project-name}.

--- a/docs/src/main/asciidoc/jwt-guide.adoc
+++ b/docs/src/main/asciidoc/jwt-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using JWT RBAC
 
 include::./attributes.adoc[]
-= {project-name} - Using JWT RBAC
 :extension-name: Smallrye JWT
 :mp-jwt: MicroProfile JWT RBAC
 

--- a/docs/src/main/asciidoc/kafka-guide.adoc
+++ b/docs/src/main/asciidoc/kafka-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using Apache Kafka with Reactive Messaging
 
 include::./attributes.adoc[]
-= {project-name} - Using Apache Kafka with Reactive Messaging
 
 This guide demonstrates how your {project-name} application can utilize MicroProfile Reactive Messaging to interact with Apache Kafka.
 

--- a/docs/src/main/asciidoc/keycloak-guide.adoc
+++ b/docs/src/main/asciidoc/keycloak-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using Keycloak to Protect JAX-RS Applications
 
 include::./attributes.adoc[]
-= {project-name} - Using Keycloak to Protect JAX-RS Applications
 
 This guide demonstrates how your {project-name} application can use Keycloak to protect your JAX-RS applications using bearer token
 authorization, where these tokens are issued by a Keycloak Server.

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using Kotlin
 
 include::./attributes.adoc[]
-= {project-name} - Using Kotlin
 
 https://kotlinlang.org/[Kotlin] is a very popular programming language that targets the JVM (amongst other environments). Kotlin has experienced a surge in popularity the last few years making it the most popular JVM language, except for Java of course.
 

--- a/docs/src/main/asciidoc/kubernetes-guide.adoc
+++ b/docs/src/main/asciidoc/kubernetes-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Deploying on Kubernetes and OpenShift
 
 include::./attributes.adoc[]
-= {project-name} - Deploying on Kubernetes and OpenShift
 
 This guide covers:
 

--- a/docs/src/main/asciidoc/logging-guide.adoc
+++ b/docs/src/main/asciidoc/logging-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Configuring Logging
 
 include::./attributes.adoc[]
-= {project-name} - Configuring Logging
 
 This guide explains logging and how to configure it.
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Building Quarkus apps with Maven
 
 include::./attributes.adoc[]
-= Building {project-name} apps with Maven
 
 [[project-creation]]
 == Creating a new project

--- a/docs/src/main/asciidoc/metrics-guide.adoc
+++ b/docs/src/main/asciidoc/metrics-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - MicroProfile Metrics
 
 include::./attributes.adoc[]
-= {project-name} - MicroProfile Metrics
 
 This guide demonstrates how your {project-name} application can utilize the MicroProfile
 Metrics specification through the SmallRye Metrics extension.

--- a/docs/src/main/asciidoc/native-and-ssl-guide.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using SSL With Native Executables
 
 include::./attributes.adoc[]
-= Quarkus - Using SSL With Native Executables
 
 We are quickly moving to an SSL-everywhere world so being able to use SSL is crucial.
 

--- a/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using OpenAPI and Swagger UI
 
 include::./attributes.adoc[]
-= {project-name} - Using OpenAPI and Swagger UI
 
 This guide explains how your Quarkus application can expose its API description through an OpenAPI specification and
 how you can test it via a user-friendly UI named Swagger UI.

--- a/docs/src/main/asciidoc/openshift-s2i-guide.adoc
+++ b/docs/src/main/asciidoc/openshift-s2i-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Deploying on OpenShift with S2I
 
 include::./attributes.adoc[]
-= {project-name} - Deploying on OpenShift with S2I
 
 This guide covers:
 

--- a/docs/src/main/asciidoc/opentracing-guide.adoc
+++ b/docs/src/main/asciidoc/opentracing-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using OpenTracing
 
 include::./attributes.adoc[]
-= {project-name} - Using OpenTracing
 
 This guide explains how your Quarkus application can utilize opentracing to provide distributed tracing for
 interactive web applications.

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Measuring Performance
 
 include::./attributes.adoc[]
-= {project-name} - Measuring Performance
 
 This guide covers:
 

--- a/docs/src/main/asciidoc/quarkus-intro.adoc
+++ b/docs/src/main/asciidoc/quarkus-intro.adoc
@@ -1,6 +1,6 @@
-include::./attributes.adoc[]
-= What is {project-name}
+= What is Quarkus
 
+include::./attributes.adoc[]
 :toc: macro
 :toclevels: 4
 :doctype: book

--- a/docs/src/main/asciidoc/reactive-postgres-client.adoc
+++ b/docs/src/main/asciidoc/reactive-postgres-client.adoc
@@ -1,5 +1,11 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Reactive Postgres Client
+
 include::./attributes.adoc[]
-= {project-name} - Reactive Postgres Client
 :config-file: application.properties
 
 The Reactive Postgres Client is a client for Postgres with a straightforward API focusing on scalability and low-overhead.

--- a/docs/src/main/asciidoc/rest-client-guide.adoc
+++ b/docs/src/main/asciidoc/rest-client-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using the REST Client
 
 include::./attributes.adoc[]
-= {project-name} - Using the REST Client
 
 This guide explains how to use the MicroProfile REST Client in order to interact with REST APIs
 with very little effort.

--- a/docs/src/main/asciidoc/rest-json-guide.adoc
+++ b/docs/src/main/asciidoc/rest-json-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Writing JSON REST Services
 
 include::./attributes.adoc[]
-= Quarkus - Writing JSON REST Services
 
 JSON is now the _lingua franca_ between microservices.
 

--- a/docs/src/main/asciidoc/scheduled-guide.adoc
+++ b/docs/src/main/asciidoc/scheduled-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Scheduling Periodic Tasks
 
 include::./attributes.adoc[]
-= {project-name} - Scheduling Periodic Tasks
 
 Modern applications often need to run specific tasks periodically.
 In this guide, you learn how to schedule periodic tasks.

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using Security
 
 include::./attributes.adoc[]
-= {project-name} - Using Security
 
 Quarkus comes with integration with the Elytron security subsystem to allow for RBAC based on the
 common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints. An example of an endpoint that makes use of both JAX-RS and Common Security annotations to describe and secure its endpoints is given in <<SubjectExposingResource Example>>.

--- a/docs/src/main/asciidoc/sending-emails.adoc
+++ b/docs/src/main/asciidoc/sending-emails.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Sending emails
 
 include::./attributes.adoc[]
-= {project-name} - Sending emails
 
 This guide demonstrates how your {project-name} application can send emails using an SMTP server.
 

--- a/docs/src/main/asciidoc/spring-di-guide.adoc
+++ b/docs/src/main/asciidoc/spring-di-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using our Spring Dependency Injection compatibility layer
 
 include::./attributes.adoc[]
-= {project-name} - Using our Spring Dependency Injection compatibility layer
 
 While you are encouraged to use CDI annotations for injection, {project-name} provides a compatibility layer for Spring dependency injection in the form of the `spring-di` extension.
 

--- a/docs/src/main/asciidoc/tooling.adoc
+++ b/docs/src/main/asciidoc/tooling.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using our Tooling
 
 include::./attributes.adoc[]
-= {project-name} - Using our Tooling
 
 {project-name} comes with a toolchain enabling developers from live reload all the way down to deploying a Kubernetes application.
 In this guide, we will explore:

--- a/docs/src/main/asciidoc/transaction-guide.adoc
+++ b/docs/src/main/asciidoc/transaction-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Using Transactions in Quarkus
 
 include::./attributes.adoc[]
-= Using Transactions in Quarkus
 
 Quarkus comes with a Transaction Manager and uses it to coordinate and expose transactions to your applications.
 Each extension dealing with persistence will integrate with it for you.

--- a/docs/src/main/asciidoc/undertow-reference.adoc
+++ b/docs/src/main/asciidoc/undertow-reference.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Undertow
 
 include::./attributes.adoc[]
-= {project-name} - Undertow
 :numbered:
 :sectnums:
 :sectnumlevels: 4

--- a/docs/src/main/asciidoc/using-vertx.adoc
+++ b/docs/src/main/asciidoc/using-vertx.adoc
@@ -1,5 +1,11 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Using Eclipse Vert.x
+
 include::./attributes.adoc[]
-= {project-name} - Using Eclipse Vert.x
 
 Eclipse https://vertx.io[Vert.x] is a toolkit for building reactive applications.
 It is designed to be lightweight and embeddable.

--- a/docs/src/main/asciidoc/validation-guide.adoc
+++ b/docs/src/main/asciidoc/validation-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Validation with Hibernate Validator
 
 include::./attributes.adoc[]
-= {project-name} - Validation with Hibernate Validator
 
 This guide covers how to use Hibernate Validator/Bean Validation for:
 

--- a/docs/src/main/asciidoc/websocket-guide.adoc
+++ b/docs/src/main/asciidoc/websocket-guide.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Using WebSockets
 
 include::./attributes.adoc[]
-= {project-name} - Using WebSockets
 
 This guide explains how your Quarkus application can utilize web sockets to create interactive web applications.
 Because it's the _canonical_ web socket application, we are going to create a simple chat application.

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -3,9 +3,9 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
+= Quarkus - Tips for writing native applications
 
 include::./attributes.adoc[]
-= {project-name} - Tips for writing native applications
 
 This guide contains various tips and tricks for getting around problems that might arise when attempting to run java applications as native executables.
 


### PR DESCRIPTION
Otherwise it gets ignored by the website and titles are automatically
generated from the URL.

See https://github.com/quarkusio/quarkusio.github.io/issues/227