### PR TITLE
Revert JniBuildItem in Netty and add in Amazon DynamoDB

### DIFF
--- a/docs/src/main/asciidoc/infinispan-client-guide.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-guide.adoc
@@ -374,6 +374,7 @@ An example is as shown here, with a comment highlighting them:
            <configuration>
                <enableHttpUrlHandler>true</enableHttpUrlHandler>
                <!-- next two are to enable security - If not needed it is recommended not to enable these-->
+               <enableJni>true</enableJni>
                <enableAllSecurityServices>true</enableAllSecurityServices>
            </configuration>
        </execution>

--- a/extensions/amazon-dynamodb/deployment/src/main/java/io/quarkus/dynamodb/deployment/DynamodbProcessor.java
+++ b/extensions/amazon-dynamodb/deployment/src/main/java/io/quarkus/dynamodb/deployment/DynamodbProcessor.java
@@ -6,6 +6,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.ServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateProxyDefinitionBuildItem;
@@ -23,6 +24,11 @@ public class DynamodbProcessor {
     @BuildStep
     void build(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(FeatureBuildItem.DYNAMODB));
+    }
+
+    @BuildStep
+    JniBuildItem jni() {
+        return new JniBuildItem();
     }
 
     @BuildStep

--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/NettyProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/NettyProcessor.java
@@ -6,7 +6,6 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateConfigBuildItem;
 
@@ -18,9 +17,7 @@ class NettyProcessor {
     private static final Logger log = Logger.getLogger(NettyProcessor.class);
 
     @BuildStep
-    SubstrateConfigBuildItem build(BuildProducer<JniBuildItem> jni) {
-        jni.produce(new JniBuildItem());
-
+    SubstrateConfigBuildItem build() {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
                 "org.neo4j.driver.internal.shaded.io.netty.channel.socket.nio.NioSocketChannel"));
         reflectiveClass

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -13,7 +13,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateConfigBuildItem;
 import io.quarkus.netty.BossGroup;
@@ -27,9 +26,7 @@ class NettyProcessor {
     private static final Logger log = Logger.getLogger(NettyProcessor.class);
 
     @BuildStep
-    SubstrateConfigBuildItem build(BuildProducer<JniBuildItem> jni) {
-        jni.produce(new JniBuildItem());
-
+    SubstrateConfigBuildItem build() {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioSocketChannel"));
         reflectiveClass
                 .produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioServerSocketChannel"));

--- a/integration-tests/amazon-dynamodb/pom.xml
+++ b/integration-tests/amazon-dynamodb/pom.xml
@@ -186,7 +186,6 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
-                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                 </configuration>
                             </execution>

--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -165,6 +165,7 @@
                                     -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <!-- next two are to enable security - If not needed it is recommended not to enable these-->
+                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                 </configuration>
                             </execution>

--- a/integration-tests/neo4j/README.md
+++ b/integration-tests/neo4j/README.md
@@ -54,6 +54,7 @@ The Quarkus maven plugin must be configured like this:
                 <enableHttpUrlHandler>true</enableHttpUrlHandler>
                 <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                 <enableAllSecurityServices>true</enableAllSecurityServices>
+                <enableJni>true</enableJni>
             </configuration>
         </execution>
     </executions>


### PR DESCRIPTION
I was a little quick in #3267. Artemis uses Netty which requires JNI, but only if the epoll and kqueue are explicitly added as dependency. This is not the case with Infinispan and neo4j. They only require JNI only if SSL is used. So hereby a revert of that change and I missed DynamoDB.

I will fix Netty in #2930 since there is already code that checks if epoll or kqueue are added as dependency.

Sorry for the mess.