### PR TITLE
Update Eclipse Vert.x to 3.8.3

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -95,7 +95,7 @@
         <wildfly-elytron.version>2.0.0.Alpha4</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Final</jboss-threads.version>
-        <vertx.version>3.8.2</vertx.version>
+        <vertx.version>3.8.3</vertx.version>
         <httpclient.version>4.5.9</httpclient.version>
         <httpcore.version>4.4.11</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -33,7 +33,7 @@
         <graal-sdk.version-for-documentation>19.2.0.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>0.0.9</axle-client.version>
-        <vertx.version>3.8.1</vertx.version>
+        <vertx.version>3.8.3</vertx.version>
         <artemis.version>2.10.0</artemis.version>
 
         <!-- Dev tools -->

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -74,6 +74,8 @@ class NettyProcessor {
                 .addRuntimeInitializedClass("io.netty.buffer.ByteBufAllocator")
                 .addRuntimeInitializedClass("io.netty.buffer.ByteBufUtil")
                 .addRuntimeInitializedClass("io.netty.handler.ssl.ConscryptAlpnSslEngine")
+                .addRuntimeInitializedClass("io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder")
+                .addRuntimeInitializedClass("io.netty.handler.codec.http2.Http2ConnectionHandler")
                 .addNativeImageSystemProperty("io.netty.leakDetection.level", "DISABLED");
         try {
             Class.forName("io.netty.handler.codec.http.HttpObjectEncoder");

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -58,6 +58,7 @@ class NettyProcessor {
         reflectiveClass
                 .produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioServerSocketChannel"));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "java.util.LinkedHashMap"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, "sun.nio.ch.SelectorImpl"));
 
         SubstrateConfigBuildItem.Builder builder = SubstrateConfigBuildItem.builder()
                 //.addNativeImageSystemProperty("io.netty.noUnsafe", "true")

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -98,7 +98,9 @@ public class SmallRyeMetricsProcessor {
             SmallRyeMetricsRecorder recorder,
             HttpRootPathBuildItem httpRoot) {
         Function<Router, Route> route = recorder.route(metrics.path + (metrics.path.endsWith("/") ? "*" : "/*"));
+        Function<Router, Route> slash = recorder.route(metrics.path);
         routes.produce(new RouteBuildItem(route, recorder.handler(httpRoot.adjustPath(metrics.path)), HandlerType.BLOCKING));
+        routes.produce(new RouteBuildItem(slash, recorder.handler(httpRoot.adjustPath(metrics.path)), HandlerType.BLOCKING));
     }
 
     @BuildStep

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.openapi.test;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * This test is a reproducer for https://github.com/quarkusio/quarkus/issues/4613.
+ */
+public class SwaggerAndOpenAPIWithCommonPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(OpenApiResource.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=/swagger"), "application.properties"));
+
+    @Test
+    public void shouldWorkEvenWithCommonPrefix() {
+        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
+        RestAssured.when().get("/swagger").then().statusCode(200)
+                .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
+    }
+}

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -39,6 +39,8 @@ import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
 
 public class SwaggerUiProcessor {
 
@@ -113,8 +115,9 @@ public class SwaggerUiProcessor {
                     throw new RuntimeException(e);
                 }
             }
-            routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*",
-                    recorder.handler(cached.cachedDirectory, swaggerUiConfig.path)));
+            Handler<RoutingContext> handler = recorder.handler(cached.cachedDirectory, swaggerUiConfig.path);
+            routes.produce(new RouteBuildItem(swaggerUiConfig.path, handler));
+            routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*", handler));
         } else if (swaggerUiConfig.alwaysInclude) {
             ResolvedArtifact artifact = getSwaggerUiArtifact();
             //we are including in a production artifact

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -147,8 +147,11 @@ public class SwaggerUiProcessor {
                     }
                 }
             }
-            routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*",
-                    recorder.handler(SWAGGER_UI_FINAL_DESTINATION, httpRootPathBuildItem.adjustPath(swaggerUiConfig.path))));
+
+            Handler<RoutingContext> handler = recorder
+                    .handler(SWAGGER_UI_FINAL_DESTINATION, httpRootPathBuildItem.adjustPath(swaggerUiConfig.path));
+            routes.produce(new RouteBuildItem(swaggerUiConfig.path, handler));
+            routes.produce(new RouteBuildItem(swaggerUiConfig.path + "/*", handler));
         }
     }
 


### PR DESCRIPTION
Bump Vert.x version to 3.8.3.

Note that this PR does not update Netty version.
Netty update is causing a few issues and will be handled in another (more complex) PR.