### PR TITLE
Add kotlin to search path for test classes using gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
@@ -98,7 +98,7 @@ public class QuarkusPluginExtension {
 
     public String finalName() {
         if (finalName == null || finalName.length() == 0)
-            return project.getName();
+            return project.getName() + "-" + project.getVersion();
         else
             return finalName;
     }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -24,6 +24,10 @@ public final class PathTestHelper {
         TEST_TO_MAIN_DIR_FRAGMENTS.put(
                 "classes" + File.separator + "java" + File.separator + "test",
                 "classes" + File.separator + "java" + File.separator + "main");
+        TEST_TO_MAIN_DIR_FRAGMENTS.put(
+                "classes" + File.separator + "kotlin" + File.separator + "test",
+                "classes" + File.separator + "kotlin" + File.separator + "main");
+
         // maven
         TEST_TO_MAIN_DIR_FRAGMENTS.put(
                 File.separator + "test-classes",


### PR DESCRIPTION
Gradle seperates classes from java and kotlin (and scala et al).

Test class search path must explicitly add kotlin, in addition to java which is already set.