### PR TITLE
Jandex quarkus-devtools-common

### DIFF
--- a/devtools/common/pom.xml
+++ b/devtools/common/pom.xml
@@ -45,6 +45,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
In code.quarkus.io, `BuildTool` is used as a JAX-RS parameter and this gets rid of the warning during the build:
```
[WARNING] [io.quarkus.deployment.steps.ReflectiveHierarchyStep] Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
	- io.quarkus.generators.BuildTool
```