### PR TITLE
Add the hibernate globally-quoted-identifiers parameter

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -207,10 +207,17 @@ public class HibernateOrmConfig {
         @ConfigItem
         public Optional<String> charset;
 
+        /**
+         * Whether Hibernate should quote all identifiers.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean globallyQuotedIdentifiers;
+
         public boolean isAnyPropertySet() {
             return !"none".equals(generation) || defaultCatalog.isPresent() || defaultSchema.isPresent()
                     || generationHaltOnError
-                    || charset.isPresent();
+                    || charset.isPresent()
+                    || globallyQuotedIdentifiers;
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -429,6 +429,10 @@ public final class HibernateOrmProcessor {
                 hibernateConfig.database.defaultSchema.ifPresent(
                         schema -> desc.getProperties().setProperty(AvailableSettings.DEFAULT_SCHEMA, schema));
 
+                if (hibernateConfig.database.globallyQuotedIdentifiers) {
+                    desc.getProperties().setProperty(AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS, "true");
+                }
+
                 // Query
                 if (hibernateConfig.batchFetchSize > 0) {
                     desc.getProperties().setProperty(AvailableSettings.DEFAULT_BATCH_FETCH_SIZE,

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoted_indentifiers/Group.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoted_indentifiers/Group.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.orm.quoted_indentifiers;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Table with reserved name.
+ * <p>
+ * http://www.h2database.com/html/advanced.html section "Keywords / Reserved Words".
+ */
+@Entity
+@Table(name = "group")
+public class Group {
+
+    private Long id;
+
+    private String name;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "groupSeq")
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoted_indentifiers/JPAQuotedTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoted_indentifiers/JPAQuotedTestCase.java
@@ -1,0 +1,32 @@
+package io.quarkus.hibernate.orm.quoted_indentifiers;
+
+import static org.hamcrest.core.StringContains.containsString;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Failed to fetch entity with reserved name.
+ */
+public class JPAQuotedTestCase {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Group.class, QuotedResource.class)
+                    .addAsResource("application-quoted-identifiers.properties", "application.properties"));
+
+    @Test
+    public void testQuotedIdentifiers() {
+        RestAssured.when().post("/jpa-test-quoted").then()
+                .body(containsString("ok"));
+
+        RestAssured.when().get("/jpa-test-quoted").then()
+                .body(containsString("group_name"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoted_indentifiers/QuotedResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/quoted_indentifiers/QuotedResource.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.orm.quoted_indentifiers;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Try to fetch entity with reserved name.
+ */
+@Path("/jpa-test-quoted")
+@ApplicationScoped
+public class QuotedResource {
+
+    @Inject
+    EntityManager em;
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public String create() {
+        Group group = new Group();
+        group.setId(1L);
+        group.setName("group_name");
+        em.merge(group);
+        return "ok";
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public String selectWithQuotedEntity() {
+        try {
+            return em.find(Group.class, 1L).getName();
+        } catch (Exception e) {
+            return "Unable to fetch group.";
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/application-quoted-identifiers.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-quoted-identifiers.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.url=jdbc:h2:mem:test
+quarkus.datasource.driver=org.h2.Driver
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.hibernate-orm.database.globally-quoted-identifiers=true


### PR DESCRIPTION
I moved this option to the `database` section and set the default value is "false".

There are two test: first when value is false and check that you cannot work when entity names conflict with the database reserved words, and the second when value is true and all work.