### PR TITLE
EventLoopSupplierBuildItem args in wrong order

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -134,7 +134,7 @@ class VertxProcessor {
 
     @Record(ExecutionTime.STATIC_INIT)
     EventLoopSupplierBuildItem eventLoop(VertxRecorder recorder) {
-        return new EventLoopSupplierBuildItem(recorder.bossSupplier(), recorder.mainSupplier());
+        return new EventLoopSupplierBuildItem(recorder.mainSupplier(), recorder.bossSupplier());
     }
 
     @BuildStep


### PR DESCRIPTION
EventLoopSupplierBuildItem expects `mainSupplier` as first argument.
In VertxProcessor the order is switched when constructing EventLoopSupplierBuildItem.

https://github.com/quarkusio/quarkus/blob/9cc4753400638d862e061e544ebe78d9836d00b0/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopSupplierBuildItem.java#L13

