### PR TITLE
remove redundant "org.quartz.threadPool.threadPriority" initialization in scheduler extension

### DIFF
--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/QuartzScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/QuartzScheduler.java
@@ -123,7 +123,6 @@ public class QuartzScheduler implements Scheduler {
                 props.put("org.quartz.threadPool.threadCount", "10");
                 props.put("org.quartz.threadPool.threadPriority", "5");
                 props.put("org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread", true);
-                props.put("org.quartz.threadPool.threadPriority", "5");
                 props.put("org.quartz.jobStore.misfireThreshold", "60000");
                 props.put("org.quartz.jobStore.class", "org.quartz.simpl.RAMJobStore");
 


### PR DESCRIPTION
A very minor one, but the `org.quartz.threadPool.threadPriority` property was previously initialized here in line 124 - see https://github.com/quarkusio/quarkus/blob/e458e8b62411631becdff914ebaafd901f60dfbb/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/QuartzScheduler.java#L124-L127 