### PR TITLE
Avoid byte[].clone() in Elytron classes

### DIFF
--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/graal/Target_org_wildfly_security_password_interfaces_BCryptPassword.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/graal/Target_org_wildfly_security_password_interfaces_BCryptPassword.java
@@ -1,0 +1,31 @@
+package io.quarkus.elytron.security.runtime.graal;
+
+import java.util.Arrays;
+
+import org.wildfly.common.Assert;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.wildfly.security.password.interfaces.BCryptPassword")
+public final class Target_org_wildfly_security_password_interfaces_BCryptPassword {
+
+    @Substitute
+    static Target_org_wildfly_security_password_interfaces_BCryptPassword createRaw(String algorithm, byte[] hash, byte[] salt,
+            int iterationCount) {
+        Assert.checkNotNullParam("hash", hash);
+        Assert.checkNotNullParam("salt", salt);
+        Assert.checkNotNullParam("algorithm", algorithm);
+        return (Target_org_wildfly_security_password_interfaces_BCryptPassword) (Object) new RawBCryptPassword(algorithm,
+                Arrays.copyOf(hash, hash.length), Arrays.copyOf(salt, salt.length), iterationCount);
+    }
+
+    @TargetClass(className = "org.wildfly.security.password.interfaces.RawBCryptPassword")
+    private static final class RawBCryptPassword {
+
+        @Alias
+        RawBCryptPassword(final String algorithm, final byte[] hash, final byte[] salt, final int iterationCount) {
+        }
+    }
+}

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/graal/Target_org_wildfly_security_password_interfaces_BSDUnixDESCryptPassword.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/graal/Target_org_wildfly_security_password_interfaces_BSDUnixDESCryptPassword.java
@@ -1,0 +1,30 @@
+package io.quarkus.elytron.security.runtime.graal;
+
+import java.util.Arrays;
+
+import org.wildfly.common.Assert;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword")
+public final class Target_org_wildfly_security_password_interfaces_BSDUnixDESCryptPassword {
+
+    @Substitute
+    static Target_org_wildfly_security_password_interfaces_BSDUnixDESCryptPassword createRaw(String algorithm, byte[] hash,
+            int salt, int iterationCount) {
+        Assert.checkNotNullParam("hash", hash);
+        Assert.checkNotNullParam("algorithm", algorithm);
+        return (Target_org_wildfly_security_password_interfaces_BSDUnixDESCryptPassword) (Object) new RawBSDUnixDESCryptPassword(
+                algorithm, iterationCount, salt, Arrays.copyOf(hash, hash.length));
+    }
+
+    @TargetClass(className = "org.wildfly.security.password.interfaces.RawBSDUnixDESCryptPassword")
+    private static final class RawBSDUnixDESCryptPassword {
+
+        @Alias
+        RawBSDUnixDESCryptPassword(final String algorithm, final int iterationCount, final int salt, final byte[] hash) {
+        }
+    }
+}


### PR DESCRIPTION
This allows the Security JDBC quickstart to compile in native.