### PR TITLE
Fix ConfigRecorder missing classloader assignment

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
@@ -21,7 +21,7 @@ public class ConfigRecorder {
         Config config = ConfigProviderResolver.instance().getConfig();
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null) {
-            ConfigRecorder.class.getClassLoader();
+            cl = ConfigRecorder.class.getClassLoader();
         }
         for (Entry<String, Set<String>> entry : properties.entrySet()) {
             Set<String> propertyTypes = entry.getValue();


### PR DESCRIPTION
I was taking a look at the `ConfigRecorder` code for another reason when I saw this.