### PR TITLE
Replace JSON-B with Jackson for Spring Web

### DIFF
--- a/extensions/spring-web/deployment/pom.xml
+++ b/extensions/spring-web/deployment/pom.xml
@@ -25,15 +25,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonb-deployment</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/spring-web/runtime/pom.xml
+++ b/extensions/spring-web/runtime/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
This is done because Jackson is what Spring users are used. It will
also pave the way to implement #4056 and related features which rely
on Jackson