### PR TITLE
Do not throw NPE when building an uberJar using a fileName configuration option

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -219,6 +219,8 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
             log.warn("Unable to set proper permissions on " + runnerJar);
         }
 
+        originalJar = outputDir.resolve(finalName + ".jar");
+
         // when using uberJar, we rename the standard jar to include the .original suffix
         // this greatly aids tools (such as s2i) that look for a single jar in the output directory to work OOTB.
         // we only do this if the standard jar was present in the output dir in the first place.
@@ -233,8 +235,6 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
             } catch (IOException e) {
                 throw new AppCreatorException("Unable to build uberjar", e);
             }
-        } else {
-            originalJar = outputDir.resolve(finalName + ".jar");
         }
 
         ctx.pushOutcome(RunnerJarOutcome.class, this);

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -450,3 +450,31 @@ When building an Uber-Jar you can specify entries that you want to exclude from 
 <1> The entries are relative to the root of the generated Uber-Jar. You can specify multiple entries by adding extra `<ignoredEntry>` elements.
 
 
+Uber-Jar's final name is configurable via a Maven's build settings `finalName` option or via a `finalName` configuration option as shown below.
+
+[source,xml,subs=attributes+]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.version}</version>
+            <configuration>
+                <uberJar>true</uberJar>
+                <finalName>uber-jar-name</finalName> <1>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>build</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+----
+
+<1> This configuration will output a file `uber-jar-name-runner.jar` inside the `target` directory. When `finalName` option is not set, project's build final name is used.
+


### PR DESCRIPTION
Also add documentation of the finalName configuration option.

Fixes #2934
