### PR TITLE
Remove redundant patterns compilations

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.regex.Pattern;
 
 import org.jboss.logging.Logger;
 
@@ -33,6 +34,7 @@ import org.jboss.logging.Logger;
 public class ClassLoaderCompiler {
 
     private static final Logger log = Logger.getLogger(ClassLoaderCompiler.class);
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile(" ");
 
     private final List<CompilationProvider> compilationProviders;
     /**
@@ -101,7 +103,7 @@ public class ClassLoaderCompiler {
                             }
                             Object classPath = mf.getMainAttributes().get(Attributes.Name.CLASS_PATH);
                             if (classPath != null) {
-                                for (String i : classPath.toString().split(" ")) {
+                                for (String i : WHITESPACE_PATTERN.split(classPath.toString())) {
                                     File f;
                                     try {
                                         f = Paths.get(new URI("file", null, "/", null).resolve(new URI(i))).toFile();

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -25,6 +26,8 @@ import io.smallrye.config.SmallRyeConfig;
  * TODO: fully implement this as required, at the moment this is mostly to read the HTTP config when startup fails
  */
 public class ConfigInstantiator {
+
+    private static final Pattern COMMA_PATTERN = Pattern.compile(",");
 
     public static void handleObject(Object o) {
         SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
@@ -78,7 +81,7 @@ public class ConfigInstantiator {
                         if (fieldIsList) {
                             Class<?> listType = (Class<?>) ((ParameterizedType) genericType)
                                     .getActualTypeArguments()[0];
-                            String[] parts = defaultValue.split(",");
+                            String[] parts = COMMA_PATTERN.split(defaultValue);
                             List<Object> list = new ArrayList<>();
                             for (String i : parts) {
                                 list.add(config.convert(i, listType));

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -45,6 +46,7 @@ import io.quarkus.runtime.StartupEvent;
 public class KafkaStreamsTopologyManager {
 
     private static final Logger LOGGER = Logger.getLogger(KafkaStreamsTopologyManager.class.getName());
+    private static final Pattern COMMA_PATTERN = Pattern.compile(",");
 
     private final ExecutorService executor;
     private KafkaStreams streams;
@@ -106,7 +108,7 @@ public class KafkaStreamsTopologyManager {
         Properties streamsProperties = getStreamsProperties(properties, bootstrapServersConfig, runtimeConfig);
 
         Set<String> topicsToAwait = runtimeConfig.topics
-                .map(n -> n.split(","))
+                .map(n -> COMMA_PATTERN.split(n))
                 .map(Arrays::asList)
                 .map(HashSet::new)
                 .map(Collections::unmodifiableSet)

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.bson.codecs.configuration.CodecProvider;
@@ -43,6 +44,7 @@ import io.quarkus.runtime.annotations.Recorder;
 public class MongoClientRecorder {
 
     private static final Logger LOGGER = Logger.getLogger(MongoClientRecorder.class);
+    private static final Pattern COLON_PATTERN = Pattern.compile(":");
 
     private static volatile MongoClient client;
     private static volatile ReactiveMongoClient reactiveMongoClient;
@@ -251,7 +253,7 @@ public class MongoClientRecorder {
         return addresses.stream()
                 .map(String::trim)
                 .map(address -> {
-                    String[] segments = address.split(":");
+                    String[] segments = COLON_PATTERN.split(address);
                     if (segments.length == 1) {
                         // Host only, default port
                         return new ServerAddress(address);

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
@@ -23,6 +24,9 @@ import io.vertx.core.http.HttpServerRequest;
  * @version $Revision: 1 $
  */
 public class VertxUtil {
+
+    private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+
     public static ResteasyUriInfo extractUriInfo(HttpServerRequest req, String contextPath) {
         String uri = req.absoluteURI();
         String protocol = req.scheme();
@@ -87,7 +91,7 @@ public class VertxUtil {
             return acceptable;
 
         for (String accept : accepts) {
-            String[] splits = accept.split(",");
+            String[] splits = COMMA_PATTERN.split(accept);
             for (String split : splits)
                 acceptable.add(split.trim());
         }

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -39,6 +39,8 @@ import io.vertx.core.net.PfxOptions;
 @Recorder
 public class VertxCoreRecorder {
 
+    private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+
     static volatile VertxSupplier vertx;
     //temporary vertx instance to work around a JAX-RS problem
     static volatile Vertx webVertx;
@@ -258,9 +260,9 @@ public class VertxCoreRecorder {
             List<String> certs = new ArrayList<>();
             List<String> keys = new ArrayList<>();
             eb.keyCertificatePem.certs.ifPresent(
-                    s -> certs.addAll(Pattern.compile(",").splitAsStream(s).map(String::trim).collect(Collectors.toList())));
+                    s -> certs.addAll(COMMA_PATTERN.splitAsStream(s).map(String::trim).collect(Collectors.toList())));
             eb.keyCertificatePem.keys.ifPresent(
-                    s -> keys.addAll(Pattern.compile(",").splitAsStream(s).map(String::trim).collect(Collectors.toList())));
+                    s -> keys.addAll(COMMA_PATTERN.splitAsStream(s).map(String::trim).collect(Collectors.toList())));
             PemKeyCertOptions o = new PemKeyCertOptions()
                     .setCertPaths(certs)
                     .setKeyPaths(keys);
@@ -284,7 +286,7 @@ public class VertxCoreRecorder {
         if (eb.trustCertificatePem != null) {
             eb.trustCertificatePem.certs.ifPresent(s -> {
                 PemTrustOptions o = new PemTrustOptions();
-                Pattern.compile(",").splitAsStream(s).map(String::trim).forEach(o::addCertPath);
+                COMMA_PATTERN.splitAsStream(s).map(String::trim).forEach(o::addCertPath);
                 opts.setPemTrustOptions(o);
             });
         }

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxOptionsBuilder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxOptionsBuilder.java
@@ -22,6 +22,8 @@ import io.vertx.core.net.PfxOptions;
 
 public class VertxOptionsBuilder {
 
+    private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+
     static VertxOptions buildVertxOptions(VertxConfiguration conf) {
         VertxOptions options = new VertxOptions();
 
@@ -93,9 +95,9 @@ public class VertxOptionsBuilder {
             List<String> certs = new ArrayList<>();
             List<String> keys = new ArrayList<>();
             eb.keyCertificatePem.certs.ifPresent(
-                    s -> certs.addAll(Pattern.compile(",").splitAsStream(s).map(String::trim).collect(Collectors.toList())));
+                    s -> certs.addAll(COMMA_PATTERN.splitAsStream(s).map(String::trim).collect(Collectors.toList())));
             eb.keyCertificatePem.keys.ifPresent(
-                    s -> keys.addAll(Pattern.compile(",").splitAsStream(s).map(String::trim).collect(Collectors.toList())));
+                    s -> keys.addAll(COMMA_PATTERN.splitAsStream(s).map(String::trim).collect(Collectors.toList())));
             PemKeyCertOptions o = new PemKeyCertOptions()
                     .setCertPaths(certs)
                     .setKeyPaths(keys);
@@ -119,7 +121,7 @@ public class VertxOptionsBuilder {
         if (eb.trustCertificatePem != null) {
             eb.trustCertificatePem.certs.ifPresent(s -> {
                 PemTrustOptions o = new PemTrustOptions();
-                Pattern.compile(",").splitAsStream(s).map(String::trim).forEach(o::addCertPath);
+                COMMA_PATTERN.splitAsStream(s).map(String::trim).forEach(o::addCertPath);
                 opts.setPemTrustOptions(o);
             });
         }


### PR DESCRIPTION
While looking for the root cause of a bug involving regex, I noticed a few redundant patterns compilations during `String` splits. All modified splits in this PR are called from an enclosing loop.