### PR TITLE
Fix building Quarkus with JDK 13

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
@@ -86,7 +86,7 @@ public class ModelUtils {
     }
 
     public static AppArtifact resolveAppArtifact(Path appJar) throws IOException {
-        try (FileSystem fs = FileSystems.newFileSystem(appJar, null)) {
+        try (FileSystem fs = FileSystems.newFileSystem(appJar, (ClassLoader) null)) {
             final Path metaInfMaven = fs.getPath("META-INF", "maven");
             if (Files.exists(metaInfMaven)) {
                 try (DirectoryStream<Path> groupIds = Files.newDirectoryStream(metaInfMaven)) {
@@ -114,7 +114,7 @@ public class ModelUtils {
     }
 
     public static Model readAppModel(Path appJar, AppArtifact appArtifact) throws IOException {
-        try (FileSystem fs = FileSystems.newFileSystem(appJar, null)) {
+        try (FileSystem fs = FileSystems.newFileSystem(appJar, (ClassLoader) null)) {
             final Path pomXml = fs.getPath("META-INF", "maven", appArtifact.getGroupId(), appArtifact.getArtifactId(), "pom.xml");
             if(!Files.exists(pomXml)) {
                 throw new IOException("Failed to located META-INF/maven/<groupId>/<artifactId>/pom.xml in " + appJar);
@@ -124,7 +124,7 @@ public class ModelUtils {
     }
 
     static Model readAppModel(Path appJar) throws IOException {
-        try (FileSystem fs = FileSystems.newFileSystem(appJar, null)) {
+        try (FileSystem fs = FileSystems.newFileSystem(appJar, (ClassLoader) null)) {
             final Path metaInfMaven = fs.getPath("META-INF", "maven");
             if (Files.exists(metaInfMaven)) {
                 try (DirectoryStream<Path> groupIds = Files.newDirectoryStream(metaInfMaven)) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
@@ -48,7 +48,7 @@ public class BootstrapUtils {
                 if(Files.isDirectory(p)) {
                     urlStrs = new String[] {urls[0].toExternalForm()};
                 } else {
-                    try (FileSystem fs = FileSystems.newFileSystem(p, null)) {
+                    try (FileSystem fs = FileSystems.newFileSystem(p, (ClassLoader) null)) {
                         Path path = fs.getPath("META-INF/MANIFEST.MF");
                         if (!Files.exists(path)) {
                             throw new IllegalStateException("Failed to locate the manifest");

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/ZipUtils.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/ZipUtils.java
@@ -141,6 +141,6 @@ public class ZipUtils {
      * @throws IOException  in case of a failure
      */
      public static FileSystem newFileSystem(Path path) throws IOException {
-         return FileSystems.newFileSystem(path, null);
+         return FileSystems.newFileSystem(path, (ClassLoader) null);
      }
 }


### PR DESCRIPTION
Wasn't too hard :).

Note: we can't have CI yet as JDK 13 is not available on Azure yet.