### PR TITLE
feat: configure java compiler plugin in gradle to add parameters arg

### DIFF
--- a/devtools/common/src/main/java/io/quarkus/cli/commands/file/BuildFile.java
+++ b/devtools/common/src/main/java/io/quarkus/cli/commands/file/BuildFile.java
@@ -116,7 +116,8 @@ public abstract class BuildFile implements Closeable {
 
     protected abstract List<Dependency> getManagedDependencies() throws IOException;
 
-    public abstract void completeFile(String groupId, String artifactId, String version) throws IOException;
+    public abstract void completeFile(String groupId, String artifactId, String version)
+            throws IOException;
 
     public BuildTool getBuildTool() {
         return buildTool;

--- a/devtools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/devtools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -42,7 +42,8 @@ public class GradleBuildFile extends BuildFile {
     }
 
     @Override
-    public void completeFile(String groupId, String artifactId, String version) throws IOException {
+    public void completeFile(String groupId, String artifactId, String version)
+            throws IOException {
         init();
         completeSettingsContent(artifactId);
         completeBuildContent(groupId, version);

--- a/devtools/common/src/main/java/io/quarkus/cli/commands/file/MavenBuildFile.java
+++ b/devtools/common/src/main/java/io/quarkus/cli/commands/file/MavenBuildFile.java
@@ -86,7 +86,8 @@ public class MavenBuildFile extends BuildFile {
     }
 
     @Override
-    public void completeFile(String groupId, String artifactId, String version) throws IOException {
+    public void completeFile(String groupId, String artifactId, String version)
+            throws IOException {
         addVersionProperty();
         addBom();
         addMainPluginConfig();

--- a/devtools/common/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/devtools/common/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -30,3 +30,10 @@ dependencies {
 
 group '${project_groupId}'
 version '${project_version}'
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+
+


### PR DESCRIPTION
Related to issue #3992
In order to allow quarkus integration when using Spring Web's @PathVariable works without a value for `name` we need to enable the java compilation of parameters to the bytecode.
The maven part seems to be done in this [PR](https://github.com/quarkusio/quarkus/pull/4441), this is the gradle part.
I let you take a look and give some feed backs @gastaldi @gsmet @geoand 