### PR TITLE
Skip generating the docs in the initial CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
             inputs:
               goals: 'package'
               mavenOptions: $(MAVEN_OPTS)
-              options: '-B --settings azure-mvn-settings.xml -DskipTests=true -Dno-format'
+              options: '-B --settings azure-mvn-settings.xml -DskipTests=true -Dno-format -DskipDocs'
       - job: Cache_Windows_Maven_Repo #windows has different line endings so the cache key is different
         displayName: 'Windows Maven Repo'
         timeoutInMinutes: 30
@@ -85,7 +85,7 @@ stages:
             inputs:
               goals: 'package'
               mavenOptions: $(MAVEN_OPTS)
-              options: '-B --settings azure-mvn-settings.xml -DskipTests=true -Dno-format'
+              options: '-B --settings azure-mvn-settings.xml -DskipTests=true -Dno-format -DskipDocs'
 
   #This stage builds the Quarkus artifacts needed for native image testing
   - stage: build_artifact_for_native_stage

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -20,6 +20,7 @@
         <quarkus-home-url>https://quarkus.io</quarkus-home-url>
         <quarkus-base-url>https://github.com/quarkusio/quarkus</quarkus-base-url>
         <quickstarts-base-url>https://github.com/quarkusio/quarkus-quickstarts</quickstarts-base-url>
+        <skipDocs>false</skipDocs>
     </properties>
 
     <name>Quarkus - Documentation</name>
@@ -67,6 +68,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skip>${skipDocs}</skip>
                     <mainClass>io.quarkus.docs.generation.AllConfigGenerator</mainClass>
                     <arguments>
                         <argument>${project.version}</argument>
@@ -81,6 +83,7 @@
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor-maven-plugin.version}</version>
                 <configuration>
+                    <skip>${skipDocs}</skip>
                     <enableVerbose>true</enableVerbose>
                     <logHandler>
                         <failIf>
@@ -146,6 +149,7 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipDocs}</skip>
                             <backend>html5</backend>
                             <sourceDirectory>src/main/asciidoc</sourceDirectory>
                             <preserveDirectories>true</preserveDirectories>


### PR DESCRIPTION
As this is running mvn package rather than install
this can fail.