### PR TITLE
test: add spring-web integration test with @PathVariable without configuration

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2421,7 +2421,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            
+
             <!-- Keycloak -->
             <dependency>
                 <groupId>org.keycloak</groupId>

--- a/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -193,14 +193,6 @@ public class SpringWebProcessor {
                         if (pathVariableInstance.target().kind() != AnnotationTarget.Kind.METHOD_PARAMETER) {
                             continue;
                         }
-                        if ((pathVariableInstance.value() == null) && (pathVariableInstance.value("name") == null)) {
-                            MethodInfo method = pathVariableInstance.target().asMethodParameter().method();
-                            throw new IllegalArgumentException(
-                                    "Currently method parameters annotated with @PathVariable must supply a value for 'name' or 'value'."
-                                            +
-                                            "Offending method is " + method.declaringClass().name() + "#" + method.name());
-                        }
-
                     }
                 }
             }

--- a/integration-tests/spring-web/pom.xml
+++ b/integration-tests/spring-web/pom.xml
@@ -58,6 +58,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/web/GreetingController.java
+++ b/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/web/GreetingController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,8 +21,8 @@ public class GreetingController {
     }
 
     @GetMapping(path = "/json/{message}")
-    public Greeting greet(@PathVariable(name = "message") String message) {
-        return greetingService.greet(message);
+    public Greeting greet(@PathVariable String message, @RequestParam String suffix) {
+        return greetingService.greet(message + suffix);
     }
 
     @PostMapping(path = "/person")

--- a/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerTest.java
+++ b/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerTest.java
@@ -19,6 +19,13 @@ public class SpringControllerTest {
     }
 
     @Test
+    public void testJsonResult2() {
+        RestAssured.when().get("/greeting/json/hello?suffix=000").then()
+                .contentType("application/json")
+                .body(containsString("hello000"));
+    }
+
+    @Test
     public void testInvalidJsonInputAndResult() {
         RestAssured.given().contentType("application/json").body("{\"name\":\"\"}").post("/greeting/person").then()
                 .statusCode(400);


### PR DESCRIPTION
Related to issue #3992
~~Requires RESTEasy: 4.4.0.Final (still unreleased)~~

This adds a integration test for spring-web using a method with @PathVariable annotated parameter without value for `name`. It's waiting for the RESTEasy fix in [this PR](https://github.com/resteasy/Resteasy/pull/2177). Could you take a look @geoand or forward to someone else?