### PR TITLE
Reinitialize ThreadLocalRandom class to ensure seed is reset at runtime

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ThreadLocalRandomProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ThreadLocalRandomProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.deployment;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.substrate.RuntimeReinitializedClassBuildItem;
+
+public class ThreadLocalRandomProcessor {
+    @BuildStep
+    RuntimeReinitializedClassBuildItem registerThreadLocalRandomReinitialize() {
+        // ThreadLocalRandom is bugged currently and doesn't reset the seeder
+        // See https://github.com/oracle/graal/issues/1614 for more details
+        return new RuntimeReinitializedClassBuildItem(ThreadLocalRandom.class.getName());
+    }
+}


### PR DESCRIPTION
The ThreadLocalRandom seeder and probeGenerator fields are never reinitialized, which causes the values generated to always be the same from native run to the next. See https://github.com/oracle/graal/issues/1614 for more details and hopefully the final fix. This PR will fix the issue until it is fixed at the GraalVM level.