### PR TITLE
issue#4099 - Show the root cause first in the 500 error page

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/devmode/ReplacementDebugPage.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/devmode/ReplacementDebugPage.java
@@ -20,8 +20,21 @@ public class ReplacementDebugPage {
     }
 
     private static String generateStackTrace(final Throwable exception) {
-        StringWriter stringWriter = new StringWriter();
-        exception.printStackTrace(new PrintWriter(stringWriter));
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter pw = new PrintWriter(stringWriter);
+        // if we have a nested cause, we go all the way to the root cause
+        // and print it first, before printing the whole stacktrace
+        if (exception.getCause() != null) {
+            Throwable rootCause = exception;
+            while (rootCause.getCause() != null) {
+                rootCause = rootCause.getCause();
+            }
+            pw.println("--- (root cause shown first) ---");
+            rootCause.printStackTrace(pw);
+            pw.println();
+            pw.println("--- (complete stacktrace follows) ---");
+        }
+        exception.printStackTrace(pw);
 
         return stringWriter.toString().trim();
     }

--- a/core/deployment/src/test/java/io/quarkus/deployment/devmode/ReplacementDebugPageTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/devmode/ReplacementDebugPageTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.deployment.devmode;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ReplacementDebugPage}
+ */
+public class ReplacementDebugPageTest {
+
+    /**
+     * Test that the stacktrace generated for display in HTML, by {@link ReplacementDebugPage},
+     * shows the root cause (if any) first
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRootCauseStackTraceGeneration() throws Exception {
+        // try with one which doesn't have a root cause
+        final String html1 = ReplacementDebugPage.generateHtml(new Exception("testStackTraceGeneration - simple"));
+        assertNotNull(html1, "HTML wasn't generated");
+        assertFalse(html1.contains("root cause shown first"),
+                "Single level exception wasn't expected to have a nested root cause");
+
+        // now try with one which has nested root cause
+        final Throwable rootNPE = new NullPointerException("intentional NPE");
+        Throwable multiNested = rootNPE;
+        for (int i = 0; i < 10; i++) {
+            multiNested = wrap(multiNested, "Level " + i);
+        }
+        final String html2 = ReplacementDebugPage.generateHtml(multiNested);
+        assertNotNull(html2, "HTML wasn't generated");
+        assertTrue(html2.contains("root cause shown first"), "Root cause wasn't displayed");
+        assertTrue(html2.contains("complete stacktrace follows"), "Complete stacktrace wasn't displayed");
+    }
+
+    private static Throwable wrap(final Throwable t, final String message) {
+        return new RuntimeException(message, t);
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
@@ -52,8 +52,21 @@ public class QuarkusErrorServlet extends HttpServlet {
     }
 
     private static String generateStackTrace(final Throwable exception) {
-        StringWriter stringWriter = new StringWriter();
-        exception.printStackTrace(new PrintWriter(stringWriter));
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter pw = new PrintWriter(stringWriter);
+        // if we have a nested cause, we go all the way to the root cause
+        // and print it first, before printing the whole stacktrace
+        if (exception.getCause() != null) {
+            Throwable rootCause = exception;
+            while (rootCause.getCause() != null) {
+                rootCause = rootCause.getCause();
+            }
+            pw.println("--- (root cause shown first) ---");
+            rootCause.printStackTrace(pw);
+            pw.println();
+            pw.println("--- (complete stacktrace follows) ---");
+        }
+        exception.printStackTrace(pw);
 
         return escapeHtml(stringWriter.toString().trim());
     }


### PR DESCRIPTION
The commit here implements the idea suggested in https://github.com/quarkusio/quarkus/issues/4099. With this change, the generated HTML will show the root cause first (if there is any nested cause), before showin the complete stacktrace.

One such sample of the HTML (generated from the testcase included in this PR) will look like https://gist.github.com/jaikiran/67264f3c22964c02b0c34e47a3692739. The root cause is displayed first https://gist.github.com/jaikiran/67264f3c22964c02b0c34e47a3692739#file-error-page-with-root-cause-html-L105 followed by the complete nested stacktrace https://gist.github.com/jaikiran/67264f3c22964c02b0c34e47a3692739#file-error-page-with-root-cause-html-L172

FWIW - I didn't make this configurable since I don't think the configuration will add much value, since what we are doing here is just changing the way we display/present content on (the default) error page.