### PR TITLE
Add Kotlin to Gradle search path for test classes

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -24,7 +24,7 @@ public final class PathTestHelper {
         TEST_TO_MAIN_DIR_FRAGMENTS.put(
                 "classes" + File.separator + "java" + File.separator + "test",
                 "classes" + File.separator + "java" + File.separator + "main");
-                "classes" + File.separator + "kotlin" + File.separator + "test",
+                "classes" + File.separator + "kotlin" + File.separator + "test";
                 "classes" + File.separator + "kotlin" + File.separator + "main");
 
         // maven

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -24,6 +24,9 @@ public final class PathTestHelper {
         TEST_TO_MAIN_DIR_FRAGMENTS.put(
                 "classes" + File.separator + "java" + File.separator + "test",
                 "classes" + File.separator + "java" + File.separator + "main");
+                "classes" + File.separator + "kotlin" + File.separator + "test",
+                "classes" + File.separator + "kotlin" + File.separator + "main");
+
         // maven
         TEST_TO_MAIN_DIR_FRAGMENTS.put(
                 File.separator + "test-classes",


### PR DESCRIPTION
Gradle seperates Java and Kotlin classes.

Add kotlin to the search path.