### PR TITLE
Add caffeine runtime dependency to Infinispan embedded runtime

### DIFF
--- a/extensions/infinispan-embedded/runtime/pom.xml
+++ b/extensions/infinispan-embedded/runtime/pom.xml
@@ -21,6 +21,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>


### PR DESCRIPTION
Trivial change - unfortunately only the deployment dependency was added originally. Fixes random seg faults when running.