### PR TITLE
Property el-impl.version used but not defined

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -165,6 +165,7 @@
         <spring.version>5.1.8.RELEASE</spring.version>
         <mvel2.version>2.4.4.Final</mvel2.version>
         <mockito.version>3.0.0</mockito.version>
+        <el-impl.version>2.2.1-b05</el-impl.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This is causing failure when running a bazel based migration to consume pom and generate bazel artifacts. Bazel has strict definitions for pom structures.