### PR TITLE
Pass the outer (managing) project to resolveManagedModel(...) instead of the list of its managed deps

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -73,11 +73,6 @@ public class AppModelGradleResolver implements AppModelResolver {
     }
 
     @Override
-    public List<AppDependency> readManagedDependencies(AppArtifact artifact) throws AppModelResolverException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public List<AppDependency> resolveUserDependencies(AppArtifact appArtifact, List<AppDependency> directDeps)
             throws AppModelResolverException {
         return Collections.emptyList();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
@@ -186,8 +186,7 @@ public class BootstrapClassLoaderFactory {
             }
             final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(mvnBuilder.build());
             final AppModel appModel = appModelResolver.resolveManagedModel(appArtifact, Collections.emptyList(),
-                    appModelResolver
-                            .readManagedDependencies(localProject == null ? appArtifact : localProject.getAppArtifact()));
+                    localProject == null ? null : localProject.getAppArtifact());
             if (hierarchical) {
                 final URLClassLoader cl = initAppCp(appModel.getUserDependencies());
                 try {
@@ -242,9 +241,9 @@ public class BootstrapClassLoaderFactory {
             try {
                 final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(mvn);
                 final AppArtifact appArtifact = ModelUtils.resolveAppArtifact(appClasses);
-                deploymentDeps = appModelResolver.resolveManagedModel(appArtifact, Collections.emptyList(),
-                        appModelResolver
-                                .readManagedDependencies(localProject == null ? appArtifact : localProject.getAppArtifact()))
+                deploymentDeps = appModelResolver
+                        .resolveManagedModel(appArtifact, Collections.emptyList(),
+                                localProject == null ? null : localProject.getAppArtifact())
                         .getDeploymentDependencies();
             } catch (Exception e) {
                 throw new BootstrapException("Failed to resolve deployment dependencies for " + appClasses, e);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/AppModelResolver.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/AppModelResolver.java
@@ -34,16 +34,6 @@ public interface AppModelResolver {
     Path resolve(AppArtifact artifact) throws AppModelResolverException;
 
     /**
-     * Returns dependency versions that are forced by the artifact
-     * on its dependencies.
-     *
-     * @param artifact  target artifact
-     * @return  list of dependency versions forced by the artifact on its dependencies
-     * @throws AppModelResolverException
-     */
-    List<AppDependency> readManagedDependencies(AppArtifact artifact) throws AppModelResolverException;
-
-    /**
      * Resolve application direct and transitive dependencies configured by the user.
      *
      * Note that deployment dependencies are not included in the result.


### PR DESCRIPTION
This is a refactoring of a recently added feature to support resolution of application models managed by an outer project. The way it was done originally was not taking into account exclusions configured in the managed dependencies.