### PR TITLE
Register any additional necessary providers for server sent event @Produce(s)

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ServerSentEventResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ServerSentEventResource.java
@@ -1,0 +1,81 @@
+package io.quarkus.it.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.OutboundSseEvent;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+
+import org.jboss.resteasy.annotations.SseElementType;
+
+@Path("/sse")
+public class ServerSentEventResource {
+
+    private Sse sse;
+
+    @Context
+    public void setSse(final Sse sse) {
+        this.sse = sse;
+    }
+
+    @GET
+    @Path("/stream")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void sendData(@Context SseEventSink sink) {
+        // send a stream of few events
+        try {
+            for (int i = 0; i < 3; i++) {
+                final OutboundSseEvent.Builder builder = this.sse.newEventBuilder();
+                builder.id(String.valueOf(i)).mediaType(MediaType.TEXT_PLAIN_TYPE)
+                        .data(Integer.class, i)
+                        .name("stream of numbers");
+
+                sink.send(builder.build());
+            }
+        } finally {
+            sink.close();
+        }
+    }
+
+    @GET
+    @Path("/stream-html")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @SseElementType("text/html")
+    public void sendHtmlData(@Context SseEventSink sink) {
+        // send a stream of few events
+        try {
+            for (int i = 0; i < 3; i++) {
+                final OutboundSseEvent.Builder builder = this.sse.newEventBuilder();
+                builder.id(String.valueOf(i)).mediaType(MediaType.TEXT_HTML_TYPE)
+                        .data("<html><body>" + i + "</body></html>")
+                        .name("stream of pages");
+
+                sink.send(builder.build());
+            }
+        } finally {
+            sink.close();
+        }
+    }
+
+    @GET
+    @Path("/stream-xml")
+    @Produces("text/event-stream;element-type=text/xml")
+    public void sendXmlData(@Context SseEventSink sink) {
+        // send a stream of few events
+        try {
+            for (int i = 0; i < 3; i++) {
+                final OutboundSseEvent.Builder builder = this.sse.newEventBuilder();
+                builder.id(String.valueOf(i)).mediaType(MediaType.TEXT_XML_TYPE)
+                        .data("<settings><foo bar=\"" + i + "\"/></settings>")
+                        .name("stream of XML data");
+
+                sink.send(builder.build());
+            }
+        } finally {
+            sink.close();
+        }
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
@@ -211,4 +211,28 @@ public class JaxRSTestCase {
                 .post("/test/max-body-size")
                 .then().statusCode(200);
     }
+
+    @Test
+    public void testSSE() throws Exception {
+        RestAssured.when().get("/sse/stream")
+                .then()
+                .contentType("text/event-stream")
+                .body(containsString("0"),
+                        containsString("1"),
+                        containsString("2"));
+
+        RestAssured.when().get("/sse/stream-html")
+                .then()
+                .contentType("text/event-stream")
+                .body(containsString("<html><body>0</body></html>"),
+                        containsString("<html><body>1</body></html>"),
+                        containsString("<html><body>2</body></html>"));
+
+        RestAssured.when().get("/sse/stream-xml")
+                .then()
+                .contentType("text/event-stream")
+                .body(containsString("<settings><foo bar=\"0\"/></settings>"),
+                        containsString("<settings><foo bar=\"1\"/></settings>"),
+                        containsString("<settings><foo bar=\"2\"/></settings>"));
+    }
 }


### PR DESCRIPTION
The commit here introduces a way where any additional necessary `providers` are registered for any resource that `@Produces` `MediaType.SERVER_SENT_EVENTS`. This should allow for fixing the issue reported in https://github.com/quarkusio/quarkus/issues/2176 such that the `PriceResouce` in that example can now use:

```
@GET
    @Path("/stream")
    @Produces("text/event-stream;element-type=text/plain")
    public Publisher<Double> stream() {
        return prices;
    }
```
and will no longer require a (dummy) resource endpoint to register the basic `text/plain` type providers.

Fixes #2176