### PR TITLE
Revert printing the printStackTrace on reflection registration error

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/SubstrateAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/SubstrateAutoFeatureStep.java
@@ -261,7 +261,7 @@ public class SubstrateAutoFeatureStep {
                 }
             }
             CatchBlockCreator cc = tc.addCatch(Throwable.class);
-            cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
+            //cc.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), cc.getCaughtException());
             mv.returnValue(null);
         }
         CatchBlockCreator print = overallCatch.addCatch(Throwable.class);


### PR DESCRIPTION
It was uncommented in
https://github.com/quarkusio/quarkus/pull/2875/files and we started to
see stacktraces when building native images.

This is not the right fix but a workaround for the release.

Fixes #2959 somehow.