### PR TITLE
Support random test port

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/RandomPortTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/RandomPortTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.vertx.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.cors.BeanRegisteringRoute;
+
+public class RandomPortTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest CONFIG = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(BeanRegisteringRoute.class)
+                    .addAsResource(new StringAsset("quarkus.http.test-port=0"),
+                            "application.properties"));
+
+    @TestHTTPResource("test")
+    URL url;
+
+    @Test
+    public void portShouldNotBeZero() {
+        assertThat(url.getPort()).isNotZero();
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -179,7 +179,8 @@ public class VertxHttpRecorder {
                 return new WebDeploymentVerticle(httpConfiguration.determinePort(launchMode),
                         httpConfiguration.determineSslPort(launchMode), httpConfiguration.host, httpServerOptions,
                         sslConfig,
-                        router);
+                        router,
+                        launchMode);
             }
         }, new DeploymentOptions().setInstances(ioThreads), new Handler<AsyncResult<String>>() {
             @Override
@@ -368,15 +369,17 @@ public class VertxHttpRecorder {
         private final HttpServerOptions httpOptions;
         private final HttpServerOptions httpsOptions;
         private final Router router;
+        private final LaunchMode launchMode;
 
         public WebDeploymentVerticle(int port, int httpsPort, String host, HttpServerOptions httpOptions,
-                HttpServerOptions httpsOptions, Router router) {
+                HttpServerOptions httpsOptions, Router router, LaunchMode launchMode) {
             this.port = port;
             this.httpsPort = httpsPort;
             this.host = host;
             this.httpOptions = httpOptions;
             this.httpsOptions = httpsOptions;
             this.router = router;
+            this.launchMode = launchMode;
         }
 
         @Override
@@ -389,7 +392,14 @@ public class VertxHttpRecorder {
                     startFuture.fail(event.cause());
                 } else {
                     // Port may be random, so set the actual port
-                    httpOptions.setPort(event.result().actualPort());
+                    int actualPort = event.result().actualPort();
+                    if (actualPort != port) {
+                        // Override quarkus.http.(test-)?port
+                        System.setProperty(launchMode == LaunchMode.TEST ? "quarkus.http.test-port" : "quarkus.http.port",
+                                String.valueOf(actualPort));
+                        // Set in HttpOptions to output the port in the Timing class
+                        httpOptions.setPort(actualPort);
+                    }
                     if (remainingCount.decrementAndGet() == 0) {
                         startFuture.complete(null);
                     }
@@ -402,7 +412,14 @@ public class VertxHttpRecorder {
                     if (event.cause() != null) {
                         startFuture.fail(event.cause());
                     } else {
-                        httpsOptions.setPort(event.result().actualPort());
+                        int actualPort = event.result().actualPort();
+                        if (actualPort != httpsPort) {
+                            // Override quarkus.https.(test-)?port
+                            System.setProperty(launchMode == LaunchMode.TEST ? "quarkus.https.test-port" : "quarkus.https.port",
+                                    String.valueOf(actualPort));
+                            // Set in HttpOptions to output the port in the Timing class
+                            httpsOptions.setPort(actualPort);
+                        }
                         if (remainingCount.decrementAndGet() == 0) {
                             startFuture.complete();
                         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.common.PathTestHelper.getAppClassLocation;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 
 import java.io.Closeable;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -112,9 +111,7 @@ public class QuarkusTestExtension
                     public void writeClass(boolean applicationClass, String className, byte[] data) throws IOException {
                         Path location = testWiringClassesDir.resolve(className.replace('.', '/') + ".class");
                         Files.createDirectories(location.getParent());
-                        try (FileOutputStream out = new FileOutputStream(location.toFile())) {
-                            out.write(data);
-                        }
+                        Files.write(location, data);
                         shutdownTasks.add(new DeleteRunnable(location));
                     }
 
@@ -122,9 +119,7 @@ public class QuarkusTestExtension
                     public void writeResource(String name, byte[] data) throws IOException {
                         Path location = testWiringClassesDir.resolve(name);
                         Files.createDirectories(location.getParent());
-                        try (FileOutputStream out = new FileOutputStream(location.toFile())) {
-                            out.write(data);
-                        }
+                        Files.write(location, data);
                         shutdownTasks.add(new DeleteRunnable(location));
                     }
                 })
@@ -192,9 +187,7 @@ public class QuarkusTestExtension
 
                                 Path location = testWiringClassesDir.resolve(resourceName);
                                 Files.createDirectories(location.getParent());
-                                try (FileOutputStream out = new FileOutputStream(location.toFile())) {
-                                    out.write(cw.toByteArray());
-                                }
+                                Files.write(location, cw.toByteArray());
                                 shutdownTasks.add(new DeleteRunnable(location));
                             } catch (IOException ex) {
                                 ex.printStackTrace();


### PR DESCRIPTION
By supporting random ports during test execution, this PR should allow running HTTP tests in parallel (as long as they run in different JVMs)

Fixes #2269 and closes #2324