### PR TITLE
Check both BuiltinQualifier.ANY and BuiltinQualifier.DEFAULT

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -212,7 +212,7 @@ public class BeanInfo implements InjectionTargetInfo {
 
     public boolean hasDefaultQualifiers() {
         return qualifiers.size() == 2 && qualifiers.contains(BuiltinQualifier.DEFAULT.getInstance())
-                && qualifiers.contains(BuiltinQualifier.DEFAULT.getInstance());
+                && qualifiers.contains(BuiltinQualifier.ANY.getInstance());
     }
 
     List<Injection> getInjections() {


### PR DESCRIPTION
Fix of BeanInfo.hasDefaultQualifiers

Check both BuiltinQualifier.ANY and BuiltinQualifier.DEFAULT

`qualifiers.contains(BuiltinQualifier.DEFAULT.getInstance())` check was present twice