### PR TITLE
Ensure default constructor for RESTEasy Resources also works for Kotlin code

### DIFF
--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -406,6 +406,7 @@ public class ResteasyServerCommonProcessor {
 
         final Set<String> allowedAnnotationPrefixes = new HashSet<>(1 + additionalJaxRsResourceDefiningAnnotations.size());
         allowedAnnotationPrefixes.add(packageName(ResteasyDotNames.PATH));
+        allowedAnnotationPrefixes.add("kotlin"); // make sure the annotation that the Kotlin compiler adds don't interfere with creating a default constructor
         for (AdditionalJaxRsResourceDefiningAnnotationBuildItem additionalJaxRsResourceDefiningAnnotation : additionalJaxRsResourceDefiningAnnotations) {
             final String packageName = packageName(additionalJaxRsResourceDefiningAnnotation.getAnnotationClass());
             if (packageName != null) {


### PR DESCRIPTION
This is needed because Kotlin adds `@kotlin.Metadata` annotation to the generated bytecode.

Based on [this](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/JAX-RS.2C.20Kotlin.20and.20constructor.20injection/near/175741440) conversation.
