### PR TITLE
Provides a JSON representation for the default quarkus error page

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ErrorServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ErrorServlet.java
@@ -1,0 +1,18 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = "/error")
+public class ErrorServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        throw new RuntimeException("Error !!!");
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ErrorServletTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ErrorServletTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.undertow.test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class ErrorServletTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ErrorServlet.class));
+
+    @Test
+    public void testHtmlError() {
+        RestAssured.when().get("/error").then()
+                .statusCode(500)
+                .body(containsString("<h1 class=\"container\">Internal Server Error</h1>"))
+                .body(containsString("<div class=\"trace\">"));
+    }
+
+    @Test
+    public void testJsonError() {
+        RestAssured.given().accept(ContentType.JSON)
+                .when().get("/error").then()
+                .statusCode(500)
+                .body("details", startsWith("Error handling"))
+                .body("stack", startsWith("java.lang.RuntimeException: Error !!!"));
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
@@ -35,9 +35,20 @@ public class QuarkusErrorServlet extends HttpServlet {
             details += "Error id " + uuid;
         }
 
-        resp.setContentType("text/html");
-        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        resp.getWriter().write(new TemplateHtmlBuilder("Internal Server Error", details, details).stack(stack).toString());
+        String accept = req.getHeader("Accept");
+        if (accept != null && accept.contains("application/json")) {
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            String escapedStack = stack.replace(System.lineSeparator(), "\\n").replace("\"", "\\\"");
+            StringBuilder jsonPayload = new StringBuilder("{\"details\":\"").append(details).append("\",\"stack\":\"")
+                    .append(escapedStack).append("\"}");
+            resp.getWriter().write(jsonPayload.toString());
+        } else {
+            //We default to HTML representation
+            resp.setContentType("text/html");
+            resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            resp.getWriter().write(new TemplateHtmlBuilder("Internal Server Error", details, details).stack(stack).toString());
+        }
     }
 
     private static String generateStackTrace(final Throwable exception) {


### PR DESCRIPTION
The default Quarkus error page is served by Undertow in HTML representation only.

I propose to add a JSON representation (if Accept header with application/json is set) with the same information on it.

As it's on the undertow layer, I don't use any json specific library and rely on string manipulation for the implementation. Not sure it's a good idea ...