### PR TITLE
Use the io.quarkus groupId explicitly for hibernate-search-elasticsearch

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -320,7 +320,7 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>${project.groupId}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Apparently, using ${project.groupId} is not supported when we try to
determine if the extension is in the bom or not. So we end up adding the
version to the generated pom even if it's not necessary.