### PR TITLE
Fix multi-project Gradle artifact resolution

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -88,13 +88,15 @@ public class AppModelGradleResolver implements AppModelResolver {
         final List<AppDependency> userDeps = new ArrayList<>();
         Map<ModuleIdentifier, ModuleVersionIdentifier> userModules = new HashMap<>();
         for (ResolvedArtifact a : compileCp.getResolvedConfiguration().getResolvedArtifacts()) {
-            if (!"jar".equals(a.getExtension())) {
+            final File f = a.getFile();
+
+            if (!"jar".equals(a.getExtension()) && !f.isDirectory()) {
                 continue;
             }
+
             userModules.put(getModuleId(a), a.getModuleVersion().getId());
             userDeps.add(toAppDependency(a));
 
-            final File f = a.getFile();
             final Dependency dep;
             if (f.isDirectory()) {
                 dep = processQuarkusDir(a, f.toPath().resolve(BootstrapConstants.META_INF));


### PR DESCRIPTION
Updates the check for resolved artifacts to include directories of
classes as well as JAR files. This supports the case where a resolved
artifact contains the build output of a Gradle project within the same
project tree.

Fixes #1874.

I wonder if it'd be worth adding Gradle TestKit as a test dependency, and building some integration tests that actually run the quarkusBuild/quarkusDev tasks and verify they ran succesfully?