### PR TITLE
Upgrade to GraalVM 19.2.0

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -67,7 +67,7 @@
         <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal
            is not available in Maven fast enough: -->
-        <graal-sdk.version>19.1.1</graal-sdk.version>
+        <graal-sdk.version>19.2.0</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha7</gizmo.version>
         <jackson.version>2.9.9.20190807</jackson.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -27,7 +27,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>19.1.1</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>19.2.0</graal-sdk.version-for-documentation>
         <rest-assured.version>3.3.0</rest-assured.version>
         <axle-client.version>0.0.7</axle-client.version>
         <vertx.version>3.7.1</vertx.version>

--- a/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/nativeimage/NativeImagePhase.java
@@ -103,7 +103,7 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
 
     private String nativeImageXmx;
 
-    private String builderImage = "quay.io/quarkus/ubi-quarkus-native-image:19.1.1";
+    private String builderImage = "quay.io/quarkus/ubi-quarkus-native-image:19.2.0";
 
     private String containerRuntime = "";
 
@@ -561,15 +561,13 @@ public class NativeImagePhase implements AppCreationPhase<NativeImagePhase>, Nat
         }
     }
 
-    //FIXME remove after transition period
     private boolean isThisGraalVMVersionObsolete() {
         final String vmName = System.getProperty("java.vm.name");
         log.info("Running Quarkus native-image plugin on " + vmName);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("-rc9", "-rc10", "-rc11", "-rc12", "-rc13", "-rc14",
-                "-rc15", "-rc16", "19.0.", "19.1.0");
+        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.");
         final boolean vmVersionIsObsolete = obsoleteGraalVmVersions.stream().anyMatch(vmName::contains);
         if (vmVersionIsObsolete) {
-            log.error("Out of date build of GraalVM detected! Please upgrade to GraalVM 19.1.1.");
+            log.error("Out of date build of GraalVM detected! Please upgrade to GraalVM 19.2.0.");
             return true;
         }
         return false;


### PR DESCRIPTION
Fixes #3604

This is a draft PR:
- we need to wait for the artifacts to hit Central. It can take a few days depending on the wind.
- we need @cescoffier to prepare a new `ubi-quarkus-native-image` image

I'm running the tests locally.