### PR TITLE
Fix registration of metrics from extended classes. 

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkus/it/metrics/inheritance/InheritanceMetricsBase.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/metrics/inheritance/InheritanceMetricsBase.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.metrics.inheritance;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+@Counted
+@ApplicationScoped
+public class InheritanceMetricsBase {
+
+    public void baseMethod() {
+
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/metrics/inheritance/InheritanceMetricsExtended.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/metrics/inheritance/InheritanceMetricsExtended.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.metrics.inheritance;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class InheritanceMetricsExtended extends InheritanceMetricsBase {
+
+    public void anotherMethod() {
+
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/metrics/inheritance/MetricsInheritanceResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/metrics/inheritance/MetricsInheritanceResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.metrics.inheritance;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+@Path("/metricsinheritanceresource")
+public class MetricsInheritanceResource {
+
+    @Inject
+    MetricRegistry metricRegistry;
+
+    @Path("/registration")
+    @GET
+    @Produces("application/json")
+    public List<String> getAllMetricNames() {
+        return metricRegistry
+                .getCounters((metricID, metric) -> metricID.getName().contains("Inheritance"))
+                .keySet()
+                .stream()
+                .map(MetricID::getName)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsInheritanceITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsInheritanceITCase.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.main;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class MetricsInheritanceITCase extends MetricsInheritanceTestCase {
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsInheritanceTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsInheritanceTestCase.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.main;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class MetricsInheritanceTestCase {
+
+    @Test
+    public void verifyRegistrations() {
+        RestAssured.when().get("/metricsinheritanceresource/registration")
+                .then().body("", Matchers.containsInAnyOrder(
+                        "io.quarkus.it.metrics.inheritance.InheritanceMetricsBase.InheritanceMetricsBase",
+                        "io.quarkus.it.metrics.inheritance.InheritanceMetricsBase.baseMethod",
+                        "io.quarkus.it.metrics.inheritance.InheritanceMetricsExtended.InheritanceMetricsExtended",
+                        "io.quarkus.it.metrics.inheritance.InheritanceMetricsExtended.anotherMethod",
+                        "io.quarkus.it.metrics.inheritance.InheritanceMetricsExtended.baseMethod"));
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/3649

This will be also partially covered in Metrics TCK by `ConcreteTimedBeanTest` and `ConcreteExtendedTimedBeanTest` once we get the TCK working