### PR TITLE
Add query projection for MongoDB with Panache

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -391,27 +391,31 @@ will use the entity field name: `name`, and native query will use the MongoDB fi
 
 Query projection can be done with the `project(Class)` method on the `PanacheQuery` object that is returned by the `find()` methods.
 
-You can use it to restrict which fields will be returned by the database, the ID field will always be returned.
+You can use it to restrict which fields will be returned by the database,
+the ID field will always be returned but it's not mandatory to include it inside the projection class.
 
-For this, you need to create a class (a Pojo) that will only contains the projected fields.
-The field names, or the getters, of the projection class will be used to restrict which properties will be loaded from the database.
-If your entity uses `@BsonProperty` to map a property to a database column, the same mapping must be used inside the projection class.
+For this, you need to create a class (a Pojo) that will only contain the projected fields.
+This pojo needs to be annotated with `@ProjectionFor(Entity.class)` where `Entity` is the name of your entity class.
+The field names, or  getters, of the projection class will be used to restrict which properties will be loaded from the database.
 
 Projection can be done for both PanacheQL and native queries.
 
 [source,java]
 ----
+import io.quarkus.mongodb.panache.ProjectionFor;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
 // using public fields
+@ProjectionFor(Person.class)
 public class PersonName {
-    @BsonProperty("lastname")
     public String name;
 }
 
 // using getters
+@ProjectionFor(Person.class)
 public class PersonNameWithGetter {
     private String name;
 
-    @BsonProperty("lastname")
     public String getName(){
         return name;
     }
@@ -427,7 +431,9 @@ PanacheQuery<PersonName> query = Person.find("'status': ?1", Status.Alive).proje
 PanacheQuery<PersonName> nativeQuery = Person.find("{'status': 'ALIVE'}", Status.Alive).project(PersonName.class);
 ----
 
-TIP: Inherited fields and methods from a super type will also be used.
+TIP: Using @BsonProperty is not needed to define custom column mappings, as the mappings from the entity class will be used.
+
+TIP: You can have your projection class extends from another class. In this case, the parent class also needs to have use `@ProjectionFor` annotation.
 
 == The DAO/Repository option
 
@@ -561,4 +567,3 @@ If you define your entities in the same project where you build your Quarkus app
 If the entities come from external projects or jars, you can make sure that your jar is treated like a Quarkus application library
 by indexing it via Jandex, see link:cdi-reference#how-to-generate-a-jandex-index[How to Generate a Jandex Index] in the CDI guide.
 This will allow Quarkus to index and enhance your entities as if they were inside the current project.
-

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -387,6 +387,48 @@ public class Person extends PanacheMongoEntity {
 Both `findByNameWithPanacheQLQuery()` and `findByNameWithNativeQuery()` methods will return the same result but query written in PanacheQL
 will use the entity field name: `name`, and native query will use the MongoDB field name: `lastname`.
 
+== Query projection
+
+Query projection can be done with the `project(Class)` method on the `PanacheQuery` object that is returned by the `find()` methods.
+
+You can use it to restrict which fields will be returned by the database, the ID field will always be returned.
+
+For this, you need to create a class (a Pojo) that will only contains the projected fields.
+The field names, or the getters, of the projection class will be used to restrict which properties will be loaded from the database.
+If your entity uses `@BsonProperty` to map a property to a database column, the same mapping must be used inside the projection class.
+
+Projection can be done for both PanacheQL and native queries.
+
+[source,java]
+----
+// using public fields
+public class PersonName {
+    @BsonProperty("lastname")
+    public String name;
+}
+
+// using getters
+public class PersonNameWithGetter {
+    private String name;
+
+    @BsonProperty("lastname")
+    public String getName(){
+        return name;
+    }
+
+    public void setName(String name){
+        this.name = name;
+    }
+}
+
+// only 'name' will be loaded from the database
+PanacheQuery<PersonName> shortQuery = Person.find("status ", Status.Alive).project(PersonName.class);
+PanacheQuery<PersonName> query = Person.find("'status': ?1", Status.Alive).project(PersonNameWithGetter.class);
+PanacheQuery<PersonName> nativeQuery = Person.find("{'status': 'ALIVE'}", Status.Alive).project(PersonName.class);
+----
+
+TIP: Inherited fields and methods from a super type will also be used.
+
 == The DAO/Repository option
 
 Repository is a very popular pattern and can be very accurate for some use case, depending on

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -1,13 +1,19 @@
 package io.quarkus.mongodb.panache.deployment;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
+import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
 import io.quarkus.deployment.Capabilities;
@@ -27,6 +33,7 @@ import io.quarkus.mongodb.panache.PanacheMongoEntity;
 import io.quarkus.mongodb.panache.PanacheMongoEntityBase;
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
 import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
+import io.quarkus.mongodb.panache.ProjectionFor;
 import io.quarkus.panache.common.deployment.PanacheFieldAccessEnhancer;
 import io.quarkus.panache.common.deployment.PanacheRepositoryEnhancer;
 
@@ -36,7 +43,12 @@ public class PanacheResourceProcessor {
     static final DotName DOTNAME_PANACHE_ENTITY_BASE = DotName.createSimple(PanacheMongoEntityBase.class.getName());
     private static final DotName DOTNAME_PANACHE_ENTITY = DotName.createSimple(PanacheMongoEntity.class.getName());
 
+    private static final DotName DOTNAME_PROJECTION_FOR = DotName.createSimple(ProjectionFor.class.getName());
+    private static final DotName DOTNAME_BSON_PROPERTY = DotName.createSimple(BsonProperty.class.getName());
+
     private static final DotName DOTNAME_OBJECT_ID = DotName.createSimple(ObjectId.class.getName());
+
+    private static final DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
 
     @BuildStep
     CapabilityBuildItem capability() {
@@ -129,6 +141,48 @@ public class PanacheResourceProcessor {
                     transformers.produce(new BytecodeTransformerBuildItem(className, panacheFieldAccessEnhancer));
                 }
             }
+        }
+
+        // manage @BsonProperty for the @ProjectionFor annotation
+        Map<ClassInfo, Map<String, String>> propertyMapping = new HashMap<>();
+        for (AnnotationInstance annotationInstance : index.getIndex().getAnnotations(DOTNAME_PROJECTION_FOR)) {
+            Type targetClass = annotationInstance.value().asClass();
+            ClassInfo target = index.getIndex().getClassByName(targetClass.name());
+            Map<String, String> classPropertyMapping = new HashMap<>();
+            extractMappings(classPropertyMapping, target, index);
+            propertyMapping.put(target, classPropertyMapping);
+        }
+        for (AnnotationInstance annotationInstance : index.getIndex().getAnnotations(DOTNAME_PROJECTION_FOR)) {
+            Type targetClass = annotationInstance.value().asClass();
+            ClassInfo target = index.getIndex().getClassByName(targetClass.name());
+            Map<String, String> targetPropertyMapping = propertyMapping.get(target);
+            if (targetPropertyMapping != null && !targetPropertyMapping.isEmpty()) {
+                ClassInfo info = annotationInstance.target().asClass();
+                ProjectionForEnhancer fieldEnhancer = new ProjectionForEnhancer(targetPropertyMapping);
+                transformers.produce(new BytecodeTransformerBuildItem(info.name().toString(), fieldEnhancer));
+            }
+        }
+    }
+
+    private void extractMappings(Map<String, String> classPropertyMapping, ClassInfo target, CombinedIndexBuildItem index) {
+        for (FieldInfo fieldInfo : target.fields()) {
+            if (fieldInfo.hasAnnotation(DOTNAME_BSON_PROPERTY)) {
+                AnnotationInstance bsonProperty = fieldInfo.annotation(DOTNAME_BSON_PROPERTY);
+                classPropertyMapping.put(fieldInfo.name(), bsonProperty.value().asString());
+            }
+        }
+        for (MethodInfo methodInfo : target.methods()) {
+            if (methodInfo.hasAnnotation(DOTNAME_BSON_PROPERTY)) {
+                AnnotationInstance bsonProperty = methodInfo.annotation(DOTNAME_BSON_PROPERTY);
+                classPropertyMapping.put(methodInfo.name(), bsonProperty.value().asString());
+            }
+        }
+
+        // climb up the hierarchy of types
+        if (!target.superClassType().name().equals(DOTNAME_OBJECT)) {
+            Type superType = target.superClassType();
+            ClassInfo superClass = index.getIndex().getClassByName(superType.name());
+            extractMappings(classPropertyMapping, superClass, index);
         }
     }
 }

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/ProjectionForEnhancer.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/ProjectionForEnhancer.java
@@ -1,0 +1,91 @@
+package io.quarkus.mongodb.panache.deployment;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ProjectionForEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+    private static final String BSONPROPERTY_BINARY_NAME = "org/bson/codecs/pojo/annotations/BsonProperty";
+    private static final String BSONPROPERTY_SIGNATURE = "L" + BSONPROPERTY_BINARY_NAME + ";";
+
+    private Map<String, String> propertyMapping;
+
+    public ProjectionForEnhancer(Map<String, String> propertyMapping) {
+        this.propertyMapping = propertyMapping;
+    }
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor classVisitor) {
+        return new BsonPropertyClassVisitor(classVisitor, propertyMapping);
+    }
+
+    static class BsonPropertyClassVisitor extends ClassVisitor {
+        Map<String, String> propertyMapping;
+
+        BsonPropertyClassVisitor(ClassVisitor outputClassVisitor, Map<String, String> propertyMapping) {
+            super(Opcodes.ASM7, outputClassVisitor);
+            this.propertyMapping = propertyMapping;
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+            FieldVisitor superVisitor = super.visitField(access, name, descriptor, signature, value);
+            if (this.propertyMapping.containsKey(name)) {
+                return new FieldVisitor(Opcodes.ASM7, superVisitor) {
+                    private Set<String> descriptors = new HashSet<>();
+
+                    @Override
+                    public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                        descriptors.add(descriptor);
+                        return super.visitAnnotation(descriptor, visible);
+                    }
+
+                    @Override
+                    public void visitEnd() {
+                        if (!descriptors.contains(BSONPROPERTY_SIGNATURE)) {
+                            AnnotationVisitor visitor = super.visitAnnotation(BSONPROPERTY_SIGNATURE, true);
+                            visitor.visit("value", propertyMapping.get(name));
+                            visitor.visitEnd();
+                        }
+                        super.visitEnd();
+                    }
+                };
+            }
+            return superVisitor;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor superVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+            if (this.propertyMapping.containsKey(name)) {
+                return new MethodVisitor(Opcodes.ASM7, superVisitor) {
+                    private Set<String> descriptors = new HashSet<>();
+
+                    @Override
+                    public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                        descriptors.add(descriptor);
+                        return super.visitAnnotation(descriptor, visible);
+                    }
+
+                    @Override
+                    public void visitEnd() {
+                        if (!descriptors.contains(BSONPROPERTY_SIGNATURE)) {
+                            AnnotationVisitor visitor = super.visitAnnotation(BSONPROPERTY_SIGNATURE, true);
+                            visitor.visit("value", propertyMapping.get(name));
+                            visitor.visitEnd();
+                        }
+                        super.visitEnd();
+                    }
+                };
+            }
+            return superVisitor;
+        }
+    }
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
@@ -20,6 +20,14 @@ public interface PanacheQuery<Entity> {
     // Builder
 
     /**
+     * Defines a projection class: the getters, and the public fields, will be used to restrict which fields should be
+     * retrieved from the database.
+     *
+     * @return this query, modified
+     */
+    public <T> PanacheQuery<T> project(Class<T> type);
+
+    /**
      * Sets the current page.
      * 
      * @param page the new page

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/ProjectionFor.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/ProjectionFor.java
@@ -1,0 +1,14 @@
+package io.quarkus.mongodb.panache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ProjectionFor {
+    public Class<?> value();
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoPropertyUtil.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoPropertyUtil.java
@@ -1,0 +1,53 @@
+package io.quarkus.mongodb.panache.runtime;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+final class MongoPropertyUtil {
+
+    private MongoPropertyUtil() {
+        //prevent initialization
+    }
+
+    static Map<String, String> extractReplacementMap(Class<?> clazz) {
+        //TODO cache the replacement map or pre-compute it during build (using reflection or jandex)
+        Map<String, String> replacementMap = new HashMap<>();
+        for (Field field : clazz.getDeclaredFields()) {
+            BsonProperty bsonProperty = field.getAnnotation(BsonProperty.class);
+            if (bsonProperty != null) {
+                replacementMap.put(field.getName(), bsonProperty.value());
+            }
+        }
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.getName().startsWith("get")) {
+                // we try to replace also for getter
+                BsonProperty bsonProperty = method.getAnnotation(BsonProperty.class);
+                if (bsonProperty != null) {
+                    String fieldName = decapitalize(method.getName().substring(3));
+                    replacementMap.put(fieldName, bsonProperty.value());
+                }
+            }
+        }
+        return replacementMap;
+    }
+
+    // copied from JavaBeanUtil that is inside the core deployment module so not accessible at runtime.
+    // See conventions expressed by https://docs.oracle.com/javase/7/docs/api/java/beans/Introspector.html#decapitalize(java.lang.String)
+    static String decapitalize(String name) {
+        if (name != null && name.length() != 0) {
+            if (name.length() > 1 && Character.isUpperCase(name.charAt(1))) {
+                return name;
+            } else {
+                char[] chars = name.toCharArray();
+                chars[0] = Character.toLowerCase(chars[0]);
+                return new String(chars);
+            }
+        } else {
+            return name;
+        }
+    }
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQlQueryBinder.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQlQueryBinder.java
@@ -1,14 +1,10 @@
 package io.quarkus.mongodb.panache.runtime;
 
-import java.beans.Introspector;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import io.quarkus.panacheql.internal.HqlLexer;
 import io.quarkus.panacheql.internal.HqlParser;
@@ -17,7 +13,7 @@ import io.quarkus.panacheql.internal.HqlParserBaseVisitor;
 public class PanacheQlQueryBinder {
 
     public static String bindQuery(Class<?> clazz, String query, Object[] params) {
-        Map<String, String> replacementMap = extractReplacementMap(clazz);
+        Map<String, String> replacementMap = MongoPropertyUtil.extractReplacementMap(clazz);
 
         //shorthand query
         if (params.length == 1 && query.indexOf('?') == -1) {
@@ -35,10 +31,10 @@ public class PanacheQlQueryBinder {
     }
 
     public static String bindQuery(Class<?> clazz, String query, Map<String, Object> params) {
-        Map<String, String> replacementMap = extractReplacementMap(clazz);
+        Map<String, String> replacementMap = MongoPropertyUtil.extractReplacementMap(clazz);
 
         Map<String, Object> parameterMaps = new HashMap<>();
-        for (Map.Entry entry : params.entrySet()) {
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
             String bindParamsKey = ":" + entry.getKey();
             parameterMaps.put(bindParamsKey, entry.getValue());
         }
@@ -48,28 +44,6 @@ public class PanacheQlQueryBinder {
 
     private static String replaceField(String field, Map<String, String> replacementMap) {
         return replacementMap.getOrDefault(field, field);
-    }
-
-    private static Map<String, String> extractReplacementMap(Class<?> clazz) {
-        //TODO cache the replacement map or pre-compute it during build (using reflection or jandex)
-        Map<String, String> replacementMap = new HashMap<>();
-        for (Field field : clazz.getDeclaredFields()) {
-            BsonProperty bsonProperty = field.getAnnotation(BsonProperty.class);
-            if (bsonProperty != null) {
-                replacementMap.put(field.getName(), bsonProperty.value());
-            }
-        }
-        for (Method method : clazz.getDeclaredMethods()) {
-            if (method.getName().startsWith("get")) {
-                // we try to replace also for getter
-                BsonProperty bsonProperty = method.getAnnotation(BsonProperty.class);
-                if (bsonProperty != null) {
-                    String fieldName = Introspector.decapitalize(method.getName().substring(3));
-                    replacementMap.put(fieldName, bsonProperty.value());
-                }
-            }
-        }
-        return replacementMap;
     }
 
     private static String prepareQuery(String query, Map<String, String> replacementMap, Map<String, Object> parameterMaps) {

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
@@ -77,8 +77,8 @@ public class BookEntityResource {
 
     @GET
     @Path("/search/{author}")
-    public List<BookEntity> getBooksByAuthor(@PathParam("author") String author) {
-        return BookEntity.list("author", author);
+    public List<BookShortView> getBooksByAuthor(@PathParam("author") String author) {
+        return BookEntity.find("author", author).project(BookShortView.class).list();
     }
 
     @GET

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
@@ -80,8 +80,8 @@ public class BookRepositoryResource {
 
     @GET
     @Path("/search/{author}")
-    public List<Book> getBooksByAuthor(@PathParam("author") String author) {
-        return bookRepository.list("author", author);
+    public List<BookShortView> getBooksByAuthor(@PathParam("author") String author) {
+        return bookRepository.find("author", author).project(BookShortView.class).list();
     }
 
     @GET

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookShortView.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookShortView.java
@@ -4,11 +4,11 @@ import java.time.LocalDate;
 
 import javax.json.bind.annotation.JsonbDateFormat;
 
-import org.bson.codecs.pojo.annotations.BsonProperty;
+import io.quarkus.mongodb.panache.ProjectionFor;
 
+@ProjectionFor(Book.class)
 public class BookShortView {
-    @BsonProperty("bookTitle")
-    private String title; // use the field name title and not the column name bookTitle
+    private String title; // uses the field name title and not the column name bookTitle
     private String author;
     @JsonbDateFormat("yyyy-MM-dd")
     private LocalDate creationDate;

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookShortView.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookShortView.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.mongodb.panache.book;
+
+import java.time.LocalDate;
+
+import javax.json.bind.annotation.JsonbDateFormat;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public class BookShortView {
+    @BsonProperty("bookTitle")
+    private String title; // use the field name title and not the column name bookTitle
+    private String author;
+    @JsonbDateFormat("yyyy-MM-dd")
+    private LocalDate creationDate;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public LocalDate getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(LocalDate creationDate) {
+        this.creationDate = creationDate;
+    }
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonEntityResource.java
@@ -21,6 +21,12 @@ public class PersonEntityResource {
         return PersonEntity.listAll();
     }
 
+    @GET
+    @Path("/search/{name}")
+    public List<PersonName> searchPersons(@PathParam("name") String name) {
+        return PersonEntity.find("lastname", name).project(PersonName.class).list();
+    }
+
     @POST
     public Response addPerson(PersonEntity person) {
         person.persist();

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonName.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonName.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.mongodb.panache.person;
+
+public class PersonName {
+    public String lastname;
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.java
@@ -26,6 +26,12 @@ public class PersonRepositoryResource {
         return personRepository.listAll();
     }
 
+    @GET
+    @Path("/search/{name}")
+    public List<PersonName> searchPersons(@PathParam("name") String name) {
+        return personRepository.find("lastname", name).project(PersonName.class).list();
+    }
+
     @POST
     public Response addPerson(Person person) {
         personRepository.persist(person);

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -165,6 +165,9 @@ class MongodbPanacheResourceTest {
         // magic query find("author", author)
         list = get(endpoint + "/search/Victor Hugo").as(LIST_OF_BOOK_TYPE_REF);
         Assertions.assertEquals(2, list.size());
+        // we have a projection so we should not have the details field but we should have the title thanks to @BsonProperty
+        Assertions.assertNotNull(list.get(0).getTitle());
+        Assertions.assertNull(list.get(0).getDetails());
 
         // magic query find("{'author':?1,'title':?1}", author, title)
         BookDTO book = get(endpoint + "/search?author=Victor Hugo&title=Notre-Dame de Paris").as(BookDTO.class);
@@ -278,6 +281,13 @@ class MongodbPanacheResourceTest {
         //with sort
         list = get(endpoint + "?sort=firstname").as(LIST_OF_PERSON_TYPE_REF);
         Assertions.assertEquals(4, list.size());
+
+        //with project
+        list = get(endpoint + "/search/Doe").as(LIST_OF_PERSON_TYPE_REF);
+        Assertions.assertEquals(2, list.size());
+        Assertions.assertNotNull(list.get(0).lastname);
+        //expected the firstname field to be null as we project on lastname only
+        Assertions.assertNull(list.get(0).firstname);
 
         //count
         Long count = get(endpoint + "/count").as(Long.class);


### PR DESCRIPTION
This PR provides query projection for MongoDB with Panache.
It offers a `project(Class)` operation on `PanacheQuery` to implements query projection based on a projection class (public fields or getters/setters).

Ping @FroMage @emmanuelbernard 

This is part of #4193