### PR TITLE
MP CP TCK addition

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -109,6 +109,7 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <rest-assured.version>4.1.1</rest-assured.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
+        <testng.version>6.14.2</testng.version>
         <assertj.version>3.13.2</assertj.version>
         <json-smart.version>2.3</json-smart.version>
         <infinispan.version>10.0.0.Beta5</infinispan.version>
@@ -1136,6 +1137,11 @@
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>${javax.ws.rs-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -27,7 +27,7 @@
         <quarkus-http.version>3.0.0.Alpha6</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.3</microprofile-config-api.version>
-        <microprofile-context-propagation.version>1.0</microprofile-context-propagation.version>
+        <microprofile-context-propagation.version>1.0.1</microprofile-context-propagation.version>
         <microprofile-opentracing-api.version>1.3.1</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.3.3</microprofile-rest-client.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -58,7 +58,7 @@
         <microprofile-reactive-messaging-api.version>1.0</microprofile-reactive-messaging-api.version>
         <microprofile-rest-client-api.version>1.2.1</microprofile-rest-client-api.version>
         <microprofile-open-api.version>1.1.2</microprofile-open-api.version>
-        <microprofile-context-propagation.version>1.0</microprofile-context-propagation.version>
+        <microprofile-context-propagation.version>1.0.1</microprofile-context-propagation.version>
         <!-- Antlr is used by the PanacheQL parser-->
         <antlr.version>4.7.2</antlr.version>
     </properties>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -58,7 +58,7 @@
         <microprofile-reactive-messaging-api.version>1.0</microprofile-reactive-messaging-api.version>
         <microprofile-rest-client-api.version>1.2.1</microprofile-rest-client-api.version>
         <microprofile-open-api.version>1.1.2</microprofile-open-api.version>
-
+        <microprofile-context-propagation.version>1.0</microprofile-context-propagation.version>
         <!-- Antlr is used by the PanacheQL parser-->
         <antlr.version>4.7.2</antlr.version>
     </properties>

--- a/tcks/microprofile-context-propagation/pom.xml
+++ b/tcks/microprofile-context-propagation/pom.xml
@@ -29,6 +29,10 @@
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.context-propagation:microprofile-context-propagation-tck</dependency>
                     </dependenciesToScan>
+                    <!-- To be removed once #3878 is implemented-->
+                    <excludes>
+                        <exclude>**/JTACDITest.java</exclude>
+                     </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/tcks/microprofile-context-propagation/pom.xml
+++ b/tcks/microprofile-context-propagation/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-tck-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-tck-microprofile-context-propagation</artifactId>
+    <name>Quarkus - TCK - MicroProfile Context Propagation</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Disable quarkus optimization -->
+                        <quarkus.arc.remove-unused-beans>false</quarkus.arc.remove-unused-beans>
+                    </systemPropertyVariables>
+                    <!-- This workaround allows us to run a single test using
+                        the "test" system property -->
+                    <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
+                    <dependenciesToScan>
+                        <dependency>org.eclipse.microprofile.context-propagation:microprofile-context-propagation-tck</dependency>
+                    </dependenciesToScan>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arquillian</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.context-propagation</groupId>
+            <artifactId>microprofile-context-propagation-tck</artifactId>
+            <version>${microprofile-context-propagation.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tcks/microprofile-context-propagation/pom.xml
+++ b/tcks/microprofile-context-propagation/pom.xml
@@ -47,5 +47,9 @@
             <artifactId>microprofile-context-propagation-tck</artifactId>
             <version>${microprofile-context-propagation.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/tcks/microprofile-context-propagation/pom.xml
+++ b/tcks/microprofile-context-propagation/pom.xml
@@ -43,6 +43,17 @@
             <artifactId>quarkus-smallrye-context-propagation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-narayana-jta</artifactId>
+            <exclusions>
+                <!--MP CP currently uses 1.2, while we run 1.3-->
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>javax.transaction-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.context-propagation</groupId>
             <artifactId>microprofile-context-propagation-tck</artifactId>
             <version>${microprofile-context-propagation.version}</version>

--- a/tcks/microprofile-context-propagation/src/main/java/io/quarkus/arquillian/ArquillianBeforeAfterEnricher.java
+++ b/tcks/microprofile-context-propagation/src/main/java/io/quarkus/arquillian/ArquillianBeforeAfterEnricher.java
@@ -1,0 +1,32 @@
+package io.quarkus.arquillian;
+
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+
+/**
+ * Activates request context before test runs and shuts it down afterwards
+ */
+public class ArquillianBeforeAfterEnricher {
+
+    private static final String ERROR_MSG = "Arc container is not running, cannot activate CDI contexts!";
+
+    public void on(@Observes(precedence = -100) org.jboss.arquillian.test.spi.event.suite.Before event) throws Throwable {
+        ArcContainer container = Arc.container();
+        if (container.isRunning()) {
+            container.requestContext().activate();
+        } else {
+            throw new IllegalStateException(ERROR_MSG);
+        }
+    }
+
+    public void on(@Observes(precedence = 100) org.jboss.arquillian.test.spi.event.suite.After event) throws Throwable {
+        ArcContainer container = Arc.container();
+        if (container.isRunning()) {
+            container.requestContext().terminate();
+        } else {
+            throw new IllegalStateException(ERROR_MSG);
+        }
+    }
+}

--- a/tcks/microprofile-context-propagation/src/main/java/io/quarkus/arquillian/QuarkusArquillianLifecycleExtension.java
+++ b/tcks/microprofile-context-propagation/src/main/java/io/quarkus/arquillian/QuarkusArquillianLifecycleExtension.java
@@ -1,0 +1,12 @@
+package io.quarkus.arquillian;
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class QuarkusArquillianLifecycleExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        // for MP CP TCK only, we want to register this observer which activated CDI contexts
+        builder.observer(ArquillianBeforeAfterEnricher.class);
+    }
+}

--- a/tcks/microprofile-context-propagation/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/tcks/microprofile-context-propagation/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.quarkus.arquillian.QuarkusArquillianLifecycleExtension

--- a/tcks/microprofile-context-propagation/src/test/java/io/quarkus/tck/context/Dummy.java
+++ b/tcks/microprofile-context-propagation/src/test/java/io/quarkus/tck/context/Dummy.java
@@ -1,0 +1,6 @@
+package io.quarkus.tck.context;
+
+// We need this class so that target/test-classes is added to the class path?
+public class Dummy {
+
+}

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -15,6 +15,7 @@
     
     <modules>
         <module>microprofile-config</module>
+        <module>microprofile-context-propagation</module>
         <module>microprofile-health</module>
         <module>microprofile-metrics</module>
         <module>microprofile-reactive-messaging</module>

--- a/test-framework/arquillian/pom.xml
+++ b/test-framework/arquillian/pom.xml
@@ -69,6 +69,29 @@
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!--Adding this seems to prevent TestNG from attempting to run the tests instead of junit-->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.surefire.plugin}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusBeforeAfterLifecycle.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusBeforeAfterLifecycle.java
@@ -8,18 +8,35 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 public class QuarkusBeforeAfterLifecycle {
 
     private static final String JUNIT_CALLBACKS = "io.quarkus.arquillian.QuarkusJunitCallbacks";
-    private static final String JUNIT_INVOKE_BEFORES = "invokeBefores";
-    private static final String JUNIT_INVOKE_AFTERS = "invokeAfters";
+    private static final String TESTNG_CALLBACKS = "io.quarkus.arquillian.QuarkusTestNgCallbacks";
+    private static final String JUNIT_INVOKE_BEFORES = "invokeJunitBefores";
+    private static final String JUNIT_INVOKE_AFTERS = "invokeJunitAfters";
+    private static final String TESTNG_INVOKE_BEFORE_CLASS = "invokeTestNgBeforeClasses";
+    private static final String TESTNG_INVOKE_AFTER_CLASS = "invokeTestNgAfterClasses";
 
     public void on(@Observes(precedence = -100) org.jboss.arquillian.test.spi.event.suite.Before event) throws Throwable {
         if (isJunitAvailable()) {
-            invokeJunitCallbacks(JUNIT_INVOKE_BEFORES);
+            invokeCallbacks(JUNIT_INVOKE_BEFORES, JUNIT_CALLBACKS);
         }
     }
 
     public void on(@Observes(precedence = 100) org.jboss.arquillian.test.spi.event.suite.After event) throws Throwable {
         if (isJunitAvailable()) {
-            invokeJunitCallbacks(JUNIT_INVOKE_AFTERS);
+            invokeCallbacks(JUNIT_INVOKE_AFTERS, JUNIT_CALLBACKS);
+        }
+    }
+
+    public void beforeClass(@Observes(precedence = -100) org.jboss.arquillian.test.spi.event.suite.BeforeClass event)
+            throws Throwable {
+        if (isTestNGAvailable()) {
+            invokeCallbacks(TESTNG_INVOKE_BEFORE_CLASS, TESTNG_CALLBACKS);
+        }
+    }
+
+    public void afterClass(@Observes(precedence = 100) org.jboss.arquillian.test.spi.event.suite.AfterClass event)
+            throws Throwable {
+        if (isTestNGAvailable()) {
+            invokeCallbacks(TESTNG_INVOKE_AFTER_CLASS, TESTNG_CALLBACKS);
         }
     }
 
@@ -33,13 +50,23 @@ public class QuarkusBeforeAfterLifecycle {
         }
     }
 
-    private void invokeJunitCallbacks(String methodName)
+    private boolean isTestNGAvailable() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        try {
+            cl.loadClass("org.jboss.arquillian.testng.container.TestNGTestRunner");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private void invokeCallbacks(String methodName, String junitOrTestNgCallbackClass)
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, ClassNotFoundException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        Class<?> callbacksClass = cl.loadClass(JUNIT_CALLBACKS);
-        Method invokeBefores = callbacksClass.getDeclaredMethod(methodName);
-        invokeBefores.invoke(null);
+        Class<?> callbacksClass = cl.loadClass(junitOrTestNgCallbackClass);
+        Method declaredMethod = callbacksClass.getDeclaredMethod(methodName);
+        declaredMethod.invoke(null);
     }
 
 }

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusDeployableContainer.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusDeployableContainer.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URLClassLoader;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -108,7 +105,20 @@ public class QuarkusDeployableContainer implements DeployableContainer<QuarkusCo
                 }
                 //META-INF -> archive/META-INF/
                 if (Files.exists(tmpLocation.resolve("META-INF"))) {
-                    Files.move(tmpLocation.resolve("META-INF"), appLocation.resolve("META-INF"));
+                    if (Files.exists(appLocation.resolve("META-INF"))) {
+                        // Target directory not empty.
+                        Files.walk(tmpLocation.resolve("META-INF"), 2).forEach(p -> {
+                            try {
+                                Files.createFile(p);
+                            } catch (FileAlreadyExistsException faee) {
+                                // Do Nothing
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                    } else {
+                        Files.move(tmpLocation.resolve("META-INF"), appLocation.resolve("META-INF"));
+                    }
                 }
                 //WEB-INF -> archive/WEB-INF
                 if (Files.exists(tmpLocation.resolve("WEB-INF"))) {

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusJunitCallbacks.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusJunitCallbacks.java
@@ -13,12 +13,12 @@ import org.junit.Before;
 /**
  * Note that we cannot use event.getExecutor().invoke() directly because the callbacks would be invoked upon the original test
  * class instance and not the real test instance.
- * 
- * TODO TestNG callbacks?
+ * <p>
+ * This class works for JUnit callbacks only, see {@link QuarkusTestNgCallbacks} for TestNG
  */
 class QuarkusJunitCallbacks {
 
-    static void invokeBefores() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    static void invokeJunitBefores() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Object testInstance = QuarkusDeployableContainer.testInstance;
         // if there is no managed deployment, then we have no test instance because it hasn't been deployed yet
         if (testInstance != null) {
@@ -30,7 +30,7 @@ class QuarkusJunitCallbacks {
         }
     }
 
-    static void invokeAfters() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    static void invokeJunitAfters() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Object testInstance = QuarkusDeployableContainer.testInstance;
         if (testInstance != null) {
             List<Method> afters = new ArrayList<>();
@@ -42,7 +42,7 @@ class QuarkusJunitCallbacks {
     }
 
     private static void collectCallbacks(Class<?> testClass, List<Method> callbacks, Class<? extends Annotation> annotation) {
-        Arrays.stream(testClass.getMethods()).filter(m -> m.isAnnotationPresent(annotation)).forEach(callbacks::add);
+        Arrays.stream(testClass.getDeclaredMethods()).filter(m -> m.isAnnotationPresent(annotation)).forEach(callbacks::add);
         Class<?> superClass = testClass.getSuperclass();
         if (superClass != null && !superClass.equals(Object.class)) {
             collectCallbacks(superClass, callbacks, annotation);

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusTestNgCallbacks.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/QuarkusTestNgCallbacks.java
@@ -1,0 +1,54 @@
+package io.quarkus.arquillian;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+/**
+ * Note that we cannot use event.getExecutor().invoke() directly because the callbacks would be invoked upon the original test
+ * class instance and not the real test instance.
+ * <p>
+ * This class works for TestNG only, see {@link QuarkusJunitCallbacks} for Junit bits
+ */
+public class QuarkusTestNgCallbacks {
+
+    private static final String ARQ_TESTNG_SUPERCLASS = "org.jboss.arquillian.testng.Arquillian";
+
+    static void invokeTestNgBeforeClasses() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Object testInstance = QuarkusDeployableContainer.testInstance;
+        if (testInstance != null) {
+            List<Method> beforeClasses = new ArrayList<>();
+            collectCallbacks(testInstance.getClass(), beforeClasses, BeforeClass.class);
+            for (Method beforeClass : beforeClasses) {
+                beforeClass.invoke(testInstance);
+            }
+        }
+    }
+
+    static void invokeTestNgAfterClasses() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Object testInstance = QuarkusDeployableContainer.testInstance;
+        if (testInstance != null) {
+            List<Method> afterClasses = new ArrayList<>();
+            collectCallbacks(testInstance.getClass(), afterClasses, AfterClass.class);
+            for (Method afterClass : afterClasses) {
+                afterClass.invoke(testInstance);
+            }
+        }
+    }
+
+    private static void collectCallbacks(Class<?> testClass, List<Method> callbacks, Class<? extends Annotation> annotation) {
+        Arrays.stream(testClass.getDeclaredMethods()).filter(m -> m.isAnnotationPresent(annotation)).forEach(callbacks::add);
+        Class<?> superClass = testClass.getSuperclass();
+        if (superClass != null && !superClass.equals(Object.class) &&
+        // TestNG Arq. superclass uses lifecycle methods as well, we don't want to pick up those
+                !superClass.toString().contains(ARQ_TESTNG_SUPERCLASS)) {
+            collectCallbacks(superClass, callbacks, annotation);
+        }
+    }
+}


### PR DESCRIPTION
ATM we have one exclusion which requires #3878 to be implemented, otherwise we should pass it all.
Requires bumping of MP CP to 1.0.1 and brings in Arq. extension for testng.