### PR TITLE
doc: upgrade to asciidoctor 2.0 and fix errors

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -15,7 +15,8 @@
 
     <packaging>pom</packaging>
     <properties>
-        <version.asciidoctor>1.5.7.1</version.asciidoctor>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctor-maven-plugin.version>2.0.0-RC.1</asciidoctor-maven-plugin.version>
         <quarkus-home-url>https://quarkus.io</quarkus-home-url>
         <quarkus-base-url>https://github.com/quarkusio/quarkus</quarkus-base-url>
         <quickstarts-base-url>https://github.com/quarkusio/quarkus-quickstarts</quickstarts-base-url>
@@ -32,8 +33,14 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>${version.asciidoctor}</version>
+                <version>${asciidoctor-maven-plugin.version}</version>
                 <configuration>
+                    <enableVerbose>true</enableVerbose>  
+                    <logHandler>
+                        <failIf>
+                          <severity>INFO</severity>
+                        </failIf>
+                    </logHandler>
                     <attributes>
                         <quarkus-version>${project.version}</quarkus-version>
                         <surefire-version>${version.surefire.plugin}</surefire-version>
@@ -95,9 +102,10 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
+                            <sourceDirectory>src/main/asciidoc</sourceDirectory>
                             <preserveDirectories>true</preserveDirectories>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <imagesdir>./images</imagesdir>
                                 <icons>font</icons>
                                 <sectanchors>true</sectanchors>
@@ -112,6 +120,13 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>${asciidoctorj.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/docs/src/main/asciidoc/0-glossary.adoc
+++ b/docs/src/main/asciidoc/0-glossary.adoc
@@ -1,5 +1,6 @@
-include::./attributes.adoc[]
 = Glossary
+
+include::./attributes.adoc[]
 
 This is a collection of preferred term in the documentation and website.
 Please stay within these terms for consistency.

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -1,4 +1,4 @@
-= How to Create {project-name} Documentation
+= How to Create Quarkus Documentation
 include::./attributes.adoc[]
 
 This guide describes the asciidoc format and conventions that the {project-name} has

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -1,5 +1,5 @@
-include::./attributes.adoc[]
 = How to Create {project-name} Documentation
+include::./attributes.adoc[]
 
 This guide describes the asciidoc format and conventions that the {project-name} has
 adopted.

--- a/docs/src/main/asciidoc/getting-started-knative-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-knative-guide.adoc
@@ -103,7 +103,7 @@ you need to run the following maven command to make them passed to the Knative r
 
 The following is the example command to generate the need knative resource files
 
-[source, shell, subs="attributes"]
+[source, shell, subs="attributes+"]
 ----
 mvn -Dgithub.deploy.key=$(cat ~/.ssh/quarkus-quickstarts | base64 -w 0) \
     -Dgithub.keyscan=$(ssh-keyscan github.com | base64 -w 0) \
@@ -111,7 +111,7 @@ mvn -Dgithub.deploy.key=$(cat ~/.ssh/quarkus-quickstarts | base64 -w 0) \
     -Dcontainer.registry.user='demo' \
     -Dcontainer.registry.password='password' \
     -Dgit.source.revision='master' \
-    -Dgit.source.repo.url='{quickstarts-clone-url}' \ # <1>
+    -Dgit.source.repo.url='{quickstarts-clone-url}' \ #<1>
     -Dapp.container.image='docker.io/demo/getting-started-knative' \
     clean process-resources
 ----
@@ -138,7 +138,6 @@ IP_ADDRESS="$(minikube ip):$(kubectl get svc $INGRESSGATEWAY --namespace istio-s
 
 curl -v -H 'Host: getting-started-knative.example.com' $IP_ADDRESS/hello/greeting/redhat
 ----
-
 <1> you can replace `minikube ip` with `minishift ip` if you are using OpenShift
 
 == Going further

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,6 @@
-include::./attributes.adoc[]
 = {project-name}
+
+include::./attributes.adoc[]
 
 include::quarkus-intro.adoc[tag=intro]
 

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= {project-name}
+= Quarkus
 
 include::./attributes.adoc[]
 

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -8,8 +8,9 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 include::./attributes.adoc[]
 
 Quarkus comes with integration with the Elytron security subsystem to allow for RBAC based on the
-common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints. An example of an endpoint that makes use of both JAX-RS and Common Security annotations to describe and secure its endpoints is given in <<SubjectExposingResource Example>>.
+common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints. An example of an endpoint that makes use of both JAX-RS and Common Security annotations to describe and secure its endpoints is given in <<subject-example>>.
 
+[#subject-example]
 .SubjectExposingResource Example
 [source,java]
 --
@@ -103,8 +104,9 @@ quarkus.security.file.realm-name=MyRealm
 --
 
 ==== Users.properties
-The `quarkus.security.users` configuration property specifies a classpath resource which is a properties file with a user to password mapping, one per line. The following <<example test-users.properties file>> illustrates the format:
+The `quarkus.security.users` configuration property specifies a classpath resource which is a properties file with a user to password mapping, one per line. The following <<test-users-example>> illustrates the format:
 
+[#test-users-example]
 .example test-users.properties file
 [source,properties]
 --
@@ -131,7 +133,7 @@ noadmin=user
 <2> User `jdoe` has been assigned the role `NoRolesUser`
 <3> User `stuart` has been assigned the roles `admin` and `user`.
 
-Given these role mappings, only user `scott` would be allowed to access the `/subject/secured` endpoint from the <<SubjectExposingResource Example>>.
+Given these role mappings, only user `scott` would be allowed to access the `/subject/secured` endpoint from the <<subject-example>>.
 
 ### Embedded Realm Configuration
 The embedded realm also supports mapping of users to password and users to roles. It uses the main application.properties Quarkus configuration file to embed this information. To enable and configure it, the following configuration properties are used:
@@ -163,8 +165,9 @@ quarkus.security.embedded.auth-mechanism=CUSTOM
 ----
 
 #### Embedded Users
-The user to password mappings are specified in the `application.properties` file by property names of the form `quarkus.security.embedded.users.<user>=<password>`. The following <<Example Passwords>> illustrates the syntax with the 4 user to password mappings shown in lines 2-5:
+The user to password mappings are specified in the `application.properties` file by property names of the form `quarkus.security.embedded.users.<user>=<password>`. The following <<password-example>> illustrates the syntax with the 4 user to password mappings shown in lines 2-5:
 
+[#password-example]
 .Example Passwords
 [source,properties,linenums,highlight='2-5']
 ----
@@ -182,8 +185,9 @@ quarkus.security.embedded.roles.noadmin=user
 <2> User `stuart` has password `test`
 
 #### Embedded Roles
-The user to role mappings are specified in the `application.properties` file by property names of the form `quarkus.security.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<Example Roles>> illustrates the syntax with the 4 user to role mappings shown in lines 6-9:
+The user to role mappings are specified in the `application.properties` file by property names of the form `quarkus.security.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<roles-example>> illustrates the syntax with the 4 user to role mappings shown in lines 6-9:
 
+[#roles-example]
 .Example Roles
 [source,properties,linenums,highlight='6-9']
 ----


### PR DESCRIPTION
- Upgrade asciidoctorj to 2.0.0 (bundling asciidoctor 2.0.8 - this is aligned with version used by jekyll on quarkusio.github.io)
- Upgrade asciidoctor-maven-plugin to 2.0.0-RC.1 for compatibility with asciidoctorj 2.0 (migration guide: https://gist.github.com/abelsromero/263ae7703f4bc5efebbfd16d9e407c28)
- Fail the Maven build in case of asciidoctor errors, to prevent broken documentation
- Fix `asciidoctor: WARNING: getting-started-knative-guide.adoc: line 118: no callout found for <1>`
- Activate verbose mode, and fix some invalid cross-reference links, as well as level 0 section errors