### PR TITLE
BeanGenerator - there is no need to use LazyValue for proxy reference

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -94,7 +94,7 @@ public class InterceptorGenerator extends BeanGenerator {
         implementCreate(classOutput, interceptorCreator, interceptor, providerTypeName, baseName, injectionPointToProviderField,
                 interceptorToProviderField,
                 reflectionRegistration, targetPackage, isApplicationClass);
-        implementGet(interceptor, interceptorCreator, providerTypeName);
+        implementGet(interceptor, interceptorCreator, providerTypeName, baseName);
         implementGetTypes(interceptorCreator, beanTypes.getFieldDescriptor());
         implementGetBeanClass(interceptor, interceptorCreator);
         // Interceptors are always @Dependent and have always default qualifiers

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -10,7 +10,6 @@ import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableReferenceProvider;
 import io.quarkus.arc.InvocationContextImpl;
 import io.quarkus.arc.InvocationContextImpl.InterceptorInvocation;
-import io.quarkus.arc.LazyValue;
 import io.quarkus.arc.Reflections;
 import io.quarkus.gizmo.MethodDescriptor;
 import java.lang.reflect.Constructor;
@@ -150,8 +149,6 @@ final class MethodDescriptors {
 
     static final MethodDescriptor CONTEXT_GET_IF_PRESENT = MethodDescriptor.ofMethod(Context.class, "get", Object.class,
             Contextual.class);
-
-    static final MethodDescriptor LAZY_VALUE_GET = MethodDescriptor.ofMethod(LazyValue.class, "get", Object.class);
 
     private MethodDescriptors() {
     }


### PR DESCRIPTION
- this will save one generated class per normal scoped bean because
gizmo generates a tiny class for each function/lambda