### PR TITLE
AWS Lambda Virtual Channel Support

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -393,6 +393,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-amazon-lambda-resteasy-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -127,7 +127,7 @@
         <scala.version>2.12.8</scala.version>
         <tika.version>1.21</tika.version>
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>
-        <aws-lambda-java-events.version>2.2.5</aws-lambda-java-events.version>
+        <aws-lambda-java-events.version>2.2.7</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <awssdk.version>2.8.0</awssdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
@@ -164,6 +164,7 @@
         <antlr.version>4.7.2</antlr.version>
         <quarkus-security.version>1.0.0.Alpha2</quarkus-security.version>
         <javax.interceptor-api.version>1.2</javax.interceptor-api.version>
+        <httpmime.version>4.5.10</httpmime.version>
     </properties>
 
     <dependencyManagement>
@@ -606,6 +607,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-amazon-lambda</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-lambda-http</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -1187,6 +1193,11 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>${httpcore.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>${httpmime.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
@@ -2160,6 +2171,12 @@
                 <groupId>com.amazonaws.serverless</groupId>
                 <artifactId>aws-serverless-java-container-core</artifactId>
                 <version>${aws-lambda-serverless-java-container.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/core/deployment/src/main/java/io/quarkus/runner/RuntimeClassLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/RuntimeClassLoader.java
@@ -425,11 +425,16 @@ public class RuntimeClassLoader extends ClassLoader implements ClassOutput, Tran
     private URL findApplicationResource(String name) {
         Path resourcePath = null;
 
-        for (Path i : applicationClassDirectories) {
-            resourcePath = i.resolve(name);
-            if (Files.exists(resourcePath)) {
-                break;
+        try {
+            for (Path i : applicationClassDirectories) {
+                resourcePath = i.resolve(name);
+                if (Files.exists(resourcePath)) {
+                    break;
+                }
             }
+        } catch (Exception e) {
+            log.debugf(e, "Exception resolving path %s", name);
+            //ignore
         }
         try {
             return resourcePath != null && Files.exists(resourcePath) ? resourcePath.toUri()

--- a/extensions/amazon-lambda-http/deployment/NOTICE
+++ b/extensions/amazon-lambda-http/deployment/NOTICE
@@ -1,0 +1,4 @@
+Tests for the AWS Serverless Java Container feature come from the AWS Serverless Java Container project.
+
+AWS Serverless Java Container
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -2,25 +2,43 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>quarkus-amazon-lambda-resteasy-parent</artifactId>
-        <groupId>io.quarkus</groupId>
-        <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
-    <name>Quarkus - Amazon Lambda - RESTEasy - Runtime</name>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-lambda-http-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
+    <name>Quarkus - Amazon Lambda HTTP - Deployment</name>
 
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-amazon-lambda-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-server-common</artifactId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-lambda-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
@@ -32,44 +50,32 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>commons-logging-jboss-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -1,0 +1,23 @@
+package io.quarkus.amazon.lambda.http.deployment;
+
+import io.quarkus.amazon.lambda.deployment.AmazonLambdaBuildItem;
+import io.quarkus.amazon.lambda.http.runtime.AwsHttpHandler;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+
+public class AmazonLambdaHttpProcessor {
+
+    @BuildStep
+    RequireVirtualHttpBuildItem virtual(LaunchModeBuildItem launchMode) {
+        return launchMode.getLaunchMode().isDevOrTest() ? null : RequireVirtualHttpBuildItem.MARKER;
+    }
+
+    @BuildStep
+    AmazonLambdaBuildItem install(BuildProducer<AdditionalBeanBuildItem> consumer) {
+        consumer.produce(AdditionalBeanBuildItem.unremovableOf(AwsHttpHandler.class));
+        return new AmazonLambdaBuildItem(AwsHttpHandler.class.getName(), null);
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/EchoResteasyResource.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/EchoResteasyResource.java
@@ -1,0 +1,284 @@
+package io.quarkus.amazon.lambda.http.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Encoded;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.commons.io.IOUtils;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import org.jboss.resteasy.spi.HttpRequest;
+
+import com.amazonaws.serverless.proxy.RequestReader;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequestContext;
+
+import io.quarkus.amazon.lambda.http.test.model.MapResponseModel;
+import io.quarkus.amazon.lambda.http.test.model.SingleValueModel;
+import io.quarkus.amazon.lambda.http.test.provider.ServletRequestFilter;
+
+/**
+ * RESTEasy resource class for aws-serverless-java-container unit proxy
+ */
+@Path("/echo")
+public class EchoResteasyResource {
+    public static final String SERVLET_RESP_HEADER_KEY = "X-HttpServletResponse";
+    public static final String EXCEPTION_MESSAGE = "Fake exception";
+
+    @Context
+    SecurityContext securityCtx;
+
+    @Path("/decoded-param")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoDecodedParam(@QueryParam("param") String param) {
+        SingleValueModel model = new SingleValueModel();
+        model.setValue(param);
+        return model;
+    }
+
+    @Path("/filter-attribute")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel returnFilterAttribute(@Context HttpServletRequest req) {
+        SingleValueModel model = new SingleValueModel();
+        if (req.getAttribute(ServletRequestFilter.FILTER_ATTRIBUTE_NAME) == null) {
+            model.setValue("");
+        } else {
+            model.setValue(req.getAttribute(ServletRequestFilter.FILTER_ATTRIBUTE_NAME).toString());
+        }
+        return model;
+    }
+
+    @Path("/list-query-string")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoQueryStringLength(@QueryParam("list") List<String> param) {
+        System.out.println("param: " + param + " = " + param.size());
+        SingleValueModel model = new SingleValueModel();
+        model.setValue(param.size() + "");
+        return model;
+    }
+
+    @Path("/encoded-param")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoEncodedParam(@QueryParam("param") @Encoded String param) {
+        SingleValueModel model = new SingleValueModel();
+        model.setValue(param);
+        return model;
+    }
+
+    @Path("/headers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public MapResponseModel echoHeaders(@Context HttpRequest httpRequest) {
+        MapResponseModel headers = new MapResponseModel();
+        for (String key : httpRequest.getHttpHeaders().getRequestHeaders().keySet()) {
+            headers.addValue(key, httpRequest.getHttpHeaders().getHeaderString(key));
+        }
+
+        return headers;
+    }
+
+    @Path("/security-context")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel getPrincipal() {
+        SingleValueModel output = new SingleValueModel();
+        if (securityCtx != null) {
+            output.setValue(securityCtx.getUserPrincipal().getName());
+        }
+        return output;
+    }
+
+    @Path("/servlet-headers")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public MapResponseModel echoServletHeaders(@Context HttpServletRequest context) {
+        MapResponseModel headers = new MapResponseModel();
+        Enumeration<String> headerNames = context.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            headers.addValue(headerName, context.getHeader(headerName));
+        }
+        return headers;
+    }
+
+    @Path("/servlet-context")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoContextInformation(@Context ServletContext context) {
+        SingleValueModel singleValueModel = new SingleValueModel();
+        singleValueModel.setValue(context.getServerInfo());
+
+        return singleValueModel;
+    }
+
+    @Path("/query-string")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public MapResponseModel echoQueryString(@Context UriInfo context) {
+        MapResponseModel queryStrings = new MapResponseModel();
+        for (String key : context.getQueryParameters().keySet()) {
+            queryStrings.addValue(key, context.getQueryParameters().getFirst(key));
+        }
+
+        return queryStrings;
+    }
+
+    @Path("/scheme")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoRequestScheme(@Context UriInfo context) {
+        SingleValueModel model = new SingleValueModel();
+        System.out.println("RequestUri: " + context.getRequestUri().toString());
+        model.setValue(context.getRequestUri().getScheme());
+        return model;
+    }
+
+    @Path("/authorizer-principal")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoAuthorizerPrincipal(@Context HttpRequest httpRequest) {
+        SingleValueModel valueModel = new SingleValueModel();
+        AwsProxyRequestContext awsProxyRequestContext = (AwsProxyRequestContext) httpRequest
+                .getAttribute(RequestReader.API_GATEWAY_CONTEXT_PROPERTY);
+        valueModel.setValue(awsProxyRequestContext.getAuthorizer().getPrincipalId());
+
+        return valueModel;
+    }
+
+    @Path("/authorizer-context")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoAuthorizerContext(@Context HttpRequest httpRequest, @QueryParam("key") String key) {
+        SingleValueModel valueModel = new SingleValueModel();
+        AwsProxyRequestContext awsProxyRequestContext = (AwsProxyRequestContext) httpRequest
+                .getAttribute(RequestReader.API_GATEWAY_CONTEXT_PROPERTY);
+        valueModel.setValue(awsProxyRequestContext.getAuthorizer().getContextValue(key));
+
+        return valueModel;
+    }
+
+    @Path("/json-body")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public SingleValueModel echoJsonValue(final SingleValueModel requestValue) {
+        SingleValueModel output = new SingleValueModel();
+        output.setValue(requestValue.getValue());
+
+        return output;
+    }
+
+    @Path("/status-code")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response echoCustomStatusCode(@QueryParam("status") int statusCode) {
+        SingleValueModel output = new SingleValueModel();
+        output.setValue("" + statusCode);
+
+        return Response.status(statusCode).entity(output).build();
+    }
+
+    @Path("/servlet-response")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response echoCustomStatusCode(@Context HttpServletResponse resp) {
+        SingleValueModel output = new SingleValueModel();
+        output.setValue("Custom header in resp");
+        resp.setHeader(SERVLET_RESP_HEADER_KEY, "1");
+        return Response.ok().entity(output).build();
+    }
+
+    @Path("/binary")
+    @GET
+    @Produces("application/octet-stream")
+    public Response echoBinaryData() {
+        byte[] b = new byte[128];
+        new Random().nextBytes(b);
+
+        return Response.ok(b).build();
+    }
+
+    @Path("/empty-stream/{paramId}/test/{param2}")
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response emptyStream(@PathParam("paramId") String paramId, @PathParam("param2") String param2) {
+        SingleValueModel sv = new SingleValueModel();
+        sv.setValue(paramId);
+        return Response.ok(sv).build();
+    }
+
+    @Path("/exception")
+    @GET
+    public Response throwException() {
+        throw new UnsupportedOperationException(EXCEPTION_MESSAGE);
+    }
+
+    @Path("/encoded-path/{resource}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response encodedPathParam(@Encoded @PathParam("resource") String resource) {
+        SingleValueModel sv = new SingleValueModel();
+        sv.setValue(resource);
+        return Response.ok(sv).build();
+    }
+
+    @Path("/referer-header")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response referer(@HeaderParam("Referer") String referer) {
+        SingleValueModel sv = new SingleValueModel();
+        sv.setValue(referer);
+        return Response.ok(sv).build();
+    }
+
+    @Path("/file-size")
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response fileSize(MultipartFormDataInput input) {
+        SingleValueModel sv = new SingleValueModel();
+
+        try {
+            Map<String, List<InputPart>> uploadForm = input.getFormDataMap();
+            List<InputPart> inputParts = uploadForm.get("file");
+
+            InputPart fileInput = inputParts.get(0);
+            InputStream inputStream = fileInput.getBody(InputStream.class, null);
+            byte[] bytes = IOUtils.toByteArray(inputStream);
+
+            sv.setValue("" + bytes.length);
+            return Response.ok(sv).build();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Response.status(500).build();
+        }
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/ResteasyAwsProxyTest.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/ResteasyAwsProxyTest.java
@@ -1,0 +1,434 @@
+package io.quarkus.amazon.lambda.http.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.codec.binary.Base64;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.amazon.lambda.http.runtime.AwsHttpHandler;
+import io.quarkus.amazon.lambda.http.test.model.MapResponseModel;
+import io.quarkus.amazon.lambda.http.test.model.SingleValueModel;
+import io.quarkus.amazon.lambda.http.test.provider.CustomExceptionMapper;
+import io.quarkus.amazon.lambda.http.test.provider.ServletRequestFilter;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+
+/**
+ * Unit test class for the RESTEasy AWS_PROXY default implementation
+ */
+public class ResteasyAwsProxyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(EchoResteasyResource.class,
+                                    MapResponseModel.class, SingleValueModel.class,
+                                    CustomExceptionMapper.class,
+                                    ServletRequestFilter.class);
+                }
+            })
+            .addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(RequireVirtualHttpBuildItem.MARKER);
+                        }
+                    }).produces(RequireVirtualHttpBuildItem.class).build();
+                }
+            });
+
+    private static final String CUSTOM_HEADER_KEY = "x-custom-header";
+    private static final String CUSTOM_HEADER_VALUE = "my-custom-value";
+    private static final String AUTHORIZER_PRINCIPAL_ID = "test-principal-" + UUID.randomUUID().toString();
+    private static final String USER_PRINCIPAL = "user1";
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    AwsHttpHandler handler;
+
+    private static Context lambdaContext = new MockLambdaContext();
+
+    private AwsProxyRequestBuilder getRequestBuilder(boolean isAlb, String path, String method) {
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder(path, method);
+        if (isAlb)
+            builder.alb();
+
+        return builder;
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void alb_basicRequest_expectSuccess(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/headers", "GET")
+                .json()
+                .header(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE)
+                .alb()
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+        assertNotNull(output.getStatusDescription());
+        System.out.println(output.getStatusDescription());
+
+        validateMapResponseModel(output);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void headers_getHeaders_echo(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/headers", "GET")
+                .json()
+                .header(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateMapResponseModel(output);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void headers_servletRequest_echo(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/servlet-headers", "GET")
+                .json()
+                .header(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateMapResponseModel(output);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void context_servletResponse_setCustomHeader(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/servlet-response", "GET")
+                .json()
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertTrue(output.getMultiValueHeaders().containsKey(EchoResteasyResource.SERVLET_RESP_HEADER_KEY));
+    }
+
+    //    @ParameterizedTest
+    //    @ValueSource(booleans = { false, true })
+    //    public void context_serverInfo_correctContext(boolean isAlb) {
+    //        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/servlet-context", "GET").build();
+    //        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+    //        for (String header : output.getMultiValueHeaders().keySet()) {
+    //            System.out.println(header + ": " + output.getMultiValueHeaders().getFirst(header));
+    //        }
+    //        Assertions.assertEquals(200, output.getStatusCode());
+    //        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+    //
+    //        validateSingleValueModel(output, AwsServletContext.SERVER_INFO);
+    //    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    @Disabled("Vert.x currently cannot modify the scheme")
+    public void requestScheme_valid_expectHttps(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/scheme", "GET")
+                .json()
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateSingleValueModel(output, "https");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void requestFilter_injectsServletRequest_expectCustomAttribute(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/filter-attribute", "GET")
+                .json()
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateSingleValueModel(output, ServletRequestFilter.FILTER_ATTRIBUTE_VALUE);
+    }
+
+    @ParameterizedTest
+    @Disabled
+    @ValueSource(booleans = { false, true })
+    public void authorizer_securityContext_customPrincipalSuccess(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/authorizer-principal", "GET")
+                .json()
+                .authorizerPrincipal(AUTHORIZER_PRINCIPAL_ID)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        if (!isAlb) {
+            Assertions.assertEquals(200, output.getStatusCode());
+            Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+            validateSingleValueModel(output, AUTHORIZER_PRINCIPAL_ID);
+        }
+
+    }
+
+    @ParameterizedTest
+    @Disabled
+    @ValueSource(booleans = { false, true })
+    public void authorizer_securityContext_customAuthorizerContextSuccess(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/authorizer-context", "GET")
+                .json()
+                .authorizerPrincipal(AUTHORIZER_PRINCIPAL_ID)
+                .authorizerContextValue(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE)
+                .queryString("key", CUSTOM_HEADER_KEY)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateSingleValueModel(output, CUSTOM_HEADER_VALUE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void errors_unknownRoute_expect404(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/test33", "GET").build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(404, output.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void error_contentType_invalidContentType(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/json-body", "POST")
+                .header("Content-Type", "application/octet-stream")
+                .body("asdasdasd")
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(415, output.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void error_statusCode_methodNotAllowed(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/status-code", "POST")
+                .json()
+                .queryString("status", "201")
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(405, output.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void responseBody_responseWriter_validBody(boolean isAlb) throws JsonProcessingException {
+        SingleValueModel singleValueModel = new SingleValueModel();
+        singleValueModel.setValue(CUSTOM_HEADER_VALUE);
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/json-body", "POST")
+                .json()
+                .body(objectMapper.writeValueAsString(singleValueModel))
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        assertNotNull(output.getBody());
+
+        validateSingleValueModel(output, CUSTOM_HEADER_VALUE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void statusCode_responseStatusCode_customStatusCode(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/status-code", "GET")
+                .json()
+                .queryString("status", "201")
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(201, output.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void base64_binaryResponse_base64Encoding(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/binary", "GET").build();
+
+        AwsProxyResponse response = handler.handleRequest(request, lambdaContext);
+        assertNotNull(response.getBody());
+        assertTrue(Base64.isBase64(response.getBody()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void exception_mapException_mapToNotImplemented(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/exception", "GET").build();
+
+        AwsProxyResponse response = handler.handleRequest(request, lambdaContext);
+        assertNotNull(response.getBody());
+        Assertions.assertEquals(EchoResteasyResource.EXCEPTION_MESSAGE, response.getBody());
+        Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED.getStatusCode(), response.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    @Disabled
+    public void stripBasePath_route_shouldRouteCorrectly(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/custompath/echo/status-code", "GET")
+                .json()
+                .queryString("status", "201")
+                .build();
+        //handler.stripBasePath("/custompath");
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(201, output.getStatusCode());
+        //handler.stripBasePath("");
+    }
+
+    /**
+     * In the case of RESTEasy, we properly route things as the AWS library includes the
+     * stripBasePath element inside the contextPath so it's automatically removed
+     * from the URL to resolve.
+     * <p>
+     * The name of this test is not really consistent with what it is doing now but
+     * we keep it that way for consistency with the Jersey tests.
+     */
+    @Disabled
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void stripBasePath_route_shouldReturn404WithStageAsContext(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/custompath/echo/status-code", "GET")
+                .stage("prod")
+                .json()
+                .queryString("status", "201")
+                .build();
+        //handler.stripBasePath("/custompath");
+        LambdaContainerHandler.getContainerConfig().setUseStageAsServletContext(true);
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(201, output.getStatusCode());
+        //handler.stripBasePath("");
+        LambdaContainerHandler.getContainerConfig().setUseStageAsServletContext(false);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void stripBasePath_route_shouldReturn404(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/custompath/echo/status-code", "GET")
+                .json()
+                .queryString("status", "201")
+                .build();
+        //handler.stripBasePath("/custom");
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(404, output.getStatusCode());
+        //handler.stripBasePath("");
+    }
+
+    @ParameterizedTest
+    @Disabled
+    @ValueSource(booleans = { false, true })
+    public void securityContext_injectPrincipal_expectPrincipalName(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/security-context", "GET")
+                .authorizerPrincipal(USER_PRINCIPAL).build();
+
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, USER_PRINCIPAL);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void emptyStream_putNullBody_expectPutToSucceed(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/empty-stream/" + CUSTOM_HEADER_KEY + "/test/2", "PUT")
+                .nullBody()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build();
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, CUSTOM_HEADER_KEY);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void refererHeader_headerParam_expectCorrectInjection(boolean isAlb) {
+        String refererValue = "test-referer";
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/referer-header", "GET")
+                .nullBody()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .header("Referer", refererValue)
+                .build();
+
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, refererValue);
+    }
+
+    private void validateMapResponseModel(AwsProxyResponse output) {
+        validateMapResponseModel(output, CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE);
+    }
+
+    private void validateMapResponseModel(AwsProxyResponse output, String key, String value) {
+        try {
+            MapResponseModel response = objectMapper.readValue(output.getBody(), MapResponseModel.class);
+            assertNotNull(response.getValues().get(key));
+            assertEquals(value, response.getValues().get(key));
+        } catch (IOException e) {
+            fail("Exception while parsing response body: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void validateSingleValueModel(AwsProxyResponse output, String value) {
+        try {
+            SingleValueModel response = objectMapper.readValue(output.getBody(), SingleValueModel.class);
+            assertNotNull(response.getValue());
+            assertEquals(value, response.getValue());
+        } catch (IOException e) {
+            fail("Exception while parsing response body: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/ResteasyParamEncodingTest.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/ResteasyParamEncodingTest.java
@@ -1,0 +1,339 @@
+package io.quarkus.amazon.lambda.http.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.amazon.lambda.http.runtime.AwsHttpHandler;
+import io.quarkus.amazon.lambda.http.test.model.MapResponseModel;
+import io.quarkus.amazon.lambda.http.test.model.SingleValueModel;
+import io.quarkus.amazon.lambda.http.test.provider.CustomExceptionMapper;
+import io.quarkus.amazon.lambda.http.test.provider.ServletRequestFilter;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
+
+public class ResteasyParamEncodingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<JavaArchive>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(EchoResteasyResource.class,
+                                    MapResponseModel.class, SingleValueModel.class,
+                                    CustomExceptionMapper.class,
+                                    ServletRequestFilter.class);
+                }
+            })
+            .addBuildChainCustomizer(new Consumer<BuildChainBuilder>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(RequireVirtualHttpBuildItem.MARKER);
+                        }
+                    }).produces(RequireVirtualHttpBuildItem.class).build();
+                }
+            });
+
+    private static final String SIMPLE_ENCODED_PARAM = "p/z+3";
+    private static final String JSON_ENCODED_PARAM = "{\"name\":\"faisal\"}";
+    private static final String QUERY_STRING_KEY = "identifier";
+    private static final String QUERY_STRING_NON_ENCODED_VALUE = "Space Test";
+    private static final String QUERY_STRING_ENCODED_VALUE = "Space%20Test";
+    private static final byte[] FILE_CONTENTS = new byte[] {
+            (byte) 47, (byte) 85, (byte) 135, (byte) 12, (byte) 53, (byte) 7, (byte) 158, (byte) 212, (byte) 55, (byte) 193,
+            (byte) 149, (byte) 3, (byte) 166, (byte) 181,
+            (byte) 151, (byte) 84, (byte) 122, (byte) 200, (byte) 244, (byte) 5, (byte) 115, (byte) 159, (byte) 66, (byte) 64,
+            (byte) 143, (byte) 211, (byte) 13, (byte) 63,
+            (byte) 235, (byte) 184, (byte) 51, (byte) 49, (byte) 143, (byte) 167, (byte) 231, (byte) 31, (byte) 78, (byte) 234,
+            (byte) 145, (byte) 105, (byte) 190, (byte) 170,
+            (byte) 49, (byte) 135, (byte) 175, (byte) 106, (byte) 25, (byte) 86, (byte) 145, (byte) 181, (byte) 156, (byte) 23,
+            (byte) 153, (byte) 99, (byte) 175, (byte) 63,
+            (byte) 43, (byte) 208, (byte) 5, (byte) 16, (byte) 140, (byte) 103, (byte) 146, (byte) 254, (byte) 155, (byte) 97,
+            (byte) 53, (byte) 100, (byte) 137, (byte) 6,
+            (byte) 62, (byte) 101, (byte) 189, (byte) 137, (byte) 140, (byte) 5, (byte) 110, (byte) 218, (byte) 113, (byte) 132,
+            (byte) 36, (byte) 188, (byte) 19, (byte) 168,
+            (byte) 93, (byte) 169, (byte) 124, (byte) 253, (byte) 201, (byte) 233, (byte) 21, (byte) 80, (byte) 4, (byte) 56,
+            (byte) 0, (byte) 204, (byte) 205, (byte) 232,
+            (byte) 213, (byte) 253, (byte) 232, (byte) 91, (byte) 153, (byte) 169, (byte) 82, (byte) 247, (byte) 78, (byte) 71,
+            (byte) 188, (byte) 71, (byte) 23, (byte) 171,
+            (byte) 232, (byte) 26, (byte) 146, (byte) 189, (byte) 145, (byte) 82, (byte) 79, (byte) 148, (byte) 1, (byte) 201,
+            (byte) 243, (byte) 73, (byte) 98, (byte) 65,
+            (byte) 236, (byte) 177, (byte) 211, (byte) 106, (byte) 105, (byte) 46, (byte) 204, (byte) 214, (byte) 55,
+            (byte) 182, (byte) 55, (byte) 149, (byte) 221, (byte) 52,
+            (byte) 186, (byte) 122, (byte) 255, (byte) 195, (byte) 60, (byte) 146, (byte) 21, (byte) 212, (byte) 139, (byte) 38,
+            (byte) 146, (byte) 166, (byte) 14, (byte) 174,
+            (byte) 242, (byte) 145, (byte) 16, (byte) 44, (byte) 68, (byte) 89, (byte) 25, (byte) 219, (byte) 62, (byte) 227,
+            (byte) 6, (byte) 89, (byte) 194, (byte) 146, (byte) 93,
+            (byte) 167, (byte) 230, (byte) 90, (byte) 59, (byte) 35, (byte) 136, (byte) 37, (byte) 196, (byte) 118, (byte) 16,
+            (byte) 28, (byte) 107, (byte) 105, (byte) 87,
+            (byte) 195, (byte) 86, (byte) 87, (byte) 180, (byte) 176, (byte) 118, (byte) 6, (byte) 29, (byte) 26, (byte) 51,
+            (byte) 94, (byte) 21, (byte) 23, (byte) 32, (byte) 156,
+            (byte) 150, (byte) 204, (byte) 53, (byte) 110, (byte) 134, (byte) 153, (byte) 138, (byte) 247, (byte) 98,
+            (byte) 135, (byte) 249, (byte) 119, (byte) 121, (byte) 2,
+            (byte) 42, (byte) 62, (byte) 198, (byte) 197, (byte) 112, (byte) 153, (byte) 244, (byte) 174, (byte) 145, (byte) 54,
+            (byte) 246, (byte) 44, (byte) 198, (byte) 50,
+            (byte) 2, (byte) 37, (byte) 102, (byte) 50, (byte) 103, (byte) 207, (byte) 81, (byte) 62, (byte) 138, (byte) 164,
+            (byte) 140, (byte) 64, (byte) 247, (byte) 115,
+            (byte) 40, (byte) 41, (byte) 252, (byte) 54, (byte) 189, (byte) 207, (byte) 124, (byte) 147, (byte) 122, (byte) 243,
+            (byte) 83, (byte) 34, (byte) 160, (byte) 64, (byte) 189, (byte) 226, (byte) 202, (byte) 181, (byte) 55, (byte) 158,
+            (byte) 121, (byte) 78, (byte) 143, (byte) 41, (byte) 58, (byte) 27, (byte) 77, (byte) 186, (byte) 214, (byte) 23,
+            (byte) 132, (byte) 100, (byte) 180, (byte) 26, (byte) 37, (byte) 247, (byte) 254, (byte) 97, (byte) 214, (byte) 57,
+            (byte) 30, (byte) 46, (byte) 96, (byte) 44, (byte) 138, (byte) 15, (byte) 162, (byte) 93, (byte) 222, (byte) 239,
+            (byte) 189, (byte) 72, (byte) 15, (byte) 79, (byte) 136, (byte) 210, (byte) 44, (byte) 233, (byte) 99, (byte) 72,
+            (byte) 234, (byte) 225, (byte) 245, (byte) 27, (byte) 111, (byte) 175, (byte) 132, (byte) 112, (byte) 135,
+            (byte) 253, (byte) 66, (byte) 215, (byte) 168, (byte) 156, (byte) 168, (byte) 79, (byte) 78, (byte) 140, (byte) 14,
+            (byte) 129, (byte) 37, (byte) 238, (byte) 196, (byte) 34, (byte) 245, (byte) 141, (byte) 148, (byte) 161, (byte) 29,
+            (byte) 110, (byte) 32, (byte) 255, (byte) 247, (byte) 52, (byte) 48, (byte) 102, (byte) 42, (byte) 54, (byte) 97,
+            (byte) 185, (byte) 10, (byte) 114, (byte) 225, (byte) 247, (byte) 254, (byte) 108, (byte) 116, (byte) 73, (byte) 84,
+            (byte) 242, (byte) 86, (byte) 15, (byte) 72, (byte) 68, (byte) 172, (byte) 74, (byte) 107, (byte) 103, (byte) 222,
+            (byte) 246, (byte) 152, (byte) 67, (byte) 12, (byte) 104, (byte) 245, (byte) 20, (byte) 112, (byte) 94, (byte) 197,
+            (byte) 201, (byte) 89, (byte) 182, (byte) 214, (byte) 6, (byte) 182, (byte) 165, (byte) 209, (byte) 79, (byte) 192,
+            (byte) 211, (byte) 163, (byte) 208, (byte) 12, (byte) 73, (byte) 53, (byte) 99, (byte) 59, (byte) 182, (byte) 186,
+            (byte) 48, (byte) 184, (byte) 215, (byte) 22, (byte) 24, (byte) 233, (byte) 109, (byte) 206, (byte) 59, (byte) 0,
+            (byte) 118, (byte) 141, (byte) 25, (byte) 50, (byte) 242, (byte) 247, (byte) 240, (byte) 238, (byte) 127,
+            (byte) 236, (byte) 241, (byte) 224, (byte) 20, (byte) 61, (byte) 65, (byte) 148, (byte) 120, (byte) 192, (byte) 99,
+            (byte) 172, (byte) 194, (byte) 135, (byte) 61, (byte) 147, (byte) 251, (byte) 161, (byte) 219, (byte) 252,
+            (byte) 187, (byte) 154, (byte) 115, (byte) 193, (byte) 118, (byte) 167, (byte) 130, (byte) 174, (byte) 211,
+            (byte) 236, (byte) 141, (byte) 14, (byte) 8, (byte) 244, (byte) 110, (byte) 66, (byte) 210, (byte) 110, (byte) 236,
+            (byte) 255, (byte) 25, (byte) 16, (byte) 134, (byte) 70, (byte) 196, (byte) 163, (byte) 30, (byte) 177, (byte) 238,
+            (byte) 225, (byte) 237, (byte) 12, (byte) 14, (byte) 215, (byte) 40, (byte) 77, (byte) 206, (byte) 76, (byte) 122,
+            (byte) 205, (byte) 20, (byte) 183, (byte) 106, (byte) 230, (byte) 230, (byte) 123, (byte) 209, (byte) 77,
+            (byte) 102, (byte) 65, (byte) 241, (byte) 41, (byte) 213, (byte) 219, (byte) 79, (byte) 37, (byte) 61, (byte) 10,
+            (byte) 154, (byte) 19, (byte) 93, (byte) 33, (byte) 72, (byte) 105, (byte) 247, (byte) 221, (byte) 145, (byte) 179,
+            (byte) 69, (byte) 38, (byte) 234, (byte) 163, (byte) 218, (byte) 131, (byte) 179, (byte) 30, (byte) 114, (byte) 150,
+            (byte) 106, (byte) 17, (byte) 187, (byte) 229, (byte) 106, (byte) 7, (byte) 112
+    };
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    AwsHttpHandler handler;
+
+    private static Context lambdaContext = new MockLambdaContext();
+
+    private AwsProxyRequestBuilder getRequestBuilder(boolean isAlb, String path, String method) {
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder(path, method);
+        if (isAlb) {
+            builder.alb();
+        }
+        return builder;
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void queryString_uriInfo_echo(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/query-string", "GET")
+                .json()
+                .queryString(QUERY_STRING_KEY, QUERY_STRING_NON_ENCODED_VALUE)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateMapResponseModel(output, QUERY_STRING_KEY, QUERY_STRING_NON_ENCODED_VALUE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void queryString_notEncoded_echo(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/query-string", "GET")
+                .json()
+                .queryString(QUERY_STRING_KEY, QUERY_STRING_NON_ENCODED_VALUE)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateMapResponseModel(output, QUERY_STRING_KEY, QUERY_STRING_NON_ENCODED_VALUE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    @Disabled("We expect to only receive decoded values from API Gateway")
+    public void queryString_encoded_echo(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/query-string", "GET")
+                .json()
+                .queryString(QUERY_STRING_KEY, QUERY_STRING_ENCODED_VALUE)
+                .build();
+
+        AwsProxyResponse output = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, output.getStatusCode());
+        Assertions.assertEquals("application/json", output.getMultiValueHeaders().getFirst("Content-Type"));
+
+        validateMapResponseModel(output, QUERY_STRING_KEY, QUERY_STRING_NON_ENCODED_VALUE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void simpleQueryParam_encoding_expectDecodedParam(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/decoded-param", "GET")
+                .queryString("param", SIMPLE_ENCODED_PARAM)
+                .build();
+
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, SIMPLE_ENCODED_PARAM);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void jsonQueryParam_encoding_expectDecodedParam(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/decoded-param", "GET")
+                .queryString("param", JSON_ENCODED_PARAM)
+                .build();
+
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, JSON_ENCODED_PARAM);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void simpleQueryParam_encoding_expectEncodedParam(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/encoded-param", "GET")
+                .queryString("param", SIMPLE_ENCODED_PARAM)
+                .build();
+        String encodedVal = "";
+        try {
+            encodedVal = URLEncoder.encode(SIMPLE_ENCODED_PARAM, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            fail("Could not encode parameter value");
+        }
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, encodedVal);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void jsonQueryParam_encoding_expectEncodedParam(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/encoded-param", "GET")
+                .queryString("param", JSON_ENCODED_PARAM)
+                .build();
+        String encodedVal = "";
+        try {
+            encodedVal = URLEncoder.encode(JSON_ENCODED_PARAM, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            fail("Could not encode parameter value");
+        }
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, encodedVal);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void queryParam_encoding_expectFullyEncodedUrl(boolean isAlb) {
+        String paramValue = "/+=";
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/encoded-param", "GET").queryString("param", paramValue)
+                .build();
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        assertNotNull(resp);
+        Assertions.assertEquals(resp.getStatusCode(), 200);
+        validateSingleValueModel(resp, "%2F%2B%3D");
+        System.out.println("body:" + resp.getBody());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void pathParam_encoded_routesToCorrectPath(boolean isAlb) {
+        String encodedParam = "http%3A%2F%2Fhelloresource.com";
+        String path = "/echo/encoded-path/" + encodedParam;
+        AwsProxyRequest request = getRequestBuilder(isAlb, path, "GET").build();
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        assertNotNull(resp);
+        Assertions.assertEquals(resp.getStatusCode(), 200);
+        validateSingleValueModel(resp, encodedParam);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void pathParam_encoded_returns404(boolean isAlb) {
+        String encodedParam = "http://helloresource.com";
+        String path = "/echo/encoded-path/" + encodedParam;
+        AwsProxyRequest request = getRequestBuilder(isAlb, path, "GET").build();
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        assertNotNull(resp);
+        Assertions.assertEquals(resp.getStatusCode(), 404);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    @Disabled
+    public void queryParam_listOfString_expectCorrectLength(boolean isAlb) {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/list-query-string", "GET").queryString("list", "v1,v2,v3")
+                .build();
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        assertNotNull(resp);
+        Assertions.assertEquals(resp.getStatusCode(), 200);
+        validateSingleValueModel(resp, "3");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void multipart_getFileSize_expectCorrectLength(boolean isAlb)
+            throws IOException {
+        AwsProxyRequest request = getRequestBuilder(isAlb, "/echo/file-size", "POST")
+                .formFilePart("file", "myfile.jpg", FILE_CONTENTS)
+                //.formFieldPart("name", QUERY_STRING_ENCODED_VALUE)
+                .build();
+        AwsProxyResponse resp = handler.handleRequest(request, lambdaContext);
+        assertNotNull(resp);
+        Assertions.assertEquals(200, resp.getStatusCode());
+        validateSingleValueModel(resp, "" + FILE_CONTENTS.length);
+    }
+
+    private void validateSingleValueModel(AwsProxyResponse output, String value) {
+        try {
+            SingleValueModel response = objectMapper.readValue(output.getBody(), SingleValueModel.class);
+            assertNotNull(response.getValue());
+            assertEquals(value, response.getValue());
+        } catch (IOException e) {
+            fail("Exception while parsing response body: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void validateMapResponseModel(AwsProxyResponse output, String key, String value) {
+        try {
+            MapResponseModel response = objectMapper.readValue(output.getBody(), MapResponseModel.class);
+            assertNotNull(response.getValues().get(key));
+            assertEquals(value, response.getValues().get(key));
+        } catch (IOException e) {
+            fail("Exception while parsing response body: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/model/MapResponseModel.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/model/MapResponseModel.java
@@ -1,0 +1,27 @@
+package io.quarkus.amazon.lambda.http.test.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Request/response model
+ */
+public class MapResponseModel {
+    private Map<String, String> values;
+
+    public MapResponseModel() {
+        this.values = new HashMap<>();
+    }
+
+    public void addValue(String key, String value) {
+        this.values.put(key, value);
+    }
+
+    public Map<String, String> getValues() {
+        return values;
+    }
+
+    public void setValues(Map<String, String> values) {
+        this.values = values;
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/model/SingleValueModel.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/model/SingleValueModel.java
@@ -1,0 +1,16 @@
+package io.quarkus.amazon.lambda.http.test.model;
+
+/**
+ * Request/response model
+ */
+public class SingleValueModel {
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/provider/CustomExceptionMapper.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/provider/CustomExceptionMapper.java
@@ -1,0 +1,22 @@
+package io.quarkus.amazon.lambda.http.test.provider;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class CustomExceptionMapper implements ExceptionMapper<UnsupportedOperationException> {
+
+    public CustomExceptionMapper() {
+        System.out.println("Starting custom exception mapper");
+    }
+
+    @Override
+    public Response toResponse(UnsupportedOperationException throwable) {
+        // This class was modified a bit to work properly with RESTEasy
+        return Response.status(Response.Status.NOT_IMPLEMENTED)
+                .entity(throwable.getMessage())
+                .type(MediaType.TEXT_PLAIN).build();
+    }
+}

--- a/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/provider/ServletRequestFilter.java
+++ b/extensions/amazon-lambda-http/deployment/src/test/java/io/quarkus/amazon/lambda/http/test/provider/ServletRequestFilter.java
@@ -1,0 +1,24 @@
+package io.quarkus.amazon.lambda.http.test.provider;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ServletRequestFilter implements ContainerRequestFilter {
+    public static final String FILTER_ATTRIBUTE_NAME = "ServletFilter";
+    public static final String FILTER_ATTRIBUTE_VALUE = "done";
+
+    @Context
+    HttpServletRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext ctx) throws IOException {
+        request.setAttribute(FILTER_ATTRIBUTE_NAME, FILTER_ATTRIBUTE_VALUE);
+    }
+
+}

--- a/extensions/amazon-lambda-http/pom.xml
+++ b/extensions/amazon-lambda-http/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-lambda-http-parent</artifactId>
+    <name>Quarkus - Amazon Lambda HTTP</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+    
+</project>

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -2,25 +2,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>quarkus-amazon-lambda-resteasy-parent</artifactId>
-        <groupId>io.quarkus</groupId>
-        <version>999-SNAPSHOT</version>
-        <relativePath>../</relativePath>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-amazon-lambda-resteasy</artifactId>
-    <name>Quarkus - Amazon Lambda - RESTEasy - Runtime</name>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-lambda-http-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-lambda-http</artifactId>
+    <name>Quarkus - Amazon Lambda HTTP - Runtime</name>
 
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-server-common</artifactId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-events</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-lambda</artifactId>
         </dependency>
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
@@ -33,33 +42,13 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>commons-logging-jboss-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/runtime/AwsHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/runtime/AwsHttpHandler.java
@@ -1,0 +1,150 @@
+package io.quarkus.amazon.lambda.http.runtime;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.model.Headers;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
+import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
+
+public class AwsHttpHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
+    @Override
+    public AwsProxyResponse handleRequest(AwsProxyRequest request, Context context) {
+        VirtualClientConnection connection = VirtualClientConnection.connect(VertxHttpRecorder.VIRTUAL_HTTP);
+        try {
+            return nettyDispatch(connection, request);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            connection.close();
+        }
+    }
+
+    private AwsProxyResponse nettyDispatch(VirtualClientConnection connection,
+            AwsProxyRequest request)
+            throws Exception {
+        String path = request.getPath();
+        if (request.getMultiValueQueryStringParameters() != null && !request.getMultiValueQueryStringParameters().isEmpty()) {
+            StringBuilder sb = new StringBuilder(path);
+            sb.append("?");
+            boolean first = true;
+            for (Map.Entry<String, List<String>> e : request.getMultiValueQueryStringParameters().entrySet()) {
+                for (String v : e.getValue()) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        sb.append("&");
+                    }
+                    if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
+                        sb.append(e.getKey());
+                        sb.append("=");
+                        sb.append(v);
+                    } else {
+                        sb.append(URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8.name()));
+                        sb.append("=");
+                        sb.append(URLEncoder.encode(v, StandardCharsets.UTF_8.name()));
+                    }
+                }
+            }
+            path = sb.toString();
+        }
+        DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.valueOf(request.getHttpMethod()), path);
+        for (Map.Entry<String, List<String>> header : request.getMultiValueHeaders().entrySet()) {
+            nettyRequest.headers().add(header.getKey(), header.getValue());
+        }
+        if (!nettyRequest.headers().contains(HttpHeaderNames.HOST)) {
+            nettyRequest.headers().add(HttpHeaderNames.HOST, "localhost");
+        }
+
+        HttpContent requestContent = LastHttpContent.EMPTY_LAST_CONTENT;
+        if (request.getBody() != null) {
+            if (request.isBase64Encoded()) {
+                ByteBuf body = Unpooled.wrappedBuffer(Base64.getMimeDecoder().decode(request.getBody()));
+                requestContent = new DefaultLastHttpContent(body);
+            } else {
+                ByteBuf body = Unpooled.copiedBuffer(request.getBody(), StandardCharsets.UTF_8); //TODO: do we need to look at the request encoding?
+                requestContent = new DefaultLastHttpContent(body);
+            }
+        }
+
+        connection.sendMessage(nettyRequest);
+        connection.sendMessage(requestContent);
+        AwsProxyResponse responseBuilder = new AwsProxyResponse();
+        ByteArrayOutputStream baos = null;
+        for (;;) {
+            // todo should we timeout? have a timeout config?
+            //log.info("waiting for message");
+            Object msg = connection.queue().poll(100, TimeUnit.MILLISECONDS);
+            try {
+                if (msg == null)
+                    continue;
+                //log.info("Got message: " + msg.getClass().getName());
+
+                if (msg instanceof HttpResponse) {
+                    HttpResponse res = (HttpResponse) msg;
+                    responseBuilder.setStatusCode(res.status().code());
+                    responseBuilder.setStatusDescription(res.status().reasonPhrase());
+                    responseBuilder.setMultiValueHeaders(new Headers());
+                    for (String name : res.headers().names()) {
+                        for (String v : res.headers().getAll(name)) {
+                            responseBuilder.getMultiValueHeaders().add(name, v);
+                        }
+                    }
+                }
+                if (msg instanceof HttpContent) {
+                    HttpContent content = (HttpContent) msg;
+                    if (baos == null) {
+                        // todo what is right size?
+                        baos = new ByteArrayOutputStream(500);
+                    }
+                    int readable = content.content().readableBytes();
+                    for (int i = 0; i < readable; i++) {
+                        baos.write(content.content().readByte());
+                    }
+                }
+                if (msg instanceof LastHttpContent) {
+                    String contentType = responseBuilder.getMultiValueHeaders().getFirst("Content-Type");
+                    //TODO: big hack, we should handle charset properly, base64 is always safe though
+                    boolean requiresEncoding = true;
+                    if (contentType != null) {
+                        String ct = contentType.toLowerCase();
+                        requiresEncoding = !ct.contains("charset=utf-8") && !ct.contains("json");
+                    }
+                    if (requiresEncoding) {
+                        responseBuilder.setBase64Encoded(true);
+                        responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
+                    } else {
+                        responseBuilder.setBase64Encoded(false);
+                        responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
+                    }
+                    return responseBuilder;
+                }
+            } finally {
+                if (msg != null)
+                    ReferenceCountUtil.release(msg);
+            }
+        }
+    }
+}

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.substrate.ReflectiveHierarchyBuildItem;
@@ -107,6 +108,7 @@ public final class AmazonLambdaProcessor {
             AmazonLambdaRecorder recorder,
             LambdaConfig config,
             RecorderContext context,
+            LaunchModeBuildItem launchMode,
             ShutdownContextBuildItem shutdownContextBuildItem) throws IOException {
         List<Class<? extends RequestHandler<?, ?>>> unnamed = new ArrayList<>();
         Map<String, Class<? extends RequestHandler<?, ?>>> named = new HashMap<>();

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaApi.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaApi.java
@@ -63,7 +63,7 @@ public class AmazonLambdaApi {
         return System.getenv("AWS_LAMBDA_FUNCTION_VERSION");
     }
 
-    private static String runtimeApi() {
+    public static String runtimeApi() {
         String testApi = System.getProperty(QUARKUS_INTERNAL_AWS_LAMBDA_TEST_API);
         if (testApi != null) {
             return testApi;

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -34,6 +34,10 @@ public class AmazonLambdaRecorder {
             ShutdownContext context,
             LambdaConfig config,
             BeanContainer beanContainer) {
+        if (AmazonLambdaApi.runtimeApi() == null) {
+            log.warn("No AWS Lambda Endpoint defined, assuming a dev/test environment, not starting lambda loop");
+            return;
+        }
         Class<? extends RequestHandler<?, ?>> handlerClass;
         if (config.handler.isPresent()) {
             handlerClass = namedHandlerClasses.get(config.handler.get());

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -103,6 +103,7 @@
 
         <!-- Integrations -->
         <module>amazon-lambda</module>
+        <module>amazon-lambda-http</module>
         <module>amazon-lambda-resteasy</module>
         <module>amazon-dynamodb</module>
         <module>azure-functions-http</module>

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Optional;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.jar.JarEntry;
@@ -166,14 +166,14 @@ public class ResteasyStandaloneBuildStep {
             InternalWebVertxBuildItem vertx,
             BeanContainerBuildItem beanContainer,
             ResteasyStandaloneBuildItem standalone,
-            Optional<RequireVirtualHttpBuildItem> requireVirtual) throws Exception {
+            List<RequireVirtualHttpBuildItem> requireVirtual) throws Exception {
 
         if (standalone == null) {
             return;
         }
         feature.produce(new FeatureBuildItem(FeatureBuildItem.RESTEASY));
 
-        boolean isVirtual = requireVirtual.isPresent();
+        boolean isVirtual = !requireVirtual.isEmpty();
         Consumer<Route> ut = recorder.start(vertx.getVertx(),
                 shutdown,
                 beanContainer.getValue(),

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireVirtualHttpBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireVirtualHttpBuildItem.java
@@ -1,10 +1,10 @@
 package io.quarkus.vertx.http.deployment;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Marker class to turn on virtual http channel
  */
-public final class RequireVirtualHttpBuildItem extends SimpleBuildItem {
+public final class RequireVirtualHttpBuildItem extends MultiBuildItem {
     public static final RequireVirtualHttpBuildItem MARKER = new RequireVirtualHttpBuildItem();
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -80,7 +80,7 @@ class VertxHttpProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     ServiceStartBuildItem finalizeRouter(
             VertxHttpRecorder recorder, BeanContainerBuildItem beanContainer,
-            Optional<RequireVirtualHttpBuildItem> requireVirtual,
+            List<RequireVirtualHttpBuildItem> requireVirtual,
             InternalWebVertxBuildItem vertx,
             LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown, List<DefaultRouteBuildItem> defaultRoutes,
             List<FilterBuildItem> filters, VertxWebRouterBuildItem router, EventLoopCountBuildItem eventLoopCountBuildItem,
@@ -106,7 +106,7 @@ class VertxHttpProcessor {
                 defaultRoute.map(DefaultRouteBuildItem::getRoute).orElse(null),
                 listOfFilters, vertx.getVertx(), router.getRouter(), httpBuildTimeConfig.rootPath, launchMode.getLaunchMode());
 
-        boolean startVirtual = requireVirtual.isPresent() || httpConfiguration.virtual;
+        boolean startVirtual = !requireVirtual.isEmpty() || httpConfiguration.virtual;
         // start http socket in dev/test mode even if virtual http is required
         boolean startSocket = !startVirtual || launchMode.getLaunchMode() != LaunchMode.NORMAL;
         recorder.startServer(vertx.getVertx(), shutdown,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -500,9 +500,6 @@ public class VertxHttpRecorder {
     public static VirtualAddress VIRTUAL_HTTP = new VirtualAddress("netty-virtual-http");
 
     private static void initializeVirtual(Vertx vertxRuntime) {
-        if (virtualBootstrap != null) {
-            return;
-        }
         VertxInternal vertx = (VertxInternal) vertxRuntime;
         virtualBootstrap = new ServerBootstrap();
 


### PR DESCRIPTION
This is an initial version of the AWS Lambda virtual channel support.

There is still a few issues outstanding:
- Extensive testing in a Lambda environment
- Docs
- Decide what to do about the missing context that can be propagated to JAX-RS requests, such as security etc. The quarkus-amazon-lambda-resteasy modulecan propagate additional context information (such as security info) that is not part of the underlying HTTP request (see the commented out/disabled tests). 

We might be able to attach these to the virtual channel somehow, encode it into the request as headers, or just ignore it for now.

- Decide what to do with the lambda-resteasy module. At the moment it provides a few extra features, but ideally we would only have one way of doing things, so eventually it should probably be removed.
