### PR TITLE
Log the H2 DB server status to provide more details on its state and URL

### DIFF
--- a/test-framework/h2/src/main/java/io/quarkus/test/h2/H2DatabaseTestResource.java
+++ b/test-framework/h2/src/main/java/io/quarkus/test/h2/H2DatabaseTestResource.java
@@ -18,7 +18,7 @@ public class H2DatabaseTestResource implements QuarkusTestResourceLifecycleManag
         try {
             tcpServer = Server.createTcpServer();
             tcpServer.start();
-            System.out.println("[INFO] H2 database started in TCP server mode");
+            System.out.println("[INFO] H2 database started in TCP server mode; server status: " + tcpServer.getStatus());
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -29,7 +29,7 @@ public class H2DatabaseTestResource implements QuarkusTestResourceLifecycleManag
     public synchronized void stop() {
         if (tcpServer != null) {
             tcpServer.stop();
-            System.out.println("[INFO] H2 database was shut down");
+            System.out.println("[INFO] H2 database was shut down; server status: " + tcpServer.getStatus());
             tcpServer = null;
         }
     }


### PR DESCRIPTION
A very minor change to print out the "status" of the H2 DB when it's started and stopped, so that details like the following gets printed when running integration tests:
```
[INFO] H2 database started in TCP server mode; server status: TCP server running at tcp://localhost:9092 (only local connections)
```
This additional info would have helped me when I ran into an issue trying to run the integration tests locally (more details on quarkus-dev mailing list)