### PR TITLE
Fix issue with runtime config being consumed at build time

### DIFF
--- a/extensions/kubernetes/deployment/pom.xml
+++ b/extensions/kubernetes/deployment/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>quarkus-kubernetes-spi</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dekorate</groupId>
             <artifactId>kubernetes-annotations</artifactId>
             <classifier>noapt</classifier>

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
@@ -91,8 +92,12 @@ class VertxWebProcessor {
     }
 
     @BuildStep
-    public void kubernetes(HttpConfiguration config, BuildProducer<KubernetesPortBuildItem> portProducer) {
-        portProducer.produce(new KubernetesPortBuildItem(config.port, "http"));
+    public void kubernetes(BuildProducer<KubernetesPortBuildItem> portProducer) {
+        // we can't use HttpConfiguration since the port is a runtime configuration value
+        // therefore we just read the value from MP Config - this is fine since the value is only ever used to create
+        // Kubernetes resources at build time
+        portProducer.produce(new KubernetesPortBuildItem(
+                ConfigProvider.getConfig().getOptionalValue("quarkus.http.port", Integer.class).orElse(8080), "http"));
     }
 
     @BuildStep


### PR DESCRIPTION
The Kubernetes resource generation only occurs at build time so it suffices
to read the http port value from MP Config

Fixes: #3677