### PR TITLE
Fix issue with runtime config being consumed at build time

### DIFF
--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
@@ -34,6 +35,7 @@ import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -90,9 +92,13 @@ class VertxWebProcessor {
         return new FeatureBuildItem(FeatureBuildItem.VERTX_WEB);
     }
 
-    @BuildStep
-    public void kubernetes(HttpConfiguration config, BuildProducer<KubernetesPortBuildItem> portProducer) {
-        portProducer.produce(new KubernetesPortBuildItem(config.port, "http"));
+    @BuildStep(onlyIf = IsNormal.class)
+    @Record(value = ExecutionTime.RUNTIME_INIT, optional = true)
+    public KubernetesPortBuildItem kubernetes(HttpConfiguration config, BuildProducer<KubernetesPortBuildItem> portProducer,
+            VertxWebRecorder recorder) {
+        int port = ConfigProvider.getConfig().getOptionalValue("quarkus.http.port", Integer.class).orElse(8080);
+        recorder.warnIfPortChanged(config, port);
+        return new KubernetesPortBuildItem(config.port, "http");
     }
 
     @BuildStep

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -410,6 +410,14 @@ public class VertxWebRecorder {
         }
     }
 
+    public void warnIfPortChanged(HttpConfiguration config, int port) {
+        if (config.port != port) {
+            LOGGER.errorf(
+                    "quarkus.http.port was specified at build time as %s however run time value is %s, Kubernetes metadata will be incorrect.",
+                    port, config.port);
+        }
+    }
+
     private static class WebDeploymentVerticle implements Verticle {
 
         private final int port;


### PR DESCRIPTION
The Kubernetes resource generation only occurs at build time so it suffices
to read the http port value from MP Config

Fixes: #3677