### PR TITLE
[smallrye-openapi] use a configuration-based filtered Jandex index

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/OpenApiFilteredIndexViewBuildItem.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/OpenApiFilteredIndexViewBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkus.smallrye.openapi.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
+
+/**
+ * The filtered Jandex index of the OpenApi
+ */
+public final class OpenApiFilteredIndexViewBuildItem extends SimpleBuildItem {
+
+    private final FilteredIndexView index;
+
+    public OpenApiFilteredIndexViewBuildItem(FilteredIndexView index) {
+        this.index = index;
+    }
+
+    public FilteredIndexView getIndex() {
+        return index;
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -56,6 +56,7 @@ import io.smallrye.openapi.api.OpenApiDocument;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
 import io.smallrye.openapi.runtime.OpenApiStaticFile;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
 import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
 
 /**
@@ -103,11 +104,22 @@ public class SmallRyeOpenApiProcessor {
     }
 
     @BuildStep
-    public void registerOpenApiSchemaClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy, CombinedIndexBuildItem combinedIndexBuildItem,
+    OpenApiFilteredIndexViewBuildItem smallryeOpenApiIndex(CombinedIndexBuildItem combinedIndexBuildItem,
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem) {
-        IndexView index = CompositeIndex.create(combinedIndexBuildItem.getIndex(), beanArchiveIndexBuildItem.getIndex());
+        CompositeIndex compositeIndex = CompositeIndex.create(combinedIndexBuildItem.getIndex(),
+                beanArchiveIndexBuildItem.getIndex());
+        return new OpenApiFilteredIndexViewBuildItem(
+                new FilteredIndexView(
+                        compositeIndex,
+                        new OpenApiConfigImpl(ConfigProvider.getConfig())));
+    }
 
+    @BuildStep
+    public void registerOpenApiSchemaClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
+            OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem) {
+
+        FilteredIndexView index = openApiFilteredIndexViewBuildItem.getIndex();
         // Generate reflection declaration from MP OpenAPI Schema definition
         // They are needed for serialization.
         Collection<AnnotationInstance> schemaAnnotationInstances = index.getAnnotations(OPENAPI_SCHEMA);
@@ -187,12 +199,12 @@ public class SmallRyeOpenApiProcessor {
 
     @BuildStep
     public void build(ApplicationArchivesBuildItem archivesBuildItem,
-            CombinedIndexBuildItem combinedIndexBuildItem, BuildProducer<FeatureBuildItem> feature,
+            BuildProducer<FeatureBuildItem> feature,
             Optional<ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig,
             BuildProducer<GeneratedWebResourceBuildItem> resourceBuildItemBuildProducer,
-            BeanArchiveIndexBuildItem beanArchiveIndexBuildItem) throws Exception {
+            OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem) throws Exception {
 
-        IndexView index = CompositeIndex.create(combinedIndexBuildItem.getIndex(), beanArchiveIndexBuildItem.getIndex());
+        FilteredIndexView index = openApiFilteredIndexViewBuildItem.getIndex();
 
         feature.produce(new FeatureBuildItem(FeatureBuildItem.SMALLRYE_OPENAPI));
         OpenAPI staticModel = generateStaticModel(archivesBuildItem);


### PR DESCRIPTION
Quarkus should support all Microprofile OpenAPI spec config properties.
https://github.com/eclipse/microprofile-open-api/blob/master/spec/src/main/asciidoc/microprofile-openapi-spec.adoc#list-of-configurable-items