### PR TITLE
Exclude the SISU dependency from our quarkus-junit artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,3 @@ docker/distroless/bazel-*
 /.apt_generated_tests/
 quarkus.log
 replay_*.log
-
-# Temporary
-integration-tests/kogito/javax.inject.Named

--- a/test-framework/arquillian/pom.xml
+++ b/test-framework/arquillian/pom.xml
@@ -30,6 +30,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.sisu</groupId>
+                    <artifactId>org.eclipse.sisu.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -18,6 +18,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.sisu</groupId>
+                    <artifactId>org.eclipse.sisu.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
It is a CDI implementation and we really don't want it when running our
tests.

It also can generate unwanted files in the case of the Kogito extension
(see #2879 and #2889).