### PR TITLE
fix runner jar outcome generated by the native-image mojo

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
@@ -194,7 +194,9 @@ public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutc
 
         if (appClassesDir == null) {
             appClassesDir = outputDir.resolve("classes");
-            Path appJar = appState.getAppArtifact().getPath();
+        }
+        if (!Files.exists(appClassesDir)) {
+            final Path appJar = appState.getAppArtifact().getPath();
             try {
                 ZipUtils.unzip(appJar, appClassesDir);
             } catch (IOException e) {


### PR DESCRIPTION
This is not affecting our currently promoted application build and/or testing use-cases. This fixes the runner jar generated for an application provided as an archive by the native-image mojo using e.g. `mvn clean quarkus:native-image -Dquarkus.appArtifact=io.quarkus:quarkus-integration-test-camel-core:999-SNAPSHOT`