### PR TITLE
Log a warning if a non-singleton bean declares a Gauge

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinScope.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinScope.java
@@ -39,6 +39,15 @@ public enum BuiltinScope {
         return null;
     }
 
+    public static BuiltinScope from(ClassInfo clazz) {
+        for (BuiltinScope scope : BuiltinScope.values()) {
+            if (clazz.classAnnotation(scope.getName()) != null) {
+                return scope;
+            }
+        }
+        return null;
+    }
+
     public static boolean isDefault(ScopeInfo scope) {
         return DEPENDENT.is(scope);
     }


### PR DESCRIPTION
This might save some confusion and trouble detected too late.
Other option would be to just disallow this completely (MP Metrics spec allows throwing a validation error), but the argument against this is that there might be cases where having a Gauge on a `@Dependent` bean is valid, if the developer makes sure there will be just one instance of the bean for the whole application lifecycle. We don't know for sure.
