### PR TITLE
Fix NPE on resteasy default NotFoundExceptionMapper

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/NotFoundExceptionMapper.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/NotFoundExceptionMapper.java
@@ -4,7 +4,6 @@
 package io.quarkus.resteasy.runtime;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -88,8 +87,8 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
             Map<String, ResourceDescription> descriptions = new HashMap<>();
 
             for (Map.Entry<String, List<ResourceInvoker>> entry : bound) {
-                Method aMethod = ((ResourceMethodInvoker) entry.getValue().get(0)).getMethod();
-                String basePath = aMethod.getDeclaringClass().getAnnotation(Path.class).value();
+                Class<?> resourceClass = ((ResourceMethodInvoker) entry.getValue().get(0)).getResourceClass();
+                String basePath = resourceClass.getAnnotation(Path.class).value();
 
                 if (!descriptions.containsKey(basePath)) {
                     descriptions.put(basePath, new ResourceDescription(basePath));


### PR DESCRIPTION
A NPE occurs in resteasy default NotFoundException mapper when the @Path annotation is set on a parent class on an unrelated resource where the exception occurs like in the following example: https://gist.github.com/brunoabdon/ba5cbad0f815a8b26c074edde99eb629

This PR fixes #3405