### PR TITLE
Disable a racey test

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketTestCase.java
@@ -14,6 +14,7 @@ import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.websocket.WebSocketOpenEndpoint;
@@ -104,6 +105,7 @@ public class WebsocketTestCase {
     }
 
     @Test
+    @Disabled("test disabled as the message handler may be registered after the messages being sent.")
     public void testSendMessageOnOpen() throws Exception {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();


### PR DESCRIPTION
Disable a test that is racey because the message handler may be registered after the messages are sent.