### PR TITLE
Bump jackson to 2.10.0

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -68,7 +68,7 @@
            is not available in Maven fast enough: -->
         <graal-sdk.version>19.2.0.1</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha8</gizmo.version>
-        <jackson.version>2.9.10</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
         <commons-codec.version>1.11</commons-codec.version>

--- a/integration-tests/jackson/model/pom.xml
+++ b/integration-tests/jackson/model/pom.xml
@@ -17,22 +17,6 @@
 
     <name>Quarkus - Integration Tests - Jackson - model</name>
 
-    <properties>
-        <jackson.version>2.9.9.20190807</jackson.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10