### PR TITLE
Throw an exception in Panache when there is no entity manager

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -6,6 +6,7 @@ import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
@@ -68,7 +69,11 @@ public class JpaOperations {
     // Private stuff
 
     public static EntityManager getEntityManager() {
-        return Arc.container().instance(EntityManager.class).get();
+        EntityManager entityManager = Arc.container().instance(EntityManager.class).get();
+        if (entityManager == null) {
+            throw new PersistenceException("No EntityManager found. Do you have any JPA entities defined?");
+        }
+        return entityManager;
     }
 
     public static TransactionManager getTransactionManager() {
@@ -366,4 +371,5 @@ public class JpaOperations {
             throw new IllegalStateException(e);
         }
     }
+
 }


### PR DESCRIPTION
there are no classes marked up with @Entity.

This is a case that bit me during a live demo.  If there are no @Entity classes, no EntityManager gets created/injected leading to unexpected NPEs trying to run queries.  This patch introduces a dummy EM that essentially only returns empty Lists so that user code at least gets something usable.

I know there are probably plenty of conversations to have about both this idea and my particular implementation.  This PR largely serves as a starting point for that conversation and, if I'm *really* lucky, its resolution as well.  :)