### PR TITLE
SmallRye Reactive Messaging MQTT requires Vert.x JSON

### DIFF
--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-core-deployment</artifactId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-core</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>


### PR DESCRIPTION
So it should use the vertx extension, not the vertx-core one.
Noticed while running the quickstart tests in native mode.