### PR TITLE
run with quarkus user (read-write access)

### DIFF
--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -20,4 +20,12 @@ ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 EXPOSE 8080
+
+# Run under user "quarkus" and be prepared for be running under OpenShift too
+RUN adduser -s /bin/bash -G root --no-create-home --disabled-password quarkus \
+  && chown -R quarkus /deployments \
+  && chmod -R "g+rwX" /deployments \
+  && chown -R quarkus:root /deployments
+USER quarkus
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -21,11 +21,11 @@ COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 EXPOSE 8080
 
-# Run under user "quarkus" and be prepared for be running under OpenShift too
-RUN adduser -s /bin/bash -G root --no-create-home --disabled-password quarkus \
-  && chown -R quarkus /deployments \
+# run with user 1001 and be prepared for be running in OpenShift too
+RUN adduser -s /bin/bash -G root --no-create-home --disabled-password 1001 \
+  && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
-  && chown -R quarkus:root /deployments
-USER quarkus
+  && chown -R 1001:root /deployments
+USER 1001
 
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/common/src/main/resources/templates/dockerfile-jvm.ftl
@@ -22,7 +22,7 @@ COPY target/*-runner.jar /deployments/app.jar
 EXPOSE 8080
 
 # run with user 1001 and be prepared for be running in OpenShift too
-RUN adduser -s /bin/bash -G root --no-create-home --disabled-password 1001 \
+RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
   && chown -R 1001:root /deployments


### PR DESCRIPTION
In OpenShift it is not allowed to run the image with the root user. Therefor OpenShift creates a read-only user. The JTA implementation used by Quarkus needs write access (see #2702). So an exception is thrown if running without a custom user.

To overcome this problem I created a quarkus user with read and write access to the /deployments directory. 