### PR TITLE
Throw a comprehensible exception when Keycloak configuration is missing

### DIFF
--- a/extensions/keycloak/runtime/src/main/java/io/quarkus/keycloak/KeycloakRecorder.java
+++ b/extensions/keycloak/runtime/src/main/java/io/quarkus/keycloak/KeycloakRecorder.java
@@ -33,6 +33,11 @@ public class KeycloakRecorder {
                 config = loadConfig(getClass().getClassLoader());
             }
 
+            if (config == null) {
+                throw new IllegalStateException(
+                        "Keycloak configuration not found, please refer to the Quarkus documentation to learn how to configure your application");
+            }
+
             deployment = KeycloakDeploymentBuilder.build(config);
         } else {
             deployment = KeycloakDeploymentBuilder.build(defaultConfig);


### PR DESCRIPTION
Resolves #3139 

This will throw the following exception instead of the one mentioned in the issue:
```
21:07:28,180 ERROR [io.qua.dev.DevModeMain] Failed to start quarkus: java.lang.ExceptionInInitializerError
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at java.base/java.lang.Class.newInstance(Class.java:584)
        at io.quarkus.runner.RuntimeRunner.run(RuntimeRunner.java:120)
        at io.quarkus.dev.DevModeMain.doStart(DevModeMain.java:171)
        at io.quarkus.dev.DevModeMain.main(DevModeMain.java:89)
Caused by: java.lang.RuntimeException: Failed to start quarkus
        at io.quarkus.runner.ApplicationImpl1.<clinit>(ApplicationImpl1.zig:327)
        ... 8 more
Caused by: java.lang.IllegalStateException: Keycloak configuration not found, please refer to the Quarkus Keycloak guide to configure your application
        at io.quarkus.keycloak.KeycloakRecorder.createKeycloakDeploymentContext(KeycloakRecorder.java:37)
        at io.quarkus.deployment.steps.KeycloakAdapterProcessor$configureAdapter5.deploy_0(KeycloakAdapterProcessor$configureAdapter5.zig:47)
        at io.quarkus.deployment.steps.KeycloakAdapterProcessor$configureAdapter5.deploy(KeycloakAdapterProcessor$configureAdapter5.zig:106)
        at io.quarkus.runner.ApplicationImpl1.<clinit>(ApplicationImpl1.zig:225)
        ... 8 more
```

I'm not sure about the exception type or message. Don't hesitate to suggest something better.