### PR TITLE
fixed typo in rest client guide - javax.inject.Singleton

### DIFF
--- a/docs/src/main/asciidoc/rest-client-guide.adoc
+++ b/docs/src/main/asciidoc/rest-client-guide.adoc
@@ -185,7 +185,7 @@ The name of the property needs to follow a certain convention which is best disp
 ----
 # Your configuration properties
 org.acme.restclient.CountriesService/mp-rest/url=https://restcountries.eu/rest # // <1>
-org.acme.restclient.CountriesService/mp-rest/scope=java.inject.Singleton # // <2>
+org.acme.restclient.CountriesService/mp-rest/scope=javax.inject.Singleton # // <2>
 ----
 
 <1> Having this configuration means that all requests performed using `org.acme.restclient.CountriesService` will use `https://restcountries.eu/rest` as the base URL.


### PR DESCRIPTION
While working on RestClient based sample I run into this warning being issued during augmentation

```
[WARNING] [io.quarkus.restclient.deployment.RestClientProcessor] Unsupported default scope java.inject.Singleton provided for rest client org.acme.travels.rest.UsersRemoteService. Defaulting to @Dependent.
```

looks like this has changed so I made the change in the guide so people do not get this warning while using RestClient.