### PR TITLE
Fix #4115 Make vertx-web handleFileUploads, uploadsDirectory, bodyLim…

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/BodyConfig.java
@@ -1,0 +1,58 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Request body related settings
+ */
+@ConfigGroup
+public class BodyConfig {
+
+    /**
+     * Whether the files sent using {@code multipart/form-data} will be stored locally.
+     * <p>
+     * If {@code true}, they will be stored in {@code quarkus.http.body-handler.uploads-directory} and will be made
+     * available via {@code io.vertx.ext.web.RoutingContext.fileUploads()}. Otherwise, the the files sent using
+     * {@code multipart/form-data} will not be stored locally, and {@code io.vertx.ext.web.RoutingContext.fileUploads()}
+     * will always return an empty collection. Note that even with this option being set to {@code false}, the
+     * {@code multipart/form-data} requests will be accepted.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean handleFileUploads;
+
+    /**
+     * The directory where the files sent using {@code multipart/form-data} should be stored.
+     * <p>
+     * Either an absolute path or a path relative to the current directory of the application process.
+     */
+    @ConfigItem(defaultValue = "file-uploads")
+    public String uploadsDirectory;
+
+    /**
+     * Whether the form attributes should be added to the request parameters.
+     * <p>
+     * If {@code true}, the form attributes will be added to the request parameters; otherwise the form parameters will
+     * not be added to the request parameters
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean mergeFormAttributes;
+
+    /**
+     * Whether the uploaded files should be removed after serving the request.
+     * <p>
+     * If {@code true} the uploaded files stored in {@code quarkus.http.body-handler.uploads-directory} will be removed
+     * after handling the request. Otherwise the files will be left there forever.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean deleteUploadedFilesOnEnd;
+
+    /**
+     * Whether the body buffer should pre-allocated based on the {@code Content-Length} header value.
+     * <p>
+     * If {@code true} the body buffer is pre-allocated according to the size read from the {@code Content-Length}
+     * header. Otherwise the body buffer is pre-allocated to 1KB, and is resized dynamically
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean preallocateBodyBuffer;
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -80,6 +80,11 @@ public class HttpConfiguration {
      */
     public ServerLimitsConfig limits;
 
+    /**
+     * Request body related settings
+     */
+    public BodyConfig body;
+
     public int determinePort(LaunchMode launchMode) {
         return launchMode == LaunchMode.TEST ? testPort : port;
     }

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/DeleteUploadedFilesOnEndTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/DeleteUploadedFilesOnEndTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.vertx.web;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+
+public class DeleteUploadedFilesOnEndTest {
+    private static final String UPLOADS_DIR = "target/delete-uploaded-files-on-end-" + UUID.randomUUID().toString();
+    private static final byte[] CAFEBABE_BYTES = new byte[] { 0xc, 0xa, 0xf, 0xe, 0xb, 0xa, 0xb, 0xe };
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class).addClasses(Routes.class)
+            .addAsResource(new StringAsset("quarkus.http.body.delete-uploaded-files-on-end = true\n" //
+                    + "quarkus.http.body.handle-file-uploads = true\n" //
+                    + "quarkus.http.body.uploads-directory = " + UPLOADS_DIR + "\n"), "application.properties"));
+
+    @Test
+    public void upload() throws IOException {
+
+        final String cafeBabe = "cafe babe";
+        final String uploadedPath = RestAssured.given().contentType("multipart/form-data")
+                .multiPart("file", "bytes.bin", CAFEBABE_BYTES).formParam("description", cafeBabe)
+                .formParam("echoAttachment", "bytes.bin").post("/vertx-web/upload") //
+                .then().statusCode(200).extract().body().asString();
+        Assertions.assertFalse(uploadedPath.trim().isEmpty());
+        /* Wait up to 5 seconds for the file to disappear */
+        final long deadline = System.currentTimeMillis() + 5000;
+        while (Files.exists(Paths.get(uploadedPath)) && System.currentTimeMillis() < deadline) {
+        }
+        Assertions.assertFalse(Files.exists(Paths.get(uploadedPath)));
+    }
+
+    public static class Routes {
+        @Route(path = "/vertx-web/upload", methods = HttpMethod.POST)
+        void upload(RoutingContext context) throws IOException {
+            final HttpServerResponse response = context.response();
+            response.headers().set("Content-Type", "text/plain");
+            response.setChunked(true);
+            if (context.fileUploads().isEmpty()) {
+                response.setStatusCode(500);
+                response.end("context.fileUploads() should not be empty");
+            }
+
+            for (FileUpload upload : context.fileUploads()) {
+                final Path path = Paths.get(upload.uploadedFileName());
+                final byte[] actualBytes = Files.readAllBytes(path);
+                if (!Arrays.equals(actualBytes, CAFEBABE_BYTES)) {
+                    response.setStatusCode(500);
+                    response.end("Unexpected content in " + upload.uploadedFileName());
+                    return;
+                }
+                response.setStatusCode(200);
+                response.write(upload.uploadedFileName());
+            }
+            response.end();
+        }
+    }
+}

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/DisabledUploadsTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/DisabledUploadsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.vertx.web;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+
+public class DisabledUploadsTest {
+    private static final String UPLOADS_DIR = "target/disabled-uploads-" + UUID.randomUUID().toString();
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Routes.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.body.handle-file-uploads = false\n" //
+                                    + "quarkus.http.body.uploads-directory = " + UPLOADS_DIR + "\n"),
+                            "application.properties"));
+
+    @Test
+    public void upload() throws IOException {
+
+        final byte[] bytes = new byte[] { 0xc, 0xa, 0xf, 0xe, 0xb, 0xa, 0xb, 0xe };
+        final String cafeBabe = "cafe babe";
+        final String uploadedPath = RestAssured.given().contentType("multipart/form-data").multiPart("file", "bytes.bin", bytes)
+                .formParam("description", cafeBabe).formParam("echoAttachment", "bytes.bin")
+                .post("/vertx-web/upload").then().statusCode(200)
+                .extract().body().asString();
+        Assertions.assertTrue(uploadedPath.isEmpty());
+        Assertions.assertTrue(!new File(UPLOADS_DIR).exists());
+    }
+
+    public static class Routes {
+        @Route(path = "/vertx-web/upload", methods = HttpMethod.POST)
+        void upload(RoutingContext context) {
+            context.response().headers().set("Content-Type", "text/plain");
+            context.response().setChunked(true).setStatusCode(200);
+            for (FileUpload upload : context.fileUploads()) {
+                context.response().write(upload.uploadedFileName());
+            }
+            context.response().end();
+        }
+    }
+}

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/UploadsDirectoryTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/UploadsDirectoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.vertx.web;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.FileUpload;
+import io.vertx.ext.web.RoutingContext;
+
+public class UploadsDirectoryTest {
+    private static final String UPLOADS_DIR = "target/test-uploads";
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Routes.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.http.body.uploads-directory = " + UPLOADS_DIR + "\n"),
+                            "application.properties"));
+
+    @Test
+    public void upload() throws IOException {
+        final byte[] bytes = new byte[] { 0xc, 0xa, 0xf, 0xe, 0xb, 0xa, 0xb, 0xe };
+        final String cafeBabe = "cafe babe";
+        final String uploadedPath = RestAssured.given().contentType("multipart/form-data").multiPart("file", "bytes.bin", bytes)
+                .formParam("description", cafeBabe).formParam("echoAttachment", "bytes.bin")
+                .post("/vertx-web/upload").then().statusCode(200)
+                .extract().body().asString();
+        Assertions.assertTrue(uploadedPath.replace('\\', '/').startsWith(UPLOADS_DIR));
+        Assertions.assertArrayEquals(bytes, Files.readAllBytes(Paths.get(uploadedPath)));
+    }
+
+    public static class Routes {
+        @Route(path = "/vertx-web/upload", methods = HttpMethod.POST)
+        void upload(RoutingContext context) {
+            context.response().headers().set("Content-Type", "text/plain");
+            context.response().setChunked(true).setStatusCode(200);
+            for (FileUpload upload : context.fileUploads()) {
+                context.response().write(upload.uploadedFileName());
+            }
+            context.response().end();
+        }
+    }
+}

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.MemorySize;
+import io.quarkus.vertx.http.runtime.BodyConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.RouterProducer;
 import io.quarkus.vertx.web.Route;
@@ -71,6 +72,12 @@ public class VertxWebRecorder {
                 if (maxBodySize.isPresent()) {
                     bodyHandler.setBodyLimit(maxBodySize.get().asLongValue());
                 }
+                final BodyConfig bodyConfig = httpConfiguration.body;
+                bodyHandler.setHandleFileUploads(bodyConfig.handleFileUploads);
+                bodyHandler.setUploadsDirectory(bodyConfig.uploadsDirectory);
+                bodyHandler.setDeleteUploadedFilesOnEnd(bodyConfig.deleteUploadedFilesOnEnd);
+                bodyHandler.setMergeFormAttributes(bodyConfig.mergeFormAttributes);
+                bodyHandler.setPreallocateBodyBuffer(bodyConfig.preallocateBodyBuffer);
 
                 route.handler(bodyHandler);
                 return route;


### PR DESCRIPTION
…it. etc. configurable

@gastaldi @machi1990 you may want to review.

This solves only the vert.x-web use case. I am not sure whether anything needs to be done about Undertow?