### PR TITLE
Change SR CP integration to make discovery based on TCCL.

### DIFF
--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -38,7 +38,7 @@ class SmallRyeContextPropagationProcessor {
             throws ClassNotFoundException, IOException {
         List<ThreadContextProvider> discoveredProviders = new ArrayList<>();
         List<ContextManagerExtension> discoveredExtensions = new ArrayList<>();
-        for (Class<?> provider : ServiceUtil.classesNamedIn(SmallRyeContextPropagationRecorder.class.getClassLoader(),
+        for (Class<?> provider : ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
                 "META-INF/services/" + ThreadContextProvider.class.getName())) {
             try {
                 discoveredProviders.add((ThreadContextProvider) provider.newInstance());
@@ -47,7 +47,7 @@ class SmallRyeContextPropagationProcessor {
                         e);
             }
         }
-        for (Class<?> extension : ServiceUtil.classesNamedIn(SmallRyeContextPropagationRecorder.class.getClassLoader(),
+        for (Class<?> extension : ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
                 "META-INF/services/" + ContextManagerExtension.class.getName())) {
             try {
                 discoveredExtensions.add((ContextManagerExtension) extension.newInstance());


### PR DESCRIPTION
Fixes #3908 

Assuming no tests crash here (tried non-native only locally), this fixes the problem of context provider discovery for MP CP TCK.