### PR TITLE
Native ssl support in the Oauth2 extension

### DIFF
--- a/docs/src/main/asciidoc/native-and-ssl-guide.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl-guide.adoc
@@ -74,7 +74,8 @@ As SSL is ipso facto the standard nowadays, we decided to enable its support aut
  * the Mailer extension (`quarkus-mailer`),
  * the MongoDB extension (`quarkus-mongodb-client`),
  * the Neo4j extension (`quarkus-neo4j`),
- * the REST client extension (`quarkus-rest-client`).
+ * the REST client extension (`quarkus-rest-client`),
+ * The OAuth2 extension (`quarkus-elytron-security-oauth2`).
 
 
 As long as you have one of those extensions in your project, the SSL support will be enabled by default.

--- a/docs/src/main/asciidoc/oauth2-guide.adoc
+++ b/docs/src/main/asciidoc/oauth2-guide.adoc
@@ -24,6 +24,7 @@ If your OAuth2 Authentication server provides JWT tokens, you should use link:jw
 |quarkus.oauth2.client-id||The OAuth2 client id used to validate the token.
 |quarkus.oauth2.client-secret||The OAuth2 client secret used to validate the token.
 |quarkus.oauth2.introspection-url||The OAuth2 introspection endpoint URL used to validate the token and gather the authentication claims.
+|quarkus.oauth2.ca-cert-file||The OAuth2 server certificate file. **Warning**: this is not supported in native mode where the certificate must be included in the truststore used during the native image generation, see link:native-and-ssl-guide.html[Using SSL With Native Executables].
 |quarkus.oauth2.role-claim|scope|The claim that is used in the introspection endpoint response to load the roles
 |===
 

--- a/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
+++ b/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateResourceBuildItem;
 import io.quarkus.elytron.security.deployment.AuthConfigBuildItem;
@@ -55,6 +56,11 @@ class OAuth2DeploymentProcessor {
     @BuildStep(providesCapabilities = "io.quarkus.elytron.security.oauth2")
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.SECURITY_OAUTH2);
+    }
+
+    @BuildStep
+    ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.SECURITY_OAUTH2);
     }
 
     /**

--- a/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
+++ b/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
@@ -10,7 +10,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.substrate.SubstrateResourceBuildItem;
 import io.quarkus.elytron.security.deployment.AuthConfigBuildItem;
 import io.quarkus.elytron.security.deployment.IdentityManagerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityDomainBuildItem;
@@ -35,23 +34,6 @@ class OAuth2DeploymentProcessor {
     private static final String AUTH_MECHANISM = "BEARER_TOKEN";
 
     OAuth2Config oauth2;
-
-    /**
-     * If the configuration specified a deployment local key resource, register it with substrate
-     *
-     * @return SubstrateResourceBuildItem
-     */
-    @BuildStep
-    SubstrateResourceBuildItem registerSubstrateResources() {
-        if (oauth2.caCertFile.isPresent()) {
-            String publicKeyLocation = oauth2.caCertFile.get();
-            if (publicKeyLocation.indexOf(':') < 0 || publicKeyLocation.startsWith("classpath:")) {
-                log.infof("Adding %s to native image", publicKeyLocation);
-                return new SubstrateResourceBuildItem(publicKeyLocation);
-            }
-        }
-        return null;
-    }
 
     @BuildStep(providesCapabilities = "io.quarkus.elytron.security.oauth2")
     FeatureBuildItem feature() {

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Config.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Config.java
@@ -36,7 +36,8 @@ public class OAuth2Config {
     public String introspectionUrl;
 
     /**
-     * The path to a ca custom cert file
+     * The path to a custom cert file
+     * This is not supported in native mode
      */
     @ConfigItem
     public Optional<String> caCertFile;


### PR DESCRIPTION
This PR:

- Enable the Native SSL support for the OAuth2 extension as most OAuth2 server will be accessible via HTTPS
- Document the `quarkus.oauth2.ca-cert-file` property and clarify it's support in native mode (not supported)

It is the current status of what can be done for issue #3435