### PR TITLE
ORM update, paving road for more persistence optimisations

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -76,7 +76,7 @@
         <classmate.version>1.3.4</classmate.version>
         <javax.el-impl.version>3.0.1-b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Alpha6</hibernate-validator.version>
-        <hibernate-orm.version>5.4.5.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.6.Final</hibernate-orm.version>
         <hibernate-search.version>6.0.0.Alpha9</hibernate-search.version>
         <narayana.version>5.9.8.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -80,7 +80,7 @@
         <hibernate-search.version>6.0.0.Alpha9</hibernate-search.version>
         <narayana.version>5.9.8.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
-        <agroal.version>1.5</agroal.version>
+        <agroal.version>1.6</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <elasticsearch-rest-client.version>7.3.0</elasticsearch-rest-client.version>


### PR DESCRIPTION
Upgrading to

- Hibernate ORM 5.4.6.Final
- Agroal 1.6

both are necessary for some optimisations, which I'll unlock with subsequent PRs.

*Untested* sorry I'm travelling, I'll need to rely on CI for full integration tets.