### PR TITLE
Document the usage of OpenTracing JDBC tracer

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -22,6 +22,7 @@
         <opentracing-web-servlet-filter.version>0.2.3</opentracing-web-servlet-filter.version>
         <opentracing-tracerresolver.version>0.1.5</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
+        <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
         <jaeger.version>0.34.0</jaeger.version>
         <quarkus-http.version>3.0.0.Alpha5</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
@@ -833,6 +834,11 @@
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-tracerresolver</artifactId>
                 <version>${opentracing-tracerresolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-jdbc</artifactId>
+                <version>${opentracing-jdbc.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/docs/src/main/asciidoc/opentracing-guide.adoc
+++ b/docs/src/main/asciidoc/opentracing-guide.adoc
@@ -137,3 +137,33 @@ Then visit the http://localhost:16686[Jaeger UI] to see the tracing information.
 
 
 Hit `CTRL+C` to stop the application.
+
+== Additional tracers
+
+The https://github.com/opentracing-contrib[OpenTracing API Contributions project] offers additional tracers that can be used to add tracing to a large variety of technologies/components.
+
+The tracers documented in the following section has been tested with Quarkus and works in both standard and native mode.
+
+=== JDBC Tracer
+
+The https://github.com/opentracing-contrib/java-jdbc[JDBC tracer] will add a span for each JDBC queries done by your application, to enable it, add the following dependency to your pom.xml:
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-jdbc</artifactId>
+</dependency>
+----
+
+As it uses a dedicated JDBC driver, you must configure your datasource and Hibernate to use it.
+
+[source, properties]
+----
+# add ':tracing' to your database URL
+quarkus.datasource.url=jdbc:tracing:postgresql://localhost:5432/mydatabase
+# use the 'TracingDriver' instead of the one for your database
+quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
+# configure Hibernate dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
+----


### PR DESCRIPTION
Fixes #3946

Note that the version defined in the pom.xml is an old one because Quarkus uses opentracing version 0.31 and most recent version of the jdbc sampler uses version 0.33.