### PR TITLE
Do not crash when encountering a RESTEasy param annotation on field/property

### DIFF
--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -585,6 +585,10 @@ public class ResteasyServerCommonProcessor {
         OUTER: for (DotName annotationType : methodParameterAnnotations) {
             Collection<AnnotationInstance> instances = index.getAnnotations(annotationType);
             for (AnnotationInstance instance : instances) {
+                // we only care about method parameters, because properties or fields always work
+                if (instance.target().kind() != Kind.METHOD_PARAMETER) {
+                    continue;
+                }
                 MethodParameterInfo param = instance.target().asMethodParameter();
                 if (param.name() == null) {
                     log.warnv(

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
@@ -277,6 +277,70 @@ public class TestResource {
             @QueryParam("query") String query) {
     }
 
+    // FIXME: don't enable this until https://github.com/smallrye/smallrye-open-api/issues/197 has been fixed
+    //    // make sure these don't break the build when fields
+    //    @org.jboss.resteasy.annotations.jaxrs.PathParam
+    //    String pathField;
+    //    @org.jboss.resteasy.annotations.jaxrs.FormParam
+    //    String formField;
+    //    @org.jboss.resteasy.annotations.jaxrs.CookieParam
+    //    String cookieField;
+    //    @org.jboss.resteasy.annotations.jaxrs.HeaderParam
+    //    String headerField;
+    //    @org.jboss.resteasy.annotations.jaxrs.MatrixParam
+    //    String matrixField;
+    //    @org.jboss.resteasy.annotations.jaxrs.QueryParam
+    //    String queryField;
+    //
+    //    // make sure these don't break the build when properties
+    //    public String getPathProperty() {
+    //        return null;
+    //    }
+    //
+    //    @org.jboss.resteasy.annotations.jaxrs.PathParam
+    //    public void setPathProperty(String p) {
+    //    }
+    //
+    //    public String getFormProperty() {
+    //        return null;
+    //    }
+    //
+    //    @org.jboss.resteasy.annotations.jaxrs.FormParam
+    //    public void setFormProperty(String p) {
+    //    }
+    //
+    //    public String getCookieProperty() {
+    //        return null;
+    //    }
+    //
+    //    @org.jboss.resteasy.annotations.jaxrs.CookieParam
+    //    public void setCookieProperty(String p) {
+    //    }
+    //
+    //    public String getHeaderProperty() {
+    //        return null;
+    //    }
+    //
+    //    @org.jboss.resteasy.annotations.jaxrs.HeaderParam
+    //    public void setHeaderProperty(String p) {
+    //    }
+    //
+    //    public String getMatrixProperty() {
+    //        return null;
+    //    }
+    //
+    //    @org.jboss.resteasy.annotations.jaxrs.MatrixParam
+    //    public void setMatrixProperty(String p) {
+    //    }
+    //
+    //    public String getQueryProperty() {
+    //        return null;
+    //    }
+    //
+    //    @org.jboss.resteasy.annotations.jaxrs.QueryParam
+    //    public void setQueryProperty(String p) {
+    //    }
+
     @GET
     @Path("params2/{path}")
     public void resteasyParams(@org.jboss.resteasy.annotations.jaxrs.PathParam String path,


### PR DESCRIPTION
This has a test, but it breaks openapi due to https://github.com/smallrye/smallrye-open-api/issues/197

I discovered this while editing the quickstarts, so it will be tested there.