### PR TITLE
Optionally replace netty JdkSslContext

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -3,6 +3,7 @@ package io.quarkus.netty.runtime.graal;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
+import java.util.function.BooleanSupplier;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
@@ -194,14 +195,21 @@ final class Target_io_netty_handler_ssl_SslContext {
 
 }
 
-@TargetClass(className = "io.netty.handler.ssl.JdkDefaultApplicationProtocolNegotiator")
+final class ReplaceJdkSslContext implements BooleanSupplier {
+    public boolean getAsBoolean() {
+        final String enabled = System.getProperty("substratevm.replacement.jdksslcontext", "true");
+        return Boolean.valueOf(enabled);
+    }
+}
+
+@TargetClass(className = "io.netty.handler.ssl.JdkDefaultApplicationProtocolNegotiator", onlyWith = ReplaceJdkSslContext.class)
 final class Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator {
 
     @Alias
     public static Target_io_netty_handler_ssl_JdkDefaultApplicationProtocolNegotiator INSTANCE;
 }
 
-@TargetClass(className = "io.netty.handler.ssl.JdkSslContext")
+@TargetClass(className = "io.netty.handler.ssl.JdkSslContext", onlyWith = ReplaceJdkSslContext.class)
 final class Target_io_netty_handler_ssl_JdkSslContext {
 
     @Substitute


### PR DESCRIPTION
In an extra extension, we have a custom implementation of ApplicationProtocolNegotiator. Unfortunately I cannot replace the values for it as the method and object reference is already used. This will allow an extension to disable the netty replacement of these classes and the extension that depends on netty can replace them instead.

I originally had the system property start with `quarkus`, but these are special and are not passed to the `native-image` command. If there is a different approach preferred, let me know.