### PR TITLE
Automatically size the Servlet buffers

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -96,6 +96,7 @@ import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.undertow.runtime.HttpSessionContext;
 import io.quarkus.undertow.runtime.ServletProducer;
+import io.quarkus.undertow.runtime.ServletRuntimeConfig;
 import io.quarkus.undertow.runtime.ServletSecurityInfoProxy;
 import io.quarkus.undertow.runtime.ServletSecurityInfoSubstitution;
 import io.quarkus.undertow.runtime.UndertowDeploymentRecorder;
@@ -134,10 +135,12 @@ public class UndertowBuildStep {
             List<HttpHandlerWrapperBuildItem> wrappers,
             ShutdownContextBuildItem shutdown,
             Consumer<DefaultRouteBuildItem> undertowProducer,
-            ExecutorBuildItem executorBuildItem, HttpConfiguration httpConfiguration) throws Exception {
+            ExecutorBuildItem executorBuildItem, HttpConfiguration httpConfiguration,
+            ServletRuntimeConfig servletRuntimeConfig) throws Exception {
         Handler<HttpServerRequest> ut = recorder.startUndertow(shutdown, executorBuildItem.getExecutorProxy(),
                 servletDeploymentManagerBuildItem.getDeploymentManager(),
-                wrappers.stream().map(HttpHandlerWrapperBuildItem::getValue).collect(Collectors.toList()), httpConfiguration);
+                wrappers.stream().map(HttpHandlerWrapperBuildItem::getValue).collect(Collectors.toList()), httpConfiguration,
+                servletRuntimeConfig);
 
         undertowProducer.accept(new DefaultRouteBuildItem(ut));
         return new ServiceStartBuildItem("undertow");

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/ServletRuntimeConfig.java
@@ -1,0 +1,29 @@
+package io.quarkus.undertow.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.MemorySize;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "servlet")
+public class ServletRuntimeConfig {
+
+    /**
+     * The buffer size to use for Servlet. If this is not specified the default will depend on the amount
+     * of available memory. If there is less than 64mb it will default to 512b heap buffer, less that 128mb
+     * 1k direct buffer and otherwise 16k direct buffers.
+     *
+     */
+    @ConfigItem
+    Optional<MemorySize> bufferSize;
+
+    /**
+     * If Servlet should use direct buffers, this gives maximum performance but can be problematic
+     * in memory constrained environments
+     */
+    @ConfigItem
+    Optional<Boolean> directBuffers;
+
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.undertow.runtime;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.SocketAddress;
 import java.nio.file.Path;
 import java.security.SecureRandom;
@@ -98,46 +99,28 @@ public class UndertowDeploymentRecorder {
     private static final AttachmentKey<InjectableContext.ContextState> REQUEST_CONTEXT = AttachmentKey
             .create(InjectableContext.ContextState.class);
 
-    /**
-     * TODO: configuration
-     */
-    protected static final int BUFFER_SIZE = 8 * 1024;
+    protected static final int DEFAULT_BUFFER_SIZE;
+    protected static final boolean DEFAULT_DIRECT_BUFFERS;
 
-    //TODO: clean this up
-    private static BufferAllocator ALLOCATOR = new BufferAllocator() {
-        @Override
-        public ByteBuf allocateBuffer() {
-            return PooledByteBufAllocator.DEFAULT.buffer(BUFFER_SIZE);
+    static {
+        long maxMemory = Runtime.getRuntime().maxMemory();
+        //smaller than 64mb of ram we use 512b buffers
+        if (maxMemory < 64 * 1024 * 1024) {
+            //use 512b buffers
+            DEFAULT_DIRECT_BUFFERS = false;
+            DEFAULT_BUFFER_SIZE = 512;
+        } else if (maxMemory < 128 * 1024 * 1024) {
+            //use 1k buffers
+            DEFAULT_DIRECT_BUFFERS = true;
+            DEFAULT_BUFFER_SIZE = 1024;
+        } else {
+            //use 16k buffers for best performance
+            //as 16k is generally the max amount of data that can be sent in a single write() call
+            DEFAULT_DIRECT_BUFFERS = true;
+            DEFAULT_BUFFER_SIZE = 1024 * 16 - 20; //the 20 is to allow some space for protocol headers, see UNDERTOW-1209
         }
 
-        @Override
-        public ByteBuf allocateBuffer(boolean direct) {
-            if (direct) {
-                return PooledByteBufAllocator.DEFAULT.directBuffer(BUFFER_SIZE);
-            } else {
-                return PooledByteBufAllocator.DEFAULT.heapBuffer(BUFFER_SIZE);
-            }
-        }
-
-        @Override
-        public ByteBuf allocateBuffer(int bufferSize) {
-            return PooledByteBufAllocator.DEFAULT.buffer(bufferSize);
-        }
-
-        @Override
-        public ByteBuf allocateBuffer(boolean direct, int bufferSize) {
-            if (direct) {
-                return PooledByteBufAllocator.DEFAULT.directBuffer(bufferSize);
-            } else {
-                return PooledByteBufAllocator.DEFAULT.heapBuffer(bufferSize);
-            }
-        }
-
-        @Override
-        public int getBufferSize() {
-            return BUFFER_SIZE;
-        }
-    };
+    }
 
     public static void setHotDeploymentResources(List<Path> resources) {
         hotDeploymentResourcePaths = resources;
@@ -300,7 +283,8 @@ public class UndertowDeploymentRecorder {
     }
 
     public Handler<HttpServerRequest> startUndertow(ShutdownContext shutdown, ExecutorService executorService,
-            DeploymentManager manager, List<HandlerWrapper> wrappers, HttpConfiguration httpConfiguration) throws Exception {
+            DeploymentManager manager, List<HandlerWrapper> wrappers, HttpConfiguration httpConfiguration,
+            ServletRuntimeConfig servletRuntimeConfig) throws Exception {
 
         shutdown.addShutdownTask(new Runnable() {
             @Override
@@ -325,10 +309,14 @@ public class UndertowDeploymentRecorder {
         currentRoot = main;
 
         DefaultExchangeHandler defaultHandler = new DefaultExchangeHandler(ROOT_HANDLER);
+
+        UndertowBufferAllocator allocator = new UndertowBufferAllocator(
+                servletRuntimeConfig.directBuffers.orElse(DEFAULT_DIRECT_BUFFERS), (int) servletRuntimeConfig.bufferSize
+                        .orElse(new MemorySize(BigInteger.valueOf(DEFAULT_BUFFER_SIZE))).asLongValue());
         return new Handler<HttpServerRequest>() {
             @Override
             public void handle(HttpServerRequest event) {
-                VertxHttpExchange exchange = new VertxHttpExchange(event, ALLOCATOR, executorService);
+                VertxHttpExchange exchange = new VertxHttpExchange(event, allocator, executorService);
                 Optional<MemorySize> maxBodySize = httpConfiguration.limits.maxBodySize;
                 if (maxBodySize.isPresent()) {
                     exchange.setMaxEntitySize(maxBodySize.get().asLongValue());
@@ -581,6 +569,50 @@ public class UndertowDeploymentRecorder {
         @Override
         public ServletContext get() {
             return servletContext;
+        }
+    }
+
+    private static class UndertowBufferAllocator implements BufferAllocator {
+
+        private final boolean defaultDirectBuffers;
+        private final int defaultBufferSize;
+
+        private UndertowBufferAllocator(boolean defaultDirectBuffers, int defaultBufferSize) {
+            this.defaultDirectBuffers = defaultDirectBuffers;
+            this.defaultBufferSize = defaultBufferSize;
+        }
+
+        @Override
+        public ByteBuf allocateBuffer() {
+            return allocateBuffer(defaultDirectBuffers);
+        }
+
+        @Override
+        public ByteBuf allocateBuffer(boolean direct) {
+            if (direct) {
+                return PooledByteBufAllocator.DEFAULT.directBuffer(defaultBufferSize);
+            } else {
+                return PooledByteBufAllocator.DEFAULT.heapBuffer(defaultBufferSize);
+            }
+        }
+
+        @Override
+        public ByteBuf allocateBuffer(int bufferSize) {
+            return allocateBuffer(defaultDirectBuffers, bufferSize);
+        }
+
+        @Override
+        public ByteBuf allocateBuffer(boolean direct, int bufferSize) {
+            if (direct) {
+                return PooledByteBufAllocator.DEFAULT.directBuffer(bufferSize);
+            } else {
+                return PooledByteBufAllocator.DEFAULT.heapBuffer(bufferSize);
+            }
+        }
+
+        @Override
+        public int getBufferSize() {
+            return defaultBufferSize;
         }
     }
 }


### PR DESCRIPTION
Fixes #3881, Servlet buffers are way to big
for constrained environments. Note that memory usage
is still a bit up due to extra classes being loaded.