### PR TITLE
MP Metrics MetadataBuilder requires name to be set

### DIFF
--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/QuarkusJaegerMetricsFactory.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/QuarkusJaegerMetricsFactory.java
@@ -63,6 +63,7 @@ public class QuarkusJaegerMetricsFactory implements MetricsFactory {
 
     static Metadata meta(String name, MetricType type) {
         return Metadata.builder()
+                .withName(name)
                 .withDisplayName(name)
                 .withType(type)
                 .withUnit("none")


### PR DESCRIPTION
MP Metrics MetadataBuilder requires name to be set

https://github.com/eclipse/microprofile-metrics/blob/master/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java#L147L150

Noticed when running using-opentracing QS which failed with
```
2019-07-17 12:42:09,961 ERROR [io.und.req.io] (executor-thread-1) Exception handling request 0f77c88a-60e8-43b9-b1ac-9fa3dbaedfbf-1 to /hello: org.jboss.resteasy.spi.UnhandledException: java.lang.RuntimeException: No reflection exceptions should be thrown unless there is a fundamental error in your code set up.
...
Caused by: java.lang.IllegalStateException: Name is required
	at org.eclipse.microprofile.metrics.MetadataBuilder.build(MetadataBuilder.java:149)
	at io.quarkus.jaeger.runtime.QuarkusJaegerMetricsFactory.meta(QuarkusJaegerMetricsFactory.java:71)
	at io.quarkus.jaeger.runtime.QuarkusJaegerMetricsFactory.createCounter(QuarkusJaegerMetricsFactory.java:24)
	at io.jaegertracing.internal.metrics.Metrics.createMetrics(Metrics.java:64)
	... 69 more

```

