### PR TITLE
Remove static driver instance.

### DIFF
--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
@@ -23,18 +23,16 @@ public class Neo4jDriverRecorder {
 
     private static final Logger log = Logger.getLogger(Neo4jDriverRecorder.class);
 
-    static volatile Driver driver;
-
     public void configureNeo4jProducer(BeanContainer beanContainer, Neo4jConfiguration configuration,
             ShutdownContext shutdownContext) {
 
-        initializeDriver(configuration, shutdownContext);
+        Driver driver = initializeDriver(configuration, shutdownContext);
 
         Neo4jDriverProducer driverProducer = beanContainer.instance(Neo4jDriverProducer.class);
         driverProducer.initialize(driver);
     }
 
-    private void initializeDriver(Neo4jConfiguration configuration,
+    private Driver initializeDriver(Neo4jConfiguration configuration,
             ShutdownContext shutdownContext) {
 
         String uri = configuration.uri;
@@ -47,8 +45,9 @@ public class Neo4jDriverRecorder {
         configureSsl(configBuilder);
         configurePoolSettings(configBuilder, configuration.pool);
 
-        driver = GraphDatabase.driver(uri, authToken, configBuilder.build());
+        Driver driver = GraphDatabase.driver(uri, authToken, configBuilder.build());
         shutdownContext.addShutdownTask(driver::close);
+        return driver;
     }
 
     private static Config.ConfigBuilder createBaseConfig() {


### PR DESCRIPTION
I just noticed that the Neo4j recorder could have been more simplified during the initial PR. As the framework makes sure, the recorder is never invoked twice after recording, we removed all checks whether the driver is initialized, but not the static instance variable in the recorder.
This can go away,  too.