### PR TITLE
Avoid walking non-existant path when checking for file changes

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
@@ -295,6 +295,9 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext {
                 continue;
             }
             Path root = Paths.get(rootPath);
+            if (!Files.exists(root) || !Files.isReadable(root)) {
+                continue;
+            }
             Path classesDir = Paths.get(module.getClassesPath());
             //copy all modified non hot deployment files over
             if (doCopy) {


### PR DESCRIPTION
While using Gradle dev mode (i.e. `./gradlew quarkusDev`) my project only had a `src/main/java` folder but no `src/main/resources` folder. The devtools plugin blew up when trying to scan the resources dir for file changes when it did not exist:

```
2019-10-16 12:48:21,127 ERROR [io.qua.dev] (vert.x-worker-thread-0) Failed to copy resources: java.nio.file.NoSuchFileException: /Users/aguibert/dev/git/basic-quarkus/src/main/resources
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:145)
        at java.base/java.nio.file.Files.readAttributes(Files.java:1763)
        at java.base/java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:219)
        at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276)
        at java.base/java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322)
        at java.base/java.nio.file.FileTreeIterator.<init>(FileTreeIterator.java:71)
        at java.base/java.nio.file.Files.walk(Files.java:3820)
        at java.base/java.nio.file.Files.walk(Files.java:3874)
        at io.quarkus.dev.RuntimeUpdatesProcessor.checkForFileChange(RuntimeUpdatesProcessor.java:304)
        at io.quarkus.dev.RuntimeUpdatesProcessor.doScan(RuntimeUpdatesProcessor.java:121)
        at io.quarkus.vertx.http.deployment.devmode.VertxHotReplacementSetup$1.handle(VertxHotReplacementSetup.java:52)
        at io.quarkus.vertx.http.deployment.devmode.VertxHotReplacementSetup$1.handle(VertxHotReplacementSetup.java:44)
        at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
        at io.vertx.core.impl.ContextImpl$$Lambda$422.00000000DD584020.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:831)
```