### PR TITLE
Change ap4k to dekorate

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -132,7 +132,7 @@
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <kotlin.version>1.3.31</kotlin.version>
         <camel.version>3.0.0-M2</camel.version>
-        <ap4k.version>0.4.1</ap4k.version>
+        <dekorate.version>0.6.1</dekorate.version>
         <javax.xml.soap-api.version>1.4.0</javax.xml.soap-api.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
@@ -670,11 +670,11 @@
                 <version>${camel.version}</version>
             </dependency>
 
-            <!-- ap4k -->
+            <!-- dekorate -->
             <dependency>
-                <groupId>io.ap4k</groupId>
+                <groupId>io.dekorate</groupId>
                 <artifactId>kubernetes-annotations</artifactId>
-                <version>${ap4k.version}</version>
+                <version>${dekorate.version}</version>
                 <classifier>noapt</classifier>
             </dependency>
 

--- a/docs/src/main/asciidoc/kubernetes-resources.adoc
+++ b/docs/src/main/asciidoc/kubernetes-resources.adoc
@@ -36,7 +36,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
 == Enable Kubernetes support
 
 Quarkus offers the ability to automatically generate Kubernetes resources based on sane defaults and user supplied configuration. The implementation that takes care
-of generating the actual Kubernetes resources is provided by https://github.com/ap4k/ap4k/[ap4k].
+of generating the actual Kubernetes resources is provided by https://github.com/dekorateio/dekorate/[dekorate].
 
 When we added the `kubernetes` extension to the command line invocation above, the following dependency was added to the `pom.xml`
 

--- a/extensions/kubernetes/deployment/pom.xml
+++ b/extensions/kubernetes/deployment/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>quarkus-kubernetes-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.ap4k</groupId>
+            <groupId>io.dekorate</groupId>
             <artifactId>kubernetes-annotations</artifactId>
             <classifier>noapt</classifier>
             <exclusions>

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -14,12 +14,12 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import io.ap4k.Session;
-import io.ap4k.SessionWriter;
-import io.ap4k.kubernetes.annotation.KubernetesApplication;
-import io.ap4k.kubernetes.generator.DefaultKubernetesApplicationGenerator;
-import io.ap4k.processor.SimpleFileWriter;
-import io.ap4k.project.Project;
+import io.dekorate.Session;
+import io.dekorate.SessionWriter;
+import io.dekorate.kubernetes.annotation.KubernetesApplication;
+import io.dekorate.kubernetes.generator.DefaultKubernetesApplicationGenerator;
+import io.dekorate.processor.SimpleFileWriter;
+import io.dekorate.project.Project;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
@@ -49,7 +49,7 @@ class KubernetesProcessor {
             return;
         }
 
-        // The resources that ap4k's execution will result in, will later-on be written
+        // The resources that dekorate's execution will result in, will later-on be written
         // by quarkus in the 'wiring-classes' directory
         // The location is needed in order to properly support s2i build triggering
 


### PR DESCRIPTION
The ap4k project has been renamed to dekorate (since it's now about
more than annotation processing) and has a first release on Maven
Central