### PR TITLE
Use host string instead of address in SyslogHandler

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -145,7 +145,7 @@ public class LoggingSetupRecorder {
     private void configureSyslogHandler(SyslogConfig config, ErrorManager errorManager,
             List<LogCleanupFilterElement> filterElements, ArrayList<Handler> handlers) {
         try {
-            final SyslogHandler handler = new SyslogHandler(config.endpoint.getAddress(), config.endpoint.getPort());
+            final SyslogHandler handler = new SyslogHandler(config.endpoint.getHostString(), config.endpoint.getPort());
             handler.setAppName(config.appName.orElse(getProcessName()));
             handler.setHostname(config.hostname.orElse(getQualifiedHostName()));
             handler.setFacility(config.facility);

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
@@ -13,7 +13,6 @@ import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -61,8 +60,5 @@ public class AsyncSyslogHandlerTest {
         assertThat(syslogHandler.isUseCountingFraming()).isEqualTo(true);
         assertThat(syslogHandler.isTruncate()).isEqualTo(false);
         assertThat(syslogHandler.isBlockOnReconnect()).isEqualTo(false);
-
-        Assertions.assertThrows(NullPointerException.class,
-                () -> assertThat(syslogHandler.getServerAddress().getHostName()).isEqualTo("localhost"));
     }
 }

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
@@ -16,7 +16,6 @@ import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -57,8 +56,5 @@ public class SyslogHandlerTest {
         assertThat(syslogHandler.isUseCountingFraming()).isEqualTo(false);
         assertThat(syslogHandler.isTruncate()).isEqualTo(true);
         assertThat(syslogHandler.isBlockOnReconnect()).isEqualTo(false);
-
-        Assertions.assertThrows(NullPointerException.class,
-                () -> assertThat(syslogHandler.getServerAddress().getHostName()).isEqualTo("localhost"));
     }
 }


### PR DESCRIPTION
in case only hostname is setup, this prevents test failures (CC @gsmet )