### PR TITLE
Extension metadata and generation of extensions.json

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -141,10 +141,11 @@
                     <version>${project.version}</version>
                     <executions>
                         <execution>
+                            <id>generate-extension-descriptor</id>
                             <goals>
                                 <goal>extension-descriptor</goal>
                             </goals>
-                            <phase>compile</phase>
+                            <phase>process-resources</phase>
                             <configuration>
                                 <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
                                 </deployment>

--- a/devtools/core-extensions-json/pom.xml
+++ b/devtools/core-extensions-json/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-devtools-all</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-core-extensions-json</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus - Core Extensions JSON</name>
+
+    <dependencies>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>generate-extensions-json</goal>
+                        </goals>
+                        <configuration>
+                            <bomArtifactId>quarkus-bom</bomArtifactId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -110,6 +110,11 @@
             <artifactId>freemarker</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+        </dependency>
+
         <!-- extensions reader -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateExtensionsJsonMojo.java
@@ -1,0 +1,197 @@
+package io.quarkus.maven;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import javax.json.JsonWriterFactory;
+import javax.json.stream.JsonGenerator;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.util.ZipUtils;
+
+/**
+ * This goal generates a list of extensions for a given BOM
+ * and stores it in a JSON format file that is later used by the tools
+ * as the catalog of available extensions.
+ */
+@Mojo(name = "generate-extensions-json")
+public class GenerateExtensionsJsonMojo extends AbstractMojo {
+
+    @Parameter(property = "bomGroupId", defaultValue = "${project.groupId}")
+    private String bomGroupId;
+
+    @Parameter(property = "bomArtifactId", defaultValue = "${project.artifactId}")
+    private String bomArtifactId;
+
+    @Parameter(property = "bomVersion", defaultValue = "${project.version}")
+    private String bomVersion;
+
+    @Parameter(property = "outputFile", defaultValue = "${project.build.directory}/extensions.json")
+    private File outputFile;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Component
+    private MavenProject project;
+    @Component
+    private MavenProjectHelper projectHelper;
+
+    public GenerateExtensionsJsonMojo() {
+        MojoLogger.logSupplier = this::getLog;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        final DefaultArtifact bomArtifact = new DefaultArtifact(bomGroupId, bomArtifactId, "", "pom", bomVersion);
+        debug("Generating catalog of extensions for %s", bomArtifact);
+
+        final List<Dependency> deps;
+        try {
+            deps = repoSystem
+                    .readArtifactDescriptor(repoSession,
+                            new ArtifactDescriptorRequest().setRepositories(repos).setArtifact(bomArtifact))
+                    .getManagedDependencies();
+        } catch (ArtifactDescriptorException e) {
+            throw new MojoExecutionException("Failed to read descriptor of " + bomArtifact, e);
+        }
+        if (deps.isEmpty()) {
+            getLog().warn("BOM " + bomArtifact + " does not include any dependency");
+            return;
+        }
+
+        final JsonArrayBuilder extListJson = Json.createArrayBuilder();
+        for (Dependency dep : deps) {
+            final Artifact artifact = dep.getArtifact();
+            if (!artifact.getExtension().equals("jar")
+                    || "javadoc".equals(artifact.getClassifier())
+                    || "tests".equals(artifact.getClassifier())
+                    || "sources".equals(artifact.getClassifier())) {
+                continue;
+            }
+            ArtifactResult resolved = null;
+            try {
+                resolved = repoSystem.resolveArtifact(repoSession,
+                        new ArtifactRequest().setRepositories(repos).setArtifact(artifact));
+                processDependency(resolved.getArtifact(), extListJson);
+            } catch (ArtifactResolutionException e) {
+                // there are some parent poms that appear as jars for some reason
+                debug("Failed to resolve dependency %s defined in %s", artifact, bomArtifact);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to process dependency " + artifact, e);
+            }
+        }
+
+        final JsonObjectBuilder platformJson = Json.createObjectBuilder();
+        final JsonObjectBuilder bomJson = Json.createObjectBuilder();
+        bomJson.add("groupId", bomGroupId);
+        bomJson.add("artifactId", bomArtifactId);
+        bomJson.add("version", bomVersion);
+        platformJson.add("bom", bomJson.build());
+        platformJson.add("extensions", extListJson.build());
+
+        final File outputDir = outputFile.getParentFile();
+        if (!outputDir.exists()) {
+            if (!outputDir.mkdirs()) {
+                throw new MojoExecutionException("Failed to create output directory " + outputDir);
+            }
+        }
+        final JsonWriterFactory jsonWriterFactory = Json
+                .createWriterFactory(Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true));
+        try (JsonWriter jsonWriter = jsonWriterFactory.createWriter(new FileOutputStream(outputFile))) {
+            jsonWriter.writeObject(platformJson.build());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to persist " + outputFile, e);
+        }
+
+        projectHelper.attachArtifact(project, "json", null, outputFile);
+    }
+
+    private void processDependency(Artifact artifact, JsonArrayBuilder extJsonBuilder) throws IOException {
+        final Path path = artifact.getFile().toPath();
+        if (Files.isDirectory(path)) {
+            processMetaInfDir(artifact, path.resolve(BootstrapConstants.META_INF), extJsonBuilder);
+        } else {
+            try (FileSystem artifactFs = ZipUtils.newFileSystem(path)) {
+                processMetaInfDir(artifact, artifactFs.getPath(BootstrapConstants.META_INF), extJsonBuilder);
+            }
+        }
+    }
+
+    private boolean processMetaInfDir(Artifact artifact, Path metaInfDir, JsonArrayBuilder extJsonBuilder)
+            throws IOException {
+        if (!Files.exists(metaInfDir)) {
+            return false;
+        }
+        final Path p = metaInfDir.resolve(BootstrapConstants.EXTENSION_PROPS_JSON_FILE_NAME);
+        if (!Files.exists(p)) {
+            return false;
+        }
+        processPlatformArtifact(artifact, p, extJsonBuilder);
+        return true;
+    }
+
+    private void processPlatformArtifact(Artifact artifact, Path descriptor, JsonArrayBuilder extJsonBuilder)
+            throws IOException {
+        try (InputStream is = Files.newInputStream(descriptor)) {
+            try (JsonReader reader = Json.createReader(is)) {
+                final JsonObject object = reader.readObject();
+                debug("Adding Quarkus extension %s:%s", object.get("groupId"), object.get("artifactId"));
+                extJsonBuilder.add(object);
+            }
+        } catch (IOException e) {
+            throw new IOException("Failed to parse " + descriptor, e);
+        }
+    }
+
+    private void debug(String msg, Object... args) {
+        if (!getLog().isDebugEnabled()) {
+            return;
+        }
+        if (args.length == 0) {
+            getLog().debug(msg);
+            return;
+        }
+        getLog().debug(String.format(msg, args));
+    }
+}

--- a/devtools/pom.xml
+++ b/devtools/pom.xml
@@ -20,6 +20,7 @@
     </properties>
 
     <modules>
+        <module>core-extensions-json</module>
         <module>common-core</module>
         <module>extension-plugin</module>
         <module>common</module>

--- a/extensions/agroal/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/agroal/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Agroal - Database connection pool",
+    "labels": [
+        "agroal",
+        "database-connection-pool"
+    ]
+}

--- a/extensions/amazon-dynamodb/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/amazon-dynamodb/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "Amazon DynamoDB",
+    "labels": [
+        "dynamodb",
+        "dynamo",
+        "aws",
+        "amazon"
+    ]
+}

--- a/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "AWS Lambda",
+    "labels": [
+        "lambda",
+        "aws",
+        "amazon"
+    ]
+}

--- a/extensions/arc/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/arc/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "Arc",
+    "shortName": "CDI",
+    "labels": [
+        "arc",
+        "cdi",
+        "dependency-injection",
+        "di"
+    ],
+    "guide": "https://quarkus.io/guides/cdi-reference"
+}

--- a/extensions/artemis-core/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/artemis-core/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Artemis Core",
+    "labels": [
+        "artemis-core",
+        "artemis"
+    ]
+}

--- a/extensions/artemis-jms/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/artemis-jms/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Artemis JMS",
+    "labels": [
+        "artemis-jms",
+        "artemis"
+    ]
+}

--- a/extensions/elytron-security-oauth2/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/elytron-security-oauth2/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Security OAuth2",
+    "labels": [
+        "security",
+        "oauth2"
+    ]
+}

--- a/extensions/elytron-security-properties-file/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/elytron-security-properties-file/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Properties File based Security",
+    "labels": [
+        "security"
+    ],
+    "guide": "https://quarkus.io/guides/elytron-properties-guide"
+}

--- a/extensions/flyway/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/flyway/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "Flyway",
+    "labels": [
+        "flyway",
+        "database",
+        "data"
+    ],
+    "guide": "https://quarkus.io/guides/flyway-guide"
+}

--- a/extensions/hibernate-orm/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/hibernate-orm/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "Hibernate ORM",
+    "shortName": "JPA",
+    "labels": [
+        "hibernate-orm",
+        "jpa",
+        "hibernate"
+    ],
+    "guide": "https://quarkus.io/guides/hibernate-orm-guide"
+}

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "Hibernate Search + Elasticsearch",
+    "labels": [
+        "hibernate-search-elasticsearch",
+        "search",
+        "full-text",
+        "hibernate",
+        "elasticsearch"
+    ],
+    "guide": "https://quarkus.io/guides/hibernate-search-guide"
+}

--- a/extensions/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "Hibernate Validator",
+    "shortName": "bean validation",
+    "labels": [
+        "hibernate-validator",
+        "bean-validation",
+        "validation"
+    ],
+    "guide": "https://quarkus.io/guides/validation-guide"
+}

--- a/extensions/infinispan-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/infinispan-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "Infinispan Client",
+    "labels": [
+        "infinispan-client",
+        "data-grid-client",
+        "infinispan"
+    ],
+    "guide": "https://quarkus.io/guides/infinispan-client-guide"
+}

--- a/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Jackson",
+    "labels": [
+        "jackson",
+        "json"
+    ]
+}

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "JDBC Driver - H2",
+    "labels": [
+        "jdbc-h2",
+        "jdbc",
+        "h2"
+    ]
+}

--- a/extensions/jdbc/jdbc-mariadb/jdbc-mariadb-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-mariadb/jdbc-mariadb-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "JDBC Driver - MariaDB",
+    "labels": [
+        "jdbc-mariadb",
+        "jdbc",
+        "mariadb"
+    ]
+}

--- a/extensions/jdbc/jdbc-mssql/jdbc-mssql-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-mssql/jdbc-mssql-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "JDBC Driver - Microsoft SQL Server",
+    "labels": [
+        "jdbc-mssql",
+        "jdbc",
+        "mssql",
+        "sql-server"
+    ]
+}

--- a/extensions/jdbc/jdbc-mysql/jdbc-mysql-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-mysql/jdbc-mysql-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "JDBC Driver - MySQL",
+    "labels": [
+        "jdbc-mysql",
+        "jdbc",
+        "mysql"
+    ]
+}

--- a/extensions/jdbc/jdbc-postgresql/jdbc-postgresql-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-postgresql/jdbc-postgresql-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "JDBC Driver - PostgreSQL",
+    "labels": [
+        "jdbc-postgresql",
+        "jdbc",
+        "postgresql"
+    ]
+}

--- a/extensions/jgit/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jgit/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,7 @@
+
+{
+    "name": "JGit",
+    "labels": [
+        "git"
+    ]
+}

--- a/extensions/jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "JSON-B",
+    "labels": [
+        "jsonb",
+        "json-b",
+        "json"
+    ],
+    "guide": "https://quarkus.io/guides/rest-json-guide"
+}

--- a/extensions/jsonp/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jsonp/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "JSON-P",
+    "labels": [
+        "jsonp",
+        "json-p",
+        "json"
+    ]
+}

--- a/extensions/kafka-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kafka-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,7 @@
+
+{
+    "name": "Apache Kafka Client",
+    "labels": [
+        "kafka"
+    ]
+}

--- a/extensions/kafka-streams/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kafka-streams/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Apache Kafka Streams",
+    "labels": [
+        "kafka",
+        "kafka-streams"
+    ]
+}

--- a/extensions/kogito/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kogito/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "Kogito",
+    "labels": [
+        "kogito",
+        "drools",
+        "jbpm"
+    ],
+    "guide": "https://quarkus.io/guides/kogito-guide"
+}

--- a/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Kotlin",
+    "labels": [
+        "kotlin"
+    ],
+    "guide": "https://quarkus.io/guides/kotlin"
+}

--- a/extensions/kubernetes-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kubernetes-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,7 @@
+
+{
+    "name": "Kubernetes Client",
+    "labels": [
+        "kubernetes-client"
+    ]
+}

--- a/extensions/kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Kubernetes",
+    "labels": [
+        "kubernetes"
+    ],
+    "guide": "https://quarkus.io/guides/kubernetes-guide"
+}

--- a/extensions/mailer/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/mailer/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "Mailer",
+    "labels": [
+        "mail",
+        "mailer"
+    ],
+    "guide": "https://quarkus.io/guides/sending-emails"
+}

--- a/extensions/mongodb-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/mongodb-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "MongoDB Client",
+    "labels": [
+        "mongo",
+        "mongodb",
+        "nosql",
+        "datastore"
+    ]
+}

--- a/extensions/narayana-jta/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/narayana-jta/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,14 @@
+
+{
+    "name": "Narayana JTA - Transaction manager",
+    "labels": [
+        "narayana-jta",
+        "narayana",
+        "jta",
+        "transactions",
+        "transaction",
+        "tx",
+        "txs"
+    ],
+    "guide": "https://quarkus.io/guides/transaction-guide"
+}

--- a/extensions/narayana-stm/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/narayana-stm/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,15 @@
+
+{
+    "name": "Narayana STM - Software Transactional Memory",
+    "labels": [
+        "narayana-stm",
+        "narayana",
+        "stm",
+        "transactions",
+        "transaction",
+        "software-transactional-memory",
+        "tx",
+        "txs"
+    ],
+    "guide": "https://quarkus.io/guides/stm-guide"
+}

--- a/extensions/neo4j/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/neo4j/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "Neo4j client",
+    "labels": [
+        "neo4j",
+        "graph",
+        "nosql",
+        "datastore"
+    ]
+}

--- a/extensions/oidc/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/oidc/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "OpenID Connect",
+    "labels": [
+        "oauth2",
+        "openid-connect"
+    ],
+    "guide": "https://quarkus.io/guides/oidc-guide"
+}

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "Hibernate ORM with Panache",
+    "labels": [
+        "hibernate-orm-panache",
+        "panache",
+        "hibernate",
+        "jpa"
+    ],
+    "guide": "https://quarkus.io/guides/hibernate-orm-panache-guide"
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/panache/mongodb-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "MongoDB with Panache",
+    "labels": [
+        "mongo",
+        "mongodb",
+        "nosql",
+        "datastore",
+        "panache"
+    ]
+}

--- a/extensions/reactive-mysql-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-mysql-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "Reactive MySQL Client",
+    "labels": [
+        "eclipse-vert.x",
+        "vertx",
+        "vert.x",
+        "reactive",
+        "database",
+        "data",
+        "mysql"
+    ]
+}

--- a/extensions/reactive-pg-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-pg-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "Reactive PostgreSQL Client",
+    "labels": [
+        "eclipse-vert.x",
+        "vertx",
+        "vert.x",
+        "reactive",
+        "database",
+        "data",
+        "postgresql"
+    ]
+}

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "SmallRye Reactive Streams Operators",
+    "shortName": "reactive streams",
+    "labels": [
+        "smallrye-reactive-streams-operators",
+        "smallrye-reactive-streams",
+        "reactive-streams-operators",
+        "reactive-streams",
+        "microprofile-reactive-streams",
+        "reactive"
+    ]
+}

--- a/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "SmallRye Reactive Type Converters",
+    "labels": [
+        "smallrye-reactive-type-converters",
+        "reactive-type-converters",
+        "reactive-streams-operators",
+        "reactive-streams",
+        "microprofile-reactive-streams",
+        "reactive"
+    ]
+}

--- a/extensions/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "REST Client",
+    "labels": [
+        "rest-client",
+        "web-client",
+        "microprofile-rest-client"
+    ],
+    "guide": "https://quarkus.io/guides/rest-client-guide"
+}

--- a/extensions/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "RESTEasy - Jackson",
+    "labels": [
+        "resteasy-jackson",
+        "jaxrs-json",
+        "resteasy-json",
+        "resteasy",
+        "jaxrs",
+        "json",
+        "jackson"
+    ]
+}

--- a/extensions/resteasy-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/resteasy-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,14 @@
+
+{
+    "name": "RESTEasy - JSON-B",
+    "labels": [
+        "resteasy-jsonb",
+        "jaxrs-json",
+        "resteasy-json",
+        "resteasy",
+        "jaxrs",
+        "json",
+        "jsonb"
+    ],
+    "guide": "https://quarkus.io/guides/rest-json-guide"
+}

--- a/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "RESTEasy",
+    "shortName": "jax-rs",
+    "labels": [
+        "resteasy",
+        "jaxrs",
+        "web",
+        "rest"
+    ],
+    "guide": "https://quarkus.io/guides/rest-json-guide"
+}

--- a/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,7 @@
+
+{
+    "name": "Scala",
+    "labels": [
+        "scala"
+    ]
+}

--- a/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "Scheduler",
+    "labels": [
+        "scheduler",
+        "tasks",
+        "periodic-tasks"
+    ],
+    "guide": "https://quarkus.io/guides/scheduled-guide"
+}

--- a/extensions/smallrye-context-propagation/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-context-propagation/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "SmallRye Context Propagation",
+    "shortName": "context propagation",
+    "labels": [
+        "smallrye-context-propagation",
+        "microprofile-context-propagation",
+        "context-propagation",
+        "context",
+        "reactive"
+    ]
+}

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "SmallRye Fault Tolerance",
+    "labels": [
+        "smallrye-fault-tolerance",
+        "fault-tolerance",
+        "microprofile-fault-tolerance",
+        "circuit-breaker",
+        "bulkhead"
+    ]
+}

--- a/extensions/smallrye-health/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-health/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "SmallRye Health",
+    "shortName": "health",
+    "labels": [
+        "smallrye-health",
+        "health-check",
+        "health",
+        "microprofile-health",
+        "microprofile-health-check"
+    ],
+    "guide": "https://quarkus.io/guides/health-guide"
+}

--- a/extensions/smallrye-jwt/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-jwt/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "SmallRye JWT",
+    "labels": [
+        "smallrye-jwt",
+        "jwt",
+        "json-web-token",
+        "rbac"
+    ],
+    "guide": "https://quarkus.io/guides/jwt-guide"
+}

--- a/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "SmallRye Metrics",
+    "shortName": "metrics",
+    "labels": [
+        "smallrye-metrics",
+        "metrics",
+        "metric",
+        "prometheus",
+        "monitoring"
+    ],
+    "guide": "https://quarkus.io/guides/metrics-guide"
+}

--- a/extensions/smallrye-openapi/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-openapi/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "SmallRye OpenAPI",
+    "labels": [
+        "smallrye-openapi",
+        "openapi",
+        "open-api"
+    ],
+    "guide": "https://quarkus.io/guides/openapi-swaggerui-guide"
+}

--- a/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "SmallRye OpenTracing",
+    "labels": [
+        "smallrye-opentracing",
+        "opentracing",
+        "tracing",
+        "distributed-tracing",
+        "jaeger"
+    ],
+    "guide": "https://quarkus.io/guides/opentracing-guide"
+}

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "SmallRye Reactive Messaging - AMQP Connector",
+    "labels": [
+        "amqp",
+        "reactive-amqp"
+    ],
+    "guide": "https://quarkus.io/guides/amqp-guide"
+}

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "SmallRye Reactive Messaging - Kafka Connector",
+    "shortName": "kafka",
+    "labels": [
+        "kafka",
+        "reactive-kafka"
+    ],
+    "guide": "https://quarkus.io/guides/kafka-guide"
+}

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "SmallRye Reactive Messaging - MQTT Connector",
+    "labels": [
+        "mqtt",
+        "reactive-mqtt"
+    ]
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,10 @@
+
+{
+    "name": "SmallRye Reactive Messaging",
+    "labels": [
+        "smallrye-reactive-messaging",
+        "reactive-messaging",
+        "reactive"
+    ],
+    "guide": "https://quarkus.io/guides/async-message-passing"
+}

--- a/extensions/spring-data-jpa/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/spring-data-jpa/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Quarkus Extension for Spring Data API",
+    "labels": [
+        "spring-data"
+    ],
+    "guide": "https://quarkus.io/guides/spring-data-jpa-guide"
+}

--- a/extensions/spring-di/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/spring-di/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Quarkus Extension for Spring DI API",
+    "labels": [
+        "spring-di"
+    ],
+    "guide": "https://quarkus.io/guides/spring-di-guide"
+}

--- a/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Quarkus Extension for Spring Web API",
+    "labels": [
+        "spring-web"
+    ],
+    "guide": "https://quarkus.io/guides/spring-web-guide"
+}

--- a/extensions/swagger-ui/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/swagger-ui/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Swagger UI",
+    "labels": [
+        "swagger-ui"
+    ],
+    "guide": "https://quarkus.io/guides/openapi-swaggerui-guide"
+}

--- a/extensions/tika/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/tika/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "Apache Tika",
+    "labels": [
+        "tika",
+        "parser"
+    ]
+}

--- a/extensions/undertow-websockets/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/undertow-websockets/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,14 @@
+
+{
+    "name": "Undertow WebSockets",
+    "shortName": "websockets",
+    "labels": [
+        "undertow-websockets",
+        "undertow-websocket",
+        "websocket",
+        "websockets",
+        "web-socket",
+        "web-sockets"
+    ],
+    "guide": "https://quarkus.io/guides/websocket-guide"
+}

--- a/extensions/undertow/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/undertow/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,9 @@
+
+{
+    "name": "Undertow",
+    "shortName": "servlet",
+    "labels": [
+        "undertow",
+        "servlet"
+    ]
+}

--- a/extensions/vertx/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,0 +1,11 @@
+
+{
+    "name": "Eclipse Vert.x",
+    "labels": [
+        "eclipse-vert.x",
+        "vertx",
+        "vert.x",
+        "reactive"
+    ],
+    "guide": "https://quarkus.io/guides/using-vertx"
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -7,6 +7,7 @@ package io.quarkus.bootstrap;
 public interface BootstrapConstants {
 
     String DESCRIPTOR_FILE_NAME = "quarkus-extension.properties";
+    String EXTENSION_PROPS_JSON_FILE_NAME = "quarkus-extension.json";
 
     String META_INF = "META-INF";
 

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>maven-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.eclipsesource.minimal-json</groupId>
+            <artifactId>minimal-json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -24,6 +24,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Versions -->
+        <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <junit.version>5.5.2</junit.version>
         <maven-core.version>3.5.4</maven-core.version>
@@ -136,6 +137,11 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>commons-logging-jboss-logging</artifactId>
                 <version>${commons-logging-jboss-logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.eclipsesource.minimal-json</groupId>
+                <artifactId>minimal-json</artifactId>
+                <version>${eclipse-minimal-json.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Fixes #833, #4317 

* Enhanced the quarkus-bootstrap:extension-descriptor mojo to also generate META-INF/quarkus-extension.json with the extension descr/props;
* Added quarkus:generate-extensions-json mojo that generates extensions.json file (and attaches it as a Maven artifact to the project) for a BOM by collecting all the META-INF/quarkus-extension.json files from its managed deps;
* Added devtools/extensions-json module that generates extensions.json file for Quarkus Core (which for now isn't used yet as it needs refinement).

I decided not to re-use `META-INF/quarkus-extension.properties` for this, I think we should deprecate it and have a simpler `META-INF/quarkus-extension-deployment-gav` or something to make it easier/faster to resolve the deployment artifact at build time.

FYI @maxandersen, @paulrobinson, @quintesse, @gastaldi 