### PR TITLE
Remove the kafka label from the Kafka Streams extension

### DIFF
--- a/devtools/common/src/main/filtered/extensions.json
+++ b/devtools/common/src/main/filtered/extensions.json
@@ -530,7 +530,6 @@
   {
     "name": "Apache Kafka Streams",
     "labels": [
-      "kafka",
       "kafka-streams"
     ],
     "groupId": "io.quarkus",


### PR DESCRIPTION
We have to wait for the new selection algorithm before adding it.

To be reverted once it has been integrated.