### PR TITLE
Allow Spring controllers to not require @RequestMapping

### DIFF
--- a/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -178,11 +178,6 @@ public class SpringWebProcessor {
     private void validate(Collection<AnnotationInstance> restControllerInstances) {
         for (AnnotationInstance restControllerInstance : restControllerInstances) {
             ClassInfo restControllerClass = restControllerInstance.target().asClass();
-            if (restControllerClass.classAnnotation(REQUEST_MAPPING) == null) {
-                throw new IllegalArgumentException(
-                        "Currently any class annotated with @RestController also needs to be annotated with @RequestMapping. " +
-                                "Offending class is " + restControllerClass.name());
-            }
 
             Map<DotName, List<AnnotationInstance>> annotations = restControllerClass.annotations();
             for (Map.Entry<DotName, List<AnnotationInstance>> entry : annotations.entrySet()) {

--- a/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/web/HelloControllerWithoutRequestMapping.java
+++ b/integration-tests/spring-web/src/main/java/io/quarkus/it/spring/web/HelloControllerWithoutRequestMapping.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.spring.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloControllerWithoutRequestMapping {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerTest.java
+++ b/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerTest.java
@@ -70,4 +70,10 @@ public class SpringControllerTest {
                 .body(containsString("hello from error"))
                 .statusCode(417);
     }
+
+    @Test
+    public void testRestControllerWithoutRequestMapping() {
+        RestAssured.when().get("/hello").then()
+                .body(containsString("hello"));
+    }
 }


### PR DESCRIPTION
Relates to: https://github.com/resteasy/Resteasy/pull/2190
~~Requires RESTEasy: `4.4.0.Final` (still unreleased)~~