### PR TITLE
Removal of unused org.glassfish.web:el-impl from BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1678,11 +1678,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.web</groupId>
-                <artifactId>el-impl</artifactId>
-                <version>${el-impl.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql-jdbc.version}</version>


### PR DESCRIPTION
Removal of unused org.glassfish.web:el-impl from BOM

I noticed that due to undefined `el-impl.version` property used by `<version>${el-impl.version}</version>`. When looking a bit more I realized that org.glassfish.web:el-impl is not used anywhere in Quarkus code.
