### PR TITLE
Workaround backtick and tick issue

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -142,7 +142,7 @@ Note that to take advantage of these features, the `quarkus-test-kubernetes-clie
 == Note on implementing the Watcher interface
 
 Due to the restrictions imposed by GraalVM, extra care needs to be taken when implementing a `io.fabric8.kubernetes.client.Watcher` if the application is intended to work in native mode.
-Essentially every `Watcher` implementation needs to specify the Kubernetes model class that it handles via the `Watcher`'s generic type at class definition time.
+Essentially every `Watcher` implementation needs to specify the Kubernetes model class that it handles via the `Watcher`&#8217;s generic type at class definition time.
 To better understand this, suppose we want to watch for changes to Kubernetes `Pod` resources. There are a couple ways to write such a Watcher that are guaranteed to work in native:
 
 [source%nowrap,java]


### PR DESCRIPTION
Seems that asciidoc cannot handle backtics followed by tics. In this case the formatting continues until `Pod` is reached. 
Commit works around the problem by reformulating slightly, I don't know ascii doc well enough to know if there is a better way to escape the tick.