### PR TITLE
Add JDK and Maven Attributes to Getting Started Guide

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -45,8 +45,8 @@
                         <quarkus-version>${project.version}</quarkus-version>
                         <surefire-version>${version.surefire.plugin}</surefire-version>
                         <graalvm-version>${graal-sdk.version-for-documentation}</graalvm-version>
-                        <jdk-version>${jdk-version}</jdk-version>
-                        <maven-version>${maven-version}</maven-version>
+                        <jdk-version>JDK 8 or 11</jdk-version>
+                        <maven-version>Apache Maven 3.5.3+</maven-version>
                         <axle-version>${axle-client.version}</axle-version>
                         <vertx-version>${vertx.version}</vertx-version>
                         <restassured-version>${rest-assured.version}</restassured-version>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -35,7 +35,7 @@
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor-maven-plugin.version}</version>
                 <configuration>
-                    <enableVerbose>true</enableVerbose>  
+                    <enableVerbose>true</enableVerbose>
                     <logHandler>
                         <failIf>
                           <severity>INFO</severity>
@@ -45,6 +45,8 @@
                         <quarkus-version>${project.version}</quarkus-version>
                         <surefire-version>${version.surefire.plugin}</surefire-version>
                         <graalvm-version>${graal-sdk.version-for-documentation}</graalvm-version>
+                        <jdk-version>${jdk-version}</jdk-version>
+                        <maven-version>${maven-version}</maven-version>
                         <axle-version>${axle-client.version}</axle-version>
                         <vertx-version>${vertx.version}</vertx-version>
                         <restassured-version>${rest-assured.version}</restassured-version>

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -46,5 +46,7 @@ complete list of externalized variables for use is given in the following table:
 |\{quickstarts-blob-url}|{quickstarts-blob-url}| Quickstarts URL to master blob source tree; used for referencing source files.
 |\{quickstarts-tree-url}|{quickstarts-tree-url}| Quickstarts URL to master source tree root; used for referencing directories.
 
-|\{graalvm-version}|{graalvm-version}| Recommended Graal VM version to use.
+|\{graalvm-version}|{graalvm-version}| Recommended Graal VM versions to use.
+|\{jdk-version}|{jdk-version}| Recommended JDK versions to use.
+|\{maven-version}|{maven-version}| Recommended Maven versions to use.
 |===

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -33,8 +33,8 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
-* Apache Maven 3.5.3+
+* {jdk-version} installed with `JAVA_HOME` configured appropriately
+* {maven-version}
 
 == Architecture
 
@@ -416,4 +416,3 @@ In addition, the link:tooling.html[tooling guide] document explains how to:
 * enable the _development mode_ (hot reload)
 * import the project in your favorite IDE
 * and more
-


### PR DESCRIPTION
This pull request corresponds with this pull request to [quarkusio.github.io](https://github.com/quarkusio/quarkusio.github.io/pull/247). The goal is to add both JDK and Maven attributes to make managing versions in documentation easier. 

JDK will have the attribute `{jdk-version}` set to `JDK 8 or 11`. Maven will have the attribute `{maven-version}` set to `Apache Maven 3.5.4+`.

The only guide being updated at this time is `getting-started-guide.adoc`. Once this is merged, and we can verify it works properly on https://quarkus.io/ , another pr will be put in to update the other guides. 