### PR TITLE
Work around an issue in JDK which causes hot deployment compilation to fail

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeContext.java
@@ -29,6 +29,8 @@ public class DevModeContext implements Serializable {
     private File cacheDir;
     private boolean test;
     private boolean abortOnFailedStart;
+    // the jar file which is used to launch the DevModeMain
+    private File devModeRunnerJarFile;
 
     private List<String> compilerOptions;
     private String sourceJavaVersion;
@@ -116,6 +118,14 @@ public class DevModeContext implements Serializable {
 
     public void setTargetJvmVersion(String targetJvmVersion) {
         this.targetJvmVersion = targetJvmVersion;
+    }
+
+    public File getDevModeRunnerJarFile() {
+        return devModeRunnerJarFile;
+    }
+
+    public void setDevModeRunnerJarFile(final File devModeRunnerJarFile) {
+        this.devModeRunnerJarFile = devModeRunnerJarFile;
     }
 
     public static class ModuleInfo implements Serializable {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -300,7 +300,7 @@ public class DevMojo extends AbstractMojo {
             //this stuff does not change
             // Do not include URIs in the manifest, because some JVMs do not like that
             StringBuilder classPathManifest = new StringBuilder();
-            DevModeContext devModeContext = new DevModeContext();
+            final DevModeContext devModeContext = new DevModeContext();
             for (Map.Entry<Object, Object> e : System.getProperties().entrySet()) {
                 devModeContext.getSystemProperties().put(e.getKey().toString(), (String) e.getValue());
             }
@@ -429,6 +429,8 @@ public class DevMojo extends AbstractMojo {
             devModeContext.setFrameworkClassesDir(wiringClassesDirectory.getAbsoluteFile());
             devModeContext.setCacheDir(new File(buildDir, "transformer-cache").getAbsoluteFile());
 
+            // this is the jar file we will use to launch the dev mode main class
+            devModeContext.setDevModeRunnerJarFile(tempFile);
             try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(tempFile))) {
                 out.putNextEntry(new ZipEntry("META-INF/"));
                 Manifest manifest = new Manifest();


### PR DESCRIPTION
The commit in this PR introduces a workaround to get past the issue noted in https://github.com/quarkusio/quarkus/issues/3592. The complete details of what's causing this issue is explained starting this comment here https://github.com/quarkusio/quarkus/issues/3592#issuecomment-541078904

The real fix should come in from https://bugs.openjdk.java.net/browse/JDK-8232170 but until then this should get us past it.

I've manually tested this issue on a Windows setup, both with JDK 8 and 11 and it used to fail (on JDK 11) without this fix. It now passes with this fix.

I don't see a way to add an automated test for this given the way we launch the tests and the different code path(s) that are involved in our testing infrastructure.