### PR TITLE
fix: error handling for gradle wrapper call

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -183,8 +183,17 @@ public class CreateProjectMojo extends AbstractMojo {
 
     private void createGradleWrapper(File projectDirectory) {
         try {
-            Runtime.getRuntime().exec("gradle wrapper", new String[0], projectDirectory);
-        } catch (IOException e) {
+            ProcessBuilder pb = new ProcessBuilder("gradle", "wrapper").directory(projectDirectory)
+                    .inheritIO();
+            Process x = pb.start();
+
+            x.waitFor();
+
+            if (x.exitValue() != 0) {
+                getLog().error("Unable to install the Gradle wrapper (./gradlew) in project. See log for details.");
+            }
+
+        } catch (InterruptedException | IOException e) {
             // no reason to fail if the wrapper could not be created
             getLog().error(
                     "Unable to install the Gradle wrapper (./gradlew) in the project. You need to have gradle installed to generate the wrapper files.",


### PR DESCRIPTION
Why:

 * if something wrong gradle wrapper would just exit withuot info/error.

This change addreses the need by:

 * Use `ProcessBuilder` to easily direct input/output/error to mvn output
 * Check the error code and warn via error
 * Don't pass empty env to the fork as otherwise JAVA_HOME is not picked
   up.

Note - Generated Gradle builds will still fail but that is due to
https://github.com/quarkusio/quarkus/issues/4365 - a separate concern.

Fixes #4321