### PR TITLE
Update application.properties settings to match docker command

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-guide.adoc
@@ -49,10 +49,10 @@ then add the relevant configuration properties in `{config-file}`.
 [source,properties]
 --
 # configure your datasource
-quarkus.datasource.url = jdbc:postgresql://localhost:5432/mydatabase
+quarkus.datasource.url = jdbc:postgresql://localhost:5432/hibernate_db
 quarkus.datasource.driver = org.postgresql.Driver
-quarkus.datasource.username = sarah
-quarkus.datasource.password = connor
+quarkus.datasource.username = hibernate
+quarkus.datasource.password = hibernate
 
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
In the [hibernate orm guide](https://quarkus.io/guides/hibernate-orm-guide) we tell users to add the following to their application.properties:
```
# configure your datasource
quarkus.datasource.url = jdbc:postgresql://localhost:5432/mydatabase
quarkus.datasource.driver = org.postgresql.Driver
quarkus.datasource.username = sarah
quarkus.datasource.password = connor
```

And then later suggest that they can start a PostgreSQL database in a docker container with the following command:
```
docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
           --name postgres-quarkus-hibernate -e POSTGRES_USER=hibernate \
           -e POSTGRES_PASSWORD=hibernate -e POSTGRES_DB=hibernate_db \
           -p 5432:5432 postgres:10.5
```

This docker command is a very useful tip, but we should have it match what we told people to put in their `applicaiton.properties` from earlier in the guide.