### PR TITLE
[#4110] Remove unnecessary dependency in MP Metrics REST TCK

### DIFF
--- a/tcks/microprofile-metrics/rest/pom.xml
+++ b/tcks/microprofile-metrics/rest/pom.xml
@@ -55,11 +55,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-            <version>2.2.6</version>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
First part of the fix for #4110
The other part will need a new MP Metrics spec micro-release