### PR TITLE
Set the MicroProfile Context Propagation version to 1.0.

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -26,7 +26,7 @@
         <quarkus-http.version>3.0.0.Alpha5</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.3</microprofile-config-api.version>
-        <microprofile-context-propagation.version>1.0-RC1</microprofile-context-propagation.version>
+        <microprofile-context-propagation.version>1.0</microprofile-context-propagation.version>
         <microprofile-opentracing-api.version>1.3.1</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.3.3</microprofile-rest-client.version>


### PR DESCRIPTION
The RC1 was a release candidate. The smallrye implementation pulled is already using the 1.0 version.