### PR TITLE
Revert "Add build system properties from Gradle build task"

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -3,8 +3,6 @@ package io.quarkus.gradle.tasks;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.Input;
@@ -143,9 +141,6 @@ public class QuarkusBuild extends QuarkusTask {
         } catch (AppModelResolverException e) {
             throw new GradleException("Failed to resolve application model " + appArtifact + " dependencies", e);
         }
-        final Map<String, ?> properties = getProject().getProperties();
-        final Properties realProperties = new Properties();
-        realProperties.putAll(properties);
 
         try (AppCreator appCreator = AppCreator.builder()
                 // configure the build phases we want the app to go through
@@ -153,8 +148,7 @@ public class QuarkusBuild extends QuarkusTask {
                         .setAppClassesDir(extension().outputDirectory().toPath())
                         .setConfigDir(extension().outputConfigDirectory().toPath())
                         .setTransformedClassesDir(getTransformedClassesDirectory().toPath())
-                        .setWiringClassesDir(getWiringClassesDirectory().toPath())
-                        .setBuildSystemProperties(realProperties))
+                        .setWiringClassesDir(getWiringClassesDirectory().toPath()))
                 .addPhase(new RunnerJarPhase()
                         .setLibDir(getLibDir().toPath())
                         .setFinalName(extension().finalName())


### PR DESCRIPTION
This reverts commit 879d6a9d6f4fa0d865318c0caeb7137c66d565f5.

We can't copy the Gradle properties as is because:
- they contain null values which is not supported by `Properties`
- they also contain complex Gradle objects that we really don't want to push to our config.

I couldn't find anything obvious in the API to get only the "real" build properties so for now I think we should revert this commit and revisit it later.

(and I won't release any new versions until we have some proper Gradle IT)