### PR TITLE
Let users select the parsers in TikaConfiguration

### DIFF
--- a/docs/src/main/asciidoc/tika-guide.adoc
+++ b/docs/src/main/asciidoc/tika-guide.adoc
@@ -16,7 +16,8 @@ https://tika.apache.org/[Apache Tika] is a content analysis toolkit which is use
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.tika.tika-config-path||Path to the https://tika.apache.org/1.22/configuring.html[Tika configuration] resource. Typically a file named `tika-config.xml` is added to the root of the application resources path. The default configuration will be used if no configuration resource is available. 
+|quarkus.tika.tika-config-path||The resource path within the application artifact to the https://tika.apache.org/1.22/configuring.html[Tika configuration] resource. Typically a file named `tika-config.xml` is added to the root of the application resources path. The default configuration will be used if no configuration resource is available.
+|quarkus.tika.parsers||Comma-separated list of the abbreviated or full parser class names which have to be loaded by the extension. A `pdf` abbreviation can be used to refer to the PDF parser and custom abbreviations must be used for all other parsers. Note that this property is mutually exclusive with the `tika-config-path` property. 
 |quarkus.tika.append-embedded-content|true|The document may have other embedded documents, for example, an Excel document may include a PDF content. If such an embedded content is available then, by default, it will be appended to the content of the master document, thus, in this example, the text extracted from PDF file will be appended to the text extracted from the Excel file. This property has to be set to `false` if one needs to access the content of the master and each of the embedded documents individually.  
 |===
 

--- a/extensions/tika/deployment/pom.xml
+++ b/extensions/tika/deployment/pom.xml
@@ -30,11 +30,6 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TestConfigSource.java
+++ b/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TestConfigSource.java
@@ -1,0 +1,24 @@
+package io.quarkus.tika.deployment;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class TestConfigSource implements ConfigSource {
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.singletonMap("opendoc", "org.apache.tika.parser.odf.OpenDocumentParser");
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return getProperties().get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return "test-source";
+    }
+}

--- a/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
+++ b/extensions/tika/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.tika.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class TikaProcessorTest {
+
+    @Test
+    public void testSupportedParserNames() throws Exception {
+        Optional<String> parserNames = Optional.of("pdf");
+        List<String> names = TikaProcessor.getSupportedParserNames(parserNames);
+        assertEquals(1, names.size());
+        assertEquals("org.apache.tika.parser.pdf.PDFParser", names.get(0));
+    }
+
+    @Test
+    public void testResolvableCustomAbbreviation() throws Exception {
+        Optional<String> parserNames = Optional.of("pdf,opendoc");
+        List<String> names = TikaProcessor.getSupportedParserNames(parserNames);
+        assertEquals(2, names.size());
+        assertTrue(names.contains("org.apache.tika.parser.pdf.PDFParser"));
+        assertTrue(names.contains("org.apache.tika.parser.odf.OpenDocumentParser"));
+    }
+
+    @Test
+    public void testUnresolvableCustomAbbreviation() throws Exception {
+        Optional<String> parserNames = Optional.of("classparser");
+        try {
+            TikaProcessor.getSupportedParserNames(parserNames);
+            fail("'classparser' is not resolvable");
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testAllSupportedParserNames() throws Exception {
+        Optional<String> parserNames = Optional.ofNullable(null);
+        List<String> names = TikaProcessor.getSupportedParserNames(parserNames);
+        assertEquals(68, names.size());
+    }
+}

--- a/extensions/tika/deployment/src/test/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/extensions/tika/deployment/src/test/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+io.quarkus.tika.deployment.TestConfigSource

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaConfiguration.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/TikaConfiguration.java
@@ -12,10 +12,36 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class TikaConfiguration {
     /**
-     * The path to the tika-config.xml
+     * The resource path within the application artifact to the {@code tika-config.xml} file.
      */
     @ConfigItem
     public Optional<String> tikaConfigPath;
+
+    /**
+     * Comma separated list of the parsers which must be supported.
+     * <p>
+     * Most of the document formats recognized by Apache Tika are supported by default but it affects
+     * the application memory and native executable sizes. One can list only the required parsers in
+     * {@code tika-config.xml} to minimize a number of parsers loaded into the memory, but using this
+     * property is recommended to achieve both optimizations.
+     * <p>
+     * Either the abbreviated or full parser class names can be used.
+     * At the moment only PDF parser can be listed using a reserved 'pdf' abbreviation.
+     * Custom class name abbreviations have to be used for all other parsers.
+     * For example:
+     * 
+     * <pre>
+     * // Only PDF parser is required:
+     * tika-parsers = pdf
+     * // Only PDF and Java class parsers are required:
+     * tika-parsers = pdf,classparser
+     * classparser = org.apache.tika.parser.asm.ClassParser
+     * </pre>
+     * 
+     * This property will have no effect if the `tikaConfigPath' property has been set.
+     */
+    @ConfigItem
+    public Optional<String> parsers;
 
     /**
      * Controls how the content of the embedded documents is parsed.


### PR DESCRIPTION
This PR introduces a way for the users to select specific Tika parsers in the configuration, using a new `quarkus.tika.parsers` property.

At the moment the only way to select the specific parsers that will be loaded is to list them in `tika-config.xml` - however it does not affect the native image size which, by default, in a simple demo with resteasy and tika, is `96MB`.
Using the new property saves, when only PDF is required, `42MB`.

I've spent a lot of time trying to ensure that the same is achievable for `tika-config.xml` but if I load `TikaConfig` in the recorder then I can not access it at the build step point where the parser providers are added for the introspection and vice versa, if I load `TikaConfig` in the processor then the loaded instance can not be passed to the recorder.  May be it is achievable but after a while I've decided that trying to make a `tika-config.xml` way of configuring this extension a 1st class citizen is wrong anyway, and using the new property is the way to go as it paves the way for configuring the parsers directly in the application properties which is preferred in Quarkus and as have been advised by few colleagues already.

For example:
```
quarkus.tika.parsers=pdf
# This is not possible yet because TikaConfig can't load the parameters without their type specified and it is only possible at the moment with tika-config.xml.
I've opened a new Tika issue and once it is fixed the following will work 
quarkus.tika.parsers.pdf.property1=value
``` 