### PR TITLE
Add support for Flyway baselineOnMigrate to auto create the history table

### DIFF
--- a/docs/src/main/asciidoc/flyway-guide.adoc
+++ b/docs/src/main/asciidoc/flyway-guide.adoc
@@ -90,6 +90,23 @@ Repeatable SQL migrations have the following file name structure: prefixSeparato
 defaults translates to R__My_description.sql +
 **default:** R
 
+`quarkus.flyway.baseline-on-migrate`::
+Whether to automatically call baseline when migrate is executed against a non-empty schema with no metadata table.
+This schema will then be baselined with the *baseline-version* before executing the migrations.
+Only migrations above *baseline-version* will then be applied.
+This is useful for initial Flyway production deployments on projects with an existing DB. +
++
+Be careful when enabling this as it removes the safety net that ensures Flyway does not
+migrate the wrong database in case of a configuration mistake! +
+**default:** false
+
+`quarkus.flyway.baseline-version`::
+The version to tag an existing schema with when executing baseline +
+**default:** 1
+
+`quarkus.flyway.baseline-description`::
+The description to tag an existing schema with when executing baseline +
+**default:** '<< Flyway Baseline >>'
 
 The following is an example for the `{config-file}` file:
 
@@ -105,12 +122,16 @@ quarkus.datasource.password: connor
 quarkus.flyway.migrate-at-start=true
 
 # Flyway optional config properties
+# quarkus.flyway.baseline-on-migrate=true
+# quarkus.flyway.baseline-version=1.0.0
+# quarkus.flyway.baseline-description=Initial version
 # quarkus.flyway.connect-retries=10
 # quarkus.flyway.schemas=TEST_SCHEMA
 # quarkus.flyway.table=flyway_quarkus_history
 # quarkus.flyway.locations=db/location1,db/location2
 # quarkus.flyway.sql-migration-prefix=X
 # quarkus.flyway.repeatable-sql-migration-prefix=K
+
 --
 
 Add a SQL migration to the default folder following the Flyway naming conventions: `{migrations-path}/V1.0.0__Quarkus.sql`

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionBaselineOnMigrateTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionBaselineOnMigrateTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.flyway.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationInfo;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FlywayExtensionBaselineOnMigrateTest {
+    // Quarkus built object
+    @Inject
+    Flyway flyway;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("baseline-on-migrate.properties", "application.properties"));
+
+    @Test
+    @DisplayName("Create history table correctly")
+    public void testFlywayInitialBaselineInfo() {
+        MigrationInfo baselineInfo = flyway.info().applied()[0];
+
+        assertEquals("0.0.1", baselineInfo.getVersion().getVersion());
+        assertEquals("Initial description for test", baselineInfo.getDescription());
+    }
+}

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionFullConfigTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionFullConfigTest.java
@@ -34,6 +34,12 @@ public class FlywayExtensionFullConfigTest {
     String sqlMigrationPrefix;
     @ConfigProperty(name = "quarkus.flyway.repeatable-sql-migration-prefix")
     String repeatableSqlMigrationPrefix;
+    @ConfigProperty(name = "quarkus.flyway.baseline-on-migrate")
+    boolean baselineOnMigrate;
+    @ConfigProperty(name = "quarkus.flyway.baseline-version")
+    String baselineVersion;
+    @ConfigProperty(name = "quarkus.flyway.baseline-description")
+    String baselineDescription;
 
     // Quarkus built object
     @Inject
@@ -68,5 +74,9 @@ public class FlywayExtensionFullConfigTest {
         assertEquals(joinedSchemas, configuredNames);
 
         assertEquals(connectRetries, configuration.getConnectRetries());
+
+        assertEquals(baselineOnMigrate, configuration.isBaselineOnMigrate());
+        assertEquals(baselineVersion, configuration.getBaselineVersion().getVersion());
+        assertEquals(baselineDescription, configuration.getBaselineDescription());
     }
 }

--- a/extensions/flyway/deployment/src/test/resources/baseline-on-migrate.properties
+++ b/extensions/flyway/deployment/src/test/resources/baseline-on-migrate.properties
@@ -1,0 +1,11 @@
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test-quarkus-baseline-on-migrate;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'src/test/resources/h2-init-data.sql'
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
+# Flyway config properties
+quarkus.flyway.migrate-at-start=true
+quarkus.flyway.table=test_flyway_history
+quarkus.flyway.baseline-on-migrate=true
+quarkus.flyway.baseline-version=0.0.1
+quarkus.flyway.baseline-description=Initial description for test

--- a/extensions/flyway/deployment/src/test/resources/db/migration/V1.0.0__Quarkus.sql
+++ b/extensions/flyway/deployment/src/test/resources/db/migration/V1.0.0__Quarkus.sql
@@ -1,5 +1,5 @@
 CREATE TABLE quarked_flyway
 (
     id   INT,
-    some VARCHAR(20)
+    name VARCHAR(20)
 );

--- a/extensions/flyway/deployment/src/test/resources/full-config.properties
+++ b/extensions/flyway/deployment/src/test/resources/full-config.properties
@@ -10,3 +10,6 @@ quarkus.flyway.locations=db/location1,db/location2
 quarkus.flyway.sql-migration-prefix=X
 quarkus.flyway.repeatable-sql-migration-prefix=K
 quarkus.flyway.migrate-at-start=false
+quarkus.flyway.baseline-on-migrate=true
+quarkus.flyway.baseline-version=2.0.1
+quarkus.flyway.baseline-description=Initial description

--- a/extensions/flyway/deployment/src/test/resources/h2-init-data.sql
+++ b/extensions/flyway/deployment/src/test/resources/h2-init-data.sql
@@ -1,0 +1,3 @@
+-- We need an existing table in the database to test the creation of the
+-- Flyway history table with the correct baseline version set.
+CREATE TABLE IF NOT EXISTS fake_existing_tbl;

--- a/extensions/flyway/deployment/src/test/resources/migrate-at-start-config.properties
+++ b/extensions/flyway/deployment/src/test/resources/migrate-at-start-config.properties
@@ -1,4 +1,4 @@
-quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test_quarkus;DB_CLOSE_DELAY=-1
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test-quarkus-migrate-at-start;DB_CLOSE_DELAY=-1
 quarkus.datasource.driver=org.h2.Driver
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayProducer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayProducer.java
@@ -37,6 +37,11 @@ public class FlywayProducer {
         }
         flywayRuntimeConfig.sqlMigrationPrefix.ifPresent(configure::sqlMigrationPrefix);
         flywayRuntimeConfig.repeatableSqlMigrationPrefix.ifPresent(configure::repeatableSqlMigrationPrefix);
+
+        configure.baselineOnMigrate(flywayRuntimeConfig.baselineOnMigrate);
+        flywayRuntimeConfig.baselineVersion.ifPresent(configure::baselineVersion);
+        flywayRuntimeConfig.baselineDescription.ifPresent(configure::baselineDescription);
+
         return configure.load();
     }
 

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayRuntimeConfig.java
@@ -53,4 +53,19 @@ public final class FlywayRuntimeConfig {
      *
      */
     public boolean migrateAtStart = false;
+    /**
+     * Enable the creation of the history table if it does not exist already.
+     */
+    @ConfigItem
+    public boolean baselineOnMigrate = false;
+    /**
+     * The initial baseline version.
+     */
+    @ConfigItem
+    public Optional<String> baselineVersion;
+    /**
+     * The description to tag an existing schema with when executing baseline.
+     */
+    @ConfigItem
+    public Optional<String> baselineDescription;
 }


### PR DESCRIPTION
Add support for Flyway baselineOnMigrate functionality. This is useful when using existing databases and you want to start to manage them by Flyway. 