### PR TITLE
Reduce the number of FixedValueSupplier instances by creating them lazily

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -107,7 +107,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             }
         }
 
-        Map<BeanInfo, ResultHandle> beanToResultSupplierHandle = new HashMap<>();
+        Map<BeanInfo, Supplier<ResultHandle>> beanToResultSupplierHandle = new HashMap<>();
         List<BeanInfo> processed = new ArrayList<>();
 
         // At this point we are going to fill the beanIdToBeanSupplier map
@@ -171,11 +171,11 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             List<ResultHandle> params = new ArrayList<>();
             List<String> paramTypes = new ArrayList<>();
 
-            ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(observer.getDeclaringBean());
+            ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(observer.getDeclaringBean()).get();
             params.add(resultSupplierHandle);
             paramTypes.add(Type.getDescriptor(Supplier.class));
             for (InjectionPointInfo injectionPoint : injectionPoints) {
-                resultSupplierHandle = beanToResultSupplierHandle.get(injectionPoint.getResolvedBean());
+                resultSupplierHandle = beanToResultSupplierHandle.get(injectionPoint.getResolvedBean()).get();
                 params.add(resultSupplierHandle);
                 paramTypes.add(Type.getDescriptor(Supplier.class));
             }
@@ -231,7 +231,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
     }
 
     private boolean addBeans(Map<BeanInfo, List<BeanInfo>> beanToInjections, List<BeanInfo> processed,
-            Map<BeanInfo, ResultHandle> beanToResultSupplierHandle, MethodCreator getComponents,
+            Map<BeanInfo, Supplier<ResultHandle>> beanToResultSupplierHandle, MethodCreator getComponents,
             ResultHandle beanIdToBeanSupplierHandle, Map<BeanInfo, String> beanToGeneratedName, Predicate<BeanInfo> filter) {
         boolean stuck = true;
         for (Iterator<Entry<BeanInfo, List<BeanInfo>>> iterator = beanToInjections.entrySet().iterator(); iterator
@@ -251,7 +251,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
 
     private void addBean(MethodCreator getComponents, ResultHandle beanIdToBeanSupplierHandle, BeanInfo bean,
             Map<BeanInfo, String> beanToGeneratedName,
-            Map<BeanInfo, ResultHandle> beanToResultSupplierHandle) {
+            Map<BeanInfo, Supplier<ResultHandle>> beanToResultSupplierHandle) {
 
         String beanType = beanToGeneratedName.get(bean);
 
@@ -261,7 +261,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         List<String> paramTypes = new ArrayList<>();
 
         if (bean.isProducerMethod() || bean.isProducerField()) {
-            ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(bean.getDeclaringBean());
+            ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(bean.getDeclaringBean()).get();
             if (resultSupplierHandle == null) {
                 throw new IllegalStateException(
                         "A supplier for a declaring bean of a producer bean is not available - most probaly an unsupported circular dependency use case \n - declaring bean: "
@@ -282,13 +282,13 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         }
         if (bean.getDisposer() != null) {
             for (InjectionPointInfo injectionPoint : bean.getDisposer().getInjection().injectionPoints) {
-                ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(injectionPoint.getResolvedBean());
+                ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(injectionPoint.getResolvedBean()).get();
                 params.add(resultSupplierHandle);
                 paramTypes.add(Type.getDescriptor(Supplier.class));
             }
         }
         for (InterceptorInfo interceptor : bean.getBoundInterceptors()) {
-            ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(interceptor);
+            ResultHandle resultSupplierHandle = beanToResultSupplierHandle.get(interceptor).get();
             params.add(resultSupplierHandle);
             paramTypes.add(Type.getDescriptor(Supplier.class));
         }
@@ -303,9 +303,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                 beanInstance);
 
         // Create a Supplier that will return the bean instance at runtime.
-        ResultHandle beanInstanceSupplier = getComponents.newInstance(MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR,
-                beanInstance);
-        beanToResultSupplierHandle.put(bean, beanInstanceSupplier);
+        beanToResultSupplierHandle.put(bean,
+                () -> getComponents.newInstance(MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanInstance));
     }
 
     private boolean isDependency(BeanInfo bean, Map<BeanInfo, List<BeanInfo>> beanToInjections) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -6,6 +6,7 @@ import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.Components;
 import io.quarkus.arc.ComponentsProvider;
+import io.quarkus.arc.LazyValue;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
@@ -107,7 +108,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             }
         }
 
-        Map<BeanInfo, Supplier<ResultHandle>> beanToResultSupplierHandle = new HashMap<>();
+        Map<BeanInfo, LazyValue<ResultHandle>> beanToResultSupplierHandle = new HashMap<>();
         List<BeanInfo> processed = new ArrayList<>();
 
         // At this point we are going to fill the beanIdToBeanSupplier map
@@ -231,7 +232,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
     }
 
     private boolean addBeans(Map<BeanInfo, List<BeanInfo>> beanToInjections, List<BeanInfo> processed,
-            Map<BeanInfo, Supplier<ResultHandle>> beanToResultSupplierHandle, MethodCreator getComponents,
+            Map<BeanInfo, LazyValue<ResultHandle>> beanToResultSupplierHandle, MethodCreator getComponents,
             ResultHandle beanIdToBeanSupplierHandle, Map<BeanInfo, String> beanToGeneratedName, Predicate<BeanInfo> filter) {
         boolean stuck = true;
         for (Iterator<Entry<BeanInfo, List<BeanInfo>>> iterator = beanToInjections.entrySet().iterator(); iterator
@@ -251,7 +252,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
 
     private void addBean(MethodCreator getComponents, ResultHandle beanIdToBeanSupplierHandle, BeanInfo bean,
             Map<BeanInfo, String> beanToGeneratedName,
-            Map<BeanInfo, Supplier<ResultHandle>> beanToResultSupplierHandle) {
+            Map<BeanInfo, LazyValue<ResultHandle>> beanToResultSupplierHandle) {
 
         String beanType = beanToGeneratedName.get(bean);
 
@@ -303,8 +304,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                 beanInstance);
 
         // Create a Supplier that will return the bean instance at runtime.
-        beanToResultSupplierHandle.put(bean,
-                () -> getComponents.newInstance(MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanInstance));
+        beanToResultSupplierHandle.put(bean, new LazyValue<>(
+                () -> getComponents.newInstance(MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanInstance)));
     }
 
     private boolean isDependency(BeanInfo bean, Map<BeanInfo, List<BeanInfo>> beanToInjections) {


### PR DESCRIPTION
I was toying around with a snapshot build of Quarkus today and noticed that the generated `ComponentsProvider` class creates a few "useless" (because: unused) `FixedValueSupplier` instances.

The `ComponentGenerator` always creates these instances, and puts them in a `Map` (at compile time). Some of these are looked up at compile time, and then it makes sense. But some of them aren't. In that case, the instance is created, but never used.

This patch addresses that. Instead of creating the `FixedValueSupplier` instance directly and putting it in the compile-time `Map`, it creates the instance _lazily_, only when it is needed. In the  `DefaultClassBeanTest`, this reduced the number of useless `FixedValueSupplier` instances from 6 to 0.