### PR TITLE
Change the order of the version property names in pom templates

### DIFF
--- a/devtools/common/src/main/java/io/quarkus/cli/commands/CreateProject.java
+++ b/devtools/common/src/main/java/io/quarkus/cli/commands/CreateProject.java
@@ -252,7 +252,7 @@ public class CreateProject {
             properties = new Properties();
             model.setProperties(properties);
         }
-        properties.putIfAbsent("quarkus.version", getPluginVersion());
+        properties.putIfAbsent("version.quarkus", getPluginVersion());
     }
 
     private boolean isParentPom(Model model) {

--- a/devtools/common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
+++ b/devtools/common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
@@ -33,7 +33,7 @@ public class MojoUtils {
     public static final String JAVA_EXTENSION = ".java";
     public static final String KOTLIN_EXTENSION = ".kt";
 
-    private static final String PLUGIN_VERSION_PROPERTY_NAME = "quarkus.version";
+    private static final String PLUGIN_VERSION_PROPERTY_NAME = "version.quarkus";
     public static final String QUARKUS_VERSION_PROPERTY = "${" + PLUGIN_VERSION_PROPERTY_NAME + "}";
 
     private static final Properties properties = new Properties();

--- a/devtools/common/src/main/resources/templates/basic-rest/java/pom-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/java/pom-template.ftl
@@ -11,8 +11,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
-        <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
+        <version.quarkus>${quarkus_version}</version.quarkus>
+        <version.surefire-plugin>${surefire_plugin_version}</version.surefire-plugin>
     </properties>
 
     <dependencyManagement>
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${bom_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${version.quarkus}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${version.quarkus}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${version.surefire-plugin}</version>
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -89,7 +89,7 @@
                     <plugin>
                         <groupId>${plugin_groupId}</groupId>
                         <artifactId>${plugin_artifactId}</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${version.quarkus}</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -105,7 +105,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
+                        <version>${version.surefire-plugin}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom-template.ftl
@@ -11,9 +11,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
-        <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
-        <kotlin.version>${kotlin_version}</kotlin.version>
+        <version.quarkus>${quarkus_version}</version.quarkus>
+        <version.surefire-plugin>${surefire_plugin_version}</version.surefire-plugin>
+        <version.kotlin>${kotlin_version}</version.kotlin>
     </properties>
 
     <dependencyManagement>
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${bom_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${version.quarkus}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${version.quarkus}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${version.surefire-plugin}</version>
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -81,7 +81,7 @@
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <version>${kotlin.version}</version>
+                <version>${version.kotlin}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -112,7 +112,7 @@
                     <dependency>
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-maven-allopen</artifactId>
-                        <version>${kotlin.version}</version>
+                        <version>${version.kotlin}</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -132,7 +132,7 @@
                     <plugin>
                         <groupId>${plugin_groupId}</groupId>
                         <artifactId>${plugin_artifactId}</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${version.quarkus}</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -147,7 +147,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
+                        <version>${version.surefire-plugin}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/devtools/maven/src/test/java/io/quarkus/maven/it/AddExtensionIT.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/AddExtensionIT.java
@@ -20,7 +20,7 @@ import io.quarkus.maven.utilities.MojoUtils;
 
 class AddExtensionIT extends MojoTestBase {
 
-    private static final String QUARKUS_VERSION = "${quarkus.version}";
+    private static final String QUARKUS_VERSION = "${version.quarkus}";
     private static final String QUARKUS_GROUPID = "io.quarkus";
     private static final String VERTX_ARTIFACT_ID = "quarkus-vertx";
     private static final String COMMONS_IO = "commons-io";

--- a/devtools/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -76,7 +76,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         final DependencyManagement dependencyManagement = model.getDependencyManagement();
         final List<Dependency> dependencies = dependencyManagement.getDependencies();
         assertThat(dependencies.stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                && d.getVersion().equalsIgnoreCase("${quarkus.version}")
+                && d.getVersion().equalsIgnoreCase("${version.quarkus}")
                 && d.getScope().equalsIgnoreCase("import")
                 && d.getType().equalsIgnoreCase("pom"))).isTrue();
 
@@ -119,7 +119,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         Model model = load(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
                 .anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                        && d.getVersion().equalsIgnoreCase("${quarkus.version}")
+                        && d.getVersion().equalsIgnoreCase("${version.quarkus}")
                         && d.getScope().equalsIgnoreCase("import")
                         && d.getType().equalsIgnoreCase("pom"))).isTrue();
 
@@ -158,7 +158,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         properties.put("className", "org.acme.MyResource.java");
         setup(properties);
 
-        check(new File(testDir, "pom.xml"), "quarkus.version");
+        check(new File(testDir, "pom.xml"), "version.quarkus");
 
         assertThat(new File(testDir, "src/main/java")).isDirectory();
 
@@ -191,7 +191,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         Model model = load(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
                 .anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                        && d.getVersion().equalsIgnoreCase("${quarkus.version}")
+                        && d.getVersion().equalsIgnoreCase("${version.quarkus}")
                         && d.getScope().equalsIgnoreCase("import")
                         && d.getType().equalsIgnoreCase("pom"))).isTrue();
 
@@ -227,7 +227,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         Model model = load(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
                 .anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                        && d.getVersion().equalsIgnoreCase("${quarkus.version}")
+                        && d.getVersion().equalsIgnoreCase("${version.quarkus}")
                         && d.getScope().equalsIgnoreCase("import")
                         && d.getType().equalsIgnoreCase("pom"))).isTrue();
 

--- a/devtools/maven/src/test/java/io/quarkus/maven/it/assertions/SetupVerifier.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/it/assertions/SetupVerifier.java
@@ -55,7 +55,7 @@ public class SetupVerifier {
 
         //Check if the properties have been set correctly
         Properties properties = model.getProperties();
-        assertThat(properties.containsKey("quarkus.version")).isTrue();
+        assertThat(properties.containsKey("version.quarkus")).isTrue();
 
         // Check plugin is set
         Plugin plugin = maybe.orElseThrow(() -> new AssertionError("Plugin expected"));
@@ -92,7 +92,7 @@ public class SetupVerifier {
         Properties projectProps = project.getProperties();
         assertNotNull(projectProps);
         assertFalse(projectProps.isEmpty());
-        assertEquals(MojoUtils.getPluginVersion(), projectProps.getProperty("quarkus.version"));
+        assertEquals(MojoUtils.getPluginVersion(), projectProps.getProperty("version.quarkus"));
     }
 
 }


### PR DESCRIPTION
This is done because it's good practice but also because it helps
to make properties not conflict with Quarkus properties