### PR TITLE
Be defensive with closeTask in HttpAuthenticator#sendChallenge

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -75,12 +75,25 @@ public class HttpAuthenticator {
      * @return
      */
     public CompletionStage<Void> sendChallenge(RoutingContext routingContext, Runnable closeTask) {
+        if (closeTask == null) {
+            closeTask = NoopCloseTask.INSTANCE;
+        }
         if (mechanism == null) {
             routingContext.response().setStatusCode(HttpResponseStatus.FORBIDDEN.code());
             closeTask.run();
             return CompletableFuture.completedFuture(null);
         }
         return mechanism.sendChallenge(routingContext).thenRun(closeTask);
+    }
+
+    static class NoopCloseTask implements Runnable {
+
+        static final NoopCloseTask INSTANCE = new NoopCloseTask();
+
+        @Override
+        public void run() {
+
+        }
     }
 
 }


### PR DESCRIPTION
Added because I spotted this usage: https://github.com/quarkusio/quarkus/blob/master/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/RequestFailer.java#L60