### PR TITLE
[mongodb-client] Avoid to fail the tests when the database cannot be stopped

### DIFF
--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -68,7 +68,11 @@ public class MongoTestBase {
     @AfterAll
     public static void stopMongoDatabase() {
         if (MONGO != null) {
-            MONGO.stop();
+            try {
+                MONGO.stop();
+            } catch (Exception e) {
+                LOGGER.error("Unable to stop MongoDB", e);
+            }
         }
     }
 

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -28,7 +28,6 @@ import de.flapdoodle.embed.mongo.config.MongoCmdOptionsBuilder;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.runtime.Executable;
 import de.flapdoodle.embed.process.runtime.Network;
 
 public class MongoWithReplicasTestBase {
@@ -63,7 +62,13 @@ public class MongoWithReplicasTestBase {
 
     @AfterAll
     public static void stopMongoDatabase() {
-        MONGOS.forEach(Executable::stop);
+        MONGOS.forEach(mongod -> {
+            try {
+                mongod.stop();
+            } catch (Exception e) {
+                LOGGER.error("Unable to stop MongoDB", e);
+            }
+        });
     }
 
     protected String getConnectionString() {


### PR DESCRIPTION
There is some intermitent failures with the mongodb-client extension tests.

Some are due to the inhability to stop the launched database (I have it multiple times).

As the Database is stopped at the end of the test and the build pipeline uses containers, it's safe to ignore those errors as we cannot do anything about it anyway and the next pipeline will start with a fresh container.