### PR TITLE
[open-api] Consider 'mp.openapi.scan.disable' value when scanning annotations

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.OASConfig;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -208,8 +209,11 @@ public class SmallRyeOpenApiProcessor {
 
         feature.produce(new FeatureBuildItem(FeatureBuildItem.SMALLRYE_OPENAPI));
         OpenAPI staticModel = generateStaticModel(archivesBuildItem);
+
         OpenAPI annotationModel;
-        if (resteasyJaxrsConfig.isPresent()) {
+        Config config = ConfigProvider.getConfig();
+        boolean scanDisable = config.getOptionalValue(OASConfig.SCAN_DISABLE, Boolean.class).orElse(false);
+        if (resteasyJaxrsConfig.isPresent() && !scanDisable) {
             annotationModel = generateAnnotationModel(index, resteasyJaxrsConfig.get());
         } else {
             annotationModel = null;

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiDefaultPathTestCase.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.openapi.test;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,10 @@ public class OpenApiDefaultPathTestCase {
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
                 .when().get(OPEN_API_PATH)
-                .then().header("Content-Type", "application/json;charset=UTF-8");
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiWithConfigTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.openapi.test;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiWithConfigTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class)
+                    .addAsManifestResource("test-openapi.yaml", "openapi.yaml")
+                    .addAsResource(new StringAsset("mp.openapi.scan.disable=true\nmp.openapi.servers=https://api.acme.org/"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenAPI() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Test OpenAPI"))
+                .body("info.description", Matchers.equalTo("Some description"))
+                .body("info.version", Matchers.equalTo("4.2"))
+                .body("servers[0].url", Matchers.equalTo("https://api.acme.org/"))
+                .body("paths", Matchers.hasKey("/openapi"))
+                .body("paths", Matchers.not(Matchers.hasKey("/resource")));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/resources/test-openapi.yaml
+++ b/extensions/smallrye-openapi/deployment/src/test/resources/test-openapi.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: Test OpenAPI
+  description: Some description
+  version: 4.2
+paths:
+  /openapi:
+    get:
+      operationId: someOperation
+      responses:
+        200:
+          description: Ok


### PR DESCRIPTION
See issue https://github.com/quarkusio/quarkus/issues/2907

Check the value of `mp.openapi.scan.disable` when computing the OpenAPI specification served by quarkus.

---
As mentioned in https://github.com/quarkusio/quarkus/issues/2907#issuecomment-512247927 if someone can point me the place and the workflow to add some test for this, I am happy to contribute something.