### PR TITLE
Add option to disable the http port when https is enabled

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -107,6 +107,18 @@ This will also work in tandem with link:https://kubernetes.io/docs/concepts/conf
 
 _Note: in order to remain compatible with earlier versions of Quarkus (before 0.16) the default password is set to "password". It is therefore not a mandatory parameter!_
 
+=== Disable the HTTP port
+
+It is possible to redirect all traffic that tries to connect using HTTP to the HTTPS protocol and port.
+Add the following property to your `application.properties`:
+
+[source, properties]
+----
+quarkus.http.port-enabled=false
+----
+
+_Note: if you disable the HTTP port and have not added a SSL certificate or keystore, your server will not start!_
+
 == CORS filter
 
 link:https://en.wikipedia.org/wiki/Cross-origin_resource_sharing[Cross-origin resource sharing] (CORS) is a mechanism that

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -114,10 +114,10 @@ Add the following property to your `application.properties`:
 
 [source, properties]
 ----
-quarkus.http.port-enabled=false
+quarkus.http.redirect-insecure-requests=true
 ----
 
-_Note: if you disable the HTTP port and have not added a SSL certificate or keystore, your server will not start!_
+_Note: if you set this option and have not added a SSL certificate or keystore, your server will not start!_
 
 == CORS filter
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DisableHttpPortTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/DisableHttpPortTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.vertx.http;
+
+import static org.hamcrest.core.Is.is;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.vertx.ext.web.Router;
+
+public class DisableHttpPortTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("src/test/resources/conf/disable-http.conf"), "application.properties")
+                    .addAsResource(new File("src/test/resources/conf/server-keystore.jks"), "server-keystore.jks"));
+
+    @BeforeAll
+    public static void setupRestAssured() {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    @AfterAll
+    public static void restoreRestAssured() {
+        RestAssured.reset();
+    }
+
+    @Disabled
+    @Test
+    public void testDisabledHttpPortForwardsRequest() throws MalformedURLException {
+        URL url = new URL("http://localhost:8081/ssl");
+        RestAssured.config().getRedirectConfig().followRedirects(false);
+        ValidatableResponse response = RestAssured.get(url).then().statusCode(301).body(is("ssl"));
+        response.header("Location", "https://localhost:8443/ssl");
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ssl").handler(rc -> {
+                Assertions.assertThat(rc.request().connection().isSsl()).isTrue();
+                Assertions.assertThat(rc.request().isSSL()).isTrue();
+                Assertions.assertThat(rc.request().connection().sslSession()).isNotNull();
+                rc.response().end("ssl");
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/resources/conf/disable-http.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/disable-http.conf
@@ -1,4 +1,4 @@
 # Enable SSL, configure the key store
-quarkus.http.port-enabled=false
-quarkus.http.ssl.certificate.key-store-file=server-keystore.jks
-quarkus.http.ssl.certificate.key-store-password=secret
+quarkus.http.redirect-insecure-requests=true
+quarkus.http.ssl.certificate.file=server-cert.pem
+quarkus.http.ssl.certificate.key-file=server-key.pem

--- a/extensions/vertx-http/deployment/src/test/resources/conf/disable-http.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/disable-http.conf
@@ -1,0 +1,4 @@
+# Enable SSL, configure the key store
+quarkus.http.port-enabled=false
+quarkus.http.ssl.certificate.key-store-file=server-keystore.jks
+quarkus.http.ssl.certificate.key-store-password=secret

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -50,6 +50,13 @@ public class HttpConfiguration {
     public int testSslPort;
 
     /**
+     * If this is true then any requests to the HTTP port
+     * will be automatically redirected to the HTTPS port.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean redirectInsecureRequests;
+
+    /**
      * The CORS config
      */
     public CORSConfig cors;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -567,7 +567,7 @@ public class VertxHttpRecorder {
 
         @Override
         public void start(Future<Void> startFuture) {
-            if (httpOptions == null && httpsOptions == null) {
+            if (redirectHttp && httpsOptions == null) {
                 throw new RuntimeException("No HTTPS options specified and HTTP has been disabled");
             }
 
@@ -582,14 +582,12 @@ public class VertxHttpRecorder {
                             req.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();
                         } else {
                             int includedPort = host.indexOf(":");
-                            int port = 80;
                             if (includedPort != -1) {
-                                port = Integer.parseInt(host.substring(includedPort + 1));
                                 host = host.substring(0, includedPort);
                             }
                             req.response()
                                     .setStatusCode(301)
-                                    .putHeader("Location", "https://" + host + ":" + port + req.uri())
+                                    .putHeader("Location", "https://" + host + ":" + httpsOptions.getPort() + req.uri())
                                     .end();
                         }
                     } catch (Exception e) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
@@ -71,8 +71,12 @@ public class RestAssuredURLManager {
             try {
                 oldBaseURI = (String) baseURIField.get(null);
                 final String protocol = useSecureConnection ? "https://" : "http://";
-                String baseURI = protocol + ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class)
+                String host = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class)
                         .orElse("localhost");
+                if (host.equals("0.0.0.0")) {
+                    host = "localhost";
+                }
+                String baseURI = protocol + host;
                 baseURIField.set(null, baseURI);
             } catch (IllegalAccessException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Looks to address #4324  

Redirects any http calls to the https endpoint when the property is set, but defaults to true:
`quarkus.http.port-enabled=false`


Sorted the unit test to test it sets the Location header and returns a 301 response.
