### PR TITLE
DynamoDB: Re-enable async support

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -131,7 +131,7 @@
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>
         <aws-lambda-java-events.version>2.2.5</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
-        <awssdk.version>2.7.35</awssdk.version>
+        <awssdk.version>2.8.0</awssdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.41</kotlin.version>
         <dekorate.version>0.6.1</dekorate.version>

--- a/extensions/amazon-dynamodb/deployment/src/main/java/io/quarkus/dynamodb/deployment/DynamodbProcessor.java
+++ b/extensions/amazon-dynamodb/deployment/src/main/java/io/quarkus/dynamodb/deployment/DynamodbProcessor.java
@@ -21,9 +21,16 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.substrate.ServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateProxyDefinitionBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
-import io.quarkus.dynamodb.runtime.*;
+import io.quarkus.dynamodb.runtime.AwsApacheHttpClientConfig;
+import io.quarkus.dynamodb.runtime.AwsCredentialsProviderType;
+import io.quarkus.dynamodb.runtime.AwsNettyNioAsyncHttpClientConfig;
+import io.quarkus.dynamodb.runtime.DynamodbClientProducer;
+import io.quarkus.dynamodb.runtime.DynamodbConfig;
+import io.quarkus.dynamodb.runtime.DynamodbRecorder;
 import software.amazon.awssdk.http.SdkHttpService;
 import software.amazon.awssdk.http.apache.ApacheSdkHttpService;
+import software.amazon.awssdk.http.async.SdkAsyncHttpService;
+import software.amazon.awssdk.http.nio.netty.NettySdkAsyncHttpService;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.utils.StringUtils;
@@ -73,11 +80,8 @@ public class DynamodbProcessor {
                 createSyncClient = true;
             }
 
-            // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-            // async support.
             if (ASYNC_CLIENT_NAME.equals(requiredType.name())) {
-                throw new UnsupportedOperationException("Async client not supported");
-                //                createAsyncClient = true;
+                createAsyncClient = true;
             }
         }
 
@@ -94,11 +98,9 @@ public class DynamodbProcessor {
 
         if (createAsyncClient) {
             //Register netty as async client
-            // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-            // async support.
-            //            serviceProvider.produce(
-            //                    new ServiceProviderBuildItem(SdkAsyncHttpService.class.getName(),
-            //                            NettySdkAsyncHttpService.class.getName()));
+            serviceProvider.produce(
+                    new ServiceProviderBuildItem(SdkAsyncHttpService.class.getName(),
+                            NettySdkAsyncHttpService.class.getName()));
         }
 
         return new DynamodbClientBuildItem(createSyncClient, createAsyncClient);

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbAsyncClientFullConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbAsyncClientFullConfigTest.java
@@ -4,15 +4,12 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
-@Disabled("Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the async"
-        + " support.")
 public class DynamodbAsyncClientFullConfigTest {
 
     @Inject

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientDefaultCredentialsProviderConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientDefaultCredentialsProviderConfigTest.java
@@ -8,14 +8,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 public class DynamodbClientDefaultCredentialsProviderConfigTest {
 
-    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-    // async support.
-    //    @Inject
-    //    DynamoDbAsyncClient async;
+    @Inject
+    DynamoDbAsyncClient async;
 
     @Inject
     DynamoDbClient sync;

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientProfileCredentialsProviderConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbClientProfileCredentialsProviderConfigTest.java
@@ -8,14 +8,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 public class DynamodbClientProfileCredentialsProviderConfigTest {
 
-    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-    // async support.
-    //    @Inject
-    //    DynamoDbAsyncClient async;
+    @Inject
+    DynamoDbAsyncClient async;
 
     @Inject
     DynamoDbClient sync;

--- a/extensions/amazon-dynamodb/runtime/pom.xml
+++ b/extensions/amazon-dynamodb/runtime/pom.xml
@@ -31,12 +31,10 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
         </dependency>
-        <!-- Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-             async support. -->
-        <!--<dependency>-->
-            <!--<groupId>software.amazon.awssdk</groupId>-->
-            <!--<artifactId>netty-nio-client</artifactId>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbClientProducer.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbClientProducer.java
@@ -11,7 +11,14 @@ import software.amazon.awssdk.core.client.builder.SdkSyncClientBuilder;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient.Builder;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
-import software.amazon.awssdk.services.dynamodb.*;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder;
+import software.amazon.awssdk.services.dynamodb.DynamoDbBaseClientBuilder;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 @ApplicationScoped
 public class DynamodbClientProducer {
@@ -72,9 +79,7 @@ public class DynamodbClientProducer {
     }
 
     private void initHttpClient(SdkAsyncClientBuilder builder, DynamodbConfig config) {
-        // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-        // async support.
-        //        builder.httpClientBuilder(createNettyClientBuilder(config.asyncClient));
+        builder.httpClientBuilder(createNettyClientBuilder(config.asyncClient));
     }
 
     private ApacheHttpClient.Builder createApacheClientBuilder(AwsApacheHttpClientConfig config) {
@@ -104,34 +109,32 @@ public class DynamodbClientProducer {
         return builder;
     }
 
-    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-    // async support.
-    //    private NettyNioAsyncHttpClient.Builder createNettyClientBuilder(AwsNettyNioAsyncHttpClientConfig config) {
-    //        NettyNioAsyncHttpClient.Builder builder = NettyNioAsyncHttpClient.builder();
-    //
-    //        config.connectionAcquisitionTimeout.ifPresent(builder::connectionAcquisitionTimeout);
-    //        config.connectionMaxIdleTime.ifPresent(builder::connectionMaxIdleTime);
-    //        config.connectionTimeout.ifPresent(builder::connectionTimeout);
-    //        config.connectionTimeToLive.ifPresent(builder::connectionTimeToLive);
-    //        config.maxConcurrency.ifPresent(builder::maxConcurrency);
-    //        config.maxHttp2Streams.ifPresent(builder::maxHttp2Streams);
-    //        config.maxPendingConnectionAcquires.ifPresent(builder::maxPendingConnectionAcquires);
-    //        config.protocol.ifPresent(builder::protocol);
-    //        config.readTimeout.ifPresent(builder::readTimeout);
-    //        config.sslProvider.ifPresent(builder::sslProvider);
-    //        config.useIdleConnectionReaper.ifPresent(builder::useIdleConnectionReaper);
-    //        config.writeTimeout.ifPresent(builder::writeTimeout);
-    //
-    //        if (config.eventLoop.override) {
-    //            SdkEventLoopGroup.Builder eventLoopBuilder = SdkEventLoopGroup.builder();
-    //            eventLoopBuilder.numberOfThreads(config.eventLoop.numberOfThreads);
-    //            if (config.eventLoop.threadNamePrefix.isPresent()) {
-    //                eventLoopBuilder.threadFactory(
-    //                        new ThreadFactoryBuilder().threadNamePrefix(config.eventLoop.threadNamePrefix.get()).build());
-    //            }
-    //            builder.eventLoopGroupBuilder(eventLoopBuilder);
-    //        }
-    //
-    //        return builder;
-    //    }
+    private NettyNioAsyncHttpClient.Builder createNettyClientBuilder(AwsNettyNioAsyncHttpClientConfig config) {
+        NettyNioAsyncHttpClient.Builder builder = NettyNioAsyncHttpClient.builder();
+
+        config.connectionAcquisitionTimeout.ifPresent(builder::connectionAcquisitionTimeout);
+        config.connectionMaxIdleTime.ifPresent(builder::connectionMaxIdleTime);
+        config.connectionTimeout.ifPresent(builder::connectionTimeout);
+        config.connectionTimeToLive.ifPresent(builder::connectionTimeToLive);
+        config.maxConcurrency.ifPresent(builder::maxConcurrency);
+        config.maxHttp2Streams.ifPresent(builder::maxHttp2Streams);
+        config.maxPendingConnectionAcquires.ifPresent(builder::maxPendingConnectionAcquires);
+        config.protocol.ifPresent(builder::protocol);
+        config.readTimeout.ifPresent(builder::readTimeout);
+        config.sslProvider.ifPresent(builder::sslProvider);
+        config.useIdleConnectionReaper.ifPresent(builder::useIdleConnectionReaper);
+        config.writeTimeout.ifPresent(builder::writeTimeout);
+
+        if (config.eventLoop.override) {
+            SdkEventLoopGroup.Builder eventLoopBuilder = SdkEventLoopGroup.builder();
+            eventLoopBuilder.numberOfThreads(config.eventLoop.numberOfThreads);
+            if (config.eventLoop.threadNamePrefix.isPresent()) {
+                eventLoopBuilder.threadFactory(
+                        new ThreadFactoryBuilder().threadNamePrefix(config.eventLoop.threadNamePrefix.get()).build());
+            }
+            builder.eventLoopGroupBuilder(eventLoopBuilder);
+        }
+
+        return builder;
+    }
 }

--- a/integration-tests/amazon-dynamodb/src/main/java/io/quarkus/it/dynamodb/DynamoDBResource.java
+++ b/integration-tests/amazon-dynamodb/src/main/java/io/quarkus/it/dynamodb/DynamoDBResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.dynamodb;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -11,6 +12,7 @@ import javax.ws.rs.Produces;
 
 import org.jboss.logging.Logger;
 
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 
@@ -24,26 +26,22 @@ public class DynamoDBResource {
     @Inject
     DynamoDbClient client;
 
-    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-    // async support.
-    //    @Inject
-    //    DynamoDbAsyncClient asyncClient;
+    @Inject
+    DynamoDbAsyncClient asyncClient;
 
-    // Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, disable the
-    // async support.
-    //    @GET
-    //    @Path("async")
-    //    @Produces(TEXT_PLAIN)
-    //    public CompletionStage<String> testAsync() {
-    //        LOG.info("Testing Async client with table: " + ASYNC_TABLE);
-    //        String keyValue = UUID.randomUUID().toString();
-    //        String rangeValue = UUID.randomUUID().toString();
-    //
-    //        return DynamoDBUtils.createTableIfNotExistsAsync(asyncClient, ASYNC_TABLE)
-    //                .thenCompose(t -> asyncClient.putItem(DynamoDBUtils.createPutRequest(ASYNC_TABLE, keyValue, rangeValue, "OK")))
-    //                .thenCompose(p -> asyncClient.getItem(DynamoDBUtils.createGetRequest(ASYNC_TABLE, keyValue, rangeValue)))
-    //                .thenApply(p -> p.item().get(DynamoDBUtils.PAYLOAD_NAME).s());
-    //    }
+    @GET
+    @Path("async")
+    @Produces(TEXT_PLAIN)
+    public CompletionStage<String> testAsync() {
+        LOG.info("Testing Async client with table: " + ASYNC_TABLE);
+        String keyValue = UUID.randomUUID().toString();
+        String rangeValue = UUID.randomUUID().toString();
+
+        return DynamoDBUtils.createTableIfNotExistsAsync(asyncClient, ASYNC_TABLE)
+                .thenCompose(t -> asyncClient.putItem(DynamoDBUtils.createPutRequest(ASYNC_TABLE, keyValue, rangeValue, "OK")))
+                .thenCompose(p -> asyncClient.getItem(DynamoDBUtils.createGetRequest(ASYNC_TABLE, keyValue, rangeValue)))
+                .thenApply(p -> p.item().get(DynamoDBUtils.PAYLOAD_NAME).s());
+    }
 
     @GET
     @Path("blocking")

--- a/integration-tests/amazon-dynamodb/src/test/java/io/quarkus/it/dynamodb/DynamoDbFunctionalityTest.java
+++ b/integration-tests/amazon-dynamodb/src/test/java/io/quarkus/it/dynamodb/DynamoDbFunctionalityTest.java
@@ -2,7 +2,6 @@ package io.quarkus.it.dynamodb;
 
 import static org.hamcrest.Matchers.is;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -16,8 +15,6 @@ import io.restassured.RestAssured;
 public class DynamoDbFunctionalityTest {
 
     @Test
-    @Disabled("Until we have a compatible version of the AWS SDK with the Netty version used in Quarkus, "
-            + "disable the async support.")
     public void testDynamoDbAsync() {
         RestAssured.when().get("/test/async").then().body(is("OK"));
     }


### PR DESCRIPTION
- Dump up AWS SDK to 2.8.0 (with Netty 4.1.39 support)
- Re-enable async support