### PR TITLE
Fully convert Arc to JUnit 5.

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -89,14 +89,7 @@
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${version.junit5}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
+                <artifactId>junit-jupiter</artifactId>
                 <version>${version.junit5}</version>
                 <scope>test</scope>
             </dependency>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -37,7 +37,7 @@
         <!-- Versions -->
         <version.cdi>2.0.SP1</version.cdi>
         <version.jandex>2.1.1.Final</version.jandex>
-        <version.junit4>4.12</version.junit4>
+        <version.junit5>5.5.2</version.junit5>
         <version.maven>3.5.2</version.maven>
         <version.assertj>3.12.2</version.assertj>
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
@@ -88,9 +88,16 @@
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit4}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${version.junit5}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${version.junit5}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -47,8 +47,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -48,12 +48,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
@@ -2,7 +2,8 @@ package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.Basics.index;
 import static io.quarkus.arc.processor.Basics.name;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.quarkus.arc.processor.types.Bar;
 import io.quarkus.arc.processor.types.Foo;
@@ -19,8 +20,7 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -66,7 +66,7 @@ public class BeanInfoInjectionsTest {
                 assertEquals(listStringType, injection.injectionPoints.get(1).getRequiredType());
                 assertEquals(fooType, injection.injectionPoints.get(0).getRequiredType());
             } else {
-                Assert.fail();
+                fail();
             }
 
         }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
@@ -2,8 +2,8 @@ package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.Basics.index;
 import static io.quarkus.arc.processor.Basics.name;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.processor.types.Bar;
 import io.quarkus.arc.processor.types.Foo;
@@ -15,7 +15,7 @@ import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
@@ -2,8 +2,8 @@ package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.Basics.index;
 import static io.quarkus.arc.processor.Basics.name;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.processor.types.Bar;
 import io.quarkus.arc.processor.types.Foo;
@@ -20,7 +20,7 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/DotNamesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/DotNamesTest.java
@@ -1,20 +1,22 @@
 package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.Basics.index;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.processor.DotNamesTest.Nested.NestedNested;
 import java.io.IOException;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DotNamesTest {
 
     @Test
     public void testSimpleName() throws IOException {
         Index index = index(Nested.class, NestedNested.class, DotNamesTest.class);
-        assertEquals("Nested", DotNames.simpleName(index.getClassByName(DotName.createSimple(Nested.class.getName()))));
+        Assertions.assertEquals("Nested",
+                DotNames.simpleName(index.getClassByName(DotName.createSimple(Nested.class.getName()))));
         assertEquals("DotNamesTest$Nested",
                 DotNames.simpleName(index.getClassByName(DotName.createSimple(Nested.class.getName())).name()));
         assertEquals("NestedNested",

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/MethodUtilsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/MethodUtilsTest.java
@@ -13,8 +13,8 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -26,7 +26,7 @@ public class MethodUtilsTest {
 
     private Index index;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         index = index(SomeClass.class, SuperClass.class, SuperSuperClass.class, TheRoot.class);
     }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.processor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -15,7 +15,7 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.jandex.TypeVariable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TypesTest {
 

--- a/independent-projects/arc/runtime/pom.xml
+++ b/independent-projects/arc/runtime/pom.xml
@@ -28,12 +28,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/runtime/pom.xml
+++ b/independent-projects/arc/runtime/pom.xml
@@ -27,8 +27,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -31,8 +31,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -32,12 +32,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/AlternativesPriorityTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/AlternativesPriorityTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.alternatives;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -11,13 +11,14 @@ import javax.enterprise.inject.Produces;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AlternativesPriorityTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(Alpha.class, Bravo.class, Charlie.class, Consumer.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Alpha.class, Bravo.class, Charlie.class,
+            Consumer.class);
 
     @SuppressWarnings("serial")
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/AlternativesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/AlternativesTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.alternatives;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -10,12 +10,12 @@ import javax.enterprise.inject.Alternative;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AlternativesTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Alpha.class, Bravo.class, Charlie.class);
 
     @SuppressWarnings("serial")

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerEventTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerEventTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.beanmanager;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -8,12 +8,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeanManager;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanManagerEventTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(StringObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerInstanceTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.beanmanager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -9,12 +9,12 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanManager;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanManagerInstanceTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(FuuService.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
@@ -3,10 +3,10 @@ package io.quarkus.arc.test.beanmanager;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
@@ -42,12 +42,12 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InterceptorBinding;
 import javax.interceptor.InvocationContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanManagerTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Legacy.class, AlternativeLegacy.class, Fool.class,
             DummyInterceptor.class, DummyBinding.class,
             LowPriorityInterceptor.class, WithInjectionPointMetadata.class);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/annotations/AddObservesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/annotations/AddObservesTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.build.extension.annotations;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.processor.AnnotationsTransformer;
@@ -14,12 +14,12 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AddObservesTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder().beanClasses(IWantToObserve.class)
             .annotationsTransformers(new AnnotationsTransformer() {
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/annotations/AnnotationsTransformerInterceptorBindingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/annotations/AnnotationsTransformerInterceptorBindingTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.build.extension.annotations;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import org.jboss.jandex.AnnotationTarget.Kind;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AnnotationsTransformerInterceptorBindingTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(IWantToBeIntercepted.class, Simple.class, SimpleInterceptor.class)
             .annotationsTransformers(new SimpleTransformer())

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/annotations/AnnotationsTransformerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/annotations/AnnotationsTransformerTest.java
@@ -1,9 +1,9 @@
 package io.quarkus.arc.test.build.extension.annotations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -16,13 +16,14 @@ import javax.enterprise.inject.Vetoed;
 import javax.inject.Inject;
 import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.DotName;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AnnotationsTransformerTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Seven.class, One.class, IWantToBeABean.class)
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Seven.class, One.class, IWantToBeABean.class)
             .annotationsTransformers(new MyTransformer(), new DisabledTransformer()).build();
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/beans/BeanRegistrarTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/beans/BeanRegistrarTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.build.extension.beans;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.BeanCreator;
@@ -13,12 +13,12 @@ import io.quarkus.gizmo.ResultHandle;
 import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanRegistrarTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder().beanClasses(UselessBean.class)
             .beanRegistrars(new TestRegistrar()).build();
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/injectionPoints/InjectionPointTransformerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/injectionPoints/InjectionPointTransformerTest.java
@@ -5,6 +5,8 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -25,13 +27,12 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InjectionPointTransformerTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(SimpleProducer.class, SimpleConsumer.class, MyQualifier.class, CasualObserver.class,
                     AnotherQualifier.class)
@@ -41,16 +42,16 @@ public class InjectionPointTransformerTest {
     @Test
     public void testQualifierWasAddedToInjectionPoint() {
         ArcContainer arc = Arc.container();
-        Assert.assertTrue(arc.instance(SimpleConsumer.class).isAvailable());
+        assertTrue(arc.instance(SimpleConsumer.class).isAvailable());
         SimpleConsumer bean = arc.instance(SimpleConsumer.class).get();
-        Assert.assertEquals("foo", bean.getFoo());
-        Assert.assertEquals("bar", bean.getBar());
+        assertEquals("foo", bean.getFoo());
+        assertEquals("bar", bean.getBar());
 
-        Assert.assertTrue(arc.instance(CasualObserver.class).isAvailable());
+        assertTrue(arc.instance(CasualObserver.class).isAvailable());
         Arc.container().beanManager().getEvent().select(Integer.class).fire(42);
         CasualObserver observer = arc.instance(CasualObserver.class).get();
-        Assert.assertEquals("bar", observer.getChangedString());
-        Assert.assertEquals("foo", observer.getUnchangedString());
+        assertEquals("bar", observer.getChangedString());
+        assertEquals("foo", observer.getUnchangedString());
     }
 
     @ApplicationScoped

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/interceptor/bindings/AdditionalInterceptorBindingsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/interceptor/bindings/AdditionalInterceptorBindingsTest.java
@@ -21,13 +21,13 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import org.jboss.jandex.DotName;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AdditionalInterceptorBindingsTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(SomeBean.class, MyInterceptor.class, ToBeBinding.class)
             .interceptorBindingRegistrars(new MyBindingRegistrar())
@@ -35,10 +35,10 @@ public class AdditionalInterceptorBindingsTest {
 
     @Test
     public void testBindingWasRegistered() {
-        Assert.assertTrue(Arc.container().instance(SomeBean.class).isAvailable());
-        Assert.assertFalse(MyInterceptor.INTERCEPTOR_TRIGGERED);
+        Assertions.assertTrue(Arc.container().instance(SomeBean.class).isAvailable());
+        Assertions.assertFalse(MyInterceptor.INTERCEPTOR_TRIGGERED);
         Arc.container().instance(SomeBean.class).get().ping();
-        Assert.assertTrue(MyInterceptor.INTERCEPTOR_TRIGGERED);
+        Assertions.assertTrue(MyInterceptor.INTERCEPTOR_TRIGGERED);
     }
 
     @Inherited

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/validator/BeanDeploymentValidatorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/validator/BeanDeploymentValidatorTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.build.extension.validator;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.BeanCreator;
@@ -19,13 +19,14 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanDeploymentValidatorTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class).beanRegistrars(new TestRegistrar())
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class)
+            .beanRegistrars(new TestRegistrar())
             .beanDeploymentValidators(new TestValidator()).build();
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/builtin/beans/BuiltInBeansAreResolvableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/builtin/beans/BuiltInBeansAreResolvableTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.arc.test.builtin.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.CreationalContextImpl;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -23,25 +27,26 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Qualifier;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BuiltInBeansAreResolvableTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(DummyBean.class, DummyQualifier.class).build();
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(DummyBean.class, DummyQualifier.class)
+            .build();
 
     @Test
     public void testBeanManagerBean() {
         // use dynamic resolution to test it
         Instance<Object> instance = Arc.container().beanManager().createInstance();
         // basic BM is resolvable
-        Assert.assertTrue(instance.select(BeanManager.class).isResolvable());
+        assertTrue(instance.select(BeanManager.class).isResolvable());
         // invoke something on the BM
-        Assert.assertEquals(1, instance.select(BeanManager.class).get().getBeans(DummyBean.class).size());
+        assertEquals(1, instance.select(BeanManager.class).get().getBeans(DummyBean.class).size());
         // you shouldn't be able to select BM with qualifiers
-        Assert.assertFalse(instance.select(BeanManager.class, new DummyQualifier.Literal()).isResolvable());
+        assertFalse(instance.select(BeanManager.class, new DummyQualifier.Literal()).isResolvable());
     }
 
     @Test
@@ -50,32 +55,32 @@ public class BuiltInBeansAreResolvableTest {
         Instance<Object> instance = Arc.container().beanManager().createInstance();
         // event with no qualifier and raw type
         Instance<Event> rawNoQualifier = instance.select(Event.class);
-        Assert.assertTrue(rawNoQualifier.isResolvable());
+        assertTrue(rawNoQualifier.isResolvable());
         DummyBean.resetCounters();
         rawNoQualifier.get().fire(new Object());
-        Assert.assertEquals(0, DummyBean.noQualifiers);
-        Assert.assertEquals(0, DummyBean.qualifierTimesTriggered);
-        Assert.assertEquals(1, DummyBean.objectTimesTriggered);
+        assertEquals(0, DummyBean.noQualifiers);
+        assertEquals(0, DummyBean.qualifierTimesTriggered);
+        assertEquals(1, DummyBean.objectTimesTriggered);
 
         // event with type and no qualifier
         Instance<Event<String>> typedEventNoQualifier = instance.select(new TypeLiteral<Event<String>>() {
         });
-        Assert.assertTrue(typedEventNoQualifier.isResolvable());
+        assertTrue(typedEventNoQualifier.isResolvable());
         DummyBean.resetCounters();
         typedEventNoQualifier.get().fire("foo");
-        Assert.assertEquals(1, DummyBean.noQualifiers);
-        Assert.assertEquals(0, DummyBean.qualifierTimesTriggered);
-        Assert.assertEquals(1, DummyBean.objectTimesTriggered);
+        assertEquals(1, DummyBean.noQualifiers);
+        assertEquals(0, DummyBean.qualifierTimesTriggered);
+        assertEquals(1, DummyBean.objectTimesTriggered);
 
         // event with type and qualifier
         Instance<Event<String>> typedEventWithQualifier = instance.select(new TypeLiteral<Event<String>>() {
         }, new DummyQualifier.Literal());
-        Assert.assertTrue(typedEventWithQualifier.isResolvable());
+        assertTrue(typedEventWithQualifier.isResolvable());
         DummyBean.resetCounters();
         typedEventWithQualifier.get().fire("foo");
-        Assert.assertEquals(1, DummyBean.noQualifiers);
-        Assert.assertEquals(1, DummyBean.qualifierTimesTriggered);
-        Assert.assertEquals(1, DummyBean.objectTimesTriggered);
+        assertEquals(1, DummyBean.noQualifiers);
+        assertEquals(1, DummyBean.qualifierTimesTriggered);
+        assertEquals(1, DummyBean.objectTimesTriggered);
 
     }
 
@@ -85,13 +90,13 @@ public class BuiltInBeansAreResolvableTest {
 
         // verify all selections have a backing bean
         Set<Bean<?>> instanceBeans = bm.getBeans(Instance.class);
-        Assert.assertEquals(1, instanceBeans.size());
+        assertEquals(1, instanceBeans.size());
         Set<Bean<?>> typedInstanceBeans = bm.getBeans(new TypeLiteral<Instance<DummyBean>>() {
         }.getType());
-        Assert.assertEquals(1, typedInstanceBeans.size());
+        assertEquals(1, typedInstanceBeans.size());
         Set<Bean<?>> typedQualifiedInstanceBean = bm.getBeans(new TypeLiteral<Instance<DummyBean>>() {
         }.getType(), new DummyQualifier.Literal());
-        Assert.assertEquals(1, typedQualifiedInstanceBean.size());
+        assertEquals(1, typedQualifiedInstanceBean.size());
 
         InjectionPoint dummyIp = new InjectionPoint() {
 
@@ -173,12 +178,12 @@ public class BuiltInBeansAreResolvableTest {
 
         Instance<DummyBean> dummyInstance = (Instance<DummyBean>) bm.getInjectableReference(dummyIp,
                 new CreationalContextImpl<>(null));
-        Assert.assertFalse(dummyInstance.isResolvable()); // not resolvable, no qualifier
+        assertFalse(dummyInstance.isResolvable()); // not resolvable, no qualifier
         dummyInstance.select(new DummyQualifier.Literal()).get().ping();
 
         Instance<DummyBean> dummyInstanceWithQualifier = (Instance<DummyBean>) bm.getInjectableReference(dummyIpWithQualifiers,
                 new CreationalContextImpl<>(null));
-        Assert.assertTrue(dummyInstanceWithQualifier.isResolvable()); // resolvable, qualifier is present
+        assertTrue(dummyInstanceWithQualifier.isResolvable()); // resolvable, qualifier is present
         dummyInstanceWithQualifier.get().ping();
     }
 
@@ -218,6 +223,8 @@ public class BuiltInBeansAreResolvableTest {
         }
 
         public void ping() {
-        };
+        }
+
+        ;
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/cdiprovider/CDIProviderTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/cdiprovider/CDIProviderTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.cdiprovider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import java.io.IOException;
@@ -11,13 +11,13 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.CDI;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CDIProviderTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Moo.class);
 
     @Test
@@ -28,7 +28,7 @@ public class CDIProviderTest {
         assertEquals(10, moo.getVal());
     }
 
-    @AfterClass
+    @AfterAll
     public static void unset() {
         assertTrue(Moo.DESTROYED.get());
         try {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/circular/CircularDependenciesChainTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/circular/CircularDependenciesChainTest.java
@@ -1,9 +1,7 @@
 package io.quarkus.arc.test.circular;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -11,11 +9,11 @@ import java.util.Comparator;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CircularDependenciesChainTest {
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(
             Foo.class,
             Bar.class,
@@ -24,8 +22,8 @@ public class CircularDependenciesChainTest {
     @Test
     public void testDependencies() {
         Foo foo = Arc.container().instance(Foo.class).get();
-        assertThat(foo, is(notNullValue(Foo.class)));
-        assertThat(foo.ping(), is("foo is not null"));
+        assertNotNull(foo);
+        assertEquals("foo is not null", foo.ping());
         assertEquals(0, Arc.container().instance(Producing.class).get().getComparator().compare("A", "A"));
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/circular/SelfInjectionWithNormalScopeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/circular/SelfInjectionWithNormalScopeTest.java
@@ -1,18 +1,17 @@
 package io.quarkus.arc.test.circular;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SelfInjectionWithNormalScopeTest {
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(
             AbstractServiceImpl.class,
             ActualServiceImpl.class,
@@ -21,8 +20,8 @@ public class SelfInjectionWithNormalScopeTest {
     @Test
     public void testDependencies() {
         Foo foo = CDI.current().select(Foo.class).get();
-        assertThat(foo, is(notNullValue(Foo.class)));
-        assertThat(foo.ping(), is("pong"));
+        assertNotNull(foo);
+        assertEquals("pong", foo.ping());
     }
 
     static abstract class AbstractServiceImpl {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/ClientProxyGetContextualInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/ClientProxyGetContextualInstanceTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.clientproxy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ClientProxy;
@@ -9,12 +9,12 @@ import io.quarkus.arc.test.ArcTestContainer;
 import java.io.IOException;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ClientProxyGetContextualInstanceTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Moo.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/ProducerClientProxyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/ProducerClientProxyTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.clientproxy;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -10,12 +10,12 @@ import java.util.function.Function;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ProducerClientProxyTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer.class, Product.class, Product2.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/constructor/ClientProxyConstructorGuardTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/constructor/ClientProxyConstructorGuardTest.java
@@ -1,19 +1,19 @@
 package io.quarkus.arc.test.clientproxy.constructor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.test.ArcTestContainer;
 import java.io.IOException;
 import javax.enterprise.context.ApplicationScoped;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ClientProxyConstructorGuardTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Moo.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/toString/ClientProxyToStringDelegatedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/toString/ClientProxyToStringDelegatedTest.java
@@ -2,18 +2,18 @@ package io.quarkus.arc.test.clientproxy.toString;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ClientProxyToStringDelegatedTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Foo.class);
 
     @Test
     public void testToStringIsDelegated() {
         Foo bean = Arc.container().instance(Foo.class).get();
-        Assert.assertFalse(bean.toString().contains("_ClientProxy"));
+        Assertions.assertFalse(bean.toString().contains("_ClientProxy"));
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/application/ApplicationInitializedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/application/ApplicationInitializedTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.contexts.application;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -10,35 +10,24 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.context.Destroyed;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ApplicationInitializedTest {
 
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(new TestRule() {
-        @Override
-        public Statement apply(final Statement base, Description description) {
-            return new Statement() {
-
-                @Override
-                public void evaluate() throws Throwable {
-                    base.evaluate();
-                    assertTrue(Observer.DESTROYED.get());
-                    assertTrue(Observer.BEFORE_DESTROYED.get());
-                }
-            };
-        }
-    }).around(new ArcTestContainer(Observer.class));
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Observer.class);
 
     @Test
     public void testEventWasFired() {
-        Assert.assertTrue(Observer.INITIALIZED.get());
+        assertTrue(Observer.INITIALIZED.get());
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        assertTrue(Observer.DESTROYED.get());
+        assertTrue(Observer.BEFORE_DESTROYED.get());
     }
 
     @Dependent

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/LifecycleEventsWithNoBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/LifecycleEventsWithNoBeanTest.java
@@ -1,20 +1,20 @@
 package io.quarkus.arc.test.contexts.request;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that lifecycle events for request scoped are fired even though no actual request scoped bean exists.
  */
 public class LifecycleEventsWithNoBeanTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(ContextObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/RequestContextTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/RequestContextTest.java
@@ -1,10 +1,10 @@
 package io.quarkus.arc.test.contexts.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -12,13 +12,14 @@ import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.context.control.RequestContextController;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RequestContextTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(Controller.class, ControllerClient.class, ContextObserver.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Controller.class, ControllerClient.class,
+            ContextObserver.class);
 
     @Test
     public void testRequestContext() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/propagation/RequestContextPropagationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/propagation/RequestContextPropagationTest.java
@@ -1,10 +1,10 @@
 package io.quarkus.arc.test.contexts.request.propagation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -12,12 +12,12 @@ import io.quarkus.arc.InjectableContext.ContextState;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ContextNotActiveException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RequestContextPropagationTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(SuperController.class, SuperButton.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultClassBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultClassBeanTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.defaultbean;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.DefaultBean;
@@ -10,12 +10,12 @@ import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DefaultClassBeanTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer.class,
             GreetingBean.class, Hello.class, PingBean.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultProducerFieldTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.defaultbean;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.DefaultBean;
@@ -10,12 +10,12 @@ import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DefaultProducerFieldTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer.class,
             GreetingBean.class, Hello.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/defaultbean/DefaultProducerMethodTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.defaultbean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.DefaultBean;
@@ -9,12 +9,12 @@ import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DefaultProducerMethodTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer1.class, Producer2.class, Producer3.class,
             GreetingBean.class, GreetingService.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/inheritance/ScopeInheritanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/inheritance/ScopeInheritanceTest.java
@@ -17,14 +17,15 @@ import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Stereotype;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ScopeInheritanceTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(SuperBean.class, SubBean.class, RequestScopedSubBean.class,
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(SuperBean.class, SubBean.class,
+            RequestScopedSubBean.class,
             InheritedScopeSubBean.class, JustSomeBeanDefiningAnnotation.class);
 
     @Test
@@ -32,11 +33,11 @@ public class ScopeInheritanceTest {
         // we'll use BM to verify scopes
         BeanManager bm = Arc.container().beanManager();
         Set<Bean<?>> beans = bm.getBeans(RequestScopedSubBean.class);
-        Assert.assertTrue(beans.size() == 1);
-        Assert.assertEquals(RequestScoped.class.getSimpleName(), beans.iterator().next().getScope().getSimpleName());
+        Assertions.assertTrue(beans.size() == 1);
+        Assertions.assertEquals(RequestScoped.class.getSimpleName(), beans.iterator().next().getScope().getSimpleName());
         beans = bm.getBeans(InheritedScopeSubBean.class);
-        Assert.assertTrue(beans.size() == 1);
-        Assert.assertEquals(ApplicationScoped.class.getSimpleName(), beans.iterator().next().getScope().getSimpleName());
+        Assertions.assertTrue(beans.size() == 1);
+        Assertions.assertEquals(ApplicationScoped.class.getSimpleName(), beans.iterator().next().getScope().getSimpleName());
     }
 
     @ApplicationScoped

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/ListJdkElementTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/ListJdkElementTypeTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.injection.assignability;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -10,12 +10,12 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ListJdkElementTypeTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(ListProducer.class, InjectList.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/OptionalAssignabilityTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/OptionalAssignabilityTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.injection.assignability;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -10,12 +10,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class OptionalAssignabilityTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(OptionalProducer.class, InjectOptionals.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/AssignabilityWithGenericsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/AssignabilityWithGenericsTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.injection.assignability.generics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -18,13 +18,14 @@ import javax.enterprise.event.ObservesAsync;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AssignabilityWithGenericsTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(Car.class, Engine.class, PetrolEngine.class, Vehicle.class,
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Car.class, Engine.class, PetrolEngine.class,
+            Vehicle.class,
             StringListConsumer.class, ListConsumer.class, ProducerBean.class, DefinitelyNotBar.class,
             Bar.class, GenericInterface.class, AlmostCompleteBean.class, ActualBean.class,
             BetaFace.class, GammaFace.class, GammaImpl.class, AbstractAlpha.class, AlphaImpl.class,

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/RawTypeAssignabilityTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/RawTypeAssignabilityTest.java
@@ -7,23 +7,23 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.Vetoed;
 import javax.inject.Inject;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RawTypeAssignabilityTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(MyProducer.class, MyConsumer.class, Foo.class);
 
     @Test
     public void testAssignabilityWithRawType() {
         ArcContainer container = Arc.container();
         MyConsumer consumer = container.instance(MyConsumer.class).get();
-        Assert.assertEquals(String.class.toString(), consumer.pingRaw());
-        Assert.assertEquals(String.class.toString(), consumer.pingObject());
-        Assert.assertEquals(Long.class.toString(), consumer.pingLong());
-        Assert.assertEquals(Long.class.toString(), consumer.pingWild());
+        Assertions.assertEquals(String.class.toString(), consumer.pingRaw());
+        Assertions.assertEquals(String.class.toString(), consumer.pingObject());
+        Assertions.assertEquals(Long.class.toString(), consumer.pingLong());
+        Assertions.assertEquals(Long.class.toString(), consumer.pingWild());
     }
 
     @ApplicationScoped

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/MultiInjectConstructorFailureTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/MultiInjectConstructorFailureTest.java
@@ -1,19 +1,19 @@
 package io.quarkus.arc.test.injection.constructornoinject;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MultiInjectConstructorFailureTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(CombineHarvester.class, Head.class)
             .shouldFail()

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/NoArgConstructorTakesPrecedenceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/NoArgConstructorTakesPrecedenceTest.java
@@ -1,16 +1,16 @@
 package io.quarkus.arc.test.injection.constructornoinject;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NoArgConstructorTakesPrecedenceTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(CombineHarvester.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/SingleNonNoArgConstructorInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/SingleNonNoArgConstructorInjectionTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.injection.constructornoinject;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SingleNonNoArgConstructorInjectionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/privateconstructor/PrivateConstructorInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/privateconstructor/PrivateConstructorInjectionTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.injection.privateconstructor;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrivateConstructorInjectionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/privatefield/PrivateFieldInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/privatefield/PrivateFieldInjectionTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.injection.privatefield;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrivateFieldInjectionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/privateinitializer/PrivateInitializerInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/privateinitializer/PrivateInitializerInjectionTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.injection.privateinitializer;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrivateInitializerInjectionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/resource/ResourceInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/resource/ResourceInjectionTest.java
@@ -1,9 +1,9 @@
 package io.quarkus.arc.test.injection.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -38,13 +38,14 @@ import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.metamodel.Metamodel;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ResourceInjectionTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(EEResourceField.class, JpaClient.class)
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(EEResourceField.class, JpaClient.class)
             .resourceReferenceProviders(EntityManagerProvider.class, DummyProvider.class)
             .resourceAnnotations(PersistenceContext.class, Dummy.class).build();
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/superclass/SuperclassInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/superclass/SuperclassInjectionTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.injection.superclass;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -15,13 +15,14 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SuperclassInjectionTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class, SuperCombineHarvester.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class,
+            SuperCombineHarvester.class);
 
     @Test
     public void testSuperclassSamePackage() {
@@ -45,7 +46,7 @@ public class SuperclassInjectionTest {
         ids.add(combineHarvester.getHead3().id);
         ids.add(combineHarvester.getHead4().id);
         ids.add(combineHarvester.head5.id);
-        assertEquals("Wrong number of ids: " + ids, 5, ids.size());
+        assertEquals(5, ids.size(), () -> "Wrong number of ids: " + ids);
     }
 
     @Dependent

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/destroy/InstanceDestroyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/destroy/InstanceDestroyTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.instance.destroy;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -15,12 +15,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InstanceDestroyTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Alpha.class, Washcloth.class, Knight.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/frombean/InstanceFromBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/frombean/InstanceFromBeanTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.instance.frombean;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
@@ -8,12 +8,12 @@ import io.quarkus.arc.test.ArcTestContainer;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InstanceFromBeanTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Alpha.class);
 
     @SuppressWarnings("unchecked")

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/SimpleInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/SimpleInterceptorTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.interceptors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SimpleInterceptorTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Counter.class, SimpleBean.class, Simple.class,
             SimpleInterceptor.class, Logging.class,
             LoggingInterceptor.class, Lifecycle.class, LifecycleInterceptor.class);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructAppliedViaConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructAppliedViaConstructorTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.test.interceptors.aroundconstruct;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -11,14 +12,13 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AroundConstructAppliedViaConstructorTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(MyTransactional.class,
             MyOtherTransactional.class,
             SimpleBean_ConstructorWithInject.class,
@@ -31,7 +31,7 @@ public class AroundConstructAppliedViaConstructorTest {
     public static AtomicBoolean INTERCEPTOR_CALLED = new AtomicBoolean(false);
     public static AtomicBoolean OTHER_INTERCEPTOR_CALLED = new AtomicBoolean(false);
 
-    @Before
+    @BeforeEach
     public void before() {
         INTERCEPTOR_CALLED.set(false);
         OTHER_INTERCEPTOR_CALLED.set(false);
@@ -41,22 +41,22 @@ public class AroundConstructAppliedViaConstructorTest {
     public void testInterception_constructorWithInject() {
         SimpleBean_ConstructorWithInject simpleBean = Arc.container().instance(SimpleBean_ConstructorWithInject.class).get();
         assertNotNull(simpleBean);
-        Assert.assertTrue(INTERCEPTOR_CALLED.get());
+        assertTrue(INTERCEPTOR_CALLED.get());
     }
 
     @Test
     public void testInterception_noArgsConstructor() {
         SimpleBean_NoArgsConstructor simpleBean = Arc.container().instance(SimpleBean_NoArgsConstructor.class).get();
         assertNotNull(simpleBean);
-        Assert.assertTrue(INTERCEPTOR_CALLED.get());
+        assertTrue(INTERCEPTOR_CALLED.get());
     }
 
     @Test
     public void testInterception_twoBindings() {
         SimpleBean_TwoBindings simpleBean = Arc.container().instance(SimpleBean_TwoBindings.class).get();
         assertNotNull(simpleBean);
-        Assert.assertTrue(INTERCEPTOR_CALLED.get());
-        Assert.assertTrue(OTHER_INTERCEPTOR_CALLED.get());
+        assertTrue(INTERCEPTOR_CALLED.get());
+        assertTrue(OTHER_INTERCEPTOR_CALLED.get());
     }
 
     @Dependent

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructReturningObjectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructReturningObjectTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.interceptors.aroundconstruct;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -10,12 +10,12 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AroundConstructReturningObjectTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(MyTransactional.class, SimpleBean.class,
             SimpleInterceptor.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.interceptors.aroundconstruct;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -9,13 +9,13 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AroundConstructTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(MyTransactional.class, SimpleBean.class,
             SimpleInterceptor.class);
 
@@ -25,7 +25,7 @@ public class AroundConstructTest {
     public void testInterception() {
         SimpleBean simpleBean = Arc.container().instance(SimpleBean.class).get();
         assertNotNull(simpleBean);
-        Assert.assertTrue(INTERCEPTOR_CALLED.get());
+        Assertions.assertTrue(INTERCEPTOR_CALLED.get());
     }
 
     @Singleton

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindingdefaultvalue/BindingDefaultValueTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindingdefaultvalue/BindingDefaultValueTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.interceptors.bindingdefaultvalue;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -10,13 +10,14 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BindingDefaultValueTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(MyTransactional.class, SimpleBean.class, AlphaInterceptor.class,
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyTransactional.class, SimpleBean.class,
+            AlphaInterceptor.class,
             BravoInterceptor.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/InvocationContextBindingsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/InvocationContextBindingsTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.interceptors.bindings;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -12,12 +12,12 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InvocationContextBindingsTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Simple.class, MyTransactional.class, SimpleBean.class,
             SimpleInterceptor.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/TransitiveInterceptorBindingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/TransitiveInterceptorBindingTest.java
@@ -2,13 +2,13 @@ package io.quarkus.arc.test.interceptors.bindings.transitive;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TransitiveInterceptorBindingTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(CounterInterceptor.class, SomeAnnotation.class,
             CounterBinding.class, MethodLevelInterceptedBean.class, ClassLevelInterceptedBean.class,
             TwoLevelsDeepClassLevelInterceptedBean.class, AnotherAnnotation.class, NotABinding.class,
@@ -16,10 +16,10 @@ public class TransitiveInterceptorBindingTest {
 
     @Test
     public void testInterceptorsAreInvoked() {
-        Assert.assertTrue(Arc.container().instance(MethodLevelInterceptedBean.class).isAvailable());
-        Assert.assertTrue(Arc.container().instance(ClassLevelInterceptedBean.class).isAvailable());
-        Assert.assertTrue(Arc.container().instance(TwoLevelsDeepClassLevelInterceptedBean.class).isAvailable());
-        Assert.assertTrue(Arc.container().instance(NotInterceptedBean.class).isAvailable());
+        Assertions.assertTrue(Arc.container().instance(MethodLevelInterceptedBean.class).isAvailable());
+        Assertions.assertTrue(Arc.container().instance(ClassLevelInterceptedBean.class).isAvailable());
+        Assertions.assertTrue(Arc.container().instance(TwoLevelsDeepClassLevelInterceptedBean.class).isAvailable());
+        Assertions.assertTrue(Arc.container().instance(NotInterceptedBean.class).isAvailable());
         MethodLevelInterceptedBean methodLevelInterceptedBean = Arc.container().instance(MethodLevelInterceptedBean.class)
                 .get();
         ClassLevelInterceptedBean classLevelInterceptedBean = Arc.container().instance(ClassLevelInterceptedBean.class).get();
@@ -27,27 +27,27 @@ public class TransitiveInterceptorBindingTest {
                 .instance(TwoLevelsDeepClassLevelInterceptedBean.class).get();
         NotInterceptedBean notIntercepted = Arc.container().instance(NotInterceptedBean.class).get();
 
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 0);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 0);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 0);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 0);
         methodLevelInterceptedBean.oneLevelDeepBinding();
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 1);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 1);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 1);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 1);
         methodLevelInterceptedBean.twoLevelsDeepBinding();
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 2);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 2);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 2);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 2);
         classLevelInterceptedBean.ping();
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 3);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 3);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 3);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 3);
         deeperHierarchyBean.ping();
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 4);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 4);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 4);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 4);
         // following two invocations use @NotABinding which should not trigger interception
         notIntercepted.ping();
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 4);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 4);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 4);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 4);
         methodLevelInterceptedBean.shouldNotBeIntercepted();
-        Assert.assertTrue(CounterInterceptor.timesInvoked == 4);
-        Assert.assertTrue(TransitiveCounterInterceptor.timesInvoked == 4);
+        Assertions.assertTrue(CounterInterceptor.timesInvoked == 4);
+        Assertions.assertTrue(TransitiveCounterInterceptor.timesInvoked == 4);
     }
 
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/TransitiveInterceptionWithTransformerApplicationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/TransitiveInterceptionWithTransformerApplicationTest.java
@@ -4,30 +4,30 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.test.ArcTestContainer;
 import org.jboss.jandex.AnnotationTarget;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests transitive interceptor bindings when annotation transformers were applied
  */
 public class TransitiveInterceptionWithTransformerApplicationTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder().beanClasses(PlainBinding.class,
             PlainInterceptor.class, MuchCoolerBinding.class, MuchCoolerInterceptor.class, DummyBean.class)
             .annotationsTransformers(new TransitiveInterceptionWithTransformerApplicationTest.MyTransformer()).build();
 
     @Test
     public void testTransformersAreApplied() {
-        Assert.assertTrue(Arc.container().instance(DummyBean.class).isAvailable());
+        Assertions.assertTrue(Arc.container().instance(DummyBean.class).isAvailable());
         DummyBean bean = Arc.container().instance(DummyBean.class).get();
 
-        Assert.assertTrue(PlainInterceptor.timesInvoked == 0);
-        Assert.assertTrue(MuchCoolerInterceptor.timesInvoked == 0);
+        Assertions.assertTrue(PlainInterceptor.timesInvoked == 0);
+        Assertions.assertTrue(MuchCoolerInterceptor.timesInvoked == 0);
         bean.ping();
-        Assert.assertTrue(PlainInterceptor.timesInvoked == 1);
-        Assert.assertTrue(MuchCoolerInterceptor.timesInvoked == 1);
+        Assertions.assertTrue(PlainInterceptor.timesInvoked == 1);
+        Assertions.assertTrue(MuchCoolerInterceptor.timesInvoked == 1);
     }
 
     static class MyTransformer implements AnnotationsTransformer {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/constructor/SubclassConstructorGuardTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/constructor/SubclassConstructorGuardTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.interceptors.constructor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -11,12 +11,12 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SubclassConstructorGuardTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Simple.class, SimpleBean.class,
             SimpleInterceptor.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/exceptionhandling/InterceptorExceptionHandlingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/exceptionhandling/InterceptorExceptionHandlingTest.java
@@ -1,37 +1,38 @@
 package io.quarkus.arc.test.interceptors.exceptionhandling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.Subclass;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InterceptorExceptionHandlingTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(ExceptionHandlingBean.class,
             ExceptionHandlingInterceptor.class, ExceptionHandlingInterceptorBinding.class);
 
-    @Test(expected = MyDeclaredException.class)
+    @Test
     public void testProperlyThrowsDeclaredExceptions() throws MyDeclaredException {
         ExceptionHandlingBean exceptionHandlingBean = Arc.container().instance(ExceptionHandlingBean.class).get();
 
         assertTrue(exceptionHandlingBean instanceof Subclass);
 
-        exceptionHandlingBean.foo(ExceptionHandlingCase.DECLARED_EXCEPTION);
+        assertThrows(MyDeclaredException.class, () -> exceptionHandlingBean.foo(ExceptionHandlingCase.DECLARED_EXCEPTION));
     }
 
-    @Test(expected = MyRuntimeException.class)
+    @Test
     public void testProperlyThrowsRuntimeExceptions() throws MyDeclaredException {
         ExceptionHandlingBean exceptionHandlingBean = Arc.container().instance(ExceptionHandlingBean.class).get();
 
         assertTrue(exceptionHandlingBean instanceof Subclass);
 
-        exceptionHandlingBean.foo(ExceptionHandlingCase.RUNTIME_EXCEPTION);
+        assertThrows(MyRuntimeException.class, () -> exceptionHandlingBean.foo(ExceptionHandlingCase.RUNTIME_EXCEPTION));
     }
 
     @Test
@@ -51,21 +52,21 @@ public class InterceptorExceptionHandlingTest {
         }
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void testThrowsException() throws Exception {
         ExceptionHandlingBean exceptionHandlingBean = Arc.container().instance(ExceptionHandlingBean.class).get();
 
         assertTrue(exceptionHandlingBean instanceof Subclass);
 
-        exceptionHandlingBean.bar();
+        assertThrows(Exception.class, () -> exceptionHandlingBean.bar());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testThrowsRuntimeException() {
         ExceptionHandlingBean exceptionHandlingBean = Arc.container().instance(ExceptionHandlingBean.class).get();
 
         assertTrue(exceptionHandlingBean instanceof Subclass);
 
-        exceptionHandlingBean.baz();
+        assertThrows(RuntimeException.class, () -> exceptionHandlingBean.baz());
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/intercepted/InterceptedBeanInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/intercepted/InterceptedBeanInjectionTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.interceptors.intercepted;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.Bean;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InterceptedBeanInjectionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Simple.class,
             SimpleInterceptor.class, InterceptedBean.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/privatemethod/PrivateInterceptorMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/privatemethod/PrivateInterceptorMethodTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.interceptors.privatemethod;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -11,13 +11,14 @@ import javax.inject.Singleton;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrivateInterceptorMethodTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(Simple.class, SimpleBean.class, SimpleInterceptor.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Simple.class, SimpleBean.class,
+            SimpleInterceptor.class);
 
     @Test
     public void testInterception() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/selfinvocation/SelfInvocationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/selfinvocation/SelfInvocationTest.java
@@ -1,17 +1,17 @@
 package io.quarkus.arc.test.interceptors.selfinvocation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SelfInvocationTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Nok.class, Ok.class,
             NokInterceptor.class, OkInterceptor.class, InterceptedBean.class, DependentInterceptedBean.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/subclasses/InterceptorSubclassesAreSharedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/subclasses/InterceptorSubclassesAreSharedTest.java
@@ -1,12 +1,12 @@
 package io.quarkus.arc.test.interceptors.subclasses;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.test.ArcTestContainer;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that interceptor instances are shared per bean.
@@ -15,8 +15,9 @@ import org.junit.Test;
  */
 public class InterceptorSubclassesAreSharedTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(MyBinding.class, WeirdInterceptor.class, SomeBean.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBinding.class, WeirdInterceptor.class,
+            SomeBean.class);
 
     @Test
     public void testInterception() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/BeanMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/BeanMetadataTest.java
@@ -1,19 +1,19 @@
 package io.quarkus.arc.test.metadata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.inject.spi.Bean;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanMetadataTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Controller.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.metadata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -21,12 +21,12 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InjectionPointMetadataTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Controller.class, Controlled.class);
 
     @SuppressWarnings({ "unchecked", "rawtypes", "serial" })

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/AmbiguousNameTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/AmbiguousNameTest.java
@@ -1,19 +1,19 @@
 package io.quarkus.arc.test.name;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AmbiguousNameTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(Bravo.class, Alpha.class)
             .shouldFail()

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NameResolutionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NameResolutionTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.name;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -9,12 +9,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NameResolutionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Bravo.class, Alpha.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ParameterizedPayloadTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ParameterizedPayloadTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.observers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -15,12 +15,12 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ParameterizedPayloadTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(ListObserver.class, ListProducer.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/RuntimeClassTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/RuntimeClassTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.observers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -12,12 +12,12 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RuntimeClassTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(NumberProducer.class, NumberObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/SimpleObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/SimpleObserverTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.observers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -12,12 +12,12 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SimpleObserverTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(StringProducer.class, StringObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/async/AsyncObserverExceptionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/async/AsyncObserverExceptionTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.observers.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -22,12 +22,12 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.ObservesAsync;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AsyncObserverExceptionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(StringProducer.class, StringObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/async/AsyncObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/async/AsyncObserverTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.observers.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -21,12 +21,12 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.event.ObservesAsync;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AsyncObserverTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(StringProducer.class, StringObserver.class,
             ThreadNameProvider.class);
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/discovery/ObserverOnClassWithoutBeanDefiningAnnotationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/discovery/ObserverOnClassWithoutBeanDefiningAnnotationTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.observers.discovery;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -8,12 +8,12 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeanManager;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ObserverOnClassWithoutBeanDefiningAnnotationTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(StringObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ifexists/ReceptionIfExistsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ifexists/ReceptionIfExistsTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.observers.ifexists;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -12,14 +12,14 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.event.Reception;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ReceptionIfExistsTest {
 
     static final List<String> EVENTS = new CopyOnWriteArrayList<>();
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(DependentObserver.class, RequestScopedObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/ObserverInheritanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/ObserverInheritanceTest.java
@@ -6,9 +6,9 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import java.lang.annotation.Annotation;
 import javax.enterprise.util.AnnotationLiteral;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -17,8 +17,9 @@ import org.junit.Test;
  */
 public class ObserverInheritanceTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(ObservingBean.THIS.class, EmittingBean.class, ObservingBean.class,
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(ObservingBean.THIS.class, EmittingBean.class,
+            ObservingBean.class,
             ObservingSubBean.class,
             NonObservingSubBean.class);
 
@@ -29,7 +30,7 @@ public class ObserverInheritanceTest {
     EmittingBean emittingBean;
 
     @SuppressWarnings("serial")
-    @Before
+    @BeforeEach
     public void setUp() {
         observingBean = Arc.container().instance(ObservingBean.class, new AnnotationLiteral<ObservingBean.THIS>() {
             @Override

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/injection/SimpleObserverInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/injection/SimpleObserverInjectionTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.observers.injection;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -14,12 +14,12 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SimpleObserverInjectionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Fool.class, StringObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/metadata/EventMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/metadata/EventMetadataTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.observers.metadata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -11,12 +11,12 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class EventMetadataTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(BigDecimalObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/metadata/EventMetadataWrongInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/metadata/EventMetadataWrongInjectionTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.observers.metadata;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.inject.spi.DefinitionException;
@@ -9,13 +9,14 @@ import javax.enterprise.inject.spi.DeploymentException;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class EventMetadataWrongInjectionTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(WrongBean.class).shouldFail().build();
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(WrongBean.class).shouldFail()
+            .build();
 
     @Test
     public void testMetadata() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ordering/ObserverOrderingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ordering/ObserverOrderingTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.observers.ordering;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -14,12 +14,12 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ObserverOrderingTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(StringProducer.class, StringObserver.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/async/AsyncProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/async/AsyncProducerTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.producer.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -13,12 +13,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AsyncProducerTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(LongProducer.class, LongClient.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/dependent/DeclaringBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/dependent/DeclaringBeanTest.java
@@ -1,9 +1,9 @@
 package io.quarkus.arc.test.producer.dependent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -15,13 +15,14 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DeclaringBeanTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(ListProducer.class, StringProducer.class, LongProducer.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(ListProducer.class, StringProducer.class,
+            LongProducer.class);
 
     @SuppressWarnings("serial")
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/discovery/ProducerOnClassWithoutBeanDefiningAnnotationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/discovery/ProducerOnClassWithoutBeanDefiningAnnotationTest.java
@@ -1,17 +1,18 @@
 package io.quarkus.arc.test.producer.discovery;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.inject.Produces;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ProducerOnClassWithoutBeanDefiningAnnotationTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(StringProducerMethod.class, IntegerProducerField.class);
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(StringProducerMethod.class,
+            IntegerProducerField.class);
 
     @Test
     public void testObserver() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/DisposerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/DisposerTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.producer.disposer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -17,30 +17,21 @@ import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DisposerTest {
 
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(new TestRule() {
-        @Override
-        public Statement apply(final Statement base, Description description) {
-            return new Statement() {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(StringProducer.class, LongProducer.class, BigDecimalProducer.class,
+            MyQualifier.class);
 
-                @Override
-                public void evaluate() throws Throwable {
-                    base.evaluate();
-                    assertNotNull(BigDecimalProducer.DISPOSED.get());
-                    assertEquals(1, BigDecimalProducer.DESTROYED.get());
-                }
-            };
-        }
-    }).around(new ArcTestContainer(StringProducer.class, LongProducer.class, BigDecimalProducer.class, MyQualifier.class));
+    @AfterAll
+    public static void afterAll() {
+        assertNotNull(BigDecimalProducer.DISPOSED.get());
+        assertEquals(1, BigDecimalProducer.DESTROYED.get());
+    }
 
     @Test
     public void testDisposers() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/ErasedGenericTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/ErasedGenericTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.producer.generic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -13,14 +13,14 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test for https://github.com/quarkus-project/quarkus/issues/120
  */
 public class ErasedGenericTest {
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(ErasedTypeProducer.class, Claim.class, Target.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/GenericProducerHierarchyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/GenericProducerHierarchyTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.producer.generic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -9,12 +9,12 @@ import java.util.function.Function;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class GenericProducerHierarchyTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Producer.class, Registry.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/IllegalProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/IllegalProducerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.producer.illegal;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -10,12 +10,12 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.IllegalProductException;
 import javax.enterprise.inject.Produces;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class IllegalProducerTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(IllegalProducer.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/ProducerFieldWithInjectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/ProducerFieldWithInjectTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.producer.illegal;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import java.time.temporal.Temporal;
@@ -9,13 +9,14 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ProducerFieldWithInjectTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(IllegalProducer.class).shouldFail().build();
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(IllegalProducer.class).shouldFail()
+            .build();
 
     @Test
     public void testFailure() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/primitive/PrimitiveProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/primitive/PrimitiveProducerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.producer.primitive;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -8,13 +8,14 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrimitiveProducerTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(IntProducer.class, LongProducer.class, StringArrayProducer.class,
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(IntProducer.class, LongProducer.class,
+            StringArrayProducer.class,
             PrimitiveConsumer.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/privatemember/PrivateProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/privatemember/PrivateProducerFieldTest.java
@@ -1,17 +1,17 @@
 package io.quarkus.arc.test.producer.privatemember;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrivateProducerFieldTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(HeadProducer.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/privatemember/PrivateProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/privatemember/PrivateProducerMethodTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.producer.privatemember;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class PrivateProducerMethodTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(HeadProducer.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/RuntimeResolutionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/RuntimeResolutionTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.resolution;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -12,12 +12,12 @@ import java.util.AbstractList;
 import java.util.List;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RuntimeResolutionTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(MyList.class);
 
     @SuppressWarnings("serial")

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/TypedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/TypedTest.java
@@ -1,9 +1,9 @@
 package io.quarkus.arc.test.resolution;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -15,14 +15,14 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.Typed;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TypedTest {
 
     static final AtomicReference<String> EVENT = new AtomicReference<String>();
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyOtherBean.class, Stage.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.stereotypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -13,12 +13,12 @@ import javax.annotation.Priority;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Stereotype;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class StereotypeAlternativeTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(BeAlternative.class, BeAlternativeWithPriority.class,
             NonAlternative.class, IamAlternative.class, NotAtAllAlternative.class, IamAlternativeWithPriority.class,
             ToBeOverridenFoo.class, MockedFoo.class, MockedFooWithExplicitPriority.class, Mock.class);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeInterceptorTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.stereotypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -10,13 +10,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import javax.enterprise.inject.Stereotype;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class StereotypeInterceptorTest {
 
-    @Rule
-    public ArcTestContainer container = new ArcTestContainer(BeIntercepted.class, IamIntercepted.class, SimpleBinding.class,
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(BeIntercepted.class, IamIntercepted.class,
+            SimpleBinding.class,
             SimpleInterceptor.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeNamedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeNamedTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.test.stereotypes;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
@@ -11,12 +11,12 @@ import java.lang.annotation.Target;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Stereotype;
 import javax.inject.Named;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class StereotypeNamedTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(BeNamed.class, IamNamed.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeScopeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeScopeTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.stereotypes;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -11,12 +11,12 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Model;
 import javax.enterprise.inject.Typed;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class StereotypeScopeTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(ModelBean.class, ApplicationModelBean.class);
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.unused;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -20,12 +20,12 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RemoveUnusedBeansTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(HasObserver.class, Foo.class, FooAlternative.class, HasName.class, UnusedProducers.class,
                     InjectedViaInstance.class, InjectedViaProvider.class, Excluded.class, UsedProducers.class,

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/BoundInterceptorFinalTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/BoundInterceptorFinalTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.DeploymentException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BoundInterceptorFinalTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(Unproxyable.class, Simple.class, SimpleInterceptor.class).shouldFail().build();
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/BoundInterceptorPrivateNoArgsConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/BoundInterceptorPrivateNoArgsConstructorTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.DeploymentException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BoundInterceptorPrivateNoArgsConstructorTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(Unproxyable.class, Simple.class, SimpleInterceptor.class).shouldFail().build();
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/ClassBeanMultipleScopesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/ClassBeanMultipleScopesTest.java
@@ -1,18 +1,18 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Singleton;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ClassBeanMultipleScopesTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class).shouldFail().build();
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/NormalScopedConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/NormalScopedConstructorTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
@@ -9,13 +9,14 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Inject;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NormalScopedConstructorTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Unproxyable.class).shouldFail().build();
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Unproxyable.class).shouldFail()
+            .build();
 
     @Test
     public void testFailure() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/NormalScopedFinalTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/NormalScopedFinalTest.java
@@ -1,19 +1,20 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.DeploymentException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NormalScopedFinalTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Unproxyable.class).shouldFail().build();
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Unproxyable.class).shouldFail()
+            .build();
 
     @Test
     public void testFailure() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/NormalScopedPrivateNoArgsConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/NormalScopedPrivateNoArgsConstructorTest.java
@@ -1,19 +1,20 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.DeploymentException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class NormalScopedPrivateNoArgsConstructorTest {
 
-    @Rule
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Unproxyable.class).shouldFail().build();
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Unproxyable.class).shouldFail()
+            .build();
 
     @Test
     public void testFailure() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/ProducerFieldMultipleScopesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/ProducerFieldMultipleScopesTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import java.util.List;
@@ -10,12 +10,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.DefinitionException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ProducerFieldMultipleScopesTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class).shouldFail().build();
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/ProducerMethodMultipleScopesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/ProducerMethodMultipleScopesTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.validation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.test.ArcTestContainer;
 import java.util.List;
@@ -10,12 +10,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.DefinitionException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ProducerMethodMultipleScopesTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class).shouldFail().build();
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/vetoed/VetoedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/vetoed/VetoedTest.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.test.vetoed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -10,12 +10,12 @@ import io.quarkus.arc.test.ArcTestContainer;
 import java.util.AbstractList;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Vetoed;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class VetoedTest {
 
-    @Rule
+    @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Seven.class, One.class);
 
     @Test


### PR DESCRIPTION
There is loads of files since effectively all tests needed some import changes in the least.
The important parts are around `POM`s and then inside `ArcTestContainer` which was transferred from Junit4 rule to Junit5 extension while keeping the functionality.

Fixes #4105 