### PR TITLE
MP Metrics 2.0 no longer supports monotonic

### DIFF
--- a/docs/src/main/asciidoc/metrics-guide.adoc
+++ b/docs/src/main/asciidoc/metrics-guide.adoc
@@ -90,7 +90,7 @@ public class PrimeNumberChecker {
     @GET
     @Path("/{number}")
     @Produces("text/plain")
-    @Counted(name = "performedChecks", monotonic = true, description = "How many primality checks have been performed.")
+    @Counted(name = "performedChecks", description = "How many primality checks have been performed.")
     @Timed(name = "checksTimer", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
     public String checkIfPrime(@PathParam("number") long number) {
         if (number < 1) {


### PR DESCRIPTION
Docs leftover removal, MP Metrics 2.0 no longer supports monotonic

MP Metrics 2.0 introduced in https://github.com/quarkusio/quarkus/commit/db171b5d7772af6a1a661b8bb86db950cc1b0ea0