### PR TITLE
[issue#2482] Bring in jacc dependency in hibernate-orm extension

### DIFF
--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.spec.javax.security.jacc</groupId>
+            <artifactId>jboss-jacc-api_1.5_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <exclusions>


### PR DESCRIPTION
One possible fix for the issue discussed in https://github.com/quarkusio/quarkus/issues/2482. Perhaps there's a better way than this?
Complete details in this comment https://github.com/quarkusio/quarkus/issues/2482#issuecomment-539531048