### PR TITLE
Publish the "debug build process" port during native image generation

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -71,6 +71,9 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "${native-image.debug-build-process}")
     private boolean debugBuildProcess;
 
+    @Parameter(defaultValue = "true")
+    private boolean publishDebugBuildProcessPort;
+
     @Parameter(readonly = true, required = true, defaultValue = "${project.build.finalName}")
     private String finalName;
 
@@ -354,6 +357,7 @@ public class NativeImageMojo extends AbstractMojo {
                 .setOutputDir(buildDir.toPath())
                 .setCleanupServer(cleanupServer)
                 .setDebugBuildProcess(debugBuildProcess)
+                .setPublishDebugBuildProcessPort(publishDebugBuildProcessPort)
                 .setDebugSymbols(debugSymbols)
                 .setDisableReports(disableReports)
                 .setDockerBuild(dockerBuild)


### PR DESCRIPTION
When the native image is built for a project using:
```
mvn package -Pnative
```

The native image generation mojo `NativeImageMojo` allows users to debug the native image generation build process by setting the:
```
<debugBuildProcess>true</debugBuildProcess>
```
plugin configuration. When this is enabled, the native image generation is passed additional `jdwp` debug parameters to the JVM and the port `5005` is setup for debugging. This all works fine currently and the port gets bound. However, since this native image generation happens within a docker container (through `docker run` or `podman run`), even though the port is bound, it's not published on the host and hence the IDE cannot attach to that port.

The commit in this PR publishes this port to the host, by default, if the `debugBuildProcess` is set to `true`. This allows IDEs to connect with this port on the host. This commit further introduces a new configuration `publishDebugBuildProcessPort` for the Mojo which users can set to `false` like below, if they want to prevent the port from being published by default:
```
<publishDebugBuildProcessPort>false</publishDebugBuildProcessPort>
```
(for example if they want to manually publish to a different port of the host through the use of `containerRuntimeOptions`)

I have done some manual testing with this change, plus the usage of various combinations of `debugBuildProcess` and `publishDebugBuildProcessPort` configurations and that testing went fine.