### PR TITLE
Test case for issues #3284 and #2556

### DIFF
--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -29,7 +29,8 @@ import io.quarkus.it.hibernate.validator.injection.InjectedConstraintValidatorCo
 import io.quarkus.it.hibernate.validator.injection.MyService;
 
 @Path("/hibernate-validator/test")
-public class HibernateValidatorTestResource {
+public class HibernateValidatorTestResource
+        implements HibernateValidatorTestResourceGenericInterface<Integer> {
 
     @Inject
     Validator validator;
@@ -101,6 +102,14 @@ public class HibernateValidatorTestResource {
     @Path("/rest-end-point-validation/{id}/")
     @Produces(MediaType.TEXT_PLAIN)
     public String testRestEndPointValidation(@Digits(integer = 5, fraction = 0) @PathParam("id") String id) {
+        return id;
+    }
+
+    @GET
+    @Path("/rest-end-point-generic-method-validation/{id}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Override
+    public Integer testRestEndpointGenericMethodValidation(@Digits(integer = 5, fraction = 0) @PathParam("id") Integer id) {
         return id;
     }
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResourceGenericInterface.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResourceGenericInterface.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.hibernate.validator;
+
+import javax.validation.constraints.Digits;
+
+public interface HibernateValidatorTestResourceGenericInterface<T extends Number> {
+
+    T testRestEndpointGenericMethodValidation(@Digits(integer = 5, fraction = 0) T id);
+
+}

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/enums/MyEnumWithValidatorAnnotation.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/enums/MyEnumWithValidatorAnnotation.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.hibernate.validator.enums;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Simply adding this class to the code, without even referencing it from anywhere,
+ * used to make Quarkus startup fail because of an error in Hibernate Validator.
+ * See https://github.com/quarkusio/quarkus/issues/3284
+ */
+public enum MyEnumWithValidatorAnnotation {
+    VALUE1,
+    VALUE2;
+
+    public static MyEnumWithValidatorAnnotation fromCode(@NotNull String code) {
+        return MyEnumWithValidatorAnnotation.valueOf(code);
+    }
+}

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -70,6 +70,20 @@ public class HibernateValidatorFunctionalityTest {
     }
 
     @Test
+    public void testRestEndPointGenericMethodValidation() {
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-generic-method-validation/9999999/")
+                .then()
+                .statusCode(400)
+                .body(containsString("numeric value out of bounds"));
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-generic-method-validation/42/")
+                .then()
+                .body(is("42"));
+    }
+
+    @Test
     public void testNoProduces() {
         RestAssured.when()
                 .get("/hibernate-validator/test/no-produces/plop/")


### PR DESCRIPTION
This tests:

* #3284 enums annotated with Hibernate Validator annotations
* #2556 implementations of generic interfaces with parameters annotated with Hibernate Validator annotations.

This fails with the current version of Hibernate Validator. We'll need a Hibernate Validator upgrade on top of this to fix the problem (HV-1730).