### PR TITLE
Improve internal component testing helpers

### DIFF
--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncConsoleHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncConsoleHandlerTest.java
@@ -11,8 +11,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.handlers.AsyncHandler;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.jboss.logmanager.handlers.DelayedHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -20,10 +18,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AsyncConsoleHandlerTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-async-console-log.properties", "application.properties"))
+            .withConfigurationResource("application-async-console-log.properties")
             .setLogFileName("AsyncConsoleHandlerTest.log");
 
     @Test

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncFileHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncFileHandlerTest.java
@@ -11,8 +11,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.handlers.AsyncHandler;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.FileHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -20,10 +18,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AsyncFileHandlerTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-async-file-log.properties", "application.properties"))
+            .withConfigurationResource("application-async-file-log.properties")
             .setLogFileName("AsyncFileHandlerTest.log");
 
     @Test

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
@@ -11,8 +11,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.handlers.AsyncHandler;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -20,10 +18,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AsyncSyslogHandlerTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-async-syslog.properties", "application.properties"))
+            .withConfigurationResource("application-async-syslog.properties")
             .setLogFileName("AsyncSyslogHandlerTest.log");
 
     @Test

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/ConsoleHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/ConsoleHandlerTest.java
@@ -12,8 +12,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.jboss.logmanager.handlers.DelayedHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -21,10 +19,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class ConsoleHandlerTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-console-output.properties", "application.properties"));
+            .withConfigurationResource("application-console-output.properties");
 
     @Test
     public void consoleOutputTest() {

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerTest.java
@@ -12,8 +12,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.FileHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -21,10 +19,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class FileHandlerTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-file-output-log.properties", "application.properties"));
+            .withConfigurationResource("application-file-output-log.properties");
 
     @Test
     public void fileOutputTest() {

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicRotatingLoggingTest.java
@@ -12,8 +12,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.PeriodicRotatingFileHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -21,10 +19,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class PeriodicRotatingLoggingTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-periodic-file-log-rotating.properties", "application.properties"))
+            .withConfigurationResource("application-periodic-file-log-rotating.properties")
             .setLogFileName("PeriodicRotatingLoggingTest.log");
 
     @Test

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingTest.java
@@ -12,8 +12,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -21,10 +19,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class PeriodicSizeRotatingLoggingTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-periodic-size-file-log-rotating.properties", "application.properties"))
+            .withConfigurationResource("application-periodic-size-file-log-rotating.properties")
             .setLogFileName("PeriodicSizeRotatingLoggingTest.log");
 
     @Test

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/SizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/SizeRotatingLoggingTest.java
@@ -12,8 +12,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -21,10 +19,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class SizeRotatingLoggingTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-size-file-log-rotating.properties", "application.properties"))
+            .withConfigurationResource("application-size-file-log-rotating.properties")
             .setLogFileName("SizeRotatingLoggingTest.log");
 
     @Test

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
@@ -14,8 +14,6 @@ import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -23,10 +21,10 @@ import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class SyslogHandlerTest {
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-syslog-output.properties", "application.properties"));
+            .withConfigurationResource("application-syslog-output.properties");
 
     @Test
     public void syslogOutputTest() {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DefaultDataSourceConfigTest.java
@@ -9,8 +9,6 @@ import java.time.Duration;
 
 import javax.inject.Inject;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -28,10 +26,8 @@ public class DefaultDataSourceConfigTest {
     //end::injection[]
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-default-datasource.properties",
-                            "application.properties"));
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-default-datasource.properties");
 
     @Test
     public void testDefaultDataSourceInjection() throws SQLException {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
@@ -24,7 +24,9 @@ public class DisabledTransactionDataSourceConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withConfigurationResource("application-disabledjta-datasource.properties");
+            .withConfigurationResource("base.properties")
+            .overrideConfigKey("quarkus.datasource.transactions", "DISABLED")
+            .overrideConfigKey("quarkus.datasource.detect-statement-leaks", "false");
 
     @Test
     public void testNonTransactionalDataSourceInjection() throws SQLException {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DisabledTransactionDataSourceConfigTest.java
@@ -8,8 +8,6 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -25,10 +23,8 @@ public class DisabledTransactionDataSourceConfigTest {
     AgroalDataSource defaultDataSource;
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-disabledjta-datasource.properties",
-                            "application.properties"));
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-disabledjta-datasource.properties");
 
     @Test
     public void testNonTransactionalDataSourceInjection() throws SQLException {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/MultipleDataSourcesConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/MultipleDataSourcesConfigTest.java
@@ -8,8 +8,6 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -34,10 +32,8 @@ public class MultipleDataSourcesConfigTest {
     //end::injection[]
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-multiple-datasources.properties",
-                            "application.properties"));
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-multiple-datasources.properties");
 
     @Test
     public void testDataSourceInjection() throws SQLException {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NamedDataSourceConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NamedDataSourceConfigTest.java
@@ -9,8 +9,6 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -25,10 +23,8 @@ public class NamedDataSourceConfigTest {
     AgroalDataSource ds;
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-named-datasource.properties",
-                            "application.properties"));
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-named-datasource.properties");
 
     @Test
     public void testNamedDataSourceInjection() throws SQLException {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NoConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NoConfigTest.java
@@ -2,8 +2,6 @@ package io.quarkus.agroal.test;
 
 import java.sql.SQLException;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -12,8 +10,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class NoConfigTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class));
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
 
     @Test
     public void testNoConfig() throws SQLException {

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
@@ -14,7 +14,8 @@ public class XaRequiresXaDatasourceTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withConfigurationResource("application-wrongdriverkind-datasource.properties")
+            .withConfigurationResource("base.properties")
+            .overrideConfigKey("quarkus.datasource.transactions", "XA")
             .assertException(t -> {
                 assertEquals(DeploymentException.class, t.getClass());
             });

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/XaRequiresXaDatasourceTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.enterprise.inject.spi.DeploymentException;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -16,8 +14,7 @@ public class XaRequiresXaDatasourceTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-wrongdriverkind-datasource.properties", "application.properties"))
+            .withConfigurationResource("application-wrongdriverkind-datasource.properties")
             .assertException(t -> {
                 assertEquals(DeploymentException.class, t.getClass());
             });

--- a/extensions/agroal/deployment/src/test/resources/application-disabledjta-datasource.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-disabledjta-datasource.properties
@@ -1,5 +1,0 @@
-quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:testing
-quarkus.datasource.driver=org.h2.Driver
-quarkus.datasource.username=username-named
-quarkus.datasource.transactions=DISABLED
-quarkus.datasource.detect-statement-leaks=false

--- a/extensions/agroal/deployment/src/test/resources/base.properties
+++ b/extensions/agroal/deployment/src/test/resources/base.properties
@@ -1,5 +1,3 @@
 quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:testing
 quarkus.datasource.driver=org.h2.Driver
 quarkus.datasource.username=username-named
-#Intentionally using the wrong driver for XA:
-quarkus.datasource.transactions=XA

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -403,6 +403,14 @@ public class QuarkusUnitTest
         }
     }
 
+    public QuarkusUnitTest overrideConfigKey(final String propertyKey, final String propertyValue) {
+        if (customApplicationProperties == null) {
+            customApplicationProperties = new Properties();
+        }
+        customApplicationProperties.put(propertyKey, propertyValue);
+        return this;
+    }
+
     private static class PropertiesAsset implements Asset {
         private final Properties props;
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -3,8 +3,11 @@ package io.quarkus.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.nio.file.FileVisitResult;
@@ -16,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.function.Consumer;
@@ -25,6 +30,8 @@ import java.util.stream.Stream;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -73,6 +80,7 @@ public class QuarkusUnitTest
     private String logFileName;
     private static final Timer timeoutTimer = new Timer("Test thread dump timer");
     private volatile TimerTask timeoutTask;
+    private Properties customApplicationProperties;
 
     private final RestAssuredURLManager restAssuredURLManager;
 
@@ -105,6 +113,7 @@ public class QuarkusUnitTest
     }
 
     public QuarkusUnitTest setArchiveProducer(Supplier<JavaArchive> archiveProducer) {
+        Objects.requireNonNull(archiveProducer);
         this.archiveProducer = archiveProducer;
         return this;
     }
@@ -148,8 +157,11 @@ public class QuarkusUnitTest
 
     private void exportArchive(Path deploymentDir, Class<?> testClass) {
         try {
-            JavaArchive archive = archiveProducer.get();
+            JavaArchive archive = getArchiveProducerOrDefault();
             archive.addClass(testClass);
+            if (customApplicationProperties != null) {
+                archive.add(new PropertiesAsset(customApplicationProperties), "application.properties");
+            }
             archive.as(ExplodedExporter.class).exportExplodedInto(deploymentDir.toFile());
 
             String exportPath = System.getProperty("quarkus.deploymentExportPath");
@@ -174,11 +186,16 @@ public class QuarkusUnitTest
         }
     }
 
+    private JavaArchive getArchiveProducerOrDefault() {
+        if (archiveProducer == null) {
+            return ShrinkWrap.create(JavaArchive.class);
+        } else {
+            return archiveProducer.get();
+        }
+    }
+
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
-        if (archiveProducer == null) {
-            throw new RuntimeException("QuarkusUnitTest does not have archive producer set");
-        }
         timeoutTask = new TimerTask() {
             @Override
             public void run() {
@@ -370,5 +387,38 @@ public class QuarkusUnitTest
     public QuarkusUnitTest setAfterUndeployListener(Runnable afterUndeployListener) {
         this.afterUndeployListener = afterUndeployListener;
         return this;
+    }
+
+    public QuarkusUnitTest withConfigurationResource(String resourceName) {
+        if (customApplicationProperties == null) {
+            customApplicationProperties = new Properties();
+        }
+        try {
+            try (InputStream in = ClassLoader.getSystemResourceAsStream(resourceName)) {
+                customApplicationProperties.load(in);
+            }
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load resource: '" + resourceName + "'");
+        }
+    }
+
+    private static class PropertiesAsset implements Asset {
+        private final Properties props;
+
+        public PropertiesAsset(final Properties props) {
+            this.props = props;
+        }
+
+        @Override
+        public InputStream openStream() {
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(128);
+            try {
+                props.store(outputStream, "Unit test Generated Application properties");
+            } catch (IOException e) {
+                throw new RuntimeException("Could not write application properties resource", e);
+            }
+            return new ByteArrayInputStream(outputStream.toByteArray());
+        }
     }
 }


### PR DESCRIPTION
While working on other (TBD) tests, I'm finding myself often needing to copy various new `application.properties` resources just to test a couple of flag permutations.

This makes it a bit more convenient.

It also defines a default Archive Producer, which allows to not have to set one when there's no need to add any additional classes/beans to the app.