### PR TITLE
Don't log a warning for quarkus.version property

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
@@ -64,7 +64,8 @@ public class ConfigDefinition extends CompoundConfigType {
     // for now just list the values manually
     private static final List<String> FALSE_POSITIVE_QUARKUS_CONFIG_MISSES = Arrays
             .asList(QUARKUS_NAMESPACE + ".live-reload.password", QUARKUS_NAMESPACE + ".live-reload.url",
-                    QUARKUS_NAMESPACE + ".debug.generated-classes-dir", QUARKUS_NAMESPACE + ".debug.reflection");
+                    QUARKUS_NAMESPACE + ".debug.generated-classes-dir", QUARKUS_NAMESPACE + ".debug.reflection",
+                    QUARKUS_NAMESPACE + ".version");
 
     private final TreeMap<String, Object> rootObjectsByContainingName = new TreeMap<>();
     private final HashMap<Class<?>, Object> rootObjectsByClass = new HashMap<>();


### PR DESCRIPTION
Maven and Gradle properties are now pushed to config and if the property
name starts with quarkus. and the property is not consumed, we get a
warning.

This is especially the case for quarkus.version and it should obviously
be ignored.

This is just a workaround, I think we need a more general solution.