### PR TITLE
Add note about prefixing properties with "quarkus."

### DIFF
--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -302,6 +302,14 @@ Quarkus itself is configured via the same mechanism as your application. Quarkus
 for its own configuration. For example to configure the HTTP server port you can set `quarkus.http.port` in
 `application.properties`.
 
+[IMPORTANT]
+====
+As mentioned above, properties prefixed with `quarkus.` are effectively reserved for configuring Quarkus itself and
+therefore `quarkus.`should **never** be used as prefix for application specific properties.
+
+In the previous examples using `quarkus.message` instead of `greeting.message` would result in unexpected behavior.
+====
+
 === List of all configuration properties
 
 All the Quarkus configuration properties are link:all-config[documented and searcheable].


### PR DESCRIPTION
This PR was opened because we have users using properties `quarkus.message` to configure their own application.

See [this](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Config.20properties.20and.20nativ.20images) discussion.