### PR TITLE
Remove containerRuntime default value from Gradle plugin

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -56,7 +56,7 @@ public class QuarkusNative extends QuarkusTask {
 
     private String nativeImageXmx;
 
-    private String containerRuntime = "docker";
+    private String containerRuntime;
 
     private String containerRuntimeOptions;
 


### PR DESCRIPTION
Fixes #2063 

The `containerRuntime = "docker"` default value was forcing `NativeImagePhase` to contact the Docker daemon at the beginning of the build even when the `--docker-build` Gradle option was not set (and therefore `false`).

That default value was also absent from `quarkus-maven-plugin`. Now, both plugins have the same behavior.