### PR TITLE
Update to kubernetes-client 4.4.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -155,7 +155,7 @@
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
         <kogito.version>0.2.0</kogito.version>
-        <kubernetes-client.version>4.3.1</kubernetes-client.version>
+        <kubernetes-client.version>4.4.1</kubernetes-client.version>
         <sundr.version>0.19.1</sundr.version> <!-- this is to avoid annoying pop-up in eclipse about failure to init Velocity logging -->
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <wiremock.version>2.23.2</wiremock.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -203,6 +203,15 @@
                 <type>pom</type>
             </dependency>
 
+            <!-- Kubernetes-client dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>${kubernetes-client.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Quarkus core -->
 
             <dependency>
@@ -2104,16 +2113,6 @@
                 <groupId>org.kie.kogito</groupId>
                 <artifactId>jbpm-bpmn2</artifactId>
                 <version>${kogito.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>kubernetes-client</artifactId>
-                <version>${kubernetes-client.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>kubernetes-server-mock</artifactId>
-                <version>${kubernetes-client.version}</version>
             </dependency>
 
             <!-- Spring -->


### PR DESCRIPTION
<details>
<summary>Release notes</summary>

*Sourced from [kubernetes-client-bom's releases](https://github.com/fabric8io/kubernetes-client/releases).*

> ## v4.4.1
> 
> ### 4.4.1 (08-08-2019)
> ####  Bugs
>   * Fix [#1690](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1690): Endpoints is always pluralized
>   * Fix [#1684](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1684): Fixed URL resolution algorithm for OpenShift resources without API Group name
> 
> #### Improvements
>   * Fix [#1650](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1650): Introduced `kubernetes.disable.autoConfig` system property to disable auto configuration in Config
>   * Fix [#1661](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1661): Remove generic parameter from KubernetesResource
>   * Improved OpenShiftOperation.wrap method performance
>   * RawCustomResourceOperationsImpl#makeCall now closes the created Response object
</details>
<details>
<summary>Changelog</summary>

*Sourced from [kubernetes-client-bom's changelog](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md).*

> ### 4.4.1 (08-08-2019)
> ####  Bugs
>   * Fix [#1690](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1690): Endpoints is always pluralized
>   * Fix [#1684](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1684): Fixed URL resolution algorithm for OpenShift resources without API Group name
> 
> #### Improvements
>   * Fix [#1650](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1650): Introduced `kubernetes.disable.autoConfig` system property to disable auto configuration in Config
>   * Fix [#1661](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1661): Remove generic parameter from KubernetesResource
>   * Improved OpenShiftOperation.wrap method performance
>   * RawCustomResourceOperationsImpl#makeCall now closes the created Response object
</details>
<details>
<summary>Commits</summary>

- [`091baad`](https://github.com/fabric8io/kubernetes-client/commit/091baad278132d5264dda283f34ece17c80c4f55) [maven-release-plugin] prepare release v4.4.1
- [`fd7490e`](https://github.com/fabric8io/kubernetes-client/commit/fd7490e9da6d4dd23d37b6c786523aba13cc217e) chore: prepared Changelog to 4.4.1
- [`9ea7f57`](https://github.com/fabric8io/kubernetes-client/commit/9ea7f571a9cea596505ffd77caccabdefc84decf) Merge pull request [#1695](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1695) from gastaldi/refactor
- [`36b1964`](https://github.com/fabric8io/kubernetes-client/commit/36b196431322181b68f5601304c5935ceaaaf37e) Merge branch 'master' into refactor
- [`b572b48`](https://github.com/fabric8io/kubernetes-client/commit/b572b48081798ae760b059b011b911000a31d581) Merge pull request [#1698](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1698) from gastaldi/raw_resource_handling
- [`e4ee3f3`](https://github.com/fabric8io/kubernetes-client/commit/e4ee3f308c55f21d23f0b1020ac8387c365f8578) chore: RawCustomResourceOperationsImpl#makeCall now closes the created Respon...
- [`6d5cb7a`](https://github.com/fabric8io/kubernetes-client/commit/6d5cb7ae1c5777d7028e17eaa7bb178c8f10d084) chore: minor refactoring to OpenShiftOperation.wrap method
- [`0f6a7c4`](https://github.com/fabric8io/kubernetes-client/commit/0f6a7c4444fc4ba1d114534301dd60fd32d55aa8) Merge pull request [#1693](https://github-redirect.dependabot.com/fabric8io/kubernetes-client/issues/1693) from gastaldi/config
- [`f2a33f7`](https://github.com/fabric8io/kubernetes-client/commit/f2a33f7a29405ae49f9c4d1bc55095dbc29838db) chore: updated javadoc
- [`61e3148`](https://github.com/fabric8io/kubernetes-client/commit/61e314800a35903b7d7722fb872bcc4e7af75f79) Merge branch 'master' into config
- Additional commits viewable in [compare view](https://github.com/fabric8io/kubernetes-client/compare/v4.4.0...v4.4.1)
</details>