### PR TITLE
Fixes #3949

### DIFF
--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
@@ -260,6 +261,8 @@ public class ResteasyServerCommonProcessor {
             resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_GZIP_MAX_INPUT,
                     Long.toString(commonConfig.gzip.maxInput.asLongValue()));
         }
+        resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_UNWRAPPED_EXCEPTIONS,
+                ArcUndeclaredThrowableException.class.getName());
 
         resteasyServerConfig.produce(new ResteasyServerConfigBuildItem(path, resteasyInitParameters));
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.processor;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
+import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InvocationContextImpl.InterceptorInvocation;
 import io.quarkus.arc.Subclass;
@@ -341,7 +342,7 @@ public class SubclassGenerator extends AbstractGenerator {
         if (addCatchException) {
             CatchBlockCreator catchOtherExceptions = tryCatch.addCatch(Exception.class);
             // and wrap them in a new RuntimeException(e)
-            catchOtherExceptions.throwException(RuntimeException.class, "Error invoking subclass method",
+            catchOtherExceptions.throwException(ArcUndeclaredThrowableException.class, "Error invoking subclass method",
                     catchOtherExceptions.getCaughtException());
         }
         // InvocationContextImpl.aroundInvoke(this, methods.get("m1"), params, interceptorChains.get("m1"), forward)

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcUndeclaredThrowableException.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcUndeclaredThrowableException.java
@@ -1,0 +1,28 @@
+package io.quarkus.arc;
+
+/**
+ * Exception that is thrown from generated arc classes if a checked exception cannot be propagated
+ */
+public class ArcUndeclaredThrowableException extends RuntimeException {
+
+    public ArcUndeclaredThrowableException(Throwable cause) {
+        super(cause);
+    }
+
+    public ArcUndeclaredThrowableException() {
+        super();
+    }
+
+    public ArcUndeclaredThrowableException(String message) {
+        super(message);
+    }
+
+    public ArcUndeclaredThrowableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected ArcUndeclaredThrowableException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
If a checked exception is thrown from an interceptor allow RESTeasy
exception mappers to unwrap it.