### PR TITLE
Rename Subclass method

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -677,7 +677,7 @@ public class BeanGenerator extends AbstractGenerator {
             if (!bean.isInterceptor()) {
                 // PreDestroy interceptors
                 if (!bean.getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()) {
-                    destroy.invokeInterfaceMethod(MethodDescriptor.ofMethod(Subclass.class, "destroy", void.class),
+                    destroy.invokeInterfaceMethod(MethodDescriptor.ofMethod(Subclass.class, "destroy$subclass", void.class),
                             destroy.getMethodParam(0));
                 }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -11,7 +11,6 @@ import io.quarkus.arc.InitializedInterceptor;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableReferenceProvider;
-import io.quarkus.arc.Subclass;
 import io.quarkus.arc.processor.BeanInfo.InterceptionInfo;
 import io.quarkus.arc.processor.BeanProcessor.PrivateMembersCollector;
 import io.quarkus.arc.processor.BuiltinBean.GeneratorContext;
@@ -196,7 +195,7 @@ public class BeanGenerator extends AbstractGenerator {
         implementGetIdentifier(bean, beanCreator);
         if (!bean.hasDefaultDestroy()) {
             implementDestroy(bean, beanCreator, providerTypeName, Collections.emptyMap(), reflectionRegistration,
-                    isApplicationClass);
+                    isApplicationClass, baseName);
         }
         implementCreate(classOutput, beanCreator, bean, providerTypeName, baseName, Collections.emptyMap(),
                 Collections.emptyMap(), reflectionRegistration,
@@ -275,7 +274,7 @@ public class BeanGenerator extends AbstractGenerator {
         implementGetIdentifier(bean, beanCreator);
         if (!bean.hasDefaultDestroy()) {
             implementDestroy(bean, beanCreator, providerTypeName, injectionPointToProviderField, reflectionRegistration,
-                    isApplicationClass);
+                    isApplicationClass, baseName);
         }
         implementCreate(classOutput, beanCreator, bean, providerTypeName, baseName, injectionPointToProviderField,
                 interceptorToProviderField,
@@ -369,7 +368,7 @@ public class BeanGenerator extends AbstractGenerator {
         implementGetIdentifier(bean, beanCreator);
         if (!bean.hasDefaultDestroy()) {
             implementDestroy(bean, beanCreator, providerTypeName, injectionPointToProviderField, reflectionRegistration,
-                    isApplicationClass);
+                    isApplicationClass, baseName);
         }
         implementCreate(classOutput, beanCreator, bean, providerTypeName, baseName, injectionPointToProviderField,
                 Collections.emptyMap(),
@@ -446,7 +445,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         implementGetIdentifier(bean, beanCreator);
         if (!bean.hasDefaultDestroy()) {
-            implementDestroy(bean, beanCreator, providerTypeName, null, reflectionRegistration, isApplicationClass);
+            implementDestroy(bean, beanCreator, providerTypeName, null, reflectionRegistration, isApplicationClass, baseName);
         }
         implementCreate(classOutput, beanCreator, bean, providerTypeName, baseName, Collections.emptyMap(),
                 Collections.emptyMap(), reflectionRegistration,
@@ -668,7 +667,7 @@ public class BeanGenerator extends AbstractGenerator {
 
     protected void implementDestroy(BeanInfo bean, ClassCreator beanCreator, String providerTypeName,
             Map<InjectionPointInfo, String> injectionPointToProviderField, ReflectionRegistration reflectionRegistration,
-            boolean isApplicationClass) {
+            boolean isApplicationClass, String baseName) {
 
         MethodCreator destroy = beanCreator.getMethodCreator("destroy", void.class, providerTypeName, CreationalContext.class)
                 .setModifiers(ACC_PUBLIC);
@@ -677,7 +676,10 @@ public class BeanGenerator extends AbstractGenerator {
             if (!bean.isInterceptor()) {
                 // PreDestroy interceptors
                 if (!bean.getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()) {
-                    destroy.invokeInterfaceMethod(MethodDescriptor.ofMethod(Subclass.class, "destroy$subclass", void.class),
+                    destroy.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(SubclassGenerator.generatedName(bean.getProviderType().name(), baseName),
+                                    SubclassGenerator.DESTROY_METHOD_NAME,
+                                    void.class),
                             destroy.getMethodParam(0));
                 }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -54,6 +54,8 @@ public class SubclassGenerator extends AbstractGenerator {
 
     static final String SUBCLASS_SUFFIX = "_Subclass";
 
+    static final String DESTROY_METHOD_NAME = "arc$destroy";
+
     private final Predicate<DotName> applicationClassPredicate;
 
     static String generatedName(DotName providerTypeName, String baseName) {
@@ -372,13 +374,12 @@ public class SubclassGenerator extends AbstractGenerator {
      * @param bean
      * @param subclass
      * @param preDestroysField
-     * @see Subclass#destroy$subclass()
      */
     protected void createDestroy(ClassOutput classOutput, BeanInfo bean, ClassCreator subclass,
             FieldDescriptor preDestroysField) {
         if (preDestroysField != null) {
             MethodCreator destroy = subclass
-                    .getMethodCreator(MethodDescriptor.ofMethod(Subclass.class, "destroy$subclass", void.class));
+                    .getMethodCreator(MethodDescriptor.ofMethod(subclass.getClassName(), DESTROY_METHOD_NAME, void.class));
             ResultHandle predestroysHandle = destroy.readInstanceField(preDestroysField, destroy.getThis());
 
             // Interceptor bindings

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -372,12 +372,13 @@ public class SubclassGenerator extends AbstractGenerator {
      * @param bean
      * @param subclass
      * @param preDestroysField
-     * @see Subclass#destroy()
+     * @see Subclass#destroy$subclass()
      */
     protected void createDestroy(ClassOutput classOutput, BeanInfo bean, ClassCreator subclass,
             FieldDescriptor preDestroysField) {
         if (preDestroysField != null) {
-            MethodCreator destroy = subclass.getMethodCreator(MethodDescriptor.ofMethod(Subclass.class, "destroy", void.class));
+            MethodCreator destroy = subclass
+                    .getMethodCreator(MethodDescriptor.ofMethod(Subclass.class, "destroy$subclass", void.class));
             ResultHandle predestroysHandle = destroy.readInstanceField(preDestroysField, destroy.getThis());
 
             // Interceptor bindings

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Subclass.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Subclass.java
@@ -7,8 +7,4 @@ package io.quarkus.arc;
  */
 public interface Subclass {
 
-    default void destroy$subclass() {
-        // Noop
-    }
-
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Subclass.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Subclass.java
@@ -7,7 +7,7 @@ package io.quarkus.arc;
  */
 public interface Subclass {
 
-    default void destroy() {
+    default void destroy$subclass() {
         // Noop
     }
 


### PR DESCRIPTION
The current name has a high chance of conflicting, e.g. HttpFilter.destroy()