### PR TITLE
The SmallRye JWT extension depends on Undertow.

### DIFF
--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -24,10 +24,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
@@ -37,6 +33,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow-deployment</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/extensions/smallrye-jwt/runtime/pom.xml
+++ b/extensions/smallrye-jwt/runtime/pom.xml
@@ -24,11 +24,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-security</artifactId>
+            <artifactId>quarkus-undertow</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
It fixes the JWT quickstart.