### PR TITLE
Generate default Tika config with the list of supported parsers

### DIFF
--- a/docs/src/main/asciidoc/tika-guide.adoc
+++ b/docs/src/main/asciidoc/tika-guide.adoc
@@ -16,7 +16,7 @@ https://tika.apache.org/[Apache Tika] is a content analysis toolkit which is use
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.tika.tika-config-path|tika-config.xml|Path to the https://tika.apache.org/1.22/configuring.html[Tika configuration] resource. Typically a file named `tika-config.xml` is located in the root of the application resources path. The default configuration will be used if no configuration resource is available. 
+|quarkus.tika.tika-config-path||Path to the https://tika.apache.org/1.22/configuring.html[Tika configuration] resource. Typically a file named `tika-config.xml` is added to the root of the application resources path. The default configuration will be used if no configuration resource is available. 
 |quarkus.tika.append-embedded-content|true|The document may have other embedded documents, for example, an Excel document may include a PDF content. If such an embedded content is available then, by default, it will be appended to the content of the master document, thus, in this example, the text extracted from PDF file will be appended to the text extracted from the Excel file. This property has to be set to `false` if one needs to access the content of the master and each of the embedded documents individually.  
 |===
 

--- a/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
+++ b/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
@@ -1,6 +1,8 @@
 package io.quarkus.tika.deployment;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -38,8 +40,8 @@ public class TikaProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void initializeTikaParser(BeanContainerBuildItem beanContainer, TikaRecorder recorder) {
-        recorder.initTikaParser(beanContainer.getValue(), config);
+    void initializeTikaParser(BeanContainerBuildItem beanContainer, TikaRecorder recorder) throws Exception {
+        recorder.initTikaParser(beanContainer.getValue(), config, getSupportedParserNames());
     }
 
     @BuildStep(providesCapabilities = "io.quarkus.tika")
@@ -53,47 +55,47 @@ public class TikaProcessor {
     }
 
     @BuildStep
-    public void produceRuntimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> resource) {
+    public void registerRuntimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> resource) {
         //org.apache.tika.parser.pdf.PDFParser (https://issues.apache.org/jira/browse/PDFBOX-4548)
         resource.produce(new RuntimeInitializedClassBuildItem("org.apache.pdfbox.pdmodel.font.PDType1Font"));
     }
 
     @BuildStep
-    public void produceTikaCoreResources(BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
+    public void registerTikaCoreResources(BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
         resource.produce(new SubstrateResourceBuildItem("org/apache/tika/mime/tika-mimetypes.xml"));
         resource.produce(new SubstrateResourceBuildItem("org/apache/tika/parser/external/tika-external-parsers.xml"));
     }
 
     @BuildStep
-    public void produceTikaParsersResources(BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
+    public void registerTikaParsersResources(BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
         resource.produce(new SubstrateResourceBuildItem("org/apache/tika/parser/pdf/PDFParser.properties"));
     }
 
     @BuildStep
-    public void producePdfBoxResources(BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
+    public void registerPdfBoxResources(BuildProducer<SubstrateResourceBuildItem> resource) throws Exception {
         resource.produce(new SubstrateResourceBuildItem("org/apache/pdfbox/resources/glyphlist/additional.txt"));
         resource.produce(new SubstrateResourceBuildItem("org/apache/pdfbox/resources/glyphlist/glyphlist.txt"));
         resource.produce(new SubstrateResourceBuildItem("org/apache/pdfbox/resources/glyphlist/zapfdingbats.txt"));
     }
 
     @BuildStep
-    public void produceTikaParsersProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider) throws Exception {
-        produceTikaServiceProviders(serviceProvider,
-                Parser.class.getName(),
-                Detector.class.getName(),
-                EncodingDetector.class.getName());
+    public void registerTikaProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider) throws Exception {
+        serviceProvider.produce(
+                new ServiceProviderBuildItem(Parser.class.getName(), getSupportedParserNames()));
+        serviceProvider.produce(
+                new ServiceProviderBuildItem(Detector.class.getName(), getProviderNames(Detector.class.getName())));
+        serviceProvider.produce(
+                new ServiceProviderBuildItem(EncodingDetector.class.getName(),
+                        getProviderNames(EncodingDetector.class.getName())));
     }
 
-    private void produceTikaServiceProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider,
-            String... serviceProviderNames) throws Exception {
-        for (String serviceProviderName : serviceProviderNames) {
-            Set<String> availableProviderClasses = ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
-                    "META-INF/services/" + serviceProviderName);
-            Predicate<String> pred = p -> !Parser.class.getName().equals(serviceProviderName)
-                    || !NOT_NATIVE_READY_PARSERS.contains(p);
-            serviceProvider.produce(new ServiceProviderBuildItem(serviceProviderName,
-                    availableProviderClasses.stream().filter(pred).collect(Collectors.toList())));
-        }
+    private static List<String> getProviderNames(String serviceProviderName) throws Exception {
+        return new ArrayList<>(ServiceUtil.classNamesNamedIn(TikaProcessor.class.getClassLoader(),
+                "META-INF/services/" + serviceProviderName));
     }
 
+    private static List<String> getSupportedParserNames() throws Exception {
+        Predicate<String> pred = p -> !NOT_NATIVE_READY_PARSERS.contains(p);
+        return getProviderNames(Parser.class.getName()).stream().filter(pred).collect(Collectors.toList());
+    }
 }

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaConfiguration.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaConfiguration.java
@@ -1,5 +1,7 @@
 package io.quarkus.tika.runtime;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -12,8 +14,8 @@ public class TikaConfiguration {
     /**
      * The path to the tika-config.xml
      */
-    @ConfigItem(defaultValue = "tika-config.xml")
-    public String tikaConfigPath;
+    @ConfigItem
+    public Optional<String> tikaConfigPath;
 
     /**
      * Controls how the content of the embedded documents is parsed.

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaRecorder.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaRecorder.java
@@ -1,6 +1,8 @@
 package io.quarkus.tika.runtime;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.List;
 
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.parser.AutoDetectParser;
@@ -15,26 +17,20 @@ import io.quarkus.tika.TikaParser;
 @Recorder
 public class TikaRecorder {
 
-    public void initTikaParser(BeanContainer container, TikaConfiguration config) {
-        TikaParser parser = initializeParser(config);
+    public void initTikaParser(BeanContainer container, TikaConfiguration config, List<String> supportedParserNames) {
+        TikaParser parser = initializeParser(config, supportedParserNames);
         TikaParserProducer producer = container.instance(TikaParserProducer.class);
         producer.initialize(parser);
     }
 
-    private TikaParser initializeParser(TikaConfiguration config) {
-        // Load tika-config.xml resource
+    private TikaParser initializeParser(TikaConfiguration config, List<String> supportedParserNames) {
         TikaConfig tikaConfig = null;
-        InputStream is = getClass().getResourceAsStream(
-                config.tikaConfigPath.startsWith("/") ? config.tikaConfigPath : "/" + config.tikaConfigPath);
-        if (is != null) {
-            try (InputStream stream = is) {
-                tikaConfig = new TikaConfig(stream);
-            } catch (Exception ex) {
-                final String errorMessage = "Invalid tika-config.xml";
-                throw new TikaParseException(errorMessage, ex);
-            }
-        } else {
-            tikaConfig = TikaConfig.getDefaultConfig();
+
+        try (InputStream stream = getTikaConfigStream(config, supportedParserNames)) {
+            tikaConfig = new TikaConfig(stream);
+        } catch (Exception ex) {
+            final String errorMessage = "Invalid tika-config.xml";
+            throw new TikaParseException(errorMessage, ex);
         }
 
         // Create a native Tika Parser. AutoDetectParser is used by default but it is wrapped
@@ -45,5 +41,34 @@ public class TikaRecorder {
             nativeParser = new RecursiveParserWrapper(nativeParser, true);
         }
         return new TikaParser(nativeParser, config.appendEmbeddedContent);
+    }
+
+    private static InputStream getTikaConfigStream(TikaConfiguration config, List<String> supportedParserNames) {
+        // Load tika-config.xml resource
+        InputStream is = null;
+        if (config.tikaConfigPath.isPresent()) {
+            is = TikaRecorder.class.getResourceAsStream(
+                    config.tikaConfigPath.get().startsWith("/") ? config.tikaConfigPath.get()
+                            : "/" + config.tikaConfigPath.get());
+            if (is == null) {
+                final String errorMessage = "tika-config.xml can not be found at " + config.tikaConfigPath.get();
+                throw new TikaParseException(errorMessage);
+            }
+        } else {
+            is = generateTikaConfig(supportedParserNames);
+        }
+        return is;
+    }
+
+    private static InputStream generateTikaConfig(List<String> supportedParserNames) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<properties>");
+        sb.append("<parsers>");
+        for (String parserName : supportedParserNames) {
+            sb.append("<parser class=\"").append(parserName).append("\"/>");
+        }
+        sb.append("</parsers>");
+        sb.append("</properties>");
+        return new ByteArrayInputStream(sb.toString().getBytes());
     }
 }

--- a/integration-tests/tika/src/main/resources/application.properties
+++ b/integration-tests/tika/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.tika.tika-config-path=tika-config.xml


### PR DESCRIPTION
This PR ensures that when no custom configuration resource is provided, the default one is generated listing explicitly all the supported parsers (with the exception of the unsupported parsers), thus ensuring that the static init recording can work with or without the custom configuration resource 