### PR TITLE
Upgrade to GraalVM 19.1.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -66,7 +66,7 @@
         <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal
            is not available in Maven fast enough: -->
-        <graal-sdk.version>19.0.2</graal-sdk.version>
+        <graal-sdk.version>19.1.1</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha5</gizmo.version>
         <jackson.version>2.9.9</jackson.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -28,7 +28,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>19.0.2</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>19.1.1</graal-sdk.version-for-documentation>
         <rest-assured.version>3.3.0</rest-assured.version>
         <axle-client.version>0.0.7</axle-client.version>
         <vertx.version>3.7.1</vertx.version>

--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -103,7 +103,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
     private String nativeImageXmx;
 
-    private String builderImage = "quay.io/quarkus/ubi-quarkus-native-image:19.0.2";
+    private String builderImage = "quay.io/quarkus/ubi-quarkus-native-image:19.1.1";
 
     private String containerRuntime = "";
 
@@ -324,7 +324,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
         final Config config = SmallRyeConfigProviderResolver.instance().getConfig();
 
-        boolean vmVersionOutOfDate = isThisGraalVMRCObsolete();
+        boolean vmVersionOutOfDate = isThisGraalVMVersionObsolete();
 
         HashMap<String, String> env = new HashMap<>(System.getenv());
         List<String> nativeImage;
@@ -562,14 +562,14 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
     }
 
     //FIXME remove after transition period
-    private boolean isThisGraalVMRCObsolete() {
+    private boolean isThisGraalVMVersionObsolete() {
         final String vmName = System.getProperty("java.vm.name");
         log.info("Running Quarkus native-image plugin on " + vmName);
         final List<String> obsoleteGraalVmVersions = Arrays.asList("-rc9", "-rc10", "-rc11", "-rc12", "-rc13", "-rc14",
-                "-rc15", "-rc16", "19.0.0");
+                "-rc15", "-rc16", "19.0.", "19.1.0");
         final boolean vmVersionIsObsolete = obsoleteGraalVmVersions.stream().anyMatch(vmName::contains);
         if (vmVersionIsObsolete) {
-            log.error("Out of date RC build of GraalVM detected! Please upgrade to GraalVM 19.0.2");
+            log.error("Out of date build of GraalVM detected! Please upgrade to GraalVM 19.1.1.");
             return true;
         }
         return false;


### PR DESCRIPTION
I did the boring work for the upgrade hoping it would work out of the box.

Locally, I have a failure in the main integration tests with the following exception:
```
2019-07-02 22:09:47,255 ERROR [io.und.req.io] (executor-thread-1) Exception handling request 49882154-7929-4a09-939b-2c477417b655-2 to /test/xml: java.lang.IllegalAccessError: Class com.sun.xml.internal.bind.v2.runtime.ClassBeanInfoImpl can not access a member of class com.sun.xml.internal.bind.v2.runtime.property.SingleElementLeafProperty with modifiers "public"
	at com.sun.xml.internal.bind.v2.runtime.property.PropertyFactory.create(PropertyFactory.java:117)
	at com.sun.xml.internal.bind.v2.runtime.ClassBeanInfoImpl.<init>(ClassBeanInfoImpl.java:166)
	at com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.getOrCreate(JAXBContextImpl.java:488)
	at com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:305)
	at com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:124)
	at com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl$JAXBContextBuilder.build(JAXBContextImpl.java:1123)
	at com.sun.xml.internal.bind.v2.ContextFactory.createContext(ContextFactory.java:147)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:247)
	at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:234)
	at javax.xml.bind.ContextFinder.find(ContextFinder.java:462)
	at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:641)
	at org.jboss.resteasy.plugins.providers.jaxb.JAXBContextWrapper.<init>(JAXBContextWrapper.java:112)
	at org.jboss.resteasy.plugins.providers.jaxb.JAXBContextWrapper.<init>(JAXBContextWrapper.java:175)
	at org.jboss.resteasy.plugins.providers.jaxb.XmlJAXBContextFinder.createContextObject(XmlJAXBContextFinder.java:52)
```

Let's see what CI has to say.