### PR TITLE
Initialize byte buffer allocators at runtime

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -45,6 +45,7 @@ class NettyProcessor {
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslClientContext")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.util.ThreadLocalInsecureRandom")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ConscryptAlpnSslEngine")
+                .addRuntimeReinitializedClass("io.netty.buffer.PooledByteBufAllocator")
                 .addNativeImageSystemProperty("io.netty.leakDetection.level", "DISABLED");
         try {
             Class.forName("io.netty.handler.codec.http.HttpObjectEncoder");

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowBufferAllocator.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowBufferAllocator.java
@@ -1,0 +1,49 @@
+package io.quarkus.undertow.runtime;
+
+import io.netty.buffer.ByteBuf;
+import io.undertow.httpcore.BufferAllocator;
+import io.vertx.core.net.impl.PartialPooledByteBufAllocator;
+
+class UndertowBufferAllocator implements BufferAllocator {
+
+    private final boolean defaultDirectBuffers;
+    private final int defaultBufferSize;
+
+    UndertowBufferAllocator(boolean defaultDirectBuffers, int defaultBufferSize) {
+        this.defaultDirectBuffers = defaultDirectBuffers;
+        this.defaultBufferSize = defaultBufferSize;
+    }
+
+    @Override
+    public ByteBuf allocateBuffer() {
+        return allocateBuffer(defaultDirectBuffers);
+    }
+
+    @Override
+    public ByteBuf allocateBuffer(boolean direct) {
+        if (direct) {
+            return PartialPooledByteBufAllocator.DEFAULT.directBuffer(defaultBufferSize);
+        } else {
+            return PartialPooledByteBufAllocator.DEFAULT.heapBuffer(defaultBufferSize);
+        }
+    }
+
+    @Override
+    public ByteBuf allocateBuffer(int bufferSize) {
+        return allocateBuffer(defaultDirectBuffers, bufferSize);
+    }
+
+    @Override
+    public ByteBuf allocateBuffer(boolean direct, int bufferSize) {
+        if (direct) {
+            return PartialPooledByteBufAllocator.DEFAULT.directBuffer(bufferSize);
+        } else {
+            return PartialPooledByteBufAllocator.DEFAULT.heapBuffer(bufferSize);
+        }
+    }
+
+    @Override
+    public int getBufferSize() {
+        return defaultBufferSize;
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -27,8 +27,6 @@ import javax.servlet.ServletException;
 
 import org.jboss.logging.Logger;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.runtime.BeanContainer;
@@ -38,7 +36,6 @@ import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.MemorySize;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
-import io.undertow.httpcore.BufferAllocator;
 import io.undertow.httpcore.StatusCodes;
 import io.undertow.server.DefaultExchangeHandler;
 import io.undertow.server.HandlerWrapper;
@@ -576,47 +573,4 @@ public class UndertowDeploymentRecorder {
         }
     }
 
-    private static class UndertowBufferAllocator implements BufferAllocator {
-
-        private final boolean defaultDirectBuffers;
-        private final int defaultBufferSize;
-
-        private UndertowBufferAllocator(boolean defaultDirectBuffers, int defaultBufferSize) {
-            this.defaultDirectBuffers = defaultDirectBuffers;
-            this.defaultBufferSize = defaultBufferSize;
-        }
-
-        @Override
-        public ByteBuf allocateBuffer() {
-            return allocateBuffer(defaultDirectBuffers);
-        }
-
-        @Override
-        public ByteBuf allocateBuffer(boolean direct) {
-            if (direct) {
-                return PooledByteBufAllocator.DEFAULT.directBuffer(defaultBufferSize);
-            } else {
-                return PooledByteBufAllocator.DEFAULT.heapBuffer(defaultBufferSize);
-            }
-        }
-
-        @Override
-        public ByteBuf allocateBuffer(int bufferSize) {
-            return allocateBuffer(defaultDirectBuffers, bufferSize);
-        }
-
-        @Override
-        public ByteBuf allocateBuffer(boolean direct, int bufferSize) {
-            if (direct) {
-                return PooledByteBufAllocator.DEFAULT.directBuffer(bufferSize);
-            } else {
-                return PooledByteBufAllocator.DEFAULT.heapBuffer(bufferSize);
-            }
-        }
-
-        @Override
-        public int getBufferSize() {
-            return defaultBufferSize;
-        }
-    }
 }

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCommonProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCommonProcessor.java
@@ -30,6 +30,7 @@ class VertxCommonProcessor {
         return SubstrateConfigBuildItem.builder()
                 .addNativeImageSystemProperty("vertx.disableDnsResolver", "true")
                 .addRuntimeInitializedClass("io.vertx.core.http.impl.VertxHttp2ClientUpgradeCodec")
+                .addRuntimeReinitializedClass("io.vertx.core.net.impl.PartialPooledByteBufAllocator")
                 .build();
     }
 


### PR DESCRIPTION
These allocatiors make decisions based on current memory size, which should be done at runtime

Also uses the same allocator for Undertow and vert.x