### PR TITLE
Fix broken quarkusDev in Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -267,7 +267,15 @@ public class QuarkusDev extends QuarkusTask {
 
             args.add("-jar");
             args.add(tempFile.getAbsolutePath());
-            args.add(extension.outputDirectory().getAbsolutePath());
+            final String outputClassDirectory = extension.outputDirectory().getAbsolutePath();
+            final String outputResourcesDirectory = extension.outputConfigDirectory().getAbsolutePath();
+            if (outputClassDirectory.equals(outputResourcesDirectory)) {
+                args.add(outputClassDirectory);
+            } else {
+                // we pass both the output class directory and the output config directory (which differ by default)
+                // so both can be added as classloader roots
+                args.add(outputClassDirectory + "," + outputResourcesDirectory);
+            }
             args.add(wiringClassesDirectory.getAbsolutePath());
             args.add(new File(getBuildDir(), "transformer-cache").getAbsolutePath());
             ProcessBuilder pb = new ProcessBuilder(args.toArray(new String[0]));


### PR DESCRIPTION
This fix utilizes the resources output directory (which differs from
that of classes by default - unlike Maven) and passes it into the
Runtime ClassLoader in order to make sure that properties can be loaded
as well

Fixes #2413