### PR TITLE
Provides extension health via builditem

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -168,6 +168,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-smallrye-health-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/datasource-guide.adoc
+++ b/docs/src/main/asciidoc/datasource-guide.adoc
@@ -244,7 +244,7 @@ to validate the datasource.
 So when you access the `/health/ready` endpoint of your application you will have information about the datasource validation status.
 If you have multiple datasources, all datasources will be checked and the status will be `DOWN` as soon as there is one datasource validation failure.
 
-This behavior can be disabled via the property `quarkus.datasource.health.disabled`.
+This behavior can be disabled via the property `quarkus.datasource.health.enabled`.
 
 
 [[configuration-reference]]

--- a/docs/src/main/asciidoc/datasource-guide.adoc
+++ b/docs/src/main/asciidoc/datasource-guide.adoc
@@ -236,6 +236,16 @@ AgroalDataSource dataSource1;
 AgroalDataSource dataSource2;
 --
 
+== Datasource Health Check
+
+If you are using the `quarkus-smallrye-health` extension, `quarkus-agroal` will automatically add a readiness health check
+to validate the datasource.
+
+So when you access the `/health/ready` endpoint of your application you will have information about the datasource validation status.
+If you have multiple datasources, all datasources will be checked and the status will be `DOWN` as soon as there is one datasource validation failure.
+
+This behavior can be disabled via the property `quarkus.datasource.health.disabled`.
+
 
 [[configuration-reference]]
 == Agroal Configuration Reference

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1206,6 +1206,36 @@ As a CDI based runtime, Quarkus extensions often make CDI beans available as par
 However, Quarkus DI solution does not support CDI Portable Extensions.
 Instead, Quarkus extensions can make use of various link:cdi-reference.html[Build Time Extension Points].
 
+=== Extension Health Check
+
+Health checks are provided via the `quarkus-smallrye-health` extension. It provides both liveness and readiness checks capabilities.
+
+When writing an extension, it's beneficial to provide health checks for the extension, that can be automatically included without the developer needing to write their own.
+
+In order to provide a health check, you should do the following:
+
+- Import the `quarkus-smallrye-health` extension as an **optional** dependency in your runtime module so it will not impact the size of the application if
+health check is not included.
+- Create your health check following the link:health-guide.html[Quarkus - MicroProfile Health] guide. We advise providing only
+readiness check for an extension (liveness check is designed to express the fact that an application is up and needs to be lightweight).
+- Import the `quarkus-smallrye-health-spi` library in your deployment module.
+- Add a build step in your deployment module that produces a `HealthBuildItem`.
+- Add a way to disable the extension health check via a config item `quarkus.<extension>.health.enabled` that should be enabled by default.
+
+Following is an example from the Agroal extension that provides a `DataSourceHealthCheck` to validate the readiness of a datasource.
+
+[source%nowrap,java]
+----
+@BuildStep
+HealthBuildItem addHealthCheck(AgroalBuildTimeConfig agroalBuildTimeConfig) {
+    if (agroalBuildTimeConfig.healthEnabled) {
+        //produce the health bean
+        return new HealthBuildItem(DataSourceHealthCheck.class);
+    }
+    return null;
+}
+----
+
 === Testing Extensions
 
 Testing of extensions should be done with the `io.quarkus.test.QuarkusUnitTest` runner. This runner allows

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1228,11 +1228,7 @@ Following is an example from the Agroal extension that provides a `DataSourceHea
 ----
 @BuildStep
 HealthBuildItem addHealthCheck(AgroalBuildTimeConfig agroalBuildTimeConfig) {
-    if (agroalBuildTimeConfig.healthEnabled) {
-        //produce the health bean
-        return new HealthBuildItem(DataSourceHealthCheck.class);
-    }
-    return null;
+    return new HealthBuildItem(DataSourceHealthCheck.class, agroalBuildTimeConfig.healthEnabled);
 }
 ----
 

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1228,7 +1228,8 @@ Following is an example from the Agroal extension that provides a `DataSourceHea
 ----
 @BuildStep
 HealthBuildItem addHealthCheck(AgroalBuildTimeConfig agroalBuildTimeConfig) {
-    return new HealthBuildItem(DataSourceHealthCheck.class, agroalBuildTimeConfig.healthEnabled);
+    return new HealthBuildItem("io.quarkus.agroal.runtime.health.DataSourceHealthCheck",
+            agroalBuildTimeConfig.healthEnabled, "datasource");
 }
 ----
 

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -296,6 +296,15 @@ error along with the health check response.
         }
 ----
 
+== Extension health checks
+
+Some extension may provide default health checks, including the extension will automatically register its health checks.
+
+For example, `quarkus-agroal` that is used to manage Quarkus datasource(s) automatically register a readiness health check
+that will validate each datasources: link:datasource-guide.html#datasource-health-check[Datasource Health Check].
+
+You can disable extension health check via the property `quarkus.health.extension.enabled` so none will be automatically registered.
+
 == Conclusion
 
 MicroProfile Health provides a way for your application to distribute information 

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -303,7 +303,7 @@ Some extension may provide default health checks, including the extension will a
 For example, `quarkus-agroal` that is used to manage Quarkus datasource(s) automatically register a readiness health check
 that will validate each datasources: link:datasource-guide.html#datasource-health-check[Datasource Health Check].
 
-You can disable extension health check via the property `quarkus.health.extension.enabled` so none will be automatically registered.
+You can disable extension health check via the property `quarkus.health.extensions.enabled` so none will be automatically registered.
 
 == Conclusion
 

--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -30,12 +30,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-narayana-jta-deployment</artifactId>
         </dependency>
-
-        <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-health</artifactId>
-            <optional>true</optional>
+            <artifactId>quarkus-smallrye-health-spi</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>quarkus-narayana-jta-deployment</artifactId>
         </dependency>
 
+        <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -25,7 +25,6 @@ import io.quarkus.agroal.runtime.AgroalBuildTimeConfig;
 import io.quarkus.agroal.runtime.AgroalRecorder;
 import io.quarkus.agroal.runtime.AgroalRuntimeConfig;
 import io.quarkus.agroal.runtime.DataSourceBuildTimeConfig;
-import io.quarkus.agroal.runtime.health.DataSourceHealthCheck;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
@@ -248,6 +247,7 @@ class AgroalProcessor {
 
     @BuildStep
     HealthBuildItem addHealthCheck(AgroalBuildTimeConfig agroalBuildTimeConfig) {
-        return new HealthBuildItem(DataSourceHealthCheck.class, agroalBuildTimeConfig.healthEnabled);
+        return new HealthBuildItem("io.quarkus.agroal.runtime.health.DataSourceHealthCheck",
+                agroalBuildTimeConfig.healthEnabled, "datasource");
     }
 }

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -248,10 +248,6 @@ class AgroalProcessor {
 
     @BuildStep
     HealthBuildItem addHealthCheck(AgroalBuildTimeConfig agroalBuildTimeConfig) {
-        if (agroalBuildTimeConfig.healthEnabled) {
-            //produce the health bean
-            return new HealthBuildItem(DataSourceHealthCheck.class);
-        }
-        return null;
+        return new HealthBuildItem(DataSourceHealthCheck.class, agroalBuildTimeConfig.healthEnabled);
     }
 }

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>svm</artifactId>
         </dependency>
 
+        <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalBuildTimeConfig.java
@@ -22,7 +22,7 @@ public class AgroalBuildTimeConfig {
     public Map<String, DataSourceBuildTimeConfig> namedDataSources;
 
     /**
-     * Whether or not an healtcheck is published in case the smallrye-health extionsion is present (default to true).
+     * Whether or not an healtcheck is published in case the smallrye-health extension is present (default to true).
      */
     @ConfigItem(name = "health.enabled", defaultValue = "true")
     public boolean healthEnabled;

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalBuildTimeConfig.java
@@ -20,4 +20,10 @@ public class AgroalBuildTimeConfig {
      */
     @ConfigItem(name = ConfigItem.PARENT)
     public Map<String, DataSourceBuildTimeConfig> namedDataSources;
+
+    /**
+     * Whether or not an healtcheck is published in case the smallrye-health extionsion is present (default to true).
+     */
+    @ConfigItem(name = "health.enabled", defaultValue = "true")
+    public boolean healthEnabled;
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
@@ -53,8 +53,7 @@ public class DataSourceHealthCheck implements HealthCheck {
                     builder.down().withData(dsName, data);
                 }
             } catch (SQLException e) {
-                String data = DEFAULT_DS.equals(dataSource.getKey())
-                        ? "Unable to execute the validation check for the default DataSource: "
+                String data = isDefault ? "Unable to execute the validation check for the default DataSource: "
                         : "Unable to execute the validation check for DataSource '" + dataSource.getKey() + "': ";
                 String dsName = isDefault ? "quarkus-default-ds" : dataSource.getKey();
                 builder.down().withData(dsName, data + e.getMessage());

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/health/DataSourceHealthCheck.java
@@ -1,0 +1,65 @@
+package io.quarkus.agroal.runtime.health;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Bean;
+import javax.sql.DataSource;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+import io.quarkus.arc.Arc;
+
+@Readiness
+@ApplicationScoped
+public class DataSourceHealthCheck implements HealthCheck {
+    private static final String DEFAULT_DS = "__default__";
+    private Map<String, DataSource> dataSources = new HashMap<>();
+
+    @PostConstruct
+    protected void init() {
+        Set<Bean<?>> beans = Arc.container().beanManager().getBeans(DataSource.class);
+        for (Bean<?> bean : beans) {
+            if (bean.getName() == null) {
+                // this is the default DataSource: retrieve it by type
+                DataSource defaultDs = Arc.container().instance(DataSource.class).get();
+                dataSources.put(DEFAULT_DS, defaultDs);
+            } else {
+                DataSource ds = (DataSource) Arc.container().instance(bean.getName()).get();
+                dataSources.put(bean.getName(), ds);
+            }
+        }
+    }
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.named("Database connection(s) health check").up();
+        for (Map.Entry<String, DataSource> dataSource : dataSources.entrySet()) {
+            boolean isDefault = DEFAULT_DS.equals(dataSource.getKey());
+            try (Connection con = dataSource.getValue().getConnection()) {
+                boolean valid = con.isValid(0);
+                if (!valid) {
+                    String data = isDefault ? "validation check failed for the default DataSource"
+                            : "validation check failed for DataSource '" + dataSource.getKey() + "'";
+                    String dsName = isDefault ? "quarkus-default-ds" : dataSource.getKey();
+                    builder.down().withData(dsName, data);
+                }
+            } catch (SQLException e) {
+                String data = DEFAULT_DS.equals(dataSource.getKey())
+                        ? "Unable to execute the validation check for the default DataSource: "
+                        : "Unable to execute the validation check for DataSource '" + dataSource.getKey() + "': ";
+                String dsName = isDefault ? "quarkus-default-ds" : dataSource.getKey();
+                builder.down().withData(dsName, data + e.getMessage());
+            }
+        }
+        return builder.build();
+    }
+}

--- a/extensions/smallrye-health/deployment/pom.xml
+++ b/extensions/smallrye-health/deployment/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
 

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/HealthBuildTimeConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/HealthBuildTimeConfig.java
@@ -1,0 +1,13 @@
+package io.quarkus.smallrye.health.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "health")
+public class HealthBuildTimeConfig {
+    /**
+     * Whether or not extensions published health check should be enabled.
+     */
+    @ConfigItem(name = "extensions.enabled", defaultValue = "true")
+    public boolean extensionsEnabled;
+}

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.smallrye.health.deployment;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.microprofile.health.Health;
@@ -22,6 +23,7 @@ import io.quarkus.kubernetes.spi.KubernetesHealthLivenessPathBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesHealthReadinessPathBuildItem;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthHandler;
 import io.quarkus.smallrye.health.runtime.SmallRyeHealthRecorder;
 import io.quarkus.smallrye.health.runtime.SmallRyeLivenessHandler;
@@ -42,6 +44,8 @@ class SmallRyeHealthProcessor {
      */
     SmallRyeHealthConfig health;
 
+    HealthBuildTimeConfig config;
+
     @ConfigRoot(name = "smallrye-health")
     static final class SmallRyeHealthConfig {
         /**
@@ -61,6 +65,16 @@ class SmallRyeHealthProcessor {
          */
         @ConfigItem(defaultValue = "/ready")
         String readinessPath;
+    }
+
+    @BuildStep
+    public void healthCheck(BuildProducer<AdditionalBeanBuildItem> buildItemBuildProducer,
+            List<HealthBuildItem> healthBuildItems) {
+        if (config.extensionsEnabled) {
+            for (HealthBuildItem buildItem : healthBuildItems) {
+                buildItemBuildProducer.produce(new AdditionalBeanBuildItem(buildItem.getHealthCheckClass()));
+            }
+        }
     }
 
     @BuildStep

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -68,11 +68,13 @@ class SmallRyeHealthProcessor {
     }
 
     @BuildStep
-    public void healthCheck(BuildProducer<AdditionalBeanBuildItem> buildItemBuildProducer,
+    void healthCheck(BuildProducer<AdditionalBeanBuildItem> buildItemBuildProducer,
             List<HealthBuildItem> healthBuildItems) {
         if (config.extensionsEnabled) {
             for (HealthBuildItem buildItem : healthBuildItems) {
-                buildItemBuildProducer.produce(new AdditionalBeanBuildItem(buildItem.getHealthCheckClass()));
+                if (buildItem.isEnabled()) {
+                    buildItemBuildProducer.produce(new AdditionalBeanBuildItem(buildItem.getHealthCheckClass()));
+                }
             }
         }
     }

--- a/extensions/smallrye-health/pom.xml
+++ b/extensions/smallrye-health/pom.xml
@@ -17,5 +17,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>spi</module>
     </modules>
 </project>

--- a/extensions/smallrye-health/spi/pom.xml
+++ b/extensions/smallrye-health/spi/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-smallrye-health-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-smallrye-health-spi</artifactId>
+    <name>Quarkus - SmallRye Health - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
+++ b/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
@@ -4,12 +4,18 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 public final class HealthBuildItem extends MultiBuildItem {
     private Class<?> healthCheckClass;
+    private boolean enabled;
 
-    public HealthBuildItem(Class<?> healthCheckClass) {
+    public HealthBuildItem(Class<?> healthCheckClass, boolean enabled) {
         this.healthCheckClass = healthCheckClass;
+        this.enabled = enabled;
     }
 
     public Class<?> getHealthCheckClass() {
         return this.healthCheckClass;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
+++ b/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
@@ -1,0 +1,15 @@
+package io.quarkus.smallrye.health.deployment.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class HealthBuildItem extends MultiBuildItem {
+    private Class<?> healthCheckClass;
+
+    public HealthBuildItem(Class<?> healthCheckClass) {
+        this.healthCheckClass = healthCheckClass;
+    }
+
+    public Class<?> getHealthCheckClass() {
+        return this.healthCheckClass;
+    }
+}

--- a/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
+++ b/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
@@ -3,19 +3,32 @@ package io.quarkus.smallrye.health.deployment.spi;
 import io.quarkus.builder.item.MultiBuildItem;
 
 public final class HealthBuildItem extends MultiBuildItem {
-    private Class<?> healthCheckClass;
+    private String healthCheckClass;
     private boolean enabled;
+    private String configRootName;
 
-    public HealthBuildItem(Class<?> healthCheckClass, boolean enabled) {
+    /**
+     * @param healthCheckClass the name of the health check class, needs to implements
+     *        org.eclipse.microprofile.health.HealthCheck
+     * @param enabled whether or not the check is enabled
+     * @param configRootName the name of the root configuration of the extension as defined by the <code>@ConfigRoot</code>
+     *        annotation.
+     */
+    public HealthBuildItem(String healthCheckClass, boolean enabled, String configRootName) {
         this.healthCheckClass = healthCheckClass;
         this.enabled = enabled;
+        this.configRootName = configRootName;
     }
 
-    public Class<?> getHealthCheckClass() {
+    public String getHealthCheckClass() {
         return this.healthCheckClass;
     }
 
     public boolean isEnabled() {
         return enabled;
+    }
+
+    public String getConfigRootName() {
+        return configRootName;
     }
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthTestCase.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.main;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -18,10 +18,17 @@ public class HealthTestCase {
         try {
             RestAssured.when().get("/health/live").then()
                     .contentType(ContentType.JSON)
-                    .header("Content-Type", Matchers.containsString("charset=UTF-8"))
+                    .header("Content-Type", containsString("charset=UTF-8"))
                     .body("status", is("UP"),
                             "checks.status", containsInAnyOrder("UP", "UP"),
                             "checks.name", containsInAnyOrder("basic", "basic-with-builder"));
+
+            RestAssured.when().get("/health/ready").then()
+                    .contentType(ContentType.JSON)
+                    .header("Content-Type", containsString("charset=UTF-8"))
+                    .body("status", is("UP"),
+                            "checks.status", containsInAnyOrder("UP"),
+                            "checks.name", containsInAnyOrder("Database connection(s) health check"));
         } finally {
             RestAssured.reset();
         }


### PR DESCRIPTION
This PR implements health check inside the Agroal extension so a user will have an health check that validate the database if it includes the agroal extension.

I create a `HealthBuildItem` that an extension needs to emmit to inlcude it's health check. Smallrye Heath extension will use these `HealthBuildItem`s to add the health check to ArC if extension health check is enabled (true by default).

It can be disabled with the following properties:
```
# disable the datasource health check
quarkus.datasource.health.enabled=false
# disable all extension health check
quarkus.health.extensions.enabled=false
```

This is part of #3107

Ping @emmanuelbernard @kenfinnigan @stuartwdouglas 