### PR TITLE
Port 8080 exposed

### DIFF
--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -19,4 +19,5 @@ ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jb
 ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+EXPOSE 8080
 ENTRYPOINT [ "/deployments/run-java.sh" ]


### PR DESCRIPTION
The port is exposed in the native Dockerfile, but not in the JVM version Dockerfile.jvm.

For e.g. OpenShift deployment, the port has to be currently exposed manually: http://adambien.blog/roller/abien/entry/building_and_deploying_a_quarkus