### PR TITLE
Add bomEntryVersion to CreateExtensionMojo

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -42,6 +42,7 @@ public class CreateExtensionMojoTest {
         mojo.encoding = CreateExtensionMojo.DEFAULT_ENCODING;
         mojo.templatesUriBase = CreateExtensionMojo.DEFAULT_TEMPLATES_URI_BASE;
         mojo.quarkusVersion = CreateExtensionMojo.DEFAULT_QUARKUS_VERSION;
+        mojo.bomEntryVersion = CreateExtensionMojo.DEFAULT_BOM_ENTRY_VERSION;
         mojo.assumeManaged = true;
         mojo.nameSegmentDelimiter = CreateExtensionMojo.DEFAULT_NAME_SEGMENT_DELIMITER;
         return mojo;


### PR DESCRIPTION
We'd need this in Camel Quarkus. Our runtime BOM is supposed to be usable as parent for user projects so we cannot use the `${project.version}` that the plugin put there so far. The new option makes it configurable and uses `${project.version}` as default so the change is backwards compatible.