### PR TITLE
[issue#4126] - include the path of the file which triggered an IOException

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/ZipUtils.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/ZipUtils.java
@@ -17,6 +17,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.zip.ZipError;
 
 /**
  *
@@ -39,6 +40,12 @@ public class ZipUtils {
             for (Path zipRoot : zipfs.getRootDirectories()) {
                 copyFromZip(zipRoot, targetDir);
             }
+        } catch (IOException | ZipError ioe) {
+            // TODO: (at a later date) Get rid of the ZipError catching (and instead only catch IOException)
+            //  since it's a JDK bug which threw the undeclared ZipError instead of an IOException.
+            //  Java 9 fixes it https://bugs.openjdk.java.net/browse/JDK-8062754
+
+            throw new IOException("Could not unzip " + zipFile + " to target dir " + targetDir, ioe);
         }
     }
 
@@ -131,7 +138,16 @@ public class ZipUtils {
         // If Multi threading required, logic should be added to wrap this fs
         // onto a fs that handles a reference counter and close the fs only when all thread are done
         // with it.
-        return FileSystems.newFileSystem(uri, env);
+        try {
+            return FileSystems.newFileSystem(uri, env);
+        } catch (IOException | ZipError ioe) {
+            // TODO: (at a later date) Get rid of the ZipError catching (and instead only catch IOException)
+            //  since it's a JDK bug which threw the undeclared ZipError instead of an IOException.
+            //  Java 9 fixes it https://bugs.openjdk.java.net/browse/JDK-8062754
+
+            // include the URI for which the filesystem creation failed
+            throw new IOException("Failed to create a new filesystem for " + uri, ioe);
+        }
     }
 
     /**
@@ -140,7 +156,16 @@ public class ZipUtils {
      * @return A new FileSystem instance
      * @throws IOException  in case of a failure
      */
-     public static FileSystem newFileSystem(Path path) throws IOException {
-         return FileSystems.newFileSystem(path, (ClassLoader) null);
+     public static FileSystem newFileSystem(final Path path) throws IOException {
+         try {
+             return FileSystems.newFileSystem(path, (ClassLoader) null);
+         } catch (IOException | ZipError ioe) {
+             // TODO: (at a later date) Get rid of the ZipError catching (and instead only catch IOException)
+             //  since it's a JDK bug which threw the undeclared ZipError instead of an IOException.
+             //  Java 9 fixes it https://bugs.openjdk.java.net/browse/JDK-8062754
+
+             // include the path for which the filesystem creation failed
+             throw new IOException("Failed to create a new filesystem for " + path, ioe);
+         }
      }
 }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/util/ZipUtilsTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/util/ZipUtilsTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.bootstrap.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+/**
+ * Tests {@link ZipUtils}
+ */
+public class ZipUtilsTest {
+
+    /**
+     * Test that when an operation on a corrupt zip file fails, the resulting IOException
+     * has the path details of the file/uri of the source file
+     *
+     * @throws Exception
+     * @see <a href="https://github.com/quarkusio/quarkus/issues/4126"/>
+     */
+    @Test
+    public void testCorruptZipException() throws Exception {
+        final Path tmpFile = Files.createTempFile(null, ".jar");
+        try {
+            final URI uri = new URI("jar", tmpFile.toUri().toString(), null);
+            try {
+                ZipUtils.newFileSystem(uri, Collections.emptyMap());
+                Assertions.fail("New filesystem creation was expected to fail for a non-zip file");
+            } catch (IOException ioe) {
+                // verify the exception message content
+                if (!ioe.getMessage().contains(uri.toString())) {
+                    throw ioe;
+                }
+            }
+
+            try {
+                ZipUtils.newFileSystem(tmpFile);
+                Assertions.fail("New filesystem creation was expected to fail for a non-zip file");
+            } catch (IOException ioe) {
+                // verify the exception message content
+                if (!ioe.getMessage().contains(tmpFile.toString())) {
+                    throw ioe;
+                }
+            }
+        } finally {
+            Files.delete(tmpFile);
+        }
+    }
+}


### PR DESCRIPTION
The commit here improves the `IOException` message to include the URI/Path which caused a zip operation to fail, through `ZipUtils`. This should address the issue noted in https://github.com/quarkusio/quarkus/issues/4126.

The commit also includes a test case to reproduce and verify the fix.

P.S: This currently catches a `java.util.zip.ZipError` which shouldn't have been thrown in first place by Java (since it's an undeclared error). As noted in the code comments, that's now been fixed in Java 9 and we can remove that `ZipError` catch once the minimal Java runtime version for Quarkus is Java 9.