### PR TITLE
Remote is API so it shouldn't be in the runtime package but in the root

### DIFF
--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/Remote.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/Remote.java
@@ -1,4 +1,4 @@
-package io.quarkus.infinispan.client.runtime;
+package io.quarkus.infinispan.client;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -17,13 +17,11 @@ import javax.inject.Qualifier;
  * Qualifier used to specify which remote cache will be injected.
  *
  * @author William Burns
- * @deprecated use {@link io.quarkus.infinispan.client.Remote} instead
  */
 @Target({ METHOD, FIELD, PARAMETER, TYPE })
 @Retention(RUNTIME)
 @Documented
 @Qualifier
-@Deprecated
 public @interface Remote {
     /**
      * The remote cache name. If no value is provided the default cache is assumed.

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -245,15 +245,27 @@ public class InfinispanClientProducer {
         }
     }
 
-    @Remote
+    @SuppressWarnings("deprecation")
+    @io.quarkus.infinispan.client.Remote
+    @io.quarkus.infinispan.client.runtime.Remote
     @Produces
     public <K, V> RemoteCache<K, V> getRemoteCache(InjectionPoint injectionPoint, RemoteCacheManager cacheManager) {
         Set<Annotation> annotationSet = injectionPoint.getQualifiers();
-        final Remote remote = getRemoteAnnotation(annotationSet);
+
+        // Deal with the regular annotation first
+        final io.quarkus.infinispan.client.Remote remote = getRemoteAnnotation(annotationSet);
 
         if (remote != null && !remote.value().isEmpty()) {
             return cacheManager.getCache(remote.value());
         }
+
+        // Then deal with the deprecated one
+        final io.quarkus.infinispan.client.runtime.Remote deprecatedRemote = getDeprecatedRemoteAnnotation(annotationSet);
+
+        if (deprecatedRemote != null && !deprecatedRemote.value().isEmpty()) {
+            return cacheManager.getCache(deprecatedRemote.value());
+        }
+
         return cacheManager.getCache();
     }
 
@@ -276,15 +288,30 @@ public class InfinispanClientProducer {
     }
 
     /**
-     * Retrieves the {@link Remote} annotation instance from the set
+     * Retrieves the deprecated {@link Remote} annotation instance from the set
      *
      * @param annotationSet the annotation set.
      * @return the {@link Remote} annotation instance or {@code null} if not found.
      */
-    private Remote getRemoteAnnotation(Set<Annotation> annotationSet) {
+    private io.quarkus.infinispan.client.Remote getRemoteAnnotation(Set<Annotation> annotationSet) {
         for (Annotation annotation : annotationSet) {
-            if (annotation instanceof Remote) {
-                return (Remote) annotation;
+            if (annotation instanceof io.quarkus.infinispan.client.Remote) {
+                return (io.quarkus.infinispan.client.Remote) annotation;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the deprecated {@link Remote} annotation instance from the set
+     *
+     * @param annotationSet the annotation set.
+     * @return the {@link Remote} annotation instance or {@code null} if not found.
+     */
+    private io.quarkus.infinispan.client.runtime.Remote getDeprecatedRemoteAnnotation(Set<Annotation> annotationSet) {
+        for (Annotation annotation : annotationSet) {
+            if (annotation instanceof io.quarkus.infinispan.client.runtime.Remote) {
+                return (io.quarkus.infinispan.client.runtime.Remote) annotation;
             }
         }
         return null;

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/TestServlet.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/TestServlet.java
@@ -45,15 +45,16 @@ import org.infinispan.query.api.continuous.ContinuousQueryListener;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
 
-import io.quarkus.infinispan.client.runtime.Remote;
+import io.quarkus.infinispan.client.Remote;
 import io.quarkus.runtime.StartupEvent;
 
 @Path("/test")
 public class TestServlet {
     private static final Log log = LogFactory.getLog(TestServlet.class);
 
+    @SuppressWarnings("deprecation")
     @Inject
-    @Remote("default")
+    @io.quarkus.infinispan.client.runtime.Remote("default")
     RemoteCache<String, Book> cache;
 
     @Inject


### PR DESCRIPTION
API annotations should be in the root package and not in the `runtime` package which is for the implementations.

Per the naming rules we decided a while ago. I deprecated the old
annotation but it should still work.