### PR TITLE
[issue#2176] register the commonly needed text/plain MediaType MessageWriter by default

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -107,9 +107,10 @@ public class ResteasyCommonProcessor {
         // add the other providers detected
         Set<String> providersToRegister = new HashSet<>(otherProviders);
 
-        // we add a couple of default providers
+        // we add a few default providers
         providersToRegister.add(StringTextStar.class.getName());
         providersToRegister.addAll(categorizedWriters.getPossible(MediaType.APPLICATION_JSON_TYPE));
+        providersToRegister.addAll(categorizedWriters.getPossible(MediaType.TEXT_PLAIN_TYPE));
 
         IndexView index = indexBuildItem.getIndex();
         IndexView beansIndex = beanArchiveIndexBuildItem.getIndex();


### PR DESCRIPTION
The commit here by default registers the `MessageWriter` which deals with the commonly needed `text/plain` `MediaType`. This should solve issues like the one noted in https://github.com/quarkusio/quarkus/issues/2176