### PR TITLE
fix: get @TransactionConfiguration from the class

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -82,7 +82,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
     private TransactionConfiguration getTransactionConfiguration(InvocationContext ic) {
         TransactionConfiguration configuration = ic.getMethod().getAnnotation(TransactionConfiguration.class);
-        if (ic == null) {
+        if (configuration == null) {
             return ic.getTarget().getClass().getAnnotation(TransactionConfiguration.class);
         }
         return configuration;


### PR DESCRIPTION
This fixes the case, when there is no @TransactionConfiguration at a method, it return null instead of searching the annotation at class level.

It fixes #3420