### PR TITLE
Use custom ClassLoader with visible defineClass when generating proxies

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentPhase.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import io.quarkus.bootstrap.BootstrapDependencyProcessingException;
+import io.quarkus.bootstrap.DefineClassVisibleURLClassLoader;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.util.IoUtils;
@@ -288,7 +289,8 @@ public class AugmentPhase implements AppCreationPhase<AugmentPhase>, AugmentOutc
                 cpUrls.add(resolvedDep.toUri().toURL());
             }
 
-            runnerClassLoader = new URLClassLoader(cpUrls.toArray(new URL[cpUrls.size()]), getClass().getClassLoader());
+            runnerClassLoader = new DefineClassVisibleURLClassLoader(cpUrls.toArray(new URL[cpUrls.size()]),
+                    getClass().getClassLoader());
 
             final Path wiringClassesDirectory = wiringClassesDir;
             ClassOutput classOutput = new ClassOutput() {

--- a/core/creator/src/main/java/io/quarkus/creator/phase/generateconfig/GenerateConfigPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/generateconfig/GenerateConfigPhase.java
@@ -20,6 +20,7 @@ import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.BootstrapDependencyProcessingException;
+import io.quarkus.bootstrap.DefineClassVisibleURLClassLoader;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.builder.BuildChain;
@@ -115,7 +116,8 @@ public class GenerateConfigPhase implements AppCreationPhase<GenerateConfigPhase
                 cpUrls.add(resolvedDep.toUri().toURL());
             }
 
-            runnerClassLoader = new URLClassLoader(cpUrls.toArray(new URL[cpUrls.size()]), getClass().getClassLoader());
+            runnerClassLoader = new DefineClassVisibleURLClassLoader(cpUrls.toArray(new URL[cpUrls.size()]),
+                    getClass().getClassLoader());
 
             ClassLoader old = Thread.currentThread().getContextClassLoader();
             try {

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/InjectIntoClassloaderClassOutput.java
@@ -1,13 +1,7 @@
 package io.quarkus.deployment.proxy;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 
 import io.quarkus.deployment.util.ClassOutputUtil;
 import io.quarkus.gizmo.ClassOutput;
@@ -15,94 +9,26 @@ import io.quarkus.gizmo.ClassOutput;
 /**
  * A Gizmo {@link ClassOutput} that is able to write the inject the bytecode directly into the classloader
  *
- * The implementation for JDK 8-11 was lifted from jboss-classwriter's org.jboss.classfilewriter.DefaultClassFactory
- *
- * This implementation for JDK 12+ is based on what is discussed at:
- * http://mail.openjdk.java.net/pipermail/jigsaw-dev/2018-April/013724.html
- * and currently does not work properly - If the generated proxy references classes outside of its package
- * a NoClassDefFoundError is thrown
+ * The {@link ClassLoader} passed to the constructor MUST contain a public visibleDefineClass method
+ * This ensures that generating proxies works in any JDK version
  */
 class InjectIntoClassloaderClassOutput implements ClassOutput {
 
-    private static Method classLoaderDefineClassMethod;
-    private static Method privateLookupInMethod;
-    private static Method lookupDefineClass;
-
-    static {
-        classLoaderDefineClassMethod = getClassLoaderDefineClassMethod();
-        if (classLoaderDefineClassMethod == null) {
-            // this is the case of JDK 12+
-            try {
-                privateLookupInMethod = getPrivateLookupInMethod();
-                lookupDefineClass = getLookupDefineClassMethod();
-            } catch (NoSuchMethodException e) {
-                throw new IllegalStateException(
-                        "Unable to initialize InjectIntoClassloaderClassOutput. Are you running an unsupported JDK version?");
-            }
-        }
-    }
-
     private final ClassLoader classLoader;
-    private final Class<?> anchorClass;
 
-    InjectIntoClassloaderClassOutput(ClassLoader classLoader, Class<?> anchorClass) {
+    private final Method visibleDefineClassMethod;
+
+    InjectIntoClassloaderClassOutput(ClassLoader classLoader) {
         this.classLoader = classLoader;
-        this.anchorClass = anchorClass;
-    }
 
-    // get a hold of java.lang.ClassLoader#defineClass
-    private static Method getClassLoaderDefineClassMethod() {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                public Method run() throws Exception {
-                    long overrideOffset;
-                    Object unsafe;
-                    Class<?> unsafeClass;
-
-                    // we cannot refer to Unsafe in a normal manner because the Java 11 build would fail
-                    try {
-                        // first we need to grab Unsafe
-                        unsafeClass = Class.forName("sun.misc.Unsafe");
-                        Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
-                        theUnsafe.setAccessible(true);
-                        unsafe = theUnsafe.get(null);
-                        Method objectFieldOffsetMethod = unsafeClass.getDeclaredMethod("objectFieldOffset", Field.class);
-                        overrideOffset = (long) objectFieldOffsetMethod.invoke(unsafe,
-                                AccessibleObject.class.getDeclaredField("override"));
-
-                        // now we gain access to CL.defineClass methods
-                        Class<?> cl = ClassLoader.class;
-                        Method classLoaderDefineClassMethod = cl.getDeclaredMethod("defineClass", String.class, byte[].class,
-                                int.class,
-                                int.class);
-
-                        // use Unsafe to crack open both CL.defineClass() methods (instead of using setAccessible())
-                        Method putBooleanMethod = unsafeClass.getDeclaredMethod("putBoolean", Object.class, long.class,
-                                boolean.class);
-                        putBooleanMethod.invoke(unsafe, classLoaderDefineClassMethod, overrideOffset, true);
-                        return classLoaderDefineClassMethod;
-                    } catch (NoSuchFieldException e) {
-                        if (e.getMessage().contains("override")) { //this we can handle
-                            return null;
-                        }
-                        throw new Exception(e);
-                    } catch (Exception e) {
-                        throw new Error(e);
-                    }
-
-                }
-            });
-        } catch (PrivilegedActionException pae) {
-            throw new RuntimeException("Cannot initialize InjectIntoClassloaderClassOutput", pae.getException());
+            visibleDefineClassMethod = classLoader.getClass().getDeclaredMethod("visibleDefineClass", String.class,
+                    byte[].class, int.class, int.class);
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalStateException(
+                    "Unable to initialize InjectIntoClassloaderClassOutput - Incorrect classloader (" + classLoader.getClass()
+                            + ") usage detected");
         }
-    }
-
-    private static Method getPrivateLookupInMethod() throws NoSuchMethodException {
-        return MethodHandles.class.getDeclaredMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
-    }
-
-    private static Method getLookupDefineClassMethod() throws NoSuchMethodException {
-        return MethodHandles.Lookup.class.getDeclaredMethod("defineClass", byte[].class);
     }
 
     @Override
@@ -110,22 +36,10 @@ class InjectIntoClassloaderClassOutput implements ClassOutput {
         if (System.getProperty("dumpClass") != null) {
             ClassOutputUtil.dumpClass(name, data);
         }
-        if (classLoaderDefineClassMethod != null) { // normal JDK 8-11 case
-            try {
-                classLoaderDefineClassMethod.invoke(classLoader, name.replace('/', '.'), data, 0, data.length);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new RuntimeException(e);
-            }
-        } else { // JDK 12+ case
-            // TODO: figure out how to solve NoClassDefFoundError for classes outside the package
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            try {
-                MethodHandles.Lookup privateLookupIn = (MethodHandles.Lookup) privateLookupInMethod.invoke(null, anchorClass,
-                        lookup);
-                lookupDefineClass.invoke(privateLookupIn, data);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new RuntimeException(e);
-            }
+        try {
+            visibleDefineClassMethod.invoke(classLoader, name.replace('/', '.'), data, 0, data.length);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -23,7 +23,6 @@ import io.quarkus.gizmo.ResultHandle;
 public class ProxyFactory<T> {
 
     private final String proxyName;
-    private final Class<?> anchorClass;
     private final ClassLoader classLoader;
 
     private final String superClassName;
@@ -34,7 +33,7 @@ public class ProxyFactory<T> {
     private final Object lock = new Object();
 
     public ProxyFactory(ProxyConfiguration<T> configuration) {
-        this.anchorClass = Objects.requireNonNull(configuration.getAnchorClass(), "anchorClass must be set");
+        Objects.requireNonNull(configuration.getAnchorClass(), "anchorClass must be set");
         Objects.requireNonNull(configuration.getProxyNameSuffix(), "proxyNameSuffix must be set");
         this.proxyName = configuration.getProxyName();
 
@@ -64,7 +63,7 @@ public class ProxyFactory<T> {
         }
 
         this.classBuilder = ClassCreator.builder()
-                .classOutput(new InjectIntoClassloaderClassOutput(configuration.getClassLoader(), this.anchorClass))
+                .classOutput(new InjectIntoClassloaderClassOutput(configuration.getClassLoader()))
                 .className(this.proxyName)
                 .superClass(this.superClassName);
         if (!configuration.getAdditionalInterfaces().isEmpty()) {

--- a/core/deployment/src/main/java/io/quarkus/runner/RuntimeClassLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/RuntimeClassLoader.java
@@ -307,6 +307,15 @@ public class RuntimeClassLoader extends ClassLoader implements ClassOutput, Tran
         resources.put(name, data);
     }
 
+    /**
+     * This is needed in order to easily inject classes into the classloader
+     * without having to resort to tricks (that don't work that well on new JDKs)
+     * See {@link io.quarkus.deployment.proxy.InjectIntoClassloaderClassOutput}
+     */
+    public Class<?> visibleDefineClass(String name, byte[] b, int off, int len) throws ClassFormatError {
+        return super.defineClass(name, b, off, len);
+    }
+
     private void definePackage(String name) {
         final String pkgName = getPackageNameFromClassName(name);
         if ((pkgName != null) && getPackage(pkgName) == null) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/TestClassLoader.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/TestClassLoader.java
@@ -1,0 +1,11 @@
+package io.quarkus.deployment;
+
+public class TestClassLoader extends io.quarkus.gizmo.TestClassLoader {
+    public TestClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    public Class<?> visibleDefineClass(String name, byte[] b, int off, int len) throws ClassFormatError {
+        return super.defineClass(name, b, off, len);
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleClassProxyTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.quarkus.deployment.TestClassLoader;
+
 public class SimpleClassProxyTest {
 
     @Test
@@ -17,7 +19,7 @@ public class SimpleClassProxyTest {
                 .setSuperClass(SimpleClass.class)
                 .setAnchorClass(SimpleClass.class)
                 .setProxyNameSuffix("$$Proxy1")
-                .setClassLoader(SimpleClass.class.getClassLoader());
+                .setClassLoader(new TestClassLoader(SimpleClass.class.getClassLoader()));
         SimpleClass instance = new ProxyFactory<>(proxyConfiguration).newInstance(invocationHandler);
 
         assertMethod1(instance);
@@ -52,24 +54,6 @@ public class SimpleClassProxyTest {
 
     private void assertMethod4(SimpleClass instance) {
         assertThatCode(() -> instance.method4(4)).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void testMultipleClassLoaders() throws InstantiationException, IllegalAccessException {
-        ClassLoader cl1 = new ClassLoader() {
-
-        };
-        ClassLoader cl2 = new ClassLoader() {
-
-        };
-        ProxyConfiguration<SimpleClass> proxyConfiguration = new ProxyConfiguration<SimpleClass>()
-                .setSuperClass(SimpleClass.class)
-                .setAnchorClass(SimpleClass.class)
-                .setProxyNameSuffix("$$Proxy2")
-                .setClassLoader(cl1);
-        ProxyFactory<SimpleClass> proxyFactory = new ProxyFactory<>(proxyConfiguration);
-        SimpleClass instance = proxyFactory.newInstance(new SimpleInvocationHandler());
-        assertThat(instance).isNotNull();
     }
 
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/proxy/SimpleInterfaceProxyTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import io.quarkus.deployment.TestClassLoader;
+
 public class SimpleInterfaceProxyTest {
 
     @Test
@@ -13,7 +15,7 @@ public class SimpleInterfaceProxyTest {
                 .setSuperClass(Object.class)
                 .setAnchorClass(SimpleInterface.class)
                 .setProxyNameSuffix("$Proxy2")
-                .setClassLoader(SimpleClass.class.getClassLoader())
+                .setClassLoader(new TestClassLoader(SimpleClass.class.getClassLoader()))
                 .addAdditionalInterface(SimpleInterface.class);
         SimpleInterface instance = (SimpleInterface) new ProxyFactory<>(proxyConfiguration).newInstance(invocationHandler);
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import io.quarkus.deployment.ClassOutput;
-import io.quarkus.gizmo.TestClassLoader;
+import io.quarkus.deployment.TestClassLoader;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.StartupContext;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapClassLoaderFactory.java
@@ -159,7 +159,7 @@ public class BootstrapClassLoaderFactory {
      * @return  classloader that is able to load both user-defined and deployment dependencies
      * @throws BootstrapException  in case of a failure
      */
-    public URLClassLoader newAllInclusiveClassLoader(boolean hierarchical) throws BootstrapException {
+    public DefineClassVisibleURLClassLoader newAllInclusiveClassLoader(boolean hierarchical) throws BootstrapException {
         if (appClasses == null) {
             throw new IllegalArgumentException("Application classes path has not been set");
         }
@@ -191,7 +191,7 @@ public class BootstrapClassLoaderFactory {
             if (hierarchical) {
                 final URLClassLoader cl = initAppCp(appModel.getUserDependencies());
                 try {
-                    return new URLClassLoader(toURLs(appModel.getDeploymentDependencies()), cl);
+                    return new DefineClassVisibleURLClassLoader(toURLs(appModel.getDeploymentDependencies()), cl);
                 } catch (Throwable e) {
                     try {
                         cl.close();
@@ -207,17 +207,17 @@ public class BootstrapClassLoaderFactory {
         }
     }
 
-    private URLClassLoader initAppCp(final List<AppDependency> deps) throws BootstrapException {
+    private DefineClassVisibleURLClassLoader initAppCp(final List<AppDependency> deps) throws BootstrapException {
         final URL[] urls = new URL[deps.size() + appCp.size() + 1];
         urls[0] = toURL(appClasses);
         int offset = addDeps(urls, 1, deps);
         if(!appCp.isEmpty()) {
             addPaths(urls, offset, appCp);
         }
-        return new URLClassLoader(urls, parent);
+        return new DefineClassVisibleURLClassLoader(urls, parent);
     }
 
-    public URLClassLoader newDeploymentClassLoader() throws BootstrapException {
+    public DefineClassVisibleURLClassLoader newDeploymentClassLoader() throws BootstrapException {
         if (appClasses == null) {
             throw new IllegalArgumentException("Application classes path has not been set");
         }
@@ -259,10 +259,10 @@ public class BootstrapClassLoaderFactory {
                         addPaths(urls, 0, appCp),
                         deploymentDeps);
             }
-            return new URLClassLoader(urls, parent);
+            return new DefineClassVisibleURLClassLoader(urls, parent);
         }
 
-        final URLClassLoader ucl;
+        final DefineClassVisibleURLClassLoader ucl;
         Path cachedCpPath = null;
         final LocalProject localProject = localProjectsDiscovery || enableClasspathCache
                 ? LocalProject.loadWorkspace(appClasses)
@@ -293,7 +293,7 @@ public class BootstrapClassLoaderFactory {
                                     }
                                     addPaths(arr, i, appCp);
                                 }
-                                return new URLClassLoader(arr, parent);
+                                return new DefineClassVisibleURLClassLoader(arr, parent);
                             } else {
                                 debug("Cached deployment classpath has expired for %s", localProject.getAppArtifact());
                             }
@@ -324,7 +324,7 @@ public class BootstrapClassLoaderFactory {
             if(cachedCpPath != null) {
                 persistCp(localProject, urls, deploymentDeps.size(), cachedCpPath);
             }
-            ucl = new URLClassLoader(urls, parent);
+            ucl = new DefineClassVisibleURLClassLoader(urls, parent);
         } catch (AppModelResolverException e) {
             throw new BootstrapException("Failed to create the deployment classloader for " + localProject.getAppArtifact(), e);
         }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/DefineClassVisibleURLClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/DefineClassVisibleURLClassLoader.java
@@ -1,0 +1,20 @@
+package io.quarkus.bootstrap;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * A wrapper around URLClassLoader whose only purpose is to expose defineClass
+ * This is needed in order to easily inject classes into the classloader
+ * without having to resort to tricks (that don't work that well on new JDKs)
+ */
+public class DefineClassVisibleURLClassLoader extends URLClassLoader {
+
+    public DefineClassVisibleURLClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    public Class<?> visibleDefineClass(String name, byte[] b, int off, int len) throws ClassFormatError {
+        return super.defineClass(name, b, off, len);
+    }
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/DefineClassVisibleClassLoader.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/DefineClassVisibleClassLoader.java
@@ -1,0 +1,17 @@
+package io.quarkus.test;
+
+/**
+ * A wrapper around ClassLoader whose only purpose is to expose defineClass
+ * This is needed in order to easily inject classes into the classloader
+ * without having to resort to tricks (that don't work that well on new JDKs)
+ */
+public class DefineClassVisibleClassLoader extends ClassLoader {
+
+    public DefineClassVisibleClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    public Class<?> visibleDefineClass(String name, byte[] b, int off, int len) throws ClassFormatError {
+        return super.defineClass(name, b, off, len);
+    }
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -199,7 +199,7 @@ public class QuarkusUnitTest
             ProxyFactory<?> factory = new ProxyFactory<>(new ProxyConfiguration<>()
                     .setAnchorClass(testClass)
                     .setProxyNameSuffix("$$QuarkusUnitTestProxy")
-                    .setClassLoader(testClass.getClassLoader())
+                    .setClassLoader(new DefineClassVisibleClassLoader(testClass.getClassLoader()))
                     .setSuperClass((Class<Object>) testClass));
             store.put(proxyFactoryKey(testClass), factory);
         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -37,6 +37,7 @@ import org.opentest4j.TestAbortedException;
 
 import io.quarkus.bootstrap.BootstrapClassLoaderFactory;
 import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.DefineClassVisibleURLClassLoader;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.bootstrap.util.PropertyUtils;
 import io.quarkus.builder.BuildChainBuilder;
@@ -280,7 +281,7 @@ public class QuarkusTestExtension
                     throw new IllegalStateException("Failed to parse a deployment classpath entry " + entry, e);
                 }
             }
-            return new URLClassLoader(list.toArray(new URL[list.size()]), getClass().getClassLoader());
+            return new DefineClassVisibleURLClassLoader(list.toArray(new URL[list.size()]), getClass().getClassLoader());
         }
         try {
             return BootstrapClassLoaderFactory.newInstance()


### PR DESCRIPTION
This makes sense for Quarkus where the ClassLoader is under our control.
The benefit is that proxy classes can be generated no matter what JDK
version is being used (so now proxies can be generated even in JDK 12+)

Fixes: #1534