### PR TITLE
Fixes #2957, check availability of native-image command

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -338,7 +338,10 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
             }
             String imageName = IS_WINDOWS ? "native-image.cmd" : "native-image";
             nativeImage = Collections.singletonList(graalvmHome + File.separator + "bin" + File.separator + imageName);
-
+            if (Files.notExists(Paths.get(nativeImage.get(0)))) {
+                throw new AppCreatorException("The `native-image` tool (" + nativeImage.get(0)
+                        + ") is not installed, this can be done by running `gu install native-image`");
+            }
         }
 
         try {


### PR DESCRIPTION
Check availability of native-image command
Fixes #2957

Error message:
```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:native-image 
(default) on project getting-started: Failed to generate a native image: The `native-image`
tool (/Users/rsvoboda/.sdkman/candidates/java/19.0.2-grl/bin/native-image) is not installed,
this can be done by running `gu install native-image` -> [Help 1]
```