### PR TITLE
Allow to configure the timeout for a specific  transaction

### DIFF
--- a/docs/src/main/asciidoc/transaction-guide.adoc
+++ b/docs/src/main/asciidoc/transaction-guide.adoc
@@ -113,6 +113,14 @@ public class SantaClausService {
 <1> Inject the `TransactionManager` to be able to activate `setRollbackOnly` semantic.
 <2> Programmatically decide to set the transaction for rollback.
 
+
+=== Transaction Configuration
+
+Extended configuration of the transaction is possible with the use of the `@TransactionConfiguration` annotation that is set in addition to the standard `@Transactional` annotation on your entry method or at the class level.
+
+The `@TransactionConfiguration` annotation allows to set a timeout property, in seconds, that applies to transactions created within the annotated method.
+
+
 === Reactive extensions
 
 If your `@Transactional`-annotated method returns a reactive value, such as:

--- a/docs/src/main/asciidoc/transaction-guide.adoc
+++ b/docs/src/main/asciidoc/transaction-guide.adoc
@@ -120,6 +120,11 @@ Extended configuration of the transaction is possible with the use of the `@Tran
 
 The `@TransactionConfiguration` annotation allows to set a timeout property, in seconds, that applies to transactions created within the annotated method.
 
+This annotation may only be placed on the top level method delineating the transaction.
+Annotated nested methods once a transaction has started will throw an exception.
+
+If defined on a class, it is equivalent to defining it on all the methods of the class marked with `@Transactional`.
+The configuration defined on a method takes precedence over the configuration defined on a class.
 
 === Reactive extensions
 

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
@@ -1,0 +1,27 @@
+package io.quarkus.narayana.jta.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to configure a different transaction timeout that the default one for a method or a class.
+ * It needs to be used on the entry method of the transaction.
+ */
+@Inherited
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface TransactionConfiguration {
+    /** The value is used to specify that no transaction timeout is configured */
+    int UNSET_TIMEOUT = -1;
+
+    /**
+     * The transaction timeout in second.
+     * Defaults to UNSET_TIMEOUT: no timeout configured.
+     * 
+     * @return The transaction timeout in second.
+     */
+    int timeout() default UNSET_TIMEOUT;
+}

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
@@ -7,21 +7,23 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation can be used to configure a different transaction timeout that the default one for a method or a class.
+ * This annotation can be used to configure a different transaction timeout than the default one for a method or a class.
  * It needs to be used on the entry method of the transaction.
  */
 @Inherited
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface TransactionConfiguration {
-    /** The value is used to specify that no transaction timeout is configured */
+    /**
+     * This value is used to specify that no transaction timeout is configured
+     */
     int UNSET_TIMEOUT = -1;
 
     /**
-     * The transaction timeout in second.
+     * The transaction timeout in seconds.
      * Defaults to UNSET_TIMEOUT: no timeout configured.
      * 
-     * @return The transaction timeout in second.
+     * @return The transaction timeout in seconds.
      */
     int timeout() default UNSET_TIMEOUT;
 }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
@@ -8,21 +8,26 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation can be used to configure a different transaction timeout than the default one for a method or a class.
- * It needs to be used on the entry method of the transaction.
+ * <p>
+ * When defined on a method, it needs to be used on the entry method of the transaction.
+ * <p>
+ * If defined on a class, it is equivalent to defining it on all the methods of the class marked with {@code @Transactional}.
+ * The configuration defined on a method takes precedence over the configuration defined on a class.
  */
 @Inherited
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface TransactionConfiguration {
+
     /**
-     * This value is used to specify that no transaction timeout is configured
+     * This value is used to specify that no transaction timeout is configured.
      */
     int UNSET_TIMEOUT = -1;
 
     /**
      * The transaction timeout in seconds.
      * Defaults to UNSET_TIMEOUT: no timeout configured.
-     * 
+     *
      * @return The transaction timeout in seconds.
      */
     int timeout() default UNSET_TIMEOUT;


### PR DESCRIPTION
Provides a way to configure the current transaction timeout via an `@TransactionTimeout` annotation.
The annotation can be put on both class and method level.
It fixes #2997 

The documentation part still needs to be done, preliminary review can be done on the code.