### PR TITLE
Provide configurable Neo4j pool settings.

### DIFF
--- a/docs/src/main/asciidoc/neo4j-guide.adoc
+++ b/docs/src/main/asciidoc/neo4j-guide.adoc
@@ -172,7 +172,7 @@ quarkus.neo4j.authentication.password = secret
 
 You'll recognize the authentication here that you passed on to the docker command above.
 
-Having done that, the driver is ready to use.
+Having done that, the driver is ready to use, there are however other configuration options, detailed below.
 
 == Using the driver
 
@@ -472,3 +472,61 @@ public class ReactiveFruitResource {
 It exposes its API based on http://www.reactive-streams.org[Reactive Streams], most prominently, as `org.reactivestreams.Publisher`.
 Those can be used directly, but we found it easier and more expressive to wrap them in reactive types from https://projectreactor.io[Project Reactor].
 
+== Configuration Reference
+
+|===
+|Configuration key|Java type|Default Value|Description
+
+|quarkus.neo4j.uri
+|String
+|`bolt://localhost:7687`
+|The uri this driver should connect to. The driver supports `bolt`, `bolt+routing` or `neo4j` as schemes.
+
+|quarkus.neo4j.authentication.username
+|String
+|`neo4j`
+|The login of the user connecting to the database.
+
+|quarkus.neo4j.authentication.password
+|String
+|`neo4j`
+|The password of the user connecting to the database.
+
+|quarkus.neo4j.authentication.disabled
+|boolean
+|false
+|Set this to `true` to disable authentication.
+
+|quarkus.neo4j.pool.metrics-enabled
+|boolean
+|`false`
+|Flag, if metrics are enabled.
+
+|quarkus.neo4j.pool.log-leaked-sessions
+|boolean
+|`false`
+|Flag, if leaked sessions logging is enabled.
+
+|quarkus.neo4j.pool.max-connection-pool-size;
+|int
+|100
+|The maximum amount of connections in the connection pool towards a single database.
+
+|quarkus.neo4j.pool.max-connection-lifetime
+|java.time.Duration
+|`1H`
+|Pooled connections older than this threshold will be closed and removed from the pool.
+
+|quarkus.neo4j.pool.connection-acquisition-timeout
+|java.time.Duration
+|`1M`
+|Acquisition of new connections will be attempted for at most configured timeout.
+
+|quarkus.neo4j.pool.idle-time-before-connection-test
+|java.time.Duration
+|A negative value.
+|Pooled connections that have been idle in the pool for longer than this timeout will be tested before they are used again. The value 0 means connections will always be tested for validity and negative values mean connections will never be tested.
+
+|===
+
+include::duration-format-note.adoc[]

--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.neo4j.deployment;
 
-import javax.inject.Inject;
-
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -17,11 +15,12 @@ import io.quarkus.neo4j.runtime.Neo4jDriverRecorder;
 
 class Neo4jDriverProcessor {
 
-    @Inject
-    BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport;
-
     @BuildStep
-    FeatureBuildItem createFeature() {
+    FeatureBuildItem createFeature(BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport) {
+
+        // Indicates that this extension would like the SSL support to be enabled
+        extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.NEO4J));
+
         return new FeatureBuildItem(FeatureBuildItem.NEO4J);
     }
 
@@ -35,9 +34,6 @@ class Neo4jDriverProcessor {
     void configureDriverProducer(Neo4jDriverRecorder recorder, BeanContainerBuildItem beanContainerBuildItem,
             Neo4jConfiguration configuration,
             ShutdownContextBuildItem shutdownContext) {
-
-        // Indicates that this extension would like the SSL support to be enabled
-        extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.NEO4J));
 
         recorder.configureNeo4jProducer(beanContainerBuildItem.getValue(), configuration, shutdownContext);
     }

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jConfiguration.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jConfiguration.java
@@ -1,5 +1,7 @@
 package io.quarkus.neo4j.runtime;
 
+import java.time.Duration;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -13,8 +15,7 @@ public class Neo4jConfiguration {
     static final String DEFAULT_PASSWORD = "neo4j";
 
     /**
-     * The uri this driver should connect to. The driver supports bolt, bolt+routing or neo4j as schemes. If uri is empty,
-     * the driver tries to connect to 'neo4j://localhost:7687'.
+     * The uri this driver should connect to. The driver supports bolt, bolt+routing or neo4j as schemes.
      */
     @ConfigItem(defaultValue = DEFAULT_SERVER_URI)
     public String uri;
@@ -24,6 +25,12 @@ public class Neo4jConfiguration {
      */
     @ConfigItem
     public Authentication authentication;
+
+    /**
+     * Advanced settings for the drivers internal connection pool.
+     */
+    @ConfigItem
+    public Pool pool;
 
     @ConfigGroup
     static class Authentication {
@@ -45,5 +52,60 @@ public class Neo4jConfiguration {
          */
         @ConfigItem(defaultValue = "false")
         public boolean disabled = false;
+    }
+
+    @ConfigGroup
+    static class Pool {
+
+        /**
+         * Flag, if metrics are enabled.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean metricsEnabled;
+
+        /**
+         * Flag, if leaked sessions logging is enabled.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean logLeakedSessions;
+
+        /**
+         * The maximum amount of connections in the connection pool towards a single database.
+         */
+        @ConfigItem(defaultValue = "100")
+        public int maxConnectionPoolSize;
+
+        /**
+         * Pooled connections that have been idle in the pool for longer than this timeout will be tested before they are used
+         * again. The value {@literal 0} means connections will always be tested for validity and negative values mean
+         * connections
+         * will never be tested.
+         */
+        @ConfigItem(defaultValue = "-0.001S")
+        public Duration idleTimeBeforeConnectionTest;
+
+        /**
+         * Pooled connections older than this threshold will be closed and removed from the pool.
+         */
+        @ConfigItem(defaultValue = "1H")
+        public Duration maxConnectionLifetime;
+
+        /**
+         * Acquisition of new connections will be attempted for at most configured timeout.
+         */
+        @ConfigItem(defaultValue = "1M")
+        public Duration connectionAcquisitionTimeout;
+
+        @Override
+        public String toString() {
+            return "Pool{" +
+                    "metricsEnabled=" + metricsEnabled +
+                    ", logLeakedSessions=" + logLeakedSessions +
+                    ", maxConnectionPoolSize=" + maxConnectionPoolSize +
+                    ", idleTimeBeforeConnectionTest=" + idleTimeBeforeConnectionTest +
+                    ", maxConnectionLifetime=" + maxConnectionLifetime +
+                    ", connectionAcquisitionTimeout=" + connectionAcquisitionTimeout +
+                    '}';
+        }
     }
 }


### PR DESCRIPTION
This provides access to configure the drivers internal pool settings under the new property group `pool`.

I have added those to the guide too.

In addition, while experimenting with moving part of the config to build phase, I moved the ssl indication out of the runtime init.