### PR TITLE
Upgrade to jackson 2.9.10

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -68,7 +68,7 @@
            is not available in Maven fast enough: -->
         <graal-sdk.version>19.2.0.1</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha8</gizmo.version>
-        <jackson.version>2.9.9.20190807</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>


### PR DESCRIPTION
Fixes two CVE: CVE-2019-16335 and CVE-2019-14540