### PR TITLE
Support running Quarkus tests from Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -7,6 +7,7 @@ import org.gradle.api.Task;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.util.GradleVersion;
 
 import io.quarkus.gradle.tasks.QuarkusAddExtension;
@@ -15,6 +16,7 @@ import io.quarkus.gradle.tasks.QuarkusDev;
 import io.quarkus.gradle.tasks.QuarkusGenerateConfig;
 import io.quarkus.gradle.tasks.QuarkusListExtensions;
 import io.quarkus.gradle.tasks.QuarkusNative;
+import io.quarkus.gradle.tasks.QuarkusTestConfig;
 
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
@@ -51,6 +53,10 @@ public class QuarkusPlugin implements Plugin<Project> {
                 });
 
         tasks.create("buildNative", QuarkusNative.class).dependsOn(quarkusBuild);
+
+        // Quarkus test configuration task which should be executed before any Quarkus test
+        final QuarkusTestConfig quarkusTestConfig = tasks.create("quarkusTestConfig", QuarkusTestConfig.class);
+        tasks.withType(Test.class).forEach(t -> t.dependsOn(quarkusTestConfig));
     }
 
     private void verifyGradleVersion() {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
@@ -1,0 +1,44 @@
+package io.quarkus.gradle.tasks;
+
+import java.util.List;
+import java.util.Map;
+
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.testing.Test;
+
+import io.quarkus.bootstrap.BootstrapClassLoaderFactory;
+import io.quarkus.bootstrap.model.AppDependency;
+import io.quarkus.gradle.QuarkusPluginExtension;
+
+public class QuarkusTestConfig extends QuarkusTask {
+
+    public QuarkusTestConfig() {
+        super("Sets the necessary system properties for the Quarkus tests to run.");
+    }
+
+    @TaskAction
+    public void setupTest() {
+        final QuarkusPluginExtension quarkusExt = extension();
+        try {
+            final List<AppDependency> deploymentDeps = quarkusExt.resolveAppModel().resolveModel(quarkusExt.getAppArtifact())
+                    .getDeploymentDependencies();
+            final StringBuilder buf = new StringBuilder();
+            for (AppDependency dep : deploymentDeps) {
+                buf.append(dep.getArtifact().getPath().toUri().toURL().toExternalForm());
+                buf.append(' ');
+            }
+            final String deploymentCp = buf.toString();
+            final String nativeRunner = getProject().getBuildDir().toPath().resolve(quarkusExt.finalName() + "-runner")
+                    .toAbsolutePath()
+                    .toString();
+
+            for (Test test : getProject().getTasks().withType(Test.class)) {
+                final Map<String, Object> props = test.getSystemProperties();
+                props.put(BootstrapClassLoaderFactory.PROP_DEPLOYMENT_CP, deploymentCp);
+                props.put("native.image.path", nativeRunner);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to resolve deployment classpath", e);
+        }
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
@@ -35,8 +35,9 @@ public class BootstrapClassLoaderFactory {
     private static final String DEPLOYMENT_CP = "deployment.cp";
 
     public static final String PROP_CP_CACHE = "quarkus-classpath-cache";
-    public static final String PROP_WS_DISCOVERY = "quarkus-workspace-discovery";
+    public static final String PROP_DEPLOYMENT_CP = "quarkus-deployment-cp";
     public static final String PROP_OFFLINE = "quarkus-bootstrap-offline";
+    public static final String PROP_WS_DISCOVERY = "quarkus-workspace-discovery";
 
     private static final int CP_CACHE_FORMAT_ID = 1;
 


### PR DESCRIPTION
Fixes #2307, #3103 

This PR adds a Quarkus Gradle task that sets Quarkus-specific properties (such as `native.image.path` and newly added `quarkus-deployment-cp` whose value is a deployment classpath necessary to build the test) on the test tasks for them to be able to run.

Gradle projects will need to add the following to their build scripts
````
test {
    useJUnitPlatform()

    // @SubstrateTest and JVM mode tests can't be mixed in the same run
    forkEvery 1
}
````