### PR TITLE
Fix 404 on link to Keycloak guide

### DIFF
--- a/docs/src/main/asciidoc/rest-json-guide.adoc
+++ b/docs/src/main/asciidoc/rest-json-guide.adoc
@@ -511,8 +511,8 @@ how to use it.
 
 [WARNING]
 ====
-If you want to use the `keycloak` Quarkus extension in your project, you should configure CORS using the `keycloak` extension
-configuration. See link:keycloak-guide#configuring-cors[the Keycloak guide] for more details.
+If you want to use the `oidc` Quarkus extension in your project, you should configure CORS using the `oidc` extension
+configuration. See link:oidc-guide#configuring-cors[the OpenID Connect Adapter guide] for more details.
 ====
 
 == GZip Support


### PR DESCRIPTION
In the rest json guide, this update the link to the cors configuration in the keycloak guide, that should point to the oidc guide.