### PR TITLE
Fix a wrong log of the error in the MongoClientRecorder

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -183,7 +183,7 @@ public class MongoClientRecorder {
                 Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(name);
                 providers.add((CodecProvider) clazz.newInstance());
             } catch (Exception e) {
-                LOGGER.warnf("Unable to load the codec provider class %s", name, e);
+                LOGGER.warnf(e, "Unable to load the codec provider class %s", name);
             }
         }
 


### PR DESCRIPTION
The error needs to be pass to the first parameter of the warnf method and not on the varargs parameter.