### PR TITLE
doc: fix the security guide for the auth mechanism

### DIFF
--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -161,7 +161,7 @@ quarkus.security.embedded.roles.scott=Admin,admin,Tester,user
 quarkus.security.embedded.roles.stuart=admin,user
 quarkus.security.embedded.roles.jdoe=NoRolesUser
 quarkus.security.embedded.roles.noadmin=user
-quarkus.security.embedded.auth-mechanism=CUSTOM
+quarkus.security.embedded.auth-mechanism=BASIC
 ----
 
 #### Embedded Users


### PR DESCRIPTION
There is no CUSTOM auth mechanism but using BASIC works for the guide.
It fixes #3002