### PR TITLE
Allow to use the Sort for something else than ORDER BY

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -171,6 +171,19 @@ public class JpaOperations {
         return "DELETE FROM " + getEntityName(entityClass) + " WHERE " + query;
     }
 
+    private static String toOrderBy(Sort sort) {
+        StringBuilder sb = new StringBuilder(" ORDER BY ");
+        for (int i = 0; i < sort.getColumns().size(); i++) {
+            Sort.Column column = sort.getColumns().get(i);
+            if (i > 0)
+                sb.append(" , ");
+            sb.append(column.getName());
+            if (column.getDirection() != Sort.Direction.Ascending)
+                sb.append(" DESC");
+        }
+        return sb.toString();
+    }
+
     //
     // Queries
 
@@ -187,7 +200,7 @@ public class JpaOperations {
         String findQuery = createFindQuery(entityClass, query, paramCount(params));
         EntityManager em = getEntityManager();
         // FIXME: check for duplicate ORDER BY clause?
-        Query jpaQuery = em.createQuery(sort != null ? findQuery + sort.toOrderBy() : findQuery);
+        Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         bindParameters(jpaQuery, params);
         return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
     }
@@ -201,7 +214,7 @@ public class JpaOperations {
         String findQuery = createFindQuery(entityClass, query, paramCount(params));
         EntityManager em = getEntityManager();
         // FIXME: check for duplicate ORDER BY clause?
-        Query jpaQuery = em.createQuery(sort != null ? findQuery + sort.toOrderBy() : findQuery);
+        Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         bindParameters(jpaQuery, params);
         return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
     }
@@ -272,7 +285,7 @@ public class JpaOperations {
     @SuppressWarnings("rawtypes")
     public static PanacheQuery<?> findAll(Class<?> entityClass, Sort sort) {
         String query = "FROM " + getEntityName(entityClass);
-        String sortedQuery = query + sort.toOrderBy();
+        String sortedQuery = query + toOrderBy(sort);
         EntityManager em = getEntityManager();
         return new PanacheQueryImpl(em, em.createQuery(sortedQuery), query, null);
     }

--- a/extensions/panache/panache-common/runtime/pom.xml
+++ b/extensions/panache/panache-common/runtime/pom.xml
@@ -19,10 +19,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-orm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
@@ -40,7 +40,7 @@ public class Sort {
         Descending;
     }
 
-    private class Column {
+    public class Column {
         private String name;
         private Direction direction;
 
@@ -50,6 +50,22 @@ public class Sort {
 
         public Column(String name, Direction direction) {
             this.name = name;
+            this.direction = direction;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Direction getDirection() {
+            return direction;
+        }
+
+        public void setDirection(Direction direction) {
             this.direction = direction;
         }
     }
@@ -195,10 +211,21 @@ public class Sort {
     }
 
     /**
+     * Get the sort columns
+     *
+     * @return the sort columns
+     */
+    public List<Column> getColumns() {
+        return columns;
+    }
+
+    /**
      * Returns an SQL "order by" clause for the current sort columns and directions.
      * 
      * @return an SQL "order by" clause for the current sort columns and directions.
+     * @deprecated panache-common should be agnostic from the database implementation
      */
+    @Deprecated
     public String toOrderBy() {
         StringBuilder sb = new StringBuilder(" ORDER BY ");
         for (int i = 0; i < columns.size(); i++) {


### PR DESCRIPTION
With the future implementation of Panache with something else than Hibernate, we need to decouple Panache Sort from SQL so providing a way to use it outside of Panache common. So I add a `getColumns()` method and opens the Column class to be use outside of the Sort class.

I deprecate the `Sort.toOrderBy()` method in case someone use it outside of hibernate-orm-panache but as I refactor hibernate-orm-panache we should be able to delete it safely.

Ping @FroMage 