### PR TITLE
Optimize serving of static classpath resources

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/InvalidMultilineSqlLoadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/InvalidMultilineSqlLoadScriptTestCase.java
@@ -5,11 +5,11 @@ import javax.persistence.PersistenceException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.MyEntity;
 import io.quarkus.test.QuarkusUnitTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InvalidMultilineSqlLoadScriptTestCase {
     @RegisterExtension

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/InvalidMultilineSqlLoadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/InvalidMultilineSqlLoadScriptTestCase.java
@@ -5,11 +5,11 @@ import javax.persistence.PersistenceException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.MyEntity;
 import io.quarkus.test.QuarkusUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class InvalidMultilineSqlLoadScriptTestCase {
     @RegisterExtension

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.jar.JarEntry;
-import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
 
@@ -90,6 +89,8 @@ public class ResteasyStandaloneBuildStep {
                             if (!file.startsWith("/")) {
                                 file = "/" + file;
                             }
+                            // Windows has a backslash
+                            file = file.replace('\\', '/');
                             knownPaths.add(file);
                         }
                     }
@@ -137,6 +138,8 @@ public class ResteasyStandaloneBuildStep {
                                 if (!file.startsWith("/")) {
                                     file = "/" + file;
                                 }
+                                // Windows has a backslash
+                                file = file.replace('\\', '/');
                                 knownPaths.add(file);
                             }
                         }

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ClasspathResourceTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ClasspathResourceTestCase.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.test;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ClasspathResourceTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RootResource.class)
+                    .addAsManifestResource(new StringAsset("hello"), "resources/other/hello.txt")
+                    .addAsManifestResource(new StringAsset("index"), "resources/index.html")
+                    .addAsManifestResource(new StringAsset("stuff"), "resources/stuff.html"));
+
+    @Test
+    public void testRootResource() {
+        RestAssured.when().get("/other/hello.txt").then().body(Matchers.is("hello"));
+        RestAssured.when().get("/stuff.html").then().body(Matchers.is("stuff"));
+        RestAssured.when().get("/index.html").then().body(Matchers.is("index"));
+        RestAssured.when().get("/").then().body(Matchers.is("index"));
+    }
+
+}

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
@@ -3,8 +3,8 @@ package io.quarkus.resteasy.runtime.standalone;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.ResteasyDeployment;
@@ -122,7 +122,7 @@ public class ResteasyStandaloneRecorder {
         if (!knownPaths.isEmpty()) {
             StaticHandler staticHandler = StaticHandler.create(META_INF_RESOURCES);
             handlers.add(ctx -> {
-                if (knownPaths.contains(ctx.request().path())) {
+                if (knownPaths.contains(ctx.normalisedPath())) {
                     staticHandler.handle(ctx);
                 } else {
                     ctx.next();

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.ResteasyDeployment;
@@ -75,19 +76,20 @@ public class ResteasyStandaloneRecorder {
     }
 
     private static ResteasyDeployment deployment;
+    private static Set<String> knownPaths;
+    private static String contextPath;
 
-    public void setupDeployment(ResteasyDeployment dep) {
+    public void staticInit(ResteasyDeployment dep, String path, Set<String> known) {
         deployment = dep;
         deployment.start();
-
+        knownPaths = known;
+        contextPath = path;
     }
 
-    public Consumer<Route> startResteasy(RuntimeValue<Vertx> vertxValue,
-            String contextPath,
+    public Consumer<Route> start(RuntimeValue<Vertx> vertxValue,
             ShutdownContext shutdown,
             BeanContainer beanContainer,
-            boolean hasClasspathResources,
-            boolean isVirtual) throws Exception {
+            boolean isVirtual) {
 
         shutdown.addShutdownTask(new Runnable() {
             @Override
@@ -117,8 +119,15 @@ public class ResteasyStandaloneRecorder {
                 });
             }
         }
-        if (hasClasspathResources) {
-            handlers.add(StaticHandler.create(META_INF_RESOURCES));
+        if (!knownPaths.isEmpty()) {
+            StaticHandler staticHandler = StaticHandler.create(META_INF_RESOURCES);
+            handlers.add(ctx -> {
+                if (knownPaths.contains(ctx.request().path())) {
+                    staticHandler.handle(ctx);
+                } else {
+                    ctx.next();
+                }
+            });
         }
 
         VertxRequestHandler requestHandler = new VertxRequestHandler(vertx, beanContainer, deployment, contextPath, ALLOCATOR);


### PR DESCRIPTION
Bypass Vert.x StaticHandler if path isn't a classpath resource.  Previously there was a big penalty to performance if a META-INF/resources directory existed in the deployment as the Vertx static handler would run even for Resteasy endpoints.