### PR TITLE
Update slf4j-jboss-logging to 1.2.0.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,7 +92,7 @@
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.11.2</log4j2.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <slf4j-jboss-logging.version>1.1.0.Final</slf4j-jboss-logging.version>
+        <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
         <wildfly-common.version>1.5.0.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.0.0.Alpha4</wildfly-elytron.version>


### PR DESCRIPTION
Fixes an issue encountered with Netty's internal logger requiring a logger name, previously reported at https://github.com/jboss-logging/slf4j-jboss-logging/issues/8.