### PR TITLE
TestScopeManager. tearDown() calls setup() instead of tearDown() Fixes issue #3784

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestScopeManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestScopeManager.java
@@ -24,7 +24,7 @@ public class TestScopeManager {
 
     public static void tearDown() {
         for (TestScopeSetup i : scopeManagers) {
-            i.setup();
+            i.tearDown();
         }
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -299,13 +299,13 @@ public class QuarkusTestExtension
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
         restAssuredURLManager.clearURL();
-        TestScopeManager.setup();
+        TestScopeManager.tearDown();
     }
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         restAssuredURLManager.setURL();
-        TestScopeManager.tearDown();
+        TestScopeManager.setup();
     }
 
     @Override


### PR DESCRIPTION
I have made the change that seemed obvious. but I am not sure how to test it since I filed the issue just looking at the code, not actually experiencing a bug.