### PR TITLE
Add the oauth2 extension in the doc index

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -44,6 +44,7 @@ include::quarkus-intro.adoc[tag=intro]
 * link:cdi-reference.html[Contexts and Dependency Injection] _(advanced)_
 * link:keycloak-guide.html[Using Keycloak]
 * link:kogito-guide.html[Using Kogito (business automation with processes and rules)]
+* link:oauth2-guide.html[Using OAuth2 RBAC]
 
 * link:faq.html[FAQs]
 


### PR DESCRIPTION
This PR add the Oauth2 extension in the `docs/src/main/asciidoc/index.adoc` file.