### PR TITLE
Add an option for create-extension mojo to create an integration test module

### DIFF
--- a/devtools/common/src/test/java/io/quarkus/maven/utilities/PomTransformerTest.java
+++ b/devtools/common/src/test/java/io/quarkus/maven/utilities/PomTransformerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Node;
 
+import io.quarkus.maven.utilities.PomTransformer.Gavtcs;
 import io.quarkus.maven.utilities.PomTransformer.Transformation;
 
 public class PomTransformerTest {
@@ -415,7 +416,8 @@ public class PomTransformerTest {
                 + "    </dependencyManagement>\n" //
                 + "</project>\n";
         asserTransformation(source,
-                Collections.singletonList(Transformation.addManagedDependency("org.acme", "my-ext", "${project.version}")),
+                Collections.singletonList(
+                        Transformation.addManagedDependency(new Gavtcs("org.acme", "my-ext", "${project.version}"))),
                 expected);
     }
 
@@ -451,7 +453,8 @@ public class PomTransformerTest {
                 + "    </dependencyManagement>\n" //
                 + "</project>\n";
         asserTransformation(source,
-                Collections.singletonList(Transformation.importBom("org.acme", "bom", "${bom.version}")),
+                Collections.singletonList(
+                        Transformation.addManagedDependency(Gavtcs.importBom("org.acme", "bom", "${bom.version}"))),
                 expected);
     }
 

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -137,10 +137,16 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>create-extension-templates/**/*</exclude>
+                </excludes>
             </resource>
             <resource>
-                <directory>src/main/templates</directory>
+                <directory>src/main/resources</directory>
                 <filtering>false</filtering>
+                <includes>
+                    <include>create-extension-templates/**/*</include>
+                </includes>
             </resource>
         </resources>
         <plugins>

--- a/devtools/maven/src/main/resources/create-extension-templates/IT.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/IT.java
@@ -1,0 +1,8 @@
+package [=javaPackageBase].it;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+class [=artifactIdBaseCamelCase]IT extends [=artifactIdBaseCamelCase]Test {
+
+}

--- a/devtools/maven/src/main/resources/create-extension-templates/Test.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/Test.java
@@ -1,0 +1,17 @@
+package [=javaPackageBase].it;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+class [=artifactIdBaseCamelCase]Test {
+
+    @Test
+    public void test() {
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/devtools/maven/src/main/resources/create-extension-templates/TestResource.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/TestResource.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package [=javaPackageBase].it;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.Path;
+
+@Path("/[=artifactIdBase]")
+@ApplicationScoped
+public class [=artifactIdBaseCamelCase]Resource {
+
+    // add some rest methods here
+
+}

--- a/devtools/maven/src/main/resources/create-extension-templates/integration-test-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/integration-test-pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+[#if itestParentGroupId?? ]    <parent>
+        <groupId>[=itestParentGroupId]</groupId>
+        <artifactId>[=itestParentArtifactId]</artifactId>
+        <version>[=itestParentVersion]</version>
+        <relativePath>[=itestParentRelativePath]</relativePath>
+    </parent>
+[/#if]
+
+    <artifactId>[=artifactId]-integration-test</artifactId>
+[#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Integration Test</name>
+[/#if]
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+[#if !assumeManaged ]            <version>[=quarkusVersion]</version>
+[/#if]
+        </dependency>
+        <dependency>
+            <groupId>[=groupId]</groupId>
+            <artifactId>[=artifactId]</artifactId>
+[#if !assumeManaged ]            <version>[=r"$"]{project.version}</version>
+[/#if]
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+[#if !assumeManaged ]            <version>[=quarkusVersion]</version>
+[/#if]
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+[#if !assumeManaged ]            <version>[=r"$"]{rest-assured.version}</version>
+[/#if]
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
+                                    <enableAllSecurityServices>true</enableAllSecurityServices>
+                                    <disableReports>true</disableReports>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -362,16 +362,18 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
 
 The above sequence of commands does the following:
 
-* Creates three new Maven modules:
-** `quarkus-my-ext-parent` in the `my-ext` directory
-** `quarkus-my-ext` in the `my-ext/runtime` directory
-** `quarkus-my-ext-deployment` in the `my-ext/deployment` directory; a basic `MyExtProcessor` class is generated in this module.
+* Creates four new Maven modules:
+** `quarkus-my-ext-parent` in the `extensions/my-ext` directory
+** `quarkus-my-ext` in the `extensions/my-ext/runtime` directory
+** `quarkus-my-ext-deployment` in the `extensions/my-ext/deployment` directory; a basic `MyExtProcessor` class is generated in this module.
+** `quarkus-my-ext-integration-test` in the `integration-tests/my-ext/deployment` directory; an empty JAX-RS Resource class and two test classes (for JVM mode and native mode) are generated in this module.
 * Links these three modules where necessary:
 ** `quarkus-my-ext-parent` is added to the `<modules>` of `quarkus-extensions-parent`
 ** `quarkus-my-ext` is added to the `<dependencyManagement>` of the runtime BOM (Bill of Materials) `bom/runtime/pom.xml`
 ** `quarkus-my-ext-deployment` is added to the `<dependencyManagement>` of the deployment BOM (Bill of Materials) `bom/deployment/pom.xml`
+** `quarkus-my-ext-integration-test` is added to the `<modules>` of `quarkus-integration-tests-parent`
 
-A Maven build performed immediately after generating the modules should pass flawlessly.
+A Maven build performed immediately after generating the modules should fail due to a `fail()` assertion in one of the test classes.
 
 There is one step (specific to the Quarkus source tree) that you should do manually when creating a new extension:
 Add the extension coordinates to `devtools/common/src/main/filtered/extensions.json`.
@@ -393,6 +395,7 @@ Note that the parameters of the mojo that will be constant for all the extension
         <namePrefix xml:space="preserve">Quarkus - </namePrefix>
         <runtimeBomPath>../bom/runtime/pom.xml</runtimeBomPath>
         <deploymentBomPath>../bom/deployment/pom.xml</deploymentBomPath>
+        <itestParentPath>../integration-tests/pom.xml</itestParentPath>
     </configuration>
 </plugin>
 ----

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -132,6 +132,7 @@
                     <quarkusVersion>@{project.version}</quarkusVersion>
                     <runtimeBomPath>../bom/runtime/pom.xml</runtimeBomPath>
                     <deploymentBomPath>../bom/deployment/pom.xml</deploymentBomPath>
+                    <itestParentPath>../integration-tests/pom.xml</itestParentPath>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -73,6 +73,19 @@ public class CreateExtensionMojoTest {
     }
 
     @Test
+    void createExtensionUnderExistingPomWithItest() throws MojoExecutionException, MojoFailureException,
+            IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
+        final CreateExtensionMojo mojo = createMojo("create-extension-pom");
+        mojo.artifactId = "my-project-(itest)";
+        mojo.assumeManaged = false;
+        mojo.itestParentPath = Paths.get("integration-tests/pom.xml");
+        mojo.execute();
+
+        assertTreesMatch(Paths.get("src/test/resources/expected/create-extension-pom-itest"),
+                mojo.basedir);
+    }
+
+    @Test
     void createExtensionUnderExistingPomCustomGrandParent() throws MojoExecutionException, MojoFailureException,
             IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
         final CreateExtensionMojo mojo = createMojo("create-extension-pom");

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -53,6 +54,21 @@ public class CreateExtensionMojoTest {
         mojo.execute();
 
         assertTreesMatch(Paths.get("src/test/resources/expected/create-extension-pom-minimal"),
+                mojo.basedir);
+    }
+
+    @Test
+    void createExtensionUnderExistingPomWithAdditionalRuntimeDependencies() throws MojoExecutionException, MojoFailureException,
+            IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
+        final CreateExtensionMojo mojo = createMojo("create-extension-pom");
+        mojo.artifactId = "my-project-(add-to-bom)";
+        mojo.assumeManaged = false;
+        mojo.runtimeBomPath = Paths.get("boms/runtime/pom.xml");
+        mojo.additionalRuntimeDependencies = Arrays.asList("org.example:example-1:1.2.3",
+                "org.acme:acme-@{quarkus.artifactIdBase}:@{$}{acme.version}");
+        mojo.execute();
+
+        assertTreesMatch(Paths.get("src/test/resources/expected/create-extension-pom-add-to-bom"),
                 mojo.basedir);
     }
 

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>my-project-add-to-bom-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-project-add-to-bom-deployment</artifactId>
+    <name>Add To Bom - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>my-project-add-to-bom</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/main/java/org/acme/my/project/add/to/bom/deployment/AddToBomProcessor.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/src/main/java/org/acme/my/project/add/to/bom/deployment/AddToBomProcessor.java
@@ -1,0 +1,15 @@
+package org.acme.my.project.add.to.bom.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class AddToBomProcessor {
+
+    private static final String FEATURE = "add-to-bom";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-project-add-to-bom-parent</artifactId>
+    <name>Add To Bom - Parent</name>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/runtime/pom.xml
@@ -4,41 +4,32 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>[=groupId]</groupId>
-        <artifactId>[=artifactId]-parent</artifactId>
-        <version>[=version]</version>
+        <groupId>org.acme</groupId>
+        <artifactId>my-project-add-to-bom-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>[=artifactId]</artifactId>
-[#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Runtime</name>
-[/#if]
-[#if additionalRuntimeDependencies?size > 0 ]
+    <artifactId>my-project-add-to-bom</artifactId>
+    <name>Add To Bom - Runtime</name>
 
     <dependencies>
-[#list additionalRuntimeDependencies as dep]
         <dependency>
-            <groupId>[=dep.groupId]</groupId>
-            <artifactId>[=dep.artifactId]</artifactId>
-[#if !runtimeBomPathSet ]            <version>[=dep.version]</version>
-[/#if]
-[#if dep.type?? ]            <type>[=dep.type]</type>
-[/#if]
-[#if dep.classifier?? ]            <type>[=dep.classifier]</type>
-[/#if]
-[#if dep.scope?? ]            <type>[=dep.scope]</type>
-[/#if]
+            <groupId>org.example</groupId>
+            <artifactId>example-1</artifactId>
         </dependency>
-[/#list]
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>acme-add-to-bom</artifactId>
+        </dependency>
     </dependencies>
-[/#if]
 
     <build>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-[#if !assumeManaged ]                <version>[=quarkusVersion]</version>
+                <version>${quarkus.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -46,12 +37,11 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <deployment>[=r"$"]{project.groupId}:[=r"$"]{project.artifactId}-deployment:[=r"$"]{project.version}
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
                             </deployment>
                         </configuration>
                     </execution>
                 </executions>
-[/#if]
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -61,7 +51,7 @@
                         <path>
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-extension-processor</artifactId>
-                            <version>[=quarkusVersion]</version>
+                            <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/boms/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/boms/deployment/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>deployment-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/boms/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/boms/runtime/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>runtime-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.acme</groupId>
+                <artifactId>my-project-add-to-bom</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-1</artifactId>
+                <version>1.2.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.acme</groupId>
+                <artifactId>acme-add-to-bom</artifactId>
+                <version>${acme.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/integration-tests/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/integration-tests/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-tests-parent</artifactId>
+
+    <packaging>pom</packaging>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/pom.xml
@@ -8,8 +8,11 @@
     <packaging>pom</packaging>
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
+        <rest-assured.version>3.3.0</rest-assured.version>
     </properties>
+
     <modules>
+        <module>integration-tests</module>
         <module>add-to-bom</module>
     </modules>
 </project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme</groupId>
+    <artifactId>grand-parent</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <quarkus.version>0.19.0</quarkus.version>
+    </properties>
+    <modules>
+        <module>add-to-bom</module>
+    </modules>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/templates/Processor.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/templates/Processor.java
@@ -1,0 +1,17 @@
+package [=javaPackageBase].deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class [=artifactIdBaseCamelCase]Processor {
+
+    // Custom
+
+    private static final String FEATURE = "[=artifactIdBase]";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/boms/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/boms/deployment/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>deployment-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/boms/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/boms/runtime/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>runtime-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>integration-tests-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-project-itest-integration-test</artifactId>
+    <name>Itest - Integration Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <version>${quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>my-project-itest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <version>${quarkus.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
+                                    <enableAllSecurityServices>true</enableAllSecurityServices>
+                                    <disableReports>true</disableReports>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/main/java/org/acme/my/project/itest/it/ItestResource.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/main/java/org/acme/my/project/itest/it/ItestResource.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme.my.project.itest.it;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.Path;
+
+@Path("/itest")
+@ApplicationScoped
+public class ItestResource {
+
+    // add some rest methods here
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/test/java/org/acme/my/project/itest/it/ItestIT.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/test/java/org/acme/my/project/itest/it/ItestIT.java
@@ -1,0 +1,8 @@
+package org.acme.my.project.itest.it;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+class ItestIT extends ItestTest {
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/test/java/org/acme/my/project/itest/it/ItestTest.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/test/java/org/acme/my/project/itest/it/ItestTest.java
@@ -1,0 +1,17 @@
+package org.acme.my.project.itest.it;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+class ItestTest {
+
+    @Test
+    public void test() {
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-tests-parent</artifactId>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>itest</module>
+    </modules>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>my-project-itest-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-project-itest-deployment</artifactId>
+    <name>Itest - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+            <version>${quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>my-project-itest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/main/java/org/acme/my/project/itest/deployment/ItestProcessor.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/src/main/java/org/acme/my/project/itest/deployment/ItestProcessor.java
@@ -1,0 +1,15 @@
+package org.acme.my.project.itest.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class ItestProcessor {
+
+    private static final String FEATURE = "itest";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-project-itest-parent</artifactId>
+    <name>Itest - Parent</name>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/runtime/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>my-project-itest-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>my-project-itest</artifactId>
+    <name>Itest - Runtime</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/pom.xml
@@ -13,6 +13,6 @@
 
     <modules>
         <module>integration-tests</module>
-        <module>with-grand-parent</module>
+        <module>itest</module>
     </modules>
 </project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/templates/Processor.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/templates/Processor.java
@@ -1,0 +1,17 @@
+package [=javaPackageBase].deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class [=artifactIdBaseCamelCase]Processor {
+
+    // Custom
+
+    private static final String FEATURE = "[=artifactIdBase]";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/integration-tests/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/integration-tests/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-tests-parent</artifactId>
+
+    <packaging>pom</packaging>
+
+</project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/pom.xml
@@ -8,8 +8,11 @@
     <packaging>pom</packaging>
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
+        <rest-assured.version>3.3.0</rest-assured.version>
     </properties>
+
     <modules>
+        <module>integration-tests</module>
         <module>minimal-extension</module>
     </modules>
 </project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/integration-tests/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/integration-tests/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-tests-parent</artifactId>
+
+    <packaging>pom</packaging>
+
+</project>

--- a/integration-tests/maven/src/test/resources/projects/create-extension-pom/integration-tests/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/create-extension-pom/integration-tests/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>grand-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-tests-parent</artifactId>
+
+    <packaging>pom</packaging>
+
+</project>

--- a/integration-tests/maven/src/test/resources/projects/create-extension-pom/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/create-extension-pom/pom.xml
@@ -8,5 +8,10 @@
     <packaging>pom</packaging>
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
+        <rest-assured.version>3.3.0</rest-assured.version>
     </properties>
+
+    <modules>
+        <module>integration-tests</module>
+    </modules>
 </project>


### PR DESCRIPTION
The first commit adding `additionalRuntimeBomEntries` is motivated by our need in Camel Quarkus, where the newly added extensions typically depend on the Camel component they add support for. That component needs be added to the runtime BOM and to the extension's runtime module.

The second commit adds the option to create also an integration test module when scaffolding a new extension. 