### PR TITLE
chore: move the "elytron-security-jdbc" alongside security related modules.

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -30,7 +30,6 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String JDBC_MYSQL = "jdbc-mysql";
     public static final String JGIT = "jgit";
     public static final String KAFKA_STREAMS = "kafka-streams";
-    public static final String KEYCLOAK = "keycloak";
     public static final String KOGITO = "kogito";
     public static final String KOTLIN = "kotlin";
     public static final String KUBERNETES = "kubernetes";

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -90,6 +90,7 @@
         <!-- Security -->
         <module>security</module>
         <module>elytron-security</module>
+        <module>elytron-security-jdbc</module>
         <module>elytron-security-properties-file</module>
         <module>elytron-security-oauth2</module>
         <module>smallrye-jwt</module>
@@ -121,7 +122,6 @@
 
         <!-- kogito -->
         <module>kogito</module>
-        <module>elytron-security-jdbc</module>
     </modules>
 
     <build>


### PR DESCRIPTION
It was previously added to "kogito" related section

A very minor cleanup PR, which I saw when I was working on adding another extension. 

Also removes trailing "keycloak" label in FeatureBuildItem class

/cc @geoand @gsmet 
