### PR TITLE
Upgrade Gradle version to 5.5.1 (includes enforcedPlatform bug fix)

### DIFF
--- a/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/devtools/gradle/gradlew
+++ b/devtools/gradle/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/devtools/gradle/gradlew.bat
+++ b/devtools/gradle/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Following [quarkus-quickstarts#246](https://github.com/quarkusio/quarkus-quickstarts/pull/246). I'm submitting this PR to keep the Gradle version consistent between `quarkus` and `quarkus-quickstarts`.

Version `5.5` fixed an `enforcedPlatform` bug: gradle/gradle#9424

The `gradle-wrapper.jar` file didn't change between versions `5.4.1` and `5.5.1` (can be verified with the checksum values [here](https://gradle.org/release-checksums/)) so it's normal if it's not changed by this PR.