### PR TITLE
Ensure Kubernetes resources are only created during a normal run

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsNormal.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsNormal.java
@@ -1,0 +1,24 @@
+package io.quarkus.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * boolean supplier that returns true if the application is running in normal
+ * mode. Intended for use with {@link BuildStep#onlyIf()}
+ */
+public class IsNormal implements BooleanSupplier {
+
+    private final LaunchMode launchMode;
+
+    public IsNormal(LaunchMode launchMode) {
+        this.launchMode = launchMode;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return launchMode == LaunchMode.NORMAL;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -20,6 +20,7 @@ import io.dekorate.kubernetes.annotation.KubernetesApplication;
 import io.dekorate.kubernetes.generator.DefaultKubernetesApplicationGenerator;
 import io.dekorate.processor.SimpleFileWriter;
 import io.dekorate.project.Project;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
@@ -37,7 +38,7 @@ class KubernetesProcessor {
     @Inject
     BuildProducer<FeatureBuildItem> featureProducer;
 
-    @BuildStep
+    @BuildStep(onlyIf = IsNormal.class)
     public void build(ApplicationInfoBuildItem applicationInfo,
             KubernetesConfig kubernetesConfig,
             List<KubernetesPortBuildItem> kubernetesPortBuildItems,


### PR DESCRIPTION
This is done to overcome some limitations in `dekorate` (which will be
addressed in subsequent releases of that project)

Fixes #3465