### PR TITLE
Add io pause

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -24,7 +24,7 @@
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
         <jaeger.version>0.34.0</jaeger.version>
-        <quarkus-http.version>3.0.0.Alpha7</quarkus-http.version>
+        <quarkus-http.version>3.0.0.Beta1</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.3</microprofile-config-api.version>
         <microprofile-context-propagation.version>1.0.1</microprofile-context-propagation.version>

--- a/extensions/elytron-security-jdbc/deployment/pom.xml
+++ b/extensions/elytron-security-jdbc/deployment/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/elytron-security-properties-file/deployment/pom.xml
+++ b/extensions/elytron-security-properties-file/deployment/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/elytron-security/deployment/pom.xml
+++ b/extensions/elytron-security/deployment/pom.xml
@@ -19,10 +19,12 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <!-- Should this be in a separate jaxrs-security extension? -->
+        <!--
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-deployment</artifactId>
@@ -35,7 +37,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxInputStream.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxInputStream.java
@@ -20,7 +20,7 @@ public class VertxInputStream extends InputStream {
     private boolean finished;
     private ByteBuf pooled;
 
-    public VertxInputStream(HttpServerRequest request) {
+    public VertxInputStream(HttpServerRequest request) throws IOException {
 
         this.exchange = new VertxBlockingInput(request);
     }
@@ -116,7 +116,7 @@ public class VertxInputStream extends InputStream {
         protected boolean waiting = false;
         protected boolean eof = false;
 
-        public VertxBlockingInput(HttpServerRequest request) {
+        public VertxBlockingInput(HttpServerRequest request) throws IOException {
             this.request = request;
             if (!request.isEnded()) {
                 request.handler(this);
@@ -137,7 +137,7 @@ public class VertxInputStream extends InputStream {
                 });
                 request.fetch(1);
             } else {
-                terminateRequest();
+                throw new IOException("Request was ended before Resteasy could process it.");
             }
         }
 

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -58,7 +58,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext request) {
         // have to create input stream here.  Cannot execute in another thread
         // otherwise request handlers may not get set up before request ends
-        VertxInputStream is ;
+        VertxInputStream is;
         try {
             is = new VertxInputStream(request.request());
         } catch (IOException e) {

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -58,7 +58,14 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext request) {
         // have to create input stream here.  Cannot execute in another thread
         // otherwise request handlers may not get set up before request ends
-        VertxInputStream is = new VertxInputStream(request.request());
+        VertxInputStream is ;
+        try {
+            is = new VertxInputStream(request.request());
+        } catch (IOException e) {
+            request.fail(e);
+            return;
+        }
+
         vertx.executeBlocking(event -> {
             dispatchRequestContext(request, is, new VertxBlockingOutput(request.request()));
         }, false, event -> {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -74,6 +74,12 @@ public class VertxHttpRecorder {
     private static final Handler<HttpServerRequest> ACTUAL_ROOT = new Handler<HttpServerRequest>() {
         @Override
         public void handle(HttpServerRequest httpServerRequest) {
+            //we need to pause the request to make sure that data does
+            //not arrive before handlers have a chance to install a read handler
+            //as it is possible filters such as the auth filter can do blocking tasks
+            //as the underlying handler has not had a chance to install a read handler yet
+            //and data that arrives while the blocking task is being processed will be lost
+            httpServerRequest.pause();
             rootHandler.handle(httpServerRequest);
         }
     };
@@ -401,11 +407,11 @@ public class VertxHttpRecorder {
         Route vr = route.apply(router.getValue());
 
         if (blocking == HandlerType.BLOCKING) {
-            vr.blockingHandler(handler);
+            vr.blockingHandler(new ResumeHandler(handler));
         } else if (blocking == HandlerType.FAILURE) {
-            vr.failureHandler(handler);
+            vr.failureHandler(new ResumeHandler(handler));
         } else {
-            vr.handler(handler);
+            vr.handler(new ResumeHandler(handler));
         }
     }
 
@@ -548,6 +554,23 @@ public class VertxHttpRecorder {
 
     public static Handler<HttpServerRequest> getRootHandler() {
         return ACTUAL_ROOT;
+    }
+
+    private static class ResumeHandler implements Handler<RoutingContext> {
+
+        final Handler<RoutingContext> next;
+
+        private ResumeHandler(Handler<RoutingContext> next) {
+            this.next = next;
+        }
+
+        @Override
+        public void handle(RoutingContext event) {
+            //we resume the request to make up for the pause that was done in the root handler
+            //this maintains normal vert.x semantics in the handlers
+            event.request().resume();
+            next.handle(event);
+        }
     }
 
 }

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -84,6 +84,12 @@ public class VertxWebRecorder {
         bodyHandler.setDeleteUploadedFilesOnEnd(bodyConfig.deleteUploadedFilesOnEnd);
         bodyHandler.setMergeFormAttributes(bodyConfig.mergeFormAttributes);
         bodyHandler.setPreallocateBodyBuffer(bodyConfig.preallocateBodyBuffer);
-        return bodyHandler;
+        return new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                event.request().resume();
+                bodyHandler.handle(event);
+            }
+        };
     }
 }

--- a/integration-tests/elytron-resteasy/pom.xml
+++ b/integration-tests/elytron-resteasy/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-elytron-resteasy</artifactId>
+
+    <name>Quarkus - Integration Tests - Elytron Resteasy </name>
+    
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/RootResource.java
+++ b/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/RootResource.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.resteasy.elytron;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/")
+public class RootResource {
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    public String posts(String data, @Context SecurityContext sec) {
+        if (data == null) {
+            throw new RuntimeException("No post data");
+        }
+        if (sec.getUserPrincipal().getName() == null) {
+            throw new RuntimeException("Failed to get user principal");
+        }
+        return "post success";
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String approval(@Context SecurityContext sec) {
+        if (sec.getUserPrincipal().getName() == null) {
+            throw new RuntimeException("Failed to get user principal");
+        }
+        return "get success";
+    }
+}

--- a/integration-tests/elytron-resteasy/src/main/resources/application.properties
+++ b/integration-tests/elytron-resteasy/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.users.john=john
+quarkus.security.users.embedded.roles.john=employees
+quarkus.security.users.embedded.users.mary=mary
+quarkus.security.users.embedded.roles.mary=managers
+quarkus.security.users.embedded.users.poul=poul
+quarkus.security.users.embedded.roles.poul=interns
+quarkus.security.users.embedded.auth-mechanism=BASIC
+quarkus.security.users.embedded.plain-text=true

--- a/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/BaseAuthWithPostTest.java
+++ b/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/BaseAuthWithPostTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.resteasy.elytron;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+class BaseAuthWithPostTest {
+
+    @Test
+    void testPost() {
+        // This is a regression test in that we had a problem where the vertx request was not paused
+        // before the authentication filters ran and the post message was thrown away by vertx because
+        // resteasy hadn't registered its request handlers yet.
+        given()
+                .header("Authorization", "Basic am9objpqb2hu")
+                .body("{\"traveller\" : {\"firstName\" : \"John\",\"lastName\" : \"Doe\",\"email\" : \"john.doe@example.com\",\"nationality\" : \"American\",\"address\" : {\"street\" : \"main street\",\"city\" : \"Boston\",\"zipCode\" : \"10005\",\"country\" : \"US\"}}}")
+                .contentType(ContentType.TEXT)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void testGet() {
+        String output = given()
+                .header("Authorization", "Basic am9objpqb2hu")
+                .when()
+                .get("/")
+                .then()
+                .statusCode(200).extract().asString();
+    }
+
+}

--- a/integration-tests/elytron-undertow/pom.xml
+++ b/integration-tests/elytron-undertow/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-elytron-undertow</artifactId>
+
+    <name>Quarkus - Integration Tests - Elytron Undertow</name>
+    
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/elytron-undertow/src/main/java/io/quarkus/it/undertow/elytron/GreetingServlet.java
+++ b/integration-tests/elytron-undertow/src/main/java/io/quarkus/it/undertow/elytron/GreetingServlet.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.undertow.elytron;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(name = "ServletGreeting", urlPatterns = "/")
+public class GreetingServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (req.getUserPrincipal().getName() == null) {
+            throw new RuntimeException("principal was null");
+        }
+        resp.setStatus(200);
+        resp.addHeader("Content-Type", "text/plain");
+        resp.getWriter().write("hello");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (req.getUserPrincipal().getName() == null) {
+            throw new RuntimeException("principal was null");
+        }
+        String name = req.getReader().readLine();
+        resp.setStatus(200);
+        resp.addHeader("Content-Type", "text/plain");
+        resp.getWriter().write("hello " + name);
+    }
+}

--- a/integration-tests/elytron-undertow/src/main/resources/application.properties
+++ b/integration-tests/elytron-undertow/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.users.john=john
+quarkus.security.users.embedded.roles.john=employees
+quarkus.security.users.embedded.users.mary=mary
+quarkus.security.users.embedded.roles.mary=managers
+quarkus.security.users.embedded.users.poul=poul
+quarkus.security.users.embedded.roles.poul=interns
+quarkus.security.users.embedded.auth-mechanism=BASIC
+quarkus.security.users.embedded.plain-text=true

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthWithPostTest.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthWithPostTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.undertow.elytron;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+class BaseAuthWithPostTest {
+
+    @Test
+    void testPost() {
+        // This is a regression test in that we had a problem where the vertx request was not paused
+        // before the authentication filters ran and the post message was thrown away by vertx because
+        // resteasy hadn't registered its request handlers yet.
+        given()
+                .header("Authorization", "Basic am9objpqb2hu")
+                .body("Bill")
+                .contentType(ContentType.TEXT)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void testGet() {
+        String output = given()
+                .header("Authorization", "Basic am9objpqb2hu")
+                .when()
+                .get("/")
+                .then()
+                .statusCode(200).extract().asString();
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -44,6 +44,8 @@
         <module>infinispan-cache-jpa</module>
         <module>elytron-security</module>
         <module>elytron-security-oauth2</module>
+        <module>elytron-resteasy</module>
+        <module>elytron-undertow</module>
         <module>flyway</module>
         <module>oidc</module>
         <module>reactive-pg-client</module>


### PR DESCRIPTION
* When adding a vertx filter like elytron, request bodies were being thrown away before resteasy had a chance to register request handlers.
* Also, elytron had a dependency on resteasy-deployment so I removed that.

-- pause code pulled in from stuarts branch I just added tests and remove the resteasy dependency.