### PR TITLE
Update to smallrye_jwt_1.1_2.0.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -36,7 +36,7 @@
         <smallrye-open-api.version>1.1.3</smallrye-open-api.version>
         <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>1.0.1</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>2.0.0</smallrye-jwt.version>
+        <smallrye-jwt.version>2.0.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.7</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.6</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.4</smallrye-converter-api.version>


### PR DESCRIPTION
It supports the file based key assets, avoids NPE for claims whose array values may contain null as well as does a correct mapping from a `scope` to `groups` claim when required.