### PR TITLE
Support customization of the project name and version in logs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
@@ -4,7 +4,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class ApplicationInfoBuildItem extends SimpleBuildItem {
 
-    public static final String UNSET_VALUE = "<<unset>>";
+    private static final String UNSET_VALUE = "<<unset>>";
 
     private final String name;
     private final String version;
@@ -15,10 +15,10 @@ public final class ApplicationInfoBuildItem extends SimpleBuildItem {
     }
 
     public String getName() {
-        return name;
+        return name == null ? UNSET_VALUE : name;
     }
 
     public String getVersion() {
-        return version;
+        return version == null ? UNSET_VALUE : version;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -17,6 +17,7 @@ import io.quarkus.deployment.ClassOutput;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.BytecodeRecorderObjectLoaderBuildItem;
 import io.quarkus.deployment.builditem.ClassOutputBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -66,7 +67,8 @@ class MainClassBuildStep {
             BuildProducer<ApplicationClassNameBuildItem> appClassNameProducer,
             List<BytecodeRecorderObjectLoaderBuildItem> loaders,
             ClassOutputBuildItem classOutput,
-            LaunchModeBuildItem launchMode) {
+            LaunchModeBuildItem launchMode,
+            ApplicationInfoBuildItem applicationInfo) {
 
         String appClassName = APP_CLASS + COUNT.incrementAndGet();
         appClassNameProducer.produce(new ApplicationClassNameBuildItem(appClassName));
@@ -197,7 +199,10 @@ class MainClassBuildStep {
                 .sorted()
                 .collect(Collectors.joining(", ")));
         tryBlock.invokeStaticMethod(
-                ofMethod(Timing.class, "printStartupTime", void.class, String.class, String.class, String.class, boolean.class),
+                ofMethod(Timing.class, "printStartupTime", void.class, String.class, String.class, String.class, String.class,
+                        String.class, boolean.class),
+                tryBlock.load(applicationInfo.getName()),
+                tryBlock.load(applicationInfo.getVersion()),
                 tryBlock.load(Version.getVersion()),
                 featuresHandle,
                 tryBlock.load(ProfileManager.getActiveProfile()),

--- a/core/runtime/src/main/java/io/quarkus/runtime/Timing.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Timing.java
@@ -18,6 +18,8 @@ public class Timing {
 
     private static volatile String httpServerInfo = "";
 
+    private static final String UNSET_VALUE = "<<unset>>";
+
     public static void staticInitStarted() {
         if (bootStartTime < 0) {
             bootStartTime = System.nanoTime();
@@ -50,12 +52,20 @@ public class Timing {
         bootStartTime = System.nanoTime();
     }
 
-    public static void printStartupTime(String version, String features, String profile, boolean liveCoding) {
+    public static void printStartupTime(String name, String version, String quarkusVersion, String features, String profile,
+            boolean liveCoding) {
         final long bootTimeNanoSeconds = System.nanoTime() - bootStartTime;
         final Logger logger = Logger.getLogger("io.quarkus");
         //Use a BigDecimal so we can render in seconds with 3 digits precision, as requested:
         final BigDecimal secondsRepresentation = convertToBigDecimalSeconds(bootTimeNanoSeconds);
-        logger.infof("Quarkus %s started in %ss. %s", version, secondsRepresentation, httpServerInfo);
+        String safeAppName = (name == null || name.isEmpty()) ? UNSET_VALUE : name;
+        String safeAppVersion = (version == null || version.isEmpty()) ? UNSET_VALUE : version;
+        if (UNSET_VALUE.equals(safeAppName) || UNSET_VALUE.equals(safeAppVersion)) {
+            logger.infof("Quarkus %s started in %ss. %s", quarkusVersion, secondsRepresentation, httpServerInfo);
+        } else {
+            logger.infof("%s %s (running on Quarkus %s) started in %ss. %s", name, version, quarkusVersion,
+                    secondsRepresentation, httpServerInfo);
+        }
         logger.infof("Profile %s activated. %s", profile, liveCoding ? "Live Coding activated." : "");
         logger.infof("Installed features: [%s]", features);
         bootStartTime = -1;


### PR DESCRIPTION
Fixes #1829 and closes #2790 

This will display an output like: 

```
2019-10-01 21:03:04,155 INFO  [io.quarkus] (main) getting-started 1.0-SNAPSHOT (running on Quarkus 999-SNAPSHOT) started in 0.561s. Listening on: http://0.0.0.0:8080
2019-10-01 21:03:04,159 INFO  [io.quarkus] (main) Profile prod activated. 
2019-10-01 21:03:04,160 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
```

or if `quarkus.application.name` and `quarkus.application.version` are explicitly set to empty in the `application.properties`: 

```
2019-10-01 21:05:43,788 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT started in 0.583s. Listening on: http://0.0.0.0:8080
2019-10-01 21:05:43,792 INFO  [io.quarkus] (main) Profile prod activated. 
2019-10-01 21:05:43,792 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
```


Based on @klearchos's work in #2790 (added him as a co-author)

@stuartwdouglas @dmlloyd @gsmet please review