### PR TITLE
Register enclosing class for reflection when used as JAX-RS return type

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.steps;
 
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +33,9 @@ import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyBuildItem;
 public class ReflectiveHierarchyStep {
 
     private static final Logger log = Logger.getLogger(ReflectiveHierarchyStep.class);
+
+    private static final Set<String> IGNORED_PARAMETERIZED_TYPE_PACKAGE_NAMES = new HashSet<>(
+            Arrays.asList("java.util", "io.reactivex"));
 
     @Inject
     List<ReflectiveHierarchyBuildItem> hierarchy;
@@ -83,7 +87,9 @@ public class ReflectiveHierarchyStep {
             addReflectiveHierarchy(i, type.asArrayType().component(), processedReflectiveHierarchies, unindexedClasses);
         } else if (type instanceof ParameterizedType) {
             ParameterizedType p = (ParameterizedType) type;
-            addReflectiveHierarchy(i, p.owner(), processedReflectiveHierarchies, unindexedClasses);
+            if (!IGNORED_PARAMETERIZED_TYPE_PACKAGE_NAMES.contains(p.name().toString())) {
+                addClassTypeHierarchy(i, p.name(), processedReflectiveHierarchies, unindexedClasses);
+            }
             for (Type arg : p.arguments()) {
                 addReflectiveHierarchy(i, arg, processedReflectiveHierarchies, unindexedClasses);
             }

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/EnvelopeClass.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/EnvelopeClass.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.rest;
+
+public class EnvelopeClass<T> {
+
+    private T content;
+
+    public EnvelopeClass(T content) {
+        this.content = content;
+    }
+
+    public T getContent() {
+        return content;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/EnvelopeClassResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/EnvelopeClassResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/envelope")
+public class EnvelopeClassResource {
+
+    @Path("/payload")
+    @GET
+    @Produces("application/json")
+    public EnvelopeClass<PayloadClass> payloadClass() {
+        return new EnvelopeClass<>(new PayloadClass("hello"));
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/PayloadClass.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/PayloadClass.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.rest;
+
+public class PayloadClass {
+
+    private final String message;
+
+    public PayloadClass(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.main;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 
@@ -183,5 +184,11 @@ public class JaxRSTestCase {
                 .post("/test/gzip")
                 .then().statusCode(413);
         obj.close();
+    }
+
+    @Test
+    public void testReturnTypeWithGenericArgument() {
+        RestAssured.when().get("/envelope/payload").then()
+                .body(containsString("content"), containsString("hello"));
     }
 }


### PR DESCRIPTION
This is needed when a JAX-RS resource returns a parameterized type that
is meant to be an enclosing class

Fixes: #3538