### PR TITLE
Remove an outdated Jackson version

### DIFF
--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -36,8 +36,8 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.3</version>
         </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This version has a CVE: we should use the one from the bom.

Note: all the versions in this pom should probably go away. Not totally sure if they should be in the bom though as they are really internal dependencies. Maybe let's wait for @aloubyansky 's work on the platform as there's a good chance we will split the internal bom from the outside world one.