### PR TITLE
test url wrong in 'Configuring Your Application' guide

### DIFF
--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -109,7 +109,7 @@ Once set, check the application with:
 
 [source,shell]
 ----
-$ curl http://localhost:8080/greeting
+$ curl http://localhost:8080/hello
 hello quarkus!
 ----
 


### PR DESCRIPTION
The test url for section 'Create the Configuration' is wrong. It should be ```http://localhost:8080/hello``` instead of ```http://localhost:8080/greeting```.