### PR TITLE
 Private methods should not have metrics applied to them.

### DIFF
--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -7,6 +7,7 @@ import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.GAU
 import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METRICS_ANNOTATIONS;
 import static io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsDotNames.METRICS_BINDING;
 
+import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -186,7 +187,9 @@ public class SmallRyeMetricsProcessor {
         for (ClassInfo clazz : collectedMetricsClasses.values()) {
             BeanInfo beanInfo = beanInfoAdapter.convert(clazz);
             for (MethodInfo method : clazz.methods()) {
-                metrics.registerMetrics(beanInfo, memberInfoAdapter.convert(method));
+                if (!Modifier.isPrivate(method.flags())) {
+                    metrics.registerMetrics(beanInfo, memberInfoAdapter.convert(method));
+                }
             }
         }
 


### PR DESCRIPTION
Current MP Metrics TCK expect this behaviour.
While it is now under discussion [in this issue](https://github.com/eclipse/microprofile-metrics/issues/416), we are better off aligning with what the TCK expects right now.