### PR TITLE
Fixes #2808, use the getAsyncContextInternal method

### DIFF
--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentTemplate.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentTemplate.java
@@ -469,8 +469,9 @@ public class UndertowDeploymentTemplate {
                             @Override
                             public T call(HttpServerExchange exchange, C context) throws Exception {
                                 // Not sure what to do here
-                                if (exchange == null)
+                                if (exchange == null) {
                                     return action.call(exchange, context);
+                                }
                                 ManagedContext requestContext = beanContainer.requestContext();
                                 if (requestContext.isActive()) {
                                     return action.call(exchange, context);
@@ -488,7 +489,7 @@ public class UndertowDeploymentTemplate {
                                             exchange.putAttachment(REQUEST_CONTEXT, requestContext.getAll());
                                             requestContext.deactivate();
                                             if (existingRequestContext == null) {
-                                                src.getServletRequest().getAsyncContext().addListener(new AsyncListener() {
+                                                req.getAsyncContextInternal().addListener(new AsyncListener() {
                                                     @Override
                                                     public void onComplete(AsyncEvent event) throws IOException {
                                                         for (io.quarkus.arc.InstanceHandle<?> i : exchange


### PR DESCRIPTION
Its possible another thread will have marked the async context completed,
if we use the internal method this will not throw an exception. As the
actual listener invocation should not happen till the initial thread
has returned this shouold still get cleaned up.