### PR TITLE
Reduce the set of recognized build system properties

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -145,7 +145,13 @@ public class QuarkusBuild extends QuarkusTask {
         }
         final Map<String, ?> properties = getProject().getProperties();
         final Properties realProperties = new Properties();
-        realProperties.putAll(properties);
+        for (Map.Entry<String, ?> entry : properties.entrySet()) {
+            final String key = entry.getKey();
+            final Object value = entry.getValue();
+            if (key != null && value instanceof String && key.startsWith("quarkus.")) {
+                realProperties.setProperty(key, (String) value);
+            }
+        }
 
         try (AppCreator appCreator = AppCreator.builder()
                 // configure the build phases we want the app to go through

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -175,6 +176,13 @@ public class BuildMojo extends AbstractMojo {
         } catch (AppModelResolverException e) {
             throw new MojoExecutionException("Failed to resolve application model " + appArtifact + " dependencies", e);
         }
+        final Properties projectProperties = project.getProperties();
+        final Properties realProperties = new Properties();
+        for (String name : projectProperties.stringPropertyNames()) {
+            if (name.startsWith("quarkus.")) {
+                realProperties.setProperty(name, projectProperties.getProperty(name));
+            }
+        }
         try (AppCreator appCreator = AppCreator.builder()
                 // configure the build phases we want the app to go through
                 .addPhase(new AugmentPhase()
@@ -183,7 +191,7 @@ public class BuildMojo extends AbstractMojo {
                         .setTransformedClassesDir(transformedClassesDirectory.toPath())
                         .setWiringClassesDir(wiringClassesDirectory.toPath())
                         .setGeneratedSourcesDir(generatedSourcesDirectory.toPath())
-                        .setBuildSystemProperties(project.getProperties()))
+                        .setBuildSystemProperties(realProperties))
                 .addPhase(new RunnerJarPhase()
                         .setLibDir(libDir.toPath())
                         .setFinalName(finalName)


### PR DESCRIPTION
The set only will include properties in the `quarkus.` namespace with string values.  Fixes #3177, fixes #3176