### PR TITLE
QuarkusUnitTest has to be excluding directory containing test classes from indexing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -5,6 +5,8 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -42,6 +44,7 @@ public class QuarkusAugmentor {
     private final List<Consumer<BuildChainBuilder>> buildChainCustomizers;
     private final LaunchMode launchMode;
     private final List<Path> additionalApplicationArchives;
+    private final Collection<Path> excludedFromIndexing;
     private final LiveReloadBuildItem liveReloadBuildItem;
     private final Properties buildSystemProperties;
 
@@ -53,6 +56,7 @@ public class QuarkusAugmentor {
         this.buildChainCustomizers = new ArrayList<>(builder.buildChainCustomizers);
         this.launchMode = builder.launchMode;
         this.additionalApplicationArchives = new ArrayList<>(builder.additionalApplicationArchives);
+        this.excludedFromIndexing = builder.excludedFromIndexing;
         this.liveReloadBuildItem = builder.liveReloadState;
         this.buildSystemProperties = builder.buildSystemProperties;
     }
@@ -101,7 +105,7 @@ public class QuarkusAugmentor {
             BuildExecutionBuilder execBuilder = chain.createExecutionBuilder("main")
                     .produce(QuarkusConfig.INSTANCE)
                     .produce(liveReloadBuildItem)
-                    .produce(new ArchiveRootBuildItem(root, rootFs == null ? root : rootFs.getPath("/")))
+                    .produce(new ArchiveRootBuildItem(root, rootFs == null ? root : rootFs.getPath("/"), excludedFromIndexing))
                     .produce(new ClassOutputBuildItem(output))
                     .produce(new ShutdownContextBuildItem())
                     .produce(new LaunchModeBuildItem(launchMode))
@@ -144,6 +148,7 @@ public class QuarkusAugmentor {
     public static final class Builder {
 
         List<Path> additionalApplicationArchives = new ArrayList<>();
+        Collection<Path> excludedFromIndexing = Collections.emptySet();
         ClassOutput output;
         ClassLoader classLoader;
         Path root;
@@ -164,6 +169,11 @@ public class QuarkusAugmentor {
 
         public Builder addAdditionalApplicationArchive(Path archive) {
             this.additionalApplicationArchives.add(archive);
+            return this;
+        }
+
+        public Builder excludeFromIndexing(Collection<Path> excludedFromIndexing) {
+            this.excludedFromIndexing = excludedFromIndexing;
             return this;
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ArchiveRootBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ArchiveRootBuildItem.java
@@ -2,6 +2,8 @@ package io.quarkus.deployment.builditem;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
@@ -9,17 +11,23 @@ public final class ArchiveRootBuildItem extends SimpleBuildItem {
 
     private final Path archiveLocation;
     private final Path archiveRoot;
+    private final Collection<Path> excludedFromIndexing;
 
     public ArchiveRootBuildItem(Path appClassesDir) {
         this(appClassesDir, appClassesDir);
     }
 
     public ArchiveRootBuildItem(Path archiveLocation, Path archiveRoot) {
+        this(archiveLocation, archiveRoot, Collections.emptySet());
+    }
+
+    public ArchiveRootBuildItem(Path archiveLocation, Path archiveRoot, Collection<Path> excludedFromIndexing) {
         this.archiveLocation = archiveLocation;
         if (!Files.isDirectory(archiveRoot)) {
             throw new IllegalArgumentException(archiveRoot + " does not point to the application classes directory");
         }
         this.archiveRoot = archiveRoot;
+        this.excludedFromIndexing = excludedFromIndexing;
     }
 
     /**
@@ -47,5 +55,9 @@ public final class ArchiveRootBuildItem extends SimpleBuildItem {
      */
     public Path getArchiveRoot() {
         return archiveRoot;
+    }
+
+    public boolean isExcludedFromIndexing(Path p) {
+        return excludedFromIndexing.contains(p);
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/index/ApplicationArchiveBuildStepTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/index/ApplicationArchiveBuildStepTestCase.java
@@ -12,18 +12,18 @@ import org.junit.Test;
 public class ApplicationArchiveBuildStepTestCase {
     @Test
     public void testUrlToPath() throws MalformedURLException {
-        assertEquals(Paths.get("/a/path"), urlToPath(new URL("jar:file:/a/path!/META-INF/services/my.Service")));
+        assertEquals(Paths.get("/a/path"), urlToPath(new URL("jar:file:/a/path!/META-INF/services/my.Service"), "META-INF"));
         assertEquals(Paths.get("/a/path with whitespace"),
-                urlToPath(new URL("jar:file:/a/path%20with%20whitespace!/META-INF/services/my.Service")));
-        assertEquals(Paths.get("/a/path"), urlToPath(new URL("file:/a/path/META-INF/services/my.Service")));
+                urlToPath(new URL("jar:file:/a/path%20with%20whitespace!/META-INF/services/my.Service"), "META-INF"));
+        assertEquals(Paths.get("/a/path"), urlToPath(new URL("file:/a/path/META-INF/services/my.Service"), "META-INF"));
         assertEquals(Paths.get("/a/path with whitespace"),
-                urlToPath(new URL("file:/a/path%20with%20whitespace/META-INF/services/my.Service")));
-        assertEquals(Paths.get("/a/path"), urlToPath(new URL("file:/a/path")));
-        assertEquals(Paths.get("/a/path with whitespace"), urlToPath(new URL("file:/a/path%20with%20whitespace")));
+                urlToPath(new URL("file:/a/path%20with%20whitespace/META-INF/services/my.Service"), "META-INF"));
+        assertEquals(Paths.get("/a/path"), urlToPath(new URL("file:/a/path"), ""));
+        assertEquals(Paths.get("/a/path with whitespace"), urlToPath(new URL("file:/a/path%20with%20whitespace"), ""));
     }
 
     @Test(expected = RuntimeException.class)
     public void testUrlToPathWithWrongProtocol() throws MalformedURLException {
-        urlToPath(new URL("http://a/path"));
+        urlToPath(new URL("http://a/path"), "");
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -423,7 +423,7 @@ public class DevMojo extends AbstractMojo {
         }
         String path = uri.getRawPath();
         classPathManifest.append(path);
-        if (file.isDirectory()) {
+        if (file.isDirectory() && path.charAt(path.length() - 1) != '/') {
             classPathManifest.append("/");
         }
         classPathManifest.append(" ");

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -223,11 +223,14 @@ public class QuarkusUnitTest
                 //ignore
             }
 
+            final Path testLocation = PathTestHelper.getTestClassesLocation(testClass);
+
             runtimeRunner = RuntimeRunner.builder()
                     .setLaunchMode(LaunchMode.TEST)
                     .setClassLoader(testClass.getClassLoader())
                     .setTarget(deploymentDir)
-                    .setFrameworkClassesPath(PathTestHelper.getTestClassesLocation(testClass))
+                    .excludeFromIndexing(testLocation)
+                    .setFrameworkClassesPath(testLocation)
                     .addChainCustomizers(customiers)
                     .build();
 


### PR DESCRIPTION
Currently QuarkusUnitTest creates a new directory for the application it is about to test where it copies the test class and whatever was configured by the test to be included into the app archive. This directory, as an app dir, is going to be indexed.
At the same time, the test class is still present in the test classes directory, which is also on the classpath that, depending on the collected `AdditionalApplicationArchiveBuildItem`, may also be indexed, resulting in, e.g., the app class being registered more than once and will cause the fail to start.

The reason it's not failing right now is that additional paths in our testsuite do not start with `io.quarkus`, i.e. the same package as the testclass.

After trying a few workarounds, this change seemed to be the less intrusive to me. However, there could probably be other ways to fix it.

Fixes #3094 