### PR TITLE
Remove dependency on junit4 JAR in quarkus-hibernate-orm-deployment tests

### DIFF
--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -35,11 +35,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/enhancer/HibernateEntityEnhancerTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/enhancer/HibernateEntityEnhancerTest.java
@@ -1,5 +1,8 @@
 package io.quarkus.hibernate.orm.enhancer;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -8,7 +11,6 @@ import java.util.Set;
 import org.hibernate.engine.spi.ManagedEntity;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.SelfDirtinessTracker;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -29,7 +31,7 @@ public class HibernateEntityEnhancerTest {
     @Test
     public void testBytecodeEnhancement() throws IOException, ClassNotFoundException {
 
-        Assert.assertFalse(isEnhanced(Address.class));
+        assertFalse(isEnhanced(Address.class));
 
         ClassReader classReader = new ClassReader(TEST_CLASSNAME);
         ClassWriter writer = new ClassWriter(classReader, ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
@@ -42,7 +44,7 @@ public class HibernateEntityEnhancerTest {
         TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
         cl.write(TEST_CLASSNAME, modifiedBytecode);
         final Class<?> modifiedClass = cl.loadClass(TEST_CLASSNAME);
-        Assert.assertTrue(isEnhanced(modifiedClass));
+        assertTrue(isEnhanced(modifiedClass));
     }
 
     private boolean isEnhanced(final Class<?> modifiedClass) {


### PR DESCRIPTION
The test is already running on JUnit 5, but using the `Assert`class from Junit4