### PR TITLE
Use 16k arena sizes for netty pooled buffers instead of 16mb for both JVM and native

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -52,6 +52,9 @@ class NettyProcessor {
 
         SubstrateConfigBuildItem.Builder builder = SubstrateConfigBuildItem.builder()
                 .addNativeImageSystemProperty("io.netty.noUnsafe", "true")
+                // Use small chunks to avoid a lot of wasted space. Default is 16mb * arenas (derived from core count)
+                // Since buffers are cached to threads, the malloc overhead is temporary anyway
+                .addNativeImageSystemProperty("io.netty.allocator.maxOrder", "1")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslEngine")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ReferenceCountedOpenSslContext")

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -16,6 +16,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.JniBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateConfigBuildItem;
 import io.quarkus.deployment.builditem.substrate.SubstrateSystemPropertyBuildItem;
@@ -39,6 +40,13 @@ class NettyProcessor {
         //in native mode we limit the size of the epoll array
         //if the array overflows the selector just moves the overflow to a map
         return new SubstrateSystemPropertyBuildItem("sun.nio.ch.maxUpdateArraySize", "100");
+    }
+
+    @BuildStep
+    public SystemPropertyBuildItem limitArenaSize() {
+        // Use small chunks to avoid a lot of wasted space. Default is 16mb * arenas (derived from core count)
+        // Since buffers are cached to threads, the malloc overhead is temporary anyway
+        return new SystemPropertyBuildItem("io.netty.allocator.maxOrder", "1");
     }
 
     @BuildStep

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -1,5 +1,6 @@
 package io.quarkus.netty.runtime.graal;
 
+import java.nio.ByteBuffer;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
@@ -282,6 +283,17 @@ final class Target_io_netty_channel_nio_NioEventLoop {
     private static Queue<Runnable> newTaskQueue0(int maxPendingTasks) {
         return new LinkedBlockingDeque<>();
     }
+}
+
+@TargetClass(className = "io.netty.util.internal.PlatformDependent")
+final class Target_io_netty_util_internal_PlatformDependent {
+
+    @Substitute
+    public static void freeDirectBuffer(ByteBuffer buffer) {
+        //we can't free direct buffers in native mode due to a NPE
+        //noop
+    }
+
 }
 
 class NettySubstitutions {


### PR DESCRIPTION
Use 16k arena sizes for netty pooled buffers instead of 16mb for both JVM and native

In the future this will be made configurable