### PR TITLE
Implement mechanism to ignore ReflectiveHierarchyStep warnings ...

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveHierarchyIgnoreWarningBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/substrate/ReflectiveHierarchyIgnoreWarningBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.deployment.builditem.substrate;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Used by {@link io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyStep} to ignore reflection warning deliberately
+ */
+public final class ReflectiveHierarchyIgnoreWarningBuildItem extends MultiBuildItem {
+
+    private final DotName dotName;
+
+    public ReflectiveHierarchyIgnoreWarningBuildItem(DotName dotName) {
+        this.dotName = dotName;
+    }
+
+    public DotName getDotName() {
+        return dotName;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyIgnoreWarningBuildItem;
 
 public class ReflectiveHierarchyStep {
 
@@ -46,12 +47,18 @@ public class ReflectiveHierarchyStep {
     @Inject
     BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
 
+    @Inject
+    List<ReflectiveHierarchyIgnoreWarningBuildItem> ignored;
+
     @BuildStep
     public void build() throws Exception {
         Set<DotName> processedReflectiveHierarchies = new HashSet<>();
         Set<DotName> unindexedClasses = new TreeSet<>();
         for (ReflectiveHierarchyBuildItem i : hierarchy) {
             addReflectiveHierarchy(i, i.getType(), processedReflectiveHierarchies, unindexedClasses);
+        }
+        for (ReflectiveHierarchyIgnoreWarningBuildItem i : ignored) {
+            unindexedClasses.remove(i.getDotName());
         }
 
         if (!unindexedClasses.isEmpty()) {


### PR DESCRIPTION
... and leverage this as needed in Kogito extension

**Example use-case**
We have the following warn triggered by ReflectiveHierarchyStep of Quarkus, despite native image compilation and results working fine in Kogito:

```
[INFO] --- quarkus-maven-plugin:0.21.1:build (default) @ dmn-quarkus-example ---
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Beginning quarkus augmentation
[INFO] [org.jboss.threads] JBoss Threads version 3.0.0.Beta5
[WARNING] [io.quarkus.deployment.steps.ReflectiveHierarchyStep] Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
	- org.kie.api.builder.Message$Level
	- org.kie.dmn.api.core.DMNContext
	- org.kie.dmn.api.core.DMNDecisionResult
	- org.kie.dmn.api.core.DMNDecisionResult$DecisionEvaluationStatus
	- org.kie.dmn.api.core.DMNMessage
	- org.kie.dmn.api.core.DMNMessage$Severity
	- org.kie.dmn.api.core.DMNMessageType
	- org.kie.dmn.api.feel.runtime.events.FEELEvent
Consider adding them to the index either by creating a Jandex index for your dependency via the Maven plugin, an empty META-INF/beans.xml or quarkus.index-dependency properties.");.
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 963ms
[INFO] [io.quarkus.creator.phase.runnerjar.RunnerJarPhase] Building jar: /Users/mmortari/git/kogito-examples/dmn-quarkus-example/target/dmn-quarkus-example-runner.jar
[INFO] 
[INFO] --- quarkus-maven-plugin:0.21.1:native-image (default) @ dmn-quarkus-example ---
[INFO] [io.quarkus.creator.phase.nativeimage.NativeImagePhase] Running Quarkus native-image plugin on OpenJDK 64-Bit GraalVM CE 19.2.0
[INFO] [io.quarkus.creator.phase.nativeimage.NativeImagePhase] /Users/mmortari/.jabba/jdk/graalvm@19.2.0/Contents/Home/bin/native-image -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime -jar dmn-quarkus-example-runner.jar -J-Djava.util.concurrent.ForkJoinPool.common.parallelism=1 -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:+PrintAnalysisCallTree -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-SpawnIsolates -H:-JNI --no-server -H:-UseServiceLoaderFeature -H:+StackTrace
[dmn-quarkus-example-runner:7536]    classlist:   8,360.70 ms
[dmn-quarkus-example-runner:7536]        (cap):   1,728.31 ms
[dmn-quarkus-example-runner:7536]        setup:   2,881.74 ms
12:30:25,587 INFO  [org.jbo.threads] JBoss Threads version 3.0.0.Beta5
12:30:25,966 INFO  [org.xnio] XNIO version 3.7.2.Final
12:30:26,026 INFO  [org.xni.nio] XNIO NIO Implementation Version 3.7.2.Final
[dmn-quarkus-example-runner:7536]   (typeflow):   9,561.29 ms
[dmn-quarkus-example-runner:7536]    (objects):   9,155.09 ms
[dmn-quarkus-example-runner:7536]   (features):     752.26 ms
[dmn-quarkus-example-runner:7536]     analysis:  20,042.97 ms
Printing call tree to /Users/mmortari/git/kogito-examples/dmn-quarkus-example/target/reports/call_tree_dmn-quarkus-example-runner_20190829_123047.txt
Printing list of used classes to /Users/mmortari/git/kogito-examples/dmn-quarkus-example/target/reports/used_classes_dmn-quarkus-example-runner_20190829_123049.txt
Printing list of used packages to /Users/mmortari/git/kogito-examples/dmn-quarkus-example/target/reports/used_packages_dmn-quarkus-example-runner_20190829_123049.txt
[dmn-quarkus-example-runner:7536]     (clinit):     368.69 ms
[dmn-quarkus-example-runner:7536]     universe:   1,000.53 ms
[dmn-quarkus-example-runner:7536]      (parse):   1,462.97 ms
[dmn-quarkus-example-runner:7536]     (inline):   2,315.83 ms
[dmn-quarkus-example-runner:7536]    (compile):  14,079.48 ms
[dmn-quarkus-example-runner:7536]      compile:  19,066.65 ms
[dmn-quarkus-example-runner:7536]        image:   2,537.92 ms
[dmn-quarkus-example-runner:7536]        write:   1,319.99 ms
[dmn-quarkus-example-runner:7536]      [total]:  60,537.93 ms
[INFO] 
[INFO] --- maven-failsafe-plugin:2.22.1:integration-test (default) @ dmn-quarkus-example ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.kie.dmn.kogito.quarkus.example.NativeTrafficViolationIT
Executing [/Users/mmortari/git/kogito-examples/dmn-quarkus-example/target/dmn-quarkus-example-runner, -Dquarkus.http.port=8081, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=target/quarkus.log]
2019-08-29 12:31:15,408 INFO  [io.quarkus] (main) Quarkus 0.21.1 started in 0.007s. Listening on: http://[::]:8081
2019-08-29 12:31:15,408 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy, resteasy-jsonb]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.145 s - in org.kie.dmn.kogito.quarkus.example.NativeTrafficViolationIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- maven-failsafe-plugin:2.22.1:verify (default) @ dmn-quarkus-example ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:15 min
[INFO] Finished at: 2019-08-29T12:31:16+02:00
[INFO] ------------------------------------------------------------------------
```

as suggested by @geoand this mechanism can be used by any extension, to explicitly ignore ReflectiveHierarchyStep undesired warnings; hence to avoid the warnings mentioned above, without having to modify the dependencies with jandex index or imposing on the user some actions in the user's project.

/cc @evacchi @mariofusco @mswiderski 