### PR TITLE
Force the version of the Maven Compiler Plugin in the templates and the -parameters option

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -25,6 +25,7 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kotlin.version>1.3.21</kotlin.version>
         <scala.version>2.12.8</scala.version>
+        <scala-plugin.version>4.1.1</scala-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,6 +21,8 @@
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
+        <!-- Quarkus uses jboss-parent and it comes with 3.8.0-jboss-2, we don't want that in the templates -->
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kotlin.version>1.3.21</kotlin.version>
         <scala.version>2.12.8</scala.version>
 

--- a/devtools/common/src/main/filtered/quarkus.properties
+++ b/devtools/common/src/main/filtered/quarkus.properties
@@ -3,6 +3,7 @@ doc-root=https://quarkus.io
 bom-artifactId=quarkus-bom
 # Versions defined in jboss-parent 
 rest-assured-version=${rest-assured.version}
+compiler-plugin-version=${compiler-plugin.version}
 surefire-plugin-version=${version.surefire.plugin}
 kotlin-version=${kotlin.version}
 scala-version=${scala.version}

--- a/devtools/common/src/main/filtered/quarkus.properties
+++ b/devtools/common/src/main/filtered/quarkus.properties
@@ -7,6 +7,7 @@ compiler-plugin-version=${compiler-plugin.version}
 surefire-plugin-version=${version.surefire.plugin}
 kotlin-version=${kotlin.version}
 scala-version=${scala.version}
+scala-plugin-version=${scala-plugin.version}
 
 # Plugin metadata
 plugin-groupId=${project.groupId}

--- a/devtools/common/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
@@ -12,6 +12,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <quarkus.version>${quarkus_version}</quarkus.version>
+        <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
     </properties>
 
@@ -60,6 +61,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
             </plugin>
             <!-- Run the tests in JVM mode -->
             <plugin>

--- a/devtools/common/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
@@ -10,6 +10,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <quarkus.version>${quarkus_version}</quarkus.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>

--- a/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -10,6 +10,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <quarkus.version>${quarkus_version}</quarkus.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>

--- a/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -12,6 +12,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <quarkus.version>${quarkus_version}</quarkus.version>
+        <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <kotlin.version>${kotlin_version}</kotlin.version>
     </properties>
@@ -67,6 +68,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
@@ -16,7 +16,7 @@
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <scala.version>${scala_version}</scala.version>
-        <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
+        <scala-maven-plugin.version>${scala_plugin_version}</scala-maven-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
@@ -10,6 +10,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <quarkus.version>${quarkus_version}</quarkus.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>

--- a/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
@@ -12,6 +12,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <quarkus.version>${quarkus_version}</quarkus.version>
+        <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <scala.version>${scala_version}</scala.version>
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
@@ -73,6 +74,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Right now, with our default project template, the version used is 3.1 (latest is 3.8.1). This is an issue.

Also using 3.6.2+ is needed to be able to use `maven.compiler.parameters`, which is better than overriding the compiler arguments.

Let's merge this at the beginning of the next development cycle.