### PR TITLE
Some new Agroal datasource improvements

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.agroal.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.sql.Driver;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map.Entry;
@@ -11,6 +12,8 @@ import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.sql.XADataSource;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -20,6 +23,7 @@ import org.jboss.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.agroal.DataSource;
+import io.quarkus.agroal.TransactionIntegration;
 import io.quarkus.agroal.runtime.AbstractDataSourceProducer;
 import io.quarkus.agroal.runtime.AgroalBuildTimeConfig;
 import io.quarkus.agroal.runtime.AgroalRecorder;
@@ -96,6 +100,9 @@ class AgroalProcessor {
                 java.sql.ResultSet.class.getName(),
                 java.sql.ResultSet[].class.getName()));
 
+        validateBuildTimeConfig(null, agroalBuildTimeConfig.defaultDataSource);
+        agroalBuildTimeConfig.namedDataSources.forEach(AgroalProcessor::validateBuildTimeConfig);
+
         // Add reflection for the drivers
         if (agroalBuildTimeConfig.defaultDataSource.driver.isPresent()) {
             reflectiveClass
@@ -125,6 +132,52 @@ class AgroalProcessor {
                 (Class<? extends AbstractDataSourceProducer>) recorderContext.classProxy(dataSourceProducerClassName),
                 agroalBuildTimeConfig,
                 sslNativeConfig.isExplicitlyDisabled()));
+    }
+
+    private static void validateBuildTimeConfig(final String datasourceName, final DataSourceBuildTimeConfig ds) {
+        //When the driver is not defined on the default datasource, we need to be more lenient as the datasource component might not be enabled at all:
+        if (!ds.driver.isPresent() && datasourceName == null) {
+            return;
+        }
+
+        String driverName = ds.driver.get();
+        Class<?> driver;
+        try {
+            driver = Class.forName(driverName, true, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            if (datasourceName == null) {
+                throw new DeploymentException("Unable to load the dataSource driver for the default datasource", e);
+            } else {
+                throw new DeploymentException(
+                        "Unable to load the dataSource driver for datasource named '" + datasourceName + "'",
+                        e);
+            }
+        }
+        if (ds.transactions == TransactionIntegration.XA) {
+            if (!XADataSource.class.isAssignableFrom(driver)) {
+                if (datasourceName == null) {
+                    throw new DeploymentException(
+                            "Driver is not an XA dataSource, while XA has been enabled in the configuration of the default datasource: either disable XA or switch the driver to an XADataSource");
+                } else {
+                    throw new DeploymentException(
+                            "Driver is not an XA dataSource, while XA has been enabled in the configuration of the datasource named '"
+                                    + datasourceName + "': either disable XA or switch the driver to an XADataSource");
+                }
+            }
+        } else {
+            if (driver != null && !javax.sql.DataSource.class.isAssignableFrom(driver)
+                    && !Driver.class.isAssignableFrom(driver)) {
+                if (datasourceName == null) {
+                    throw new DeploymentException(
+                            "Driver is an XA dataSource, but XA transactions have not been enabled on the default datasource; please either set 'quarkus.datasource.xa=true' or switch to a standard non-XA JDBC driver implementation");
+                } else {
+                    throw new DeploymentException(
+                            "Driver is an XA dataSource, but XA transactions have not been enabled on the datasource named '"
+                                    + datasourceName + "'; please either set 'quarkus.datasource." + datasourceName
+                                    + ".xa=true' or switch to a standard non-XA JDBC driver implementation");
+                }
+            }
+        }
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -135,8 +135,12 @@ class AgroalProcessor {
     }
 
     private static void validateBuildTimeConfig(final String datasourceName, final DataSourceBuildTimeConfig ds) {
-        //When the driver is not defined on the default datasource, we need to be more lenient as the datasource component might not be enabled at all:
-        if (!ds.driver.isPresent() && datasourceName == null) {
+        if (!ds.driver.isPresent()) {
+            // When the driver is not defined on the default datasource, we need to be more lenient as the datasource
+            // component might not be enabled at all so we only throw an exception for named datasources
+            if (datasourceName != null) {
+                throw new DeploymentException("Named datasource '" + datasourceName + "' doesn't have a driver defined.");
+            }
             return;
         }
 
@@ -146,10 +150,10 @@ class AgroalProcessor {
             driver = Class.forName(driverName, true, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             if (datasourceName == null) {
-                throw new DeploymentException("Unable to load the dataSource driver for the default datasource", e);
+                throw new DeploymentException("Unable to load the datasource driver for the default datasource", e);
             } else {
                 throw new DeploymentException(
-                        "Unable to load the dataSource driver for datasource named '" + datasourceName + "'",
+                        "Unable to load the datasource driver for datasource named '" + datasourceName + "'",
                         e);
             }
         }

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.agroal.narayana.NarayanaTransactionIntegration;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class DefaultDataSourceConfigTest {
@@ -56,6 +57,7 @@ public class DefaultDataSourceConfigTest {
         assertEquals(leakDetectionInterval, configuration.leakTimeout());
         assertEquals(idleRemovalInterval, configuration.reapTimeout());
         assertEquals(maxLifetime, configuration.maxLifetime());
+        assertTrue(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration);
         assertEquals(AgroalConnectionFactoryConfiguration.TransactionIsolation.SERIALIZABLE,
                 agroalConnectionFactoryConfiguration.jdbcTransactionIsolation());
         assertTrue(dataSource.getConfiguration().metricsEnabled());

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
@@ -60,6 +60,7 @@ public class DefaultDataSourceConfigTest {
         assertTrue(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration);
         assertEquals(AgroalConnectionFactoryConfiguration.TransactionIsolation.SERIALIZABLE,
                 agroalConnectionFactoryConfiguration.jdbcTransactionIsolation());
+        assertTrue(agroalConnectionFactoryConfiguration.trackJdbcResources());
         assertTrue(dataSource.getConfiguration().metricsEnabled());
         assertEquals(newConnectionSql, agroalConnectionFactoryConfiguration.initialSql());
         try (Connection connection = dataSource.getConnection()) {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
@@ -2,7 +2,6 @@ package io.quarkus.agroal.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -35,7 +34,7 @@ public class DisabledTransactionDataSourceConfigTest {
     public void testNonTransactionalDataSourceInjection() throws SQLException {
         AgroalConnectionPoolConfiguration configuration = defaultDataSource.getConfiguration().connectionPoolConfiguration();
 
-        assertTrue(!(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration));
+        assertFalse(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration);
         Class<? extends TransactionIntegration> nonTxIntegrator = TransactionIntegration.none().getClass();
         assertEquals(nonTxIntegrator, configuration.transactionIntegration().getClass());
         assertFalse(configuration.connectionFactoryConfiguration().trackJdbcResources());

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.agroal.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
@@ -37,6 +38,7 @@ public class DisabledTransactionDataSourceConfigTest {
         assertTrue(!(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration));
         Class<? extends TransactionIntegration> nonTxIntegrator = TransactionIntegration.none().getClass();
         assertEquals(nonTxIntegrator, configuration.transactionIntegration().getClass());
+        assertFalse(configuration.connectionFactoryConfiguration().trackJdbcResources());
 
         try (Connection connection = defaultDataSource.getConnection()) {
         }

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.agroal.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.agroal.api.transaction.TransactionIntegration;
+import io.agroal.narayana.NarayanaTransactionIntegration;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DisabledTransactionDataSourceConfigTest {
+
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-disabledjta-datasource.properties",
+                            "application.properties"));
+
+    @Test
+    public void testNonTransactionalDataSourceInjection() throws SQLException {
+        AgroalConnectionPoolConfiguration configuration = defaultDataSource.getConfiguration().connectionPoolConfiguration();
+
+        assertTrue(!(configuration.transactionIntegration() instanceof NarayanaTransactionIntegration));
+        Class<? extends TransactionIntegration> nonTxIntegrator = TransactionIntegration.none().getClass();
+        assertEquals(nonTxIntegrator, configuration.transactionIntegration().getClass());
+
+        try (Connection connection = defaultDataSource.getConnection()) {
+        }
+    }
+}

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.agroal.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.common.Assert;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class XaRequiresXaDatasourceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-wrongdriverkind-datasource.properties", "application.properties"))
+            .assertException(t -> {
+                assertEquals(DeploymentException.class, t.getClass());
+            });
+
+    @Test
+    public void xaRequiresJta() {
+        //Should not be reached: verify
+        Assert.assertTrue(false);
+    }
+
+}

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.agroal.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.enterprise.inject.spi.DeploymentException;
 
@@ -8,7 +9,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.wildfly.common.Assert;
 
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -25,7 +25,7 @@ public class XaRequiresXaDatasourceTest {
     @Test
     public void xaRequiresJta() {
         //Should not be reached: verify
-        Assert.assertTrue(false);
+        assertTrue(false);
     }
 
 }

--- a/extensions/agroal/deployment/src/test/resources/application-disabledjta-datasource.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-disabledjta-datasource.properties
@@ -2,3 +2,4 @@ quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:testing
 quarkus.datasource.driver=org.h2.Driver
 quarkus.datasource.username=username-named
 quarkus.datasource.transactions=DISABLED
+quarkus.datasource.detect-statement-leaks=false

--- a/extensions/agroal/deployment/src/test/resources/application-disabledjta-datasource.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-disabledjta-datasource.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:testing
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=username-named
+quarkus.datasource.transactions=DISABLED

--- a/extensions/agroal/deployment/src/test/resources/application-wrongdriverkind-datasource.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-wrongdriverkind-datasource.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:testing
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=username-named
+#Intentionally using the wrong driver for XA:
+quarkus.datasource.transactions=XA

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/TransactionIntegration.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/TransactionIntegration.java
@@ -1,0 +1,25 @@
+package io.quarkus.agroal;
+
+public enum TransactionIntegration {
+
+    /**
+     * Integrate the JDBC Datasource with the JTA TransactionManager of Quarkus.
+     * This is the default.
+     */
+    ENABLED,
+
+    /**
+     * Similarly to {@link #ENABLED}, also enables integration with the JTA
+     * TransactionManager of Quarkus, but enabling XA transactions as well.
+     * Requires a JDBC driver implementing {@link javax.sql.XADataSource}
+     */
+    XA,
+
+    /**
+     * Disables the Agroal integration with the Narayana TransactionManager.
+     * This is typically a bad idea, and is only useful in special cases:
+     * make sure to not use this without having a deep understanding of the
+     * implications.
+     */
+    DISABLED
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -101,6 +101,7 @@ public abstract class AbstractDataSourceProducer {
                 .connectionFactoryConfiguration();
         agroalConnectionFactoryConfigurationSupplier.jdbcUrl(url);
         agroalConnectionFactoryConfigurationSupplier.connectionProviderClass(driver);
+        agroalConnectionFactoryConfigurationSupplier.trackJdbcResources(dataSourceRuntimeConfig.detectStatementLeaks);
 
         if (dataSourceRuntimeConfig.transactionIsolationLevel.isPresent()) {
             agroalConnectionFactoryConfigurationSupplier

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -169,7 +169,9 @@ public abstract class AbstractDataSourceProducer {
         // Explicit reference to bypass reflection need of the ServiceLoader used by AgroalDataSource#from
         AgroalDataSource dataSource = new io.agroal.pool.DataSource(dataSourceConfiguration.get());
 
-        log.debug("Started data source " + dataSourceName + " connected to " + url);
+        if (log.isDebugEnabled()) {
+            log.debug("Started data source " + dataSourceName + " connected to " + url);
+        }
 
         this.dataSources.add(dataSource);
 

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceBuildTimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.agroal.runtime;
 
 import java.util.Optional;
 
+import io.quarkus.agroal.TransactionIntegration;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -15,11 +16,11 @@ public class DataSourceBuildTimeConfig {
     public Optional<String> driver;
 
     /**
-     * Whether we want to use XA.
+     * Whether we want to use regular JDBC transactions, XA, or disable all transactional capabilities.
      * <p>
-     * If used, the driver has to support it.
+     * When enabling XA you will need a driver implementing {@link javax.sql.XADataSource}.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean xa;
+    @ConfigItem(defaultValue = "enabled")
+    public TransactionIntegration transactions;
 
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceRuntimeConfig.java
@@ -91,6 +91,16 @@ public class DataSourceRuntimeConfig {
     public boolean enableMetrics;
 
     /**
+     * When enabled Agroal will be able to produce a warning when a connection is returned
+     * to the pool without the application having closed all open statements.
+     * This is unrelated with tracking of open connections.
+     * Disable for peak performance, but only when there's high confidence that
+     * no leaks are happening.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean detectStatementLeaks;
+
+    /**
      * Query executed when first using a connection.
      */
     @ConfigItem


### PR DESCRIPTION
- Move validations we can do at built time, to actually run at build time
- Change the "XA / Not XA" boolean configuration property into a three-state enum:  Transactions (ENABLED, DISABLED, XA)
- Expose the new feature of Agroal to skip tracking of JDBC Statements