### PR TITLE
Fixes #2885, Transform -D arguments to system properties

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/Application.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Application.java
@@ -193,6 +193,7 @@ public abstract class Application {
 
             final ShutdownHookThread shutdownHookThread = new ShutdownHookThread(Thread.currentThread());
             Runtime.getRuntime().addShutdownHook(shutdownHookThread);
+            parseArgs(args);
             start(args);
             try {
                 while (!shutdownRequested) {
@@ -204,6 +205,15 @@ public abstract class Application {
             }
         } finally {
             exit();
+        }
+    }
+
+    private void parseArgs(String[] args) {
+        for (String arg : args) {
+            if (arg.startsWith("-D") && arg.contains("=")) {
+                String[] property = arg.substring(2).split("=");
+                System.setProperty(property[0], property[1]);
+            }
         }
     }
 


### PR DESCRIPTION
Transform `-D` arguments to system properties so that users can just append properties to the command and don't need to jump back and forth.

Currently users have to pass properties prior to`-jar` - e.g. `java -Dfoo=bar -Dgoo=baz -jar myApplication-runner.jar` 
With this change we are able to support also this style: `java -jar myApplication-runner.jar -Dfoo=bar -Dgoo=baz -D...`

Checked with getting-started project - `java -jar target/getting-started-1.0-SNAPSHOT-runner.jar -Dquarkus.log.category.\"io.quarkus\".level=DEBUG -Dquarkus.log.console.level=DEBUG -Dquarkus.http.port=9090`