### PR TITLE
Fix list extension regression when called without project

### DIFF
--- a/devtools/common/src/test/java/io/quarkus/cli/commands/ListExtensionsTest.java
+++ b/devtools/common/src/test/java/io/quarkus/cli/commands/ListExtensionsTest.java
@@ -4,6 +4,7 @@ import static io.quarkus.maven.utilities.MojoUtils.getPluginGroupId;
 import static io.quarkus.maven.utilities.MojoUtils.getPluginVersion;
 import static io.quarkus.maven.utilities.MojoUtils.readPom;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -220,5 +221,11 @@ public class ListExtensionsTest {
             ++nbLine;
         }
         Assertions.assertTrue(nbLine > 7, "search to unexpected extension must return a message");
+    }
+
+    @Test
+    void testListExtensionsWithoutAPomFile() throws IOException {
+        ListExtensions listExtensions = new ListExtensions(null, BuildTool.MAVEN);
+        assertThat(listExtensions.findInstalled()).isEmpty();
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
@@ -49,7 +49,9 @@ public class ListExtensionsMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         try {
             FileProjectWriter writer = null;
-            if (project != null) {
+            // Even when we have no pom, the project is not null, but it's set to `org.apache.maven:standalone-pom:1`
+            // So we need to also check for the project's file (the pom.xml file).
+            if (project != null && project.getFile() != null) {
                 writer = new FileProjectWriter(project.getBasedir());
             }
             new ListExtensions(writer, BuildTool.MAVEN).listExtensions(all, format,


### PR DESCRIPTION
Fix #3571

Even when we have no pom, the project is not null, but it's set to `org.apache.maven:standalone-pom:1`. So we need to also check for the project's file (the pom.xml file).