### PR TITLE
Don't suspend the JVM launch when debug port is non-default

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -96,7 +96,7 @@ public class DevMojo extends AbstractMojo {
      * </tr>
      * <tr>
      * <td><b>{port}</b></td>
-     * <td>The JVM is started in debug mode and suspends until a debugger is attached to {port}</td>
+     * <td>The JVM is started in debug mode without suspending and will listen on {port}</td>
      * </tr>
      * </table>
      */
@@ -213,7 +213,7 @@ public class DevMojo extends AbstractMojo {
                         throw new MojoFailureException("The specified debug port must be greater than 0");
                     }
                     args.add("-Xdebug");
-                    args.add("-Xrunjdwp:transport=dt_socket,address=" + port + ",server=y,suspend=y");
+                    args.add("-Xrunjdwp:transport=dt_socket,address=" + port + ",server=y,suspend=n");
                 } catch (NumberFormatException e) {
                     throw new MojoFailureException(
                             "Invalid value for debug parameter: " + debug + " must be true|false|client|{port}");


### PR DESCRIPTION
As discussed here https://github.com/quarkusio/quarkus/issues/3316#issuecomment-537764463 the commit in this PR changes the launch configuration to not suspend the JVM, when a custom debug port is specified.

P.S: The `debug` also takes a `true` value and that configuration will continue to suspend by default. I didn't change it in this PR. If it feels right to make that consistent with the rest of these values, I  can change it too. That way, if someone really wants to suspend the JVM debug launch, they can do so by `debug=false` and `jvmArgs` using the exact arguments needed to launch and suspend the JVM in debug mode.