### PR TITLE
Fix thread safety of TransactionEntityManagers

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionEntityManagers.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionEntityManagers.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.runtime;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -11,6 +12,7 @@ import javax.transaction.TransactionSynchronizationRegistry;
 
 import io.quarkus.hibernate.orm.runtime.entitymanager.TransactionScopedEntityManager;
 
+@ApplicationScoped
 public class TransactionEntityManagers {
 
     @Inject


### PR DESCRIPTION
Without this, it is possible to trigger ConcurrentModificationException if
sending parallel requests before TransactionEntityManagers.managers was
filled. One way to do so would be to invoke ab (ApacheBench) with a
concurrency level > 4 on a fresh started instance of Quarkus.

For further details see #2848

fixes #2848