### PR TITLE
fix Java heap space when OpenAPI is enabled and enums are used in a JAX-RS endpoint

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -34,7 +34,7 @@
         <smallrye-config.version>1.3.9</smallrye-config.version>
         <smallrye-health.version>2.0.0</smallrye-health.version>
         <smallrye-metrics.version>2.1.4</smallrye-metrics.version>
-        <smallrye-open-api.version>1.1.8</smallrye-open-api.version>
+        <smallrye-open-api.version>1.1.9</smallrye-open-api.version>
         <smallrye-opentracing.version>1.3.2</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>2.0.9</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.0.9</smallrye-jwt.version>

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiResource.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/OpenApiResource.java
@@ -2,6 +2,7 @@ package io.quarkus.smallrye.openapi.test;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 @Path("/resource")
 public class OpenApiResource {
@@ -9,5 +10,16 @@ public class OpenApiResource {
     @GET
     public String root() {
         return "resource";
+    }
+
+    @GET
+    @Path("/test-enums")
+    public Query testEnums(@QueryParam("query") Query query) {
+        return query;
+    }
+
+    public enum Query {
+        QUERY_PARAM_1,
+        QUERY_PARAM_2;
     }
 }


### PR DESCRIPTION
Fixes #4329