### PR TITLE
Prevent infinite loop if pom parent has empty relative path

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -67,7 +67,7 @@ public class LocalProject {
         Model model = readModel(pomXml);
         Parent parent = model.getParent();
         while(parent != null) {
-            if(parent.getRelativePath() != null) {
+            if(parent.getRelativePath() != null && !parent.getRelativePath().isEmpty()) {
                 pomXml = pomXml.getParent().resolve(parent.getRelativePath()).normalize();
                 if(!Files.exists(pomXml)) {
                     return model;


### PR DESCRIPTION
Fixes #2719 

I've noticed the files formatting was not matching the Quarkus eclipse-format.xml, but I've tried keeping the diff noise to a minimum.