### PR TITLE
Undertow common is not an extension

### DIFF
--- a/extensions/undertow/common/pom.xml
+++ b/extensions/undertow/common/pom.xml
@@ -37,25 +37,4 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>io.quarkus</groupId>
-                            <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${project.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
So we shouldn't make it one.

For the record, we have Gradle projects failing with:
```
* What went wrong:
Execution failed for task ':quarkusBuild'.
> Could not resolve all dependencies for configuration ':detachedConfiguration1'.
   > Could not find io.quarkus:quarkus-undertow-common-substitutions-deployment:0.21.0.
     Searched in the following locations:
       - file:/data/home/gsmet/.m2/repository/io/quarkus/quarkus-undertow-common-substitutions-deployment/0.21.0/quarkus-undertow-common-substitutions-deployment-0.21.0.pom
       - file:/data/home/gsmet/.m2/repository/io/quarkus/quarkus-undertow-common-substitutions-deployment/0.21.0/quarkus-undertow-common-substitutions-deployment-0.21.0.jar
       - https://repo.maven.apache.org/maven2/io/quarkus/quarkus-undertow-common-substitutions-deployment/0.21.0/quarkus-undertow-common-substitutions-deployment-0.21.0.pom
       - https://repo.maven.apache.org/maven2/io/quarkus/quarkus-undertow-common-substitutions-deployment/0.21.0/quarkus-undertow-common-substitutions-deployment-0.21.0.jar
     Required by:
         project :
```