### PR TITLE
Externalize hotrod-client.properties with infinispan-client

### DIFF
--- a/docs/src/main/asciidoc/infinispan-client-guide.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-guide.adoc
@@ -49,6 +49,51 @@ can be configured in this file:
 for each. (eg. host1:11222;host:11222)
 | Runtime overridable
 
+| `quarkus.infinispan-client.client-intelligence`
+| <empty>
+| Sets client intelligence used by authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.use-auth`
+| <empty>
+| Enables or disables authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.auth-username`
+| <empty>
+| Sets user name used by authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.auth-password`
+| <empty>
+|
+| Runtime overridable
+
+| `quarkus.infinispan-client.auth-realm`
+| <empty>
+| Sets realm used by authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.auth-server-name`
+| <empty>
+| Sets server name used by authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.auth-client-subject`
+| <empty>
+| Sets client subject used by authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.auth-callback-handler`
+| <empty>
+| Sets callback handler used by authentication
+| Runtime overridable
+
+| `quarkus.infinispan-client.sasl-mechanism`
+| <empty>
+| Sets SASL mechanism used by authentication
+| Runtime overridable
+
 | `quarkus.infinispan-client.near-cache-max-entries`
 | 0
 | Controls whether the near cache is enabled (allowing repeated retrievals to be stored).

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Scanner;
 import java.util.Set;
@@ -167,12 +166,31 @@ public class InfinispanClientProducer {
             builder.marshaller((Marshaller) marshallerInstance);
         }
 
-        // Override serverList property value at runtime if such configuration exists
         if (infinispanClientRuntimeConfig != null) {
-            Optional<String> runtimeServerList = infinispanClientRuntimeConfig.serverList;
-            if (runtimeServerList.isPresent()) {
-                properties.put(ConfigurationProperties.SERVER_LIST, runtimeServerList.get());
-            }
+
+            infinispanClientRuntimeConfig.serverList
+                    .ifPresent(v -> properties.put(ConfigurationProperties.SERVER_LIST, v));
+
+            infinispanClientRuntimeConfig.clientIntelligence
+                    .ifPresent(v -> properties.put(ConfigurationProperties.CLIENT_INTELLIGENCE, v));
+
+            infinispanClientRuntimeConfig.useAuth
+                    .ifPresent(v -> properties.put(ConfigurationProperties.USE_AUTH, v));
+            infinispanClientRuntimeConfig.authUsername
+                    .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_USERNAME, v));
+            infinispanClientRuntimeConfig.authPassword
+                    .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_PASSWORD, v));
+            infinispanClientRuntimeConfig.authRealm
+                    .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_REALM, v));
+            infinispanClientRuntimeConfig.authServerName
+                    .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_SERVER_NAME, v));
+            infinispanClientRuntimeConfig.authClientSubject
+                    .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_CLIENT_SUBJECT, v));
+            infinispanClientRuntimeConfig.authCallbackHandler
+                    .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_CALLBACK_HANDLER, v));
+
+            infinispanClientRuntimeConfig.saslMechanism
+                    .ifPresent(v -> properties.put(ConfigurationProperties.SASL_MECHANISM, v));
         }
 
         builder.withProperties(properties);

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientRuntimeConfig.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientRuntimeConfig.java
@@ -18,6 +18,60 @@ public class InfinispanClientRuntimeConfig {
     @ConfigItem
     public Optional<String> serverList;
 
+    /**
+     * Sets client intelligence used by authentication
+     */
+    @ConfigItem
+    Optional<String> clientIntelligence;
+
+    /**
+     * Enables or disables authentication
+     */
+    @ConfigItem
+    Optional<String> useAuth;
+
+    /**
+     * Sets user name used by authentication
+     */
+    @ConfigItem
+    Optional<String> authUsername;
+
+    /**
+     * Sets password used by authentication
+     */
+    @ConfigItem
+    Optional<String> authPassword;
+
+    /**
+     * Sets realm used by authentication
+     */
+    @ConfigItem
+    Optional<String> authRealm;
+
+    /**
+     * Sets server name used by authentication
+     */
+    @ConfigItem
+    Optional<String> authServerName;
+
+    /**
+     * Sets client subject used by authentication
+     */
+    @ConfigItem
+    Optional<String> authClientSubject;
+
+    /**
+     * Sets callback handler used by authentication
+     */
+    @ConfigItem
+    Optional<String> authCallbackHandler;
+
+    /**
+     * Sets SASL mechanism used by authentication
+     */
+    @ConfigItem
+    Optional<String> saslMechanism;
+
     @Override
     public String toString() {
         return "InfinispanClientRuntimeConfig{" +


### PR DESCRIPTION
@wburns could you please review?

I went ahead with config properties to avoid loading file on startup. Focused on properties from hotrod.properties that relates to authentication. We can extend it more with any other properties we think make sense to be overridden at runtime.