### PR TITLE
Maven plugin: Support <compilerArgs/>, <source/>, <target/> in dev mode

### DIFF
--- a/core/devmode/pom.xml
+++ b/core/devmode/pom.xml
@@ -22,6 +22,23 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager-embedded</artifactId>
         </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
@@ -137,7 +137,10 @@ public class ClassLoaderCompiler {
                                     new File(i.getProjectDirectory()),
                                     new File(sourcePath),
                                     new File(i.getClassesPath()),
-                                    context.getSourceEncoding()));
+                                    context.getSourceEncoding(),
+                                    context.getCompilerOptions(),
+                                    context.getSourceJavaVersion(),
+                                    context.getTargetJvmVersion()));
                 });
             }
         }

--- a/core/devmode/src/main/java/io/quarkus/dev/CompilationProvider.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/CompilationProvider.java
@@ -4,7 +4,9 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public interface CompilationProvider {
@@ -27,6 +29,9 @@ public interface CompilationProvider {
         private final File sourceDirectory;
         private final File outputDirectory;
         private final Charset sourceEncoding;
+        private final List<String> compilerOptions;
+        private final String sourceJavaVersion;
+        private final String targetJvmVersion;
 
         public Context(
                 String name,
@@ -34,7 +39,10 @@ public interface CompilationProvider {
                 File projectDirectory,
                 File sourceDirectory,
                 File outputDirectory,
-                String sourceEncoding) {
+                String sourceEncoding,
+                List<String> compilerOptions,
+                String sourceJavaVersion,
+                String targetJvmVersion) {
 
             this.name = name;
             this.classpath = classpath;
@@ -42,6 +50,9 @@ public interface CompilationProvider {
             this.sourceDirectory = sourceDirectory;
             this.outputDirectory = outputDirectory;
             this.sourceEncoding = sourceEncoding == null ? StandardCharsets.UTF_8 : Charset.forName(sourceEncoding);
+            this.compilerOptions = compilerOptions == null ? new ArrayList<String>() : compilerOptions;
+            this.sourceJavaVersion = sourceJavaVersion;
+            this.targetJvmVersion = targetJvmVersion;
         }
 
         public String getName() {
@@ -66,6 +77,18 @@ public interface CompilationProvider {
 
         public Charset getSourceEncoding() {
             return sourceEncoding;
+        }
+
+        public List<String> getCompilerOptions() {
+            return compilerOptions;
+        }
+
+        public String getSourceJavaVersion() {
+            return sourceJavaVersion;
+        }
+
+        public String getTargetJvmVersion() {
+            return targetJvmVersion;
         }
     }
 }

--- a/core/devmode/src/main/java/io/quarkus/dev/CompilerFlags.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/CompilerFlags.java
@@ -1,0 +1,75 @@
+package io.quarkus.dev;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.quarkus.runtime.util.StringUtil;
+
+/**
+ * A set of compiler flags for javac.
+ *
+ * Can combine system-provided default flags with user-supplied flags and <code>-source</code>
+ * and <code>-target</code> settings.
+ */
+public class CompilerFlags {
+
+    private final Set<String> defaultFlags;
+    private final List<String> userFlags;
+    private final String sourceJavaVersion; //can be null
+    private final String targetJavaVersion; //can be null
+
+    public CompilerFlags(
+            Set<String> defaultFlags,
+            Collection<String> userFlags,
+            String sourceJavaVersion,
+            String targetJavaVersion) {
+
+        this.defaultFlags = defaultFlags == null ? new HashSet<>() : new HashSet<>(defaultFlags);
+        this.userFlags = userFlags == null ? new ArrayList<>() : new ArrayList<>(userFlags);
+        this.sourceJavaVersion = sourceJavaVersion;
+        this.targetJavaVersion = targetJavaVersion;
+    }
+
+    public List<String> toList() {
+        List<String> flagList = new ArrayList<>();
+
+        // The set of effective default flags is the set of default flags except the ones also
+        // set by the user.  This ensures that we do not needlessly pass the default flags twice.
+        Set<String> effectiveDefaultFlags = new HashSet<>(this.defaultFlags);
+        effectiveDefaultFlags.removeAll(userFlags);
+
+        flagList.addAll(effectiveDefaultFlags);
+
+        // Add -source and -target flags.
+        if (sourceJavaVersion != null) {
+            flagList.add("-source");
+            flagList.add(sourceJavaVersion);
+        }
+        if (targetJavaVersion != null) {
+            flagList.add("-target");
+            flagList.add(targetJavaVersion);
+        }
+
+        flagList.addAll(userFlags);
+
+        return flagList;
+    }
+
+    @Override
+    public int hashCode() {
+        return toList().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof CompilerFlags && toList().equals(((CompilerFlags) obj).toList());
+    }
+
+    @Override
+    public String toString() {
+        return "CompilerFlags@{" + StringUtil.join(", ", toList().iterator()) + "}";
+    }
+}

--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
@@ -30,6 +30,10 @@ public class DevModeContext implements Serializable {
     private boolean test;
     private boolean abortOnFailedStart;
 
+    private List<String> compilerOptions;
+    private String sourceJavaVersion;
+    private String targetJvmVersion;
+
     public List<URL> getClassPath() {
         return classPath;
     }
@@ -88,6 +92,30 @@ public class DevModeContext implements Serializable {
 
     public void setAbortOnFailedStart(boolean abortOnFailedStart) {
         this.abortOnFailedStart = abortOnFailedStart;
+    }
+
+    public List<String> getCompilerOptions() {
+        return compilerOptions;
+    }
+
+    public void setCompilerOptions(List<String> compilerOptions) {
+        this.compilerOptions = compilerOptions;
+    }
+
+    public String getSourceJavaVersion() {
+        return sourceJavaVersion;
+    }
+
+    public void setSourceJavaVersion(String sourceJavaVersion) {
+        this.sourceJavaVersion = sourceJavaVersion;
+    }
+
+    public String getTargetJvmVersion() {
+        return targetJvmVersion;
+    }
+
+    public void setTargetJvmVersion(String targetJvmVersion) {
+        this.targetJvmVersion = targetJvmVersion;
     }
 
     public static class ModuleInfo implements Serializable {

--- a/core/devmode/src/test/java/io/quarkus/dev/CompilerFlagsTest.java
+++ b/core/devmode/src/test/java/io/quarkus/dev/CompilerFlagsTest.java
@@ -1,0 +1,91 @@
+package io.quarkus.dev;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class CompilerFlagsTest {
+
+    @Test
+    void nullHandling() {
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(null, null, null, null),
+                        new CompilerFlags(setOf(), listOf(), null, null)));
+    }
+
+    @Test
+    void defaulting() {
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(setOf("-a", "-b"), listOf(), null, null),
+                        new CompilerFlags(setOf(), listOf("-a", "-b"), null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf("-a", "-b"), listOf("-c", "-d"), null, null),
+                        new CompilerFlags(setOf(), listOf("-a", "-b", "-c", "-d"), null, null)));
+    }
+
+    @Test
+    void redundancyReduction() {
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(setOf("-a", "-b"), listOf(), null, null),
+                        new CompilerFlags(setOf(), listOf("-a", "-b"), null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf("-a", "-b", "-c"), listOf("-a", "-b"), null, null),
+                        new CompilerFlags(setOf("-c"), listOf("-a", "-b"), null, null)));
+    }
+
+    @Test
+    void sourceAndTarget() {
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf(), "1", null),
+                        new CompilerFlags(setOf(), listOf("-source", "1"), null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf(), null, "2"),
+                        new CompilerFlags(setOf(), listOf("-target", "2"), null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf(), "1", "2"),
+                        new CompilerFlags(setOf(), listOf("-source", "1", "-target", "2"), null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf("-source", "3", "-target", "4"), "1", "2"),
+                        new CompilerFlags(setOf(), listOf("-source", "1", "-target", "2", "-source", "3", "-target", "4"), null,
+                                null)));
+    }
+
+    @Test
+    void allFeatures() {
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(setOf("-b", "-c", "-d"), listOf("-a", "-b", "-c"), "1", "2"),
+                        new CompilerFlags(setOf(), listOf("-d", "-source", "1", "-target", "2", "-a", "-b", "-c"), null,
+                                null)));
+    }
+
+    @Test
+    void listConversion() {
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(null, null, null, null).toList(),
+                        listOf()),
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf("-a", "-b", "-c", "-d"), null, null).toList(),
+                        listOf("-a", "-b", "-c", "-d")));
+    }
+
+    private List<String> listOf(String... strings) {
+        return Arrays.asList(strings);
+    }
+
+    private Set<String> setOf(String... strings) {
+        return new HashSet<>(Arrays.asList(strings));
+    }
+
+}

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -169,6 +169,39 @@ Start Quarkus in dev mode on the remote host. Now you need to connect your local
 Now every time you refresh the browser you should see any changes you have made locally immediately visible in the remote
 app.
 
+=== Configuring Development Mode
+
+By default, the Maven plugin picks up compiler flags to pass to
+`javac` from `maven-compiler-plugin`.
+
+If you need to customize the compiler flags used in development mode,
+add a `configuration` section to the `plugin` block and set the
+`compilerArgs` property just as you would when configuring
+`maven-compiler-plugin`.  You can also set `source`, `target`, and
+`jvmArgs`.  For example, to pass `--enable-preview` to both the JVM
+and `javac`:
+
+[source,xml]
+----
+<plugin>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-maven-plugin</artifactId>
+  <version>${quarkus.version}</version>
+
+  <configuration>
+    <source>${maven.compiler.source}</source>
+    <target>${maven.compiler.target}</target>
+    <compilerArgs>
+      <arg>--enable-preview</arg>
+    </compilerArgs>
+    <jvmArgs>--enable-preview</jvmArgs>
+  </configuration>
+
+  ...
+</plugin>
+----
+
+
 == Debugging
 
 In development mode, Quarkus starts by default with debug mode enabled, listening to port `5005` without suspending the JVM.


### PR DESCRIPTION
Adds support for the `<compilerArgs/>`, `<source/>`, and `<target/>`
settings to the Maven plugin, which are then used to configure javac
in development mode.

This enables users to set lint flags and enable preview language
features, among other things.