### PR TITLE
Update of REST Assured to 4.1.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -109,7 +109,7 @@
         <mariadb-jdbc.version>2.4.3</mariadb-jdbc.version>
         <mssql-jdbc.version>7.2.1.jre8</mssql-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
-        <rest-assured.version>3.3.0</rest-assured.version>
+        <rest-assured.version>4.1.1</rest-assured.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
         <assertj.version>3.13.2</assertj.version>
         <json-smart.version>2.3</json-smart.version>
@@ -137,7 +137,7 @@
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
-        <awaitility.version>3.1.6</awaitility.version>
+        <awaitility.version>4.0.1</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
         <jboss-logmanager.version>1.0.3</jboss-logmanager.version>
         <jgit.version>5.4.3.201909031940-r</jgit.version>

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RestEasyDevModeTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RestEasyDevModeTestCase.java
@@ -30,7 +30,7 @@ public class RestEasyDevModeTestCase {
                 .when()
                 .post("/post")
                 .then()
-                .content(Matchers.equalTo("Hello: Stuart"));
+                .body(Matchers.equalTo("Hello: Stuart"));
         test.modifySourceFile(PostResource.class, new Function<String, String>() {
             @Override
             public String apply(String s) {
@@ -41,6 +41,6 @@ public class RestEasyDevModeTestCase {
                 .when()
                 .post("/post")
                 .then()
-                .content(Matchers.equalTo("Hi: Stuart"));
+                .body(Matchers.equalTo("Hi: Stuart"));
     }
 }

--- a/integration-tests/maven/src/it/setup-on-existing-pom-it/pom.xml
+++ b/integration-tests/maven/src/it/setup-on-existing-pom-it/pom.xml
@@ -23,9 +23,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/maven/src/it/setup-with-custom-quarkus-version-it/pom.xml
+++ b/integration-tests/maven/src/it/setup-with-custom-quarkus-version-it/pom.xml
@@ -22,9 +22,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -26,10 +26,10 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.mapper.ObjectMapper;
 import io.restassured.mapper.ObjectMapperDeserializationContext;
 import io.restassured.mapper.ObjectMapperSerializationContext;
-import io.restassured.mapper.TypeRef;
 import io.restassured.response.Response;
 
 @QuarkusTest


### PR DESCRIPTION
Limiting JUnit 4 and Hamcrest 1.3 usage
 - update of restassured to 4.1.1
 - update of awaitility to 4.0.1 (awaitility 3.1.6 depends on Hamcrest 1.3)
 - move to JUnit5 in integration-tests/maven/src/it (JUnit 4 depends on Hamcrest 1.3)

Relates to https://github.com/quarkusio/quarkus/issues/3607

JUnit4 is still used in Arc (discussed in https://github.com/quarkusio/quarkus/issues/3607#issuecomment-532646552) and Arquillian extension (ARQ depends on Junit4, https://issues.jboss.org/browse/ARQ-2066)
```
git grep '>junit<'
independent-projects/arc/pom.xml:                <groupId>junit</groupId>
independent-projects/arc/pom.xml:                <artifactId>junit</artifactId>
independent-projects/arc/processor/pom.xml:            <groupId>junit</groupId>
independent-projects/arc/processor/pom.xml:            <artifactId>junit</artifactId>
independent-projects/arc/runtime/pom.xml:            <groupId>junit</groupId>
independent-projects/arc/runtime/pom.xml:            <artifactId>junit</artifactId>
independent-projects/arc/tests/pom.xml:            <groupId>junit</groupId>
independent-projects/arc/tests/pom.xml:            <artifactId>junit</artifactId>
test-framework/arquillian/pom.xml:            <groupId>junit</groupId>
test-framework/arquillian/pom.xml:            <artifactId>junit</artifactId>
```

Hamcrest 1.3 still sneaks in, so having maven-enforcer-plugin rule for org.hamcrest:hamcrest-core is not possible atm.
```
mvn dependency:tree | grep -B 10 hamcrest-core
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.1.1:tree (default-cli) @ arc ---
[INFO] io.quarkus.arc:arc:jar:999-SNAPSHOT
[INFO] +- javax.enterprise:cdi-api:jar:2.0.SP1:compile
[INFO] |  +- javax.el:javax.el-api:jar:3.0.0:compile
[INFO] |  +- javax.interceptor:javax.interceptor-api:jar:1.2:compile
[INFO] |  \- javax.inject:javax.inject:jar:1:compile
[INFO] +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO] |  \- javax.inject:javax.inject:jar:1:compile
[INFO] +- org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
[INFO] +- org.jboss:jandex:jar:2.1.1.Final:compile
[INFO] +- io.quarkus.gizmo:gizmo:jar:1.0.0.Alpha4:compile
[INFO] |  +- org.ow2.asm:asm:jar:7.1:compile
[INFO] |  \- org.ow2.asm:asm-util:jar:7.1:compile
[INFO] |     +- org.ow2.asm:asm-tree:jar:7.1:compile
[INFO] |     \- org.ow2.asm:asm-analysis:jar:7.1:compile
[INFO] +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO]    |  |  \- org.yaml:snakeyaml:jar:1.23:compile
[INFO]    |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.9.3:compile
[INFO]    |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.0:compile
[INFO]    |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.9:compile
[INFO]    |  +- io.fabric8:zjsonpatch:jar:0.3.0:compile
[INFO]    |  \- com.github.mifmif:generex:jar:1.0.2:compile
[INFO]    |     \- dk.brics.automaton:automaton:jar:1.11-8:compile
[INFO]    \- io.fabric8:mockwebserver:jar:0.1.3:compile
[INFO]       +- com.squareup.okhttp3:mockwebserver:jar:3.12.1:compile
[INFO]       |  \- junit:junit:jar:4.12:compile
[INFO]       |     \- org.hamcrest:hamcrest-core:jar:1.3:compile
--
[INFO] +- org.jboss.arquillian.container:arquillian-container-test-impl-base:jar:1.4.1.Final:compile
[INFO] |  \- org.jboss.arquillian.test:arquillian-test-api:jar:1.4.1.Final:compile
[INFO] +- org.jboss.arquillian.junit:arquillian-junit-container:jar:1.4.1.Final:compile (optional)
[INFO] |  +- org.jboss.arquillian.junit:arquillian-junit-core:jar:1.4.1.Final:compile (optional)
[INFO] |  +- org.jboss.arquillian.core:arquillian-core-impl-base:jar:1.4.1.Final:compile (optional)
[INFO] |  +- org.jboss.arquillian.test:arquillian-test-impl-base:jar:1.4.1.Final:compile (optional)
[INFO] |  +- org.jboss.arquillian.container:arquillian-container-impl-base:jar:1.4.1.Final:compile (optional)
[INFO] |  \- org.jboss.shrinkwrap:shrinkwrap-impl-base:jar:1.2.6:compile (optional)
[INFO] |     \- org.jboss.shrinkwrap:shrinkwrap-spi:jar:1.2.6:compile (optional)
[INFO] \- junit:junit:jar:4.12:compile (optional)
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:compile (optional)
--
[INFO] |  +- javax.inject:javax.inject:jar:1:compile
[INFO] |  \- org.apache.commons:commons-lang3:jar:3.8.1:compile
[INFO] +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:compile
[INFO] |  \- org.apache.maven:maven-compat:jar:3.0-alpha-2:compile
[INFO] |     +- org.codehaus.plexus:plexus-container-default:jar:1.0-beta-3.0.5:compile
[INFO] |     |  +- org.apache.xbean:xbean-reflect:jar:3.4:compile
[INFO] |     |  |  +- log4j:log4j:jar:1.2.17:compile
[INFO] |     |  |  \- commons-logging:commons-logging-api:jar:1.1:compile
[INFO] |     |  +- com.google.code.google-collections:google-collect:jar:snapshot-20080530:compile
[INFO] |     |  \- junit:junit:jar:4.12:compile
[INFO] |     |     \- org.hamcrest:hamcrest-core:jar:1.3:compile
--
[INFO] |  |  +- org.apache.maven.wagon:wagon-file:jar:3.0.0:compile
[INFO] |  |  \- org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
[INFO] |  +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:compile
[INFO] |  |  \- org.apache.maven:maven-compat:jar:3.0-alpha-2:compile
[INFO] |  |     +- org.codehaus.plexus:plexus-container-default:jar:1.0-beta-3.0.5:compile
[INFO] |  |     |  +- org.apache.xbean:xbean-reflect:jar:3.4:compile
[INFO] |  |     |  |  +- log4j:log4j:jar:1.2.17:compile
[INFO] |  |     |  |  \- commons-logging:commons-logging-api:jar:1.1:compile
[INFO] |  |     |  +- com.google.code.google-collections:google-collect:jar:snapshot-20080530:compile
[INFO] |  |     |  \- junit:junit:jar:4.12:compile
[INFO] |  |     |     \- org.hamcrest:hamcrest-core:jar:1.3:compile
--
[INFO]    |  |  |  \- org.slf4j:jcl-over-slf4j:jar:1.7.22:test
[INFO]    |  |  \- org.apache.maven.wagon:wagon-file:jar:3.0.0:test
[INFO]    |  +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:test
[INFO]    |  |  \- org.apache.maven:maven-compat:jar:3.0-alpha-2:test
[INFO]    |  |     +- org.codehaus.plexus:plexus-container-default:jar:1.0-beta-3.0.5:test
[INFO]    |  |     |  +- org.apache.xbean:xbean-reflect:jar:3.4:test
[INFO]    |  |     |  |  +- log4j:log4j:jar:1.2.17:test
[INFO]    |  |     |  |  \- commons-logging:commons-logging-api:jar:1.1:test
[INFO]    |  |     |  +- com.google.code.google-collections:google-collect:jar:snapshot-20080530:test
[INFO]    |  |     |  \- junit:junit:jar:4.12:test
[INFO]    |  |     |     \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO] |     +- org.jboss.logging:jboss-logging-annotations:jar:2.1.0.Final:compile
[INFO] |     +- org.jboss.threads:jboss-threads:jar:3.0.0.Final:compile
[INFO] |     +- org.jboss.slf4j:slf4j-jboss-logging:jar:1.2.0.Final:compile
[INFO] |     +- org.graalvm.sdk:graal-sdk:jar:19.2.0:compile
[INFO] |     \- org.wildfly.common:wildfly-common:jar:1.5.0.Final-format-001:compile
[INFO] \- io.quarkus:quarkus-test-kubernetes-client:jar:999-SNAPSHOT:test
[INFO]    \- io.fabric8:kubernetes-server-mock:jar:4.5.1:test
[INFO]       \- io.fabric8:mockwebserver:jar:0.1.3:test
[INFO]          +- com.squareup.okhttp3:mockwebserver:jar:3.12.1:test
[INFO]          |  \- junit:junit:jar:4.12:test
[INFO]          |     \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO] |  +- org.ccil.cowan.tagsoup:tagsoup:jar:1.2.1:test
[INFO] |  +- io.rest-assured:json-path:jar:4.1.1:test
[INFO] |  |  +- org.codehaus.groovy:groovy-json:jar:2.5.6:test
[INFO] |  |  \- io.rest-assured:rest-assured-common:jar:4.1.1:test
[INFO] |  \- io.rest-assured:xml-path:jar:4.1.1:test
[INFO] |     +- org.apache.commons:commons-lang3:jar:3.8.1:test
[INFO] |     +- javax.xml.bind:jaxb-api:jar:2.3.1:compile
[INFO] |     \- org.apache.sling:org.apache.sling.javax.activation:jar:0.1.0:test
[INFO] \- org.arquillian.smart.testing:git-rules:jar:0.0.10:test
[INFO]    +- junit:junit:jar:4.12:test
[INFO]    |  \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO]    |  |  +- org.apache.maven.wagon:wagon-file:jar:3.0.0:test
[INFO]    |  |  \- org.jboss.logging:jboss-logging:jar:3.3.2.Final:test
[INFO]    |  +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:test
[INFO]    |  |  \- org.apache.maven:maven-compat:jar:3.0-alpha-2:test
[INFO]    |  |     +- org.codehaus.plexus:plexus-container-default:jar:1.0-beta-3.0.5:test
[INFO]    |  |     |  +- org.apache.xbean:xbean-reflect:jar:3.4:test
[INFO]    |  |     |  |  +- log4j:log4j:jar:1.2.17:test
[INFO]    |  |     |  |  \- commons-logging:commons-logging-api:jar:1.1:test
[INFO]    |  |     |  +- com.google.code.google-collections:google-collect:jar:snapshot-20080530:test
[INFO]    |  |     |  \- junit:junit:jar:4.12:test
[INFO]    |  |     |     \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO]    |  |  +- org.apache.maven.wagon:wagon-file:jar:3.0.0:test
[INFO]    |  |  \- org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
[INFO]    |  +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:test
[INFO]    |  |  \- org.apache.maven:maven-compat:jar:3.0-alpha-2:test
[INFO]    |  |     +- org.codehaus.plexus:plexus-container-default:jar:1.0-beta-3.0.5:test
[INFO]    |  |     |  +- org.apache.xbean:xbean-reflect:jar:3.4:test
[INFO]    |  |     |  |  +- log4j:log4j:jar:1.2.17:test
[INFO]    |  |     |  |  \- commons-logging:commons-logging-api:jar:1.1:test
[INFO]    |  |     |  +- com.google.code.google-collections:google-collect:jar:snapshot-20080530:test
[INFO]    |  |     |  \- junit:junit:jar:4.12:test
[INFO]    |  |     |     \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO]    |  |  +- org.apache.maven.wagon:wagon-file:jar:3.0.0:test
[INFO]    |  |  \- org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
[INFO]    |  +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:test
[INFO]    |  |  \- org.apache.maven:maven-compat:jar:3.0-alpha-2:test
[INFO]    |  |     +- org.codehaus.plexus:plexus-container-default:jar:1.0-beta-3.0.5:test
[INFO]    |  |     |  +- org.apache.xbean:xbean-reflect:jar:3.4:test
[INFO]    |  |     |  |  +- log4j:log4j:jar:1.2.17:test
[INFO]    |  |     |  |  \- commons-logging:commons-logging-api:jar:1.1:test
[INFO]    |  |     |  +- com.google.code.google-collections:google-collect:jar:snapshot-20080530:test
[INFO]    |  |     |  \- junit:junit:jar:4.12:test
[INFO]    |  |     |     \- org.hamcrest:hamcrest-core:jar:1.3:test
--
[INFO] |  +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] |  \- org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
[INFO] +- io.quarkus.arc:arc-processor:jar:999-SNAPSHOT:compile
[INFO] |  +- org.jboss:jandex:jar:2.1.1.Final:compile
[INFO] |  \- io.quarkus.gizmo:gizmo:jar:1.0.0.Alpha4:compile
[INFO] |     +- org.ow2.asm:asm:jar:7.1:compile
[INFO] |     \- org.ow2.asm:asm-util:jar:7.1:compile
[INFO] |        +- org.ow2.asm:asm-tree:jar:7.1:compile
[INFO] |        \- org.ow2.asm:asm-analysis:jar:7.1:compile
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
```