### PR TITLE
Arc - fix bean generic injection for then required and bean type parameters are type variable, but bean one has no bounds

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolver.java
@@ -111,7 +111,14 @@ class BeanResolver {
                     throw new IllegalArgumentException("Invalid argument combination " + requiredType + "; " + beanType);
                 }
                 for (int i = 0; i < requiredTypeArguments.size(); i++) {
-                    if (!parametersMatch(requiredTypeArguments.get(i), beanTypeArguments.get(i))) {
+                    Type requiredTypeArg = requiredTypeArguments.get(i);
+                    Type beanTypeArg = beanTypeArguments.get(i);
+                    if (isActualType(requiredTypeArg) && isActualType(beanTypeArg)
+                            && beanTypeArg.name().equals(DotNames.OBJECT)) {
+                        // required type = FooTyped<Long> and bean type is FooTyped<Object>, that is a match
+                        return true;
+                    }
+                    if (!parametersMatch(requiredTypeArg, beanTypeArg)) {
                         return false;
                     }
                 }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -26,7 +26,7 @@ public class TypesTest {
         DotName fooName = DotName.createSimple(Foo.class.getName());
         ClassInfo fooClass = index.getClassByName(fooName);
         Map<ClassInfo, Map<TypeVariable, Type>> resolvedTypeVariables = new HashMap<>();
-        Set<Type> types = Types.getTypeClosure(index.getClassByName(bazName),
+        Set<Type> types = Types.getTypeClosure(index.getClassByName(bazName), false,
                 Collections.emptyMap(),
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/AssignabilityWithGenericsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/AssignabilityWithGenericsTest.java
@@ -16,6 +16,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.enterprise.event.ObservesAsync;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,7 +27,8 @@ public class AssignabilityWithGenericsTest {
     public ArcTestContainer container = new ArcTestContainer(Car.class, Engine.class, PetrolEngine.class, Vehicle.class,
             StringListConsumer.class, ListConsumer.class, ProducerBean.class, DefinitelyNotBar.class,
             Bar.class, GenericInterface.class, AlmostCompleteBean.class, ActualBean.class,
-            BetaFace.class, GammaFace.class, GammaImpl.class, AbstractAlpha.class, AlphaImpl.class);
+            BetaFace.class, GammaFace.class, GammaImpl.class, AbstractAlpha.class, AlphaImpl.class,
+            BeanInjectingActualType.class, FooTyped.class);
 
     @Test
     public void testSelectingInstanceOfCar() {
@@ -57,6 +59,27 @@ public class AssignabilityWithGenericsTest {
         assertTrue(gammaInstance.isAvailable());
         AlphaImpl alpha = alphaInstance.get();
         assertEquals(GammaImpl.class.getSimpleName(), alpha.ping(alpha.getParam()));
+    }
+
+    @Test
+    public void testRequiredTypeIsActualTypeAndBeanHasObject() {
+        InstanceHandle<FooTyped<Object>> fooTypedInstance = Arc.container().instance(new TypeLiteral<FooTyped<Object>>() {
+        });
+        InstanceHandle<BeanInjectingActualType> beanInjectingActualTypeInstance = Arc.container()
+                .instance(BeanInjectingActualType.class);
+        assertTrue(fooTypedInstance.isAvailable());
+        assertTrue(beanInjectingActualTypeInstance.isAvailable());
+    }
+
+    @ApplicationScoped
+    static class BeanInjectingActualType {
+        @Inject
+        FooTyped<Long> bean;
+    }
+
+    @Dependent
+    static class FooTyped<T> {
+        // arc will translate this as FooTyped<Object>
     }
 
     interface GenericInterface<T, K> {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/RawTypeAssignabilityTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/RawTypeAssignabilityTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.arc.test.injection.assignability.generics;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Vetoed;
+import javax.inject.Inject;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RawTypeAssignabilityTest {
+
+    @Rule
+    public ArcTestContainer container = new ArcTestContainer(MyProducer.class, MyConsumer.class, Foo.class);
+
+    @Test
+    public void testAssignabilityWithRawType() {
+        ArcContainer container = Arc.container();
+        MyConsumer consumer = container.instance(MyConsumer.class).get();
+        Assert.assertEquals(String.class.toString(), consumer.pingRaw());
+        Assert.assertEquals(String.class.toString(), consumer.pingObject());
+        Assert.assertEquals(Long.class.toString(), consumer.pingLong());
+        Assert.assertEquals(Long.class.toString(), consumer.pingWild());
+    }
+
+    @ApplicationScoped
+    static class MyConsumer {
+
+        @Inject
+        Foo rawFoo;
+
+        @Inject
+        Foo<Object> objectFoo;
+
+        @Inject
+        Foo<?> wildFoo;
+
+        @Inject
+        Foo<Long> longFoo;
+
+        public String pingWild() {
+            return wildFoo.ping();
+        }
+
+        public String pingRaw() {
+            return rawFoo.ping();
+        }
+
+        public String pingObject() {
+            return objectFoo.ping();
+        }
+
+        public String pingLong() {
+            return longFoo.ping();
+        }
+    }
+
+    @ApplicationScoped
+    static class MyProducer {
+
+        @Produces
+        public Foo produceRaw() {
+            return new Foo("foo");
+        }
+
+        @Produces
+        public Foo<Long> produceLong() {
+            return new Foo<>(1l);
+        }
+    }
+
+    @Vetoed
+    static class Foo<T> {
+
+        T type;
+
+        public Foo(T type) {
+            this.type = type;
+        }
+
+        public String ping() {
+            return type.getClass().toString();
+        }
+    }
+}


### PR DESCRIPTION
…meters are type variable, but bean one has no bounds.

Fixes #3619 
