### PR TITLE
Drop jboss-invocation and start working on JDK 12+ proxy creation

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -47,8 +47,6 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.security.jacc-api.version>1.0.2.Final</javax.security.jacc-api.version>
         <javax.security.jaspi-api.version>1.0.2.Final</javax.security.jaspi-api.version>
-        <jboss-classfilewriter.version>1.2.4.Final</jboss-classfilewriter.version>
-        <jboss-invocation.version>1.5.2.Final</jboss-invocation.version>
         <javax.json.version>1.1.4</javax.json.version>
         <javax.json.bind-api.version>1.0</javax.json.bind-api.version>
         <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
@@ -1354,12 +1352,7 @@
                 <artifactId>aesh</artifactId>
                 <version>${aesh.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.jboss.classfilewriter</groupId>
-                <artifactId>jboss-classfilewriter</artifactId>
-                <version>${jboss-classfilewriter.version}</version>
-            </dependency>
+            
             <dependency>
                 <groupId>com.oracle.substratevm</groupId>
                 <artifactId>svm</artifactId>
@@ -1372,11 +1365,6 @@
                         <groupId>*</groupId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.invocation</groupId>
-                <artifactId>jboss-invocation</artifactId>
-                <version>${jboss-invocation.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -20,22 +20,8 @@
             <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.common</groupId>
-                    <artifactId>wildfly-common</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.classfilewriter</groupId>
-            <artifactId>jboss-classfilewriter</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.gizmo</groupId>

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
@@ -1,0 +1,83 @@
+package io.quarkus.deployment.proxy;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import io.quarkus.deployment.util.ClassOutputUtil;
+import io.quarkus.gizmo.ClassOutput;
+
+/**
+ * A Gizmo {@link ClassOutput} that is able to write the inject the bytecode directly into the classloader
+ * The implementation was lifted from jboss-classwriter's org.jboss.classfilewriter.DefaultClassFactory
+ *
+ * This does NOT work in JDK 12+ where the defineClass has been removed from sun.misc.Unsafe
+ */
+class InjectIntoClassloaderClassOutput implements ClassOutput {
+
+    private static final Method defineClassMethod = getClassLoaderDefineClassMethod();
+
+    private final ClassLoader classLoader;
+
+    InjectIntoClassloaderClassOutput(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    // get a hold of java.lang.ClassLoader#defineClass
+    private static Method getClassLoaderDefineClassMethod() {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                public Method run() throws Exception {
+                    long overrideOffset;
+                    Object unsafe;
+                    Class<?> unsafeClass;
+
+                    // we cannot refer to Unsafe in a normal manner because the Java 11 build would fail
+                    try {
+                        // first we need to grab Unsafe
+                        unsafeClass = Class.forName("sun.misc.Unsafe");
+                        Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+                        theUnsafe.setAccessible(true);
+                        unsafe = theUnsafe.get(null);
+                        Method objectFieldOffsetMethod = unsafeClass.getDeclaredMethod("objectFieldOffset", Field.class);
+                        overrideOffset = (long) objectFieldOffsetMethod.invoke(unsafe,
+                                AccessibleObject.class.getDeclaredField("override"));
+
+                        // now we gain access to CL.defineClass methods
+                        Class<?> cl = ClassLoader.class;
+                        Method classLoaderDefineClassMethod = cl.getDeclaredMethod("defineClass", String.class, byte[].class,
+                                int.class,
+                                int.class);
+
+                        // use Unsafe to crack open both CL.defineClass() methods (instead of using setAccessible())
+                        Method putBooleanMethod = unsafeClass.getDeclaredMethod("putBoolean", Object.class, long.class,
+                                boolean.class);
+                        putBooleanMethod.invoke(unsafe, classLoaderDefineClassMethod, overrideOffset, true);
+                        return classLoaderDefineClassMethod;
+                    } catch (Exception e) {
+                        throw new Error(e);
+                    }
+
+                }
+            });
+        } catch (PrivilegedActionException pae) {
+            throw new RuntimeException("Cannot initialize InjectIntoClassloaderClassOutput", pae.getException());
+        }
+    }
+
+    @Override
+    public void write(String name, byte[] data) {
+        if (System.getProperty("dumpClass") != null) {
+            ClassOutputUtil.dumpClass(name, data);
+        }
+        try {
+            defineClassMethod.invoke(classLoader, name.replace('/', '.'), data, 0, data.length);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.proxy;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -13,18 +14,40 @@ import io.quarkus.gizmo.ClassOutput;
 
 /**
  * A Gizmo {@link ClassOutput} that is able to write the inject the bytecode directly into the classloader
- * The implementation was lifted from jboss-classwriter's org.jboss.classfilewriter.DefaultClassFactory
  *
- * This does NOT work in JDK 12+ where the defineClass has been removed from sun.misc.Unsafe
+ * The implementation for JDK 8-11 was lifted from jboss-classwriter's org.jboss.classfilewriter.DefaultClassFactory
+ *
+ * This implementation for JDK 12+ is based on what is discussed at:
+ * http://mail.openjdk.java.net/pipermail/jigsaw-dev/2018-April/013724.html
+ * and currently does not work properly - If the generated proxy references classes outside of its package
+ * a NoClassDefFoundError is thrown
  */
 class InjectIntoClassloaderClassOutput implements ClassOutput {
 
-    private static final Method defineClassMethod = getClassLoaderDefineClassMethod();
+    private static Method classLoaderDefineClassMethod;
+    private static Method privateLookupInMethod;
+    private static Method lookupDefineClass;
+
+    static {
+        classLoaderDefineClassMethod = getClassLoaderDefineClassMethod();
+        if (classLoaderDefineClassMethod == null) {
+            // this is the case of JDK 12+
+            try {
+                privateLookupInMethod = getPrivateLookupInMethod();
+                lookupDefineClass = getLookupDefineClassMethod();
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException(
+                        "Unable to initialize InjectIntoClassloaderClassOutput. Are you running an unsupported JDK version?");
+            }
+        }
+    }
 
     private final ClassLoader classLoader;
+    private final Class<?> anchorClass;
 
-    InjectIntoClassloaderClassOutput(ClassLoader classLoader) {
+    InjectIntoClassloaderClassOutput(ClassLoader classLoader, Class<?> anchorClass) {
         this.classLoader = classLoader;
+        this.anchorClass = anchorClass;
     }
 
     // get a hold of java.lang.ClassLoader#defineClass
@@ -58,6 +81,11 @@ class InjectIntoClassloaderClassOutput implements ClassOutput {
                                 boolean.class);
                         putBooleanMethod.invoke(unsafe, classLoaderDefineClassMethod, overrideOffset, true);
                         return classLoaderDefineClassMethod;
+                    } catch (NoSuchFieldException e) {
+                        if (e.getMessage().contains("override")) { //this we can handle
+                            return null;
+                        }
+                        throw new Exception(e);
                     } catch (Exception e) {
                         throw new Error(e);
                     }
@@ -69,15 +97,35 @@ class InjectIntoClassloaderClassOutput implements ClassOutput {
         }
     }
 
+    private static Method getPrivateLookupInMethod() throws NoSuchMethodException {
+        return MethodHandles.class.getDeclaredMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+    }
+
+    private static Method getLookupDefineClassMethod() throws NoSuchMethodException {
+        return MethodHandles.Lookup.class.getDeclaredMethod("defineClass", byte[].class);
+    }
+
     @Override
     public void write(String name, byte[] data) {
         if (System.getProperty("dumpClass") != null) {
             ClassOutputUtil.dumpClass(name, data);
         }
-        try {
-            defineClassMethod.invoke(classLoader, name.replace('/', '.'), data, 0, data.length);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
+        if (classLoaderDefineClassMethod != null) { // normal JDK 8-11 case
+            try {
+                classLoaderDefineClassMethod.invoke(classLoader, name.replace('/', '.'), data, 0, data.length);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        } else { // JDK 12+ case
+            // TODO: figure out how to solve NoClassDefFoundError for classes outside the package
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            try {
+                MethodHandles.Lookup privateLookupIn = (MethodHandles.Lookup) privateLookupInMethod.invoke(null, anchorClass,
+                        lookup);
+                lookupDefineClass.invoke(privateLookupIn, data);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyConfiguration.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyConfiguration.java
@@ -11,7 +11,8 @@ import java.util.List;
  */
 public class ProxyConfiguration<T> {
 
-    private String proxyName = null;
+    private Class<?> anchorClass;
+    private String proxyNameSuffix;
     private ClassLoader classLoader;
     private Class<T> superClass;
     private List<Class<?>> additionalInterfaces = new ArrayList<>(0);
@@ -37,18 +38,26 @@ public class ProxyConfiguration<T> {
         return this;
     }
 
+    public Class<?> getAnchorClass() {
+        return anchorClass;
+    }
+
+    public ProxyConfiguration<T> setAnchorClass(Class<?> anchorClass) {
+        this.anchorClass = anchorClass;
+        return this;
+    }
+
+    public String getProxyNameSuffix() {
+        return proxyNameSuffix;
+    }
+
+    public ProxyConfiguration<T> setProxyNameSuffix(final String proxyNameSuffix) {
+        this.proxyNameSuffix = proxyNameSuffix;
+        return this;
+    }
+
     public String getProxyName() {
-        return proxyName;
-    }
-
-    public ProxyConfiguration<T> setProxyName(final String proxyName) {
-        this.proxyName = proxyName;
-        return this;
-    }
-
-    public ProxyConfiguration<T> setProxyName(final Package pkg, final String simpleName) {
-        this.proxyName = pkg.getName() + '.' + simpleName;
-        return this;
+        return getAnchorClass().getName() + proxyNameSuffix;
     }
 
     public Class<T> getSuperClass() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyConfiguration.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyConfiguration.java
@@ -1,0 +1,62 @@
+package io.quarkus.deployment.proxy;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Basic configuration needed to generate a proxy of a class.
+ * This was inspired from jboss-invocations's org.jboss.invocation.proxy.ProxyConfiguration
+ */
+public class ProxyConfiguration<T> {
+
+    private String proxyName = null;
+    private ClassLoader classLoader;
+    private Class<T> superClass;
+    private List<Class<?>> additionalInterfaces = new ArrayList<>(0);
+
+    public List<Class<?>> getAdditionalInterfaces() {
+        return Collections.unmodifiableList(additionalInterfaces);
+    }
+
+    public ProxyConfiguration<T> addAdditionalInterface(final Class<?> iface) {
+        if (!Modifier.isInterface(iface.getModifiers())) {
+            throw new IllegalArgumentException("Class " + iface.getName() + " is not an interface");
+        }
+        additionalInterfaces.add(iface);
+        return this;
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    public ProxyConfiguration<T> setClassLoader(final ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        return this;
+    }
+
+    public String getProxyName() {
+        return proxyName;
+    }
+
+    public ProxyConfiguration<T> setProxyName(final String proxyName) {
+        this.proxyName = proxyName;
+        return this;
+    }
+
+    public ProxyConfiguration<T> setProxyName(final Package pkg, final String simpleName) {
+        this.proxyName = pkg.getName() + '.' + simpleName;
+        return this;
+    }
+
+    public Class<T> getSuperClass() {
+        return superClass;
+    }
+
+    public ProxyConfiguration<T> setSuperClass(final Class<T> superClass) {
+        this.superClass = superClass;
+        return this;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -1,0 +1,190 @@
+package io.quarkus.deployment.proxy;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+/**
+ * A factory that can generate proxies of a class.
+ * This was inspired from jboss-invocations's org.jboss.invocation.proxy.ProxyFactory
+ */
+public class ProxyFactory<T> {
+
+    private final String proxyName;
+    private final ClassLoader classLoader;
+
+    private final String superClassName;
+    private final List<Method> methods;
+    private final ClassCreator.Builder classBuilder;
+
+    private boolean classDefined = false;
+    private final Object lock = new Object();
+
+    public ProxyFactory(ProxyConfiguration<T> configuration) {
+        this.proxyName = Objects.requireNonNull(configuration.getProxyName(), "proxyName must be set");
+
+        Class<T> superClass = configuration.getSuperClass() != null ? configuration.getSuperClass() : (Class<T>) Object.class;
+        this.superClassName = superClass.getName();
+        if (!hasNoArgsConstructor(superClass)) {
+            throw new IllegalArgumentException(
+                    "A proxy cannot be created for class " + this.superClassName
+                            + " because it does contain a no-arg constructor");
+        }
+        if (Modifier.isFinal(superClass.getModifiers())) {
+            throw new IllegalArgumentException(
+                    "A proxy cannot be created for class " + this.superClassName + " because it is a final class");
+        }
+        if (!Modifier.isPublic(superClass.getModifiers())) {
+            throw new IllegalArgumentException(
+                    "A proxy cannot be created for class " + this.superClassName + " because the it is not public");
+        }
+
+        Objects.requireNonNull(configuration.getClassLoader(), "classLoader must be set");
+        this.classLoader = configuration.getClassLoader();
+
+        this.methods = new ArrayList<>(superClass.getMethods().length);
+        addMethodsOfClass(superClass);
+        for (Class<?> additionalInterface : configuration.getAdditionalInterfaces()) {
+            addMethodsOfClass(additionalInterface);
+        }
+
+        this.classBuilder = ClassCreator.builder()
+                .classOutput(new InjectIntoClassloaderClassOutput(configuration.getClassLoader())).className(this.proxyName)
+                .superClass(this.superClassName);
+        if (!configuration.getAdditionalInterfaces().isEmpty()) {
+            this.classBuilder.interfaces(configuration.getAdditionalInterfaces().toArray(new Class[0]));
+        }
+    }
+
+    private boolean hasNoArgsConstructor(Class<?> clazz) {
+        for (Constructor<?> constructor : clazz.getConstructors()) {
+            if (constructor.getParameterCount() == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void addMethodsOfClass(Class<?> clazz) {
+        for (Method methodInfo : clazz.getMethods()) {
+            if (!Modifier.isStatic(methodInfo.getModifiers()) &&
+                    !Modifier.isFinal(methodInfo.getModifiers()) &&
+                    !methodInfo.getName().equals("<init>")) {
+                methods.add(methodInfo);
+            }
+        }
+    }
+
+    public Class<? extends T> defineClass() {
+        synchronized (lock) {
+            if (!classDefined) {
+                doDefineClass();
+                classDefined = true;
+            }
+        }
+        return loadClass();
+    }
+
+    private void doDefineClass() {
+        try (ClassCreator cc = classBuilder.build()) {
+            FieldDescriptor invocationHandlerField = cc.getFieldCreator("invocationHandler", InvocationHandler.class)
+                    .setModifiers(Modifier.PRIVATE).getFieldDescriptor();
+
+            try (MethodCreator ctor = cc.getMethodCreator(MethodDescriptor.ofConstructor(proxyName))) {
+                ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(this.superClassName), ctor.getThis());
+                ctor.writeInstanceField(invocationHandlerField, ctor.getThis(), ctor.loadNull());
+                ctor.returnValue(null);
+            }
+
+            try (MethodCreator ctor = cc
+                    .getMethodCreator(MethodDescriptor.ofConstructor(proxyName, InvocationHandler.class.getName()))) {
+                ctor.invokeSpecialMethod(MethodDescriptor.ofConstructor(this.superClassName), ctor.getThis());
+                ctor.writeInstanceField(invocationHandlerField, ctor.getThis(), ctor.getMethodParam(0));
+                ctor.returnValue(null);
+            }
+
+            // proxy each method by forwarding to InvocationHandler
+            for (Method methodInfo : methods) {
+                try (MethodCreator mc = cc.getMethodCreator(toMethodDescriptor(methodInfo)).setModifiers(Modifier.PUBLIC)) {
+
+                    // method = clazz.getDeclaredMethod(...)
+
+                    ResultHandle getDeclaredMethodParamsArray = mc.newArray(Class.class,
+                            mc.load(methodInfo.getParameterCount()));
+                    for (int i = 0; i < methodInfo.getParameterCount(); i++) {
+                        ResultHandle paramClass = mc.loadClass(methodInfo.getParameters()[i].getType());
+                        mc.writeArrayValue(getDeclaredMethodParamsArray, i, paramClass);
+                    }
+                    ResultHandle method = mc.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(Class.class, "getDeclaredMethod", Method.class, String.class,
+                                    Class[].class),
+                            mc.loadClass(methodInfo.getDeclaringClass()), mc.load(methodInfo.getName()),
+                            getDeclaredMethodParamsArray);
+
+                    // result = invocationHandler.invoke(...)
+
+                    ResultHandle invokeParamsArray = mc.newArray(Object.class, mc.load(methodInfo.getParameterCount()));
+                    for (int i = 0; i < methodInfo.getParameterCount(); i++) {
+                        mc.writeArrayValue(invokeParamsArray, i, mc.getMethodParam(i));
+                    }
+                    ResultHandle result = mc.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(InvocationHandler.class, "invoke", Object.class, Object.class,
+                                    Method.class,
+                                    Object[].class),
+                            mc.readInstanceField(invocationHandlerField, mc.getThis()), mc.getThis(), method,
+                            invokeParamsArray);
+
+                    if (void.class.equals(methodInfo.getReturnType())) {
+                        mc.returnValue(null);
+                    } else {
+                        mc.returnValue(result);
+                    }
+
+                }
+            }
+        }
+    }
+
+    private MethodDescriptor toMethodDescriptor(Method methodInfo) {
+        final List<String> parameterTypesStr = new ArrayList<>();
+        for (Parameter parameter : methodInfo.getParameters()) {
+            parameterTypesStr.add(parameter.getType().getName());
+        }
+        return MethodDescriptor.ofMethod(proxyName, methodInfo.getName(), methodInfo.getReturnType(),
+                parameterTypesStr.toArray(new Object[0]));
+    }
+
+    public T newInstance(InvocationHandler handler) throws IllegalAccessException, InstantiationException {
+        synchronized (lock) {
+            try {
+                return defineClass().getConstructor(InvocationHandler.class).newInstance(handler);
+            } catch (NoSuchMethodException | InvocationTargetException e) {
+                // if this happens, we have not created the proxy correctly
+                throw new IllegalStateException(e);
+            }
+        }
+
+    }
+
+    private Class<? extends T> loadClass() {
+        try {
+            return (Class<? extends T>) classLoader.loadClass(proxyName);
+        } catch (ClassNotFoundException e) {
+            // if this happens, we have not "written" the proxy to the class loader correctly
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -23,6 +23,7 @@ import io.quarkus.gizmo.ResultHandle;
 public class ProxyFactory<T> {
 
     private final String proxyName;
+    private final Class<?> anchorClass;
     private final ClassLoader classLoader;
 
     private final String superClassName;
@@ -33,7 +34,9 @@ public class ProxyFactory<T> {
     private final Object lock = new Object();
 
     public ProxyFactory(ProxyConfiguration<T> configuration) {
-        this.proxyName = Objects.requireNonNull(configuration.getProxyName(), "proxyName must be set");
+        this.anchorClass = Objects.requireNonNull(configuration.getAnchorClass(), "anchorClass must be set");
+        Objects.requireNonNull(configuration.getProxyNameSuffix(), "proxyNameSuffix must be set");
+        this.proxyName = configuration.getProxyName();
 
         Class<T> superClass = configuration.getSuperClass() != null ? configuration.getSuperClass() : (Class<T>) Object.class;
         this.superClassName = superClass.getName();
@@ -61,7 +64,8 @@ public class ProxyFactory<T> {
         }
 
         this.classBuilder = ClassCreator.builder()
-                .classOutput(new InjectIntoClassloaderClassOutput(configuration.getClassLoader())).className(this.proxyName)
+                .classOutput(new InjectIntoClassloaderClassOutput(configuration.getClassLoader(), this.anchorClass))
+                .className(this.proxyName)
                 .superClass(this.superClassName);
         if (!configuration.getAdditionalInterfaces().isEmpty()) {
             this.classBuilder.interfaces(configuration.getAdditionalInterfaces().toArray(new Class[0]));

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -34,8 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.jboss.invocation.proxy.ProxyConfiguration;
-import org.jboss.invocation.proxy.ProxyFactory;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
@@ -44,6 +42,8 @@ import org.jboss.jandex.Type;
 import org.wildfly.common.Assert;
 
 import io.quarkus.deployment.ClassOutput;
+import io.quarkus.deployment.proxy.ProxyConfiguration;
+import io.quarkus.deployment.proxy.ProxyFactory;
 import io.quarkus.deployment.recording.AnnotationProxyProvider.AnnotationProxy;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BytecodeCreator;

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -159,7 +159,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
         ProxyFactory<Object> factory = new ProxyFactory<>(new ProxyConfiguration<Object>()
                 .setSuperClass(Object.class)
                 .setClassLoader(classLoader)
-                .setProxyName(getClass().getName() + "$$ClassProxy" + COUNT.incrementAndGet()));
+                .setAnchorClass(getClass())
+                .setProxyNameSuffix("$$ClassProxy" + COUNT.incrementAndGet()));
         Class theClass = factory.defineClass();
         classProxies.put(theClass, name);
         return theClass;
@@ -200,11 +201,15 @@ public class BytecodeRecorderImpl implements RecorderContext {
         if (existingProxyClasses.containsKey(theClass)) {
             return theClass.cast(existingProxyClasses.get(theClass));
         }
-        String proxyName = getClass().getName() + "$$RecordingProxyProxy" + COUNT.incrementAndGet();
-        ProxyFactory<T> factory = new ProxyFactory<T>(new ProxyConfiguration<T>()
+        String proxyNameSuffix = "$$RecordingProxyProxy" + COUNT.incrementAndGet();
+
+        ProxyConfiguration<T> proxyConfiguration = new ProxyConfiguration<T>()
                 .setSuperClass(theClass)
                 .setClassLoader(classLoader)
-                .setProxyName(proxyName));
+                .setAnchorClass(getClass())
+                .setProxyNameSuffix(proxyNameSuffix);
+        String proxyName = proxyConfiguration.getProxyName();
+        ProxyFactory<T> factory = new ProxyFactory<T>(proxyConfiguration);
         try {
             T recordingProxy = factory.newInstance(new InvocationHandler() {
                 @Override
@@ -251,7 +256,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
                     .setSuperClass(returnInterface ? Object.class : (Class) returnType)
                     .setClassLoader(classLoader)
                     .addAdditionalInterface(ReturnedProxy.class)
-                    .setProxyName(getClass().getName() + "$$ReturnValueProxy" + COUNT.incrementAndGet());
+                    .setAnchorClass(getClass())
+                    .setProxyNameSuffix("$$ReturnValueProxy" + COUNT.incrementAndGet());
 
             if (returnInterface) {
                 proxyConfiguration.addAdditionalInterface(returnType);

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ClassOutputUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ClassOutputUtil.java
@@ -1,0 +1,25 @@
+package io.quarkus.deployment.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Utility that dumps bytes from a class to a file - useful for debugging generated clases
+ */
+public final class ClassOutputUtil {
+
+    private ClassOutputUtil() {
+    }
+
+    public static void dumpClass(String name, byte[] data) {
+        try {
+            File dir = new File("target/test-classes/", name.substring(0, name.lastIndexOf("/")));
+            dir.mkdirs();
+            File output = new File("target/test-classes/", name + ".class");
+            Files.write(output.toPath(), data);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot dump the class: " + name, e);
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/FirstArgInvocationHandler.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/FirstArgInvocationHandler.java
@@ -1,0 +1,18 @@
+package io.quarkus.deployment.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class FirstArgInvocationHandler implements InvocationHandler {
+
+    public int invocationCount = 0;
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        invocationCount++;
+        if ((args != null) && args.length >= 1) {
+            return args[0];
+        }
+        return null;
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClass.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClass.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.deployment.proxy;
+
+import java.util.List;
+
+public class SimpleClass {
+
+    public SimpleClass() {
+
+    }
+
+    public Object[] method1() {
+        return null;
+    }
+
+    public Object[] method2(long v1, double v2, Object v3, int[] v4) {
+        return null;
+    }
+
+    public Object[] method3(List v1) {
+        return null;
+    }
+
+    public void method4(int v1) {
+
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
@@ -15,7 +15,8 @@ public class SimpleClassProxyTest {
         SimpleInvocationHandler invocationHandler = new SimpleInvocationHandler();
         ProxyConfiguration<SimpleClass> proxyConfiguration = new ProxyConfiguration<SimpleClass>()
                 .setSuperClass(SimpleClass.class)
-                .setProxyName(SimpleClass.class.getPackage(), "SimpleClass$$Proxy3")
+                .setAnchorClass(SimpleClass.class)
+                .setProxyNameSuffix("$$Proxy1")
                 .setClassLoader(SimpleClass.class.getClassLoader());
         SimpleClass instance = new ProxyFactory<>(proxyConfiguration).newInstance(invocationHandler);
 
@@ -63,7 +64,8 @@ public class SimpleClassProxyTest {
         };
         ProxyConfiguration<SimpleClass> proxyConfiguration = new ProxyConfiguration<SimpleClass>()
                 .setSuperClass(SimpleClass.class)
-                .setProxyName(SimpleClass.class.getPackage(), "SimpleClass$$Proxy")
+                .setAnchorClass(SimpleClass.class)
+                .setProxyNameSuffix("$$Proxy2")
                 .setClassLoader(cl1);
         ProxyFactory<SimpleClass> proxyFactory = new ProxyFactory<>(proxyConfiguration);
         SimpleClass instance = proxyFactory.newInstance(new SimpleInvocationHandler());

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.deployment.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class SimpleClassProxyTest {
+
+    @Test
+    public void testProxyCreation() throws InstantiationException, IllegalAccessException {
+        SimpleInvocationHandler invocationHandler = new SimpleInvocationHandler();
+        ProxyConfiguration<SimpleClass> proxyConfiguration = new ProxyConfiguration<SimpleClass>()
+                .setSuperClass(SimpleClass.class)
+                .setProxyName(SimpleClass.class.getPackage(), "SimpleClass$$Proxy3")
+                .setClassLoader(SimpleClass.class.getClassLoader());
+        SimpleClass instance = new ProxyFactory<>(proxyConfiguration).newInstance(invocationHandler);
+
+        assertMethod1(instance);
+        assertMethod2(instance);
+        assertMethod3(instance);
+        assertMethod4(instance);
+
+        assertThat(invocationHandler.invocationCount).isEqualTo(4);
+    }
+
+    private void assertMethod1(SimpleClass instance) {
+        Object result = instance.method1();
+        assertThat(result.getClass().isArray()).isTrue();
+        assertThat((Object[]) result).isEmpty();
+    }
+
+    private void assertMethod2(SimpleClass instance) {
+        Object result = instance.method2(10, 0, this, new int[0]);
+        assertThat(result.getClass().isArray()).isTrue();
+        assertThat((Object[]) result).hasSize(4).contains(10L, 0.0);
+    }
+
+    private void assertMethod3(SimpleClass instance) {
+        Object result = instance.method3(Arrays.asList(1, 2, 3));
+        assertThat(result.getClass().isArray()).isTrue();
+        assertThat((Object[]) result).hasSize(1).satisfies(o -> {
+            assertThat(o[0]).isInstanceOfSatisfying(List.class, l -> {
+                assertThat(l).containsExactly(1, 2, 3);
+            });
+        });
+    }
+
+    private void assertMethod4(SimpleClass instance) {
+        assertThatCode(() -> instance.method4(4)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testMultipleClassLoaders() throws InstantiationException, IllegalAccessException {
+        ClassLoader cl1 = new ClassLoader() {
+
+        };
+        ClassLoader cl2 = new ClassLoader() {
+
+        };
+        ProxyConfiguration<SimpleClass> proxyConfiguration = new ProxyConfiguration<SimpleClass>()
+                .setSuperClass(SimpleClass.class)
+                .setProxyName(SimpleClass.class.getPackage(), "SimpleClass$$Proxy")
+                .setClassLoader(cl1);
+        ProxyFactory<SimpleClass> proxyFactory = new ProxyFactory<>(proxyConfiguration);
+        SimpleClass instance = proxyFactory.newInstance(new SimpleInvocationHandler());
+        assertThat(instance).isNotNull();
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterface.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterface.java
@@ -1,0 +1,8 @@
+package io.quarkus.deployment.proxy;
+
+public interface SimpleInterface {
+
+    void doNothing();
+
+    String capitalize(String input);
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
@@ -11,7 +11,8 @@ public class SimpleInterfaceProxyTest {
         FirstArgInvocationHandler invocationHandler = new FirstArgInvocationHandler();
         ProxyConfiguration<Object> proxyConfiguration = new ProxyConfiguration<>()
                 .setSuperClass(Object.class)
-                .setProxyName(SimpleInterface.class.getName() + "$Proxy2")
+                .setAnchorClass(SimpleInterface.class)
+                .setProxyNameSuffix("$Proxy2")
                 .setClassLoader(SimpleClass.class.getClassLoader())
                 .addAdditionalInterface(SimpleInterface.class);
         SimpleInterface instance = (SimpleInterface) new ProxyFactory<>(proxyConfiguration).newInstance(invocationHandler);

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.deployment.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class SimpleInterfaceProxyTest {
+
+    @Test
+    public void testProxyCreation() throws InstantiationException, IllegalAccessException {
+        FirstArgInvocationHandler invocationHandler = new FirstArgInvocationHandler();
+        ProxyConfiguration<Object> proxyConfiguration = new ProxyConfiguration<>()
+                .setSuperClass(Object.class)
+                .setProxyName(SimpleInterface.class.getName() + "$Proxy2")
+                .setClassLoader(SimpleClass.class.getClassLoader())
+                .addAdditionalInterface(SimpleInterface.class);
+        SimpleInterface instance = (SimpleInterface) new ProxyFactory<>(proxyConfiguration).newInstance(invocationHandler);
+
+        String result = instance.capitalize("in");
+        assertThat(result).isEqualTo("in");
+
+        instance.doNothing();
+
+        assertThat(invocationHandler.invocationCount).isEqualTo(2);
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInvocationHandler.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInvocationHandler.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.deployment.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class SimpleInvocationHandler implements InvocationHandler {
+
+    public int invocationCount = 0;
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        invocationCount++;
+        return args;
+    }
+
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 
-import org.jboss.invocation.proxy.ProxyConfiguration;
-import org.jboss.invocation.proxy.ProxyFactory;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -41,6 +39,8 @@ import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildException;
 import io.quarkus.builder.BuildStep;
 import io.quarkus.builder.item.BuildItem;
+import io.quarkus.deployment.proxy.ProxyConfiguration;
+import io.quarkus.deployment.proxy.ProxyFactory;
 import io.quarkus.runner.RuntimeRunner;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.common.PathTestHelper;
@@ -119,16 +119,14 @@ public class QuarkusUnitTest
             throws TestInstantiationException {
         try {
             Class testClass = extensionContext.getRequiredTestClass();
-            ProxyFactory<?> factory = new ProxyFactory<>(new ProxyConfiguration<>()
-                    .setProxyName(testClass.getName() + "$$QuarkusUnitTestProxy")
-                    .setClassLoader(testClass.getClassLoader())
-                    .setSuperClass(testClass));
 
-            Object actualTestInstance = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(testClass.getName());
+            ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
+            Object actualTestInstance = store.get(testClass.getName());
             if (actualTestInstance != null) { //happens if a deployment exception is expected
                 TestHTTPResourceManager.inject(actualTestInstance);
             }
-            return factory.newInstance(new InvocationHandler() {
+            ProxyFactory<?> proxyFactory = (ProxyFactory<?>) store.get(proxyFactoryKey(testClass));
+            return proxyFactory.newInstance(new InvocationHandler() {
                 @Override
                 public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                     if (assertException != null) {
@@ -196,6 +194,15 @@ public class QuarkusUnitTest
         }
 
         Class<?> testClass = extensionContext.getRequiredTestClass();
+
+        if (store.get(proxyFactoryKey(testClass)) == null) {
+            ProxyFactory<?> factory = new ProxyFactory<>(new ProxyConfiguration<>()
+                    .setProxyName(testClass.getName() + "$$QuarkusUnitTestProxy")
+                    .setClassLoader(testClass.getClassLoader())
+                    .setSuperClass((Class<Object>) testClass));
+            store.put(proxyFactoryKey(testClass), factory);
+        }
+
         try {
             deploymentDir = Files.createTempDirectory("quarkus-unit-test");
 
@@ -278,6 +285,10 @@ public class QuarkusUnitTest
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String proxyFactoryKey(Class<?> testClass) {
+        return testClass + "proxyFactory";
     }
 
     @Override

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -197,7 +197,8 @@ public class QuarkusUnitTest
 
         if (store.get(proxyFactoryKey(testClass)) == null) {
             ProxyFactory<?> factory = new ProxyFactory<>(new ProxyConfiguration<>()
-                    .setProxyName(testClass.getName() + "$$QuarkusUnitTestProxy")
+                    .setAnchorClass(testClass)
+                    .setProxyNameSuffix("$$QuarkusUnitTestProxy")
                     .setClassLoader(testClass.getClassLoader())
                     .setSuperClass((Class<Object>) testClass));
             store.put(proxyFactoryKey(testClass), factory);


### PR DESCRIPTION
This PR has two commits:

* The first drops `jboss-invocation` and introduces a few classes that allows the creation of the proxy classes using only Gizmo. Proxy creation supports JDK 8-11 but the classes aren't particularly optimized (but since they are meant to only be used during augmentation maybe it doesn't really matter?)
* The second commit attempts to lay the groundwork  for allowing the creation of proxies for JDK 12+. As can be seen in the comments, this currently only works for a small set of proxies - not enough to build Quarkus apps with JDK 12.

I would like to hear your thoughts, particularly @stuartwdouglas and @dmlloyd :)