### PR TITLE
Add quarkus-test-h2 dependency to BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -554,6 +554,11 @@
                 <artifactId>quarkus-arquillian</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-h2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- External dependencies -->
 


### PR DESCRIPTION
This module is useful for integration tests in application code so
best add it to the BOM to make it easily consumable

Based on [this](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Hibernate.20Panache.20-.20testing/near/168847279) discussion.