### PR TITLE
Arc - fix constructor injection

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -236,7 +236,7 @@ public class BeanInfo implements InjectionTargetInfo {
     }
 
     Optional<Injection> getConstructorInjection() {
-        return injections.isEmpty() ? Optional.empty() : injections.stream().filter(i -> i.isConstructor()).findAny();
+        return injections.isEmpty() ? Optional.empty() : injections.stream().filter(Injection::isConstructor).findAny();
     }
 
     Map<MethodInfo, InterceptionInfo> getInterceptedMethods() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/MultiInjectConstructorFailureTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/MultiInjectConstructorFailureTest.java
@@ -1,23 +1,29 @@
 package io.quarkus.arc.test.injection.constructornoinject;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class SingleNonNoArgConstructorInjectionTest {
+public class MultiInjectConstructorFailureTest {
 
     @Rule
-    public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class);
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(CombineHarvester.class, Head.class)
+            .shouldFail()
+            .build();
 
     @Test
     public void testInjection() {
-        assertNotNull(Arc.container().instance(CombineHarvester.class).get().getHead());
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
     }
 
     @Dependent
@@ -28,17 +34,16 @@ public class SingleNonNoArgConstructorInjectionTest {
     @Singleton
     static class CombineHarvester {
 
-        final Head head;
+        Head head;
 
         @Inject
-        Head head2;
-
-        public CombineHarvester(Head head) {
-            this.head = head;
+        public CombineHarvester() {
+            this.head = null;
         }
 
-        public Head getHead() {
-            return head;
+        @Inject
+        public CombineHarvester(Head head) {
+            this.head = head;
         }
 
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/NoArgConstructorTakesPrecedenceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/NoArgConstructorTakesPrecedenceTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.arc.test.injection.constructornoinject;
+
+import static org.junit.Assert.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.inject.Singleton;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NoArgConstructorTakesPrecedenceTest {
+
+    @Rule
+    public ArcTestContainer container = new ArcTestContainer(CombineHarvester.class);
+
+    @Test
+    public void testInjection() {
+        assertEquals("OK", Arc.container().instance(CombineHarvester.class).get().getHead());
+    }
+
+    @Singleton
+    static class CombineHarvester {
+
+        private String head;
+
+        public CombineHarvester() {
+            this.head = "OK";
+        }
+
+        public CombineHarvester(String head) {
+            this.head = head;
+        }
+
+        public String getHead() {
+            return head;
+        }
+
+    }
+}


### PR DESCRIPTION
- ignore bean constructors declared on superclasses
- if a bean class does not explicitly declare a constructor using
@Inject, the constructor that accepts no parameters is the bean
constructor
- also throw definition error if more than one constructor annotated
@Inject is found
- resolves #3126