### PR TITLE
Fix for #2961

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -53,7 +53,7 @@ public class IndexingUtil {
                 }
             }
         }
-        if (!beanInfo.superName().equals(OBJECT)) {
+        if (beanInfo.superName() != null && !beanInfo.superName().equals(OBJECT)) {
             indexClass(beanInfo.superName().toString(), indexer, quarkusIndex, additionalIndex, classLoader);
         }
     }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -8,8 +8,11 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,8 +26,10 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -36,6 +41,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.resteasy.deployment.ResteasyJaxrsConfigBuildItem;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
@@ -215,10 +221,25 @@ public class SmallRyeOpenApiProcessor {
     }
 
     private OpenAPI generateAnnotationModel(IndexView indexView, ResteasyJaxrsConfigBuildItem jaxrsConfig) {
+        // build a composite index with additional JDK classes, because SmallRye-OpenAPI will check if some
+        // app types implement Map and Collection and will go through super classes until Object is reached,
+        // and yes, it even checks Object
+        // see https://github.com/quarkusio/quarkus/issues/2961
+        Indexer indexer = new Indexer();
+        Set<DotName> additionalIndex = new HashSet<>();
+        IndexingUtil.indexClass(Collection.class.getName(), indexer, indexView, additionalIndex,
+                SmallRyeOpenApiProcessor.class.getClassLoader());
+        IndexingUtil.indexClass(Map.class.getName(), indexer, indexView, additionalIndex,
+                SmallRyeOpenApiProcessor.class.getClassLoader());
+        IndexingUtil.indexClass(Object.class.getName(), indexer, indexView, additionalIndex,
+                SmallRyeOpenApiProcessor.class.getClassLoader());
+
+        CompositeIndex compositeIndex = CompositeIndex.create(indexView, indexer.complete());
+
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
-        return new OpenApiAnnotationScanner(openApiConfig, indexView,
-                Collections.singletonList(new RESTEasyExtension(jaxrsConfig, indexView))).scan();
+        return new OpenApiAnnotationScanner(openApiConfig, compositeIndex,
+                Collections.singletonList(new RESTEasyExtension(jaxrsConfig, compositeIndex))).scan();
     }
 
     private Result findStaticModel(ApplicationArchivesBuildItem archivesBuildItem) {


### PR DESCRIPTION
This is a fix I'm not proud of, and I don't think it fixes the underlying issue that we'll see pop up at other places, which is that some extensions will load instrumented types before they're instrumented and cause them to stick around in the main class loader which means the instrumented types will never be used, leading to many hairy and weird runtime issues.

BUT it fixes the issue in this case, and is a much quicker fix than tweaking smallrye-openapi. Perhaps a more quarkus-build-step-specific fix can be conceived where the smallrye-openapi build item will wait for augmentation to be done, but I'm not sure how to.