### PR TITLE
feat: test custom exception mapper with resteasy

### DIFF
--- a/extensions/resteasy/deployment/pom.xml
+++ b/extensions/resteasy/deployment/pom.xml
@@ -40,6 +40,17 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- These are needed to test the JSON representation of the NotFoundExceptionMapper-->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/CustomExceptionMapperTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/CustomExceptionMapperTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.test;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class CustomExceptionMapperTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RootResource.class, CustomExceptionMapper.class));
+
+    @Test
+    public void testResourceNotFound() {
+        RestAssured.when().get("/not_found")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("not found but OK"));
+    }
+
+    @Provider
+    public static class CustomExceptionMapper implements ExceptionMapper<NotFoundException> {
+        @Override
+        public Response toResponse(NotFoundException exception) {
+            return Response.status(200).entity("not found but OK").build();
+        }
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NotFoundExceptionMapperTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NotFoundExceptionMapperTestCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.resteasy.test;
+
+import static org.hamcrest.Matchers.is;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class NotFoundExceptionMapperTestCase {
+    @RegisterExtension
+    static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RootResource.class));
+
+    @Test
+    public void testHtmlResourceNotFound() {
+        // test the default exception mapper provided in dev mode : displays HTML by default
+        RestAssured.when().get("/not_found")
+                .then()
+                .statusCode(404)
+                .body(Matchers.containsString("<div class=\"component-name\"><h1>Resource Not Found</h1>"));
+    }
+
+    @Test
+    public void testJsonResourceNotFound() {
+        // test the default exception mapper provided in dev mode : displays json when accept is application/json
+        RestAssured.given().accept(ContentType.JSON)
+                .when().get("/not_found")
+                .then()
+                .statusCode(404)
+                .body("errorMessage", is("Resource Not Found"))
+                .body("existingResourcesDetails[0].basePath", is("/"));
+    }
+
+}


### PR DESCRIPTION
Now that #3317 is merged, we can add devmode specific tests.

This PR provides tests for the two already merged PR:
- Custom NotFoundExceptionMapper : #3309
- JSON representation in the default NotFoundExceptionMapper : #3401

In order to be able to test the JSON representation I had to add the jsonb provider as test dependency. If it's not desirable I can move this test to the resteady-jsonb dependency (but there is no existing test there) or remove it ...