### PR TITLE
Remove unnecessary dependencies versions from using-vertx guide

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -63,13 +63,11 @@ In the `pom.xml` file you should see 2 test dependencies:
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-junit5</artifactId>
-    <version>${quarkus.version}</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.rest-assured</groupId>
     <artifactId>rest-assured</artifactId>
-    <version>{restassured-version}</version>
     <scope>test</scope>
 </dependency>
 ----

--- a/docs/src/main/asciidoc/using-vertx.adoc
+++ b/docs/src/main/asciidoc/using-vertx.adoc
@@ -354,21 +354,18 @@ Depending on the API model you want to use you need to add the right dependency 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web-client</artifactId>
-  <version>{vertx-version}</version>
 </dependency>
 
 <!-- Axle API -->
 <dependency>
   <groupId>io.smallrye.reactive</groupId>
   <artifactId>smallrye-axle-web-client</artifactId>
-  <version>{axle-version}</version>
 </dependency>
 
 <!-- RX Java 2 API -->
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-rx-java2</artifactId>
-  <version>{vertx-version}</version>
 </dependency>
 ----
 
@@ -381,7 +378,6 @@ In this guide, we are going to use the Axle API, so:
 <dependency>
   <groupId>io.smallrye.reactive</groupId>
   <artifactId>smallrye-axle-web-client</artifactId>
-  <version>{axle-version}</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Fixes #3544 