### PR TITLE
feat: added sample Dockerfile for the SunEC lib

### DIFF
--- a/docs/src/main/asciidoc/native-and-ssl-guide.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl-guide.adoc
@@ -180,6 +180,24 @@ Now, the application should work as expected:
 
 When working with containers, the idea is to bundle both the SunEC library and the certificates in the container and to point your binary to them using the system properties mentioned above.
 
+You can for example modify your `Dockerfile.native` as following to allow copying the required lib in your final image:
+
+[source, subs=attributes+]
+----
+FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version} as nativebuilder
+RUN mkdir -p /tmp/ssl-libs/lib \
+  && cp /opt/graalvm/jre/lib/security/cacerts /tmp/ssl-libs \
+  && cp /opt/graalvm/jre/lib/amd64/libsunec.so /tmp/ssl-libs/lib/ 
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /work/
+COPY target/*-runner /work/application
+COPY --from=nativebuilder /tmp/ssl-libs/ /work/
+RUN chmod 775 /work
+EXPOSE 8080
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Djava.library.path=/work/lib", "-Djavax.net.ssl.trustStore=/work/cacerts"]
+----
+
 [TIP]
 ====
 The root certificates file of GraalVM might not be totally up to date.


### PR DESCRIPTION
# SSL connection problem in native image

## Why?
As described in the SunEC libraries and friends section, the default final docker images is not containing the GraalVM libraries to allow the usage of the SSL connection. Which means all the HTTPS client connection will fail to initialize the SSL protocol.
This part is actually quite cryptical and some information can actually be found into the Issue #2125.

## What?
An example showing how you can fix the SSL problem directly within your Docker build (nothing more necessary in your local/build machine).