### PR TITLE
docs: mention the quarkus.smallrye-openapi.path config

### DIFF
--- a/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
@@ -273,6 +273,15 @@ components:
           type: string
 ----
 
+[NOTE]
+====
+If you do not like the default endpoint location `/openapi`, you can change it with following configuration in your `application.properties`:
+[source, properties]
+----
+quarkus.smallrye-openapi.path=/swagger
+----
+====
+
 Hit `CTRL+C` to stop the application.
 
 == Use Swagger UI for development

--- a/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
@@ -275,7 +275,7 @@ components:
 
 [NOTE]
 ====
-If you do not like the default endpoint location `/openapi`, you can change it with following configuration in your `application.properties`:
+If you do not like the default endpoint location `/openapi`, you can change it by adding the following configuration to your `application.properties`:
 [source, properties]
 ----
 quarkus.smallrye-openapi.path=/swagger


### PR DESCRIPTION
The "Quarkus - Using OpenAPI and Swagger UI" guide should mention the `quarkus.smallrye-openapi.path` that gives the possibility to change where the OpenAPI spec will be exposed.

Related PR: #2779 (add unit-tests for this)
Related issue: #2756
