### PR TITLE
Injection into test method parameters in Arquillian tests

### DIFF
--- a/tcks/microprofile-metrics/api/pom.xml
+++ b/tcks/microprofile-metrics/api/pom.xml
@@ -37,14 +37,6 @@
                         <!-- These depend on metrics from CDI producers -->
                         <exclude>io.astefanutti.metrics.cdi.se.MetricProducerFieldBeanTest</exclude>
                         <exclude>io.astefanutti.metrics.cdi.se.MetricProducerMethodBeanTest</exclude>
-                        <!-- These depend on injection of method parameters via @Metric -->
-                        <exclude>io.astefanutti.metrics.cdi.se.ConcurrentGaugedMethodBeanTest</exclude>
-                        <exclude>io.astefanutti.metrics.cdi.se.CountedMethodBeanTest</exclude>
-                        <exclude>io.astefanutti.metrics.cdi.se.CountedMethodTagBeanTest</exclude>
-                        <exclude>io.astefanutti.metrics.cdi.se.GaugeInjectionBeanTest</exclude>
-                        <!-- These depend on injection of MetricRegistry into test method params -->
-                        <exclude>io.astefanutti.metrics.cdi.se.ConcreteExtendedTimedBeanTest</exclude>
-                        <exclude>io.astefanutti.metrics.cdi.se.ConcreteTimedBeanTest</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/CreationalContextDestroyer.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/CreationalContextDestroyer.java
@@ -1,0 +1,27 @@
+package io.quarkus.arquillian;
+
+import javax.enterprise.context.spi.CreationalContext;
+
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.EventContext;
+import org.jboss.arquillian.test.spi.event.suite.After;
+
+public class CreationalContextDestroyer {
+
+    @Inject
+    private Instance<CreationalContext> creationalContext;
+
+    public void destroy(@Observes EventContext<After> event) {
+        try {
+            event.proceed();
+        } finally {
+            CreationalContext<Object> cc = creationalContext.get();
+            if (cc != null) {
+                cc.release();
+            }
+        }
+    }
+
+}

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/InjectionEnricher.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/InjectionEnricher.java
@@ -1,0 +1,83 @@
+package io.quarkus.arquillian;
+
+import static io.quarkus.arquillian.QuarkusProtocol.convertToTCCL;
+
+import java.lang.reflect.Method;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.annotation.TestScoped;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+
+/**
+ * Enricher that provides method argument injection.
+ */
+public class InjectionEnricher implements TestEnricher {
+
+    private static final Logger log = Logger.getLogger(TestEnricher.class.getName());
+
+    @Inject
+    @TestScoped
+    private InstanceProducer<CreationalContext> creationalContextProducer;
+
+    public BeanManager getBeanManager() {
+        return Arc.container().beanManager();
+    }
+
+    @SuppressWarnings("unchecked")
+    public CreationalContext<Object> getCreationalContext() {
+        CreationalContext<Object> cc = creationalContextProducer.get();
+        if (cc == null) {
+            cc = getBeanManager().createCreationalContext(null);
+            creationalContextProducer.set(cc);
+        }
+        return cc;
+    }
+
+    @Override
+    public void enrich(Object testCase) {
+
+    }
+
+    @Override
+    public Object[] resolve(Method method) {
+        Object[] values = new Object[method.getParameterTypes().length];
+        if (values.length > 0) {
+            BeanManager beanManager = getBeanManager();
+            if (beanManager == null) {
+                return values;
+            }
+            try {
+                // obtain the same method definition but from the TCCL
+                method = Thread.currentThread().getContextClassLoader()
+                        .loadClass(method.getDeclaringClass().getName())
+                        .getMethod(method.getName(), convertToTCCL(method.getParameterTypes()));
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            for (int i = 0; i < parameterTypes.length; i++) {
+                try {
+                    values[i] = getInstanceByType(beanManager, i, method);
+                } catch (Exception e) {
+                    log.warn("InjectionEnricher tried to lookup method parameter of type "
+                            + parameterTypes[i] + " but caught exception", e);
+                }
+            }
+        }
+        return values;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getInstanceByType(BeanManager manager, final int position, final Method method) {
+        CreationalContext<?> cc = getCreationalContext();
+        return (T) manager.getInjectableReference(new MethodParameterInjectionPoint<T>(method, position, manager), cc);
+    }
+
+}

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/MethodParameterInjectionPoint.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/MethodParameterInjectionPoint.java
@@ -1,0 +1,113 @@
+package io.quarkus.arquillian;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.AnnotatedCallable;
+import javax.enterprise.inject.spi.AnnotatedParameter;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Qualifier;
+
+public class MethodParameterInjectionPoint<T> implements InjectionPoint {
+    private Method method;
+    private int position;
+    private BeanManager beanManager;
+
+    public MethodParameterInjectionPoint(Method method, int position, BeanManager beanManager) {
+        this.method = method;
+        this.position = position;
+        this.beanManager = beanManager;
+    }
+
+    public Bean<?> getBean() {
+        return null;
+    }
+
+    public Member getMember() {
+        return method;
+    }
+
+    public Set<Annotation> getQualifiers() {
+        Set<Annotation> qualifiers = new HashSet<>();
+        for (Annotation potentialQualifier : method.getParameterAnnotations()[position]) {
+            if (potentialQualifier.annotationType().getAnnotation(Qualifier.class) != null) {
+                qualifiers.add(potentialQualifier);
+            }
+        }
+        if (qualifiers.size() == 0) {
+            qualifiers.add(Default.Literal.INSTANCE);
+        }
+        return qualifiers;
+    }
+
+    public Type getType() {
+        return findTypeOrGenericType();
+    }
+
+    public boolean isDelegate() {
+        return false;
+    }
+
+    public boolean isTransient() {
+        return false;
+    }
+
+    public Annotated getAnnotated() {
+        return new ArgumentAnnotated<T>();
+    }
+
+    private Type findTypeOrGenericType() {
+        if (method.getGenericParameterTypes().length > 0) {
+            return method.getGenericParameterTypes()[position];
+        }
+        return method.getParameterTypes()[position];
+    }
+
+    private class ArgumentAnnotated<X> implements AnnotatedParameter<X> {
+
+        public AnnotatedCallable<X> getDeclaringCallable() {
+            return null;
+        }
+
+        public int getPosition() {
+            return position;
+        }
+
+        public <Y extends Annotation> Y getAnnotation(Class<Y> annotationType) {
+            for (Annotation annotation : method.getParameterAnnotations()[position]) {
+                if (annotation.annotationType() == annotationType) {
+                    return annotationType.cast(annotation);
+                }
+            }
+            return null;
+        }
+
+        public Set<Annotation> getAnnotations() {
+            return new HashSet<>(Arrays.asList(method.getParameterAnnotations()[position]));
+        }
+
+        public Type getBaseType() {
+            return getType();
+        }
+
+        public Set<Type> getTypeClosure() {
+            Set<Type> types = new HashSet<>();
+            types.add(findTypeOrGenericType());
+            types.add(Object.class);
+            return types;
+        }
+
+        public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+            return getAnnotation(annotationType) != null;
+        }
+    }
+}

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusExtension.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusExtension.java
@@ -3,6 +3,7 @@ package io.quarkus.arquillian;
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
 import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
 
 public class QuarkusExtension implements LoadableExtension {
 
@@ -10,6 +11,8 @@ public class QuarkusExtension implements LoadableExtension {
     public void register(ExtensionBuilder builder) {
         builder.service(DeployableContainer.class, QuarkusDeployableContainer.class);
         builder.service(Protocol.class, QuarkusProtocol.class);
+        builder.service(TestEnricher.class, InjectionEnricher.class);
+        builder.observer(CreationalContextDestroyer.class);
         builder.observer(QuarkusBeforeAfterLifecycle.class);
     }
 

--- a/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/MethodParameterInjectionTest.java
+++ b/test-framework/arquillian/src/test/java/io/quarkus/arquillian/test/MethodParameterInjectionTest.java
@@ -1,0 +1,127 @@
+package io.quarkus.arquillian.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests injection of parameter values into @Test methods.
+ */
+@RunWith(Arquillian.class)
+public class MethodParameterInjectionTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class);
+    }
+
+    @Test
+    public void injectOneApplicationScopedBean(AppScopedBean1 param) {
+        assertNotNull("Method param was not injected", param);
+        assertNotNull("@Inject did not work", injected);
+        assertEquals(injected, param);
+    }
+
+    @Test
+    public void injectTwoApplicationScopedBeans(AppScopedBean1 param1, AppScopedBean2 param2) {
+        assertNotNull("Method param was not injected", param1);
+        assertNotNull("Method param was not injected", param2);
+    }
+
+    @Test
+    public void injectFromProducer(OtherBean param1, OtherBean param2) {
+        assertNotNull(param1);
+        assertNotNull(param2);
+        assertNotSame(param1, param2);
+    }
+
+    @Test
+    public void injectWithQualifier(@Good X param) {
+        assertNotNull(param);
+        assertTrue(Y.class.isAssignableFrom(param.getClass()));
+        assertFalse(Z.class.isAssignableFrom(param.getClass()));
+    }
+
+    public interface X {
+
+    }
+
+    @Good
+    @ApplicationScoped
+    public static class Y implements X {
+
+    }
+
+    @Bad
+    @ApplicationScoped
+    public static class Z implements X {
+
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+    public @interface Good {
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+    public @interface Bad {
+    }
+
+    @Inject
+    AppScopedBean1 injected;
+
+    @Inject
+    AppScopedBean2 injected2;
+
+    @Inject
+    @Good
+    X yInstance;
+
+    @Inject
+    @Bad
+    X zInstance;
+
+    @Produces
+    @Dependent
+    OtherBean producer() {
+        return new OtherBean();
+    }
+
+    @ApplicationScoped
+    public static class AppScopedBean1 {
+
+    }
+
+    @ApplicationScoped
+    public static class AppScopedBean2 {
+
+    }
+
+    public static class OtherBean {
+
+    }
+
+}


### PR DESCRIPTION
#3943
@mkouba @kenfinnigan @manovotn please have a look. I don't feel very comfortable with the `convertToTCCL` thingy but for some reason it was necessary (Arquillian is passing the method metadata to `TestEnricher` and `TestMethodExecutor` loaded by system class loader). Any better solution to go with?