### PR TITLE
Removal of quarkus-jaxrs-json and smallrye-context-propagation-resteasy from BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -466,11 +466,6 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-jaxrs-json</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-narayana-jta</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1009,11 +1004,6 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-context-propagation-api</artifactId>
-                <version>${smallrye-context-propagation.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-context-propagation-resteasy</artifactId>
                 <version>${smallrye-context-propagation.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Removal of quarkus-jaxrs-json and smallrye-context-propagation-resteasy from BOM

`io.quarkus:quarkus-jaxrs-json:jar:999-SNAPSHOT` doesn't exist in the project

`io.smallrye:smallrye-context-propagation-resteasy` was removed in https://github.com/smallrye/smallrye-context-propagation/commit/f585def0e0652b3c98ad3c7711daf6b67beaa59e
This dependency is replaced by `org.jboss.resteasy:resteasy-context-propagation` which is already present in BOM