### PR TITLE
docs(hibernate): updates example of locking management

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-guide.adoc
@@ -23,15 +23,15 @@ public class Person extends PanacheEntity {
     public String name;
     public LocalDate birth;
     public Status status;
-    
+
     public static Person findByName(String name){
       return find("name", name).firstResult();
     }
-    
+
     public static List<Person> findAlive(){
       return list("status", Status.Alive);
     }
-    
+
     public static void deleteStefs(){
       delete("name", "Stef");
     }
@@ -114,13 +114,13 @@ public class Person extends PanacheEntity {
     public String name;
     public LocalDate birth;
     public Status status;
-    
+
     // this will store all names in lowercase in the DB,
     // and make them uppercase in the model
     public String getName(){
       return name.toUppercase();
     }
-    
+
     public String setName(String name){
       this.name = name.toLowercase();
     }
@@ -153,7 +153,7 @@ person.persist();
 if(person.isPersistent()){
   // delete it
   person.delete();
-} 
+}
 
 // getting a list of all Person entities
 List<Person> allPersons = Person.listAll();
@@ -259,15 +259,15 @@ public class Person extends PanacheEntity {
     public String name;
     public LocalDate birth;
     public Status status;
-    
+
     public static Person findByName(String name){
       return find("name", name).firstResult();
     }
-    
+
     public static List<Person> findAlive(){
       return list("status", Status.Alive);
     }
-    
+
     public static void deleteStefs(){
       delete("name", "Stef");
     }
@@ -285,7 +285,7 @@ If your query does not start with `from`, we support the following additional fo
 - `<singleColumnName>` (and single parameter) which will expand to `from EntityName where <singleColumnName> = ?`
 - `<query>` will expand to `from EntityName where <query>`
 
-NOTE: You can also write your queries in plain 
+NOTE: You can also write your queries in plain
 link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#hql[HQL]:
 
 [source,java]
@@ -318,11 +318,11 @@ Or using the convenience class `Parameters` to either build a `Map` or just use 
 [source,java]
 --
 // generate a Map
-Person.find("name = :name and status = :status", 
+Person.find("name = :name and status = :status",
          Parameters.with("name", "stef").and("status", Status.Alive).map());
 
 // use it as-is
-Person.find("name = :name and status = :status", 
+Person.find("name = :name and status = :status",
          Parameters.with("name", "stef").and("status", Status.Alive));
 --
 
@@ -342,15 +342,15 @@ implement `PanacheRepository`:
 public class PersonRepository implements PanacheRepository<Person> {
 
    // put your custom logic here as instance methods
-   
+
    public Person findByName(String name){
      return find("name", name).firstResult();
    }
-   
+
    public List<Person> findAlive(){
      return list("status", Status.Alive);
    }
-   
+
    public void deleteStefs(){
      delete("name", "Stef");
   }
@@ -377,15 +377,37 @@ go back to specifying your ID and using getters and setters if that's your thing
 
 == Transactions
 
-Make sure to wrap methods modifying your database (e.g. `entity.persist()`) within a transaction. Marking a 
-CDI bean method `@Transactional` will do that for you and make that method a transaction boundary. We recommend doing 
+Make sure to wrap methods modifying your database (e.g. `entity.persist()`) within a transaction. Marking a
+CDI bean method `@Transactional` will do that for you and make that method a transaction boundary. We recommend doing
 so at your application entry point boundaries like your REST endpoint controllers.
 
 == Lock management
 
-Panache does not provide direct support for database locking, but you can do it by injecting the `EntityManager` in your entity (or `PanacheRepository`) and creating a specific method that will use the entity manager to lock the entity after retrieval. The entity manager can also be retrieved via `Panache.getEntityManager()`.
+Panache does not provide direct support for database locking, but you can do it by injecting the `EntityManager` (see first example below) in your entity (or `PanacheRepository`) and creating a specific method that will use the entity manager to lock the entity after retrieval. The entity manager can also be retrieved via `Panache.getEntityManager()` see second example below.
 
-The following example contains a `findByIdForUpdate` method that finds the entity by primary key then locks it. The lock will generate a `SELECT ... FOR UPDATE` query (the same principle can be used for other kinds of `find*` methods):
+The following examples contain a `findByIdForUpdate` method that finds the entity by primary key then locks it. The lock will generate a `SELECT ... FOR UPDATE` query (the same principle can be used for other kinds of `find*` methods):
+
+== First: Locking in a PanacheRepository example
+
+[source,java]
+--
+@ApplicationScoped
+public class PersonRepository implements PanacheRepository<Person> {
+    // inject the EntityManager inside the entity
+    @Inject
+    EntityManager entityManager;
+
+    public Person findByIdForUpdate(Long id){
+        Person person = findById(id);
+        //lock with the PESSIMISTIC_WRITE mode type : this will generate a SELECT ... FOR UPDATE query
+        entityManager.lock(person, LockModeType.PESSIMISTIC_WRITE);
+        return person;
+    }
+
+}
+--
+
+== Second: Locking in a PanacheEntity example
 
 [source,java]
 --
@@ -395,11 +417,10 @@ public class Person extends PanacheEntity {
     public LocalDate birth;
     public Status status;
 
-    // inject the EntityManager inside the entity
-    @Inject
-    EntityManager entityManager;
-    
     public static Person findByIdForUpdate(Long id){
+      // get the EntityManager inside the entity
+      EntityManager entityManager = Panache.getEntityManager();
+
       Person person = findById(id);
       //lock with the PESSIMISTIC_WRITE mode type : this will generate a SELECT ... FOR UPDATE query
       entityManager.lock(person, LockModeType.PESSIMISTIC_WRITE);
@@ -452,7 +473,7 @@ public class PersonRepository implements PanacheRepositoryBase<Person,Integer> {
 
 == How and why we simplify Hibernate ORM mappings
 
-When it comes to writing Hibernate ORM entities, there are a number of annoying things that users have grown used to 
+When it comes to writing Hibernate ORM entities, there are a number of annoying things that users have grown used to
 reluctantly deal with, such as:
 
 - Duplicating ID logic: most entities need an ID, most people don't care how it's set, because it's not really
@@ -485,7 +506,7 @@ your entity `Person` by typing `Person.` and getting completion for all the oper
 `Person.find("name = ?1 and status = ?2", "stef", Status.Alive)` or even better
 `Person.find("name", "stef")`.
 
-That's all there is to it: with Panache, Hibernate ORM has never looked so trim and neat. 
+That's all there is to it: with Panache, Hibernate ORM has never looked so trim and neat.
 
 == Defining entities in external projects or jars
 


### PR DESCRIPTION
The provided example was not compiling - access of a non-static entityManager in a static method.


