### PR TITLE
Update Kubernetes Client to 4.3.1 and fix annoying error pop-up in Eclipse

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -155,7 +155,8 @@
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
         <kogito.version>0.2.0</kogito.version>
-        <kubernetes-client.version>4.3.0</kubernetes-client.version>
+        <kubernetes-client.version>4.3.1</kubernetes-client.version>
+        <sundr.version>0.19.1</sundr.version> <!-- this is to avoid annoying pop-up in eclipse about failure to init Velocity logging -->
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
     </properties>
 
@@ -1090,6 +1091,11 @@
                         <artifactId>javaee-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.sundr</groupId>
+                <artifactId>builder-annotations</artifactId>
+                <version>${sundr.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>


### PR DESCRIPTION
about failed Velocity logging initialization which in the logs looks like this
```
io.sundr.shaded.org.apache.velocity.exception.VelocityException: Error initializing log: Failed to initialize an instance of io.sundr.shaded.org.apache.velocity.runtime.log.NullLogChute with the current runtime configuration.
        at io.sundr.shaded.org.apache.velocity.runtime.RuntimeInstance.initializeLog(RuntimeInstance.java:875)
        at io.sundr.shaded.org.apache.velocity.runtime.RuntimeInstance.init(RuntimeInstance.java:262)
        at io.sundr.shaded.org.apache.velocity.app.VelocityEngine.init(VelocityEngine.java:93)
        at io.sundr.codegen.generator.CodeGeneratorContext.<init>(CodeGeneratorContext.java:56)
        at io.sundr.codegen.generator.CodeGeneratorContext.<init>(CodeGeneratorContext.java:41)
        at io.sundr.codegen.processor.JavaGeneratingProcessor.<init>(JavaGeneratingProcessor.java:40)
        at io.sundr.builder.internal.processor.AbstractBuilderProcessor.<init>(AbstractBuilderProcessor.java:51)
        at io.sundr.builder.internal.processor.BuildableProcessor.<init>(BuildableProcessor.java:49)
        at sun.reflect.GeneratedConstructorAccessor269.newInstance(Unknown Source)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at java.lang.Class.newInstance(Class.java:442)
        at org.eclipse.jdt.apt.core.internal.ClassServiceFactory.newInstance(ClassServiceFactory.java:30)
        at org.eclipse.jdt.internal.apt.pluggable.core.dispatch.IdeAnnotationProcessorManager.discoverNextProcessor(IdeAnnotationProcessorManager.java:96)
        at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.round(RoundDispatcher.java:119)
        at org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager.processAnnotations(BaseAnnotationProcessorManager.java:171)
        at org.eclipse.jdt.internal.apt.pluggable.core.dispatch.IdeAnnotationProcessorManager.processAnnotations(IdeAnnotationProcessorManager.java:138)
        at org.eclipse.jdt.internal.compiler.Compiler.processAnnotations(Compiler.java:940)
        at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:450)
        at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:426)
        at org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.compile(AbstractImageBuilder.java:386)
        at org.eclipse.jdt.internal.core.builder.BatchImageBuilder.compile(BatchImageBuilder.java:214)
        at org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.compile(AbstractImageBuilder.java:318)
        at org.eclipse.jdt.internal.core.builder.BatchImageBuilder.build(BatchImageBuilder.java:79)
        at org.eclipse.jdt.internal.core.builder.JavaBuilder.buildAll(JavaBuilder.java:262)
        at org.eclipse.jdt.internal.core.builder.JavaBuilder.build(JavaBuilder.java:185)
        at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:833)
        at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
        at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:220)
        at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:263)
        at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:316)
        at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
        at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:319)
        at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:371)
        at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:392)
        at org.eclipse.core.internal.events.AutoBuildJob.doBuild(AutoBuildJob.java:154)
        at org.eclipse.core.internal.events.AutoBuildJob.run(AutoBuildJob.java:244)
        at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
Caused by: io.sundr.shaded.org.apache.velocity.exception.VelocityException: Failed to initialize an instance of io.sundr.shaded.org.apache.velocity.runtime.log.NullLogChute with the current runtime configuration.
        at io.sundr.shaded.org.apache.velocity.runtime.log.LogManager.createLogChute(LogManager.java:220)
        at io.sundr.shaded.org.apache.velocity.runtime.log.LogManager.updateLog(LogManager.java:269)
        at io.sundr.shaded.org.apache.velocity.runtime.RuntimeInstance.initializeLog(RuntimeInstance.java:871)
        ... 37 more
Caused by: io.sundr.shaded.org.apache.velocity.exception.VelocityException: The specified logger class io.sundr.shaded.org.apache.velocity.runtime.log.NullLogChute does not implement the io.sundr.shaded.org.apache.velocity.runtime.log.LogChute interface.
        at io.sundr.shaded.org.apache.velocity.runtime.log.LogManager.createLogChute(LogManager.java:181)
        ... 39 more
```