### PR TITLE
Update jackson-bom to 2.9.9.20190807 to fix a regression

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -70,7 +70,7 @@
            is not available in Maven fast enough: -->
         <graal-sdk.version>19.1.1</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha6</gizmo.version>
-        <jackson.version>2.9.9.20190727</jackson.version>
+        <jackson.version>2.9.9.20190807</jackson.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>


### PR DESCRIPTION
Update to the latest [micro-patch](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches) of jackson-databind 2.9.9.3 to fix a regression https://github.com/FasterXML/jackson-databind/issues/2395