### PR TITLE
Check if the absolute path is a directory when scanning for static files

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
@@ -60,7 +60,7 @@ public class UndertowStaticResourcesBuildStep {
                             return;
                         }
                         Path rel = resource.relativize(path);
-                        if (Files.isDirectory(rel)) {
+                        if (Files.isDirectory(path)) {
                             knownDirectories.add(rel.toString());
                         } else {
                             knownFiles.add(rel.toString());


### PR DESCRIPTION
instead of the relative path
This caused the welcome page not to be found in sub directories,
since the KnownPathResourceManager did not know about this specific
folder, and did not return a DirectoryResource
fixes #3091