### PR TITLE
Add noDeps to the integration tests

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -76,7 +76,20 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                    <configuration>
+                        <noDeps>true</noDeps>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This allows dev mode to just work for some quick and dirty testing