### PR TITLE
MongoDB client enhancements

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -267,6 +267,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-mongodb-client-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>quarkus-hibernate-search-elasticsearch-deployment</artifactId>
                 <version>${project.version}</version>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
@@ -36,7 +36,7 @@ public class CredentialConfig {
     /**
      * Configures the source of the authentication credentials.
      * This is typically the database that the credentials have been created. The value defaults to the database
-     * specified in the path portion of the connection string.
+     * specified in the path portion of the connection string or in the 'database' configuration property..
      * If the database is specified in neither place, the default value is {@code admin}. This option is only
      * respected when using the MONGO-CR mechanism (the default).
      */

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -69,6 +69,12 @@ public class MongoClientConfig {
     public List<String> hosts;
 
     /**
+     * Configure the database name.
+     */
+    @ConfigItem
+    public Optional<String> database;
+
+    /**
      * Configures the application name.
      */
     @ConfigItem

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.Conventions;
+import org.bson.codecs.pojo.PojoCodecProvider;
 import org.jboss.logging.Logger;
 
 import com.mongodb.AuthenticationMechanism;
@@ -86,11 +88,19 @@ public class MongoClientRecorder {
             settings.applyConnectionString(connectionString);
         }
 
-        CodecRegistry registry = defaultCodecRegistry;
+        List<CodecProvider> providers = new ArrayList<>();
         if (!codecProviders.isEmpty()) {
-            registry = CodecRegistries.fromRegistries(defaultCodecRegistry,
-                    CodecRegistries.fromProviders(getCodecProviders(codecProviders)));
+            providers.addAll(getCodecProviders(codecProviders));
         }
+        // add pojo codec provider with automatic capabilities
+        // it always needs to be the last codec provided
+        CodecProvider pojoCodecProvider = PojoCodecProvider.builder()
+                .automatic(true)
+                .conventions(Conventions.DEFAULT_CONVENTIONS)
+                .build();
+        providers.add(pojoCodecProvider);
+        CodecRegistry registry = CodecRegistries.fromRegistries(defaultCodecRegistry,
+                CodecRegistries.fromProviders(providers));
         settings.codecRegistry(registry);
 
         config.applicationName.ifPresent(settings::applicationName);
@@ -176,6 +186,7 @@ public class MongoClientRecorder {
                 LOGGER.warnf("Unable to load the codec provider class %s", name, e);
             }
         }
+
         return providers;
     }
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -96,7 +96,7 @@ public class MongoClientRecorder {
         config.applicationName.ifPresent(settings::applicationName);
 
         if (config.credentials != null) {
-            MongoCredential credential = createMongoCredential(config.credentials);
+            MongoCredential credential = createMongoCredential(config);
             if (credential != null) {
                 settings.credential(credential);
             }
@@ -189,18 +189,19 @@ public class MongoClientRecorder {
         return mechanism;
     }
 
-    private MongoCredential createMongoCredential(CredentialConfig config) {
-        String username = config.username.orElse(null);
+    private MongoCredential createMongoCredential(MongoClientConfig config) {
+        String username = config.credentials.username.orElse(null);
         if (username == null) {
             return null;
         }
 
-        char[] password = config.password.map(String::toCharArray).orElse(null);
-        //admin is the default auth source in mongo and null is not allowed
-        String authSource = config.authSource.orElse("admin");
+        char[] password = config.credentials.password.map(String::toCharArray).orElse(null);
+        // get the authsource, or the database from the config, or 'admin' as it is the default auth source in mongo
+        // and null is not allowed
+        String authSource = config.credentials.authSource.orElse(config.database.orElse("admin"));
         // AuthMechanism
         AuthenticationMechanism mechanism = null;
-        Optional<String> maybeMechanism = config.authMechanism;
+        Optional<String> maybeMechanism = config.credentials.authMechanism;
         if (maybeMechanism.isPresent()) {
             mechanism = getAuthenticationMechanism(maybeMechanism.get());
         }
@@ -222,8 +223,8 @@ public class MongoClientRecorder {
         }
 
         //add the properties
-        if (!config.authMechanismProperties.isEmpty()) {
-            for (Map.Entry<String, String> entry : config.authMechanismProperties.entrySet()) {
+        if (!config.credentials.authMechanismProperties.isEmpty()) {
+            for (Map.Entry<String, String> entry : config.credentials.authMechanismProperties.entrySet()) {
                 credential = credential.withMechanismProperty(entry.getKey(), entry.getValue());
             }
         }


### PR DESCRIPTION
Three MongoDB Client enhancements:
- add the deployment dependency to the deployment bom
- add a 'database' property, this is needed for the future Panache MongoDB extension, I also upgrade de credential management code to use it as default auth source in case no authSource is provided (as it is the case when a database is set in the connection URL)
- add the PojoCodec in automatic mode with support for Bson annotations: this is needed for the current implementation of Panache Mongo that will use this features to automatically map an entity to a Bson Document. If didn't put it behind a flag as it cannot be disabled, I can if needed

Ping @cescoffier @FroMage 