### PR TITLE
Unify how Arc attemps to load classes from Index, add logging for missing classes

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByNameNoLogging;
+
 import io.quarkus.arc.ActivateRequestContextInterceptor;
 import io.quarkus.arc.InjectableRequestContextController;
 import java.io.IOException;
@@ -39,7 +41,7 @@ public final class BeanArchives {
     private static final Logger LOGGER = Logger.getLogger(BeanArchives.class);
 
     /**
-     * 
+     *
      * @param applicationIndexes
      * @return the final bean archive index
      */
@@ -98,7 +100,7 @@ public final class BeanArchives {
 
         @Override
         public ClassInfo getClassByName(DotName className) {
-            ClassInfo classInfo = index.getClassByName(className);
+            ClassInfo classInfo = getClassByNameNoLogging(index, className);
             if (classInfo == null) {
                 classInfo = additionalClasses.computeIfAbsent(className, this::computeAdditional).orElse(null);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import io.quarkus.arc.BeanCreator;
 import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -67,7 +69,7 @@ public final class BeanConfigurator<T> {
      */
     BeanConfigurator(DotName implClassName, BeanDeployment beanDeployment, Consumer<BeanInfo> beanConsumer) {
         this.consumed = new AtomicBoolean(false);
-        this.implClass = beanDeployment.getIndex().getClassByName(Objects.requireNonNull(implClassName));
+        this.implClass = getClassByName(beanDeployment.getIndex(), Objects.requireNonNull(implClassName));
         this.beanDeployment = beanDeployment;
         this.beanConsumer = beanConsumer;
         this.types = new HashSet<>();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import static org.objectweb.asm.Opcodes.ACC_BRIDGE;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
@@ -1579,7 +1580,7 @@ public class BeanGenerator extends AbstractGenerator {
                         constructor.readStaticField(FieldDescriptor.of(InjectLiteral.class, "INSTANCE", InjectLiteral.class)));
             } else {
                 // Create annotation literal if needed
-                ClassInfo literalClass = beanDeployment.getIndex().getClassByName(annotation.name());
+                ClassInfo literalClass = getClassByName(beanDeployment.getIndex(), annotation.name());
                 constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotationsHandle,
                         annotationLiterals.process(constructor,
                                 classOutput, literalClass, annotation,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import io.quarkus.arc.processor.BeanDeploymentValidator.ValidationRule;
 import io.quarkus.arc.processor.Methods.MethodKey;
 import io.quarkus.gizmo.MethodCreator;
@@ -451,7 +453,7 @@ public class BeanInfo implements InjectionTargetInfo {
                         && bindings.stream().noneMatch(e -> e.name().equals(a.name())))
                 .forEach(a -> bindings.add(a));
         if (classInfo.superClassType() != null && !classInfo.superClassType().name().equals(DotNames.OBJECT)) {
-            ClassInfo superClass = beanDeployment.getIndex().getClassByName(classInfo.superName());
+            ClassInfo superClass = getClassByName(beanDeployment.getIndex(), classInfo.superName());
             if (superClass != null) {
                 addClassLevelBindings(superClass, bindings);
             }
@@ -538,14 +540,14 @@ public class BeanInfo implements InjectionTargetInfo {
                 Type fieldType = target.asField().type();
                 if (fieldType.kind() != org.jboss.jandex.Type.Kind.PRIMITIVE
                         && fieldType.kind() != org.jboss.jandex.Type.Kind.ARRAY) {
-                    return beanDeployment.getIndex().getClassByName(fieldType.name());
+                    return getClassByName(beanDeployment.getIndex(), fieldType.name());
                 }
                 break;
             case METHOD:
                 Type returnType = target.asMethod().returnType();
                 if (returnType.kind() != org.jboss.jandex.Type.Kind.PRIMITIVE
                         && returnType.kind() != org.jboss.jandex.Type.Kind.ARRAY) {
-                    return beanDeployment.getIndex().getClassByName(returnType.name());
+                    return getClassByName(beanDeployment.getIndex(), returnType.name());
                 }
                 break;
             default:

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import io.quarkus.arc.processor.InjectionPointInfo.TypeAndQualifiers;
 import io.quarkus.arc.processor.InjectionTargetInfo.TargetKind;
 import java.util.ArrayList;
@@ -122,7 +124,7 @@ final class Beans {
     private static ScopeInfo inheritScope(ClassInfo beanClass, BeanDeployment beanDeployment) {
         DotName superClassName = beanClass.superName();
         while (!superClassName.equals(DotNames.OBJECT)) {
-            ClassInfo classFromIndex = beanDeployment.getIndex().getClassByName(superClassName);
+            ClassInfo classFromIndex = getClassByName(beanDeployment.getIndex(), superClassName);
             if (classFromIndex == null) {
                 // class not in index
                 LOGGER.warnf("Unable to determine scope for bean %s using inheritance because its super class " +
@@ -571,7 +573,7 @@ final class Beans {
         }
         if (type.kind() == Type.Kind.CLASS) {
             // Index the class additionally if needed
-            beanDeployment.getIndex().getClassByName(type.name());
+            getClassByName(beanDeployment.getIndex(), type.name());
         } else {
             analyzeType(type, beanDeployment);
         }
@@ -584,7 +586,7 @@ final class Beans {
             }
         }
         if (clazz.superName() != null) {
-            ClassInfo superClass = index.getClassByName(clazz.superName());
+            ClassInfo superClass = getClassByName(index, clazz.superName());
             if (superClass != null) {
                 collectCallbacks(superClass, callbacks, annotation, index);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import io.quarkus.arc.BeanManagerProvider;
 import io.quarkus.arc.BeanMetadataProvider;
 import io.quarkus.arc.EventProvider;
@@ -153,7 +155,7 @@ enum BuiltinBean {
         if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
             for (AnnotationInstance annotation : ctx.injectionPoint.getRequiredQualifiers()) {
                 // Create annotation literal first
-                ClassInfo annotationClass = ctx.beanDeployment.getIndex().getClassByName(annotation.name());
+                ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getIndex(), annotation.name());
                 ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotations,
                         ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
                                 annotationClass, annotation,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
@@ -60,7 +61,7 @@ public class ClientProxyGenerator extends AbstractGenerator {
         ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()));
 
         Type providerType = bean.getProviderType();
-        ClassInfo providerClass = bean.getDeployment().getIndex().getClassByName(providerType.name());
+        ClassInfo providerClass = getClassByName(bean.getDeployment().getIndex(), providerType.name());
         String providerTypeName = providerClass.name().toString();
         String baseName = getBaseName(bean, beanClassName);
         String targetPackage = getPackageName(bean);
@@ -230,11 +231,11 @@ public class ClientProxyGenerator extends AbstractGenerator {
                     methods);
         } else if (bean.isProducerMethod()) {
             MethodInfo producerMethod = bean.getTarget().get().asMethod();
-            ClassInfo returnTypeClass = bean.getDeployment().getIndex().getClassByName(producerMethod.returnType().name());
+            ClassInfo returnTypeClass = getClassByName(bean.getDeployment().getIndex(), producerMethod.returnType().name());
             Methods.addDelegatingMethods(bean.getDeployment().getIndex(), returnTypeClass, methods);
         } else if (bean.isProducerField()) {
             FieldInfo producerField = bean.getTarget().get().asField();
-            ClassInfo fieldClass = bean.getDeployment().getIndex().getClassByName(producerField.type().name());
+            ClassInfo fieldClass = getClassByName(bean.getDeployment().getIndex(), producerField.type().name());
             Methods.addDelegatingMethods(bean.getDeployment().getIndex(), fieldClass, methods);
         } else if (bean.isSynthetic()) {
             Methods.addDelegatingMethods(bean.getDeployment().getIndex(), bean.getImplClazz(), methods);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/IndexClassLookupUtils.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/IndexClassLookupUtils.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.processor;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.logging.Logger;
+
+final class IndexClassLookupUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(IndexClassLookupUtils.class);
+
+    private IndexClassLookupUtils() {
+    }
+
+    static ClassInfo getClassByName(IndexView index, DotName dotName) {
+        return lookupClassInIndex(index, dotName, true);
+    }
+
+    /**
+     * Used by {@code BeanArchives.IndexWrapper#getClassByName()} while gathering additional classes for indexing
+     */
+    static ClassInfo getClassByNameNoLogging(IndexView index, DotName dotName) {
+        return lookupClassInIndex(index, dotName, false);
+    }
+
+    private static ClassInfo lookupClassInIndex(IndexView index, DotName dotName, boolean withLogging) {
+        if (dotName == null) {
+            throw new IllegalArgumentException("Cannot lookup class, provided DotName was null.");
+        }
+        if (index == null) {
+            throw new IllegalArgumentException("Cannot lookup class, provided Jandex Index was null.");
+        }
+        ClassInfo info = index.getClassByName(dotName);
+        if (info == null && withLogging) {
+            // class not in index, log warning as this may cause the application to blow up or behave weirdly
+            LOGGER.info("Class for name: " + dotName + " was not found in Jandex index. Please ensure the class " +
+                    "is part of the index.");
+        }
+        return info;
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -128,7 +130,7 @@ public class Injection {
         }
 
         if (!classInfo.superName().equals(DotNames.OBJECT)) {
-            ClassInfo info = beanDeployment.getIndex().getClassByName(classInfo.superName());
+            ClassInfo info = getClassByName(beanDeployment.getIndex(), classInfo.superName());
             if (info != null) {
                 forClassBean(beanClass, info, beanDeployment, injections, transformer, true);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
@@ -61,7 +62,7 @@ public class InterceptorGenerator extends BeanGenerator {
         } else {
             baseName = DotNames.simpleName(interceptorClass);
         }
-        ClassInfo providerClass = interceptor.getDeployment().getIndex().getClassByName(providerType.name());
+        ClassInfo providerClass = getClassByName(interceptor.getDeployment().getIndex(), providerType.name());
         String providerTypeName = providerClass.name().toString();
         String targetPackage = DotNames.packageName(providerType.name());
         String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,13 +72,13 @@ final class Methods {
             }
             // Interfaces
             for (Type interfaceType : classInfo.interfaceTypes()) {
-                ClassInfo interfaceClassInfo = index.getClassByName(interfaceType.name());
+                ClassInfo interfaceClassInfo = getClassByName(index, interfaceType.name());
                 if (interfaceClassInfo != null) {
                     addDelegatingMethods(index, interfaceClassInfo, methods);
                 }
             }
             if (classInfo.superClassType() != null) {
-                ClassInfo superClassInfo = index.getClassByName(classInfo.superName());
+                ClassInfo superClassInfo = getClassByName(index, classInfo.superName());
                 if (superClassInfo != null) {
                     addDelegatingMethods(index, superClassInfo, methods);
                 }
@@ -145,7 +147,7 @@ final class Methods {
             }
         }
         if (classInfo.superClassType() != null) {
-            ClassInfo superClassInfo = beanDeployment.getIndex().getClassByName(classInfo.superName());
+            ClassInfo superClassInfo = getClassByName(beanDeployment.getIndex(), classInfo.superName());
             if (superClassInfo != null) {
                 addInterceptedMethodCandidates(beanDeployment, superClassInfo, candidates, classLevelBindings);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
@@ -86,7 +87,7 @@ public class SubclassGenerator extends AbstractGenerator {
         ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()));
 
         Type providerType = bean.getProviderType();
-        ClassInfo providerClass = bean.getDeployment().getIndex().getClassByName(providerType.name());
+        ClassInfo providerClass = getClassByName(bean.getDeployment().getIndex(), providerType.name());
         String providerTypeName = providerClass.name().toString();
         String baseName = getBaseName(bean, beanClassName);
         String generatedName = generatedName(providerType.name(), baseName);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import io.quarkus.arc.GenericArrayTypeImpl;
 import io.quarkus.arc.ParameterizedTypeImpl;
 import io.quarkus.arc.TypeVariableImpl;
@@ -140,7 +142,7 @@ final class Types {
             types.add(OBJECT_TYPE);
             return types;
         } else {
-            ClassInfo returnTypeClassInfo = beanDeployment.getIndex().getClassByName(returnType.name());
+            ClassInfo returnTypeClassInfo = getClassByName(beanDeployment.getIndex(), returnType.name());
             if (returnTypeClassInfo == null) {
                 throw new IllegalArgumentException(
                         "Producer method return type not found in index: " + producerMethod.returnType().name());
@@ -167,7 +169,7 @@ final class Types {
             types.add(fieldType);
             types.add(OBJECT_TYPE);
         } else {
-            ClassInfo fieldClassInfo = beanDeployment.getIndex().getClassByName(producerField.type().name());
+            ClassInfo fieldClassInfo = getClassByName(beanDeployment.getIndex(), producerField.type().name());
             if (fieldClassInfo == null) {
                 throw new IllegalArgumentException("Producer field type not found in index: " + producerField.type().name());
             }
@@ -222,7 +224,7 @@ final class Types {
         }
         // Interfaces
         for (Type interfaceType : classInfo.interfaceTypes()) {
-            ClassInfo interfaceClassInfo = beanDeployment.getIndex().getClassByName(interfaceType.name());
+            ClassInfo interfaceClassInfo = getClassByName(beanDeployment.getIndex(), interfaceType.name());
             if (interfaceClassInfo != null) {
                 Map<TypeVariable, Type> resolved = Collections.emptyMap();
                 if (Kind.PARAMETERIZED_TYPE.equals(interfaceType.kind())) {
@@ -234,7 +236,7 @@ final class Types {
         }
         // Superclass
         if (classInfo.superClassType() != null) {
-            ClassInfo superClassInfo = beanDeployment.getIndex().getClassByName(classInfo.superName());
+            ClassInfo superClassInfo = getClassByName(beanDeployment.getIndex(), classInfo.superName());
             if (superClassInfo != null) {
                 Map<TypeVariable, Type> resolved = Collections.emptyMap();
                 if (Kind.PARAMETERIZED_TYPE.equals(classInfo.superClassType().kind())) {
@@ -293,7 +295,7 @@ final class Types {
             return resolvedTypeParameters.getOrDefault(typeParam, typeParam);
         } else if (typeParam.kind() == Kind.PARAMETERIZED_TYPE) {
             ParameterizedType parameterizedType = typeParam.asParameterizedType();
-            ClassInfo classInfo = index.getClassByName(parameterizedType.name());
+            ClassInfo classInfo = getClassByName(index, parameterizedType.name());
             if (classInfo != null) {
                 List<TypeVariable> typeParameters = classInfo.typeParameters();
                 List<Type> arguments = parameterizedType.arguments();

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
@@ -33,7 +33,7 @@ public class BeanInfoInjectionsTest {
 
         Index index = index(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
                 Collection.class, List.class,
-                Iterable.class);
+                Iterable.class, Object.class, String.class);
         DotName barName = name(Bar.class);
         ClassInfo barClass = index.getClassByName(barName);
         Type fooType = Type.create(name(Foo.class), Kind.CLASS);

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
@@ -9,7 +9,11 @@ import io.quarkus.arc.processor.types.Bar;
 import io.quarkus.arc.processor.types.Foo;
 import io.quarkus.arc.processor.types.FooQualifier;
 import java.io.IOException;
+import java.util.AbstractCollection;
+import java.util.AbstractList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.ClassInfo;
@@ -25,7 +29,8 @@ public class BeanInfoQualifiersTest {
 
     @Test
     public void testQualifiers() throws IOException {
-        Index index = index(Foo.class, Bar.class, FooQualifier.class);
+        Index index = index(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
+                List.class, Collection.class, Object.class, String.class, Iterable.class);
         DotName fooName = name(Foo.class);
         DotName fooQualifierName = name(FooQualifier.class);
         ClassInfo fooClass = index.getClassByName(fooName);

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
@@ -33,7 +33,7 @@ public class BeanInfoTypesTest {
 
         Index index = index(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
                 Collection.class, List.class,
-                Iterable.class);
+                Iterable.class, Object.class, String.class);
 
         BeanDeployment deployment = new BeanDeployment(index, null, null);
         DotName fooName = name(Foo.class);
@@ -41,8 +41,8 @@ public class BeanInfoTypesTest {
         ClassInfo fooClass = index.getClassByName(fooName);
         BeanInfo fooBean = Beans.createClassBean(fooClass, deployment, null);
         Set<Type> types = fooBean.getTypes();
-        // Foo, AbstractList<String>, AbstractCollection<String>, List<String>, Collection<String>, Iterable<String>
-        assertEquals(6, types.size());
+        // Foo, AbstractList<String>, AbstractCollection<String>, List<String>, Collection<String>, Iterable<String>, Object
+        assertEquals(7, types.size());
         assertTrue(types.contains(Type.create(fooName, Kind.CLASS)));
         assertTrue(types.contains(ParameterizedType.create(name(AbstractList.class),
                 new Type[] { Type.create(name(String.class), Kind.CLASS) }, null)));

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -21,20 +21,20 @@ public class TypesTest {
 
     @Test
     public void testGetTypeClosure() throws IOException {
-        IndexView index = Basics.index(Foo.class, Baz.class);
+        IndexView index = Basics.index(Foo.class, Baz.class, Object.class);
         DotName bazName = DotName.createSimple(Baz.class.getName());
         DotName fooName = DotName.createSimple(Foo.class.getName());
         ClassInfo fooClass = index.getClassByName(fooName);
         Map<ClassInfo, Map<TypeVariable, Type>> resolvedTypeVariables = new HashMap<>();
 
-        // Baz, Foo<String>
+        // Baz, Foo<String>, Object
         Set<Type> bazTypes = Types.getTypeClosure(index.getClassByName(bazName),
                 Collections.emptyMap(),
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,
                         false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList()),
                 resolvedTypeVariables::put);
-        assertEquals(2, bazTypes.size());
+        assertEquals(3, bazTypes.size());
         assertTrue(bazTypes.contains(Type.create(bazName, Kind.CLASS)));
         assertTrue(bazTypes.contains(ParameterizedType.create(fooName,
                 new Type[] { Type.create(DotName.createSimple(String.class.getName()), Kind.CLASS) },
@@ -45,15 +45,19 @@ public class TypesTest {
                 Type.create(DotName.createSimple(String.class.getName()), Kind.CLASS));
 
         resolvedTypeVariables.clear();
-        // Foo<T>
+        // Foo<T>, Object
         Set<Type> fooTypes = Types.getClassBeanTypeClosure(fooClass,
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,
                         false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList()));
-        assertEquals(1, fooTypes.size());
-        ParameterizedType fooType = fooTypes.iterator().next().asParameterizedType();
-        assertEquals("T", fooType.arguments().get(0).asTypeVariable().identifier());
-        assertEquals(DotNames.OBJECT, fooType.arguments().get(0).asTypeVariable().bounds().get(0).name());
+        assertEquals(2, fooTypes.size());
+        for (Type t : fooTypes) {
+            if (t.kind().equals(Kind.PARAMETERIZED_TYPE)) {
+                ParameterizedType fooType = t.asParameterizedType();
+                assertEquals("T", fooType.arguments().get(0).asTypeVariable().identifier());
+                assertEquals(DotNames.OBJECT, fooType.arguments().get(0).asTypeVariable().bounds().get(0).name());
+            }
+        }
     }
 
     static class Foo<T> {


### PR DESCRIPTION
…sing classes.

Fixes #4080 

@mkouba looking at what we had in Arc now, we sometimes blow up, sometimes silently continue and at other times we logged something. So in the end I added a util class that does _info_ logging but still allows to return `null` as in some cases blowing up might be a tad bit too harsh?