### PR TITLE
fix: add a lesser priority than the default one

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/NotFoundExceptionMapper.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/NotFoundExceptionMapper.java
@@ -13,8 +13,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Priority;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -33,6 +35,7 @@ import io.quarkus.runtime.TemplateHtmlBuilder;
  * 
  */
 @Provider
+@Priority(Priorities.USER + 1)
 public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
 
     @Context


### PR DESCRIPTION
Adding a lesser priority than the default one for the NotFoundExceptionMapper allow a user to easily override it.

Be careful that for this to work the exception mapper needs to be of the same parameter type: `ExceptionMapper<NotFoundException>` if a broader parameter type is used like `ExceptionMapper<RuntimeException` it will not take precedence from the default one.

Tested on a local project but no test provided.

Refers to #3253 