### PR TITLE
Make java.time.Duration serializable to bytecode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -581,6 +582,14 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 ResultHandle doLoad(MethodContext context, MethodCreator method, ResultHandle array) {
                     return method.invokeVirtualMethod(ofMethod(StartupContext.class, "getValue", Object.class, String.class),
                             method.getMethodParam(0), method.load(proxyId));
+                }
+            };
+        } else if (param instanceof Duration) {
+            return new DeferredParameter() {
+                @Override
+                ResultHandle doLoad(MethodContext context, MethodCreator method, ResultHandle array) {
+                    return method.invokeStaticMethod(ofMethod(Duration.class, "parse", Duration.class, CharSequence.class),
+                            method.load(param.toString()));
                 }
             };
         } else if (param instanceof Class<?>) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -1,6 +1,8 @@
 package io.quarkus.deployment.recording;
 
 import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -8,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Consumer;
@@ -17,6 +20,7 @@ import org.junit.Test;
 
 import io.quarkus.deployment.ClassOutput;
 import io.quarkus.gizmo.TestClassLoader;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.StartupContext;
 import io.quarkus.runtime.StartupTask;
@@ -192,6 +196,35 @@ public class BytecodeRecorderTestCase {
         TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
         Assert.assertNotNull(recorder.toString());
         Assert.assertTrue(recorder.toString().contains("$$RecordingProxyProxy"));
+    }
+
+    @Test
+    public void testObjects() throws Exception {
+        Optional<String> quarkusOptional = Optional.of("quarkus");
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            recorder.object(quarkusOptional);
+        }, quarkusOptional);
+        Optional<?> emptyOptional = Optional.empty();
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            recorder.object(emptyOptional);
+        }, emptyOptional);
+        URL url = new URL("https://quarkus.io");
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            recorder.object(url);
+        }, url);
+        LaunchMode launchMode = LaunchMode.TEST;
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            recorder.object(launchMode);
+        }, launchMode);
+        Duration duration = Duration.ofSeconds(30);
+        runTest(generator -> {
+            TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
+            recorder.object(duration);
+        }, duration);
     }
 
     void runTest(Consumer<BytecodeRecorderImpl> generator, Object... expected) throws Exception {


### PR DESCRIPTION
I used a workaround in #3394 to use `java.time.Duration` objects from a `Recorder` which is usually impossible because `Duration` doesn't have a zero-arg constructor and therefore can't be serialized to bytecode.

@gsmet [suggested](https://github.com/quarkusio/quarkus/pull/3394#discussion_r315190695) to try and make `Duration` serializable to bytecode by modifying `BytecodeRecorderImpl`, so here I am with a PR that gave positive results with the #3394 tests involving the `Recorder` mentioned above.

@stuartwdouglas Would you please review this PR?