### PR TITLE
chore: remove generated config docs from gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ docker/distroless/bazel-*
 /.apt_generated_tests/
 quarkus.log
 replay_*.log
-docs/src/main/asciidoc/generated
+
+
 


### PR DESCRIPTION
following #3909 docs are now generated in the global /target/ folder and not in
docs/src/main/asciidoc/generated. 

See this comment
https://github.com/quarkusio/quarkus/issues/3909#issuecomment-529945707
and corresponding PR #3887

/cc @gsmet, I planned to add a review comment on #3887 about it but looks like I missed the train and it was merged. So here is a minor cleanup PR. 
