### PR TITLE
Offer `no-file` option to override `import.sql`

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -137,6 +137,7 @@ The storage engine to use when the dialect supports multiple storage engines.
 `quarkus.hibernate-orm.sql-load-script`::
 (defaults to `/import.sql`) Name of the file containing the SQL statements to execute when Hibernate ORM starts.
 By default, simply add `import.sql` in the root of your resources directory and it will be picked up without having to set this property.
+Pass `no-file` to force Hibernate ORM to ignore the SQL import file.
 If you need different SQL statements between dev mode, test (`@QuarkusTest`) and in production, use Quarkus https://quarkus.io/guides/application-configuration-guide#configuration-profiles[configuration profiles facility].
 
 [source,property]
@@ -144,12 +145,13 @@ If you need different SQL statements between dev mode, test (`@QuarkusTest`) and
 --
 %dev.quarkus.hibernate-orm.sql-load-script = import-dev.sql
 %test.quarkus.hibernate-orm.sql-load-script = import-test.sql
-%prod.quarkus.hibernate-orm.sql-load-script = import-prod.sql
+%prod.quarkus.hibernate-orm.sql-load-script = no-file
 --
 
 [NOTE]
 ====
-Quarkus supports `.sql` file with sql statements or comments spread over multiple lines. Each SQL statement must be terminated by a semicolon.
+Quarkus supports `.sql` file with SQL statements or comments spread over multiple lines.
+Each SQL statement must be terminated by a semicolon.
 ====
 
 `quarkus.hibernate-orm.batch-fetch-size`:: (defaults to `-1` i.e. batch fetching is disabled).
@@ -317,10 +319,10 @@ to select different behaviors depending on your environment.
 %dev.quarkus.hibernate-orm.sql-load-script = import-dev.sql
 
 %dev-with-data.quarkus.hibernate-orm.database.generation = update
-%dev-with-data.quarkus.hibernate-orm.sql-load-script =
+%dev-with-data.quarkus.hibernate-orm.sql-load-script = no-file
 
 %prod.quarkus.hibernate-orm.database.generation = none
-%prod.quarkus.hibernate-orm.sql-load-script =
+%prod.quarkus.hibernate-orm.sql-load-script = no-file
 --
 
 [source,bash]

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/NoFileOptionTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/NoFileOptionTestCase.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class NoFileOptionTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyEntity.class, SqlLoadScriptTestResource.class)
+                    .addAsResource("application-no-file-option-test.properties", "application.properties")
+                    .addAsResource("import.sql"));
+
+    @Test
+    public void testSqlLoadScriptFileAbsentTest() {
+        String name = "no entity";
+        //despite the presence of import.sql, the file is not processed
+        RestAssured.when().get("/orm-sql-load-script/1").then().body(Matchers.is(name));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/SqlLoadScriptTestResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/SqlLoadScriptTestResource.java
@@ -22,6 +22,6 @@ public class SqlLoadScriptTestResource {
             return entity.getName();
         }
 
-        return null;
+        return "no entity";
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-no-file-option-test.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-no-file-option-test.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.url=jdbc:h2:mem:test
+quarkus.datasource.driver=org.h2.Driver
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.sql-load-script=load-script-test.sql
+quarkus.hibernate-orm.sql-load-script=no-file


### PR DESCRIPTION
This is to address https://github.com/quarkusio/quarkusio.github.io/pull/254#discussion_r306181911 to make it clearer.

Right now the user would use `quarkus.hibernate-orm.sql-load-script = no-file`

Another option would be to have different defaults between `DEV` and `TEST` mode using `import.sql` by default and `PROD` use `no-file`. This is not implemented but I was wondering about this idea. @FroMage seems to like it