### PR TITLE
Make RegisterForReflection annotation inheritable

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
@@ -1,6 +1,7 @@
 package io.quarkus.runtime.annotations;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -8,6 +9,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation that can be used to force a class to be registered for reflection in native image mode
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface RegisterForReflection {


### PR DESCRIPTION
This allows setting this annotation in interfaces and superclasses. Useful for annotation-based generators like http://immutables.github.io/