### PR TITLE
Add Jackson Databind substitutions to vert.x

### DIFF
--- a/extensions/vertx-core/deployment/pom.xml
+++ b/extensions/vertx-core/deployment/pom.xml
@@ -28,10 +28,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-core</artifactId>
         </dependency>
         <dependency>

--- a/extensions/vertx-core/runtime/pom.xml
+++ b/extensions/vertx-core/runtime/pom.xml
@@ -32,12 +32,14 @@
             <artifactId>quarkus-netty</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -33,8 +33,6 @@ import io.vertx.core.net.PfxOptions;
 @Recorder
 public class VertxCoreRecorder {
 
-    public static final String ENABLE_JSON = "quarkus-internal.vertx.enabled-json";
-
     static volatile Vertx vertx;
     //temporary vertx instance to work around a JAX-RS problem
     static volatile Vertx webVertx;

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -52,7 +52,6 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.substrate.SubstrateSystemPropertyBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.deployment.util.HashUtil;
 import io.quarkus.gizmo.AssignableResultHandle;
@@ -67,7 +66,6 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TryBlock;
 import io.quarkus.vertx.ConsumeEvent;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
-import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.runtime.EventConsumerInvoker;
 import io.quarkus.vertx.runtime.VertxProducer;
 import io.quarkus.vertx.runtime.VertxRecorder;
@@ -117,11 +115,6 @@ class VertxProcessor {
 
     @Inject
     BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
-
-    @BuildStep
-    SubstrateSystemPropertyBuildItem enableJson() {
-        return new SubstrateSystemPropertyBuildItem(VertxCoreRecorder.ENABLE_JSON, "true");
-    }
 
     @BuildStep
     AdditionalBeanBuildItem registerBean() {


### PR DESCRIPTION
This is needed in order to be able to build native images without Jackson databind on the classpath.

This work was done using in progress Vert.x work that will end up in version `3.8.2` the release of which is of course a prerequisite to merging this.
It goes without saying that CI will fail until we have such a release