### PR TITLE
Fixes #3907, move Vert.x producers to Resteasy

### DIFF
--- a/extensions/resteasy-server-common/runtime/pom.xml
+++ b/extensions/resteasy-server-common/runtime/pom.xml
@@ -34,6 +34,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonArrayReader.java
+++ b/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonArrayReader.java
@@ -1,4 +1,4 @@
-package io.quarkus.vertx.runtime;
+package io.quarkus.resteasy.server.common.vertx;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,28 +15,28 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
 
 /**
- * A body reader that allows to get a Vert.x {@link JsonObject} as JAX-RS request content.
+ * A body reader that allows to get a Vert.x {@link JsonArray} as JAX-RS request content.
  */
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
-public class JsonObjectReader implements MessageBodyReader<JsonObject> {
+public class JsonArrayReader implements MessageBodyReader<JsonArray> {
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return type == JsonObject.class;
+        return type == JsonArray.class;
     }
 
     @Override
-    public JsonObject readFrom(Class<JsonObject> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+    public JsonArray readFrom(Class<JsonArray> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         byte[] bytes = getBytes(entityStream);
         if (bytes.length == 0) {
-            throw new NoContentException("Cannot create JsonObject");
+            throw new NoContentException("Cannot create JsonArray");
         }
-        return new JsonObject(Buffer.buffer(bytes));
+        return new JsonArray(Buffer.buffer(bytes));
     }
 
     private static byte[] getBytes(InputStream entityStream) throws IOException {

--- a/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonArrayWriter.java
+++ b/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonArrayWriter.java
@@ -1,4 +1,4 @@
-package io.quarkus.vertx.runtime;
+package io.quarkus.resteasy.server.common.vertx;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonObjectReader.java
+++ b/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonObjectReader.java
@@ -1,4 +1,4 @@
-package io.quarkus.vertx.runtime;
+package io.quarkus.resteasy.server.common.vertx;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,28 +15,28 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 /**
- * A body reader that allows to get a Vert.x {@link JsonArray} as JAX-RS request content.
+ * A body reader that allows to get a Vert.x {@link JsonObject} as JAX-RS request content.
  */
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
-public class JsonArrayReader implements MessageBodyReader<JsonArray> {
+public class JsonObjectReader implements MessageBodyReader<JsonObject> {
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return type == JsonArray.class;
+        return type == JsonObject.class;
     }
 
     @Override
-    public JsonArray readFrom(Class<JsonArray> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+    public JsonObject readFrom(Class<JsonObject> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         byte[] bytes = getBytes(entityStream);
         if (bytes.length == 0) {
-            throw new NoContentException("Cannot create JsonArray");
+            throw new NoContentException("Cannot create JsonObject");
         }
-        return new JsonArray(Buffer.buffer(bytes));
+        return new JsonObject(Buffer.buffer(bytes));
     }
 
     private static byte[] getBytes(InputStream entityStream) throws IOException {

--- a/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonObjectWriter.java
+++ b/extensions/resteasy-server-common/runtime/src/main/java/io/quarkus/resteasy/server/common/vertx/JsonObjectWriter.java
@@ -1,4 +1,4 @@
-package io.quarkus.vertx.runtime;
+package io.quarkus.resteasy.server.common.vertx;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/extensions/resteasy-server-common/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/extensions/resteasy-server-common/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,0 +1,4 @@
+io.quarkus.resteasy.server.common.vertx.JsonObjectWriter
+io.quarkus.resteasy.server.common.vertx.JsonArrayWriter
+io.quarkus.resteasy.server.common.vertx.JsonObjectReader
+io.quarkus.resteasy.server.common.vertx.JsonArrayReader

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -19,11 +19,6 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,4 +1,0 @@
-io.quarkus.vertx.runtime.JsonObjectWriter
-io.quarkus.vertx.runtime.JsonArrayWriter
-io.quarkus.vertx.runtime.JsonObjectReader
-io.quarkus.vertx.runtime.JsonArrayReader


### PR DESCRIPTION
Resteasy will always run on top of vert.x in the new model
so this dependency arrangement makes more sense