### PR TITLE
#4587: Reversed isAssignableFrom arguments

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/QuarkusMediatorConfigurationUtil.java
@@ -195,7 +195,7 @@ final class QuarkusMediatorConfigurationUtil {
             List<Type> arguments = type.asParameterizedType().arguments();
             if (arguments.size() >= index + 1) {
                 Class<?> argumentClass = load(arguments.get(index).name().toString(), classLoader);
-                return argumentClass.isAssignableFrom(target) ? Result.Assignable : Result.NotAssignable;
+                return target.isAssignableFrom(argumentClass) ? Result.Assignable : Result.NotAssignable;
             } else {
                 return Result.InvalidIndex;
             }


### PR DESCRIPTION
QuarkusMediatorConfigurationUtil.JandexGenericTypeAssignable.check() results in NotAssignable where Assignable is expected. Especially the following part: argumentClass.isAssignableFrom(target). This basically results in AmqpMessage.isAssignableFrom(Message) or MqttMessage.isAssignableFrom(Message). This should be the other way around Message.isAssignableFrom(AmqpMessage).