### PR TITLE
Remove duplicate vertx-mysql-client dependency from BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1777,11 +1777,6 @@
                 <version>${vertx.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-mysql-client</artifactId>
-                <version>${vertx.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-axle-sql-client</artifactId>
                 <version>${axle-client.version}</version>


### PR DESCRIPTION
This fixes the following warning:
```
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-bom:pom:999-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.vertx:vertx-mysql-client:jar -> duplicate declaration of version ${vertx.version} @ io.quarkus:quarkus-bom:[unknown-version]
```