### PR TITLE
 Update to vertx 3.8.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -38,9 +38,9 @@
         <smallrye-fault-tolerance.version>1.0.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.0.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.11</smallrye-context-propagation.version>
-        <smallrye-reactive-streams-operators.version>1.0.6</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.0.4</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>0.0.10</smallrye-reactive-messaging.version>
+        <smallrye-reactive-streams-operators.version>1.0.9</smallrye-reactive-streams-operators.version>
+        <smallrye-converter-api.version>1.0.9</smallrye-converter-api.version>
+        <smallrye-reactive-messaging.version>1.0.3</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.20.9</swagger-ui.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         <javax.inject.version>1</javax.inject.version>
@@ -100,7 +100,7 @@
         <wildfly-elytron.version>2.0.0.Alpha4</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Beta5</jboss-threads.version>
-        <vertx.version>3.8.0</vertx.version>
+        <vertx.version>3.8.1</vertx.version>
         <httpclient.version>4.5.9</httpclient.version>
         <httpcore.version>4.4.11</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>
@@ -123,7 +123,7 @@
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <test-containers.version>1.12.0</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <axle-client.version>0.0.8</axle-client.version>
+        <axle-client.version>0.0.9</axle-client.version>
         <kafka-clients.version>2.2.1</kafka-clients.version>
         <kafka2.version>2.2.1</kafka2.version>
         <debezium.version>0.9.5.Final</debezium.version>
@@ -412,7 +412,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
+                <artifactId>quarkus-smallrye-reactive-amqp</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -1829,17 +1829,17 @@
 
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-provider-1.0</artifactId>
+                <artifactId>smallrye-reactive-messaging-provider</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-mqtt-1.0</artifactId>
+                <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-kafka-1.0</artifactId>
+                <artifactId>smallrye-reactive-messaging-kafka</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
                 <exclusions>
                     <exclusion>
@@ -1866,7 +1866,7 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-amqp-1.0</artifactId>
+                <artifactId>smallrye-reactive-messaging-amqp</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
                 <exclusions>
                     <exclusion>
@@ -1950,7 +1950,7 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-streams-operators-1.0</artifactId>
+                <artifactId>smallrye-reactive-streams-operators</artifactId>
                 <version>${smallrye-reactive-streams-operators.version}</version>
             </dependency>
             <dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -133,7 +133,7 @@
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>
         <aws-lambda-java-events.version>2.2.5</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
-        <awssdk.version>2.7.0</awssdk.version>
+        <awssdk.version>2.7.35</awssdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.41</kotlin.version>
         <dekorate.version>0.6.1</dekorate.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -23,7 +23,7 @@
         <opentracing-tracerresolver.version>0.1.5</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <jaeger.version>0.34.0</jaeger.version>
-        <quarkus-http.version>3.0.0.Alpha4</quarkus-http.version>
+        <quarkus-http.version>3.0.0.Alpha5</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.3</microprofile-config-api.version>
         <microprofile-context-propagation.version>1.0-RC1</microprofile-context-propagation.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -119,7 +119,7 @@
         <infinispan.version>10.0.0.Beta5</infinispan.version>
         <infinispan.protostream.version>4.3.0.Alpha9</infinispan.protostream.version>
         <caffeine.version>2.6.2</caffeine.version>
-        <netty.version>4.1.34.Final</netty.version>
+        <netty.version>4.1.39.Final</netty.version>
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <test-containers.version>1.12.0</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -29,8 +29,8 @@
            what we work with by self downloading it: -->
         <graal-sdk.version-for-documentation>19.2.0</graal-sdk.version-for-documentation>
         <rest-assured.version>3.3.0</rest-assured.version>
-        <axle-client.version>0.0.7</axle-client.version>
-        <vertx.version>3.7.1</vertx.version>
+        <axle-client.version>0.0.9</axle-client.version>
+        <vertx.version>3.8.1</vertx.version>
         <artemis.version>2.9.0</artemis.version>
 
         <!-- Dev tools -->

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbAsyncClientFullConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbAsyncClientFullConfigTest.java
@@ -4,12 +4,15 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
+@Disabled("Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the async"
+        + " support.")
 public class DynamodbAsyncClientFullConfigTest {
 
     @Inject

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientDefaultCredentialsProviderConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientDefaultCredentialsProviderConfigTest.java
@@ -8,13 +8,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 public class DynamodbClientDefaultCredentialsProviderConfigTest {
 
-    @Inject
-    DynamoDbAsyncClient async;
+    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+    // async support.
+    //    @Inject
+    //    DynamoDbAsyncClient async;
 
     @Inject
     DynamoDbClient sync;

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientProfileCredentialsProviderConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientProfileCredentialsProviderConfigTest.java
@@ -8,13 +8,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 public class DynamodbClientProfileCredentialsProviderConfigTest {
 
-    @Inject
-    DynamoDbAsyncClient async;
+    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+    // async support.
+    //    @Inject
+    //    DynamoDbAsyncClient async;
 
     @Inject
     DynamoDbClient sync;

--- a/extensions/amazon-dynamodb/runtime/pom.xml
+++ b/extensions/amazon-dynamodb/runtime/pom.xml
@@ -31,10 +31,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>netty-nio-client</artifactId>
-        </dependency>
+        <!-- Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+             async support. -->
+        <!--<dependency>-->
+            <!--<groupId>software.amazon.awssdk</groupId>-->
+            <!--<artifactId>netty-nio-client</artifactId>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbClientProducer.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbClientProducer.java
@@ -11,14 +11,7 @@ import software.amazon.awssdk.core.client.builder.SdkSyncClientBuilder;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient.Builder;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
-import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
-import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder;
-import software.amazon.awssdk.services.dynamodb.DynamoDbBaseClientBuilder;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
-import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+import software.amazon.awssdk.services.dynamodb.*;
 
 @ApplicationScoped
 public class DynamodbClientProducer {
@@ -79,7 +72,9 @@ public class DynamodbClientProducer {
     }
 
     private void initHttpClient(SdkAsyncClientBuilder builder, DynamodbConfig config) {
-        builder.httpClientBuilder(createNettyClientBuilder(config.asyncClient));
+        // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+        // async support.
+        //        builder.httpClientBuilder(createNettyClientBuilder(config.asyncClient));
     }
 
     private ApacheHttpClient.Builder createApacheClientBuilder(AwsApacheHttpClientConfig config) {
@@ -109,32 +104,34 @@ public class DynamodbClientProducer {
         return builder;
     }
 
-    private NettyNioAsyncHttpClient.Builder createNettyClientBuilder(AwsNettyNioAsyncHttpClientConfig config) {
-        NettyNioAsyncHttpClient.Builder builder = NettyNioAsyncHttpClient.builder();
-
-        config.connectionAcquisitionTimeout.ifPresent(builder::connectionAcquisitionTimeout);
-        config.connectionMaxIdleTime.ifPresent(builder::connectionMaxIdleTime);
-        config.connectionTimeout.ifPresent(builder::connectionTimeout);
-        config.connectionTimeToLive.ifPresent(builder::connectionTimeToLive);
-        config.maxConcurrency.ifPresent(builder::maxConcurrency);
-        config.maxHttp2Streams.ifPresent(builder::maxHttp2Streams);
-        config.maxPendingConnectionAcquires.ifPresent(builder::maxPendingConnectionAcquires);
-        config.protocol.ifPresent(builder::protocol);
-        config.readTimeout.ifPresent(builder::readTimeout);
-        config.sslProvider.ifPresent(builder::sslProvider);
-        config.useIdleConnectionReaper.ifPresent(builder::useIdleConnectionReaper);
-        config.writeTimeout.ifPresent(builder::writeTimeout);
-
-        if (config.eventLoop.override) {
-            SdkEventLoopGroup.Builder eventLoopBuilder = SdkEventLoopGroup.builder();
-            eventLoopBuilder.numberOfThreads(config.eventLoop.numberOfThreads);
-            if (config.eventLoop.threadNamePrefix.isPresent()) {
-                eventLoopBuilder.threadFactory(
-                        new ThreadFactoryBuilder().threadNamePrefix(config.eventLoop.threadNamePrefix.get()).build());
-            }
-            builder.eventLoopGroupBuilder(eventLoopBuilder);
-        }
-
-        return builder;
-    }
+    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+    // async support.
+    //    private NettyNioAsyncHttpClient.Builder createNettyClientBuilder(AwsNettyNioAsyncHttpClientConfig config) {
+    //        NettyNioAsyncHttpClient.Builder builder = NettyNioAsyncHttpClient.builder();
+    //
+    //        config.connectionAcquisitionTimeout.ifPresent(builder::connectionAcquisitionTimeout);
+    //        config.connectionMaxIdleTime.ifPresent(builder::connectionMaxIdleTime);
+    //        config.connectionTimeout.ifPresent(builder::connectionTimeout);
+    //        config.connectionTimeToLive.ifPresent(builder::connectionTimeToLive);
+    //        config.maxConcurrency.ifPresent(builder::maxConcurrency);
+    //        config.maxHttp2Streams.ifPresent(builder::maxHttp2Streams);
+    //        config.maxPendingConnectionAcquires.ifPresent(builder::maxPendingConnectionAcquires);
+    //        config.protocol.ifPresent(builder::protocol);
+    //        config.readTimeout.ifPresent(builder::readTimeout);
+    //        config.sslProvider.ifPresent(builder::sslProvider);
+    //        config.useIdleConnectionReaper.ifPresent(builder::useIdleConnectionReaper);
+    //        config.writeTimeout.ifPresent(builder::writeTimeout);
+    //
+    //        if (config.eventLoop.override) {
+    //            SdkEventLoopGroup.Builder eventLoopBuilder = SdkEventLoopGroup.builder();
+    //            eventLoopBuilder.numberOfThreads(config.eventLoop.numberOfThreads);
+    //            if (config.eventLoop.threadNamePrefix.isPresent()) {
+    //                eventLoopBuilder.threadFactory(
+    //                        new ThreadFactoryBuilder().threadNamePrefix(config.eventLoop.threadNamePrefix.get()).build());
+    //            }
+    //            builder.eventLoopGroupBuilder(eventLoopBuilder);
+    //        }
+    //
+    //        return builder;
+    //    }
 }

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-streams-operators-1.0</artifactId>
+            <artifactId>smallrye-reactive-streams-operators</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -41,11 +41,14 @@ class NettyProcessor {
                 .addNativeImageSystemProperty("io.netty.noUnsafe", "true")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
+                .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslContext")
+                .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslClientContext")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.util.ThreadLocalInsecureRandom")
+                .addRuntimeInitializedClass("io.netty.handler.ssl.ConscryptAlpnSslEngine")
                 .addNativeImageSystemProperty("io.netty.leakDetection.level", "DISABLED");
         try {
             Class.forName("io.netty.handler.codec.http.HttpObjectEncoder");
-            builder.addRuntimeReinitializedClass("io.netty.handler.codec.http2.Http2CodecUtil")
+            builder.addRuntimeInitializedClass("io.netty.handler.codec.http2.Http2CodecUtil")
                     .addRuntimeInitializedClass("io.netty.handler.codec.http.HttpObjectEncoder")
                     .addRuntimeInitializedClass("io.netty.handler.codec.http2.DefaultHttp2FrameWriter")
                     .addRuntimeInitializedClass("io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder");

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -11,8 +11,6 @@ import javax.net.ssl.TrustManagerFactory;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Delete;
-import com.oracle.svm.core.annotate.RecomputeFieldValue;
-import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.jdk.JDK11OrLater;
@@ -45,42 +43,6 @@ final class Target_io_netty_util_internal_logging_InternalLoggerFactory {
     private static InternalLoggerFactory newDefaultFactory(String name) {
         return JdkLoggerFactory.INSTANCE;
     }
-}
-
-/**
- * This substitution allows the usage of platform specific code to do low level
- * buffer related tasks
- */
-@TargetClass(className = "io.netty.util.internal.CleanerJava6")
-final class Target_io_netty_util_internal_CleanerJava6 {
-
-    @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, declClassName = "java.nio.DirectByteBuffer", name = "cleaner")
-    private static long CLEANER_FIELD_OFFSET;
-}
-
-/**
- * This substitution allows the usage of platform specific code to do low level
- * buffer related tasks
- */
-@TargetClass(className = "io.netty.util.internal.PlatformDependent0")
-final class Target_io_netty_util_internal_PlatformDependent0 {
-
-    @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FieldOffset, declClassName = "java.nio.Buffer", name = "address")
-    private static long ADDRESS_FIELD_OFFSET;
-}
-
-/**
- * This substitution allows the usage of platform specific code to do low level
- * buffer related tasks
- */
-@TargetClass(className = "io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess")
-final class Target_io_netty_util_internal_shaded_org_jctools_util_UnsafeRefArrayAccess {
-
-    @Alias
-    @RecomputeFieldValue(kind = Kind.ArrayIndexShift, declClass = Object[].class)
-    public static int REF_ELEMENT_SHIFT;
 }
 
 // SSL

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -48,20 +48,17 @@ final class Target_io_netty_util_internal_logging_InternalLoggerFactory {
 // SSL
 // This whole section is mostly about removing static analysis references to openssl/tcnative
 
-@Delete
-@TargetClass(className = "io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
-final class Target_io_netty_handler_ssl_ReferenceCountedOpenSslEngine {
-}
-
 @TargetClass(className = "io.netty.handler.ssl.JdkSslServerContext")
 final class Target_io_netty_handler_ssl_JdkSslServerContext {
 
     @Alias
-    Target_io_netty_handler_ssl_JdkSslServerContext(Provider provider, X509Certificate[] trustCertCollection,
-            TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
-            String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-            CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, long sessionCacheSize,
-            long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls)
+    Target_io_netty_handler_ssl_JdkSslServerContext(Provider provider,
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+            KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout,
+            ClientAuth clientAuth, String[] protocols, boolean startTls,
+            String keyStore)
             throws SSLException {
     }
 }
@@ -74,8 +71,9 @@ final class Target_io_netty_handler_ssl_JdkSslClientContext {
             TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
             String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
             CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-            long sessionCacheSize, long sessionTimeout)
+            long sessionCacheSize, long sessionTimeout, String keyStoreType)
             throws SSLException {
+
     }
 }
 
@@ -119,39 +117,39 @@ final class Target_io_netty_handler_ssl_Java9SslEngine {
 final class Target_io_netty_handler_ssl_SslContext {
 
     @Substitute
-    static SslContext newServerContextInternal(SslProvider provider, Provider sslContextProvider,
-            X509Certificate[] trustCertCollection,
-            TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
-            String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-            CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, long sessionCacheSize,
-            long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
-            boolean enableOcsp)
+    static SslContext newServerContextInternal(SslProvider provider,
+            Provider sslContextProvider,
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
+            boolean enableOcsp, String keyStoreType)
             throws SSLException {
 
         if (enableOcsp) {
             throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
         }
         return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslServerContext(sslContextProvider,
-                trustCertCollection,
-                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
-                sessionCacheSize,
-                sessionTimeout, clientAuth, protocols, startTls);
+                trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                clientAuth, protocols, startTls, keyStoreType);
     }
 
     @Substitute
-    static SslContext newClientContextInternal(SslProvider provider, Provider sslContextProvider, X509Certificate[] trustCert,
-            TrustManagerFactory trustManagerFactory, X509Certificate[] keyCertChain, PrivateKey key,
-            String keyPassword, KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
-            CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
-            long sessionCacheSize, long sessionTimeout, boolean enableOcsp)
-            throws SSLException {
+    static SslContext newClientContextInternal(
+            SslProvider provider,
+            Provider sslContextProvider,
+            X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+            long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStoreType) throws SSLException {
         if (enableOcsp) {
             throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
         }
-        return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslClientContext(sslContextProvider, trustCert,
-                trustManagerFactory,
-                keyCertChain, key, keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                sessionTimeout);
+        return (SslContext) (Object) new Target_io_netty_handler_ssl_JdkSslClientContext(sslContextProvider,
+                trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
+                keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize,
+                sessionTimeout, keyStoreType);
     }
 
 }

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-streams-operators-1.0</artifactId>
+            <artifactId>smallrye-reactive-streams-operators</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-amqp-1.0</artifactId>
+            <artifactId>smallrye-reactive-messaging-amqp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-provider-1.0</artifactId>
+            <artifactId>smallrye-reactive-messaging-provider</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-kafka-1.0</artifactId>
+            <artifactId>smallrye-reactive-messaging-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-provider-1.0</artifactId>
+            <artifactId>smallrye-reactive-messaging-provider</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-mqtt-1.0</artifactId>
+            <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-messaging-provider-1.0</artifactId>
+            <artifactId>smallrye-reactive-messaging-provider</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/EmitterBuildItem.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/EmitterBuildItem.java
@@ -5,16 +5,48 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class EmitterBuildItem extends MultiBuildItem {
 
     /**
+     * Creates a new instance of {@link EmitterBuildItem} setting the overflow strategy.
+     *
+     * @param name the name of the stream
+     * @param overflow the overflow strategy
+     * @param bufferSize the buffer size, if overflow is set to {@code BUFFER}
+     * @return the new {@link EmitterBuildItem}
+     */
+    static EmitterBuildItem of(String name, String overflow, int bufferSize) {
+        return new EmitterBuildItem(name, overflow, bufferSize);
+    }
+
+    /**
+     * Creates a new instance of {@link EmitterBuildItem} using the default overflow strategy.
+     *
+     * @param name the name of the stream
+     * @return the new {@link EmitterBuildItem}
+     */
+    static EmitterBuildItem of(String name) {
+        return new EmitterBuildItem(name, null, -1);
+    }
+
+    /**
      * The name of the stream the emitter is connected to.
      */
     private final String name;
 
-    private String overflow;
+    /**
+     * The name of the overflow strategy. Valid values are {@code BUFFER, DROP, FAIL, LATEST, NONE}.
+     * If not set, it uses {@code BUFFER} with a default buffer size.
+     */
+    private final String overflow;
 
-    private int bufferSize;
+    /**
+     * The buffer size, used when {@code overflow} is set to {@code BUFFER}. Not that if {@code overflow} is set to
+     * {@code BUFFER} and {@code bufferSize} is not set, an unbounded buffer is used.
+     */
+    private final int bufferSize;
 
-    public EmitterBuildItem(String name) {
+    public EmitterBuildItem(String name, String overflow, int bufferSize) {
         this.name = name;
+        this.overflow = overflow;
+        this.bufferSize = bufferSize;
     }
 
     public String getName() {
@@ -25,17 +57,8 @@ public final class EmitterBuildItem extends MultiBuildItem {
         return overflow;
     }
 
-    public EmitterBuildItem setOverflow(String overflow) {
-        this.overflow = overflow;
-        return this;
-    }
-
     public int getBufferSize() {
         return bufferSize;
     }
 
-    public EmitterBuildItem setBufferSize(int bufferSize) {
-        this.bufferSize = bufferSize;
-        return this;
-    }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/EmitterBuildItem.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/EmitterBuildItem.java
@@ -9,6 +9,10 @@ public final class EmitterBuildItem extends MultiBuildItem {
      */
     private final String name;
 
+    private String overflow;
+
+    private int bufferSize;
+
     public EmitterBuildItem(String name) {
         this.name = name;
     }
@@ -17,4 +21,21 @@ public final class EmitterBuildItem extends MultiBuildItem {
         return name;
     }
 
+    public String getOverflow() {
+        return overflow;
+    }
+
+    public EmitterBuildItem setOverflow(String overflow) {
+        this.overflow = overflow;
+        return this;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public EmitterBuildItem setBufferSize(int bufferSize) {
+        this.bufferSize = bufferSize;
+        return this;
+    }
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -96,12 +96,15 @@ public class SmallRyeReactiveMessagingProcessor {
 
                     LOGGER.debugf("Emitter injection point '%s' detected, stream name: '%s'",
                             injectionPoint.getTargetInfo(), name);
-                    EmitterBuildItem item = new EmitterBuildItem(name);
+
                     if (annotation != null) {
-                        item.setOverflow(annotation.value().toString());
-                        item.setBufferSize(annotation.value("bufferSize").asInt());
+                        emitters.produce(
+                                EmitterBuildItem.of(name,
+                                        annotation.value().toString(),
+                                        annotation.value("bufferSize").asInt()));
+                    } else {
+                        emitters.produce(EmitterBuildItem.of(name));
                     }
-                    emitters.produce(item);
                 }
             }
         }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/EmitterWithOverflowTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/EmitterWithOverflowTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.smallrye.reactivemessaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EmitterWithOverflowTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(StreamEmitterWithOverflow.class));
+
+    @Inject
+    StreamEmitterWithOverflow streamEmitter;
+
+    @Test
+    public void testStreamEmitter() {
+        streamEmitter.run();
+        List<String> list = streamEmitter.list();
+        assertEquals(3, list.size());
+        assertEquals("a", list.get(0));
+        assertEquals("b", list.get(1));
+        assertEquals("c", list.get(2));
+
+        List<String> sink1 = streamEmitter.sink1();
+        assertEquals(3, sink1.size());
+        assertEquals("a1", sink1.get(0));
+        assertEquals("b1", sink1.get(1));
+        assertEquals("c1", sink1.get(2));
+
+        List<String> sink2 = streamEmitter.sink2();
+        assertEquals(3, sink2.size());
+        assertEquals("a2", sink2.get(0));
+        assertEquals("b2", sink2.get(1));
+        assertEquals("c2", sink2.get(2));
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SimpleTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/SimpleTest.java
@@ -56,4 +56,5 @@ public class SimpleTest {
         assertEquals("b", list.get(1));
         assertEquals("c", list.get(2));
     }
+
 }

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/StreamEmitterWithOverflow.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/StreamEmitterWithOverflow.java
@@ -1,0 +1,70 @@
+package io.quarkus.smallrye.reactivemessaging;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.annotations.Emitter;
+import io.smallrye.reactive.messaging.annotations.OnOverflow;
+import io.smallrye.reactive.messaging.annotations.Stream;
+
+@ApplicationScoped
+public class StreamEmitterWithOverflow {
+
+    @Inject
+    @Stream("sink")
+    @OnOverflow(value = OnOverflow.Strategy.BUFFER)
+    Emitter<String> emitter;
+
+    private Emitter<String> emitterForSink2;
+    private Emitter<String> emitterForSink1;
+
+    @Inject
+    public void setEmitter(@Stream("sink-1") Emitter<String> sink1,
+            @Stream("sink-2") @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 2) Emitter<String> sink2) {
+        this.emitterForSink1 = sink1;
+        this.emitterForSink2 = sink2;
+    }
+
+    private List<String> list = new CopyOnWriteArrayList<>();
+    private List<String> sink1 = new CopyOnWriteArrayList<>();
+    private List<String> sink2 = new CopyOnWriteArrayList<>();
+
+    public void run() {
+        emitter.send("a").send("b").send("c").complete();
+        emitterForSink1.send("a1").send("b1").send("c1").complete();
+        emitterForSink2.send("a2").send("b2").send("c2").complete();
+    }
+
+    @Incoming("sink")
+    public void consume(String s) {
+        list.add(s);
+    }
+
+    @Incoming("sink-1")
+    public void consume1(String s) {
+        sink1.add(s);
+    }
+
+    @Incoming("sink-2")
+    public void consume2(String s) {
+        sink2.add(s);
+    }
+
+    public List<String> list() {
+        return list;
+    }
+
+    public List<String> sink1() {
+        return sink1;
+    }
+
+    public List<String> sink2() {
+        return sink2;
+    }
+
+}

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -28,7 +28,7 @@
       </dependency>
       <dependency>
          <groupId>io.smallrye.reactive</groupId>
-         <artifactId>smallrye-reactive-messaging-provider-1.0</artifactId>
+         <artifactId>smallrye-reactive-messaging-provider</artifactId>
          <exclusions>
             <exclusion>
                <groupId>com.fasterxml.jackson.core</groupId>

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/SmallRyeReactiveMessagingRecorder.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/SmallRyeReactiveMessagingRecorder.java
@@ -1,6 +1,5 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -10,16 +9,19 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 
 /**
- *
  * @author Martin Kouba
  */
 @Recorder
 public class SmallRyeReactiveMessagingRecorder {
 
-    public void registerMediators(Map<String, String> beanClassToBeanId, BeanContainer container, List<String> emitters) {
-        // Extract the configuration and register mediators
+    public void configureEmitter(BeanContainer container, String name, String strategy, int bufferSize,
+            int defaultBufferSize) {
         MediatorManager mediatorManager = container.instance(MediatorManager.class);
-        mediatorManager.initializeEmitters(emitters);
+        mediatorManager.initializeEmitter(name, strategy, bufferSize, defaultBufferSize);
+    }
+
+    public void registerMediators(Map<String, String> beanClassToBeanId, BeanContainer container) {
+        MediatorManager mediatorManager = container.instance(MediatorManager.class);
         for (Entry<String, String> entry : beanClassToBeanId.entrySet()) {
             try {
                 Class<?> beanClass = Thread.currentThread()

--- a/extensions/vertx/deployment/pom.xml
+++ b/extensions/vertx/deployment/pom.xml
@@ -19,7 +19,7 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
-        <groupId>io.quarkus</groupId>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
@@ -34,7 +34,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
-	    <dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
         </dependency>

--- a/extensions/vertx/deployment/pom.xml
+++ b/extensions/vertx/deployment/pom.xml
@@ -34,7 +34,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
-	<dependency>
+	    <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
         </dependency>

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -124,7 +124,10 @@ class VertxProcessor {
 
     @BuildStep
     SubstrateConfigBuildItem build() {
-        return SubstrateConfigBuildItem.builder().addNativeImageSystemProperty("vertx.disableDnsResolver", "true").build();
+        return SubstrateConfigBuildItem.builder()
+                .addNativeImageSystemProperty("vertx.disableDnsResolver", "true")
+                .addRuntimeInitializedClass("io.vertx.core.http.impl.VertxHttp2ClientUpgradeCodec")
+                .build();
     }
 
     @BuildStep

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -47,6 +47,10 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-rx-java2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.oracle.substratevm</groupId>

--- a/integration-tests/amazon-dynamodb/src/main/java/io/quarkus/it/dynamodb/DynamoDBResource.java
+++ b/integration-tests/amazon-dynamodb/src/main/java/io/quarkus/it/dynamodb/DynamoDBResource.java
@@ -3,7 +3,6 @@ package io.quarkus.it.dynamodb;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -12,7 +11,6 @@ import javax.ws.rs.Produces;
 
 import org.jboss.logging.Logger;
 
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 
@@ -26,22 +24,26 @@ public class DynamoDBResource {
     @Inject
     DynamoDbClient client;
 
-    @Inject
-    DynamoDbAsyncClient asyncClient;
+    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+    // async support.
+    //    @Inject
+    //    DynamoDbAsyncClient asyncClient;
 
-    @GET
-    @Path("async")
-    @Produces(TEXT_PLAIN)
-    public CompletionStage<String> testAsync() {
-        LOG.info("Testing Async client with table: " + ASYNC_TABLE);
-        String keyValue = UUID.randomUUID().toString();
-        String rangeValue = UUID.randomUUID().toString();
-
-        return DynamoDBUtils.createTableIfNotExistsAsync(asyncClient, ASYNC_TABLE)
-                .thenCompose(t -> asyncClient.putItem(DynamoDBUtils.createPutRequest(ASYNC_TABLE, keyValue, rangeValue, "OK")))
-                .thenCompose(p -> asyncClient.getItem(DynamoDBUtils.createGetRequest(ASYNC_TABLE, keyValue, rangeValue)))
-                .thenApply(p -> p.item().get(DynamoDBUtils.PAYLOAD_NAME).s());
-    }
+    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
+    // async support.
+    //    @GET
+    //    @Path("async")
+    //    @Produces(TEXT_PLAIN)
+    //    public CompletionStage<String> testAsync() {
+    //        LOG.info("Testing Async client with table: " + ASYNC_TABLE);
+    //        String keyValue = UUID.randomUUID().toString();
+    //        String rangeValue = UUID.randomUUID().toString();
+    //
+    //        return DynamoDBUtils.createTableIfNotExistsAsync(asyncClient, ASYNC_TABLE)
+    //                .thenCompose(t -> asyncClient.putItem(DynamoDBUtils.createPutRequest(ASYNC_TABLE, keyValue, rangeValue, "OK")))
+    //                .thenCompose(p -> asyncClient.getItem(DynamoDBUtils.createGetRequest(ASYNC_TABLE, keyValue, rangeValue)))
+    //                .thenApply(p -> p.item().get(DynamoDBUtils.PAYLOAD_NAME).s());
+    //    }
 
     @GET
     @Path("blocking")

--- a/integration-tests/amazon-dynamodb/src/test/java/io/quarkus/it/dynamodb/DynamoDbFunctionalityTest.java
+++ b/integration-tests/amazon-dynamodb/src/test/java/io/quarkus/it/dynamodb/DynamoDbFunctionalityTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.dynamodb;
 
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -15,6 +16,8 @@ import io.restassured.RestAssured;
 public class DynamoDbFunctionalityTest {
 
     @Test
+    @Disabled("Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, "
+            + "disable the async support.")
     public void testDynamoDbAsync() {
         RestAssured.when().get("/test/async").then().body(is("OK"));
     }


### PR DESCRIPTION
This PR updates the Vert.x version to 3.8.1 as well as dependencies using Vert.x.
It also updates the smallrye artifacts Ids that have been renamed.
Finally, it provides support for the back pressure control on emitter in Reactive Messaging.

It supersedes #3711. 