### PR TITLE
Vertx 3.8 and new sql client

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -100,7 +100,7 @@
         <wildfly-elytron.version>2.0.0.Alpha4</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Beta5</jboss-threads.version>
-        <vertx.version>3.7.1</vertx.version>
+        <vertx.version>3.8.0</vertx.version>
         <httpclient.version>4.5.9</httpclient.version>
         <httpcore.version>4.4.11</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>
@@ -122,7 +122,7 @@
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <test-containers.version>1.11.3</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <axle-client.version>0.0.7</axle-client.version>
+        <axle-client.version>0.0.8</axle-client.version>
         <reactive-pg-client.version>0.11.4</reactive-pg-client.version>
         <kafka-clients.version>2.2.1</kafka-clients.version>
         <kafka2.version>2.2.1</kafka2.version>
@@ -1721,13 +1721,33 @@
                 <version>${axle-client.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.reactiverse</groupId>
-                <artifactId>reactive-pg-client</artifactId>
-                <version>${reactive-pg-client.version}</version>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-sql-client</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-mysql-client</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-pg-client</artifactId>
+                <version>${vertx.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-axle-postgres-client</artifactId>
+                <artifactId>smallrye-axle-sql-client</artifactId>
+                <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-axle-mysql-client</artifactId>
+                <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-axle-pg-client</artifactId>
                 <version>${axle-client.version}</version>
             </dependency>
             <dependency>

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/PgPoolBuildItem.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/PgPoolBuildItem.java
@@ -2,7 +2,7 @@ package io.quarkus.reactive.pg.client.deployment;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.runtime.RuntimeValue;
-import io.reactiverse.pgclient.PgPool;
+import io.vertx.pgclient.PgPool;
 
 public final class PgPoolBuildItem extends SimpleBuildItem {
 

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -16,7 +16,7 @@ import io.quarkus.reactive.pg.client.runtime.PgPoolProducer;
 import io.quarkus.reactive.pg.client.runtime.PgPoolRecorder;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.deployment.VertxBuildItem;
-import io.reactiverse.pgclient.PgPool;
+import io.vertx.pgclient.PgPool;
 
 class ReactivePgClientProcessor {
 

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolProducerTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolProducerTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.reactiverse.pgclient.PgPool;
+import io.vertx.pgclient.PgPool;
 
 public class PgPoolProducerTest {
 
@@ -60,7 +60,7 @@ public class PgPoolProducerTest {
     static class BeanUsingAxlePgClient {
 
         @Inject
-        io.reactiverse.axle.pgclient.PgPool pgClient;
+        io.vertx.axle.pgclient.PgPool pgClient;
 
         public CompletionStage<Void> verify() {
             return pgClient.query("SELECT 1")
@@ -73,7 +73,7 @@ public class PgPoolProducerTest {
     static class BeanUsingRXPgClient {
 
         @Inject
-        io.reactiverse.reactivex.pgclient.PgPool pgClient;
+        io.vertx.reactivex.pgclient.PgPool pgClient;
 
         public CompletionStage<Void> verify() {
             CompletableFuture<Void> cf = new CompletableFuture<>();

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -21,12 +21,12 @@
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.reactiverse</groupId>
-            <artifactId>reactive-pg-client</artifactId>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-pg-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-axle-postgres-client</artifactId>
+            <artifactId>smallrye-axle-pg-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolProducer.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolProducer.java
@@ -4,19 +4,19 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
-import io.reactiverse.pgclient.PgPool;
+import io.vertx.pgclient.PgPool;
 
 @ApplicationScoped
 public class PgPoolProducer {
 
     private volatile PgPool pgPool;
-    private volatile io.reactiverse.axle.pgclient.PgPool axlePgPool;
-    private volatile io.reactiverse.reactivex.pgclient.PgPool rxPgPool;
+    private volatile io.vertx.axle.pgclient.PgPool axlePgPool;
+    private volatile io.vertx.reactivex.pgclient.PgPool rxPgPool;
 
     void initialize(PgPool pgPool) {
         this.pgPool = pgPool;
-        this.axlePgPool = io.reactiverse.axle.pgclient.PgPool.newInstance(pgPool);
-        this.rxPgPool = io.reactiverse.reactivex.pgclient.PgPool.newInstance(pgPool);
+        this.axlePgPool = io.vertx.axle.pgclient.PgPool.newInstance(pgPool);
+        this.rxPgPool = io.vertx.reactivex.pgclient.PgPool.newInstance(pgPool);
     }
 
     @Singleton
@@ -27,13 +27,13 @@ public class PgPoolProducer {
 
     @Singleton
     @Produces
-    public io.reactiverse.axle.pgclient.PgPool axlePgPool() {
+    public io.vertx.axle.pgclient.PgPool axlePgPool() {
         return axlePgPool;
     }
 
     @Singleton
     @Produces
-    public io.reactiverse.reactivex.pgclient.PgPool rxPgPool() {
+    public io.vertx.reactivex.pgclient.PgPool rxPgPool() {
         return rxPgPool;
     }
 }

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
@@ -38,7 +38,7 @@ public class SimpleRouteTest {
         RestAssured.when().get("/hello-event-bus?name=ping").then().statusCode(200).body(is("Hello PING!"));
         RestAssured.when().get("/foo?name=foo").then().statusCode(200).body(is("Hello foo!"));
         RestAssured.when().get("/bar").then().statusCode(200).body(is("Hello bar!"));
-        RestAssured.when().get("/delete").then().statusCode(404);
+        RestAssured.when().get("/delete").then().statusCode(405);
         RestAssured.when().delete("/delete").then().statusCode(200).body(is("deleted"));
         RestAssured.when().get("/routes").then().statusCode(200)
                 .body(Matchers.containsString("/hello-event-bus"));

--- a/integration-tests/reactive-pg-client/src/main/java/io/quarkus/it/reactive/pg/client/FruitResource.java
+++ b/integration-tests/reactive-pg-client/src/main/java/io/quarkus/it/reactive/pg/client/FruitResource.java
@@ -9,8 +9,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.reactiverse.axle.pgclient.PgPool;
-import io.reactiverse.axle.pgclient.Row;
+import io.vertx.axle.pgclient.PgPool;
+import io.vertx.axle.sqlclient.Row;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -337,7 +337,7 @@ public class QuarkusDevModeTest
             //this sucks, but some file systems only resolve last modified times to the second granularity
             //we need to sleep here before modification to make sure the detector actually picks up the change
             //we sleep to the nearest whole second plus two ms
-            Thread.sleep(1002 - (System.currentTimeMillis() % 1000));
+            Thread.sleep(2002 - (System.currentTimeMillis() % 2000));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This is a draft PR because I want to wait for opinions about the new mysql async client.

Right now I've just updated the `quarkus-reactive-pg-client` module to use the new `vertx-sql` module, but I wonder if it should support both pg and mysql, by discriminating on the URL string. It would make it depend on both clients, though.

An alternative would be to make a new `quarkus-reactive-mysql-client` module, but it would largely be similar.

Opinions @vietj and @tsegismont ?

This may be related to the ongoing work of @gsmet about supporting multiple datasources, but I don't know what state it is in.