### PR TITLE
Introduce quarkus-cache extension

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -564,6 +564,11 @@
                 <artifactId>quarkus-resteasy-qute-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-cache-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- Quarkus test dependencies -->
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -120,7 +120,7 @@
         <json-smart.version>2.3</json-smart.version>
         <infinispan.version>10.0.0.Final</infinispan.version>
         <infinispan.protostream.version>4.3.1.Final</infinispan.protostream.version>
-        <caffeine.version>2.6.2</caffeine.version>
+        <caffeine.version>2.8.0</caffeine.version>
         <netty.version>4.1.42.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <test-containers.version>1.12.4</test-containers.version>
@@ -177,6 +177,8 @@
         <logstash-gelf.version>1.14.0</logstash-gelf.version>
         <jsch.version>0.1.55</jsch.version>
         <jzlib.version>1.1.1</jzlib.version>
+        <checker-qual.version>2.5.2</checker-qual.version>
+        <error-prone-annotations.version>2.2.0</error-prone-annotations.version>
     </properties>
 
     <dependencyManagement>
@@ -759,6 +761,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-logging-gelf</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -2487,6 +2494,17 @@
                 <groupId>org.webjars</groupId>
                 <artifactId>bootstrap</artifactId>
                 <version>${bootstrap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>${checker-qual.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${error-prone-annotations.version}</version>
             </dependency>
 
             <!-- Kogito -->

--- a/ci-templates/stages.yml
+++ b/ci-templates/stages.yml
@@ -311,7 +311,8 @@ stages:
           modules:
             - infinispan-cache-jpa
             - infinispan-client
-          name: infinispan
+            - cache
+          name: cache
 
       - template: native-build-steps.yaml
         parameters:

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -13,6 +13,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String AMAZON_LAMBDA = "amazon-lambda";
     public static final String ARTEMIS_CORE = "artemis-core";
     public static final String ARTEMIS_JMS = "artemis-jms";
+    public static final String CACHE = "cache";
     public static final String CDI = "cdi";
     public static final String CONFIG_YAML = "config-yaml";
     public static final String DYNAMODB = "dynamodb";

--- a/docs/src/main/asciidoc/application-data-caching.adoc
+++ b/docs/src/main/asciidoc/application-data-caching.adoc
@@ -1,0 +1,434 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Application Data Caching
+:extension-status: preview
+
+include::./attributes.adoc[]
+
+In this guide, you will learn how to enable application data caching in any CDI managed bean of your Quarkus application.
+
+include::./status-include.adoc[]
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* less than 15 minutes
+* an IDE
+* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* Apache Maven 3.5.3+
+
+== Scenario
+
+Let's imagine you want to expose in your Quarkus application a REST API that allows users to retrieve the weather forecast for the next three days.
+The problem is that you have to rely on an external meteorological service which only accepts requests for one day at a time and takes forever to answer.
+Since the weather forecast is updated once every twelve hours, caching the service responses would definitely improve your API performances.
+
+We'll do that using a single Quarkus annotation.
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `cache-quickstart` directory.
+
+== Creating the Maven project
+
+First, we need to create a new Quarkus project using Maven with the following command:
+
+[source,shell,subs=attributes+]
+----
+mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=cache-quickstart \
+    -DclassName="org.acme.caching.WeatherForecastResource" \
+    -Dpath="/weather" \
+    -Dextensions="cache,resteasy-jsonb"
+----
+
+This command generates the Maven project with a REST endpoint and imports the `cache` and `resteasy-jsonb` extensions.
+
+== Creating the REST API
+
+Let's start by creating a service that will simulate an extremely slow call to the external meteorological service.
+Create `src/main/java/org/acme/caching/WeatherForecastService.java` with the following content:
+
+[source,java]
+----
+package org.acme.caching;
+
+import java.time.LocalDate;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class WeatherForecastService {
+
+    public String getDailyForecast(LocalDate date, String city) {
+        try {
+            Thread.sleep(2000L); <1>
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return date.getDayOfWeek() + " will be " + getDailyResult(date.getDayOfMonth() % 4) + " in " + city;
+    }
+
+    private String getDailyResult(int dayOfMonthModuloFour) {
+        switch (dayOfMonthModuloFour) {
+            case 0:
+                return "sunny";
+            case 1:
+                return "cloudy";
+            case 2:
+                return "chilly";
+            case 3:
+                return "rainy";
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+}
+----
+<1> This is where the slowness comes from.
+
+We also need a class that will contain the response sent to the users when they ask for the next three days weather forecast.
+Create `src/main/java/org/acme/caching/WeatherForecast.java` this way:
+
+[source,java]
+----
+package org.acme.caching;
+
+import java.util.List;
+
+public class WeatherForecast {
+
+    private List<String> dailyForecasts;
+
+    private long executionTimeInMs;
+
+    public WeatherForecast(List<String> dailyForecasts, long executionTimeInMs) {
+        this.dailyForecasts = dailyForecasts;
+        this.executionTimeInMs = executionTimeInMs;
+    }
+
+    public List<String> getDailyForecasts() {
+        return dailyForecasts;
+    }
+
+    public long getExecutionTimeInMs() {
+        return executionTimeInMs;
+    }
+}
+----
+
+Now, we just need to update the generated `WeatherForecastResource` class to use the service and response:
+
+[source,java]
+----
+package org.acme.caching;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+@Path("/weather")
+public class WeatherForecastResource {
+
+    @Inject
+    WeatherForecastService service;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public WeatherForecast getForecast(@QueryParam String city, @QueryParam long daysInFuture) { <1>
+        long executionStart = System.currentTimeMillis();
+        List<String> dailyForecasts = Arrays.asList(
+                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture), city),
+                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 1L), city),
+                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 2L), city)
+        );
+        long executionEnd = System.currentTimeMillis();
+        return new WeatherForecast(dailyForecasts, executionEnd - executionStart);
+    }
+}
+----
+<1> If the `daysInFuture` query parameter is omitted, the three days weather forecast will start from the current day.
+Otherwise, it will start from the current day plus the `daysInFuture` value.
+
+We're all done! Let's check if everything's working.
+
+First, run the application using `./mvnw compile quarkus:dev` from the project directory.
+
+Then, call `http://localhost:8080/weather?city=Raleigh` from a browser.
+After six long seconds, the application will answer something like this:
+
+[source]
+----
+{"dailyForecasts":["MONDAY will be cloudy in Raleigh","TUESDAY will be chilly in Raleigh","WEDNESDAY will be rainy in Raleigh"],"executionTimeInMs":6001}
+----
+
+[TIP]
+====
+The response content may vary depending on the day you run the code.
+====
+
+You can try calling the same URL again and again, it will always take six seconds to answer.
+
+== Enabling the cache
+
+Now that your Quarkus application is up and running, let's tremendously improve its response time by caching the external meteorological service responses.
+Update the `WeatherForecastService` class like this:
+
+[source,java]
+----
+package org.acme.caching;
+
+import java.time.LocalDate;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.cache.CacheResult;
+
+@ApplicationScoped
+public class WeatherForecastService {
+
+    @CacheResult(cacheName = "weather-cache") <1>
+    public String getDailyForecast(LocalDate date, String city) {
+        try {
+            Thread.sleep(2000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return date.getDayOfWeek() + " will be " + getDailyResult(date.getDayOfMonth() % 4) + " in " + city;
+    }
+
+    private String getDailyResult(int dayOfMonthModuloFour) {
+        switch (dayOfMonthModuloFour) {
+            case 0:
+                return "sunny";
+            case 1:
+                return "cloudy";
+            case 2:
+                return "chilly";
+            case 3:
+                return "rainy";
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+}
+----
+<1> We only added this annotation (and the associated import of course).
+
+Let's try to call `http://localhost:8080/weather?city=Raleigh` again.
+You're still waiting a long time before receiving an answer.
+This is normal since the server just restarted and the cache was empty.
+
+Wait a second! The server restarted by itself after the `WeatherForecastService` update?
+Yes, this is one of Quarkus amazing features for developers called `live coding`.
+
+Now that the cache was loaded during the previous call, try calling the same URL.
+This time, you should get a super fast answer with an `executionTimeInMs` value close to 0.
+
+Let's see what happens if we start from one day in the future using the `http://localhost:8080/weather?city=Raleigh&daysInFuture=1` URL.
+You should get an answer two seconds later since two of the requested days were already loaded in the cache.
+
+You can also try calling the same URL with a different city and see the cache in action again.
+The first call will take six seconds and the following ones will be answered immediately.  
+
+Congratulations! You just added application data caching to your Quarkus application with a single line of code!
+
+Do you want to learn more about the Quarkus application data caching abilities?
+The following sections will show you everything there is to know about it.
+
+== Caching annotations
+
+Quarkus offers a set of annotations that can be used in a CDI managed bean to enable caching abilities.
+
+=== @CacheResult
+
+Loads a method result from the cache without executing the method body whenever possible.
+
+When a method annotated with `@CacheResult` is invoked, Quarkus will compute a cache key and use it to check in the cache whether the method has been already invoked.
+If the method has one or more arguments, the key computation is done from all the method arguments if none of them is annotated with `@CacheKey`, or all the arguments annotated with `@CacheKey` otherwise.
+This annotation can also be used on a method with no arguments, a default key derived from the cache name is generated in that case.
+If a value is found in the cache, it is returned and the annotated method is never actually executed.
+If no value is found, the annotated method is invoked and the returned value is stored in the cache using the computed or generated key.
+
+A method annotated with `CacheResult` is protected by a lock on cache miss mechanism.
+If several concurrent invocations try to retrieve a cache value from the same missing key, the method will only be invoked once.
+The first concurrent invocation will trigger the method invocation while the subsequent concurrent invocations will wait for the end of the method invocation to get the cached result.
+The `lockTimeout` parameter can be used to interrupt the lock after a given delay.
+The lock timeout is disabled by default, meaning the lock is never interrupted.
+See the parameter Javadoc for more details.
+
+This annotation cannot be used on a method returning `void`.
+
+You can only use one of the cache operations (and this annotation) on a given method: `@CacheResult`, `@CacheInvalidate` or `@CacheInvalidateAll`.
+
+=== @CacheInvalidate
+
+Removes an entry from the cache.
+
+When a method annotated with `@CacheInvalidate` is invoked, Quarkus will compute a cache key and use it to try to remove an existing entry from the cache.
+If the method has one or more arguments, the key computation is done from all the method arguments if none of them is annotated with `@CacheKey`, or all the arguments annotated with `@CacheKey` otherwise.
+This annotation can also be used on a method with no arguments, a default key derived from the cache name is generated in that case.
+If the key does not identify any cache entry, nothing will happen.
+
+You can only use one of the cache operations (and this annotation) on a given method: `@CacheResult`, `@CacheInvalidate` or `@CacheInvalidateAll`.
+
+[TIP]
+====
+If the `@CacheResult` or `@CacheInvalidate` annotations are used on a method with no parameters, a unique default cache key derived from the cache name will be generated and used.
+====
+
+=== @CacheInvalidateAll
+
+When a method annotated with `@CacheInvalidateAll` is invoked, Quarkus will remove all entries from the cache.
+
+You can only use one of the cache operations (and this annotation) on a given method: `@CacheResult`, `@CacheInvalidate` or `@CacheInvalidateAll`.
+
+=== @CacheKey
+
+When a method argument is annotated with `@CacheKey`, it is identified as a part of the cache key during an invocation of a
+method annotated with `@CacheResult` or `@CacheInvalidate`.
+
+This annotation is optional and should only be used when some of the method arguments are NOT part of the cache key.
+
+== Configuring the underlying caching provider
+
+This extension uses https://github.com/ben-manes/caffeine[Caffeine] as its underlying caching provider.
+Caffeine is a high performance, near optimal caching library.
+
+=== Caffeine configuration properties
+
+Each of the Caffeine caches backing up the Quarkus application data caching extension can be configured using the following
+properties in the `application.properties` file.
+
+[TIP]
+====
+You need to replace `cache-name` in all of the following properties with the real name of the cache you want to configure.
+====
+
+include::{generated-dir}/config/quarkus-cache-config-group-cache-config-caffeine-config.adoc[opts=optional, leveloffset=+1]
+
+Here's what your cache configuration could look like:
+
+[source,properties]
+----
+quarkus.cache.caffeine."foo".initial-capacity=10 <1>
+quarkus.cache.caffeine."foo".maximum-size=20 <1>
+quarkus.cache.caffeine."foo".expire-after-write <1>
+quarkus.cache.caffeine."bar".maximum-size=1000 <2>
+----
+<1> The `foo` cache is being configured.
+<2> The `bar` cache is being configured.
+
+== Annotated beans examples
+
+=== Implicit simple cache key
+
+[source,java]
+----
+package org.acme.caching;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+
+@ApplicationScoped
+public class CachedBean {
+
+    @CacheResult(cacheName = "foo")
+    public Object load(Object key) { <1>
+        // Call expensive service here.
+    }
+
+    @CacheInvalidate(cacheName = "foo")
+    public void invalidate(Object key) { <1>
+    }
+
+    @CacheInvalidateAll(cacheName = "foo")
+    public void invalidateAll() {
+    }
+}
+----
+<1> The cache key is implicit since there's no `@CacheKey` annotation.
+
+=== Explicit composite cache key
+
+[source,java]
+----
+package org.acme.caching;
+
+import javax.enterprise.context.Dependent;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+
+@Dependent
+public class CachedService {
+
+    @CacheResult(cacheName = "foo")
+    public String load(@CacheKey Object keyElement1, @CacheKey Object keyElement2, Object notPartOfTheKey) { <1>
+        // Call expensive service here.
+    }
+
+    @CacheInvalidate(cacheName = "foo")
+    public void invalidate(@CacheKey Object keyElement1, @CacheKey Object keyElement2, Object notPartOfTheKey) { <1>
+    }
+
+    @CacheInvalidateAll(cacheName = "foo")
+    public void invalidateAll() {
+    }
+}
+----
+<1> The cache key is explicitly composed of two elements. The method signature also contains a third argument which is not part of the key.
+
+=== Default cache key
+
+[source,java]
+----
+package org.acme.caching;
+
+import javax.enterprise.context.Dependent;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+
+@Dependent
+public class CachedService {
+
+    @CacheResult(cacheName = "foo")
+    public String load() { <1>
+        // Call expensive service here.
+    }
+
+    @CacheInvalidate(cacheName = "foo")
+    public void invalidate() { <1>
+    }
+
+    @CacheInvalidateAll(cacheName = "foo")
+    public void invalidateAll() {
+    }
+}
+----
+<1> A unique default cache key derived from the cache name is generated and used.

--- a/extensions/cache/deployment/pom.xml
+++ b/extensions/cache/deployment/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-cache-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-cache-deployment</artifactId>
+    <name>Quarkus - Cache - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-caffeine-deployment</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheAnnotationsTransformer.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheAnnotationsTransformer.java
@@ -1,0 +1,65 @@
+package io.quarkus.cache.deployment;
+
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.AUGMENTED_CACHE_INVALIDATE;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.AUGMENTED_CACHE_INVALIDATE_ALL;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.AUGMENTED_CACHE_RESULT;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_INVALIDATE;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_INVALIDATE_ALL;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_NAME_PARAMETER_NAME;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_RESULT;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.LOCK_TIMEOUT_PARAMETER_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.arc.processor.AnnotationsTransformer;
+
+/**
+ * This class transforms at build time the caching API annotations (which have a mandatory {@code cacheName} parameter and can
+ * only be used on methods) into augmented annotations that are used as interceptors bindings for the caching interceptors.
+ */
+public class CacheAnnotationsTransformer implements AnnotationsTransformer {
+
+    @Override
+    public boolean appliesTo(Kind kind) {
+        return Kind.METHOD == kind;
+    }
+
+    @Override
+    public void transform(TransformationContext context) {
+        MethodInfo method = context.getTarget().asMethod();
+        if (method.hasAnnotation(CACHE_RESULT)) {
+            List<AnnotationValue> parameters = new ArrayList<>();
+            parameters.add(getCacheName(method, CACHE_RESULT));
+            findLockTimeout(method, CACHE_RESULT).ifPresent(parameters::add);
+            context.transform().add(AUGMENTED_CACHE_RESULT, parameters.toArray(new AnnotationValue[parameters.size()])).done();
+        }
+        if (method.hasAnnotation(CACHE_INVALIDATE)) {
+            AnnotationValue cacheName = getCacheName(method, CACHE_INVALIDATE);
+            context.transform().add(AUGMENTED_CACHE_INVALIDATE, cacheName).done();
+        }
+        if (method.hasAnnotation(CACHE_INVALIDATE_ALL)) {
+            AnnotationValue cacheName = getCacheName(method, CACHE_INVALIDATE_ALL);
+            context.transform().add(AUGMENTED_CACHE_INVALIDATE_ALL, cacheName).done();
+        }
+    }
+
+    private AnnotationValue getCacheName(MethodInfo method, DotName apiAnnotation) {
+        String cacheName = method.annotation(apiAnnotation).value(CACHE_NAME_PARAMETER_NAME).asString();
+        return AnnotationValue.createStringValue(CACHE_NAME_PARAMETER_NAME, cacheName);
+    }
+
+    private Optional<AnnotationValue> findLockTimeout(MethodInfo method, DotName apiAnnotation) {
+        AnnotationValue lockTimeout = method.annotation(apiAnnotation).value(LOCK_TIMEOUT_PARAMETER_NAME);
+        if (lockTimeout == null) {
+            return Optional.empty();
+        }
+        return Optional.of(AnnotationValue.createLongalue(LOCK_TIMEOUT_PARAMETER_NAME, lockTimeout.asLong()));
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheConfig.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheConfig.java
@@ -1,0 +1,72 @@
+package io.quarkus.cache.deployment;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot
+public class CacheConfig {
+
+    /**
+     * Cache type.
+     */
+    @ConfigItem(defaultValue = CacheDeploymentConstants.CAFFEINE_CACHE_TYPE)
+    String type;
+
+    /**
+     * Caffeine configuration.
+     */
+    CaffeineConfig caffeine;
+
+    @ConfigGroup
+    public static class CaffeineConfig {
+
+        /**
+         * Namespace configuration.
+         */
+        @ConfigItem(name = ConfigItem.PARENT)
+        @ConfigDocMapKey("cache-name")
+        Map<String, CaffeineNamespaceConfig> namespace;
+
+        @ConfigGroup
+        public static class CaffeineNamespaceConfig {
+
+            /**
+             * Minimum total size for the internal data structures. Providing a large enough estimate at construction time
+             * avoids the need for expensive resizing operations later, but setting this value unnecessarily high wastes memory.
+             */
+            @ConfigItem
+            OptionalInt initialCapacity;
+
+            /**
+             * Maximum number of entries the cache may contain. Note that the cache <b>may evict an entry before this limit is
+             * exceeded or temporarily exceed the threshold while evicting</b>. As the cache size grows close to the maximum,
+             * the cache evicts entries that are less likely to be used again. For example, the cache may evict an entry because
+             * it hasn't been used recently or very often.
+             */
+            @ConfigItem
+            OptionalLong maximumSize;
+
+            /**
+             * Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after
+             * the entry's creation, or the most recent replacement of its value.
+             */
+            @ConfigItem
+            Optional<Duration> expireAfterWrite;
+
+            /**
+             * Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after
+             * the entry's creation, the most recent replacement of its value, or its last read.
+             */
+            @ConfigItem
+            Optional<Duration> expireAfterAccess;
+        }
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
@@ -1,0 +1,33 @@
+package io.quarkus.cache.deployment;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.runtime.augmented.AugmentedCacheInvalidate;
+import io.quarkus.cache.runtime.augmented.AugmentedCacheInvalidateAll;
+import io.quarkus.cache.runtime.augmented.AugmentedCacheResult;
+
+public class CacheDeploymentConstants {
+
+    public static final DotName CACHE_RESULT = dotName(CacheResult.class);
+    public static final DotName CACHE_INVALIDATE = dotName(CacheInvalidate.class);
+    public static final DotName CACHE_INVALIDATE_ALL = dotName(CacheInvalidateAll.class);
+    public static final DotName AUGMENTED_CACHE_RESULT = dotName(AugmentedCacheResult.class);
+    public static final DotName AUGMENTED_CACHE_INVALIDATE = dotName(AugmentedCacheInvalidate.class);
+    public static final DotName AUGMENTED_CACHE_INVALIDATE_ALL = dotName(AugmentedCacheInvalidateAll.class);
+    public static final List<DotName> ALL_CACHE_ANNOTATIONS = Arrays.asList(CACHE_RESULT, CACHE_INVALIDATE,
+            CACHE_INVALIDATE_ALL);
+
+    public static final String CAFFEINE_CACHE_TYPE = "caffeine";
+    public static final String CACHE_NAME_PARAMETER_NAME = "cacheName";
+    public static final String LOCK_TIMEOUT_PARAMETER_NAME = "lockTimeout";
+
+    private static DotName dotName(Class<?> annotationClass) {
+        return DotName.createSimple(annotationClass.getName());
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheMethodValidator.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheMethodValidator.java
@@ -1,0 +1,52 @@
+package io.quarkus.cache.deployment;
+
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_INVALIDATE;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_INVALIDATE_ALL;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_RESULT;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+import io.quarkus.arc.processor.AnnotationStore;
+import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.cache.deployment.exception.IllegalReturnTypeException;
+import io.quarkus.cache.deployment.exception.MultipleCacheAnnotationsException;
+
+public class CacheMethodValidator {
+
+    public static void validateAnnotations(AnnotationStore annotationStore, BeanInfo bean, MethodInfo method,
+            List<Throwable> throwables) {
+        int methodAnnotationsCount = 0;
+        if (annotationStore.getAnnotation(method, CACHE_RESULT) != null) {
+            checkVoidReturnType(CACHE_RESULT, bean, method).ifPresent(throwables::add);
+            methodAnnotationsCount++;
+        }
+        if (annotationStore.getAnnotation(method, CACHE_INVALIDATE) != null) {
+            methodAnnotationsCount++;
+        }
+        if (annotationStore.getAnnotation(method, CACHE_INVALIDATE_ALL) != null) {
+            methodAnnotationsCount++;
+        }
+        if (methodAnnotationsCount > 1) {
+            String error = "Multiple incompatible cache annotations found on the same method";
+            throwables.add(new MultipleCacheAnnotationsException(buildExceptionMessage(error, bean.getBeanClass(), method)));
+        }
+    }
+
+    private static Optional<IllegalReturnTypeException> checkVoidReturnType(DotName annotation, BeanInfo bean,
+            MethodInfo method) {
+        if (method.returnType().kind() == Type.Kind.VOID) {
+            String error = annotation + " annotation is not allowed on a method returning void";
+            return Optional.of(new IllegalReturnTypeException(buildExceptionMessage(error, bean.getBeanClass(), method)));
+        }
+        return Optional.empty();
+    }
+
+    private static String buildExceptionMessage(String error, DotName beanClass, MethodInfo method) {
+        return error + ": [class: " + beanClass + ", method: " + method + "]";
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
@@ -1,0 +1,101 @@
+package io.quarkus.cache.deployment;
+
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.ALL_CACHE_ANNOTATIONS;
+import static io.quarkus.cache.deployment.CacheDeploymentConstants.CACHE_NAME_PARAMETER_NAME;
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+import static org.jboss.jandex.AnnotationTarget.Kind.METHOD;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
+import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
+import io.quarkus.arc.processor.AnnotationStore;
+import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.arc.processor.BuildExtension.Key;
+import io.quarkus.cache.runtime.augmented.AugmentedCacheInvalidateAllInterceptor;
+import io.quarkus.cache.runtime.augmented.AugmentedCacheInvalidateInterceptor;
+import io.quarkus.cache.runtime.augmented.AugmentedCacheResultInterceptor;
+import io.quarkus.cache.runtime.caffeine.CaffeineCacheBuildRecorder;
+import io.quarkus.cache.runtime.caffeine.CaffeineCacheInfo;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class CacheProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FeatureBuildItem.CACHE);
+    }
+
+    @BuildStep
+    AnnotationsTransformerBuildItem annotationsTransformer() {
+        return new AnnotationsTransformerBuildItem(new CacheAnnotationsTransformer());
+    }
+
+    @BuildStep
+    List<AdditionalBeanBuildItem> additionalBeans() {
+        return Arrays.asList(
+                new AdditionalBeanBuildItem(AugmentedCacheInvalidateAllInterceptor.class),
+                new AdditionalBeanBuildItem(AugmentedCacheInvalidateInterceptor.class),
+                new AdditionalBeanBuildItem(AugmentedCacheResultInterceptor.class));
+    }
+
+    @BuildStep
+    ValidationErrorBuildItem validateBeanDeployment(ValidationPhaseBuildItem validationPhase) {
+        AnnotationStore annotationStore = validationPhase.getContext().get(Key.ANNOTATION_STORE);
+        List<Throwable> throwables = new ArrayList<>();
+        for (BeanInfo bean : validationPhase.getContext().get(Key.BEANS)) {
+            if (bean.isClassBean()) {
+                for (MethodInfo method : bean.getTarget().get().asClass().methods()) {
+                    if (annotationStore.hasAnyAnnotation(method, ALL_CACHE_ANNOTATIONS)) {
+                        CacheMethodValidator.validateAnnotations(annotationStore, bean, method, throwables);
+                    }
+                }
+            }
+        }
+        return new ValidationErrorBuildItem(throwables.toArray(new Throwable[throwables.size()]));
+    }
+
+    @BuildStep
+    @Record(STATIC_INIT)
+    void recordCachesBuild(CombinedIndexBuildItem combinedIndex, BeanContainerBuildItem beanContainer, CacheConfig config,
+            CaffeineCacheBuildRecorder caffeineRecorder) {
+        Set<String> cacheNames = getCacheNames(combinedIndex.getIndex());
+        switch (config.type) {
+            case CacheDeploymentConstants.CAFFEINE_CACHE_TYPE:
+                Set<CaffeineCacheInfo> cacheInfos = CaffeineCacheInfoBuilder.build(cacheNames, config);
+                caffeineRecorder.buildCaches(beanContainer.getValue(), cacheInfos);
+                break;
+            default:
+                throw new DeploymentException("Unknown cache type: " + config.type);
+        }
+    }
+
+    private Set<String> getCacheNames(IndexView index) {
+        Set<String> cacheNames = new HashSet<>();
+        for (DotName cacheAnnotation : ALL_CACHE_ANNOTATIONS) {
+            for (AnnotationInstance annotation : index.getAnnotations(cacheAnnotation)) {
+                if (annotation.target().kind() == METHOD) {
+                    cacheNames.add(annotation.value(CACHE_NAME_PARAMETER_NAME).asString());
+                }
+            }
+        }
+        return cacheNames;
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CaffeineCacheInfoBuilder.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CaffeineCacheInfoBuilder.java
@@ -1,0 +1,27 @@
+package io.quarkus.cache.deployment;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.quarkus.cache.deployment.CacheConfig.CaffeineConfig.CaffeineNamespaceConfig;
+import io.quarkus.cache.runtime.caffeine.CaffeineCacheInfo;
+
+public class CaffeineCacheInfoBuilder {
+
+    public static Set<CaffeineCacheInfo> build(Set<String> cacheNames, CacheConfig cacheConfig) {
+        return cacheNames.stream().map(cacheName -> {
+            CaffeineCacheInfo cacheInfo = new CaffeineCacheInfo();
+            cacheInfo.name = cacheName;
+
+            CaffeineNamespaceConfig namespaceConfig = cacheConfig.caffeine.namespace.get(cacheInfo.name);
+            if (namespaceConfig != null) {
+                namespaceConfig.initialCapacity.ifPresent(capacity -> cacheInfo.initialCapacity = capacity);
+                namespaceConfig.maximumSize.ifPresent(size -> cacheInfo.maximumSize = size);
+                namespaceConfig.expireAfterWrite.ifPresent(delay -> cacheInfo.expireAfterWrite = delay);
+                namespaceConfig.expireAfterAccess.ifPresent(delay -> cacheInfo.expireAfterAccess = delay);
+            }
+
+            return cacheInfo;
+        }).collect(Collectors.toSet());
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/exception/IllegalReturnTypeException.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/exception/IllegalReturnTypeException.java
@@ -1,0 +1,9 @@
+package io.quarkus.cache.deployment.exception;
+
+@SuppressWarnings("serial")
+public class IllegalReturnTypeException extends RuntimeException {
+
+    public IllegalReturnTypeException(String message) {
+        super(message);
+    }
+}

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/exception/MultipleCacheAnnotationsException.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/exception/MultipleCacheAnnotationsException.java
@@ -1,0 +1,9 @@
+package io.quarkus.cache.deployment.exception;
+
+@SuppressWarnings("serial")
+public class MultipleCacheAnnotationsException extends RuntimeException {
+
+    public MultipleCacheAnnotationsException(String message) {
+        super(message);
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheConfigTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheConfigTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.cache.test.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.runtime.CacheRepository;
+import io.quarkus.cache.runtime.caffeine.CaffeineCache;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CacheConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClass(TestResource.class).addAsResource(
+                            "cache-config-test.properties", "application.properties"));
+
+    private static final String CACHE_NAME = "test-cache";
+
+    @Inject
+    CacheRepository cacheRepository;
+
+    @Test
+    public void testConfig() {
+        CaffeineCache cache = (CaffeineCache) cacheRepository.getCache(CACHE_NAME);
+        assertEquals(10, cache.getInitialCapacity());
+        assertEquals(100L, cache.getMaximumSize());
+        assertEquals(Duration.ofSeconds(30L), cache.getExpireAfterWrite());
+        assertEquals(Duration.ofDays(2L), cache.getExpireAfterAccess());
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        @CacheResult(cacheName = CACHE_NAME)
+        public String foo(String key) {
+            return "bar";
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheResultVoidReturnTypeTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheResultVoidReturnTypeTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.cache.test.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.deployment.exception.IllegalReturnTypeException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CacheResultVoidReturnTypeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(TestResource.class)).assertException(e -> {
+                assertEquals(DeploymentException.class, e.getClass());
+                assertEquals(IllegalReturnTypeException.class, e.getCause().getClass());
+            });
+
+    @Test
+    public void shouldNotBeInvoked() {
+        fail("This method should not be invoked");
+    }
+
+    @Path("/test")
+    static class TestResource {
+
+        @GET
+        @CacheResult(cacheName = "test-cache")
+        public void shouldThrowDeploymentException(String key) {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/MultipleCacheAnnotationsTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/MultipleCacheAnnotationsTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.cache.test.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.deployment.exception.MultipleCacheAnnotationsException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleCacheAnnotationsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(TestResource.class)).assertException(e -> {
+                assertEquals(DeploymentException.class, e.getClass());
+                assertEquals(MultipleCacheAnnotationsException.class, e.getCause().getClass());
+            });
+
+    @Test
+    public void shouldNotBeInvoked() {
+        fail("This method should not be invoked");
+    }
+
+    @Path("/test")
+    static class TestResource {
+
+        private static final String CACHE_NAME = "multipleCacheAnnotationsCache";
+
+        @GET
+        @CacheResult(cacheName = CACHE_NAME)
+        @CacheInvalidateAll(cacheName = CACHE_NAME)
+        public String shouldThrowDeploymentException(String key) {
+            return null;
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/UnknownCacheTypeTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/UnknownCacheTypeTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.cache.test.deployment;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnknownCacheTypeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.cache.type=i_am_an_unknown_cache_type"), "application.properties"))
+            .setExpectedException(DeploymentException.class);
+
+    @Test
+    public void shouldNotBeInvoked() {
+        fail("This method should not be invoked");
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/devmode/CacheHotReloadResource.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/devmode/CacheHotReloadResource.java
@@ -1,0 +1,29 @@
+package io.quarkus.cache.test.devmode;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import io.quarkus.cache.CacheResult;
+
+@ApplicationScoped
+@Path("/cache-hot-reload-test")
+public class CacheHotReloadResource {
+
+    private int invocations;
+
+    @GET
+    @Path("/greet")
+    @CacheResult(cacheName = "hotReloadCache")
+    public String greet(@QueryParam("key") String key) {
+        invocations++;
+        return "hello " + key + "!";
+    }
+
+    @GET
+    @Path("/invocations")
+    public int getInvocations() {
+        return invocations;
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/devmode/CacheHotReloadTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/devmode/CacheHotReloadTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.cache.test.devmode;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Function;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class CacheHotReloadTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(CacheHotReloadResource.class));
+
+    @Test
+    public void testHotReload() {
+        checkInvocations("0");
+
+        checkBody("hello foo!");
+        checkInvocations("1");
+
+        checkBody("hello foo!");
+        checkInvocations("1");
+
+        TEST.modifySourceFile(CacheHotReloadResource.class.getSimpleName() + ".java", new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return s.replace("hello", "goodbye");
+            }
+        });
+
+        checkInvocations("0");
+
+        checkBody("goodbye foo!");
+        checkInvocations("1");
+
+        checkBody("goodbye foo!");
+        checkInvocations("1");
+    }
+
+    private void checkInvocations(String expectedBody) {
+        RestAssured.when().get("/cache-hot-reload-test/invocations").then().statusCode(200)
+                .body(is(expectedBody));
+    }
+
+    private void checkBody(String expectedBody) {
+        RestAssured.when().get("/cache-hot-reload-test/greet?key=foo").then().statusCode(200)
+                .body(is(expectedBody));
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheKeyBuilderTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheKeyBuilderTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.cache.runtime.CacheKeyBuilder;
+
+public class CacheKeyBuilderTest {
+
+    @Test
+    public void testInvalidKeyElements() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            CacheKeyBuilder.build(null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            CacheKeyBuilder.build(Collections.emptyList());
+        });
+        assertThrows(NullPointerException.class, () -> {
+            CacheKeyBuilder.build(Collections.singletonList(null));
+        }, CacheKeyBuilder.NULL_KEYS_NOT_SUPPORTED_MSG);
+    }
+
+    @Test
+    public void testSimpleKey() {
+        String keyElement = "quarkus";
+
+        // A cache key with one element should be the element itself (same object reference).
+        Object simpleKey1 = CacheKeyBuilder.build(Collections.singletonList(keyElement));
+        assertTrue(keyElement == simpleKey1);
+
+        // Two cache keys built from the same single element should have the same object reference.
+        Object simpleKey2 = CacheKeyBuilder.build(Collections.singletonList(keyElement));
+        assertTrue(simpleKey1 == simpleKey2);
+
+        // Two cache keys built from different single elements should not be equal.
+        Object simpleKey3 = CacheKeyBuilder.build(Collections.singletonList(Boolean.valueOf("true")));
+        assertNotEquals(simpleKey2, simpleKey3);
+    }
+
+    @Test
+    public void testCompositeKey() {
+        String keyElement1 = "quarkus";
+        long keyElement2 = 123L;
+        Object keyElement3 = new Object();
+
+        // Two cache keys built from the same elements and in the same order should be equal.
+        Object compositeKey1 = CacheKeyBuilder.build(Arrays.asList(keyElement1, keyElement2, keyElement3));
+        Object compositeKey2 = CacheKeyBuilder.build(Arrays.asList(keyElement1, keyElement2, keyElement3));
+        assertEquals(compositeKey1, compositeKey2);
+
+        // Two cache keys built from the same elements but not in the same order should not be equal.
+        Object compositeKey3 = CacheKeyBuilder.build(Arrays.asList(keyElement2, keyElement1, keyElement3));
+        assertNotEquals(compositeKey2, compositeKey3);
+
+        // Two cache keys built from a different number of elements should not be equal.
+        Object compositeKey4 = CacheKeyBuilder
+                .build(Arrays.asList(keyElement1, keyElement2, keyElement3, keyElement1, keyElement2, keyElement3));
+        assertNotEquals(compositeKey2, compositeKey4);
+
+        // Two cache keys built from multiple elements should only be equal if all elements are equal pairwise.
+        Object compositeKey5 = CacheKeyBuilder.build(Arrays.asList(new AtomicInteger(456), keyElement2, keyElement3));
+        assertNotEquals(compositeKey2, compositeKey5);
+        Object compositeKey6 = CacheKeyBuilder.build(Arrays.asList(keyElement1, new Object(), keyElement3));
+        assertNotEquals(compositeKey2, compositeKey6);
+        Object compositeKey7 = CacheKeyBuilder.build(Arrays.asList(keyElement1, keyElement2, new BigDecimal(10)));
+        assertNotEquals(compositeKey2, compositeKey7);
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheResultCompletionStageReturnTypeTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheResultCompletionStageReturnTypeTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CacheResultCompletionStageReturnTypeTest {
+
+    private static final Object KEY_1 = new Object();
+    private static final Object KEY_2 = new Object();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() throws InterruptedException, ExecutionException {
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        CompletionStage<Object> completionStage1 = cachedService.cachedMethod(KEY_1);
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        CompletionStage<Object> completionStage2 = cachedService.cachedMethod(KEY_1);
+        assertTrue(completionStage1 == completionStage2);
+
+        // STEP 3
+        // Action: same call as STEP 2 with a new key.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 3 results.
+        CompletionStage<Object> completionStage3 = cachedService.cachedMethod(KEY_2);
+        assertTrue(completionStage2 != completionStage3);
+
+        // We need all of the futures to complete at this point.
+        CompletableFuture.allOf(completionStage1.toCompletableFuture(), completionStage2.toCompletableFuture(),
+                completionStage3.toCompletableFuture()).get();
+
+        Object value1 = completionStage1.toCompletableFuture().get();
+        Object value2 = completionStage2.toCompletableFuture().get();
+        Object value3 = completionStage3.toCompletableFuture().get();
+
+        // Values objects references resulting from STEPS 1 and 2 should be equal since the same cache key was used.
+        assertTrue(value1 == value2);
+
+        // Values objects references resulting from STEPS 2 and 3 should be different since a different cache key was used.
+        assertTrue(value2 != value3);
+    }
+
+    @ApplicationScoped
+    static class CachedService {
+
+        // This is required to make sure the CompletableFuture from the tests are executed concurrently.
+        private ExecutorService executorService = Executors.newFixedThreadPool(3);
+
+        @CacheResult(cacheName = "test-cache")
+        public CompletionStage<Object> cachedMethod(Object key) {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    // This is another requirement for concurrent CompletableFuture executions.
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return new Object();
+            }, executorService);
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CaffeineCacheLockTimeoutTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CaffeineCacheLockTimeoutTest.java
@@ -1,0 +1,112 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CaffeineCacheLockTimeoutTest {
+
+    private static final Object TIMEOUT_KEY = new Object();
+    private static final Object NO_TIMEOUT_KEY = new Object();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+            .addAsResource(new StringAsset("quarkus.cache.type=caffeine"), "application.properties")
+            .addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testConcurrentCacheAccessWithLockTimeout() throws InterruptedException, ExecutionException {
+        // This is required to make sure the CompletableFuture from this test are executed concurrently.
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        CompletableFuture<Object> future1 = CompletableFuture.supplyAsync(() -> {
+            try {
+                return cachedService.cachedMethodWithLockTimeout(TIMEOUT_KEY);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, executorService);
+
+        CompletableFuture<Object> future2 = CompletableFuture.supplyAsync(() -> {
+            try {
+                return cachedService.cachedMethodWithLockTimeout(TIMEOUT_KEY);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, executorService);
+
+        CompletableFuture.allOf(future1, future2).get();
+
+        // The following assertion checks that the objects references resulting from both futures executions are different,
+        // which means the method was invoked twice because the lock timeout was triggered.
+        assertTrue(future1.get() != future2.get());
+    }
+
+    @Test
+    public void testConcurrentCacheAccessWithoutLockTimeout() throws InterruptedException, ExecutionException {
+        // This is required to make sure the CompletableFuture from this test are executed concurrently.
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        CompletableFuture<Object> future1 = CompletableFuture.supplyAsync(() -> {
+            try {
+                return cachedService.cachedMethodWithoutLockTimeout(NO_TIMEOUT_KEY);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, executorService);
+
+        CompletableFuture<Object> future2 = CompletableFuture.supplyAsync(() -> {
+            try {
+                return cachedService.cachedMethodWithoutLockTimeout(NO_TIMEOUT_KEY);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }, executorService);
+
+        CompletableFuture.allOf(future1, future2).get();
+
+        // The following assertion checks that the objects references resulting from both futures executions are the same,
+        // which means the method was invoked once and the lock timeout was NOT triggered.
+        assertTrue(future1.get() == future2.get());
+    }
+
+    @Singleton
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME, lockTimeout = 500)
+        public Object cachedMethodWithLockTimeout(Object key) throws InterruptedException {
+            // The following sleep is longer than the @CacheResult lockTimeout parameter value, a timeout will be triggered if
+            // two concurrent calls are made at the same time.
+            Thread.sleep(1000);
+            return new Object();
+        }
+
+        @CacheResult(cacheName = CACHE_NAME, lockTimeout = 1000)
+        public Object cachedMethodWithoutLockTimeout(Object key) throws InterruptedException {
+            // The following sleep is shorter than the @CacheResult lockTimeout parameter value, two concurrent calls made at
+            // the same time won't trigger a timeout.
+            Thread.sleep(500);
+            return new Object();
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/DefaultKeyCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/DefaultKeyCacheTest.java
@@ -1,0 +1,118 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests a cache with a <b>default</b> cache key.
+ */
+public class DefaultKeyCacheTest {
+
+    private static final Object KEY = new Object();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+        // STEP 1
+        // Action: no-arg @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethod();
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethod();
+        assertTrue(value1 == value2);
+
+        // STEP 3
+        // Action: @CacheResult-annotated method call with a key argument.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 3 results.
+        String value3 = cachedService.cachedMethodWithKey(KEY);
+        assertTrue(value2 != value3);
+
+        // STEP 4
+        // Action: default key cache entry invalidation.
+        // Expected effect: STEP 2 cache entry removed.
+        // Verified by: STEP 5.
+        cachedService.invalidate();
+
+        // STEP 5
+        // Action: same call as STEP 2.
+        // Expected effect: method invoked because of STEP 4 and result cached.
+        // Verified by: different objects references between STEPS 2 and 5 results.
+        String value5 = cachedService.cachedMethod();
+        assertTrue(value2 != value5);
+
+        // STEP 6
+        // Action: same call as STEP 3.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 3 and 6 results.
+        String value6 = cachedService.cachedMethodWithKey(KEY);
+        assertTrue(value3 == value6);
+
+        // STEP 7
+        // Action: full cache invalidation.
+        // Expected effect: empty cache.
+        // Verified by: STEPS 8 and 9.
+        cachedService.invalidateAll();
+
+        // STEP 8
+        // Action: same call as STEP 5.
+        // Expected effect: method invoked because of STEP 7 and result cached.
+        // Verified by: different objects references between STEPS 5 and 8 results.
+        String value8 = cachedService.cachedMethod();
+        assertTrue(value5 != value8);
+
+        // STEP 9
+        // Action: same call as STEP 6.
+        // Expected effect: method invoked because of STEP 7 and result cached.
+        // Verified by: different objects references between STEPS 6 and 9 results.
+        String value9 = cachedService.cachedMethodWithKey(KEY);
+        assertTrue(value6 != value9);
+    }
+
+    @Singleton
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public String cachedMethod() {
+            return new String();
+        }
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public String cachedMethodWithKey(Object key) {
+            return new String();
+        }
+
+        @CacheInvalidate(cacheName = CACHE_NAME)
+        public void invalidate() {
+        }
+
+        @CacheInvalidateAll(cacheName = CACHE_NAME)
+        public void invalidateAll() {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ExplicitCompositeKeyCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ExplicitCompositeKeyCacheTest.java
@@ -1,0 +1,139 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests a cache with <b>explicit composite</b> cache keys.<br>
+ * All methods with {@link CacheKey @CacheKey}-annotated arguments also have another argument which is not part of the key.
+ */
+public class ExplicitCompositeKeyCacheTest {
+
+    private static final Locale KEY_1_ELEMENT_1 = Locale.US;
+    private static final BigDecimal KEY_1_ELEMENT_2 = new BigDecimal(123);
+    private static final Locale KEY_2_ELEMENT_1 = Locale.FRANCE;
+    private static final BigDecimal KEY_2_ELEMENT_2 = new BigDecimal(456);
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+
+        // In most of the cached service methods calls below, a changing third argument will be passed to the methods.
+        // The fact that it changes each time should not have any effect on the cache because it is not part of the cache key.
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2, new Object());
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2, new Object());
+        assertTrue(value1 == value2);
+
+        // STEP 3
+        // Action: same call as STEP 2 with a changing key element.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 3 results.
+        String value3 = cachedService.cachedMethod(KEY_1_ELEMENT_1, new BigDecimal(789), new Object());
+        assertTrue(value2 != value3);
+
+        // STEP 4
+        // Action: same principle as STEP 3, but this time we're changing the other key element.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 4 results.
+        String value4 = cachedService.cachedMethod(Locale.JAPAN, KEY_1_ELEMENT_2, new Object());
+        assertTrue(value2 != value4);
+
+        // STEP 5
+        // Action: same call as STEP 2 with an entirely new key.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 5 results.
+        String value5 = cachedService.cachedMethod(KEY_2_ELEMENT_1, KEY_2_ELEMENT_2, new Object());
+        assertTrue(value2 != value5);
+
+        // STEP 6
+        // Action: cache entry invalidation.
+        // Expected effect: STEP 2 cache entry removed.
+        // Verified by: STEP 7.
+        cachedService.invalidate(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2, new Object());
+
+        // STEP 7
+        // Action: same call as STEP 2.
+        // Expected effect: method invoked because of STEP 6 and result cached.
+        // Verified by: different objects references between STEPS 2 and 7 results.
+        String value7 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2, new Object());
+        assertTrue(value2 != value7);
+
+        // STEP 8
+        // Action: same call as STEP 5.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 5 and 8 results.
+        String value8 = cachedService.cachedMethod(KEY_2_ELEMENT_1, KEY_2_ELEMENT_2, new Object());
+        assertTrue(value5 == value8);
+
+        // STEP 9
+        // Action: full cache invalidation.
+        // Expected effect: empty cache.
+        // Verified by: STEPS 10 and 11.
+        cachedService.invalidateAll();
+
+        // STEP 10
+        // Action: same call as STEP 7.
+        // Expected effect: method invoked because of STEP 9 and result cached.
+        // Verified by: different objects references between STEPS 7 and 10 results.
+        String value10 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2, new Object());
+        assertTrue(value7 != value10);
+
+        // STEP 11
+        // Action: same call as STEP 8.
+        // Expected effect: method invoked because of STEP 9 and result cached.
+        // Verified by: different objects references between STEPS 8 and 11 results.
+        String value11 = cachedService.cachedMethod(KEY_2_ELEMENT_1, KEY_2_ELEMENT_2, new Object());
+        assertTrue(value8 != value11);
+    }
+
+    @Dependent
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public String cachedMethod(@CacheKey Locale keyElement1, @CacheKey BigDecimal keyElement2, Object notPartOfTheKey) {
+            return new String();
+        }
+
+        @CacheInvalidate(cacheName = CACHE_NAME)
+        public void invalidate(@CacheKey Locale keyElement1, @CacheKey BigDecimal keyElement2, Object notPartOfTheKey) {
+        }
+
+        @CacheInvalidateAll(cacheName = CACHE_NAME)
+        public void invalidateAll() {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ExplicitSimpleKeyCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ExplicitSimpleKeyCacheTest.java
@@ -1,0 +1,120 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests a cache with <b>explicit simple</b> cache keys.<br>
+ * All methods with a {@link CacheKey @CacheKey}-annotated argument also have another argument which is not part of the key.
+ */
+public class ExplicitSimpleKeyCacheTest {
+
+    private static final long KEY_1 = 123L;
+    private static final long KEY_2 = 456L;
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+
+        // In most of the cached service methods calls below, a changing second argument will be passed to the methods.
+        // The fact that it changes each time should not have any effect on the cache because it is not part of the cache key.
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethod(KEY_1, new Object());
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethod(KEY_1, new Object());
+        assertTrue(value1 == value2);
+
+        // STEP 3
+        // Action: same call as STEP 2 with a new key.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 3 results.
+        String value3 = cachedService.cachedMethod(KEY_2, new Object());
+        assertTrue(value2 != value3);
+
+        // STEP 4
+        // Action: cache entry invalidation.
+        // Expected effect: STEP 2 cache entry removed.
+        // Verified by: STEP 5.
+        cachedService.invalidate(KEY_1, new Object());
+
+        // STEP 5
+        // Action: same call as STEP 2.
+        // Expected effect: method invoked because of STEP 4 and result cached.
+        // Verified by: different objects references between STEPS 2 and 5 results.
+        String value5 = cachedService.cachedMethod(KEY_1, new Object());
+        assertTrue(value2 != value5);
+
+        // STEP 6
+        // Action: same call as STEP 3.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 3 and 6 results.
+        String value6 = cachedService.cachedMethod(KEY_2, new Object());
+        assertTrue(value3 == value6);
+
+        // STEP 7
+        // Action: full cache invalidation.
+        // Expected effect: empty cache.
+        // Verified by: STEPS 8 and 9.
+        cachedService.invalidateAll();
+
+        // STEP 8
+        // Action: same call as STEP 5.
+        // Expected effect: method invoked because of STEP 7 and result cached.
+        // Verified by: different objects references between STEPS 5 and 8 results.
+        String value8 = cachedService.cachedMethod(KEY_1, new Object());
+        assertTrue(value5 != value8);
+
+        // STEP 9
+        // Action: same call as STEP 6.
+        // Expected effect: method invoked because of STEP 7 and result cached.
+        // Verified by: different objects references between STEPS 6 and 9 results.
+        String value9 = cachedService.cachedMethod(KEY_2, new Object());
+        assertTrue(value6 != value9);
+    }
+
+    @Dependent
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public String cachedMethod(@CacheKey long key, Object notPartOfTheKey) {
+            return new String();
+        }
+
+        @CacheInvalidate(cacheName = CACHE_NAME)
+        public void invalidate(@CacheKey long key, Object notPartOfTheKey) {
+        }
+
+        @CacheInvalidateAll(cacheName = CACHE_NAME)
+        public void invalidateAll() {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ImplicitCompositeKeyCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ImplicitCompositeKeyCacheTest.java
@@ -1,0 +1,130 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests a cache with <b>implicit composite</b> cache keys.
+ */
+public class ImplicitCompositeKeyCacheTest {
+
+    private static final String KEY_1_ELEMENT_1 = "foo";
+    private static final int KEY_1_ELEMENT_2 = 123;
+    private static final String KEY_2_ELEMENT_1 = "bar";
+    private static final int KEY_2_ELEMENT_2 = 456;
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2);
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2);
+        assertTrue(value1 == value2);
+
+        // STEP 3
+        // Action: same call as STEP 2 with a changing key element.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 3 results.
+        String value3 = cachedService.cachedMethod(KEY_1_ELEMENT_1, 789);
+        assertTrue(value2 != value3);
+
+        // STEP 4
+        // Action: same principle as STEP 3, but this time we're changing the other key element.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 4 results.
+        String value4 = cachedService.cachedMethod("quarkus", KEY_1_ELEMENT_2);
+        assertTrue(value2 != value4);
+
+        // STEP 5
+        // Action: same call as STEP 2 with an entirely new key.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 5 results.
+        String value5 = cachedService.cachedMethod(KEY_2_ELEMENT_1, KEY_2_ELEMENT_2);
+        assertTrue(value2 != value5);
+
+        // STEP 6
+        // Action: cache entry invalidation.
+        // Expected effect: STEP 2 cache entry removed.
+        // Verified by: STEP 7.
+        cachedService.invalidate(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2);
+
+        // STEP 7
+        // Action: same call as STEP 2.
+        // Expected effect: method invoked because of STEP 6 and result cached.
+        // Verified by: different objects references between STEPS 2 and 7 results.
+        String value7 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2);
+        assertTrue(value2 != value7);
+
+        // STEP 8
+        // Action: same call as STEP 5.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 5 and 8 results.
+        String value8 = cachedService.cachedMethod(KEY_2_ELEMENT_1, KEY_2_ELEMENT_2);
+        assertTrue(value5 == value8);
+
+        // STEP 9
+        // Action: full cache invalidation.
+        // Expected effect: empty cache.
+        // Verified by: STEPS 10 and 11.
+        cachedService.invalidateAll();
+
+        // STEP 10
+        // Action: same call as STEP 7.
+        // Expected effect: method invoked because of STEP 9 and result cached.
+        // Verified by: different objects references between STEPS 7 and 10 results.
+        String value10 = cachedService.cachedMethod(KEY_1_ELEMENT_1, KEY_1_ELEMENT_2);
+        assertTrue(value7 != value10);
+
+        // STEP 11
+        // Action: same call as STEP 8.
+        // Expected effect: method invoked because of STEP 9 and result cached.
+        // Verified by: different objects references between STEPS 8 and 11 results.
+        String value11 = cachedService.cachedMethod(KEY_2_ELEMENT_1, KEY_2_ELEMENT_2);
+        assertTrue(value8 != value11);
+    }
+
+    @Singleton
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public String cachedMethod(String keyElement1, int keyElement2) {
+            return new String();
+        }
+
+        @CacheInvalidate(cacheName = CACHE_NAME)
+        public void invalidate(String keyElement1, int keyElement2) {
+        }
+
+        @CacheInvalidateAll(cacheName = CACHE_NAME)
+        public void invalidateAll() {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ImplicitSimpleKeyCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ImplicitSimpleKeyCacheTest.java
@@ -1,0 +1,114 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests a cache with <b>implicit simple</b> cache keys.
+ */
+public class ImplicitSimpleKeyCacheTest {
+
+    private static final Object KEY_1 = new Object();
+    private static final Object KEY_2 = new Object();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        String value1 = cachedService.cachedMethod(KEY_1);
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        String value2 = cachedService.cachedMethod(KEY_1);
+        assertTrue(value1 == value2);
+
+        // STEP 3
+        // Action: same call as STEP 2 with a new key.
+        // Expected effect: method invoked and result cached.
+        // Verified by: different objects references between STEPS 2 and 3 results.
+        String value3 = cachedService.cachedMethod(KEY_2);
+        assertTrue(value2 != value3);
+
+        // STEP 4
+        // Action: cache entry invalidation.
+        // Expected effect: STEP 2 cache entry removed.
+        // Verified by: STEP 5.
+        cachedService.invalidate(KEY_1);
+
+        // STEP 5
+        // Action: same call as STEP 2.
+        // Expected effect: method invoked because of STEP 4 and result cached.
+        // Verified by: different objects references between STEPS 2 and 5 results.
+        String value5 = cachedService.cachedMethod(KEY_1);
+        assertTrue(value2 != value5);
+
+        // STEP 6
+        // Action: same call as STEP 3.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same object reference between STEPS 3 and 6 results.
+        String value6 = cachedService.cachedMethod(KEY_2);
+        assertTrue(value3 == value6);
+
+        // STEP 7
+        // Action: full cache invalidation.
+        // Expected effect: empty cache.
+        // Verified by: STEPS 8 and 9.
+        cachedService.invalidateAll();
+
+        // STEP 8
+        // Action: same call as STEP 5.
+        // Expected effect: method invoked because of STEP 7 and result cached.
+        // Verified by: different objects references between STEPS 5 and 8 results.
+        String value8 = cachedService.cachedMethod(KEY_1);
+        assertTrue(value5 != value8);
+
+        // STEP 9
+        // Action: same call as STEP 6.
+        // Expected effect: method invoked because of STEP 7 and result cached.
+        // Verified by: different objects references between STEPS 6 and 9 results.
+        String value9 = cachedService.cachedMethod(KEY_2);
+        assertTrue(value6 != value9);
+    }
+
+    @ApplicationScoped
+    static class CachedService {
+
+        static final String CACHE_NAME = "test-cache";
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public String cachedMethod(Object key) {
+            return new String();
+        }
+
+        @CacheInvalidate(cacheName = CACHE_NAME)
+        public void invalidate(Object key) {
+        }
+
+        @CacheInvalidateAll(cacheName = CACHE_NAME)
+        public void invalidateAll() {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/NullKeyOrValueCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/NullKeyOrValueCacheTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.cache.test.runtime;
+
+import static io.quarkus.cache.runtime.CacheKeyBuilder.NULL_KEYS_NOT_SUPPORTED_MSG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests {@code null} cache keys or values.
+ */
+public class NullKeyOrValueCacheTest {
+
+    private static final Object KEY = new Object();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
+
+    @Inject
+    CachedService cachedService;
+
+    @Test
+    public void testNullKeys() {
+        assertThrows(NullPointerException.class, () -> {
+            cachedService.cachedMethod(null);
+        }, NULL_KEYS_NOT_SUPPORTED_MSG);
+        assertThrows(NullPointerException.class, () -> {
+            cachedService.invalidate(null);
+        }, NULL_KEYS_NOT_SUPPORTED_MSG);
+    }
+
+    @Test
+    public void testNullValues() {
+        assertEquals(0, cachedService.getCachedMethodInvocations());
+
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached.
+        // Verified by: STEP 2.
+        Object value1 = cachedService.cachedMethod(KEY);
+        assertEquals(1, cachedService.getCachedMethodInvocations());
+        assertNull(value1);
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the cache.
+        // Verified by: same number of cached method invocations between STEPS 1 and 2.
+        Object value2 = cachedService.cachedMethod(KEY);
+        assertEquals(1, cachedService.getCachedMethodInvocations());
+        assertNull(value2);
+    }
+
+    @Dependent
+    static class CachedService {
+
+        private static final String CACHE_NAME = "test-cache";
+
+        private int cachedMethodInvocations;
+
+        @CacheResult(cacheName = CACHE_NAME)
+        public Object cachedMethod(Object key) {
+            cachedMethodInvocations++;
+            return null;
+        }
+
+        @CacheInvalidate(cacheName = CACHE_NAME)
+        public void invalidate(Object key) {
+        }
+
+        public int getCachedMethodInvocations() {
+            return cachedMethodInvocations;
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SharedCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SharedCacheTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.cache.test.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.test.runtime.ImplicitSimpleKeyCacheTest.CachedService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests a cache shared between different beans.
+ */
+public class SharedCacheTest {
+
+    private static final Object KEY = new Object();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClasses(CachedService.class, LocalCachedService.class));
+
+    @Inject
+    CachedService externalCachedService;
+
+    @Inject
+    LocalCachedService localCachedService;
+
+    @Test
+    public void testAllCacheAnnotations() {
+        // STEP 1
+        // Action: @CacheResult-annotated method call.
+        // Expected effect: method invoked and result cached in shared cache.
+        // Verified by: STEP 2.
+        String value1 = externalCachedService.cachedMethod(KEY);
+
+        // STEP 2
+        // Action: same call as STEP 1.
+        // Expected effect: method not invoked and result coming from the shared cache.
+        // Verified by: same object reference between STEPS 1 and 2 results.
+        String value2 = externalCachedService.cachedMethod(KEY);
+        assertTrue(value1 == value2);
+
+        // STEP 3
+        // Action: full shared cache invalidation launched from a different bean than STEPS 1 and 2 calls.
+        // Expected effect: empty cache.
+        // Verified by: STEPS 4.
+        localCachedService.invalidateAll();
+
+        // STEP 4
+        // Action: same call as STEP 2.
+        // Expected effect: method invoked because of STEP 3 and result cached.
+        // Verified by: different objects references between STEPS 2 and 4 results.
+        String value4 = externalCachedService.cachedMethod(KEY);
+        assertTrue(value2 != value4);
+    }
+
+    @Dependent
+    static class LocalCachedService {
+
+        @CacheInvalidateAll(cacheName = CachedService.CACHE_NAME)
+        public void invalidateAll() {
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/resources/cache-config-test.properties
+++ b/extensions/cache/deployment/src/test/resources/cache-config-test.properties
@@ -1,0 +1,4 @@
+quarkus.cache.caffeine."test-cache".initial-capacity=10
+quarkus.cache.caffeine."test-cache".maximum-size=100
+quarkus.cache.caffeine."test-cache".expire-after-write=30
+quarkus.cache.caffeine."test-cache".expire-after-access=P2D

--- a/extensions/cache/pom.xml
+++ b/extensions/cache/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-cache-parent</artifactId>
+    <name>Quarkus - Cache</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/cache/runtime/pom.xml
+++ b/extensions/cache/runtime/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-cache-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-cache</artifactId>
+    <name>Quarkus - Cache - Runtime</name>
+    <description>Enable application data caching in any CDI managed bean of your Quarkus application</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-caffeine</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheInvalidate.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheInvalidate.java
@@ -1,0 +1,31 @@
+package io.quarkus.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+
+/**
+ * When a method annotated with {@link CacheInvalidate} is invoked, Quarkus will compute a cache key and use it to try to
+ * remove an existing entry from the cache. If the method has one or more arguments, the key computation is done from all the
+ * method arguments if none of them is annotated with {@link CacheKey}, or all the arguments annotated with {@link CacheKey}
+ * otherwise. This annotation can also be used on a method with no arguments, a default key derived from the cache name is
+ * generated in that case. If the key does not identify any cache entry, nothing will happen.
+ * <p>
+ * You can only use one of the cache operations (and this annotation) on a given method: {@link CacheResult},
+ * {@link CacheInvalidate} or {@link CacheInvalidateAll}.
+ * <p>
+ * The underlying caching provider can be chosen and configured in the Quarkus {@link application.properties} file.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CacheInvalidate {
+
+    /**
+     * The name of the cache.
+     */
+    @Nonbinding
+    String cacheName();
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheInvalidateAll.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheInvalidateAll.java
@@ -1,0 +1,27 @@
+package io.quarkus.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+
+/**
+ * When a method annotated with {@link CacheInvalidateAll} is invoked, Quarkus will remove all entries from the cache.
+ * <p>
+ * You can only use one of the cache operations (and this annotation) on a given method: {@link CacheResult},
+ * {@link CacheInvalidate} or {@link CacheInvalidateAll}.
+ * <p>
+ * The underlying caching provider can be chosen and configured in the Quarkus {@link application.properties} file.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CacheInvalidateAll {
+
+    /**
+     * The name of the cache.
+     */
+    @Nonbinding
+    String cacheName();
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheKey.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheKey.java
@@ -1,0 +1,17 @@
+package io.quarkus.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When a method argument is annotated with {@link CacheKey}, it is identified as a part of a cache key during an invocation of
+ * a method annotated with {@link CacheResult} or {@link CacheInvalidate}.
+ * <p>
+ * This annotation is optional and should only be used when some of the method arguments are NOT part of the cache key.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface CacheKey {
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheResult.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CacheResult.java
@@ -1,0 +1,50 @@
+package io.quarkus.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+
+/**
+ * When a method annotated with {@link CacheResult} is invoked, Quarkus will compute a cache key and use it to check in the
+ * cache whether the method has been already invoked. If the method has one or more arguments, the key computation is done from
+ * all the method arguments if none of them is annotated with {@link CacheKey}, or all the arguments annotated with
+ * {@link CacheKey} otherwise. This annotation can also be used on a method with no arguments, a default key derived from the
+ * cache name is generated in that case. If a value is found in the cache, it is returned and the annotated method is never
+ * actually executed. If no value is found, the annotated method is invoked and the returned value is stored in the cache using
+ * the computed or generated key.
+ * <p>
+ * A method annotated with {@link CacheResult} is protected by a lock on cache miss mechanism. If several concurrent
+ * invocations try to retrieve a cache value from the same missing key, the method will only be invoked once. The first
+ * concurrent invocation will trigger the method invocation while the subsequent concurrent invocations will wait for the end
+ * of the method invocation to get the cached result. The {@code lockTimeout} parameter can be used to interrupt the lock after
+ * a given delay. The lock timeout is disabled by default, meaning the lock is never interrupted. See the parameter Javadoc for
+ * more details.
+ * <p>
+ * This annotation cannot be used on a method returning {@code void}.
+ * <p>
+ * You can only use one of the cache operations (and this annotation) on a given method: {@link CacheResult},
+ * {@link CacheInvalidate} or {@link CacheInvalidateAll}.
+ * <p>
+ * The underlying caching provider can be chosen and configured in the Quarkus {@link application.properties} file.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CacheResult {
+
+    /**
+     * The name of the cache.
+     */
+    @Nonbinding
+    String cacheName();
+
+    /**
+     * Delay in milliseconds before the lock on cache miss is interrupted. If such interruption happens, the cached method will
+     * be invoked and its result will be returned without being cached. A value of {@code 0} (which is the default one) means
+     * that the lock timeout is disabled.
+     */
+    @Nonbinding
+    long lockTimeout() default 0;
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheKeyBuilder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheKeyBuilder.java
@@ -1,0 +1,93 @@
+package io.quarkus.cache.runtime;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class CacheKeyBuilder {
+
+    public static final String NULL_KEYS_NOT_SUPPORTED_MSG = "Null keys are not supported by the Quarkus application data cache";
+
+    /**
+     * Builds a default immutable and unique cache key from a cache name. This key is intended to be used for no-args methods
+     * annotated with {@link io.quarkus.cache.CacheResult CacheResult} or {@link io.quarkus.cache.CacheInvalidate
+     * CacheInvalidate}.
+     * 
+     * @param cacheName cache name
+     * @return default immutable and unique cache key
+     */
+    public static Object buildDefault(String cacheName) {
+        return new DefaultCacheKey(cacheName);
+    }
+
+    /**
+     * Builds a cache key from a list of key elements. The list must be non-null and contain at least one key element.
+     * 
+     * @param keyElements key elements
+     * @return cache key
+     */
+    public static Object build(List<Object> keyElements) {
+        if (keyElements == null || keyElements.isEmpty()) {
+            throw new IllegalArgumentException("At least one key element is required to build a cache key");
+        } else if (keyElements.size() == 1) {
+            if (keyElements.get(0) == null) {
+                throw new NullPointerException(NULL_KEYS_NOT_SUPPORTED_MSG);
+            }
+            return keyElements.get(0);
+        } else {
+            return new CompositeCacheKey(keyElements);
+        }
+    }
+
+    private static class DefaultCacheKey {
+
+        private final String cacheName;
+
+        public DefaultCacheKey(String cacheName) {
+            this.cacheName = cacheName;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(cacheName);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof DefaultCacheKey) {
+                DefaultCacheKey other = (DefaultCacheKey) obj;
+                return Objects.equals(cacheName, other.cacheName);
+            }
+            return false;
+        }
+    }
+
+    private static class CompositeCacheKey {
+
+        private final Object[] keyElements;
+
+        public CompositeCacheKey(List<Object> keyElements) {
+            this.keyElements = keyElements.toArray(new Object[0]);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.deepHashCode(keyElements);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (CompositeCacheKey.class.isInstance(obj)) {
+                final CompositeCacheKey other = (CompositeCacheKey) obj;
+                return Arrays.deepEquals(keyElements, other.keyElements);
+            }
+            return false;
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheRepository.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheRepository.java
@@ -1,0 +1,26 @@
+package io.quarkus.cache.runtime;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.cache.runtime.caffeine.CaffeineCache;
+
+@ApplicationScoped
+public class CacheRepository {
+
+    // There's no need for concurrency here since the map is created at build time and never modified after that.
+    private Map<String, CaffeineCache> caches;
+
+    public void setCaches(Map<String, CaffeineCache> caches) {
+        if (this.caches != null) {
+            throw new IllegalStateException("The caches map must only be set at build time");
+        }
+        this.caches = Collections.unmodifiableMap(caches);
+    }
+
+    public CaffeineCache getCache(String cacheName) {
+        return caches.get(cacheName);
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/NullValueConverter.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/NullValueConverter.java
@@ -1,0 +1,20 @@
+package io.quarkus.cache.runtime;
+
+/**
+ * This class is used to allow the storage of {@code null} values in the Quarkus cache while it is forbidden by the underlying
+ * caching provider.
+ */
+public class NullValueConverter {
+
+    private static final class NullValue {
+        public static Object INSTANCE = new NullValue();
+    }
+
+    public static Object toCacheValue(Object value) {
+        return value == null ? NullValue.INSTANCE : value;
+    }
+
+    public static Object fromCacheValue(Object value) {
+        return value == NullValue.INSTANCE ? null : value;
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheAnnotationInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheAnnotationInterceptor.java
@@ -1,0 +1,52 @@
+package io.quarkus.cache.runtime.augmented;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.interceptor.InvocationContext;
+
+import io.quarkus.arc.runtime.InterceptorBindings;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.runtime.CacheKeyBuilder;
+import io.quarkus.cache.runtime.CacheRepository;
+
+public abstract class AugmentedCacheAnnotationInterceptor {
+
+    @Inject
+    CacheRepository cacheRepository;
+
+    @SuppressWarnings("unchecked")
+    protected <T> T getCacheAnnotation(InvocationContext context, Class<T> cacheAnnotationClass) {
+        for (Annotation annotation : InterceptorBindings.getInterceptorBindings(context)) {
+            if (cacheAnnotationClass.isInstance(annotation)) {
+                return (T) annotation;
+            }
+        }
+        // The following exception should never be thrown.
+        throw new IllegalStateException("Unable to find the cache annotation");
+    }
+
+    protected Object getCacheKey(InvocationContext context, String cacheName) {
+        // If the method doesn't have any parameter, then a unique default key is generated and used.
+        if (context.getParameters().length == 0) {
+            return CacheKeyBuilder.buildDefault(cacheName);
+        } else {
+            List<Object> cacheKeyElements = new ArrayList<>();
+            // If at least one of the method parameters is annotated with @CacheKey, then the key is composed of all
+            // @CacheKey-annotated parameters.
+            for (int i = 0; i < context.getParameters().length; i++) {
+                if (context.getMethod().getParameters()[i].isAnnotationPresent(CacheKey.class)) {
+                    cacheKeyElements.add(context.getParameters()[i]);
+                }
+            }
+            // If there's no @CacheKey-annotated parameter, then the key is composed of all of the method parameters.
+            if (cacheKeyElements.isEmpty()) {
+                cacheKeyElements.addAll(Arrays.asList(context.getParameters()));
+            }
+            return CacheKeyBuilder.build(cacheKeyElements);
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidate.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidate.java
@@ -1,0 +1,18 @@
+package io.quarkus.cache.runtime.augmented;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface AugmentedCacheInvalidate {
+
+    @Nonbinding
+    String cacheName() default "";
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidateAll.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidateAll.java
@@ -1,0 +1,18 @@
+package io.quarkus.cache.runtime.augmented;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface AugmentedCacheInvalidateAll {
+
+    @Nonbinding
+    String cacheName() default "";
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidateAllInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidateAllInterceptor.java
@@ -1,0 +1,31 @@
+package io.quarkus.cache.runtime.augmented;
+
+import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.cache.runtime.caffeine.CaffeineCache;
+
+@AugmentedCacheInvalidateAll
+@Interceptor
+@Priority(PLATFORM_BEFORE)
+public class AugmentedCacheInvalidateAllInterceptor extends AugmentedCacheAnnotationInterceptor {
+
+    private static final Logger LOGGER = Logger.getLogger(AugmentedCacheInvalidateAllInterceptor.class);
+
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        AugmentedCacheInvalidateAll annotation = getCacheAnnotation(context, AugmentedCacheInvalidateAll.class);
+        CaffeineCache cache = cacheRepository.getCache(annotation.cacheName());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugf("Invalidating all entries from cache [%s]", cache.getName());
+        }
+        cache.invalidateAll();
+        return context.proceed();
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidateInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheInvalidateInterceptor.java
@@ -1,0 +1,32 @@
+package io.quarkus.cache.runtime.augmented;
+
+import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.cache.runtime.caffeine.CaffeineCache;
+
+@AugmentedCacheInvalidate
+@Interceptor
+@Priority(PLATFORM_BEFORE)
+public class AugmentedCacheInvalidateInterceptor extends AugmentedCacheAnnotationInterceptor {
+
+    private static final Logger LOGGER = Logger.getLogger(AugmentedCacheInvalidateInterceptor.class);
+
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        AugmentedCacheInvalidate annotation = getCacheAnnotation(context, AugmentedCacheInvalidate.class);
+        CaffeineCache cache = cacheRepository.getCache(annotation.cacheName());
+        Object key = getCacheKey(context, cache.getName());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugf("Invalidating entry with key [%s] from cache [%s]", key, cache.getName());
+        }
+        cache.invalidate(key);
+        return context.proceed();
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheResult.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheResult.java
@@ -1,0 +1,21 @@
+package io.quarkus.cache.runtime.augmented;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface AugmentedCacheResult {
+
+    @Nonbinding
+    String cacheName() default "";
+
+    @Nonbinding
+    long lockTimeout() default 0;
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/augmented/AugmentedCacheResultInterceptor.java
@@ -1,0 +1,31 @@
+package io.quarkus.cache.runtime.augmented;
+
+import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.cache.runtime.caffeine.CaffeineCache;
+
+@AugmentedCacheResult
+@Interceptor
+@Priority(PLATFORM_BEFORE)
+public class AugmentedCacheResultInterceptor extends AugmentedCacheAnnotationInterceptor {
+
+    private static final Logger LOGGER = Logger.getLogger(AugmentedCacheResultInterceptor.class);
+
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        AugmentedCacheResult annotation = getCacheAnnotation(context, AugmentedCacheResult.class);
+        CaffeineCache cache = cacheRepository.getCache(annotation.cacheName());
+        Object key = getCacheKey(context, cache.getName());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugf("Loading entry with key [%s] from cache [%s]", key, cache.getName());
+        }
+        return cache.get(key, () -> context.proceed(), annotation.lockTimeout());
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java
@@ -1,0 +1,146 @@
+package io.quarkus.cache.runtime.caffeine;
+
+import static io.quarkus.cache.runtime.NullValueConverter.fromCacheValue;
+import static io.quarkus.cache.runtime.NullValueConverter.toCacheValue;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+public class CaffeineCache {
+
+    private AsyncCache<Object, Object> cache;
+
+    private String name;
+
+    private Integer initialCapacity;
+
+    private Long maximumSize;
+
+    private Duration expireAfterWrite;
+
+    private Duration expireAfterAccess;
+
+    public CaffeineCache(CaffeineCacheInfo cacheInfo) {
+        this.name = cacheInfo.name;
+        Caffeine<Object, Object> builder = Caffeine.newBuilder();
+        /*
+         * The following line is a workaround for a GraalVM issue: https://github.com/oracle/graal/issues/1524
+         * TODO: Remove it as soon as a Quarkus release depends on GraalVM 19.3.0 or higher.
+         */
+        builder.executor(task -> ForkJoinPool.commonPool().execute(task));
+        if (cacheInfo.initialCapacity != null) {
+            this.initialCapacity = cacheInfo.initialCapacity;
+            builder.initialCapacity(cacheInfo.initialCapacity);
+        }
+        if (cacheInfo.maximumSize != null) {
+            this.maximumSize = cacheInfo.maximumSize;
+            builder.maximumSize(cacheInfo.maximumSize);
+        }
+        if (cacheInfo.expireAfterWrite != null) {
+            this.expireAfterWrite = cacheInfo.expireAfterWrite;
+            builder.expireAfterWrite(cacheInfo.expireAfterWrite);
+        }
+        if (cacheInfo.expireAfterAccess != null) {
+            this.expireAfterAccess = cacheInfo.expireAfterAccess;
+            builder.expireAfterAccess(cacheInfo.expireAfterAccess);
+        }
+        cache = builder.buildAsync();
+    }
+
+    public Object get(Object key, Callable<Object> valueLoader, long lockTimeout) throws Exception {
+        if (lockTimeout <= 0) {
+            return fromCacheValue(cache.synchronous().get(key, k -> new MappingSupplier(valueLoader).get()));
+        }
+
+        // The lock timeout logic starts here.
+
+        /*
+         * If the current key is not already associated with a value in the Caffeine cache, there's no way to know if the
+         * current thread or another one started the missing value computation. The following variable will be used to
+         * determine whether or not a timeout should be triggered during the computation depending on which thread started it.
+         */
+        boolean[] isCurrentThreadComputation = { false };
+
+        CompletableFuture<Object> future = cache.get(key, (k, executor) -> {
+            isCurrentThreadComputation[0] = true;
+            return CompletableFuture.supplyAsync(new MappingSupplier(valueLoader), executor);
+        });
+
+        if (isCurrentThreadComputation[0]) {
+            // The value is missing and its computation was started from the current thread.
+            // We'll wait for the result no matter how long it takes.
+            return fromCacheValue(future.get());
+        } else {
+            // The value is either already present in the cache or missing and its computation was started from another thread.
+            // We want to retrieve it from the cache within the lock timeout delay.
+            try {
+                return fromCacheValue(future.get(lockTimeout, TimeUnit.MILLISECONDS));
+            } catch (TimeoutException e) {
+                // Timeout triggered! We don't want to wait any longer for the value computation and we'll simply invoke the
+                // cached method and return its result without caching it.
+                // TODO: Add statistics here to monitor the timeout.
+                return valueLoader.call();
+            }
+        }
+    }
+
+    public void invalidate(Object key) {
+        cache.synchronous().invalidate(key);
+    }
+
+    public void invalidateAll() {
+        cache.synchronous().invalidateAll();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    // For testing purposes only.
+    public Integer getInitialCapacity() {
+        return initialCapacity;
+    }
+
+    // For testing purposes only.
+    public Long getMaximumSize() {
+        return maximumSize;
+    }
+
+    // For testing purposes only.
+    public Duration getExpireAfterWrite() {
+        return expireAfterWrite;
+    }
+
+    // For testing purposes only.
+    public Duration getExpireAfterAccess() {
+        return expireAfterAccess;
+    }
+
+    private static class MappingSupplier implements Supplier<Object> {
+
+        private final Callable<?> valueLoader;
+
+        public MappingSupplier(Callable<?> valueLoader) {
+            this.valueLoader = valueLoader;
+        }
+
+        @Override
+        public Object get() {
+            try {
+                return toCacheValue(valueLoader.call());
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheBuildRecorder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheBuildRecorder.java
@@ -1,0 +1,35 @@
+package io.quarkus.cache.runtime.caffeine;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.cache.runtime.CacheRepository;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class CaffeineCacheBuildRecorder {
+
+    private static final Logger LOGGER = Logger.getLogger(CaffeineCacheBuildRecorder.class);
+
+    public void buildCaches(BeanContainer beanContainer, Set<CaffeineCacheInfo> cacheInfos) {
+        // The number of caches is known at build time so we can use fixed initialCapacity and loadFactor for the caches map.
+        Map<String, CaffeineCache> caches = new HashMap<>(cacheInfos.size() + 1, 1.0F);
+
+        for (CaffeineCacheInfo cacheInfo : cacheInfos) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debugf(
+                        "Building Caffeine cache [%s] with [initialCapacity=%s], [maximumSize=%s], [expireAfterWrite=%s] and [expireAfterAccess=%s]",
+                        cacheInfo.name, cacheInfo.initialCapacity, cacheInfo.maximumSize, cacheInfo.expireAfterWrite,
+                        cacheInfo.expireAfterAccess);
+            }
+            CaffeineCache cache = new CaffeineCache(cacheInfo);
+            caches.put(cacheInfo.name, cache);
+        }
+
+        beanContainer.instance(CacheRepository.class).setCaches(caches);
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheInfo.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheInfo.java
@@ -1,0 +1,34 @@
+package io.quarkus.cache.runtime.caffeine;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public class CaffeineCacheInfo {
+
+    public String name;
+
+    public Integer initialCapacity;
+
+    public Long maximumSize;
+
+    public Duration expireAfterWrite;
+
+    public Duration expireAfterAccess;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof CaffeineCacheInfo) {
+            CaffeineCacheInfo other = (CaffeineCacheInfo) obj;
+            return Objects.equals(name, other.name);
+        }
+        return false;
+    }
+}

--- a/extensions/cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,10 @@
+---
+name: "Application Data Caching"
+metadata:
+  keywords:
+  - "cache"
+  - "caching"
+  guide: "https://quarkus.io/guides/application-data-caching"
+  categories:
+  - "data"
+  status: "preview"

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -113,6 +113,7 @@
 
         <!-- Caching -->
         <module>caffeine</module>
+        <module>cache</module>
 
         <!-- Integrations -->
         <module>amazon-lambda</module>

--- a/integration-tests/cache/pom.xml
+++ b/integration-tests/cache/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-cache</artifactId>
+    <name>Quarkus - Integration Tests - Cache</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/cache/src/main/java/io/quarkus/it/cache/ExpensiveResource.java
+++ b/integration-tests/cache/src/main/java/io/quarkus/it/cache/ExpensiveResource.java
@@ -1,0 +1,51 @@
+package io.quarkus.it.cache;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+
+@ApplicationScoped
+@Path("/expensive-resource")
+public class ExpensiveResource {
+
+    private int invocations;
+
+    @GET
+    @Path("/{keyElement1}/{keyElement2}/{keyElement3}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @CacheResult(cacheName = "expensiveResourceCache", lockTimeout = 5000)
+    public ExpensiveResponse getExpensiveResponse(@PathParam("keyElement1") @CacheKey String keyElement1,
+            @PathParam("keyElement2") @CacheKey String keyElement2, @PathParam("keyElement3") @CacheKey String keyElement3,
+            @QueryParam("foo") String foo) {
+        invocations++;
+        ExpensiveResponse response = new ExpensiveResponse();
+        response.setResult(keyElement1 + " " + keyElement2 + " " + keyElement3 + " too!");
+        return response;
+    }
+
+    @GET
+    @Path("/invocations")
+    public int getInvocations() {
+        return invocations;
+    }
+
+    public static class ExpensiveResponse {
+
+        private String result;
+
+        public String getResult() {
+            return result;
+        }
+
+        public void setResult(String result) {
+            this.result = result;
+        }
+    }
+}

--- a/integration-tests/cache/src/test/java/io/quarkus/it/cache/CacheITCase.java
+++ b/integration-tests/cache/src/test/java/io/quarkus/it/cache/CacheITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.cache;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class CacheITCase extends CacheTestCase {
+}

--- a/integration-tests/cache/src/test/java/io/quarkus/it/cache/CacheTestCase.java
+++ b/integration-tests/cache/src/test/java/io/quarkus/it/cache/CacheTestCase.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.cache;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisplayName("Tests the cache extension")
+public class CacheTestCase {
+
+    @Test
+    public void testCache() {
+        runExpensiveRequest();
+        runExpensiveRequest();
+        RestAssured.given().when().get("/expensive-resource/invocations").then().statusCode(200).body(is("1"));
+    }
+
+    private void runExpensiveRequest() {
+        RestAssured.given().when().get("/expensive-resource/I/love/Quarkus?foo=bar").then().statusCode(200).body("result",
+                is("I love Quarkus too!"));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -93,6 +93,7 @@
         <module>jpa-without-entity</module>
         <module>quartz</module>
         <module>logging-gelf</module>
+        <module>cache</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Here's a very first version of a draft PR for the cache extension discussed in #3128 (initially) and #3306 (current active issue on this subject). As you will see, this is a work in progress with many features and tests not developed yet, but it's already working for simple cases (see `CacheTest.java` tests).

I'll try to keep the following (unordered) todo list updated, do not hesitate to suggest any improvement (preferably in #3306 for design suggestions)!

First iteration:
- [x] Use a default cache name derived from the class FQN.
- [x] Initiate cache API Javadoc.
- [x] Remove lamdbas from runtime code.
- [x] Make @CacheKey optional (if absent, the key is composed of all method parameters).
- [x] Change configuration management to avoid repeating JCache limitations.
- [x] Increase tests coverage (deployment, runtime, devmode).

Next iterations?
- In progress: Initiate the guide. Mandatory examples: default cache name, to be completed...
- Under investigation: Implement locks to prevent cache miss storm. Update @CacheLoad javadoc after (synchronous, holding a lock, etc).
- Under investigation: Refresh.
- Implement timeout for `@CacheLoad` and `@CacheStore` annotated methods invocation.
- Manage async cache computation.
- Caching API.
- Statistics.
- Remove the native mode exception workaround from `CaffeineCache` when `org.graalvm.sdk:graal-sdk` is updated to version to `19.2.0`.
- Create a quickstarts example?