### PR TITLE
Move the initialization of the delayed logger handler up in the RuntimeRunner

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/RuntimeRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/RuntimeRunner.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.logging.Handler;
 
 import org.objectweb.asm.ClassVisitor;
 
@@ -25,6 +26,7 @@ import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.runtime.Application;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.runtime.logging.InitialConfigurator;
 
 /**
  * Class that can be used to run quarkus directly, executing the build and runtime
@@ -124,11 +126,15 @@ public class RuntimeRunner implements Runnable, Closeable {
                     application.stop();
                 }
             };
-
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            // if the log handler is not activated, activate it with a default configuration to flush the messages
+            if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
+                InitialConfigurator.DELAYED_HANDLER.setHandlers(new Handler[] { InitialConfigurator.createDefaultHandler() });
+            }
         }
     }
 

--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
-import java.util.logging.Handler;
 
 import org.jboss.logging.Logger;
 
@@ -31,7 +30,6 @@ import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.runner.RuntimeRunner;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.Timing;
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
 /**
@@ -174,11 +172,6 @@ public class DevModeMain {
         } catch (Throwable t) {
             deploymentProblem = t;
             log.error("Failed to start quarkus", t);
-
-            // if the log handler is not activated, activate it with a default configuration to flush the messages
-            if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
-                InitialConfigurator.DELAYED_HANDLER.setHandlers(new Handler[] { InitialConfigurator.createDefaultHandler() });
-            }
         }
     }
 


### PR DESCRIPTION
We used to have a workaround for dev mode but, in fact, we also have the
issue in the QuarkusTestExtension and, basically, in everything using
the RuntimeRunner.

Typically, for some test failures, you didn't have anything logged
because the delayed handler was never initialized.

So let's move the forced initialization of the logger in the
RuntimeRunner itself.