### PR TITLE
Support IndexDependencyBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/IndexDependencyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/IndexDependencyBuildItem.java
@@ -1,0 +1,35 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Build item that defines dependencies that should be indexed. This can be used when a dependency does not contain
+ * a marker file (e.g. META-INF/beans.xml).
+ */
+public final class IndexDependencyBuildItem extends MultiBuildItem {
+    private final String groupId;
+    private final String artifactId;
+    private final String classifier;
+
+    public IndexDependencyBuildItem(String groupId, String artifactId) {
+        this(groupId, artifactId, null);
+    }
+
+    public IndexDependencyBuildItem(String groupId, String artifactId, String classifier) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.classifier = classifier;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
@@ -34,12 +34,14 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.ApplicationArchiveImpl;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveBuildItem;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -67,9 +69,18 @@ public class ApplicationArchiveBuildStep {
     }
 
     @BuildStep
+    void addConfiguredIndexedDependencies(BuildProducer<IndexDependencyBuildItem> indexDependencyBuildItemBuildProducer) {
+        for (IndexDependencyConfig indexDependencyConfig : config.indexDependency.values()) {
+            indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem(indexDependencyConfig.groupId,
+                    indexDependencyConfig.artifactId, indexDependencyConfig.classifier));
+        }
+    }
+
+    @BuildStep
     ApplicationArchivesBuildItem build(ArchiveRootBuildItem root, ApplicationIndexBuildItem appindex,
             List<AdditionalApplicationArchiveMarkerBuildItem> appMarkers,
             List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchiveBuildItem,
+            List<IndexDependencyBuildItem> indexDependencyBuildItems,
             LiveReloadBuildItem liveReloadContext) throws IOException {
 
         Set<String> markerFiles = new HashSet<>();
@@ -84,7 +95,7 @@ public class ApplicationArchiveBuildStep {
         }
 
         List<ApplicationArchive> applicationArchives = scanForOtherIndexes(Thread.currentThread().getContextClassLoader(),
-                markerFiles, root, additionalApplicationArchiveBuildItem, indexCache);
+                markerFiles, root, additionalApplicationArchiveBuildItem, indexDependencyBuildItems, indexCache);
         return new ApplicationArchivesBuildItem(
                 new ApplicationArchiveImpl(appindex.getIndex(), root.getArchiveRoot(), null, false, root.getArchiveLocation()),
                 applicationArchives);
@@ -92,11 +103,11 @@ public class ApplicationArchiveBuildStep {
 
     private List<ApplicationArchive> scanForOtherIndexes(ClassLoader classLoader, Set<String> applicationArchiveFiles,
             ArchiveRootBuildItem root, List<AdditionalApplicationArchiveBuildItem> additionalApplicationArchives,
-            IndexCache indexCache)
+            List<IndexDependencyBuildItem> indexDependencyBuildItem, IndexCache indexCache)
             throws IOException {
         Set<Path> dependenciesToIndex = new HashSet<>();
         //get paths that are included via index-dependencies
-        dependenciesToIndex.addAll(getIndexDependencyPaths(classLoader, root));
+        dependenciesToIndex.addAll(getIndexDependencyPaths(indexDependencyBuildItem, classLoader, root));
         //get paths that are included via marker files
         Set<String> markers = new HashSet<>(applicationArchiveFiles);
         markers.add(JANDEX_INDEX);
@@ -112,18 +123,21 @@ public class ApplicationArchiveBuildStep {
         return indexPaths(dependenciesToIndex, classLoader, indexCache);
     }
 
-    public List<Path> getIndexDependencyPaths(ClassLoader classLoader, ArchiveRootBuildItem root) {
+    public List<Path> getIndexDependencyPaths(List<IndexDependencyBuildItem> indexDependencyBuildItems,
+            ClassLoader classLoader, ArchiveRootBuildItem root) {
         ArtifactIndex artifactIndex = new ArtifactIndex(new ClassPathArtifactResolver(classLoader));
         try {
             List<Path> ret = new ArrayList<>();
 
-            for (Map.Entry<String, IndexDependencyConfig> entry : this.config.indexDependency.entrySet()) {
+            for (IndexDependencyBuildItem indexDependencyBuildItem : indexDependencyBuildItems) {
                 Path path;
-                if (entry.getValue().classifier.isEmpty()) {
-                    path = artifactIndex.getPath(entry.getValue().groupId, entry.getValue().artifactId, null);
+                String classifier = indexDependencyBuildItem.getClassifier();
+                if (classifier == null || classifier.isEmpty()) {
+                    path = artifactIndex.getPath(indexDependencyBuildItem.getGroupId(),
+                            indexDependencyBuildItem.getArtifactId(), null);
                 } else {
-                    path = artifactIndex.getPath(entry.getValue().groupId, entry.getValue().artifactId,
-                            entry.getValue().classifier);
+                    path = artifactIndex.getPath(indexDependencyBuildItem.getGroupId(),
+                            indexDependencyBuildItem.getArtifactId(), classifier);
                 }
                 if (!root.isExcludedFromIndexing(path)) {
                     ret.add(path);


### PR DESCRIPTION
Adds a new BuildItem that can be used by extensions to define what artifact should be also indexed that currently doesn't have a Jandex index included or doesn't have a marker to find. This also consolidates the `application.properties` `index-dependency` setting to create the build items.