### PR TITLE
Do not delete generated files

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
@@ -202,12 +202,8 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext {
                 for (Path classFilePath : classFilePaths) {
                     final Path sourceFilePath = retrieveSourceFilePathForClassFile(classFilePath, moduleChangedSourceFiles,
                             module);
-                    if (sourceFilePath == null) {
-                        Files.deleteIfExists(classFilePath);
-                        classFilePathToSourceFilePath.remove(classFilePath);
-                        hasChanges = true;
-                    } else {
-                        final long classFileModificationTime = Files.getLastModifiedTime(classFilePath).toMillis();
+                    final long classFileModificationTime = Files.getLastModifiedTime(classFilePath).toMillis();
+                    if (sourceFilePath != null) {
                         if (Files.notExists(sourceFilePath)) {
                             // Source file has been deleted. Delete class and restart
                             Files.deleteIfExists(classFilePath);
@@ -226,6 +222,8 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext {
                                 hasChanges = true;
                             }
                         }
+                    } else if (classFileModificationTime > lastChange) {
+                        hasChanges = true;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #3448 - generated files that are not within module source paths returned a null sourceFilePath. We should not delete the corresponding generated .class file in this case.

/cc @antoniomacri @masini this should fix the issue you encountered. 

/cc @gsmet 