### PR TITLE
Fix for running Swagger UI extension on Windows 

### DIFF
--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -94,7 +94,7 @@ public class SwaggerUiProcessor {
                 }
                 try {
                     ResolvedArtifact artifact = getSwaggerUiArtifact();
-                    Path tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
+                    Path tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX).toRealPath();
                     extractSwaggerUi(artifact, tempDir);
                     updateApiUrl(tempDir.resolve("index.html"));
                     cached.cachedDirectory = tempDir.toAbsolutePath().toString();


### PR DESCRIPTION
This PR provides a fix for running Swagger UI extension on Windows in dev mode (#3313).

`Files::createTempDirectory` returns a path with short directory name, e.g.:
```
C:\Users\myusern~1\AppData\Local\Temp\quarkus-swagger-ui_68267708355431116007045174363617492
```
which is not properly handled by undertow (https://github.com/quarkusio/quarkus/issues/3313#issuecomment-518655662). By invoking `.toRealPath()` the path becomes:
```
C:\Users\myusername\AppData\Local\Temp\quarkus-swagger-ui_68267708355431116007045174363617492
```
and thanks to that Swagger can be properly served by undertow.