### PR TITLE
Upgrade Gradle version to 5.6.2

### DIFF
--- a/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/devtools/gradle/gradlew
+++ b/devtools/gradle/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`


### PR DESCRIPTION
Version `5.6` fixes a critical CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-15052

The full release note is available here: https://docs.gradle.org/5.6/release-notes.html

The `gradle-wrapper.jar` file didn't change between `5.5.1` and `5.6.2` so it is not affected by this PR ([see wrappers checksum](https://gradle.org/release-checksums/)).

I'll also submit a `quarkus-quickstarts` PR shortly.