### PR TITLE
Use canonical path for checking -dev.jar location

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/ClassLoaderCompiler.java
@@ -83,9 +83,9 @@ public class ClassLoaderCompiler {
                 classPathElements.add(new File(i.getClassesPath()));
             }
         }
-        final String devModeRunnerJarAbsolutePath = context.getDevModeRunnerJarFile() == null
+        final String devModeRunnerJarCanonicalPath = context.getDevModeRunnerJarFile() == null
                 ? null
-                : context.getDevModeRunnerJarFile().getAbsolutePath();
+                : context.getDevModeRunnerJarFile().getCanonicalPath();
         while (!toParse.isEmpty()) {
             String s = toParse.poll();
             if (!parsedFiles.contains(s)) {
@@ -108,7 +108,8 @@ public class ClassLoaderCompiler {
                     // in various different ways in this very own ClassLoaderCompiler class, so
                     // not passing this jar to the JDK's compiler won't prevent its Class-Path
                     // references from being part of the hot deployment compile classpath.
-                    if (devModeRunnerJarAbsolutePath != null && file.getAbsolutePath().equals(devModeRunnerJarAbsolutePath)) {
+                    if (devModeRunnerJarCanonicalPath != null
+                            && file.getCanonicalPath().equals(devModeRunnerJarCanonicalPath)) {
                         log.debug("Dev mode runner jar " + file + " won't be added to compilation classpath of hot deployment");
                     } else {
                         classPathElements.add(file);


### PR DESCRIPTION
The final piece to get https://github.com/quarkusio/quarkus/issues/3592 working. The user has tested this change and verified that this works https://github.com/quarkusio/quarkus/issues/3592#issuecomment-543167894.
I should have anyway started off with canonical path in my original PR, for a check like this.