### PR TITLE
Improve native-image detection

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -46,6 +46,9 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     protected MavenProject project;
 
+    @Parameter(defaultValue = "${java.home}", required = true, readonly = true)
+    public File javaHome;
+
     @Parameter(defaultValue = "${project.build.directory}")
     private File buildDir;
 
@@ -355,6 +358,7 @@ public class NativeImageMojo extends AbstractMojo {
                 .setEnableVMInspection(enableVMInspection)
                 .setFullStackTraces(fullStackTraces)
                 .setGraalvmHome(graalvmHome)
+                .setJavaHome(javaHome)
                 .setNativeImageXmx(nativeImageXmx)
                 .setReportErrorsAtRuntime(reportErrorsAtRuntime)
                 .setReportExceptionStackTraces(reportExceptionStackTraces));


### PR DESCRIPTION
When not running in container mode, it:

* checks for GRAALVM_HOME and if set and if it contains bin/native-image use it
* checks for java.home / JAVA_HOME and if set and if it contains bin/native-image use it
* checks for system path and if native-image is found, use it

Fix #3048.