### PR TITLE
refactor: use ConfigItem annotation in HttpAuthConfig configuration root

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpAuthConfig.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpAuthConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.http.deployment;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
+import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 /**
@@ -18,18 +17,18 @@ public class HttpAuthConfig {
      * is present that supports {@link io.quarkus.security.identity.request.TokenAuthenticationRequest} in which case
      * form auth will be the default.
      */
-    @ConfigProperty(defaultValue = "false")
+    @ConfigItem
     public boolean basic;
 
     /**
      * If form auth should be enabled.
      */
-    @ConfigProperty(defaultValue = "false")
+    @ConfigItem
     public boolean form;
 
     /**
      * The authentication realm
      */
-    @ConfigProperty(name = "realm", defaultValue = "Quarkus")
+    @ConfigItem(defaultValue = "Quarkus")
     public String realm;
 }


### PR DESCRIPTION
use the annotation so that Http config docs are properly generated
