### PR TITLE
Update to GraalVM 19.2.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -64,8 +64,7 @@
         <plexus-utils.version>3.0.24</plexus-utils.version>
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
         <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
-        <!-- What we actually depend on for the annotations, as latest Graal
-           is not available in Maven fast enough: -->
+        <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
         <graal-sdk.version>19.2.0.1</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha8</gizmo.version>
         <jackson.version>2.9.10.20191020</jackson.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -30,7 +30,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>19.2.0.1</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>19.2.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>0.0.9</axle-client.version>
         <vertx.version>3.8.3</vertx.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -133,7 +133,7 @@ public class NativeConfig {
     /**
      * The docker image to use to do the image build
      */
-    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.2.0.1")
+    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.2.1")
     public String builderImage;
 
     /**


### PR DESCRIPTION
This is the update to GraalVM 19.2.1

The build won't pass until the artifacts are in maven central