### PR TITLE
Always specify the project version when building the Gradle plugin

### DIFF
--- a/devtools/gradle/gradle.properties
+++ b/devtools/gradle/gradle.properties
@@ -1,1 +1,0 @@
-version = 999-SNAPSHOT

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -120,6 +120,7 @@
                                 <argument>${gradle.task}</argument>
                                 <argument>-Pdescription=${project.description}</argument>
                                 <argument>-S</argument>
+                                <argument>-Pversion=${project.version}</argument>
                             </arguments>
                             <environmentVariables>
                                 <MAVEN_LOCAL_REPO>${settings.localRepository}</MAVEN_LOCAL_REPO>


### PR DESCRIPTION
This avoids errors during the release. 
@geoand @gsmet please review