### PR TITLE
Fix #4407 - Allow user route registration after the base route

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/route/UserRouteTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/route/UserRouteTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.resteasy.test.route;
+
+import static org.hamcrest.core.Is.is;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.test.RootResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+/**
+ * Test that user route are still called even if registered after the default route.
+ */
+public class UserRouteTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RootResource.class, MyRoute.class));
+
+    @Inject
+    MyRoute myRoute;
+
+    @Test
+    public void test() {
+        // test accessing the root resource
+        RestAssured.get("/").then()
+                .statusCode(200)
+                .body(is("Root Resource"));
+        // test without the route
+        RestAssured.get("/my-route").then()
+                .statusCode(404);
+
+        myRoute.register();
+
+        // test with the route
+        RestAssured.get("/my-route").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        // test we can still access the default route
+        RestAssured.get("/").then()
+                .statusCode(200)
+                .body(is("Root Resource"));
+    }
+
+    @ApplicationScoped
+    public static class MyRoute {
+
+        @Inject
+        Router router;
+
+        public void register() {
+            router.route("/my-route").handler(rc -> rc.response().end("OK"));
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -175,7 +175,7 @@ public class VertxHttpRecorder {
         }
 
         if (defaultRouteHandler != null) {
-            defaultRouteHandler.accept(router.route());
+            defaultRouteHandler.accept(router.route().order(10_000));
         }
 
         container.instance(RouterProducer.class).initialize(router);


### PR DESCRIPTION
Just add a high order to the default route meaning that the user routes will be called first.
I didn't use Integer.MAX on purpose to allow an advanced user to register route AFTER the default route.

@lburgazzoli That should fix your (first) issue