### PR TITLE
Tighten integration between Kafka client and jsonb - Add Jackson support

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -12,6 +12,7 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String CDI_ARC = "io.quarkus.cdi";
     public static final String SERVLET = "io.quarkus.servlet";
     public static final String TRANSACTIONS = "io.quarkus.transactions";
+    public static final String JSONB = "io.quarkus.jsonb";
     public static final String RESTEASY_JSON_EXTENSION = "io.quarkus.resteasy-json";
     public static final String SECURITY = "io.quarkus.security";
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -12,6 +12,7 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String CDI_ARC = "io.quarkus.cdi";
     public static final String SERVLET = "io.quarkus.servlet";
     public static final String TRANSACTIONS = "io.quarkus.transactions";
+    public static final String JACKSON = "io.quarkus.jackson";
     public static final String JSONB = "io.quarkus.jsonb";
     public static final String RESTEASY_JSON_EXTENSION = "io.quarkus.resteasy-json";
     public static final String SECURITY = "io.quarkus.security";

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -63,7 +64,7 @@ public class JacksonProcessor {
     @Inject
     List<IgnoreJsonDeserializeClassBuildItem> ignoreJsonDeserializeClassBuildItems;
 
-    @BuildStep
+    @BuildStep(providesCapabilities = Capabilities.JACKSON)
     void register() {
         addReflectiveClass(true, false,
                 "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",

--- a/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
+++ b/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
@@ -29,6 +29,7 @@ import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -53,7 +54,7 @@ public class JsonbProcessor {
     private static final DotName JSONB_TYPE_SERIALIZER = DotName.createSimple(JsonbTypeSerializer.class.getName());
     private static final DotName JSONB_TYPE_DESERIALIZER = DotName.createSimple(JsonbTypeDeserializer.class.getName());
 
-    @BuildStep
+    @BuildStep(providesCapabilities = Capabilities.JSONB)
     void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<SubstrateResourceBundleBuildItem> resourceBundle,
             BuildProducer<ServiceProviderBuildItem> serviceProvider,

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.zip.Checksum;
 
-import io.quarkus.deployment.Capabilities;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.consumer.RoundRobinAssignor;
 import org.apache.kafka.clients.consumer.StickyAssignor;
@@ -34,6 +33,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -46,6 +46,8 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.kafka.client.serialization.JsonbDeserializer;
 import io.quarkus.kafka.client.serialization.JsonbSerializer;
+import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
+import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
 
 public class KafkaProcessor {
 
@@ -91,6 +93,10 @@ public class KafkaProcessor {
         }
         if (capabilities.isCapabilityPresent(Capabilities.JSONB)) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, JsonbSerializer.class, JsonbDeserializer.class));
+        }
+        if (capabilities.isCapabilityPresent(Capabilities.JACKSON)) {
+            reflectiveClass.produce(
+                    new ReflectiveClassBuildItem(false, false, ObjectMapperSerializer.class, ObjectMapperDeserializer.class));
         }
 
         for (Collection<ClassInfo> list : Arrays.asList(serializers, deserializers, partitioners, partitionAssignors)) {

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>quarkus-jsonb</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbDeserializer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbDeserializer.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.util.Map;
 
 import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -20,7 +19,7 @@ public class JsonbDeserializer<T> implements Deserializer<T> {
     private final boolean jsonbNeedsClosing;
 
     public JsonbDeserializer(Class<T> type) {
-        this(type, JsonbBuilder.create(), true);
+        this(type, JsonbProducer.get(), true);
     }
 
     public JsonbDeserializer(Class<T> type, Jsonb jsonb) {

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbProducer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbProducer.java
@@ -1,0 +1,24 @@
+package io.quarkus.kafka.client.serialization;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+
+final class JsonbProducer {
+
+    private JsonbProducer() {
+    }
+
+    // Try to get JSON-B from Arc but fallback to regular JSON-B creation
+    // The fallback could be used for example in unit tests where Arc has not been initialized
+    static Jsonb get() {
+        Jsonb jsonb = null;
+        ArcContainer container = Arc.container();
+        if (container != null) {
+            jsonb = container.instance(Jsonb.class).get();
+        }
+        return jsonb != null ? jsonb : JsonbBuilder.create();
+    }
+}

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbSerde.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbSerde.java
@@ -3,7 +3,6 @@ package io.quarkus.kafka.client.serialization;
 import java.util.Map;
 
 import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -21,7 +20,7 @@ public class JsonbSerde<T> implements Serde<T> {
     private final JsonbDeserializer<T> deserializer;
 
     public JsonbSerde(Class<T> type) {
-        this(type, JsonbBuilder.create(), true);
+        this(type, JsonbProducer.get(), true);
     }
 
     public JsonbSerde(Class<T> type, Jsonb jsonb) {

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbSerializer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/JsonbSerializer.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -18,7 +17,7 @@ public class JsonbSerializer<T> implements Serializer<T> {
     private final boolean jsonbNeedsClosing;
 
     public JsonbSerializer() {
-        this(JsonbBuilder.create(), true);
+        this(JsonbProducer.get(), true);
     }
 
     public JsonbSerializer(Jsonb jsonb) {

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperDeserializer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperDeserializer.java
@@ -1,0 +1,46 @@
+package io.quarkus.kafka.client.serialization;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectMapperDeserializer<T> implements Deserializer<T> {
+
+    private final Class<T> type;
+    private final ObjectMapper objectMapper;
+
+    public ObjectMapperDeserializer(Class<T> type) {
+        this(type, ObjectMapperProducer.get());
+    }
+
+    public ObjectMapperDeserializer(Class<T> type, ObjectMapper objectMapper) {
+        this.type = type;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        try (InputStream is = new ByteArrayInputStream(data)) {
+            return objectMapper.readValue(is, type);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperProducer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperProducer.java
@@ -1,0 +1,23 @@
+package io.quarkus.kafka.client.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+
+final class ObjectMapperProducer {
+
+    private ObjectMapperProducer() {
+    }
+
+    // Try to get JSON-B from Arc but fallback to regular ObjectMapper creation
+    // The fallback could be used for example in unit tests where Arc has not been initialized
+    static ObjectMapper get() {
+        ObjectMapper objectMapper = null;
+        ArcContainer container = Arc.container();
+        if (container != null) {
+            objectMapper = container.instance(ObjectMapper.class).get();
+        }
+        return objectMapper != null ? objectMapper : new ObjectMapper();
+    }
+}

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperSerde.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperSerde.java
@@ -1,0 +1,48 @@
+package io.quarkus.kafka.client.serialization;
+
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A {@link Serde} that (de-)serializes JSON using Jackson's ObjectMapper.
+ */
+public class ObjectMapperSerde<T> implements Serde<T> {
+
+    private final ObjectMapperSerializer<T> serializer;
+    private final ObjectMapperDeserializer<T> deserializer;
+
+    public ObjectMapperSerde(Class<T> type) {
+        this(type, ObjectMapperProducer.get());
+    }
+
+    public ObjectMapperSerde(Class<T> type, ObjectMapper objectMapper) {
+        this.serializer = new ObjectMapperSerializer<T>(objectMapper);
+        this.deserializer = new ObjectMapperDeserializer<T>(type, objectMapper);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+
+    }
+
+    @Override
+    public void close() {
+        serializer.close();
+        deserializer.close();
+    }
+
+    @Override
+    public Serializer<T> serializer() {
+        return serializer;
+    }
+
+    @Override
+    public Deserializer<T> deserializer() {
+        return deserializer;
+    }
+}

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperSerializer.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/serialization/ObjectMapperSerializer.java
@@ -1,0 +1,44 @@
+package io.quarkus.kafka.client.serialization;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A {@link Deserializer} that deserializes JSON using Jackson's ObjectMapper.
+ */
+public class ObjectMapperSerializer<T> implements Serializer<T> {
+
+    private final ObjectMapper objectMapper;
+
+    public ObjectMapperSerializer() {
+        this(ObjectMapperProducer.get());
+    }
+
+    public ObjectMapperSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, T data) {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            objectMapper.writeValue(output, data);
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/extensions/kafka-client/runtime/src/test/java/io/quarkus/kafka/client/serde/ObjectMapperSerdeTest.java
+++ b/extensions/kafka-client/runtime/src/test/java/io/quarkus/kafka/client/serde/ObjectMapperSerdeTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.kafka.client.serde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
+
+public class ObjectMapperSerdeTest {
+
+    @Test
+    public void shouldSerializeAndDeserializeEntity() {
+        MyEntity entity = new MyEntity();
+        entity.id = 42L;
+        entity.name = "Bob";
+
+        try (ObjectMapperSerde<MyEntity> serde = new ObjectMapperSerde<>(MyEntity.class)) {
+            byte[] serialized = serde.serializer().serialize("my-topic", entity);
+            MyEntity deserialized = serde.deserializer().deserialize("my-topic", serialized);
+
+            assertThat(deserialized.id).isEqualTo(42L);
+            assertThat(deserialized.name).isEqualTo("Bob");
+        }
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeEntityWithGivenObjectMapper() throws Exception {
+        MyEntity entity = new MyEntity();
+        entity.id = 42L;
+        entity.name = "Bob";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try (ObjectMapperSerde<MyEntity> serde = new ObjectMapperSerde<>(MyEntity.class, objectMapper)) {
+            byte[] serialized = serde.serializer().serialize("my-topic", entity);
+            MyEntity deserialized = serde.deserializer().deserialize("my-topic", serialized);
+
+            assertThat(deserialized.id).isEqualTo(42L);
+            assertThat(deserialized.name).isEqualTo("Bob");
+        }
+    }
+
+    public static class MyEntity {
+        public long id;
+        public String name;
+    }
+}

--- a/extensions/kafka-client/runtime/src/test/java/io/quarkus/kafka/client/serialization/JsonProducerTest.java
+++ b/extensions/kafka-client/runtime/src/test/java/io/quarkus/kafka/client/serialization/JsonProducerTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.kafka.client.serialization;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JsonProducerTest {
+
+    @Test
+    public void shouldProduceJsonb() {
+        Assertions.assertThat(JsonbProducer.get()).isNotNull();
+    }
+
+    @Test
+    public void shouldProduceObjectMapper() {
+        Assertions.assertThat(ObjectMapperProducer.get()).isNotNull();
+    }
+}

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
 
         <!-- Kafka -->

--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
@@ -15,7 +15,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.Stores;
 
-import io.quarkus.kafka.client.serialization.JsonbSerde;
+import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
 
 @ApplicationScoped
 public class KafkaStreamsPipeline {
@@ -24,9 +24,9 @@ public class KafkaStreamsPipeline {
     public Topology buildTopology() {
         StreamsBuilder builder = new StreamsBuilder();
 
-        JsonbSerde<Category> categorySerde = new JsonbSerde<>(Category.class);
-        JsonbSerde<Customer> customerSerde = new JsonbSerde<>(Customer.class);
-        JsonbSerde<EnrichedCustomer> enrichedCustomerSerde = new JsonbSerde<>(EnrichedCustomer.class);
+        ObjectMapperSerde<Category> categorySerde = new ObjectMapperSerde<>(Category.class);
+        ObjectMapperSerde<Customer> customerSerde = new ObjectMapperSerde<>(Customer.class);
+        ObjectMapperSerde<EnrichedCustomer> enrichedCustomerSerde = new ObjectMapperSerde<>(EnrichedCustomer.class);
 
         KTable<Integer, Category> categories = builder.table(
                 "streams-test-categories",

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.kafka.KafkaTestResource;
-import io.quarkus.kafka.client.serialization.JsonbDeserializer;
-import io.quarkus.kafka.client.serialization.JsonbSerializer;
+import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
+import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
@@ -42,7 +42,7 @@ public class KafkaStreamsTest {
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "streams-test-producer");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonbSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ObjectMapperSerializer.class.getName());
 
         return new KafkaProducer<Integer, Customer>(props);
     }
@@ -52,7 +52,7 @@ public class KafkaStreamsTest {
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "streams-test-producer");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonbSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ObjectMapperSerializer.class.getName());
 
         return new KafkaProducer<>(props);
     }
@@ -168,7 +168,7 @@ public class KafkaStreamsTest {
         return result;
     }
 
-    public static class EnrichedCustomerDeserializer extends JsonbDeserializer<EnrichedCustomer> {
+    public static class EnrichedCustomerDeserializer extends ObjectMapperDeserializer<EnrichedCustomer> {
 
         public EnrichedCustomerDeserializer() {
             super(EnrichedCustomer.class);


### PR DESCRIPTION
* Use Jsonb bean from Arc if possible
* Only register serializer / deserializer for reflection if JSON-B is present
* Add Jackson module that does the same things as the JSON-B module
* Update Kafka test to ensure that everything works when one of these json dependencies is missing