### PR TITLE
Remove High contention on TransactionManager class

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaProducers.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaProducers.java
@@ -3,6 +3,7 @@ package io.quarkus.narayana.jta.runtime;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
 import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.tm.JBossXATerminator;
@@ -10,6 +11,7 @@ import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.jboss.tm.usertx.UserTransactionRegistry;
 
 import com.arjuna.ats.internal.jbossatx.jta.jca.XATerminator;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import com.arjuna.ats.jta.TransactionManager;
@@ -19,7 +21,8 @@ import com.arjuna.ats.jta.UserTransaction;
 public class NarayanaJtaProducers {
 
     private static final javax.transaction.UserTransaction USER_TRANSACTION = UserTransaction.userTransaction();
-    private static final javax.transaction.TransactionManager TRANSACTION_MANAGER = TransactionManager.transactionManager();
+    private static final com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple TRANSACTION_MANAGER = (TransactionManagerImple) TransactionManager
+            .transactionManager();
 
     @Produces
     @ApplicationScoped
@@ -46,7 +49,7 @@ public class NarayanaJtaProducers {
     }
 
     @Produces
-    @ApplicationScoped
+    @Singleton
     public javax.transaction.TransactionManager transactionManager() {
         return TRANSACTION_MANAGER;
     }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -97,8 +97,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
             throws Exception {
 
         TransactionConfiguration configAnnotation = getTransactionConfiguration(ic);
-        int currentTmTimeout = ((TransactionManagerImple) com.arjuna.ats.jta.TransactionManager.transactionManager())
-                .getTimeout();
+        int currentTmTimeout = ((TransactionManagerImple) transactionManager).getTimeout();
         if (configAnnotation != null && configAnnotation.timeout() != TransactionConfiguration.UNSET_TIMEOUT) {
             tm.setTransactionTimeout(configAnnotation.timeout());
         }


### PR DESCRIPTION
… causes high contention on TransactionManager class.

The current Narayana integration frequently calls `TransactionalInterceptorBase.invokeInOurTx()`, which looks up the current configured TX timeout via 
`((TransactionManagerImple) com.arjuna.ats.jta.TransactionManager.transactionManager()).getTimeout()`

This is a very expensive call, as `com.arjuna.ats.jta.TransactionManager.transactionManager()` is synchronized on the `com.arjuna.ats.jta.TransactionManager` class.

We *could* use the @ApplicationScoped TransationManager injected into io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase if the API defined `getTimeout()`, but it does not.  At present `@inject TransationManager transactionManager` can not be cast to `TransactionManagerImple` as it is a proxy.

I am not 100% happy with this PR, as it changes the injected bean to an impl bean instead of an api bean, but it does remove the monitor contention under heavy load.

@stuartwdouglas @mkouba can you think of any other way of resolving this issue?