### PR TITLE
Reactive Messaging - initialize MediatorManager earlier giving priority to StartupEvent observer

### DIFF
--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/SmallRyeReactiveMessagingLifecycle.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/SmallRyeReactiveMessagingLifecycle.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -13,7 +14,7 @@ public class SmallRyeReactiveMessagingLifecycle {
     @Inject
     MediatorManager mediatorManager;
 
-    void onApplicationStart(@Observes StartupEvent event) {
+    void onApplicationStart(@Observes @Priority(javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE) StartupEvent event) {
         try {
             mediatorManager.initializeAndRun();
         } catch (Exception e) {


### PR DESCRIPTION
related to #3400 
Because this extension observes StartupEvent which is a common event to be observed by user code I think it's necessary add priority to this observer in order to ensure reactive-messaging extension is fully initialized prior any user code execution