### PR TITLE
Periodically validate JDBC connections

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -16,6 +16,7 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import org.jboss.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration.ConnectionValidator;
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
@@ -129,6 +130,7 @@ public abstract class AbstractDataSourceProducer {
         }
 
         // Connection management
+        poolConfiguration.connectionValidator(ConnectionValidator.defaultValidator());
         if (dataSourceRuntimeConfig.acquisitionTimeout.isPresent()) {
             poolConfiguration.acquisitionTimeout(dataSourceRuntimeConfig.acquisitionTimeout.get());
         }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceRuntimeConfig.java
@@ -47,7 +47,9 @@ public class DataSourceRuntimeConfig {
     public int maxSize;
 
     /**
-     * The interval at which we validate idle connections in the background
+     * The interval at which we validate idle connections in the background.
+     * <p>
+     * Set to {@code 0} to disable background validation.
      */
     @ConfigItem(defaultValue = "2M")
     public Optional<Duration> backgroundValidationInterval;


### PR DESCRIPTION
Fixes #2336 

Agroal uses `ConnectionValidator.emptyValidator()` by default,
so even if we set the default validation interval to 2 minutes by
default, it will just do nothing every 2 minutes.

Tested manually by putting a thread-suspending breakpoint on the line `storeTestPersons(entityManagerFactory);` in `JPAFunctionalityTestEndpoint`.
Just run `io.quarkus.it.jpa.mariadb.JPAFunctionalityTest`, and when the breakpoint is hit, restart the database, wait 2 minutes, and resume execution. Before this patch, the call to `storeTestPersons(entityManagerFactory);` would fail because a stale connection was in the ppol; after this patch, it will succeed because the connection was removed and renewed.