### PR TITLE
Deprecated warnings removal

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -122,7 +122,7 @@ public class DevModeMain {
         try {
             final URL[] urls = new URL[classesRoots.size()];
             for (int i = 0; i < classesRoots.size(); i++) {
-                urls[i] = classesRoots.get(i).toURL();
+                urls[i] = classesRoots.get(i).toURI().toURL();
             }
             runtimeCl = new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
             currentAppClassLoader = runtimeCl;

--- a/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
+++ b/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
@@ -121,7 +121,7 @@ public class KogitoAssetsProcessor {
     private ApplicationGenerator createApplicationGenerator(ArchiveRootBuildItem root, LaunchMode launchMode,
             boolean generateRuleUnits, boolean generateProcesses, CombinedIndexBuildItem combinedIndexBuildItem)
             throws IOException {
-        Path targetClassesPath = root.getPath();
+        Path targetClassesPath = root.getArchiveLocation();
         Path projectPath = targetClassesPath.toString().endsWith("target" + File.separator + "classes")
                 ? targetClassesPath.getParent().getParent()
                 : targetClassesPath;

--- a/integration-tests/keycloak/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/keycloak/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.everyItem;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -126,7 +127,7 @@ public class BearerTokenAuthorizationTest {
     private static void configureConfidentialResourcePermission(ResourceServerRepresentation authorizationSettings) {
         ResourceRepresentation resource = new ResourceRepresentation("Confidential Resource");
 
-        resource.setUri("/api/confidential");
+        resource.setUris(Collections.singleton("/api/confidential"));
 
         authorizationSettings.getResources().add(resource);
 
@@ -159,7 +160,7 @@ public class BearerTokenAuthorizationTest {
     private static void configurePermissionResourcePermission(ResourceServerRepresentation authorizationSettings) {
         ResourceRepresentation resource = new ResourceRepresentation("Permission Resource");
 
-        resource.setUri("/api/permission");
+        resource.setUris(Collections.singleton("/api/permission"));
 
         authorizationSettings.getResources().add(resource);
 


### PR DESCRIPTION
Deprecated warnings removal

 - File.toURL is deprecated, File.toURI.toURL is the way
 - ArchiveRootBuildItem.getPath is replaced by ArchiveRootBuildItem.getArchiveLocation
 - setUri -> setUris: https://github.com/keycloak/keycloak/commit/5aebc74f8c2687db44eb01eeaf02872a3f910483