### PR TITLE
Add native-image.docker-build=true in the native profile

### DIFF
--- a/devtools/common/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
@@ -84,6 +84,9 @@
                     <name>native</name>
                 </property>
             </activation>
+            <properties>
+                <native-image.docker-build>true</native-image.docker-build>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -127,6 +127,9 @@
                     <name>native</name>
                 </property>
             </activation>
+            <properties>
+                <native-image.docker-build>true</native-image.docker-build>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
@@ -128,6 +128,9 @@
                     <name>native</name>
                 </property>
             </activation>
+            <properties>
+                <native-image.docker-build>true</native-image.docker-build>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
That will save developers from having to install GraalVM locally and provide a much nicer user experience when compiling to native (specially because developers wouldn't need to care about upgrading GraalVM everytime a new version is available)

@emmanuelbernard @cescoffier @gsmet WDYT?