### PR TITLE
Pin keycloak version in docker run to known working version

### DIFF
--- a/ci-templates/native-build-steps.yaml
+++ b/ci-templates/native-build-steps.yaml
@@ -29,7 +29,7 @@ jobs:
       - script: docker run --rm --publish 8000:8000 --name build-dynamodb -d amazon/dynamodb-local:1.11.477
         displayName: 'start dynamodb'
     - ${{ if eq(parameters.keycloak, 'true') }}:
-        - script: docker run --rm --publish 8180:8080 --name build-keycloak  -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -d quay.io/keycloak/keycloak
+        - script: docker run --rm --publish 8180:8080 --name build-keycloak  -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -d quay.io/keycloak/keycloak:7.0.0
           displayName: 'start keycloak'
     - ${{ if eq(parameters.mysql, 'true') }}:
         - bash: |


### PR DESCRIPTION
Fixes #4626

This is intended to fix the failures we are seeing in the security integration tests in native mode.