### PR TITLE
Fix Hot reload when mixing filters and routes

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/DevFilter.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/DevFilter.java
@@ -1,0 +1,15 @@
+package io.quarkus.vertx.http.hotreload;
+
+import javax.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.runtime.filters.Filters;
+
+public class DevFilter {
+
+    public void init(@Observes Filters filters) {
+        filters.register(rc -> {
+            rc.response().putHeader("X-Header", "AAAA");
+            rc.next();
+        }, 100);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/HotReloadWithFilterTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/HotReloadWithFilterTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.vertx.http.hotreload;
+
+import static org.hamcrest.core.Is.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class HotReloadWithFilterTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(DevBean.class)
+                    .addClass(DevFilter.class));
+
+    private static final String USER_FILE = "DevBean.java";
+    private static final String USER_FILTER = "DevFilter.java";
+
+    @Test
+    public void testFilterChange() {
+        RestAssured.when().get("/dev").then()
+                .statusCode(200)
+                .body(is("Hello World"))
+                .header("X-Header", is("AAAA"));
+
+        test.modifySourceFile(USER_FILTER, s -> s.replace("AAAA", "BBBB"));
+
+        RestAssured.when().get("/dev").then()
+                .statusCode(200)
+                .body(is("Hello World"))
+                .header("X-Header", is("BBBB"));
+
+        test.modifySourceFile(USER_FILE, s -> s.replace("World", "Quarkus"));
+        RestAssured.when().get("/dev").then()
+                .statusCode(200)
+                .body(is("Hello Quarkus"))
+                .header("X-Header", is("BBBB"));
+
+        test.modifySourceFile(USER_FILTER, s -> s.replace("BBBB", "CCC"));
+
+        RestAssured.when().get("/dev").then()
+                .statusCode(200)
+                .body(is("Hello Quarkus"))
+                .header("X-Header", is("CCC"));
+
+    }
+
+    @Test
+    public void testAddFilter() {
+        test.addSourceFile(NewFilter.class);
+
+        RestAssured.when().get("/dev").then()
+                .statusCode(200)
+                .body(is("Hello World"))
+                .header("X-Header", is("AAAA"))
+                .header("X-Header-2", is("Some new header"));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/HotReloadWithRouteTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/HotReloadWithRouteTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-public class HotReloadTest {
+public class HotReloadWithRouteTest {
 
     @RegisterExtension
     static final QuarkusDevModeTest test = new QuarkusDevModeTest()

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/NewFilter.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/hotreload/NewFilter.java
@@ -1,0 +1,15 @@
+package io.quarkus.vertx.http.hotreload;
+
+import javax.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.runtime.filters.Filters;
+
+public class NewFilter {
+
+    public void init(@Observes Filters filters) {
+        filters.register(rc -> {
+            rc.response().putHeader("X-Header-2", "Some new header");
+            rc.next();
+        }, 100);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -98,7 +98,7 @@ public class VertxHttpRecorder {
 
             router = Router.router(VertxCoreRecorder.getWebVertx());
             if (hotReplacementHandler != null) {
-                router.route().blockingHandler(hotReplacementHandler);
+                router.route().order(Integer.MIN_VALUE).blockingHandler(hotReplacementHandler);
             }
 
             //we can't really do
@@ -118,13 +118,14 @@ public class VertxHttpRecorder {
             final LaunchMode launchMode, final ShutdownContext shutdownContext) {
 
         Vertx vertx = vertxRuntimeValue.getValue();
+
         if (router == null) {
             router = Router.router(vertx);
             if (launchMode != LaunchMode.DEVELOPMENT) {
                 shutdownContext.addShutdownTask(cleanupRouterTask);
             }
             if (hotReplacementHandler != null) {
-                router.route().handler(hotReplacementHandler);
+                router.route().order(Integer.MIN_VALUE).handler(hotReplacementHandler);
             }
         }
 


### PR DESCRIPTION
The solution is simple: make sure that the hot replacement handler is first.

A test has been added.