### PR TITLE
Make the Jackson mapper of Amazon Lambda case insensitive

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -12,6 +12,7 @@ import com.amazonaws.services.lambda.runtime.ClientContext;
 import com.amazonaws.services.lambda.runtime.CognitoIdentity;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
@@ -34,7 +35,9 @@ public class AmazonLambdaRecorder {
 
         RequestHandler handler = beanContainer.instance(handlerClass);
 
-        final ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        final ObjectMapper mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         AtomicBoolean running = new AtomicBoolean(true);
         ObjectReader objectReader = mapper.readerFor(handlerType.getValue());
         ObjectReader cognitoIdReader = mapper.readerFor(CognitoIdentity.class);


### PR DESCRIPTION
I tried to create a unit test for the AmazonLambdaRecorder but was not possible ( for me ... ) to have it tested. It creates a URLConnection with no possibility to mock this.

I noticed there is a LambdaResourceManager which can be used to achieve this, but I could not add this as a dependency because it would end up as a cyclic dependency.

Fixes https://github.com/quarkusio/quarkus/issues/3481