### PR TITLE
Comments are now ignored by ServiceUtil

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ServiceUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ServiceUtil.java
@@ -67,12 +67,17 @@ public final class ServiceUtil {
         return set;
     }
 
+    /**
+     * - Lines starting by a # (or white spaces and a #) are ignored. - For
+     * lines containing data before a comment (#) are parsed and only the value
+     * before the comment is used.
+     */
     private static void readStream(final Set<String> classNames, final BufferedReader br) throws IOException {
         String line;
         while ((line = br.readLine()) != null) {
             int commentMarkerIndex = line.indexOf('#');
-            if (commentMarkerIndex > 0) {
-                line = line.substring(commentMarkerIndex);
+            if (commentMarkerIndex >= 0) {
+                line = line.substring(0, commentMarkerIndex);
             }
             line = line.trim();
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/ServiceUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/ServiceUtilTest.java
@@ -1,0 +1,39 @@
+
+package io.quarkus.deployment.util;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class ServiceUtilTest {
+
+    /**
+     * Test that shows how comments (#) are ignored by {@link ServiceUtil}. See
+     * Issue #2892.
+     */
+    @Test
+    public void testNamesNamedIn() throws IOException {
+        String fileName = "META-INF/services/test.javax.servlet.ServletContainerInitializer";
+        String[] classNames = new String[] {
+                "org.apache.logging.log4j.web.Log4jServletContainerInitializer",
+                "org.apache.logging.log4j.core.Appender",
+                "org.apache.logging.log4j.core.Core",
+                "org.apache.logging.log4j.core.Core2",
+                "org.apache.logging.log4j.core.Core3",
+                "org.apache.logging.log4j.core.Layout",
+                "org.apache.logging.log4j.core.Layout2"
+        };
+
+        Set<String> classes = ServiceUtil.classNamesNamedIn(Thread.currentThread().getContextClassLoader(), fileName);
+
+        assertEquals(7, classes.size());
+
+        assertThat(classes, hasItems(classNames));
+
+    }
+}

--- a/core/deployment/src/test/resources/META-INF/services/test.javax.servlet.ServletContainerInitializer
+++ b/core/deployment/src/test/resources/META-INF/services/test.javax.servlet.ServletContainerInitializer
@@ -1,0 +1,29 @@
+org.apache.logging.log4j.web.Log4jServletContainerInitializer
+#
+# See https://issues.apache.org/jira/browse/LOG4J2-890
+# See https://issues.jboss.org/browse/WFLY-4458
+#
+org.apache.logging.log4j.core.Appender
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache license, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the license for the specific language governing permissions and
+# limitations under the license.
+#
+org.apache.logging.log4j.core.Core
+org.apache.logging.log4j.core.Layout #This is a valid line
+org.apache.logging.log4j.core.Layout2#This is a valid line
+ # comment
+  org.apache.logging.log4j.core.Core2 # This is a valid line
+    org.apache.logging.log4j.core.Core3#This is a valid line


### PR DESCRIPTION
There was kind of an attempt to deal with comments in the original code, but (as far as I can tell) it was broken.

With this commit:
-  lines starting with a comment char are ignored by ServiceUtil.
-  lines containing a value and then a comment are parsed in a way that only the value before the comment is used

A test was added showing how comments are dealt.