### PR TITLE
renamed quarkus-deployment-bom to quarkus-bom-deployment

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>quarkus-deployment-bom</artifactId>
+    <artifactId>quarkus-bom-deployment</artifactId>
     <name>Quarkus - Deployment BOM</name>
     <packaging>pom</packaging>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -54,10 +54,10 @@
     <dependencyManagement>
         <dependencies>
 
-            <!-- Quarkus Extensions Dependencies are coming from quarkus-deployment-bom (that also imports quarkus-bom) -->
+            <!-- Quarkus Extensions Dependencies are coming from quarkus-bom-deployment (that also imports quarkus-bom) -->
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-deployment-bom</artifactId>
+                <artifactId>quarkus-bom-deployment</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-deployment-bom</artifactId>
+            <artifactId>quarkus-bom-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
         </dependency>


### PR DESCRIPTION
to be consistent with the runtime/deployment extension artifact naming convention