### PR TITLE
Make native tests 'image wait time' configurable

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
@@ -70,7 +70,8 @@ public class ConfigDefinition extends CompoundConfigType {
     private static final List<String> FALSE_POSITIVE_QUARKUS_CONFIG_MISSES = Arrays
             .asList(QUARKUS_NAMESPACE + ".live-reload.password", QUARKUS_NAMESPACE + ".live-reload.url",
                     QUARKUS_NAMESPACE + ".debug.generated-classes-dir", QUARKUS_NAMESPACE + ".debug.reflection",
-                    QUARKUS_NAMESPACE + ".version", QUARKUS_NAMESPACE + ".profile", QUARKUS_NAMESPACE + ".test.profile");
+                    QUARKUS_NAMESPACE + ".version", QUARKUS_NAMESPACE + ".profile", QUARKUS_NAMESPACE + ".test.profile",
+                    QUARKUS_NAMESPACE + ".test.native-image-wait-time");
 
     private final TreeMap<String, Object> rootObjectsByContainingName = new TreeMap<>();
     private final HashMap<Class<?>, Object> rootObjectsByClass = new HashMap<>();

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -202,6 +202,13 @@ Executing [/data/home/gsmet/git/quarkus-quickstarts/getting-started/target/getti
 ...
 ----
 
+[TIP]
+====
+By default, Quarkus waits for 60 seconds for the native image to start before automatically failing the native tests. This
+duration can be changed using the `quarkus.test.native-image-wait-time` system property. For example, to increase the duration
+to 300 seconds, use: `./mvnw verify -Pnative -Dquarkus.test.native-image-wait-time=300`.
+====
+
 === Excluding tests when running as a native executable
 
 When running tests this way, the only things that actually run natively are you application endpoints, which


### PR DESCRIPTION
Fixes #3413 