### PR TITLE
Add support for running integration tests from Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -1,5 +1,7 @@
 package io.quarkus.gradle;
 
+import javax.inject.Inject;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -7,8 +9,10 @@ import org.gradle.api.Task;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.util.GradleVersion;
 
+import io.quarkus.gradle.model.RemoteToolingModelBuilder;
 import io.quarkus.gradle.tasks.QuarkusAddExtension;
 import io.quarkus.gradle.tasks.QuarkusBuild;
 import io.quarkus.gradle.tasks.QuarkusDev;
@@ -21,6 +25,13 @@ import io.quarkus.gradle.tasks.QuarkusNative;
  */
 public class QuarkusPlugin implements Plugin<Project> {
 
+    private final ToolingModelBuilderRegistry registry;
+
+    @Inject
+    public QuarkusPlugin(ToolingModelBuilderRegistry registry) {
+        this.registry = registry;
+    }
+
     @Override
     public void apply(Project project) {
         verifyGradleVersion();
@@ -28,6 +39,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         project.getExtensions().create("quarkus", QuarkusPluginExtension.class, project);
 
         registerTasks(project);
+        registry.register(new RemoteToolingModelBuilder());
     }
 
     private void registerTasks(Project project) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/model/RemoteToolingModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/model/RemoteToolingModelBuilder.java
@@ -1,0 +1,32 @@
+package io.quarkus.gradle.model;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.tooling.provider.model.ToolingModelBuilder;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.gradle.tooling.DefaultRemoteAppModel;
+import io.quarkus.bootstrap.resolver.gradle.tooling.RemoteAppModel;
+import io.quarkus.gradle.QuarkusPluginExtension;
+
+public class RemoteToolingModelBuilder implements ToolingModelBuilder {
+
+    @Override
+    public boolean canBuild(String modelName) {
+        return modelName.equals(RemoteAppModel.class.getName());
+    }
+
+    @Override
+    public RemoteAppModel buildAll(String modelName, Project project) {
+        QuarkusPluginExtension extension = project.getExtensions().findByType(QuarkusPluginExtension.class);
+        AppArtifact artifact = extension.getAppArtifact();
+
+        try {
+            AppModel appModel = extension.resolveAppModel().resolveModel(artifact);
+            return DefaultRemoteAppModel.from(appModel);
+        } catch (Exception ex) {
+            throw new GradleException("Unable to resolve AppModel for artifact (" + artifact + ")", ex);
+        }
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1,5 +1,6 @@
 package io.quarkus.maven;
 
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenProject;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -47,7 +48,6 @@ import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.deployment.ApplicationInfoUtil;
 import io.quarkus.dev.DevModeContext;
 import io.quarkus.dev.DevModeMain;
@@ -228,13 +228,13 @@ public class DevMojo extends AbstractMojo {
 
             final AppModel appModel;
             try {
-                final LocalProject localProject;
+                final LocalMavenProject localProject;
                 if (noDeps) {
-                    localProject = LocalProject.load(outputDirectory.toPath());
+                    localProject = LocalMavenProject.load(outputDirectory.toPath());
                     addProject(devModeContext, localProject);
                 } else {
-                    localProject = LocalProject.loadWorkspace(outputDirectory.toPath());
-                    for (LocalProject project : localProject.getSelfWithLocalDeps()) {
+                    localProject = LocalMavenProject.loadWorkspace(outputDirectory.toPath());
+                    for (LocalMavenProject project : localProject.getSelfWithLocalDeps()) {
                         if (project.getClassesDir() != null) {
                             //if this project also contains Quarkus extensions we do no want to include these in the discovery
                             //a bit of an edge case, but if you try and include a sample project with your extension you will
@@ -368,7 +368,7 @@ public class DevMojo extends AbstractMojo {
         }
     }
 
-    private void addProject(DevModeContext devModeContext, LocalProject localProject) {
+    private void addProject(DevModeContext devModeContext, LocalMavenProject localProject) {
 
         String projectDirectory = null;
         Set<String> sourcePaths = null;

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateConfigMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateConfigMojo.java
@@ -1,5 +1,6 @@
 package io.quarkus.maven;
 
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenProject;
 import java.io.File;
 import java.util.List;
 
@@ -22,7 +23,6 @@ import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.creator.AppCreator;
 import io.quarkus.creator.AppCreatorException;
 import io.quarkus.creator.phase.curate.CurateOutcome;
@@ -111,7 +111,7 @@ public class GenerateConfigMojo extends AbstractMojo {
         final AppModel appModel;
         final BootstrapAppModelResolver modelResolver;
         try {
-            LocalProject localProject = LocalProject.load(project.getBasedir().toPath());
+            LocalMavenProject localProject = LocalMavenProject.load(project.getBasedir().toPath());
             modelResolver = new BootstrapAppModelResolver(
                     MavenArtifactResolver.builder()
                             .setRepositorySystem(repoSystem)

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>maven-resolver-transport-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
@@ -21,7 +21,7 @@ import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
 
 /**
@@ -85,11 +85,11 @@ public class BootstrapClassLoaderFactory {
         }
     }
 
-    private static Path resolveCachedCpPath(LocalProject project) {
+    private static Path resolveCachedCpPath(LocalMavenProject project) {
         return project.getOutputDir().resolve(QUARKUS).resolve(BOOTSTRAP).resolve(DEPLOYMENT_CP);
     }
 
-    private static void persistCp(LocalProject project, URL[] urls, int limit, Path p) {
+    private static void persistCp(LocalMavenProject project, URL[] urls, int limit, Path p) {
         try {
             Files.createDirectories(p.getParent());
             try (BufferedWriter writer = Files.newBufferedWriter(p)) {
@@ -133,7 +133,7 @@ public class BootstrapClassLoaderFactory {
         return this;
     }
 
-    public BootstrapClassLoaderFactory setLocalProjectsDiscovery(boolean localProjectsDiscovery) {
+    public BootstrapClassLoaderFactory setLocalMavenProjectsDiscovery(boolean localProjectsDiscovery) {
         this.localProjectsDiscovery = localProjectsDiscovery;
         return this;
     }
@@ -167,18 +167,18 @@ public class BootstrapClassLoaderFactory {
             if(offline != null) {
                 mvnBuilder.setOffline(offline);
             }
-            final LocalProject localProject;
+            final LocalMavenProject localProject;
             final AppArtifact appArtifact;
             if (Files.isDirectory(appClasses)) {
                 if (localProjectsDiscovery) {
-                    localProject = LocalProject.loadWorkspace(appClasses);
+                    localProject = LocalMavenProject.loadWorkspace(appClasses);
                     mvnBuilder.setWorkspace(localProject.getWorkspace());
                 } else {
-                    localProject = LocalProject.load(appClasses);
+                    localProject = LocalMavenProject.load(appClasses);
                 }
                 appArtifact = localProject.getAppArtifact();
             } else {
-                localProject = localProjectsDiscovery ? LocalProject.loadWorkspace(Paths.get("").normalize().toAbsolutePath(), false) : null;
+                localProject = localProjectsDiscovery ? LocalMavenProject.loadWorkspace(Paths.get("").normalize().toAbsolutePath(), false) : null;
                 if(localProject != null) {
                     mvnBuilder.setWorkspace(localProject.getWorkspace());
                 }
@@ -227,7 +227,7 @@ public class BootstrapClassLoaderFactory {
             if (offline != null) {
                 mvnBuilder.setOffline(offline);
             }
-            final LocalProject localProject = localProjectsDiscovery ? LocalProject.loadWorkspace(Paths.get("").normalize().toAbsolutePath(), false) : null;
+            final LocalMavenProject localProject = localProjectsDiscovery ? LocalMavenProject.loadWorkspace(Paths.get("").normalize().toAbsolutePath(), false) : null;
             if(localProject != null) {
                 mvnBuilder.setWorkspace(localProject.getWorkspace());
             }
@@ -264,9 +264,9 @@ public class BootstrapClassLoaderFactory {
 
         final URLClassLoader ucl;
         Path cachedCpPath = null;
-        final LocalProject localProject = localProjectsDiscovery || enableClasspathCache
-                ? LocalProject.loadWorkspace(appClasses)
-                : LocalProject.load(appClasses);
+        final LocalMavenProject localProject = localProjectsDiscovery || enableClasspathCache
+                ? LocalMavenProject.loadWorkspace(appClasses)
+                : LocalMavenProject.load(appClasses);
         try {
             if (enableClasspathCache) {
                 cachedCpPath = resolveCachedCpPath(localProject);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/LocalProject.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/LocalProject.java
@@ -1,0 +1,20 @@
+package io.quarkus.bootstrap.resolver;
+
+import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.model.AppArtifact;
+
+public interface LocalProject extends AutoCloseable {
+
+    /**
+     * Create an {@link AppModelResolver} for the application built by this local project.
+     */
+    AppModelResolver createAppModelResolver() throws AppModelResolverException;
+
+    /**
+     * Get the {@link AppArtifact} built by this local project.
+     */
+    AppArtifact getAppArtifact();
+
+    @Override
+    void close() throws BootstrapException;
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/LocalProjectLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/LocalProjectLoader.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.resolver;
 
+import io.quarkus.bootstrap.resolver.gradle.LocalGradleProject;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -7,6 +8,10 @@ import io.quarkus.bootstrap.BootstrapException;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenProject;
 
 public class LocalProjectLoader {
+
+    private static boolean isGradleProjectDirectory(Path p) {
+        return Files.exists(p.resolve("build.gradle")) || Files.exists(p.resolve("build.gradle.kts"));
+    }
 
     private static boolean isMavenProjectDirectory(Path p) {
         return Files.exists(p.resolve("pom.xml"));
@@ -17,6 +22,8 @@ public class LocalProjectLoader {
         while (projectDir != null) {
             if (isMavenProjectDirectory(projectDir)) {
                 return LocalMavenProject.load(projectDir);
+            } else if (isGradleProjectDirectory(projectDir)) {
+                return LocalGradleProject.load(projectDir);
             }
 
             projectDir = projectDir.getParent();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/LocalProjectLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/LocalProjectLoader.java
@@ -1,0 +1,27 @@
+package io.quarkus.bootstrap.resolver;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenProject;
+
+public class LocalProjectLoader {
+
+    private static boolean isMavenProjectDirectory(Path p) {
+        return Files.exists(p.resolve("pom.xml"));
+    }
+
+    public LocalProject open(Path appOutputDir) throws BootstrapException {
+        Path projectDir = appOutputDir;
+        while (projectDir != null) {
+            if (isMavenProjectDirectory(projectDir)) {
+                return LocalMavenProject.load(projectDir);
+            }
+
+            projectDir = projectDir.getParent();
+        }
+
+        throw new BootstrapException("Project not found in " + appOutputDir);
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/LocalGradleProject.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/LocalGradleProject.java
@@ -1,0 +1,50 @@
+package io.quarkus.bootstrap.resolver.gradle;
+
+import io.quarkus.bootstrap.resolver.gradle.tooling.RemoteAppModelGradleResolver;
+import java.nio.file.Path;
+
+import org.gradle.tooling.GradleConnectionException;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+
+import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.resolver.AppModelResolver;
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.bootstrap.resolver.LocalProject;
+
+public class LocalGradleProject implements LocalProject {
+
+    private final ProjectConnection project;
+
+    public LocalGradleProject(ProjectConnection project) {
+        this.project = project;
+    }
+
+    public static LocalGradleProject load(Path path) throws BootstrapException {
+        try {
+            ProjectConnection project = GradleConnector.newConnector()
+                .forProjectDirectory(path.toFile())
+                .connect();
+            return new LocalGradleProject(project);
+
+        } catch (GradleConnectionException ex) {
+            throw new BootstrapException("Unable to load Gradle project", ex);
+        }
+    }
+
+    @Override
+    public AppModelResolver createAppModelResolver() throws AppModelResolverException {
+        return new RemoteAppModelGradleResolver(project);
+    }
+
+    @Override
+    public AppArtifact getAppArtifact() {
+        return new AppArtifact("test", "test", "1.0");
+    }
+
+    @Override
+    public void close() {
+        project.close();
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/DefaultRemoteAppArtifact.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/DefaultRemoteAppArtifact.java
@@ -1,0 +1,66 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+
+public class DefaultRemoteAppArtifact implements RemoteAppArtifact {
+
+    private String groupId;
+    private String artifactId;
+    private String classifier;
+    private String type;
+    private String version;
+    private String path;
+
+    public DefaultRemoteAppArtifact() {
+
+    }
+
+    DefaultRemoteAppArtifact(String groupId, String artifactId, String classifier, String type, String version,
+            String path) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.classifier = classifier;
+        this.type = type;
+        this.version = version;
+        this.path = path;
+    }
+
+    public static RemoteAppArtifact from(AppArtifact appArtifact) {
+        return new DefaultRemoteAppArtifact(appArtifact.getGroupId(), appArtifact.getArtifactId(), appArtifact.getClassifier(),
+                appArtifact.getType(), appArtifact.getVersion(),
+                appArtifact.isResolved() ? appArtifact.getPath().toString() : null);
+    }
+
+    @Override
+    public String getGroupId() {
+        return groupId;
+    }
+
+    @Override
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/DefaultRemoteAppDependency.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/DefaultRemoteAppDependency.java
@@ -1,0 +1,40 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import io.quarkus.bootstrap.model.AppDependency;
+
+public class DefaultRemoteAppDependency implements RemoteAppDependency {
+
+    private RemoteAppArtifact artifact;
+    private String scope;
+    private boolean optional;
+
+    public DefaultRemoteAppDependency() {
+    }
+
+    DefaultRemoteAppDependency(RemoteAppArtifact artifact, String scope, boolean optional) {
+        this.artifact = artifact;
+        this.scope = scope;
+        this.optional = optional;
+    }
+
+    public static RemoteAppDependency from(AppDependency appDependency) {
+        return new DefaultRemoteAppDependency(DefaultRemoteAppArtifact.from(appDependency.getArtifact()),
+                appDependency.getScope(),
+                appDependency.isOptional());
+    }
+
+    @Override
+    public RemoteAppArtifact getArtifact() {
+        return artifact;
+    }
+
+    @Override
+    public String getScope() {
+        return scope;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return optional;
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/DefaultRemoteAppModel.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/DefaultRemoteAppModel.java
@@ -1,0 +1,53 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.quarkus.bootstrap.BootstrapDependencyProcessingException;
+import io.quarkus.bootstrap.model.AppModel;
+
+public class DefaultRemoteAppModel implements RemoteAppModel {
+
+    private RemoteAppArtifact appArtifact;
+    private List<RemoteAppDependency> userDependencies;
+    private List<RemoteAppDependency> deploymentDependencies;
+
+    public DefaultRemoteAppModel(RemoteAppArtifact artifact, List<RemoteAppDependency> userDependencies,
+            List<RemoteAppDependency> deploymentDependencies) {
+        this.appArtifact = artifact;
+        this.userDependencies = userDependencies;
+        this.deploymentDependencies = deploymentDependencies;
+    }
+
+    public static RemoteAppModel from(AppModel appModel) throws BootstrapDependencyProcessingException {
+        List<RemoteAppDependency> userDependencies = appModel.getUserDependencies()
+                .stream()
+                .map(DefaultRemoteAppDependency::from)
+                .collect(Collectors.toList());
+
+        List<RemoteAppDependency> deploymentDependencies = appModel.getDeploymentDependencies()
+                .stream()
+                .map(DefaultRemoteAppDependency::from)
+                .collect(Collectors.toList());
+
+        RemoteAppArtifact artifact = DefaultRemoteAppArtifact.from(appModel.getAppArtifact());
+
+        return new DefaultRemoteAppModel(artifact, userDependencies, deploymentDependencies);
+    }
+
+    @Override
+    public RemoteAppArtifact getAppArtifact() {
+        return appArtifact;
+    }
+
+    @Override
+    public List<RemoteAppDependency> getUserDependencies() {
+        return userDependencies;
+    }
+
+    @Override
+    public List<RemoteAppDependency> getDeploymentDependencies() {
+        return deploymentDependencies;
+    }
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppArtifact.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppArtifact.java
@@ -1,0 +1,19 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import java.io.Serializable;
+
+public interface RemoteAppArtifact extends Serializable {
+
+    String getGroupId();
+
+    String getArtifactId();
+
+    String getClassifier();
+
+    String getPath();
+
+    String getType();
+
+    String getVersion();
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppDependency.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppDependency.java
@@ -1,0 +1,13 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import java.io.Serializable;
+
+public interface RemoteAppDependency extends Serializable {
+
+    RemoteAppArtifact getArtifact();
+
+    String getScope();
+
+    boolean isOptional();
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppModel.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppModel.java
@@ -1,0 +1,13 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import java.io.Serializable;
+import java.util.List;
+
+public interface RemoteAppModel extends Serializable {
+
+    RemoteAppArtifact getAppArtifact();
+
+    List<RemoteAppDependency> getUserDependencies();
+
+    List<RemoteAppDependency> getDeploymentDependencies();
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppModelGradleResolver.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/gradle/tooling/RemoteAppModelGradleResolver.java
@@ -1,0 +1,99 @@
+package io.quarkus.bootstrap.resolver.gradle.tooling;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.gradle.tooling.ProjectConnection;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppDependency;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.AppModelResolver;
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+
+public class RemoteAppModelGradleResolver implements AppModelResolver {
+
+    private final ProjectConnection connection;
+
+    public RemoteAppModelGradleResolver(ProjectConnection connection) {
+        this.connection = connection;
+    }
+
+    private static AppArtifact resolveRemoteArtifact(RemoteAppArtifact remote) {
+        AppArtifact appArtifact = new AppArtifact(remote.getGroupId(), remote.getArtifactId(), remote.getClassifier(),
+                remote.getType(), remote.getVersion());
+        appArtifact.setPath(remote.getPath() == null ? null : Paths.get(remote.getPath()));
+
+        return appArtifact;
+    }
+
+    private static AppDependency resolveRemoteDependency(RemoteAppDependency remote) {
+        return new AppDependency(resolveRemoteArtifact(remote.getArtifact()), remote.getScope(), remote.isOptional());
+    }
+
+    @Override
+    public void relink(AppArtifact appArtifact, Path localPath) throws AppModelResolverException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Path resolve(AppArtifact artifact) throws AppModelResolverException {
+        if (!artifact.isResolved()) {
+            throw new AppModelResolverException("Artifact has not been resolved: " + artifact);
+        }
+        return artifact.getPath();
+    }
+
+    @Override
+    public List<AppDependency> resolveUserDependencies(AppArtifact artifact, List<AppDependency> deps)
+            throws AppModelResolverException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public AppModel resolveModel(AppArtifact artifact) throws AppModelResolverException {
+        RemoteAppModel remoteModel = connection.getModel(RemoteAppModel.class);
+        List<AppDependency> userDependencies = remoteModel.getUserDependencies()
+                .stream()
+                .map(RemoteAppModelGradleResolver::resolveRemoteDependency)
+                .collect(Collectors.toList());
+
+        List<AppDependency> deploymentDependencies = remoteModel.getDeploymentDependencies()
+                .stream()
+                .map(RemoteAppModelGradleResolver::resolveRemoteDependency)
+                .collect(Collectors.toList());
+
+        AppArtifact resolvedArtifact = resolveRemoteArtifact(remoteModel.getAppArtifact());
+        artifact.setPath(resolvedArtifact.getPath());
+
+        return new AppModel(artifact, userDependencies, deploymentDependencies);
+    }
+
+    @Override
+    public AppModel resolveModel(AppArtifact root, List<AppDependency> deps) throws AppModelResolverException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> listLaterVersions(AppArtifact artifact, String upToVersion, boolean inclusive)
+            throws AppModelResolverException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getNextVersion(AppArtifact artifact, String fromVersion, boolean fromVersionIncluded,
+            String upToVersion, boolean upToVersionIncluded) throws AppModelResolverException {
+        throw new UnsupportedOperationException();
+
+    }
+
+    @Override
+    public String getLatestVersion(AppArtifact artifact, String upToVersion, boolean inclusive)
+            throws AppModelResolverException {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -47,7 +47,7 @@ import org.eclipse.aether.util.artifact.JavaScopes;
 
 import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenWorkspace;
 
 /**
  *
@@ -62,7 +62,7 @@ public class MavenArtifactResolver {
         private RepositorySystemSession repoSession;
         private List<RemoteRepository> remoteRepos = null;
         private Boolean offline;
-        private LocalWorkspace workspace;
+        private LocalMavenWorkspace workspace;
 
         private Builder() {
         }
@@ -92,7 +92,7 @@ public class MavenArtifactResolver {
             return this;
         }
 
-        public Builder setWorkspace(LocalWorkspace workspace) {
+        public Builder setWorkspace(LocalMavenWorkspace workspace) {
             this.workspace = workspace;
             return this;
         }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalMavenProject.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalMavenProject.java
@@ -1,5 +1,10 @@
 package io.quarkus.bootstrap.resolver.maven.workspace;
 
+import io.quarkus.bootstrap.resolver.AppModelResolver;
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.LocalProject;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,39 +29,39 @@ import io.quarkus.bootstrap.model.AppArtifactKey;
  *
  * @author Alexey Loubyansky
  */
-public class LocalProject {
+public class LocalMavenProject implements LocalProject {
 
     public static final String PROJECT_GROUPID = "${project.groupId}";
 
     private static final String PROJECT_BASEDIR = "${project.basedir}";
     private static final String POM_XML = "pom.xml";
 
-    public static LocalProject load(Path path) throws BootstrapException {
-        return new LocalProject(readModel(locateCurrentProjectDir(path, true).resolve(POM_XML)), null);
+    public static LocalMavenProject load(Path path) throws BootstrapException {
+        return new LocalMavenProject(readModel(locateCurrentProjectDir(path, true).resolve(POM_XML)), null);
     }
 
-    public static LocalProject loadWorkspace(Path path) throws BootstrapException {
+    public static LocalMavenProject loadWorkspace(Path path) throws BootstrapException {
         return loadWorkspace(path, true);
     }
 
-    public static LocalProject loadWorkspace(Path path, boolean required) throws BootstrapException {
+    public static LocalMavenProject loadWorkspace(Path path, boolean required) throws BootstrapException {
         final Path currentProjectDir = locateCurrentProjectDir(path, required);
-        final LocalWorkspace ws = new LocalWorkspace();
-        final LocalProject project = load(ws, null, loadRootModel(currentProjectDir), currentProjectDir);
+        final LocalMavenWorkspace ws = new LocalMavenWorkspace();
+        final LocalMavenProject project = load(ws, null, loadRootModel(currentProjectDir), currentProjectDir);
         return project == null ? load(ws, null, readModel(currentProjectDir.resolve(POM_XML)), currentProjectDir) : project;
     }
 
-    private static LocalProject load(LocalWorkspace workspace, LocalProject parent, Model model, Path currentProjectDir) throws BootstrapException {
-        final LocalProject project = new LocalProject(model, workspace);
+    private static LocalMavenProject load(LocalMavenWorkspace workspace, LocalMavenProject parent, Model model, Path currentProjectDir) throws BootstrapException {
+        final LocalMavenProject project = new LocalMavenProject(model, workspace);
         if(parent != null) {
             parent.modules.add(project);
         }
-        LocalProject result = currentProjectDir == null || !currentProjectDir.equals(project.getDir()) ? null : project;
+        LocalMavenProject result = currentProjectDir == null || !currentProjectDir.equals(project.getDir()) ? null : project;
         final List<String> modules = project.getRawModel().getModules();
         if (!modules.isEmpty()) {
             Path dirArg = result == null ? currentProjectDir : null;
             for (String module : modules) {
-                final LocalProject loaded = load(workspace, project, readModel(project.getDir().resolve(module).resolve(POM_XML)), dirArg);
+                final LocalMavenProject loaded = load(workspace, project, readModel(project.getDir().resolve(module).resolve(POM_XML)), dirArg);
                 if(loaded != null && result == null) {
                     result = loaded;
                     dirArg = null;
@@ -120,10 +125,10 @@ public class LocalProject {
     private final String artifactId;
     private final String version;
     private final Path dir;
-    private final LocalWorkspace workspace;
-    private final List<LocalProject> modules = new ArrayList<>(0);
+    private final LocalMavenWorkspace workspace;
+    private final List<LocalMavenProject> modules = new ArrayList<>(0);
 
-    private LocalProject(Model rawModel, LocalWorkspace workspace) throws BootstrapException {
+    private LocalMavenProject(Model rawModel, LocalMavenWorkspace workspace) throws BootstrapException {
         this.rawModel = rawModel;
         this.dir = rawModel.getProjectDirectory().toPath();
         this.workspace = workspace;
@@ -199,7 +204,7 @@ public class LocalProject {
         return rawModel;
     }
 
-    public LocalWorkspace getWorkspace() {
+    public LocalMavenWorkspace getWorkspace() {
         return workspace;
     }
 
@@ -213,24 +218,25 @@ public class LocalProject {
         return appArtifact;
     }
 
-    public List<LocalProject> getSelfWithLocalDeps() {
+    public List<LocalMavenProject> getSelfWithLocalDeps() {
         if(workspace == null) {
             return Collections.singletonList(this);
         }
-        final List<LocalProject> ordered = new ArrayList<>();
+        final List<LocalMavenProject> ordered = new ArrayList<>();
         collectSelfWithLocalDeps(this, new HashSet<>(),  ordered);
         return ordered;
     }
 
-    private static void collectSelfWithLocalDeps(LocalProject project, Set<AppArtifactKey> addedDeps, List<LocalProject> ordered) {
+    private static void collectSelfWithLocalDeps(
+        LocalMavenProject project, Set<AppArtifactKey> addedDeps, List<LocalMavenProject> ordered) {
         if(!project.modules.isEmpty()) {
-            for(LocalProject module : project.modules) {
+            for(LocalMavenProject module : project.modules) {
                 collectSelfWithLocalDeps(module, addedDeps, ordered);
             }
         }
         for(Dependency dep : project.getRawModel().getDependencies()) {
             final AppArtifactKey depKey = project.getKey(dep);
-            final LocalProject localDep = project.workspace.getProject(depKey);
+            final LocalMavenProject localDep = project.workspace.getProject(depKey);
             if(localDep == null || addedDeps.contains(depKey)) {
                 continue;
             }
@@ -243,5 +249,20 @@ public class LocalProject {
 
     private AppArtifactKey getKey(Dependency dep) {
         return new AppArtifactKey(PROJECT_GROUPID.equals(dep.getGroupId()) ? getGroupId() : dep.getGroupId(), dep.getArtifactId());
+    }
+
+    @Override
+    public AppModelResolver createAppModelResolver() throws AppModelResolverException {
+        final MavenArtifactResolver.Builder mvn = MavenArtifactResolver.builder().setWorkspace(workspace);
+//        if (offline != null) {
+//            mvn.setOffline(offline);
+//        }
+
+        return new BootstrapAppModelResolver(mvn.build());
+    }
+
+    @Override
+    public void close() {
+
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalMavenWorkspace.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalMavenWorkspace.java
@@ -20,9 +20,9 @@ import io.quarkus.bootstrap.model.AppArtifactKey;
  *
  * @author Alexey Loubyansky
  */
-public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
+public class LocalMavenWorkspace implements WorkspaceModelResolver, WorkspaceReader {
 
-    private final Map<AppArtifactKey, LocalProject> projects = new HashMap<>();
+    private final Map<AppArtifactKey, LocalMavenProject> projects = new HashMap<>();
 
     private final WorkspaceRepository wsRepo = new WorkspaceRepository();
     private AppArtifactKey lastFindVersionsKey;
@@ -30,7 +30,7 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
     private long lastModified;
     private int id = 1;
 
-    protected void addProject(LocalProject project, long lastModified) {
+    protected void addProject(LocalMavenProject project, long lastModified) {
         projects.put(project.getKey(), project);
         if(lastModified > this.lastModified) {
             this.lastModified = lastModified;
@@ -38,11 +38,11 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
         id = 31 * id + (int) (lastModified ^ (lastModified >>> 32));
     }
 
-    public LocalProject getProject(String groupId, String artifactId) {
+    public LocalMavenProject getProject(String groupId, String artifactId) {
         return getProject(new AppArtifactKey(groupId, artifactId));
     }
 
-    public LocalProject getProject(AppArtifactKey key) {
+    public LocalMavenProject getProject(AppArtifactKey key) {
         return projects.get(key);
     }
 
@@ -57,7 +57,7 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
     @Override
     public Model resolveRawModel(String groupId, String artifactId, String versionConstraint)
             throws UnresolvableModelException {
-        final LocalProject project = getProject(groupId, artifactId);
+        final LocalMavenProject project = getProject(groupId, artifactId);
         if(project == null || !project.getVersion().equals(versionConstraint)) {
             return null;
         }
@@ -70,7 +70,7 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
         return null;
     }
 
-    public Map<AppArtifactKey, LocalProject> getProjects() {
+    public Map<AppArtifactKey, LocalMavenProject> getProjects() {
         return projects;
     }
 
@@ -81,7 +81,7 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
 
     @Override
     public File findArtifact(Artifact artifact) {
-        final LocalProject lp = getProject(artifact.getGroupId(), artifact.getArtifactId());
+        final LocalMavenProject lp = getProject(artifact.getGroupId(), artifact.getArtifactId());
         if (lp == null || !lp.getVersion().equals(artifact.getVersion())) {
             return null;
         }
@@ -108,7 +108,7 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader {
             return lastFindVersions;
         }
         lastFindVersionsKey = new AppArtifactKey(artifact.getGroupId(), artifact.getArtifactId());
-        final LocalProject lp = getProject(lastFindVersionsKey);
+        final LocalMavenProject lp = getProject(lastFindVersionsKey);
         if (lp == null || !lp.getVersion().equals(artifact.getVersion())) {
             lastFindVersionsKey = null;
             return Collections.emptyList();

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/workspace/test/LocalMavenWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/workspace/test/LocalMavenWorkspaceDiscoveryTest.java
@@ -18,10 +18,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.quarkus.bootstrap.model.AppArtifactKey;
-import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalMavenProject;
 import io.quarkus.bootstrap.util.IoUtils;
 
-public class LocalWorkspaceDiscoveryTest {
+public class LocalMavenWorkspaceDiscoveryTest {
 
     private static Dependency newDependency(String artifactId) {
         return newDependency(MvnProjectBuilder.DEFAULT_GROUP_ID, artifactId, MvnProjectBuilder.DEFAULT_VERSION);
@@ -63,7 +63,7 @@ public class LocalWorkspaceDiscoveryTest {
         .addModule("module2", "root-module-with-parent", true)
         .addDependency(newDependency("root-no-parent-module"))
         .addDependency(newDependency("external-dep"))
-        .addDependency(newDependency(LocalProject.PROJECT_GROUPID, "root-module-not-direct-child", MvnProjectBuilder.DEFAULT_VERSION))
+        .addDependency(newDependency(LocalMavenProject.PROJECT_GROUPID, "root-module-not-direct-child", MvnProjectBuilder.DEFAULT_VERSION))
         .getParent()
 
         .addModule("other/module3", "root-module-not-direct-child", true)
@@ -99,14 +99,14 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadIndependentProjectInTheWorkspaceTree() throws Exception {
-        final LocalProject project = LocalProject
+        final LocalMavenProject project = LocalMavenProject
                 .loadWorkspace(workDir.resolve("root").resolve("independent").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNotNull(project.getWorkspace());
         assertEquals(MvnProjectBuilder.DEFAULT_GROUP_ID, project.getGroupId());
         assertEquals("independent", project.getArtifactId());
         assertEquals(MvnProjectBuilder.DEFAULT_VERSION, project.getVersion());
-        final Map<AppArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
+        final Map<AppArtifactKey, LocalMavenProject> projects = project.getWorkspace().getProjects();
         assertEquals(1, projects.size());
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "independent")));
 
@@ -115,7 +115,7 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadModuleProjectWithoutParent() throws Exception {
-        final LocalProject project = LocalProject
+        final LocalMavenProject project = LocalMavenProject
                 .load(workDir.resolve("root").resolve("module1").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNull(project.getWorkspace());
@@ -127,14 +127,14 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadWorkspaceForModuleWithoutParent() throws Exception {
-        final LocalProject project = LocalProject
+        final LocalMavenProject project = LocalMavenProject
                 .loadWorkspace(workDir.resolve("root").resolve("module1").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertEquals(MvnProjectBuilder.DEFAULT_GROUP_ID, project.getGroupId());
         assertEquals("root-no-parent-module", project.getArtifactId());
         assertEquals(MvnProjectBuilder.DEFAULT_VERSION, project.getVersion());
         assertNotNull(project.getWorkspace());
-        final Map<AppArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
+        final Map<AppArtifactKey, LocalMavenProject> projects = project.getWorkspace().getProjects();
         assertEquals(1, projects.size());
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-no-parent-module")));
         assertLocalDeps(project);
@@ -142,7 +142,7 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadModuleProjectWithParent() throws Exception {
-        final LocalProject project = LocalProject
+        final LocalMavenProject project = LocalMavenProject
                 .load(workDir.resolve("root").resolve("module2").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNull(project.getWorkspace());
@@ -154,7 +154,7 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadWorkspaceForModuleWithParent() throws Exception {
-        final LocalProject project = LocalProject
+        final LocalMavenProject project = LocalMavenProject
                 .loadWorkspace(workDir.resolve("root").resolve("module2").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNotNull(project.getWorkspace());
@@ -168,7 +168,7 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadWorkspaceForModuleWithNotDirectParentPath() throws Exception {
-        final LocalProject project = LocalProject.loadWorkspace(
+        final LocalMavenProject project = LocalMavenProject.loadWorkspace(
                 workDir.resolve("root").resolve("other").resolve("module3").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNotNull(project.getWorkspace());
@@ -182,12 +182,12 @@ public class LocalWorkspaceDiscoveryTest {
 
     @Test
     public void loadNonModuleChildProject() throws Exception {
-        final LocalProject project = LocalProject
+        final LocalMavenProject project = LocalMavenProject
                 .loadWorkspace(workDir.resolve("root").resolve("non-module-child").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNotNull(project.getWorkspace());
         assertEquals("non-module-child", project.getArtifactId());
-        final Map<AppArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
+        final Map<AppArtifactKey, LocalMavenProject> projects = project.getWorkspace().getProjects();
         assertEquals(7, projects.size());
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-no-parent-module")));
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-module-with-parent")));
@@ -205,7 +205,7 @@ public class LocalWorkspaceDiscoveryTest {
      */
     @Test
     public void loadWorkspaceForModuleWithEmptyRelativePathParent() throws Exception {
-        final LocalProject project = LocalProject.loadWorkspace(
+        final LocalMavenProject project = LocalMavenProject.loadWorkspace(
                 workDir.resolve("root").resolve("module4").resolve("target").resolve("classes"));
         assertNotNull(project);
         assertNotNull(project.getWorkspace());
@@ -217,8 +217,8 @@ public class LocalWorkspaceDiscoveryTest {
         assertLocalDeps(project);
     }
 
-    private void assertCompleteWorkspace(final LocalProject project) {
-        final Map<AppArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
+    private void assertCompleteWorkspace(final LocalMavenProject project) {
+        final Map<AppArtifactKey, LocalMavenProject> projects = project.getWorkspace().getProjects();
         assertEquals(5, projects.size());
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-no-parent-module")));
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-module-with-parent")));
@@ -228,16 +228,16 @@ public class LocalWorkspaceDiscoveryTest {
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root")));
     }
 
-    private static void assertLocalDeps(LocalProject project, String... deps) {
-        final List<LocalProject> list = project.getSelfWithLocalDeps();
+    private static void assertLocalDeps(LocalMavenProject project, String... deps) {
+        final List<LocalMavenProject> list = project.getSelfWithLocalDeps();
         assertEquals(deps.length + 1, list.size());
         int i = 0;
         while (i < deps.length) {
-            final LocalProject dep = list.get(i);
+            final LocalMavenProject dep = list.get(i);
             assertEquals(deps[i++], dep.getArtifactId());
             assertEquals(project.getGroupId(), dep.getGroupId());
         }
-        final LocalProject self = list.get(i);
+        final LocalMavenProject self = list.get(i);
         assertEquals(project.getGroupId(), self.getGroupId());
         assertEquals(project.getArtifactId(), self.getArtifactId());
         assertEquals(project.getVersion(), self.getVersion());

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -30,11 +30,19 @@
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
         <maven-resolver.version>1.1.1</maven-resolver.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <gradle-tooling-api.version>5.4.1</gradle-tooling-api.version>
     </properties>
     <modules>
         <module>core</module>
         <module>maven-plugin</module>
     </modules>
+    <repositories>
+        <repository>
+            <id>gradle-releases</id>
+            <name>Gradle Releases Repository</name>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+        </repository>
+    </repositories>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -130,6 +138,11 @@
                 <artifactId>junit</artifactId>
                 <scope>test</scope>
                 <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.gradle</groupId>
+                <artifactId>gradle-tooling-api</artifactId>
+                <version>${gradle-tooling-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This set of patches adds support for running tests annotated with `@QuarkusTest` via Gradle. It uses the Gradle Tooling API to query the actual underlying `AppModelResolver` from the existing Gradle plugin. This has the benefit of being able to use all the existing infrastructure.

This is still very much a proof of concept and work in progress, but I think it's worth getting some feedback on the general approach of using the tooling API to expose the existing resolver code at this stage.

There are some API snags (i.e., `LocalProject` implements `AutoCloseable`) and I'm not up to date on the latest "managed dependencies" changes in the `AppModelResolver` code. I've rebased on master, but have yet to read through the actual changes that were involved in my merge conflicts.

Also, some features that relied on specific features of the `LocalProject` code have been disabled until I come up with an alternative.