### PR TITLE
Fix build warnings

### DIFF
--- a/integration-tests/artemis-core/pom.xml
+++ b/integration-tests/artemis-core/pom.xml
@@ -58,7 +58,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${project.groupId}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/artemis-jms/pom.xml
+++ b/integration-tests/artemis-jms/pom.xml
@@ -58,7 +58,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${project.groupId}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/jgit/pom.xml
+++ b/integration-tests/jgit/pom.xml
@@ -58,7 +58,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${project.groupId}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Let's avoid these warnings when building:
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-integration-test-jgit:jar:999-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for ${project.groupId}:quarkus-maven-plugin is missing. @ io.quarkus:quarkus-integration-test-jgit:[unknown-version], /data/home/gsmet/git/quarkus/integration-tests/jgit/pom.xml, line 60, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-integration-test-artemis-core:jar:999-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for ${project.groupId}:quarkus-maven-plugin is missing. @ io.quarkus:quarkus-integration-test-artemis-core:[unknown-version], /data/home/gsmet/git/quarkus/integration-tests/artemis-core/pom.xml, line 60, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-integration-test-artemis-jms:jar:999-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for ${project.groupId}:quarkus-maven-plugin is missing. @ io.quarkus:quarkus-integration-test-artemis-jms:[unknown-version], /data/home/gsmet/git/quarkus/integration-tests/artemis-jms/pom.xml, line 60, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```