### PR TITLE
fix: stop color mode on windows cmd/powershell

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime.logging;
 
+import java.util.Optional;
 import java.util.logging.Level;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -29,10 +30,11 @@ public class ConsoleConfig {
     Level level;
 
     /**
-     * If the console logging should be in color
+     * If the console logging should be in color. If undefined quarkus takes
+     * best guess based on operating system and environment.
      */
-    @ConfigItem(defaultValue = "true")
-    boolean color;
+    @ConfigItem()
+    Optional<Boolean> color;
 
     /**
      * Specify how much the colors should be darkened

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -7,6 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.ErrorManager;
@@ -35,6 +36,25 @@ import io.quarkus.runtime.annotations.Recorder;
  */
 @Recorder
 public class LoggingSetupRecorder {
+
+    static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+
+    /**
+     * <a href="https://conemu.github.io">ConEmu</a> ANSI X3.64 support enabled,
+     * used by <a href="https://cmder.net/">cmder</a>
+     */
+    static final boolean IS_CON_EMU_ANSI = "ON".equals(System.getenv("ConEmuANSI"));
+
+    static final boolean IS_CYGWIN = IS_WINDOWS
+            && System.getenv("PWD") != null
+            && System.getenv("PWD").startsWith("/")
+            && !"cygwin".equals(System.getenv("TERM"));
+
+    static final boolean IS_MINGW_XTERM = IS_WINDOWS
+            && System.getenv("MSYSTEM") != null
+            && System.getenv("MSYSTEM").startsWith("MINGW")
+            && "xterm".equals(System.getenv("TERM"));
+
     public LoggingSetupRecorder() {
     }
 
@@ -73,10 +93,29 @@ public class LoggingSetupRecorder {
         InitialConfigurator.DELAYED_HANDLER.setHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
     }
 
+    private boolean workingConsole() {
+        if (System.console() != null) {
+            if (IS_WINDOWS && !(IS_CON_EMU_ANSI || IS_CYGWIN || IS_MINGW_XTERM)) {
+                // On Windows without a known good emulator
+                // TODO: optimally we would check if Win32 getConsoleMode has
+                // ENABLE_VIRTUAL_TERMINAL_PROCESSING enabled or enable it via 
+                // setConsoleMode.
+                // For now we turn it off to not generate noisy output for most
+                // users.
+                return false;
+            } else {
+                // Must be on some Unix variant or ANSI-enabled windows terminal...
+                return true;
+            }
+        } else {
+            return false;
+        }
+    }
+
     private ErrorManager configureConsoleHandler(ConsoleConfig config, ErrorManager errorManager,
             List<LogCleanupFilterElement> filterElements, ArrayList<Handler> handlers) {
         final PatternFormatter formatter;
-        if (config.color && System.console() != null) {
+        if (config.color && workingConsole()) {
             formatter = new ColorPatternFormatter(config.darken, config.format);
         } else {
             formatter = new PatternFormatter(config.format);

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -93,7 +93,8 @@ public class LoggingSetupRecorder {
         InitialConfigurator.DELAYED_HANDLER.setHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
     }
 
-    private boolean workingConsole() {
+    private boolean hasColorSupport() {
+
         if (System.console() != null) {
             if (IS_WINDOWS && !(IS_CON_EMU_ANSI || IS_CYGWIN || IS_MINGW_XTERM)) {
                 // On Windows without a known good emulator
@@ -115,7 +116,7 @@ public class LoggingSetupRecorder {
     private ErrorManager configureConsoleHandler(ConsoleConfig config, ErrorManager errorManager,
             List<LogCleanupFilterElement> filterElements, ArrayList<Handler> handlers) {
         final PatternFormatter formatter;
-        if (config.color && workingConsole()) {
+        if (config.color && hasColorSupport()) {
             formatter = new ColorPatternFormatter(config.darken, config.format);
         } else {
             formatter = new PatternFormatter(config.format);

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -43,7 +43,7 @@ public class LoggingSetupRecorder {
      * <a href="https://conemu.github.io">ConEmu</a> ANSI X3.64 support enabled,
      * used by <a href="https://cmder.net/">cmder</a>
      */
-    static final boolean IS_CON_EMU_ANSI = "ON".equals(System.getenv("ConEmuANSI"));
+    static final boolean IS_CON_EMU_ANSI = IS_WINDOWS && "ON".equals(System.getenv("ConEmuANSI"));
 
     /**
      * These tests are same as used in jansi
@@ -122,7 +122,7 @@ public class LoggingSetupRecorder {
     private ErrorManager configureConsoleHandler(ConsoleConfig config, ErrorManager errorManager,
             List<LogCleanupFilterElement> filterElements, ArrayList<Handler> handlers) {
         final PatternFormatter formatter;
-        if (config.color && hasColorSupport()) {
+        if (config.color.orElse(hasColorSupport())) {
             formatter = new ColorPatternFormatter(config.darken, config.format);
         } else {
             formatter = new PatternFormatter(config.format);

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -45,6 +45,10 @@ public class LoggingSetupRecorder {
      */
     static final boolean IS_CON_EMU_ANSI = "ON".equals(System.getenv("ConEmuANSI"));
 
+    /**
+     * These tests are same as used in jansi
+     * Source: https://github.com/fusesource/jansi/commit/bb3d538315c44f799d34fd3426f6c91c8e8dfc55
+     */
     static final boolean IS_CYGWIN = IS_WINDOWS
             && System.getenv("PWD") != null
             && System.getenv("PWD").startsWith("/")
@@ -95,8 +99,8 @@ public class LoggingSetupRecorder {
 
     private boolean hasColorSupport() {
 
-        if (System.console() != null) {
-            if (IS_WINDOWS && !(IS_CON_EMU_ANSI || IS_CYGWIN || IS_MINGW_XTERM)) {
+        if (IS_WINDOWS) {
+            if (!(IS_CON_EMU_ANSI || IS_CYGWIN || IS_MINGW_XTERM)) {
                 // On Windows without a known good emulator
                 // TODO: optimally we would check if Win32 getConsoleMode has
                 // ENABLE_VIRTUAL_TERMINAL_PROCESSING enabled or enable it via 
@@ -109,7 +113,9 @@ public class LoggingSetupRecorder {
                 return true;
             }
         } else {
-            return false;
+            // on sane operating systems having a console is a good indicator
+            // you are attached to a TTY with colors.
+            return System.console() != null;
         }
     }
 


### PR DESCRIPTION
Why:

 * by default ANSI colors are not enabled for cmd/powershell
   on Windows 10 machines so users will by default get garbled output.

This change addreses the need by:

 * Detect when running on Windows and NOT in known working windows
   emulators and there not enable colors.

Solves #1029