### PR TITLE
RESTEasy SAM support

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1421,6 +1421,11 @@
                 <artifactId>aesh</artifactId>
                 <version>${aesh.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.oracle.substratevm</groupId>

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -120,7 +120,7 @@ class MainClassBuildStep {
         // Application class: start method
 
         mv = file.getMethodCreator("doStart", void.class, String[].class);
-        mv.setModifiers(Modifier.PROTECTED | Modifier.FINAL);
+        mv.setModifiers(Modifier.PUBLIC | Modifier.FINAL);
 
         // very first thing is to set system props (for run time, which use substitutions for a different
         // storage from build-time)

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -186,6 +186,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/amazon-lambda-resteasy/deployment/pom.xml
+++ b/extensions/amazon-lambda-resteasy/deployment/pom.xml
@@ -15,6 +15,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
@@ -25,6 +29,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>

--- a/extensions/amazon-lambda-resteasy/deployment/src/main/java/io/quarkus/amazon/lambda/resteasy/deployment/AmazonLambdaResteasyProcessor.java
+++ b/extensions/amazon-lambda-resteasy/deployment/src/main/java/io/quarkus/amazon/lambda/resteasy/deployment/AmazonLambdaResteasyProcessor.java
@@ -1,18 +1,37 @@
 package io.quarkus.amazon.lambda.resteasy.deployment;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.quarkus.amazon.lambda.resteasy.runtime.AmazonLambdaResteasyConfig;
 import io.quarkus.amazon.lambda.resteasy.runtime.AmazonLambdaResteasyRecorder;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.resteasy.server.common.deployment.ResteasyInjectionReadyBuildItem;
 import io.quarkus.resteasy.server.common.deployment.ResteasyServerConfigBuildItem;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 
 public class AmazonLambdaResteasyProcessor {
+    public static final String SAM_HANDLER = "io.quarkus.amazon.lambda.resteasy.runtime.container.StreamLambdaHandler::handleRequest";
+    public static final String SAM_RUNTIME = "java8";
 
     AmazonLambdaResteasyConfig config;
+
+    @BuildStep
+    public RequireVirtualHttpBuildItem requestVirtualHttp(LaunchModeBuildItem launchMode) {
+        return launchMode.getLaunchMode() == LaunchMode.NORMAL ? RequireVirtualHttpBuildItem.MARKER : null;
+    }
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
@@ -21,5 +40,61 @@ public class AmazonLambdaResteasyProcessor {
         if (resteasyServerConfig.isPresent()) {
             recorder.initHandler(resteasyServerConfig.get().getInitParameters(), config);
         }
+    }
+
+    @BuildStep
+    void sam() {
+        if (config.updateConfig) {
+            try {
+                File configFile = new File(config.template);
+                if (!configFile.exists()) {
+                    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("template.yaml")) {
+                        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+                        Map template = mapper.readValue(inputStream, LinkedHashMap.class);
+                        Map<String, Object> resources = walk(template, "Resources");
+
+                        Map<String, Object> resource = walk(resources, "QuarkusSam");
+                        resources.put(config.resourceName, resource);
+                        resources.remove("QuarkusSam");
+
+                        mapper.writer().withDefaultPrettyPrinter().writeValue(configFile, template);
+                    }
+                } else {
+                    try (InputStream inputStream = new FileInputStream(configFile)) {
+                        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+                        Map template = mapper.readValue(inputStream, LinkedHashMap.class);
+                        Map<String, Object> resources = walk(template, "Resources");
+
+                        Map<String, Object> resource = walk(resources, config.resourceName);
+
+                        if (resource == null && resources.size() == 1) {
+                            resource = (Map<String, Object>) resources.entrySet().iterator().next().getValue();
+                        }
+                        if (resource != null) {
+                            Map<String, Object> properties = walk(resource, "Properties");
+                            properties.put("Handler", SAM_HANDLER);
+                            properties.put("Runtime", SAM_RUNTIME);
+                        }
+
+                        mapper.writer().withDefaultPrettyPrinter().writeValue(configFile, template);
+                    }
+
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T walk(final Map template, final String... keys) {
+        Map map = template;
+        for (int i = 0; i < keys.length - 1; i++) {
+            map = (Map) map.get(keys[i]);
+            if (map == null) {
+                throw new IllegalArgumentException("No object found with the key: " + keys[i]);
+            }
+        }
+        return (T) map.get(keys[keys.length - 1]);
     }
 }

--- a/extensions/amazon-lambda-resteasy/deployment/src/main/resources/template.yaml
+++ b/extensions/amazon-lambda-resteasy/deployment/src/main/resources/template.yaml
@@ -1,0 +1,16 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  QuarkusSam:
+    Type: AWS::Serverless::Function
+
+    Properties:
+      Handler: io.quarkus.amazon.lambda.resteasy.runtime.container.StreamLambdaHandler::handleRequest
+      Runtime: java8
+
+      Events:
+        GetResource:
+          Type: Api
+          Properties:
+            Path: /{proxy+}
+            Method: any

--- a/extensions/amazon-lambda-resteasy/runtime/pom.xml
+++ b/extensions/amazon-lambda-resteasy/runtime/pom.xml
@@ -26,6 +26,22 @@
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/AmazonLambdaResteasyConfig.java
+++ b/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/AmazonLambdaResteasyConfig.java
@@ -4,12 +4,39 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(name = "amazon-lambda", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class AmazonLambdaResteasyConfig {
+
+    /**
+     * The template file to create or update
+     */
+    @ConfigItem(name = "sam-template", defaultValue = "template.yaml")
+    public String template;
 
     /**
      * Indicates if we are in debug mode.
      */
     @ConfigItem(defaultValue = "false")
-    boolean debug;
+    public boolean debug;
+
+    /**
+     * Indicates if we are in debug mode.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean updateConfig;
+
+    /**
+     * The name of the SAM resource
+     */
+    @ConfigItem(name = "resource-name")
+    public String resourceName;
+
+    @Override
+    public String toString() {
+        return "AmazonLambdaResteasyConfig{" +
+                "debug=" + debug +
+                ", resourceName='" + resourceName + '\'' +
+                ", template='" + template + '\'' +
+                '}';
+    }
 }

--- a/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/container/AwsProxyResteasyRequest.java
+++ b/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/container/AwsProxyResteasyRequest.java
@@ -1,0 +1,23 @@
+package io.quarkus.amazon.lambda.resteasy.runtime.container;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+
+class AwsProxyResteasyRequest extends AwsProxyRequest {
+    private Map<String, String> headers = new TreeMap<>();
+
+    public Map<String, String> getHeaders() {
+
+        throw new UnsupportedOperationException("shouldn't be called");
+    }
+
+    public void setHeaders(final Map<String, String> headers) {
+        this.headers = headers;
+        for (final Entry<String, String> entry : headers.entrySet()) {
+            getMultiValueHeaders().putSingle(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/container/ResteasyLambdaFilter.java
+++ b/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/container/ResteasyLambdaFilter.java
@@ -68,7 +68,9 @@ public class ResteasyLambdaFilter implements Filter, HttpRequestFactory, HttpRes
         servletContainerDispatcher.service(httpServletRequest.getMethod(), httpServletRequest, httpServletResponse, true);
 
         Timer.stop("RESTEASY_FILTER_DOFILTER");
-        filterChain.doFilter(servletRequest, servletResponse);
+        if (filterChain != null) {
+            filterChain.doFilter(servletRequest, servletResponse);
+        }
     }
 
     @Override

--- a/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/container/StreamLambdaHandler.java
+++ b/extensions/amazon-lambda-resteasy/runtime/src/main/java/io/quarkus/amazon/lambda/resteasy/runtime/container/StreamLambdaHandler.java
@@ -6,16 +6,18 @@ import java.io.OutputStream;
 import java.util.Map;
 
 import com.amazonaws.serverless.proxy.internal.testutils.Timer;
-import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
-import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 
 public class StreamLambdaHandler implements RequestStreamHandler {
 
-    private static ResteasyLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
+    private static ResteasyLambdaContainerHandler handler;
 
-    public StreamLambdaHandler() {
+    public StreamLambdaHandler() throws ReflectiveOperationException {
+        final Class<?> aClass = Class.forName("io.quarkus.runner.ApplicationImpl1");
+
+        aClass.getMethod("doStart", String[].class)
+                .invoke(aClass.newInstance(), new Object[] { new String[0] });
     }
 
     public static void initHandler(Map<String, String> initParameters, boolean debugMode) {
@@ -26,8 +28,7 @@ public class StreamLambdaHandler implements RequestStreamHandler {
     }
 
     @Override
-    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
-            throws IOException {
+    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
         handler.proxyStream(inputStream, outputStream, context);
     }
 }

--- a/extensions/amazon-lambda/runtime/pom.xml
+++ b/extensions/amazon-lambda/runtime/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/integration-tests/amazon-lambda-resteasy/pom.xml
+++ b/integration-tests/amazon-lambda-resteasy/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-amazon-lambda-resteasy</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-lambda-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-maven</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>../deployment/src/test/resources/filtered</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <cloneClean>true</cloneClean>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                    <addTestClassPath>true</addTestClassPath>
+                    <skipInvocation>${maven.test.skip}</skipInvocation>
+                    <streamLogs>true</streamLogs>
+                    <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--suppress MavenModelInspection -->
+                        <maven.home>${maven.home}</maven.home>
+                        <maven.repo>${settings.localRepository}</maven.repo>
+                        <project.version>${project.version}</project.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/amazon-lambda-resteasy/src/test/java/io/quarkus/amazon/lambda/resteasy/GenerateSamConfig.java
+++ b/integration-tests/amazon-lambda-resteasy/src/test/java/io/quarkus/amazon/lambda/resteasy/GenerateSamConfig.java
@@ -1,0 +1,106 @@
+package io.quarkus.amazon.lambda.resteasy;
+
+import static io.quarkus.amazon.lambda.resteasy.deployment.AmazonLambdaResteasyProcessor.SAM_HANDLER;
+import static io.quarkus.amazon.lambda.resteasy.deployment.AmazonLambdaResteasyProcessor.SAM_RUNTIME;
+import static io.quarkus.amazon.lambda.resteasy.deployment.AmazonLambdaResteasyProcessor.walk;
+import static java.util.Arrays.asList;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.quarkus.maven.it.MojoTestBase;
+
+public class GenerateSamConfig extends MojoTestBase {
+
+    private File testDir;
+    private DefaultInvoker invoker;
+
+    @Test
+    public void testConfigureSAMWithNoTemplate() throws MavenInvocationException, IOException {
+        testDir = initProject("projects/configure-new-template");
+        initRepo();
+
+        Map<String, Object> properties = walk(invoke(testDir, "sam.yaml"), "Resources", "new-template", "Properties");
+        Assert.assertEquals(SAM_HANDLER, properties.get("Handler"));
+        Assert.assertEquals(SAM_RUNTIME, properties.get("Runtime"));
+    }
+
+    @Test
+    public void testConfigureSAMWithConfiguredName() throws MavenInvocationException, IOException {
+        testDir = initProject("projects/configure-named-template");
+
+        Map<String, Object> properties = walk(invoke(testDir, "sam.yaml"), "Resources", "named-template", "Properties");
+        Assert.assertEquals(SAM_HANDLER, properties.get("Handler"));
+        Assert.assertEquals(SAM_RUNTIME, properties.get("Runtime"));
+    }
+
+    @Test
+    public void testConfigureSAMWithExistingTemplate() throws MavenInvocationException, IOException {
+        testDir = initProject("projects/configure-existing-template");
+        initRepo();
+
+        Map<String, Object> properties = walk(invoke(testDir, "template.yaml"), "Resources", "ThumbnailFunction",
+                "Properties");
+        Assert.assertEquals(SAM_HANDLER, properties.get("Handler"));
+        Assert.assertEquals(SAM_RUNTIME, properties.get("Runtime"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadFile(String template) throws IOException {
+        return new ObjectMapper(new YAMLFactory())
+                .readValue(new File(testDir, template), LinkedHashMap.class);
+    }
+
+    private void initRepo() {
+        invoker = new DefaultInvoker();
+        invoker.setWorkingDirectory(testDir);
+        String repo = System.getProperty("maven.repo");
+        if (repo == null) {
+            repo = new File(System.getProperty("user.home"), ".m2/repository").getAbsolutePath();
+        }
+        invoker.setLocalRepositoryDirectory(new File(repo));
+    }
+
+    private Map<String, Object> invoke(File testDir, String template) throws MavenInvocationException, IOException {
+        Properties properties = new Properties();
+        properties.put("projectGroupId", "org.acme");
+        properties.put("projectArtifactId", "acme");
+        properties.put("projectVersion", "1.0-SNAPSHOT");
+
+        return invoke(template, properties);
+    }
+
+    private Map<String, Object> invoke(String template, Properties properties) throws MavenInvocationException, IOException {
+        initRepo();
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setBatchMode(true);
+        request.setShowErrors(true);
+        request.setGoals(asList("package"));
+        request.setProperties(properties);
+        getEnv().forEach(request::addShellEnvironment);
+        File log = new File(testDir, "maven.log");
+        PrintStreamLogger logger = new PrintStreamLogger(new PrintStream(new FileOutputStream(log), false, "UTF-8"),
+                InvokerLogger.DEBUG);
+        invoker.setLogger(logger);
+        invoker.execute(request);
+
+        return loadFile(template);
+    }
+}

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/filtered/quarkus.properties
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/filtered/quarkus.properties
@@ -1,0 +1,4 @@
+# Plugin metadata
+plugin-groupId=${project.groupId}
+plugin-artifactId=${project.artifactId}
+plugin-version=${project.version}

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/pom.xml
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme</groupId>
+    <artifactId>existing-template</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <wiringClassesDirectory>target/classes/</wiringClassesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.version>999-SNAPSHOT</quarkus.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/src/main/java/io/quarkus/amazon/resteasy/maven/SamApp.java
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/src/main/java/io/quarkus/amazon/resteasy/maven/SamApp.java
@@ -1,0 +1,7 @@
+package io.quarkus.amazon.resteasy.maven;
+
+import javax.ws.rs.Path;
+
+@Path("/sam")
+public class SamApp {
+}

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.amazon-lambda.resource-name=new-template
+quarkus.amazon-lambda.update-config=true

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/template.yaml
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-existing-template/template.yaml
@@ -1,0 +1,29 @@
+Transform: 'AWS::Serverless-2016-10-31'
+Resources:
+
+  ThumbnailFunction:
+    # This resource creates a Lambda function.
+    Type: 'AWS::Serverless::Function'
+
+    Properties:
+
+      # This function uses the Nodejs v6.10 runtime.
+      Runtime: nodejs6.10
+
+      # This is the Lambda function's handler.
+      Handler: index.handler
+
+      # The location of the Lambda function code.
+      CodeUri: ./src
+
+      # Event sources to attach to this function. In this case, we are attaching
+      # one API Gateway endpoint to the Lambda function. The function is
+      # called when a HTTP request is made to the API Gateway endpoint.
+      Events:
+
+        ThumbnailApi:
+          # Define an API Gateway endpoint that responds to HTTP GET at /thumbnail
+          Type: Api
+          Properties:
+            Path: /thumbnail
+            Method: GET

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-named-template/pom.xml
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-named-template/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme</groupId>
+    <artifactId>named-template</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <wiringClassesDirectory>target/classes/</wiringClassesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.version>999-SNAPSHOT</quarkus.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-named-template/src/main/java/io/quarkus/amazon/resteasy/maven/SamApp.java
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-named-template/src/main/java/io/quarkus/amazon/resteasy/maven/SamApp.java
@@ -1,0 +1,7 @@
+package io.quarkus.amazon.resteasy.maven;
+
+import javax.ws.rs.Path;
+
+@Path("/sam")
+public class SamApp {
+}

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-named-template/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-named-template/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.amazon-lambda.sam-template=sam.yaml
+quarkus.amazon-lambda.resource-name=named-template

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-new-template/pom.xml
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-new-template/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme</groupId>
+    <artifactId>new-template</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <wiringClassesDirectory>target/classes/</wiringClassesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.version>999-SNAPSHOT</quarkus.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-new-template/src/main/java/io/quarkus/amazon/resteasy/maven/SamApp.java
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-new-template/src/main/java/io/quarkus/amazon/resteasy/maven/SamApp.java
@@ -1,0 +1,7 @@
+package io.quarkus.amazon.resteasy.maven;
+
+import javax.ws.rs.Path;
+
+@Path("/sam")
+public class SamApp {
+}

--- a/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-new-template/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-resteasy/src/test/resources/projects/configure-new-template/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.amazon-lambda.sam-template=sam.yaml
+quarkus.amazon-lambda.resource-name=new-template
+quarkus.amazon-lambda.update-config=true

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -50,6 +50,7 @@
         <module>amazon-dynamodb</module>
         <module>test-extension</module>
         <module>amazon-lambda</module>
+        <module>amazon-lambda-resteasy</module>
         <module>kogito</module>
         <module>kogito-maven</module>
         <module>kubernetes-client</module>

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/MojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/MojoTestBase.java
@@ -69,6 +69,10 @@ public class MojoTestBase {
         return tc;
     }
 
+    public static File initProject(String name) {
+        return initProject(name, name);
+    }
+
     public static File initProject(String name, String output) {
         File tc = new File("target/test-classes");
         if (!tc.isDirectory()) {


### PR DESCRIPTION
This provides support for using RESTEasy as the provider for SAM based applications.  It does not currently support native mode.  However, the needs for native mode here are essentially the same as the native mode Lambda support.  In a subsequent PR, I'll update that code to support both deployment paradigms and attempt to clean up some performance issues.