### PR TITLE
#2967 change expected value for the format parameter

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiDefaultPathTestCase.java
@@ -18,9 +18,17 @@ public class OpenApiDefaultPathTestCase {
 
     @Test
     public void testOpenApiPathAccessResource() {
-        RestAssured.given().queryParam("format", "application/yaml").when().get(OPEN_API_PATH).then().header("Content-Type",
-                "application/yaml;charset=UTF-8");
-        RestAssured.given().queryParam("format", "application/json").when().get(OPEN_API_PATH).then().header("Content-Type",
-                "application/json;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiPathWithSegmentsTestCase.java
@@ -21,9 +21,17 @@ public class OpenApiPathWithSegmentsTestCase {
 
     @Test
     public void testOpenApiPathAccessResource() {
-        RestAssured.given().queryParam("format", "application/yaml").when().get(OPEN_API_PATH).then().header("Content-Type",
-                "application/yaml;charset=UTF-8");
-        RestAssured.given().queryParam("format", "application/json").when().get(OPEN_API_PATH).then().header("Content-Type",
-                "application/json;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiPathWithoutSegmentsTestCase.java
@@ -21,9 +21,17 @@ public class OpenApiPathWithoutSegmentsTestCase {
 
     @Test
     public void testOpenApiPathAccessResource() {
-        RestAssured.given().queryParam("format", "application/yaml").when().get(OPEN_API_PATH).then().header("Content-Type",
-                "application/yaml;charset=UTF-8");
-        RestAssured.given().queryParam("format", "application/json").when().get(OPEN_API_PATH).then().header("Content-Type",
-                "application/json;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiServlet.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiServlet.java
@@ -39,7 +39,7 @@ public class OpenApiServlet extends HttpServlet {
 
         // Check Accept, then query parameter "format" for JSON; else use YAML.
         if ((accept != null && accept.contains(OpenApiSerializer.Format.JSON.getMimeType())) ||
-                (OpenApiSerializer.Format.JSON.getMimeType().equalsIgnoreCase(formatParam))) {
+                ("JSON".equalsIgnoreCase(formatParam))) {
             format = OpenApiSerializer.Format.JSON;
         }
 


### PR DESCRIPTION
Fixes #2967

This changes the expected value for the `format` query parameter. To get the spec in the JSON format, you now need to specify `?format=JSON` instead of `?format=application/json` to be conform with the MicroProfile spec:
https://github.com/eclipse/microprofile-open-api/blob/1.x/spec/src/main/asciidoc/microprofile-openapi-spec.adoc#53-query-parameters

