### PR TITLE
Disable native image PrintAnalysisCallTree by default, change semantics to 'enabledReports=true'

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -164,7 +164,7 @@ public class NativeConfig {
      * If reporting on call paths should be enabled
      */
     @ConfigItem(defaultValue = "false")
-    public boolean disableReports;
+    public boolean enableReports;
 
     /**
      * Additional arguments to pass to the build process

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -198,7 +198,7 @@ public class NativeImageBuildStep {
             if (nativeConfig.debugBuildProcess) {
                 command.add("-J-Xrunjdwp:transport=dt_socket,address=" + DEBUG_BUILD_PROCESS_PORT + ",server=y,suspend=y");
             }
-            if (!nativeConfig.disableReports) {
+            if (nativeConfig.enableReports) {
                 command.add("-H:+PrintAnalysisCallTree");
             }
             if (nativeConfig.dumpProxies) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -72,7 +72,7 @@ public class QuarkusNative extends QuarkusTask {
 
     private boolean fullStackTraces = true;
 
-    private boolean disableReports;
+    private boolean enableReports;
 
     private List<String> additionalBuildArgs;
 
@@ -343,13 +343,19 @@ public class QuarkusNative extends QuarkusTask {
 
     @Optional
     @Input
-    public boolean isDisableReports() {
-        return disableReports;
+    public boolean isEnableReports() {
+        return enableReports;
     }
 
+    @Deprecated
     @Option(description = "Disable reports", option = "disable-reports")
     public void setDisableReports(boolean disableReports) {
-        this.disableReports = disableReports;
+        this.enableReports = !disableReports;
+    }
+
+    @Option(description = "Enable reports", option = "enable-reports")
+    public void setEnableReports(boolean enableReports) {
+        this.enableReports = enableReports;
     }
 
     @Optional
@@ -435,7 +441,7 @@ public class QuarkusNative extends QuarkusTask {
                 configs.add("quarkus.native.debug-build-process", debugBuildProcess);
 
                 configs.add("quarkus.native.debug-symbols", debugSymbols);
-                configs.add("quarkus.native.disable-reports", disableReports);
+                configs.add("quarkus.native.enable-reports", enableReports);
                 if (dockerBuild != null) {
                     configs.add("quarkus.native.docker-build", dockerBuild);
                 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -130,8 +130,12 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private Boolean fullStackTraces;
 
+    @Deprecated
     @Parameter(defaultValue = "${native-image.disable-reports}")
     private Boolean disableReports;
+
+    @Parameter(defaultValue = "${native-image.enable-reports}")
+    private Boolean enableReports;
 
     @Parameter
     private List<String> additionalBuildArgs;
@@ -333,7 +337,10 @@ public class NativeImageMojo extends AbstractMojo {
                     configs.add("quarkus.native.debug-symbols", debugSymbols.toString());
                 }
                 if (disableReports != null) {
-                    configs.add("quarkus.native.disable-reports", disableReports.toString());
+                    configs.add("quarkus.native.enable-reports", new Boolean(!disableReports).toString());
+                }
+                if (enableReports != null) {
+                    configs.add("quarkus.native.enable-reports", enableReports.toString());
                 }
                 if (containerRuntime != null) {
                     configs.add("quarkus.native.container-runtime", containerRuntime);

--- a/devtools/maven/src/main/resources/create-extension-templates/integration-test-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/integration-test-pom.xml
@@ -107,7 +107,7 @@
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
-                                    <disableReports>true</disableReports>
+                                    <enableReports>false</enableReports>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/elytron-security-jdbc/pom.xml
+++ b/integration-tests/elytron-security-jdbc/pom.xml
@@ -106,7 +106,7 @@
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
-                                    <disableReports>true</disableReports>
+                                    <enableReports>false</enableReports>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/pom.xml
@@ -101,7 +101,7 @@
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
-                                    <disableReports>true</disableReports>
+                                    <enableReports>false</enableReports>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
…cs to 'enabledReports=true'

Reduces heap allocation and increase build speed of a default native image build