### PR TITLE
Skip Quarkus build of integration tests when using -DskipTests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,10 @@ cd quarkus
 
 The default build does not create native images, which is quite time consuming.
 
+Note that the full build with all tests is quite slow, you will usually want to build with ``-DskipTests`. This will also
+skip creation of the integration-test runner jars. If you want to skip tests but still create the runners you can set
+`-DskipTests -Dquarkus.build.skip=fase`
+
 You can build and test native images in the integration tests supporting it by using `./mvnw install -Dnative`.
 
 By default the build will use the native image server. This speeds up the build, but can cause problems due to the cache

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -147,6 +147,9 @@ public class BuildMojo extends AbstractMojo {
     @Parameter(property = "ignoredEntries")
     private String[] ignoredEntries;
 
+    @Parameter(defaultValue = "false")
+    private boolean skip = false;
+
     public BuildMojo() {
         MojoLogger.logSupplier = this::getLog;
     }
@@ -156,6 +159,10 @@ public class BuildMojo extends AbstractMojo {
 
         if (project.getPackaging().equals("pom")) {
             getLog().info("Type of the artifact is POM, skipping build goal");
+            return;
+        }
+        if (skip) {
+            getLog().info("Skipping Quarkus build");
             return;
         }
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <quarkus.build.skip>${skipTests}</quarkus.build.skip>
     </properties>
 
     <modules>
@@ -88,6 +89,7 @@
                     <version>${project.version}</version>
                     <configuration>
                         <noDeps>true</noDeps>
+                        <skip>${quarkus.build.skip}</skip>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
This saves around 1m from the -DskipTests full build

They can be enabled by using -Dquarkus.skip=false