### PR TITLE
Rename quarkus-profile to quarkus.profile

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
@@ -65,7 +65,7 @@ public class ConfigDefinition extends CompoundConfigType {
     private static final List<String> FALSE_POSITIVE_QUARKUS_CONFIG_MISSES = Arrays
             .asList(QUARKUS_NAMESPACE + ".live-reload.password", QUARKUS_NAMESPACE + ".live-reload.url",
                     QUARKUS_NAMESPACE + ".debug.generated-classes-dir", QUARKUS_NAMESPACE + ".debug.reflection",
-                    QUARKUS_NAMESPACE + ".version");
+                    QUARKUS_NAMESPACE + ".version", QUARKUS_NAMESPACE + ".profile");
 
     private final TreeMap<String, Object> rootObjectsByContainingName = new TreeMap<>();
     private final HashMap<Class<?>, Object> rootObjectsByClass = new HashMap<>();

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ProfileManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ProfileManager.java
@@ -10,14 +10,15 @@ import io.quarkus.runtime.LaunchMode;
  * The profile is resolved in the following way:
  *
  * - The QUARKUS_PROFILE environment entry
- * - The quarkus-profile system property
+ * - The quarkus.profile system property
  * - The default property for the launch mode
  *
  */
 public class ProfileManager {
 
     public static final String QUARKUS_PROFILE_ENV = "QUARKUS_PROFILE";
-    public static final String QUARKUS_PROFILE_PROP = "quarkus-profile";
+    public static final String QUARKUS_PROFILE_PROP = "quarkus.profile";
+    private static final String BACKWARD_COMPATIBLE_QUARKUS_PROFILE_PROP = "quarkus-profile";
 
     private static volatile LaunchMode launchMode = LaunchMode.NORMAL;
 
@@ -31,6 +32,10 @@ public class ProfileManager {
             return profile;
         }
         profile = System.getProperty(QUARKUS_PROFILE_PROP);
+        if (profile != null) {
+            return profile;
+        }
+        profile = System.getProperty(BACKWARD_COMPATIBLE_QUARKUS_PROFILE_PROP);
         if (profile != null) {
             return profile;
         }

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigProfileTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigProfileTestCase.java
@@ -66,7 +66,25 @@ public class ConfigProfileTestCase {
     }
 
     @Test
-    public void testOverrdenProdile() {
+    public void testOverridenProfile() {
+        System.setProperty("quarkus.profile", "foo");
+        try {
+            final SmallRyeConfig config = buildConfig(maps(
+                    singletonMap("foo.one", "v1"),
+                    singletonMap("foo.two", "v2"),
+                    singletonMap("%foo.foo.three", "f1"),
+                    singletonMap("%prod.foo.four", "v4")));
+            assertEquals("v1", config.getValue("foo.one", String.class));
+            assertEquals("v2", config.getValue("foo.two", String.class));
+            assertEquals("f1", config.getValue("foo.three", String.class));
+            assertFalse(config.getOptionalValue("foo.four", String.class).isPresent());
+        } finally {
+            System.clearProperty("quarkus.profile");
+        }
+    }
+
+    @Test
+    public void testBackwardCompatibleOverridenProfile() {
         System.setProperty("quarkus-profile", "foo");
         try {
             final SmallRyeConfig config = buildConfig(maps(

--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -243,7 +243,7 @@ By default Quarkus has three profiles, although it is possible to use as many as
 * *test* - Activated when running tests
 * *prod* - The default profile when not running in development or test mode
 
-There are two ways to set a custom profile, either via the `quarkus-profile` system property or the `QUARKUS_PROFILE`
+There are two ways to set a custom profile, either via the `quarkus.profile` system property or the `QUARKUS_PROFILE`
 environment variable. If both are set the environment variable takes precedence. Note that it is not necessary to
 define the names of these profiles anywhere, all that is necessary is to create a config property with the profile
 name, and then set the current profile to that name. For example if I want a 'staging' profile with a different HTTP port

--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -321,7 +321,7 @@ to select different behaviors depending on your environment.
 [source,bash]
 
 --
-mvn compile quarkus:dev -Dquarkus-profile=dev-with-data
+mvn compile quarkus:dev -Dquarkus.profile=dev-with-data
 --
 
 == Caching


### PR DESCRIPTION
Resolves #3145 

I didn't find any `quarkus-profile` occurence in `quarkus-quickstarts`, so no change there for now. Did I miss something?