### PR TITLE
Explicitly register also IntOrString class for reflection

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -88,6 +88,8 @@ public class KubernetesClientProcessor {
         reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, deserializerClasses));
 
         reflectiveClasses
+                .produce(new ReflectiveClassBuildItem(true, false, "io.fabric8.kubernetes.api.model.IntOrString"));
+        reflectiveClasses
                 .produce(new ReflectiveClassBuildItem(true, false, "io.fabric8.kubernetes.internal.KubernetesDeserializer"));
 
         // Enable SSL support by default


### PR DESCRIPTION
Purpose of this (value) class is to hold a value for port when describing service or route or container.
From some reason this class is not registered automatically during serde by Jackson, so this PR adds it explicitly.

w/o this change I got this exception during run time with native image of [spark-operator](https://github.com/radanalyticsio/spark-operator):

<details><summary>stacktrace</summary>
<p>

```
io.fabric8.kubernetes.client.KubernetesClientException: Operation: [create]  for kind: [Service]  with name: [null]  in namespace: [default]  failed.
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:328)
	at io.fabric8.kubernetes.client.handlers.ServiceHandler.create(ServiceHandler.java:53)
	at io.fabric8.kubernetes.client.handlers.ServiceHandler.create(ServiceHandler.java:39)
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.createOrReplace(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:212)
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.createOrReplace(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:64)
	at io.radanalytics.operator.cluster.SparkClusterOperator.onAdd(SparkClusterOperator.java:57)
	at io.radanalytics.operator.cluster.SparkClusterOperator.onAdd(SparkClusterOperator.java:34)
	at io.radanalytics.operator.common.AbstractOperator.onAction(AbstractOperator.java:174)
	at io.radanalytics.operator.common.AbstractOperator.onAdd(AbstractOperator.java:111)
	at io.radanalytics.operator.common.AbstractWatcher.handleAction(AbstractWatcher.java:188)
	at io.radanalytics.operator.common.AbstractWatcher.access$300(AbstractWatcher.java:29)
	at io.radanalytics.operator.common.AbstractWatcher$2.eventReceived(AbstractWatcher.java:138)
	at io.radanalytics.operator.common.AbstractWatcher$2.eventReceived(AbstractWatcher.java:127)
	at io.fabric8.kubernetes.client.utils.WatcherToggle.eventReceived(WatcherToggle.java:49)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:232)
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323)
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219)
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105)
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:473)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:193)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Class io.fabric8.kubernetes.api.model.IntOrString$Serializer has no default (no arg) constructor (through reference chain: io.fabric8.kubernetes.api.model.Service["spec"]->io.fabric8.kubernetes.api.model.ServiceSpec["ports"]->java.util.ArrayList[0]->io.fabric8.kubernetes.api.model.ServicePort["targetPort"])
	at com.fasterxml.jackson.databind.SerializerProvider.reportMappingProblem(SerializerProvider.java:1223)
	at com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1341)
	at com.fasterxml.jackson.databind.SerializerProvider.findPrimaryPropertySerializer(SerializerProvider.java:668)
	at com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap.findAndAddPrimarySerializer(PropertySerializerMap.java:64)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter._findAndAddDynamic(BeanPropertyWriter.java:897)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:705)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:719)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:119)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:79)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:18)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:727)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:719)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:727)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:719)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:155)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3905)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3219)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:232)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:735)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:325)
	... 26 more
Caused by: java.lang.IllegalArgumentException: Class io.fabric8.kubernetes.api.model.IntOrString$Serializer has no default (no arg) constructor
	at com.fasterxml.jackson.databind.util.ClassUtil.createInstance(ClassUtil.java:554)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializerInstance(DefaultSerializerProvider.java:135)
	at com.fasterxml.jackson.databind.ser.BasicSerializerFactory.findSerializerFromAnnotation(BasicSerializerFactory.java:489)
	at com.fasterxml.jackson.databind.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:136)
	at com.fasterxml.jackson.databind.SerializerProvider._createUntypedSerializer(SerializerProvider.java:1388)
	at com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1336)
	... 48 more
```

</p>
</details>

@geoand could you ptal?