### PR TITLE
Upgrade to Yasson 1.0.5 (JSON-B impl)

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -143,7 +143,7 @@
         <jgit.version>5.5.0.201909110433-r</jgit.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
         <flyway.version>6.0.4</flyway.version>
-        <yasson.version>1.0.4</yasson.version>
+        <yasson.version>1.0.5</yasson.version>
         <neo4j-java-driver.version>2.0.0-alpha03</neo4j-java-driver.version>
         <mongo-client.version>3.10.2</mongo-client.version>
         <mongo-reactivestreams-client.version>1.11.0</mongo-reactivestreams-client.version>


### PR DESCRIPTION
Yasson 1.0.5 is now available and includes some good bug fixes and usability enhancements that we should pull in. See the [release notes](https://github.com/eclipse-ee4j/yasson/releases/tag/1.0.5-RELEASE) for details.