### PR TITLE
Introduce KubernetesMockServerTestResource  

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -563,6 +563,11 @@
                 <artifactId>quarkus-test-h2</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-kubernetes-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- External dependencies -->
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -779,6 +779,12 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-kubernetes-client</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-junit4</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -1,0 +1,79 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Kubernetes Client
+
+include::./attributes.adoc[]
+
+
+Quarkus includes the `kubernetes-client` extension which enables the use of the [Fabric8 Kubernetes Client](https://github.com/fabric8io/kubernetes-client)
+in native mode while also making it easier to work with.
+
+== Configuration
+
+Once you have your Quarkus project configured you can add the `kubernetes-client` extension
+to your project by running the following command in your project base directory.
+
+[source]
+mvn quarkus:add-extension -Dextensions="kubernetes-client"
+
+This will add the following to your pom.xml:
+
+[source,xml]
+----
+    <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-kubernetes-client</artifactId>
+    </dependency>
+----
+
+== Testing
+
+To make testing against a mock Kubernetes API extremely simple, Quarkus provides the `KubernetesMockServerTestResource` which automatically launches
+a mock of the Kubernetes API server and sets the proper environment variables needed so that the Kubernetes Client configures itself to use said mock.
+Tests can inject the mock and set it up in any way necessary for the particular testing using the `@MockServer` annotation.
+
+Here is an example of such test:
+
+[source%nowrap,java]
+----
+@QuarkusTestResource(KubernetesMockServerTestResource.class)
+@QuarkusTest
+public class KubernetesClientTest {
+
+    @MockServer
+    private KubernetesMockServer mockServer;
+
+    @Test
+    public void before() {
+        final Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+        final Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods")
+                .andReturn(200,
+                        new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1, pod2)
+                                .build())
+                .always();
+    }
+
+    @Test
+    public void testInteractionWithAPIServer() {
+        RestAssured.when().get("/pod/test").then()
+                .body("size()", is(2));
+    }
+
+}
+----
+
+Note that to take advantage of these features, the `quarkus-test-kubernetes-client` dependency needs to be added, for example like so:
+
+[source,xml]
+----
+    <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-kubernetes-client</artifactId>
+        <scope>test</scope>
+    </dependency>
+----

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -34,15 +34,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-server-mock</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-kubernetes-client</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -3,28 +3,57 @@ package io.quarkus.it.kubernetes.client;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
-import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.KubernetesMockServerTestResource;
+import io.quarkus.test.kubernetes.client.MockServer;
 import io.restassured.RestAssured;
 
 /*
  * KubernetesClientTest.TestResource contains the entire process of setting up the Mock Kubernetes API Server
  * It has to live there otherwise the Kubernetes client in native mode won't be able to locate the mock API Server
  */
-@QuarkusTestResource(KubernetesClientTest.TestResource.class)
+@QuarkusTestResource(KubernetesMockServerTestResource.class)
 @QuarkusTest
 public class KubernetesClientTest {
+
+    @MockServer
+    private KubernetesMockServer mockServer;
+
+    @Test
+    public void before() {
+        Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+        Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods")
+                .andReturn(200,
+                        new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1, pod2)
+                                .build())
+                .always();
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods/pod1")
+                .andReturn(200, pod1)
+                .always();
+
+        mockServer.expect().delete().withPath("/api/v1/namespaces/test/pods/pod1")
+                .andReturn(200, "{}")
+                .once();
+
+        // it doesn't really matter what we return here, we just need to return a Pod to make sure
+        // deserialization works
+        mockServer.expect().put().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder()
+                .withNewMetadata().withName("pod1").addToLabels("key1", "value1").endMetadata().build()).once();
+
+        // same here, the content itself doesn't really matter
+        mockServer.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, new PodBuilder()
+                .withNewMetadata().withResourceVersion("12345").and().build()).once();
+    }
 
     @Test
     public void testInteractionWithAPIServer() {
@@ -41,55 +70,4 @@ public class KubernetesClientTest {
                 .body(containsString("12345"));
     }
 
-    public static class TestResource implements QuarkusTestResourceLifecycleManager {
-        private KubernetesMockServer mockServer;
-
-        @Override
-        public Map<String, String> start() {
-            // TODO flip to true when SSL is properly setup on CI
-            mockServer = new KubernetesMockServer(false);
-            mockServer.init();
-
-            final Map<String, String> systemProps = new HashMap<>();
-            systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
-                    mockServer.createClient().getConfiguration().getMasterUrl());
-            systemProps.put(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
-            systemProps.put(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
-            systemProps.put(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
-            systemProps.put(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
-
-            Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-            Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
-
-            mockServer.expect().get().withPath("/api/v1/namespaces/test/pods")
-                    .andReturn(200,
-                            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1, pod2)
-                                    .build())
-                    .always();
-
-            mockServer.expect().get().withPath("/api/v1/namespaces/test/pods/pod1")
-                    .andReturn(200, pod1)
-                    .always();
-
-            mockServer.expect().delete().withPath("/api/v1/namespaces/test/pods/pod1")
-                    .andReturn(200, "{}")
-                    .once();
-
-            // it doesn't really matter what we return here, we just need to return a Pod to make sure
-            // deserialization works
-            mockServer.expect().put().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder()
-                    .withNewMetadata().withName("pod1").addToLabels("key1", "value1").endMetadata().build()).once();
-
-            // same here, the content itself doesn't really matter
-            mockServer.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, new PodBuilder()
-                    .withNewMetadata().withResourceVersion("12345").and().build()).once();
-
-            return systemProps;
-        }
-
-        @Override
-        public void stop() {
-            mockServer.destroy();
-        }
-    }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
@@ -26,4 +26,10 @@ public interface QuarkusTestResourceLifecycleManager {
      * Stop the test resource.
      */
     void stop();
+
+    /**
+     * Allow each resource to provide custom injection of fields of the test class
+     */
+    default void inject(Object testInstance) {
+    }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -50,6 +50,12 @@ public class TestResourceManager {
         return ret;
     }
 
+    public void inject(Object testInstance) {
+        for (QuarkusTestResourceLifecycleManager testResource : testResources) {
+            testResource.inject(testInstance);
+        }
+    }
+
     public void stop() {
         if (oldSystemProps != null) {
             for (Map.Entry<String, String> e : oldSystemProps.entrySet()) {

--- a/test-framework/junit4/src/main/java/io/quarkus/test/junit4/AbstractQuarkusRunListener.java
+++ b/test-framework/junit4/src/main/java/io/quarkus/test/junit4/AbstractQuarkusRunListener.java
@@ -83,6 +83,10 @@ abstract class AbstractQuarkusRunListener extends RunListener {
         restAssuredURLManager.clearURL();
     }
 
+    public void inject(Object testInstance) {
+        testResourceManager.inject(testInstance);
+    }
+
     protected abstract void startQuarkus() throws Exception;
 
     protected abstract void stopQuarkus() throws Exception;

--- a/test-framework/junit4/src/main/java/io/quarkus/test/junit4/AbstractQuarkusTestRunner.java
+++ b/test-framework/junit4/src/main/java/io/quarkus/test/junit4/AbstractQuarkusTestRunner.java
@@ -12,7 +12,7 @@ import io.quarkus.test.common.http.TestHTTPResourceManager;
 abstract class AbstractQuarkusTestRunner extends BlockJUnit4ClassRunner {
 
     private static boolean first = true;
-    private static AbstractQuarkusRunListener quarkusRunListener;
+    protected static AbstractQuarkusRunListener quarkusRunListener;
 
     private final BiFunction<Class<?>, RunNotifier, AbstractQuarkusRunListener> quarkusRunListenerSupplier;
 

--- a/test-framework/junit4/src/main/java/io/quarkus/test/junit4/QuarkusTest.java
+++ b/test-framework/junit4/src/main/java/io/quarkus/test/junit4/QuarkusTest.java
@@ -70,6 +70,7 @@ public class QuarkusTest extends AbstractQuarkusTestRunner {
         Object instance = TestInstantiator.instantiateTest(getTestClass().getJavaClass());
         TestHTTPResourceManager.inject(instance);
         TestInjectionManager.inject(instance);
+        quarkusRunListener.inject(instance);
         return instance;
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -331,6 +331,7 @@ public class QuarkusTestExtension
         Object instance = TestInstantiator.instantiateTest(factoryContext.getTestClass());
         TestHTTPResourceManager.inject(instance);
         TestInjectionManager.inject(instance);
+        state.testResourceManager.inject(instance);
         return instance;
     }
 

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-test-kubernetes-client</artifactId>
+    <name>Quarkus - Test framework - Kubernetes Client Mock Server support</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
@@ -1,0 +1,65 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class KubernetesMockServerTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private KubernetesMockServer mockServer;
+
+    @Override
+    public Map<String, String> start() {
+        mockServer = new KubernetesMockServer(useHttps());
+        mockServer.init();
+
+        final Map<String, String> systemProps = new HashMap<>();
+        systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
+                mockServer.createClient().getConfiguration().getMasterUrl());
+        systemProps.put(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+        systemProps.put(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+        systemProps.put(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+        systemProps.put(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+
+        return systemProps;
+    }
+
+    @Override
+    public void stop() {
+        mockServer.destroy();
+    }
+
+    @Override
+    public void inject(Object testInstance) {
+        Class<?> c = testInstance.getClass();
+        while (c != Object.class) {
+            for (Field f : c.getDeclaredFields()) {
+                if (f.getAnnotation(MockServer.class) != null) {
+                    if (!KubernetesMockServer.class.isAssignableFrom(f.getType())) {
+                        throw new RuntimeException("@MockServer can only be used on fields of type KubernetesMockServer");
+                    }
+
+                    f.setAccessible(true);
+                    try {
+                        f.set(testInstance, mockServer);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            c = c.getSuperclass();
+        }
+    }
+
+    private boolean useHttps() {
+        final String property = System.getProperty("quarkus.kubernetes-client.test.https");
+        if (property == null || property.isEmpty()) {
+            return false;
+        }
+        return property.toLowerCase().trim().equals("true");
+    }
+}

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/MockServer.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/MockServer.java
@@ -1,0 +1,17 @@
+package io.quarkus.test.kubernetes.client;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+
+/**
+ * Used to specify that the field should be injected with the mock Kubernetes API server
+ * Can only be used on type {@link KubernetesMockServer}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MockServer {
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>common</module>
         <module>h2</module>
+        <module>kubernetes-client</module>
         <module>junit4</module>
         <module>junit5-internal</module>
         <module>junit5</module>


### PR DESCRIPTION
This can be used by application code to automatically setup the Kubernetes Server API mock

**TODO**

~~- Update the Kubernetes Client documentation to highlight this new capability~~