### PR TITLE
Arc - use different package for client proxy generation if the bean comes from default package

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
@@ -81,8 +81,8 @@ abstract class AbstractGenerator {
             }
         }
         String packageName = DotNames.packageName(providerTypeName);
-        if (packageName.startsWith("java.")) {
-            // It is not possible to place a class in a JDK package
+        if (packageName.isEmpty() || packageName.startsWith("java.")) {
+            // It is not possible to place a class in a JDK package or in default package
             packageName = DEFAULT_PACKAGE;
         }
         return packageName;


### PR DESCRIPTION
…omes from default package.

Fixes #4469 

Tried with Michal's reproducer, otherwise not sure how to write an automated test without bloating the test structure with default package classes.