### PR TITLE
Manifest Variable Expansion #4684

### DIFF
--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -16,7 +16,18 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -444,8 +455,6 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
         attributes.put(Attributes.Name.MAIN_CLASS, mainClass);
     }
 
-
-
     /**
      * Resolve any attribute name that is a place holder between ${...} notation.
      * This is used by build systems that inject metadata to the manifest at build time,
@@ -460,7 +469,8 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
                 String trimmedValue = value.trim();
                 if (!trimmedValue.isEmpty() && trimmedValue.startsWith(PLACEHOLDER_PREFIX) &&
                         trimmedValue.endsWith(PLACEHOLDER_SUFFIX)) {
-                    String variableName = trimmedValue.substring(PLACEHOLDER_PREFIX.length(), trimmedValue.length() - PLACEHOLDER_SUFFIX.length());
+                    String variableName = trimmedValue.substring(PLACEHOLDER_PREFIX.length(),
+                            trimmedValue.length() - PLACEHOLDER_SUFFIX.length());
                     String systemPropertyValue = System.getenv(variableName);
                     if (Objects.nonNull(systemPropertyValue) && !systemPropertyValue.trim().isEmpty()) {
                         attributes.put(k, systemPropertyValue);

--- a/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
+++ b/core/creator/src/main/java/io/quarkus/creator/phase/runnerjar/RunnerJarPhase.java
@@ -471,7 +471,7 @@ public class RunnerJarPhase implements AppCreationPhase<RunnerJarPhase>, RunnerJ
                         trimmedValue.endsWith(PLACEHOLDER_SUFFIX)) {
                     String variableName = trimmedValue.substring(PLACEHOLDER_PREFIX.length(),
                             trimmedValue.length() - PLACEHOLDER_SUFFIX.length());
-                    String systemPropertyValue = System.getenv(variableName);
+                    String systemPropertyValue = System.getProperty(variableName);
                     if (Objects.nonNull(systemPropertyValue) && !systemPropertyValue.trim().isEmpty()) {
                         attributes.put(k, systemPropertyValue);
                     }

--- a/core/creator/src/test/java/io/quarkus/creator/phase/runnerjar/test/VariableSubstitutionTest.java
+++ b/core/creator/src/test/java/io/quarkus/creator/phase/runnerjar/test/VariableSubstitutionTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.creator.phase.runnerjar.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This tests the core logic of the variable substitution;
+ */
+public class VariableSubstitutionTest {
+    private static final String PLACEHOLDER_PREFIX = "${";
+    private static final String PLACEHOLDER_SUFFIX = "}";
+
+    @Test
+    public void testVariableSubstitution() {
+        System.setProperty("env.TEST", "TEST");
+        String trimmedValue = "${env.TEST}";
+        if (!trimmedValue.isEmpty() && trimmedValue.startsWith(PLACEHOLDER_PREFIX) &&
+                trimmedValue.endsWith(PLACEHOLDER_SUFFIX)) {
+
+            String variableName = trimmedValue.substring(PLACEHOLDER_PREFIX.length(),
+                    trimmedValue.length() - PLACEHOLDER_SUFFIX.length());
+            assertNotNull(variableName);
+            assertEquals("env.TEST", variableName);
+            String systemPropertyValue = System.getProperty(variableName);
+            if (Objects.nonNull(systemPropertyValue) && !systemPropertyValue.trim().isEmpty()) {
+                assertEquals("TEST", systemPropertyValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The following code will handle variable expansion if a static MANIFEST.MF is used for the runner jar.

I broke the current manifest method into two smaller parts, these could become static for easier unit testing.

- Note: Unable to add a clean test for this, guidance welcome here as there were no additional tests for supporting the static META-INF/MANIFEST.MF file. 