### PR TITLE
Force java.io.tmpdir = /tmp for native executable 

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/resources/bootstrap
+++ b/extensions/amazon-lambda/deployment/src/main/resources/bootstrap
@@ -4,7 +4,7 @@ RUNNER=$( find . -maxdepth 1 -name '*-runner' )
 if [[ ! -z "$RUNNER" ]]
 then
     export DISABLE_SIGNAL_HANDLERS=true
-    $RUNNER
+    $RUNNER -Djava.io.tmpdir=/tmp
 else
     java -jar *-runner.jar
 fi


### PR DESCRIPTION
The only writeable folder for Amazon Lambda is /tmp.

vert.x upon startup attempts to create [tmpdir]/vertx-cache, which for the native executable is pointing to a readonly folder (/var/tmp) and not /tmp.

By modifying the bootstrap script it will force the native executable to use the correct java.io.tmpdir=/tmp, and the vertx-cache folder can be created.