### PR TITLE
Do not wrap custom claim strings into JSONString

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtCallerPrincipalUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtCallerPrincipalUnitTest.java
@@ -9,7 +9,6 @@ import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonNumber;
 import javax.json.JsonObject;
-import javax.json.JsonString;
 
 import org.eclipse.microprofile.jwt.Claims;
 import org.jose4j.jwt.JwtClaims;
@@ -62,8 +61,7 @@ public class JwtCallerPrincipalUnitTest {
         Assertions.assertEquals(Json.createValue(4.4), customDoubleArray.getJsonNumber(4));
 
         // "customString": "customStringValue",
-        JsonString customString = principal.getClaim("customString");
-        Assertions.assertEquals(Json.createValue("customStringValue"), customString);
+        Assertions.assertEquals("customStringValue", principal.getClaim("customString"));
         // "customInteger": 123456789,
         JsonNumber customInteger = principal.getClaim("customInteger");
         Assertions.assertEquals(Json.createValue(123456789), customInteger);

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/ElytronJwtCallerPrincipal.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/ElytronJwtCallerPrincipal.java
@@ -1,8 +1,5 @@
 package io.quarkus.smallrye.jwt.runtime.auth;
 
-import javax.json.JsonStructure;
-
-import org.eclipse.microprofile.jwt.Claims;
 import org.jose4j.jwt.JwtClaims;
 import org.wildfly.security.authz.Attributes;
 
@@ -46,15 +43,4 @@ public class ElytronJwtCallerPrincipal extends DefaultJWTCallerPrincipal {
         return customPrincipalName != null ? customPrincipalName : super.getName();
     }
 
-    @Override
-    protected Object getClaimValue(String claimName) {
-        Object value = super.getClaimValue(claimName);
-
-        Claims claimType = getClaimType(claimName);
-        if (claimType == Claims.UNKNOWN && !(value instanceof JsonStructure)) {
-            value = wrapClaimValue(value);
-        }
-
-        return value;
-    }
 }


### PR DESCRIPTION
Quarkus smallrye-jwt extension wraps the unknown claim string values into `JSONString` - looks like it creates a major portability issue for the custom applications working with MP-JWT since a number of other implementations prefer to stay TCK compliant (even if one of the TCK tests goes against the text - but realistically it also means that the relevant text will unlikely be ever enforced given how widespead the expectations are that a claim string value can be accessed as `String`).
Fixes #3596
 