### PR TITLE
Flyway - Internal .sql files are no longer present and don't need to be added as substrate resource

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -45,24 +45,6 @@ class FlywayProcessor {
     private static final String JAR_APPLICATION_MIGRATIONS_PROTOCOL = "jar";
     private static final String FILE_APPLICATION_MIGRATIONS_PROTOCOL = "file";
 
-    /**
-     * Flyway internal resources that must be added to the native image
-     */
-    private static final String FLYWAY_DATABASES_PATH_ROOT = "org/flywaydb/core/internal/database";
-    private static final String FLYWAY_METADATA_TABLE_FILENAME = "createMetaDataTable.sql";
-    private static final String[] FLYWAY_DATABASES_WITH_SQL_FILE = {
-            "cockroachdb",
-            "derby",
-            "h2",
-            "hsqldb",
-            "mysql",
-            "oracle",
-            "postgresql",
-            "redshift",
-            "saphana",
-            "sqlite",
-            "sybasease"
-    };
     private static final Logger LOGGER = Logger.getLogger(FlywayProcessor.class);
     /**
      * Flyway build config
@@ -111,7 +93,7 @@ class FlywayProcessor {
             BuildProducer<GeneratedResourceBuildItem> generatedResourceProducer,
             FlywayBuildConfig flywayBuildConfig)
             throws IOException, URISyntaxException {
-        List<String> nativeResources = generateDatabasesSQLFiles();
+        final List<String> nativeResources = new ArrayList<>();
         List<String> applicationMigrations = discoverApplicationMigrations(flywayBuildConfig);
         nativeResources.addAll(applicationMigrations);
         // Store application migration in a generated resource that will be accessed later by the Quarkus-Flyway path scanner
@@ -181,13 +163,4 @@ class FlywayProcessor {
         return FileSystems.newFileSystem(uri, env);
     }
 
-    private List<String> generateDatabasesSQLFiles() {
-        List<String> result = new ArrayList<>(FLYWAY_DATABASES_WITH_SQL_FILE.length);
-        for (String database : FLYWAY_DATABASES_WITH_SQL_FILE) {
-            String filePath = FLYWAY_DATABASES_PATH_ROOT + "/" + database + "/" + FLYWAY_METADATA_TABLE_FILENAME;
-            result.add(filePath);
-            LOGGER.debug("Adding flyway internal migration: " + filePath);
-        }
-        return result;
-    }
 }


### PR DESCRIPTION
As noted in https://github.com/quarkusio/quarkus/issues/2326#issuecomment-539479565, the `.sql` files which were previously present within the flyway jar are no longer present in it and are instead inlined into various java files. The code in our Flyway extension which was adding these files are substrate resources is effectively a no-op now. This commit removes that code.

For verification, here's what 5.x of flyway had:
```
jar -tf .m2/repository/org/flywaydb/flyway-core/5.2.4/flyway-core-5.2.4.jar  | grep \\.sql

org/flywaydb/core/internal/database/redshift/createMetaDataTable.sql
org/flywaydb/core/internal/database/saphana/createMetaDataTable.sql
org/flywaydb/core/internal/database/hsqldb/createMetaDataTable.sql
org/flywaydb/core/internal/database/sqlite/createMetaDataTable.sql
org/flywaydb/core/internal/database/cockroachdb/createMetaDataTable.sql
org/flywaydb/core/internal/database/mysql/createMetaDataTable.sql
org/flywaydb/core/internal/database/oracle/createMetaDataTable.sql
org/flywaydb/core/internal/database/h2/createMetaDataTable.sql
org/flywaydb/core/internal/database/derby/createMetaDataTable.sql
org/flywaydb/core/internal/database/sybasease/createMetaDataTable.sql
org/flywaydb/core/internal/database/postgresql/createMetaDataTable.sql
```
6.0.6 (the version we now use) doesn't have those anymore:
```
jar -tf .m2/repository/org/flywaydb/flyway-core/6.0.6/flyway-core-6.0.6.jar  | grep \\.sql
```
returns empty.