### PR TITLE
Force Netty to use an internal logger based on JBoss logging

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.shared.utils.logging.MessageBuilder;
 import org.apache.maven.shared.utils.logging.MessageUtils;

--- a/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.shared.utils.logging.MessageBuilder;
 import org.apache.maven.shared.utils.logging.MessageUtils;

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/JBossNettyLoggerFactory.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/JBossNettyLoggerFactory.java
@@ -1,0 +1,177 @@
+package io.quarkus.netty.deployment;
+
+import org.jboss.logging.Logger;
+
+import io.netty.util.internal.logging.AbstractInternalLogger;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class JBossNettyLoggerFactory extends InternalLoggerFactory {
+
+    @Override
+    protected InternalLogger newInstance(String name) {
+        return new JBossNettyInternalLogger(name);
+    }
+
+    private static final class JBossNettyInternalLogger extends AbstractInternalLogger {
+
+        final Logger log;
+
+        JBossNettyInternalLogger(String name) {
+            super(name);
+            log = Logger.getLogger(name);
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return log.isTraceEnabled();
+        }
+
+        @Override
+        public void trace(String msg) {
+            log.trace(msg);
+        }
+
+        @Override
+        public void trace(String format, Object arg) {
+            log.tracef(format, arg);
+        }
+
+        @Override
+        public void trace(String format, Object argA, Object argB) {
+            log.tracef(format, argA, argB);
+        }
+
+        @Override
+        public void trace(String format, Object... arguments) {
+            log.tracef(format, arguments);
+        }
+
+        @Override
+        public void trace(String msg, Throwable t) {
+            log.trace(msg, t);
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return log.isDebugEnabled();
+        }
+
+        @Override
+        public void debug(String msg) {
+            log.debug(msg);
+        }
+
+        @Override
+        public void debug(String format, Object arg) {
+            log.debugf(format, arg);
+        }
+
+        @Override
+        public void debug(String format, Object argA, Object argB) {
+            log.debugf(format, argA, argB);
+        }
+
+        @Override
+        public void debug(String format, Object... arguments) {
+            log.debugf(format, arguments);
+        }
+
+        @Override
+        public void debug(String msg, Throwable t) {
+            log.debug(msg, t);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return log.isInfoEnabled();
+        }
+
+        @Override
+        public void info(String msg) {
+            log.info(msg);
+        }
+
+        @Override
+        public void info(String format, Object arg) {
+            log.infof(format, arg);
+        }
+
+        @Override
+        public void info(String format, Object argA, Object argB) {
+            log.infof(format, argA, argB);
+        }
+
+        @Override
+        public void info(String format, Object... arguments) {
+            log.infof(format, arguments);
+        }
+
+        @Override
+        public void info(String msg, Throwable t) {
+            log.info(msg, t);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return log.isEnabled(Logger.Level.WARN);
+        }
+
+        @Override
+        public void warn(String msg) {
+            log.warn(msg);
+        }
+
+        @Override
+        public void warn(String format, Object arg) {
+            log.warnf(format, arg);
+        }
+
+        @Override
+        public void warn(String format, Object... arguments) {
+            log.warnf(format, arguments);
+        }
+
+        @Override
+        public void warn(String format, Object argA, Object argB) {
+            log.warnf(format, argA, argB);
+        }
+
+        @Override
+        public void warn(String msg, Throwable t) {
+            log.warn(msg, t);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return log.isEnabled(Logger.Level.ERROR);
+        }
+
+        @Override
+        public void error(String msg) {
+            log.error(msg);
+        }
+
+        @Override
+        public void error(String format, Object arg) {
+            log.errorf(format, arg);
+        }
+
+        @Override
+        public void error(String format, Object argA, Object argB) {
+            log.errorf(format, argA, argB);
+        }
+
+        @Override
+        public void error(String format, Object... arguments) {
+            log.errorf(format, arguments);
+        }
+
+        @Override
+        public void error(String msg, Throwable t) {
+            log.error(msg, t);
+        }
+
+    }
+
+}

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import org.jboss.logging.Logger;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.quarkus.arc.deployment.RuntimeBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -27,6 +28,10 @@ class NettyProcessor {
     BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
 
     private static final Logger log = Logger.getLogger(NettyProcessor.class);
+
+    static {
+        InternalLoggerFactory.setDefaultFactory(new JBossNettyLoggerFactory());
+    }
 
     @BuildStep
     SubstrateConfigBuildItem build(BuildProducer<JniBuildItem> jni) {


### PR DESCRIPTION
With this, exceptions appear ok:

```
[DEBUG] [io.quarkus.builder] Dependency of "io.quarkus.elytron.security.deployment.SecurityDeploymentProcessor#registerAdditionalBeans" finished; 0 remaining
[DEBUG] [io.quarkus.builder] Starting step "io.quarkus.elytron.security.deployment.SecurityDeploymentProcessor#registerAdditionalBeans"
[DEBUG] [io.netty.util.internal.PlatformDependent0] direct buffer constructor: unavailable
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
    at io.netty.util.internal.ReflectionUtil.trySetAccessible (ReflectionUtil.java:31)
    at io.netty.util.internal.PlatformDependent0$4.run (PlatformDependent0.java:224)
    at java.security.AccessController.doPrivileged (Native Method)
    at io.netty.util.internal.PlatformDependent0.<clinit> (PlatformDependent0.java:218)
    at io.netty.util.internal.PlatformDependent.isAndroid (PlatformDependent.java:213)
    at io.netty.util.internal.PlatformDependent.<clinit> (PlatformDependent.java:81)
    at io.netty.buffer.UnpooledByteBufAllocator.<clinit> (UnpooledByteBufAllocator.java:37)
    at io.netty.buffer.Unpooled.<clinit> (Unpooled.java:73)
    at io.netty.handler.codec.http.HttpObjectEncoder.<clinit> (HttpObjectEncoder.java:53)
    at java.lang.Class.forName0 (Native Method)
    at java.lang.Class.forName (Class.java:315)
    at io.quarkus.netty.deployment.NettyProcessor.build (NettyProcessor.java:50)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at io.quarkus.deployment.ExtensionLoader$1.execute (ExtensionLoader.java:768)
    at io.quarkus.builder.BuildContext.run (BuildContext.java:415)
    at org.jboss.threads.ContextClassLoaderSavingRunnable.run (ContextClassLoaderSavingRunnable.java:35)
    at org.jboss.threads.EnhancedQueueExecutor.safeRun (EnhancedQueueExecutor.java:2011)
    at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask (EnhancedQueueExecutor.java:1535)
    at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run (EnhancedQueueExecutor.java:1426)
    at java.lang.Thread.run (Thread.java:834)
    at org.jboss.threads.JBossThread.run (JBossThread.java:479)
[DEBUG] [io.quarkus.builder] Dependency of "io.quarkus.arc.deployment.BeanArchiveProcessor#build" finished; 8 remaining
```

As mentioned on #3928, there might be easier ways to get this fixed. This is one way.