### PR TITLE
Improve the generated code for Spring Data JPA fragments

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/FragmentMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/FragmentMethodsAdder.java
@@ -1,7 +1,5 @@
 package io.quarkus.spring.data.deployment.generate;
 
-import java.lang.annotation.Annotation;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -11,9 +9,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.arc.ArcContainer;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
@@ -33,29 +28,8 @@ public class FragmentMethodsAdder {
     public void add(ClassCreator classCreator, String generatedClassName,
             List<DotName> customInterfaceNamesToImplement, Map<String, FieldDescriptor> customImplNameToHandle) {
         for (DotName customInterfaceToImplement : customInterfaceNamesToImplement) {
-            Collection<ClassInfo> knownImplementors = index.getAllKnownImplementors(customInterfaceToImplement);
-            ClassInfo customInterfaceImpl = null;
-            if (knownImplementors.size() > 1) {
-                for (ClassInfo knownImplementor : knownImplementors) {
-                    if (knownImplementor.name().toString().endsWith("Impl")) { // the default suffix that Spring Data JPA looks for is 'Impl'
-                        if (customInterfaceImpl != null) { // make sure we don't have multiple implementations suffixed with 'Impl'
-                            throw new IllegalArgumentException(
-                                    "Interface " + customInterfaceToImplement
-                                            + " must contain a single implementation whose name ends with 'Impl'. Multiple implementations were found: "
-                                            + customInterfaceImpl + "," + knownImplementor);
-                        }
-                        customInterfaceImpl = knownImplementor;
-                    }
-                }
-
-            } else if (knownImplementors.size() == 1) {
-                customInterfaceImpl = knownImplementors.iterator().next();
-            } else {
-                throw new IllegalArgumentException(
-                        "No implementation of interface " + customInterfaceToImplement + " was found");
-            }
-
-            String customImplementationClassName = customInterfaceImpl.name().toString();
+            String customImplementationClassName = FragmentMethodsUtil
+                    .getImplementationDotName(customInterfaceToImplement, index).toString();
             fragmentImplClassResolvedCallback.accept(customImplementationClassName);
 
             ClassInfo customInterfaceToImplementClassInfo = index.getClassByName(customInterfaceToImplement);
@@ -80,18 +54,8 @@ public class FragmentMethodsAdder {
                 if (!classCreator.getExistingMethods().contains(methodDescriptor)) {
                     try (MethodCreator methodCreator = classCreator.getMethodCreator(methodDescriptor)) {
                         // obtain the bean from Arc
-                        ResultHandle arcContainer = methodCreator
-                                .invokeStaticMethod(MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class));
-                        ResultHandle implClass = methodCreator.readInstanceField(
+                        ResultHandle bean = methodCreator.readInstanceField(
                                 customImplNameToHandle.get(customImplementationClassName), methodCreator.getThis());
-                        ResultHandle instanceHandle = methodCreator.invokeInterfaceMethod(
-                                MethodDescriptor.ofMethod(ArcContainer.class, "instance", InstanceHandle.class, Class.class,
-                                        Annotation[].class),
-                                arcContainer, implClass, methodCreator.loadNull());
-                        ResultHandle get = methodCreator.invokeInterfaceMethod(
-                                MethodDescriptor.ofMethod(InstanceHandle.class, "get", Object.class),
-                                instanceHandle);
-                        ResultHandle bean = methodCreator.checkCast(get, customImplementationClassName);
 
                         ResultHandle[] methodParameterHandles = new ResultHandle[methodToImplement.parameters().size()];
                         for (int i = 0; i < methodToImplement.parameters().size(); i++) {

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/FragmentMethodsUtil.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/FragmentMethodsUtil.java
@@ -1,0 +1,42 @@
+package io.quarkus.spring.data.deployment.generate;
+
+import java.util.Collection;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+
+final class FragmentMethodsUtil {
+
+    private FragmentMethodsUtil() {
+    }
+
+    /**
+     * Returns the simple expected implementation of a Fragment interface or throws an
+     * exception indicating the problem
+     */
+    static DotName getImplementationDotName(DotName customInterfaceToImplement, IndexView index) {
+        Collection<ClassInfo> knownImplementors = index.getAllKnownImplementors(customInterfaceToImplement);
+
+        if (knownImplementors.size() > 1) {
+            DotName previouslyFound = null;
+            for (ClassInfo knownImplementor : knownImplementors) {
+                if (knownImplementor.name().toString().endsWith("Impl")) { // the default suffix that Spring Data JPA looks for is 'Impl'
+                    if (previouslyFound != null) { // make sure we don't have multiple implementations suffixed with 'Impl'
+                        throw new IllegalArgumentException(
+                                "Interface " + customInterfaceToImplement
+                                        + " must contain a single implementation whose name ends with 'Impl'. Multiple implementations were found: "
+                                        + previouslyFound + "," + knownImplementor);
+                    }
+                    previouslyFound = knownImplementor.name();
+                }
+            }
+            return previouslyFound;
+        } else if (knownImplementors.size() == 1) {
+            return knownImplementors.iterator().next().name();
+        } else {
+            throw new IllegalArgumentException(
+                    "No implementation of interface " + customInterfaceToImplement + " was found");
+        }
+    }
+}


### PR DESCRIPTION
This is done by actually creating an injection point for the bean
that implements each fragment instead of pulling the bean out of
Arc at runtime