### PR TITLE
Only include the jars in the lib/ directory and classpath entries

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -259,6 +259,12 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
         for (AppDependency appDep : appDeps) {
             final AppArtifact depArtifact = appDep.getArtifact();
             final Path resolvedDep = depResolver.resolve(depArtifact);
+
+            // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
+            if (!resolvedDep.getFileName().toString().endsWith(".jar")) {
+                continue;
+            }
+
             Set<String> transformedFromThisArchive = transformedClasses.get(resolvedDep);
             if (uberJar) {
                 try (FileSystem artifactFs = ZipUtils.newFileSystem(resolvedDep)) {

--- a/core/creator/src/test/java/io/quarkus/creator/phase/runnerjar/test/RunnerJarOutcomeTestBase.java
+++ b/core/creator/src/test/java/io/quarkus/creator/phase/runnerjar/test/RunnerJarOutcomeTestBase.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -57,7 +58,9 @@ public abstract class RunnerJarOutcomeTestBase extends CreatorOutcomeTestBase {
             // assert the Class-Path contains all the entries in the lib dir
             final String cp = mainAttrs.getValue("Class-Path");
             assertNotNull(cp);
-            String[] cpEntries = cp.trim().split("\\s+");
+            String[] cpEntries = Arrays.stream(cp.trim().split("\\s+"))
+                    .filter(s -> !s.trim().isEmpty())
+                    .toArray(String[]::new);
             assertEquals(actualLib.size(), cpEntries.length);
             for (String entry : cpEntries) {
                 assertTrue(entry.startsWith(LIB_PREFIX));


### PR DESCRIPTION
This is a very naive fix for #2852 .

I wonder if we should filter the files earlier but that might be a bit too soon (and we might want to keep the non-jars entry in the model?).

@aloubyansky WDYT?

Fixes #2852 .