### PR TITLE
Boostrap resolver : Do not merge managed dependencies before collection process

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -328,7 +328,7 @@ public class MavenArtifactResolver {
 
         return new CollectRequest()
                 .setRootArtifact(artifact)
-                .setDependencies(mergeDeps(deps, originalDeps, managedVersions))
+                .setDependencies(mergeDeps(deps, originalDeps))
                 .setManagedDependencies(mergedManagedDeps)
                 .setRepositories(remoteRepoManager.aggregateRepositories(repoSession, remoteRepos, descr.getRepositories(), true));
     }
@@ -347,7 +347,7 @@ public class MavenArtifactResolver {
                 .setRepositories(remoteRepos);
     }
 
-    private List<Dependency> mergeDeps(List<Dependency> dominant, List<Dependency> recessive, Map<AppArtifactKey, String> managedVersions) {
+    private List<Dependency> mergeDeps(List<Dependency> dominant, List<Dependency> recessive) {
         final int initialCapacity = dominant.size() + recessive.size();
         if(initialCapacity == 0) {
             return Collections.emptyList();
@@ -357,19 +357,11 @@ public class MavenArtifactResolver {
         for (Dependency dependency : dominant) {
             final AppArtifactKey id = getId(dependency.getArtifact());
             ids.add(id);
-            final String managedVersion = managedVersions.get(id);
-            if(managedVersion != null) {
-                dependency = dependency.setArtifact(dependency.getArtifact().setVersion(managedVersion));
-            }
             result.add(dependency);
         }
         for (Dependency dependency : recessive) {
             final AppArtifactKey id = getId(dependency.getArtifact());
             if (!ids.contains(id)) {
-                final String managedVersion = managedVersions.get(id);
-                if(managedVersion != null) {
-                    dependency = dependency.setArtifact(dependency.getArtifact().setVersion(managedVersion));
-                }
                 result.add(dependency);
             }
         }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
@@ -90,6 +90,10 @@ public abstract class CollectDependenciesBase extends ResolverSetupCleanup {
         addCollectedDep(artifact, dep.scope == null ? "compile" : dep.scope, dep.optional);
     }
 
+    protected void addManagedDep(TsArtifact dep) {
+        root.addManagedDependency(new TsDependency(dep));
+    }
+
     protected void addCollectedDep(final TsArtifact artifact) {
         addCollectedDep(artifact, "compile", false);
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 
 import io.quarkus.bootstrap.model.AppArtifact;
@@ -55,6 +56,7 @@ public class TsArtifact {
 
     private List<TsDependency> deps = Collections.emptyList();
     private List<TsQuarkusExt> extDeps = Collections.emptyList();
+    private List<TsDependency> managedDeps = Collections.emptyList();
 
     protected ContentProvider content;
 
@@ -123,6 +125,14 @@ public class TsArtifact {
         return this;
     }
 
+    public TsArtifact addManagedDependency(TsDependency dep) {
+        if (managedDeps.isEmpty()) {
+            managedDeps = new ArrayList<>();
+        }
+        managedDeps.add(dep);
+        return this;
+    }
+
     public String getArtifactFileName() {
         if(artifactId == null) {
             throw new IllegalArgumentException("artifactId is missing");
@@ -158,6 +168,13 @@ public class TsArtifact {
         if(!deps.isEmpty()) {
             for (TsDependency dep : deps) {
                 model.addDependency(dep.toPomDependency());
+            }
+        }
+
+        if (!managedDeps.isEmpty()) {
+            model.setDependencyManagement(new DependencyManagement());
+            for (TsDependency dep : managedDeps) {
+                model.getDependencyManagement().addDependency(dep.toPomDependency());
             }
         }
 

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DirectDependencyOverridesManagedDepency.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/DirectDependencyOverridesManagedDepency.java
@@ -1,0 +1,21 @@
+package io.quarkus.bootstrap.resolver.test;
+
+import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+
+/**
+ *
+ */
+public class DirectDependencyOverridesManagedDepency extends CollectDependenciesBase {
+
+    @Override
+    protected void setupDependencies() {
+
+        final TsArtifact x12 = new TsArtifact("x", "2");
+        final TsArtifact x13 = new TsArtifact("x", "3");
+
+        installAsDep(x12);
+        install(x13);
+        addManagedDep(x13);
+    }
+}


### PR DESCRIPTION
Hello

I noticed an issue with the bootstrap dependencies resolver.
I have a dependency in the pom.xml of my quarkus application that are managed by the bootstrap resolver out of the << maven resolving policy >>  making the build overriding the version of my dependency. 
This seems to be a regression from #2922

I made a pull request, to "try" to fix the issue, but it may remove the feature carried by #2922, so I need some guidance here. However, my local build, it's not showing any integration/unit tests failed.

I also made a reproducer available there : https://github.com/vietk/QuarkusReproducer explaining the impacts of the issue.
 
Regards
Kevin