### PR TITLE
chore: minor cleanup in QuarkusDevModeTest

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -3,7 +3,7 @@ package io.quarkus.test;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
@@ -239,12 +239,10 @@ public class QuarkusDevModeTest
                             byte[] data = FileUtil.readFileContents(in);
                             Path resolved = deploymentResourcePath.resolve(relative);
                             Files.createDirectories(resolved.getParent());
-                            try (OutputStream out = Files.newOutputStream(resolved)) {
-                                out.write(data);
-                            }
+                            Files.write(resolved, data);
                         }
                     } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        throw new UncheckedIOException(e);
                     }
                 });
             }
@@ -328,17 +326,14 @@ public class QuarkusDevModeTest
                         content = mutator.apply(content);
 
                         sleepForFileChanges(path);
-                        try (OutputStream out = Files.newOutputStream(s)) {
-                            out.write(content.getBytes(StandardCharsets.UTF_8));
-                        }
-
+                        Files.write(s, content.getBytes(StandardCharsets.UTF_8));
                     } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        throw new UncheckedIOException(e);
                     }
                 }
             });
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
 
     }
@@ -374,12 +369,10 @@ public class QuarkusDevModeTest
             String content = new String(data, StandardCharsets.UTF_8);
             content = mutator.apply(content);
 
-            try (OutputStream out = Files.newOutputStream(resourcePath)) {
-                out.write(content.getBytes(StandardCharsets.UTF_8));
-            }
+            Files.write(resourcePath, content.getBytes(StandardCharsets.UTF_8));
             sleepForFileChanges(resourcePath);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -389,11 +382,9 @@ public class QuarkusDevModeTest
      */
     public void addResourceFile(String path, byte[] data) {
         try {
-            try (OutputStream out = Files.newOutputStream(deploymentResourcePath.resolve(path))) {
-                out.write(data);
-            }
+            Files.write(deploymentResourcePath.resolve(path), data);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -405,7 +396,7 @@ public class QuarkusDevModeTest
         try {
             Files.delete(deploymentResourcePath.resolve(path));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -441,12 +432,10 @@ public class QuarkusDevModeTest
                     byte[] data = FileUtil.readFileContents(in);
                     Path resolved = deploymentSourcesDir.resolve(relative);
                     Files.createDirectories(resolved.getParent());
-                    try (OutputStream out = Files.newOutputStream(resolved)) {
-                        out.write(data);
-                    }
+                    Files.write(resolved, data);
                     return resolved;
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
             }
         }


### PR DESCRIPTION
Thrown IOExceptions should be UncheckedIOExceptions instead of simply RuntimeException and Files.write instead of try-catch with OutputStream