### PR TITLE
SmallRye Context Propagation version update

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -37,7 +37,7 @@
         <smallrye-opentracing.version>1.3.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>1.0.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.0.1</smallrye-jwt.version>
-        <smallrye-context-propagation.version>1.0.7</smallrye-context-propagation.version>
+        <smallrye-context-propagation.version>1.0.11</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.6</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.4</smallrye-converter-api.version>
         <smallrye-reactive-messaging.version>0.0.10</smallrye-reactive-messaging.version>


### PR DESCRIPTION
SmallRye Context Propagation version update from 1.0.7 to 1.0.11

diff: https://github.com/smallrye/smallrye-context-propagation/compare/1.0.7...1.0.11
fyi @manovotn if you want to check this too, tests passed locally (jvm mode)