### PR TITLE
Arc - propose a new API for context propagation

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/context/ArcContextProvider.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/context/ArcContextProvider.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.runtime.context;
 
-import java.util.Collection;
 import java.util.Map;
 
 import org.eclipse.microprofile.context.ThreadContext;
@@ -10,7 +9,7 @@ import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
-import io.quarkus.arc.ContextInstanceHandle;
+import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
 
 /**
@@ -35,8 +34,8 @@ public class ArcContextProvider implements ThreadContextProvider {
             return NOOP_SNAPSHOT;
         }
 
-        // capture all instances
-        Collection<ContextInstanceHandle<?>> instancesToPropagate = arc.requestContext().getAll();
+        // capture the state
+        InjectableContext.ContextState state = arc.requestContext().getState();
         return () -> {
             // can be called later on, we should retrieve the container again
             ArcContainer arcContainer = Arc.container();
@@ -48,17 +47,17 @@ public class ArcContextProvider implements ThreadContextProvider {
             // this is executed on another thread, context can but doesn't need to be active here
             if (isContextActiveOnThisThread(arcContainer)) {
                 // context active, store current state, feed it new one and restore state afterwards
-                Collection<ContextInstanceHandle<?>> instancesToRestore = requestContext.getAll();
+                InjectableContext.ContextState stateToRestore = requestContext.getState();
                 requestContext.deactivate();
-                requestContext.activate(instancesToPropagate);
+                requestContext.activate(state);
                 controller = () -> {
                     // clean up, reactivate context with previous values
                     requestContext.deactivate();
-                    requestContext.activate(instancesToRestore);
+                    requestContext.activate(stateToRestore);
                 };
             } else {
                 // context not active, activate and pass it new instance, deactivate afterwards
-                requestContext.activate(instancesToPropagate);
+                requestContext.activate(state);
                 controller = () -> {
                     requestContext.deactivate();
                 };
@@ -92,13 +91,13 @@ public class ArcContextProvider implements ThreadContextProvider {
             // this is executed on another thread, context can but doesn't need to be active here
             if (isContextActiveOnThisThread(arcContainer)) {
                 // context active, store current state, start blank context anew and restore state afterwards
-                Collection<ContextInstanceHandle<?>> instancesToRestore = requestContext.getAll();
+                InjectableContext.ContextState stateToRestore = requestContext.getState();
                 requestContext.deactivate();
                 requestContext.activate();
                 controller = () -> {
                     // clean up, reactivate context with previous values
                     requestContext.deactivate();
-                    requestContext.activate(instancesToRestore);
+                    requestContext.activate(stateToRestore);
                 };
             } else {
                 // context not active, activate blank one, deactivate afterwards

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/HttpSessionContext.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/HttpSessionContext.java
@@ -1,10 +1,10 @@
 package io.quarkus.undertow.runtime;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.context.SessionScoped;
@@ -65,12 +65,19 @@ public class HttpSessionContext implements InjectableContext, HttpSessionListene
     }
 
     @Override
-    public Collection<ContextInstanceHandle<?>> getAll() {
-        HttpServletRequest httpServletRequest = servletRequest();
-        if (httpServletRequest != null) {
-            return new ArrayList<>(getContextualInstances(httpServletRequest).getPresentValues());
-        }
-        return Collections.emptyList();
+    public ContextState getState() {
+        return new ContextState() {
+
+            @Override
+            public Map<InjectableBean<?>, Object> getContextualInstances() {
+                HttpServletRequest httpServletRequest = servletRequest();
+                if (httpServletRequest != null) {
+                    return HttpSessionContext.this.getContextualInstances(httpServletRequest).getPresentValues().stream()
+                            .collect(Collectors.toMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
+                }
+                return Collections.emptyMap();
+            }
+        };
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AbstractSharedContext.java
@@ -1,9 +1,9 @@
 package io.quarkus.arc;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
 
@@ -31,8 +31,15 @@ abstract class AbstractSharedContext implements InjectableContext {
     }
 
     @Override
-    public Collection<ContextInstanceHandle<?>> getAll() {
-        return new ArrayList<>(instances.getPresentValues());
+    public ContextState getState() {
+        return new ContextState() {
+
+            @Override
+            public Map<InjectableBean<?>, Object> getContextualInstances() {
+                return instances.getPresentValues().stream()
+                        .collect(Collectors.toMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
+            }
+        };
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc;
 
-import java.util.Collection;
+import java.util.Map;
 import javax.enterprise.context.spi.AlterableContext;
 
 /**
@@ -10,15 +10,26 @@ import javax.enterprise.context.spi.AlterableContext;
 public interface InjectableContext extends AlterableContext {
 
     /**
-     * Note that we cannot actually return just a map of contextuals to contextual instances because we need to preserve the
-     * {@link javax.enterprise.context.spi.CreationalContext} too so that we're able to destroy the dependent objects correctly.
-     *
-     * @return all existing contextual instances
-     */
-    Collection<ContextInstanceHandle<?>> getAll();
-
-    /**
      * Destroy all existing contextual instances.
      */
     void destroy();
+
+    /**
+     * @return the current state
+     */
+    ContextState getState();
+
+    /**
+    *
+    */
+    interface ContextState {
+
+        /**
+         * The changes to the map are not reflected in the underlying context state.
+         * 
+         * @return a map of contextual instances
+         */
+        Map<InjectableBean<?>, Object> getContextualInstances();
+
+    }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
@@ -1,7 +1,5 @@
 package io.quarkus.arc;
 
-import java.util.Collection;
-
 /**
  *
  * @author Martin Kouba
@@ -16,13 +14,11 @@ public interface ManagedContext extends InjectableContext {
     }
 
     /**
-     * Activate the context. All instance handles from the initial state must have the same scope as the context, otherwise an
-     * {@link IllegalArgumentException}
-     * is thrown.
-     *
+     * Activate the context.
+     * 
      * @param initialState The initial state, may be {@code null}
      */
-    void activate(Collection<ContextInstanceHandle<?>> initialState);
+    void activate(ContextState initialState);
 
     /**
      * Deactivate the context - do not destoy existing contextual instances.

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/RequestContext.java
@@ -90,6 +90,8 @@ class RequestContext implements ManagedContext {
     public void activate(ContextState initialState) {
         if (initialState == null) {
             currentContext.set(new ConcurrentHashMap<>());
+            // Fire an event with qualifier @Initialized(RequestScoped.class) if there are any observers for it
+            fireIfNotEmpty(initializedNotifier);
         } else {
             if (initialState instanceof RequestContextState) {
                 currentContext.set(((RequestContextState) initialState).value);
@@ -97,8 +99,6 @@ class RequestContext implements ManagedContext {
                 throw new IllegalArgumentException("Invalid inital state: " + initialState);
             }
         }
-        // Fire an event with qualifier @Initialized(RequestScoped.class) if there are any observers for it
-        fireIfNotEmpty(initializedNotifier);
     }
 
     @Override

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/propagation/RequestContextPropagationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/propagation/RequestContextPropagationTest.java
@@ -8,10 +8,9 @@ import static org.junit.Assert.fail;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
-import io.quarkus.arc.ContextInstanceHandle;
+import io.quarkus.arc.InjectableContext.ContextState;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.test.ArcTestContainer;
-import java.util.Collection;
 import javax.enterprise.context.ContextNotActiveException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +42,7 @@ public class RequestContextPropagationTest {
         assertTrue(controller2.getButton() == controller1.getButton());
 
         // Store existing instances
-        Collection<ContextInstanceHandle<?>> instances = requestContext.getAll();
+        ContextState state = requestContext.getState();
         // Deactivate but don't destroy
         requestContext.deactivate();
 
@@ -57,7 +56,7 @@ public class RequestContextPropagationTest {
         } catch (ContextNotActiveException expected) {
         }
 
-        requestContext.activate(instances);
+        requestContext.activate(state);
         assertEquals(arc.instance(SuperController.class).get().getId(), controller2Id);
 
         requestContext.terminate();


### PR DESCRIPTION
Note that `RequestContext` is not thread-safe (intentionally). We use `ConcurrentMap` just to make sure the changes in the map are visible from different threads.