### PR TITLE
Fix possible timeouts on devtools project generation tests

### DIFF
--- a/devtools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
+++ b/devtools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
@@ -219,10 +219,10 @@ public class CreateProjectTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(2)
     @DisplayName("Should create correctly multiple times in parallel with multiple threads")
     void createMultipleTimes() throws InterruptedException {
-        final ExecutorService executorService = Executors.newFixedThreadPool(10);
+        final ExecutorService executorService = Executors.newFixedThreadPool(4);
         final CountDownLatch latch = new CountDownLatch(20);
         Map<String, Object> properties = new HashMap<>();
         properties.put("extensions", "commons-io:commons-io:2.5");

--- a/devtools/common/src/test/java/io/quarkus/generators/rest/BasicRestProjectGeneratorTest.java
+++ b/devtools/common/src/test/java/io/quarkus/generators/rest/BasicRestProjectGeneratorTest.java
@@ -41,10 +41,10 @@ class BasicRestProjectGeneratorTest {
             .build();
 
     @Test
-    @Timeout(1)
+    @Timeout(2)
     @DisplayName("Should generate correctly multiple times in parallel with multiple threads")
     void generateMultipleTimes() throws InterruptedException {
-        final ExecutorService executorService = Executors.newFixedThreadPool(10);
+        final ExecutorService executorService = Executors.newFixedThreadPool(4);
         final CountDownLatch latch = new CountDownLatch(20);
         final BasicRestProjectGenerator basicRestProjectGenerator = new BasicRestProjectGenerator();
         List<Callable<Void>> collect = IntStream.range(0, 20).boxed().map(i -> (Callable<Void>) () -> {


### PR DESCRIPTION
- Change timeout to 2s
- Use only 4 threads to reduce and make the duration stabler
- Local tested duration is under 250ms