### PR TITLE
Support live-reload of multi-project Gradle builds

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -31,10 +31,17 @@ import java.util.zip.ZipOutputStream;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.plugins.Convention;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -237,6 +244,43 @@ public class QuarkusDev extends QuarkusTask {
                 resources.append(file.getAbsolutePath());
                 res = file.getAbsolutePath();
             }
+
+            final Configuration compileCp = project.getConfigurations().getByName("compileClasspath");
+            final DependencySet compileCpDependencies = compileCp.getAllDependencies();
+
+            for (Dependency dependency : compileCpDependencies) {
+                if (!(dependency instanceof ProjectDependency)) {
+                    continue;
+                }
+
+                Project dependencyProject = ((ProjectDependency) dependency).getDependencyProject();
+                Convention convention = dependencyProject.getConvention();
+                JavaPluginConvention javaConvention = convention.findPlugin(JavaPluginConvention.class);
+                if (javaConvention == null) {
+                    continue;
+                }
+
+                SourceSetContainer sourceSets = javaConvention.getSourceSets();
+                SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                Set<String> sourcePaths = new HashSet<>();
+
+                for (File sourceDir : mainSourceSet.getAllJava().getSrcDirs()) {
+                    sourcePaths.add(sourceDir.getAbsolutePath());
+                }
+
+                String classesPaths = mainSourceSet.getOutput().getClassesDirs().getAsPath();
+                String resourcePaths = mainSourceSet.getResources().getSourceDirectories().getAsPath();
+
+                DevModeContext.ModuleInfo wsModuleInfo = new DevModeContext.ModuleInfo(
+                        dependencyProject.getName(),
+                        dependencyProject.getProjectDir().getAbsolutePath(),
+                        sourcePaths,
+                        classesPaths,
+                        resourcePaths);
+
+                context.getModules().add(wsModuleInfo);
+            }
+
             DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(
                     project.getName(),
                     project.getProjectDir().getAbsolutePath(),


### PR DESCRIPTION
Extends the quarkusDev task to register all Java projects within the
Gradle workspace as modules with the DevModeContext, causing any source
changes within a Java file in the workspace to automatically recompile
and hot deploy.

This gets live-reloading working within a basic test project (like the one in https://github.com/quarkusio/quarkus-quickstarts/pull/229), but I think there might be a better approach to take here.