### PR TITLE
spring-di: support scopes on bean methods #2778

### DIFF
--- a/integration-tests/spring-di/pom.xml
+++ b/integration-tests/spring-di/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/AppConfiguration.java
+++ b/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/AppConfiguration.java
@@ -1,8 +1,11 @@
 package io.quarkus.it.spring;
 
+import javax.inject.Singleton;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
 public class AppConfiguration {
@@ -11,5 +14,30 @@ public class AppConfiguration {
     public StringFunction capitalizer(@Qualifier("dumb") Dummy notUsedJustMakingSureDIInMethodsWorks,
             OtherDummy alsoNotUsed) {
         return String::toUpperCase;
+    }
+
+    @Bean
+    @Singleton
+    public SingletonBean explicitSingletonBean() {
+        return new SingletonBean();
+    }
+
+    @Bean
+    public SingletonBean implicitSingletonBean() {
+        return new SingletonBean();
+    }
+
+    @Bean
+    @RequestScope
+    public AnotherRequestBean requestBean() {
+        return new AnotherRequestBean();
+    }
+
+    private static class SingletonBean {
+
+    }
+
+    private static class AnotherRequestBean {
+
     }
 }


### PR DESCRIPTION
Fixes #2778 

- Fix NPE when org.springframework.context.annotation.Scope is used on a bean method
- Change default bean implicit scope from dependent to singleton
- Do not process non-spring annotations (i.e. an explicit singleton) in spring-di, to avoid adding duplicate scopes with Arc processor