### PR TITLE
Security guides tweaks

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/JavaDocParser.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/JavaDocParser.java
@@ -25,6 +25,7 @@ final class JavaDocParser {
     private static final Pattern REPLACE_WINDOWS_EOL = Pattern.compile("\r\n");
     private static final Pattern REPLACE_MACOS_EOL = Pattern.compile("\r");
 
+    private static final String BACKTICK = "`";
     private static final String HASH = "#";
     private static final String STAR = "*";
     private static final String S_NODE = "s";
@@ -33,6 +34,7 @@ final class JavaDocParser {
     private static final String LINK_NODE = "a";
     private static final String BOLD_NODE = "b";
     private static final String BIG_NODE = "big";
+    private static final String CODE_NODE = "code";
     private static final String DEL_NODE = "del";
     private static final String ITALICS_NODE = "i";
     private static final String TEXT_NODE = "#text";
@@ -193,10 +195,16 @@ final class JavaDocParser {
                     break;
                 case LINK_NODE:
                     final String link = childNode.attr(HREF_ATTRIBUTE);
+                    sb.append("link:");
                     sb.append(link);
                     final StringBuilder caption = new StringBuilder();
                     appendHtml(caption, childNode);
                     sb.append(String.format(LINK_ATTRIBUTE_FORMAT, caption.toString().trim()));
+                    break;
+                case CODE_NODE:
+                    sb.append(BACKTICK);
+                    appendHtml(sb, childNode);
+                    sb.append(BACKTICK);
                     break;
                 case BOLD_NODE:
                 case EMPHASIS_NODE:

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
@@ -157,7 +157,7 @@ public class JavaDocConfigDescriptionParserTest {
     @Test
     public void parseJavaDocWithLinkTag() {
         String javaDoc = "this is a <a href='http://link.com'>hello</a> link";
-        String expectedOutput = "this is a http://link.com[hello] link";
+        String expectedOutput = "this is a link:http://link.com[hello] link";
         String parsed = parser.parseConfigDescription(javaDoc);
 
         assertEquals(expectedOutput, parsed);

--- a/docs/src/main/asciidoc/elytron-properties-guide.adoc
+++ b/docs/src/main/asciidoc/elytron-properties-guide.adoc
@@ -27,21 +27,14 @@ Add the following to your `pom.xml`:
 == Configuration
 
 The elytron-security-properties-file extension currently supports two different realms for the storage of authentication
-and authorization information. Both support storage of this information in properties type files. The next two sections detail the specific configuration properties.
+and authorization information. Both support storage of this information in properties type files. The following sections
+detail the specific configuration properties.
+
+include::{generated-dir}/config/quarkus-elytron-security.adoc[opts=optional, leveloffset=+2]
 
 === Property Files Realm Configuration
 
-The property files realm supports mapping of users to password and users to roles with a combination of properties files. To enable and configure it, the following configuration properties are used:
-
-|===
-|Property Name|Default|Description
-|quarkus.security.users.file.enabled|false|Determine whether security via the file realm is enabled
-|quarkus.security.users.file.auth-mechanism|BASIC|Name of authentication mechanism to use
-|quarkus.security.users.file.realm-name|Quarkus|Name to assign the security realm
-|quarkus.security.users.file.plain-text|false|If this is true passwords are plain text, otherwise they must be in the form MD5( username : realm : password )
-|quarkus.security.users.file.users|users.properties|Classpath resource name of properties file containing user to password mappings; see <<Users.properties>>
-|quarkus.security.users.file.roles|roles.properties|Classpath resource name of properties file containing user to role mappings; see <<Roles.properties>>
-|===
+The property files realm supports mapping of users to password and users to roles with a combination of properties files. They are configured with properties starting with `quarkus.security.users.file`.
 
 .example application.properties file section for property files realm
 [source,properties]
@@ -49,7 +42,6 @@ The property files realm supports mapping of users to password and users to role
 quarkus.security.users.file.enabled=true
 quarkus.security.users.file.users=test-users.properties
 quarkus.security.users.file.roles=test-roles.properties
-quarkus.security.users.file.auth-mechanism=BASIC
 quarkus.security.users.file.realm-name=MyRealm
 quarkus.security.users.file.plain-text=true
 ----
@@ -90,17 +82,7 @@ noadmin=user
 
 === Embedded Realm Configuration
 
-The embedded realm also supports mapping of users to password and users to roles. It uses the main application.properties Quarkus configuration file to embed this information. To enable and configure it, the following configuration properties are used:
-
-|===
-|Property Name|Default|Description
-|quarkus.security.users.embedded.enabled|false|Determine whether security via the embedded realm is enabled.
-|quarkus.security.users.embedded.auth-mechanism|BASIC|Name of authentication mechanism to use
-|quarkus.security.users.embedded.realm-name|Quarkus|Name to assign the security realm
-|quarkus.security.users.embedded.plain-text|false|If this is true passwords are plain text, otherwise they must be in the form MD5( username : realm : password )
-|quarkus.security.users.embedded.users.*|none|Prefix for the properties that specify user to password mappings; see <<Embedded Users>>
-|quarkus.security.users.embedded.roles.*|none|Prefix for the properties that specify user to role mappings; see <<Embedded Roles>>
-|===
+The embedded realm also supports mapping of users to password and users to roles. It uses the main application.properties Quarkus configuration file to embed this information. They are configured with properties starting with `quarkus.security.users.embedded`.
 
 The following is an example application.properties file section illustrating the embedded realm configuration:
 
@@ -108,6 +90,7 @@ The following is an example application.properties file section illustrating the
 [source,properties]
 ----
 quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.users.scott=jb0ss
 quarkus.security.users.embedded.users.stuart=test
 quarkus.security.users.embedded.users.jdoe=p4ssw0rd
@@ -116,7 +99,6 @@ quarkus.security.users.embedded.roles.scott=Admin,admin,Tester,user
 quarkus.security.users.embedded.roles.stuart=admin,user
 quarkus.security.users.embedded.roles.jdoe=NoRolesUser
 quarkus.security.users.embedded.roles.noadmin=user
-quarkus.security.users.embedded.auth-mechanism=BASIC
 ----
 
 As with the first example this file has the usernames and passwords stored in plain text, which is not recommended. If plain-text is set to false
@@ -126,38 +108,28 @@ be generated for the first example above by running the command `echo -n scott:M
 
 ==== Embedded Users
 
-The user to password mappings are specified in the `application.properties` file by property names of the form `quarkus.security.users.embedded.users.<user>=<password>`. The following <<password-example>> illustrates the syntax with the 4 user to password mappings shown in lines 2-5:
+The user to password mappings are specified in the `application.properties` file by property names of the form `quarkus.security.users.embedded.users.<user>=<password>`. The following <<password-example>> illustrates the syntax with 4 user to password mappings:
 
 [#password-example]
 .Example Passwords
-[source,properties,linenums,highlight='2-5']
+[source,properties,linenums]
 ----
-quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.users.scott=jb0ss # <1>
 quarkus.security.users.embedded.users.stuart=test # <2>
 quarkus.security.users.embedded.users.jdoe=p4ssw0rd
 quarkus.security.users.embedded.users.noadmin=n0Adm1n
-quarkus.security.users.embedded.roles.scott=Admin,admin,Tester,user
-quarkus.security.users.embedded.roles.stuart=admin,user
-quarkus.security.users.embedded.roles.jdoe=NoRolesUser
-quarkus.security.users.embedded.roles.noadmin=user
 ----
 <1> User `scott` has password `jb0ss`
 <2> User `stuart` has password `test`
 
 ==== Embedded Roles
 
-The user to role mappings are specified in the `application.properties` file by property names of the form `quarkus.security.users.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<roles-example>> illustrates the syntax with the 4 user to role mappings shown in lines 6-9:
+The user to role mappings are specified in the `application.properties` file by property names of the form `quarkus.security.users.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<roles-example>> illustrates the syntax with 4 user to role mappings:
 
 [#roles-example]
 .Example Roles
-[source,properties,linenums,highlight='6-9']
+[source,properties,linenums]
 ----
-quarkus.security.users.embedded.enabled=true
-quarkus.security.users.embedded.users.scott=jb0ss
-quarkus.security.users.embedded.users.stuart=test
-quarkus.security.users.embedded.users.jdoe=p4ssw0rd
-quarkus.security.users.embedded.users.noadmin=n0Adm1n
 quarkus.security.users.embedded.roles.scott=Admin,admin,Tester,user # <1>
 quarkus.security.users.embedded.roles.stuart=admin,user # <2>
 quarkus.security.users.embedded.roles.jdoe=NoRolesUser

--- a/docs/src/main/asciidoc/elytron-properties-guide.adoc
+++ b/docs/src/main/asciidoc/elytron-properties-guide.adoc
@@ -27,14 +27,14 @@ Add the following to your `pom.xml`:
 == Configuration
 
 The elytron-security-properties-file extension currently supports two different realms for the storage of authentication
-and authorization information. Both support storage of this information in properties type files. The following sections
+and authorization information. Both support storage of this information in properties files. The following sections
 detail the specific configuration properties.
 
 include::{generated-dir}/config/quarkus-elytron-security.adoc[opts=optional, leveloffset=+2]
 
-=== Property Files Realm Configuration
+=== Properties Files Realm Configuration
 
-The property files realm supports mapping of users to password and users to roles with a combination of properties files. They are configured with properties starting with `quarkus.security.users.file`.
+The properties files realm supports mapping of users to password and users to roles with a combination of properties files. They are configured with properties starting with `quarkus.security.users.file`.
 
 .example application.properties file section for property files realm
 [source,properties]
@@ -82,7 +82,7 @@ noadmin=user
 
 === Embedded Realm Configuration
 
-The embedded realm also supports mapping of users to password and users to roles. It uses the main application.properties Quarkus configuration file to embed this information. They are configured with properties starting with `quarkus.security.users.embedded`.
+The embedded realm also supports mapping of users to password and users to roles. It uses the main `application.properties` Quarkus configuration file to embed this information. They are configured with properties starting with `quarkus.security.users.embedded`.
 
 The following is an example application.properties file section illustrating the embedded realm configuration:
 
@@ -108,7 +108,7 @@ be generated for the first example above by running the command `echo -n scott:M
 
 ==== Embedded Users
 
-The user to password mappings are specified in the `application.properties` file by property names of the form `quarkus.security.users.embedded.users.<user>=<password>`. The following <<password-example>> illustrates the syntax with 4 user to password mappings:
+The user to password mappings are specified in the `application.properties` file by properties keys of the form `quarkus.security.users.embedded.users.<user>=<password>`. The following <<password-example>> illustrates the syntax with 4 user to password mappings:
 
 [#password-example]
 .Example Passwords
@@ -124,7 +124,7 @@ quarkus.security.users.embedded.users.noadmin=n0Adm1n
 
 ==== Embedded Roles
 
-The user to role mappings are specified in the `application.properties` file by property names of the form `quarkus.security.users.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<roles-example>> illustrates the syntax with 4 user to role mappings:
+The user to role mappings are specified in the `application.properties` file by properties keys of the form `quarkus.security.users.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<roles-example>> illustrates the syntax with 4 user to role mappings:
 
 [#roles-example]
 .Example Roles

--- a/docs/src/main/asciidoc/jwt-guide.adoc
+++ b/docs/src/main/asciidoc/jwt-guide.adoc
@@ -9,7 +9,8 @@ include::./attributes.adoc[]
 :extension-name: Smallrye JWT
 :mp-jwt: MicroProfile JWT RBAC
 
-This guide explains how your Quarkus application can utilize {mp-jwt} to provide
+This guide explains how your Quarkus application can utilize MicroProfile Json Web Token (link:https://jwt.io/[JWT]) 
+Role-Based Access Control (link:https://en.wikipedia.org/wiki/Role-based_access_control[RBAC]) to provide
 secured access to the JAX-RS endpoints.
 
 [[configuration-reference]]

--- a/docs/src/main/asciidoc/oauth2-guide.adoc
+++ b/docs/src/main/asciidoc/oauth2-guide.adoc
@@ -15,19 +15,6 @@ It can be used to implement an application authentication mechanism based on tok
 
 If your OAuth2 Authentication server provides JWT tokens, you should use link:jwt-guide.html[MicroProfile JWT RBAC] instead, this extension aims to be used with opaque tokens and validate the token by calling an introspection endpoint.
 
-== Configuration
-
-[cols="<m,<m,<2",options="header"]
-|===
-|Property Name|Default|Description
-|quarkus.oauth2.enabled|true|Determine if the OAuth2 extension is enabled. Enabled by default if you include the `elytron-security-oauth2` dependency, so this would be used to disable it.
-|quarkus.oauth2.client-id||The OAuth2 client id used to validate the token.
-|quarkus.oauth2.client-secret||The OAuth2 client secret used to validate the token.
-|quarkus.oauth2.introspection-url||The OAuth2 introspection endpoint URL used to validate the token and gather the authentication claims.
-|quarkus.oauth2.ca-cert-file||The OAuth2 server certificate file. **Warning**: this is not supported in native mode where the certificate must be included in the truststore used during the native image generation, see link:native-and-ssl-guide.html[Using SSL With Native Executables].
-|quarkus.oauth2.role-claim|scope|The claim that is used in the introspection endpoint response to load the roles
-|===
-
 == Creating the Maven project
 
 First, we need a new project. Create a new project with the following command:
@@ -244,7 +231,7 @@ Excellent, we have not provided any OAuth2 token in the request, so we should no
 
 == Configuring the {extension-name} Extension Security Information
 
-In the <<Configuration>> section we introduce the configuration properties that affect the {extension-name} extension.
+include::{generated-dir}/config/quarkus-elytron-security-oauth2.adoc[opts=optional, leveloffset=+1]
 
 === Setting up application.properties
 

--- a/docs/src/main/asciidoc/oidc-guide.adoc
+++ b/docs/src/main/asciidoc/oidc-guide.adoc
@@ -141,6 +141,10 @@ The OpenID Connect extension allows you to define the adapter configuration usin
 
 === Configuring using the application.properties file
 
+include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional, leveloffset=+1]
+
+Example configuration:
+
 [source,properties]
 ----
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -260,9 +260,8 @@ for JAX-RS or `JsonWebToken` for JWT.
 
 There are two configuration settings that alter the RBAC behavior:
 
-- `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints will be
-denied by default. That is if the security annotations do not define the access control.
-Defaults to `false`
+- `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints by default.
+That is if the security annotations do not define the access control. Defaults to `false`
 - `quarkus.security.deny-unannotated=true|false` - if set to true, the access will be denied to all CDI methods
 and JAX-RS endpoints that do not have security annotations but are defined in classes that contain methods with
 security annotations. Defaults to `false`.

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -260,9 +260,9 @@ for JAX-RS or `JsonWebToken` for JWT.
 
 There are two configuration settings that alter the RBAC behavior:
 
-- `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints by default.
+- `quarkus.security.jaxrs.deny-unannotated-endpoints=true|false` - if set to true, the access will be denied for all JAX-RS endpoints by default.
 That is if the security annotations do not define the access control. Defaults to `false`
-- `quarkus.security.deny-unannotated=true|false` - if set to true, the access will be denied to all CDI methods
+- `quarkus.security.deny-unannotated-members=true|false` - if set to true, the access will be denied to all CDI methods
 and JAX-RS endpoints that do not have security annotations but are defined in classes that contain methods with
 security annotations. Defaults to `false`.
 

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -133,6 +133,9 @@ public class SubjectExposingResource {
 Quarkus has an integrated plugable web security layer. If security is enabled all HTTP requests will have a permission
 check performed to make sure they are permitted to continue.
 
+NOTE: Configuration authorization checks are executed before any annotation-based authorization check is done, so both
+checks have to pass for a request to be allowed.
+
 The default implementation allows you to define permissions using config in `application.properties`. An example
 config is shown below:
 

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -163,8 +163,6 @@ which permit all, deny all and only allow authenticated users respectively.
 It is also possible to define role based policies, as shown in the example. These policies will only allow users with the
 specified roles to access the resources.
 
-Policies are pluggable so it is possible for other Quarkus extensions to provide additional policies.
-
 ### Matching on paths, methods
 
 Permission sets can also specify paths and methods as a comma separated list. If a path ends with '*' then it is considered

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -7,7 +7,9 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-Quarkus comes with build in security to allow for RBAC (role based access control)
+## Securing REST endpoints
+
+Quarkus comes with build in security to allow for Role-Based Access Control (link:https://en.wikipedia.org/wiki/Role-based_access_control[RBAC])
 based on the common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints and CDI beans.
 An example of an endpoint that makes use of both JAX-RS and Common Security annotations to describe and secure its endpoints is given in <<subject-example>>. Quarkus also provides
 the `io.quarkus.security.Authenticated` annotation that will permit any authenticated user to access the resource
@@ -168,25 +170,88 @@ specified roles to access the resources.
 
 Policies are pluggable so it is possible for other Quarkus extensions to provide additional policies.
 
+### Matching on paths, methods
+
 Permission sets can also specify paths and methods as a comma separated list. If a path ends with '*' then it is considered
-to be a wildcard match and will match all sub paths, otherwise it is an exact match and will only match that specific path.
+to be a wildcard match and will match all sub paths, otherwise it is an exact match and will only match that specific path:
+
+[source,properties]
+--
+quarkus.http.auth.permission.permit1.paths=/public/*,/css/*,/js/*,/robots.txt
+quarkus.http.auth.permission.permit1.policy=permit
+quarkus.http.auth.permission.permit1.methods=GET,HEAD
+--
+
+### Matching path but not method
 
 If a request would match one or more permission sets based on the path, but does not match any due to method requirements
 then the request is rejected.
 
+TIP: Given the above permission set, `GET /public/foo` would match both the path and method and thus be allowed,
+whereas `POST /public/foo` would match the path but not the method and would thus be rejected.
+
+### Matching multiple paths: longest wins
+
 Matching is always done on a longest path basis, less specific permission sets are not considered if a more specific one
-has been matched.
+has been matched:
+
+[source,properties]
+--
+quarkus.http.auth.permission.permit1.paths=/public/*
+quarkus.http.auth.permission.permit1.policy=permit
+quarkus.http.auth.permission.permit1.methods=GET,HEAD
+
+quarkus.http.auth.permission.deny1.paths=/public/forbidden-folder/*
+quarkus.http.auth.permission.deny1.policy=deny
+--
+
+TIP: Given the above permission set, `GET /public/forbidden-folder/foo` would match both permission sets' paths,
+but because it matches the `deny1` permission set's path on a longer match, `deny1` will be chosen and the request will
+be rejected.
+
+### Matching multiple paths: most specific method wins
 
 If a path is registered with multiple permission sets then any permission sets that specify a HTTP method will take
 precedence and permissions sets without a method will not be considered (assuming of course the method matches). In this
-instance permission sets will only come into effect if the request method does not match any of the sets with method permissions.
-If a request would have matched based on path, but does not match any permission sets because of method requirements
-then this request is rejected.
+instance, the permission sets without methods will only come into effect if the request method does not match any of the
+sets with method permissions.
+
+[source,properties]
+--
+quarkus.http.auth.permission.permit1.paths=/public/*
+quarkus.http.auth.permission.permit1.policy=permit
+quarkus.http.auth.permission.permit1.methods=GET,HEAD
+
+quarkus.http.auth.permission.deny1.paths=/public/*
+quarkus.http.auth.permission.deny1.policy=deny
+--
+
+TIP: Given the above permission set, `GET /public/foo` would match both permission sets' paths,
+but because it matches the `permit1` permission set's explicit method, `permit1` will be chosen and the request will
+be accepted. `PUT /public/foo` on the other hand, will not match the method permissions of `permit1` and so
+`deny1` will be activated and reject the request.
+
+### Matching multiple paths and methods: both win
 
 If multiple permission sets specify the same path and method (or multiple have no method) then both permissions have to
 allow access for the request to proceed. Note that for this to happen both have to either have specified the method, or
-have no method, method specific matches take precedence as stated above.
+have no method, method specific matches take precedence as stated above:
 
+[source,properties]
+--
+
+quarkus.http.auth.policy.user-policy1.roles-allowed=user
+quarkus.http.auth.policy.admin-policy1.roles-allowed=admin
+
+quarkus.http.auth.permission.roles1.paths=/api/*,/restricted/*
+quarkus.http.auth.permission.roles1.policy=user-policy1
+
+quarkus.http.auth.permission.roles2.paths=/api/*,/admin/*
+quarkus.http.auth.permission.roles2.policy=admin-policy1
+--
+
+TIP: Given the above permission set, `GET /api/foo` would match both permission sets' paths,
+so would require both the `user` and `admin` roles.
 
 ### Registering Security Providers
 When running in native mode the default behavior for Graal native image generation is to only include the main "SUN" provider

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -66,6 +66,8 @@ public class SubjectExposingResource {
 <4> This call to obtain the user principal will return null if the caller is unauthenticated, non-null if the caller is authenticated.
 <5> The `/subject/denied` endpoint disallows any access regardless of whether the call is authenticated by specifying the `@DenyAll` annotation.
 
+## Configuration
+
 There are two configuration settings that alter the RBAC behavior:
 
 - `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints will be

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -249,6 +249,13 @@ quarkus.http.auth.permission.roles2.policy=admin-policy1
 TIP: Given the above permission set, `GET /api/foo` would match both permission sets' paths,
 so would require both the `user` and `admin` roles.
 
+## Authenticated representation
+
+For every authenticated resource, you can inject an `SecurityIdentity` instance to get the authenticated identity information.
+
+In some other contexts you may have other parallel representations of the same information (or parts of it) such as `SecurityContext`
+for JAX-RS or `JsonWebToken` for JWT.
+
 ## Configuration
 
 There are two configuration settings that alter the RBAC behavior:

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -88,6 +88,9 @@ very much a work in progress, so this list will be expanded over the coming week
 |link:elytron-properties-guide.html[quarkus-elytron-security-properties-file]
 |Provides support for simples properties files that can be used for testing security. This supports both embedding user info in `application.properties` and standalone properties files.
 
+|link:security-jdbc-guide.html[quarkus-elytron-security-jdbc]
+|Provides support for authenticating via JDBC.
+
 |link:oauth2-guide.html[quarkus-elytron-security-oauth2]
 |Provides support for OAuth2 flows using Elytron. This extension will likely be deprecated soon and replaced by a reactive Vert.x version.
 

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -7,7 +7,68 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-## Securing REST endpoints
+Quarkus security allows you to define security authorization requirements for your code using annotations and/or configuration, and provides
+several ways to load security authentication information using Quarkus extensions.
+
+## Authentication sources
+
+Quarkus supports several sources to load authentication information from. You need to import at least one of the following extensions
+in order for Quarkus to know how to find the authentication information to check for authorizations:
+
+.Security Extensions
+|===
+|Extension |Description
+
+|link:elytron-properties-guide.html[quarkus-elytron-security-properties-file]
+|Provides support for simples properties files that can be used for testing security. This supports both embedding user info in `application.properties` and standalone properties files.
+
+|link:security-jdbc-guide.html[quarkus-elytron-security-jdbc]
+|Provides support for authenticating via JDBC.
+
+|link:oauth2-guide.html[quarkus-elytron-security-oauth2]
+|Provides support for OAuth2 flows using Elytron. This extension will likely be deprecated soon and replaced by a reactive Vert.x version.
+
+|link:jwt-guide.html[quarkus-smallrye-jwt]
+|A Microprofile JWT implementation that provides support for authenticating using Json Web Tokens. This also allows you to inject the token and claims into the application as per the MP JWT spec.
+
+|link:oidc-guide.html[quarkus-oidc]
+|Provides support for authenticating via an OpenID Connect provider such as Keycloak.
+
+|link:keycloak-authorization-guide.html[quarkus-keycloak-authorization]
+|Provides support for a policy enforcer using Keycloak Authorization Services.
+
+|===
+
+Please see the linked documents above for details on how to setup the various extensions.
+
+## Authenticating via HTTP
+
+Quarkus has two built in authentication mechanisms for HTTP based FORM and BASIC auth. This mechanism is pluggable
+however so extensions can add additional mechanisms (most notably OpenID Connect for Keycloak based auth).
+
+### Basic Authentication
+
+To enable basic authentication set `quarkus.http.auth.basic=true`. You must also have at least one extension installed
+that provides a username/password based `IdentityProvider`, such as link:security-jdbc-guide.html[Elytron JDBC].
+
+### Form Based Authentication
+
+Quarkus provides form based authentication that works in a similar manner to traditional Servlet form based auth. Unlike
+traditional form authentication the authenticated user is not stored in a HTTP session, as Quarkus does not provide
+clustered HTTP session support. Instead the authentication information is stored in an encrypted cookie, which can
+be read by all members of the cluster (provided they all share the same encryption key).
+
+The encryption key can be set using the `quarkus.http.auth.session.encryption-key` property, and it must be at least 16 characters
+long. This key is hashed using SHA-256 and the resulting digest is used as a key for AES-256 encryption of the cookie
+value. This cookie contains a expiry time as part of the encrypted value, so all nodes in the cluster must have their
+clocks synchronised. At one minute intervals a new cookie will be generated with an updated expiry time if the session
+is in use.
+
+The following properties can be used to configure form based auth:
+
+include::{generated-dir}/config/quarkus-http-auth-form.adoc[opts=optional, leveloffset=+1]
+
+## Authorization in REST endpoints and CDI beans using annotations
 
 Quarkus comes with build in security to allow for Role-Based Access Control (link:https://en.wikipedia.org/wiki/Role-based_access_control[RBAC])
 based on the common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints and CDI beans.
@@ -66,79 +127,8 @@ public class SubjectExposingResource {
 <4> This call to obtain the user principal will return null if the caller is unauthenticated, non-null if the caller is authenticated.
 <5> The `/subject/denied` endpoint disallows any access regardless of whether the call is authenticated by specifying the `@DenyAll` annotation.
 
-## Configuration
 
-There are two configuration settings that alter the RBAC behavior:
-
-- `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints will be
-denied by default. That is if the security annotations security annotations do not define the access control.
-Defaults to `false`
-- `quarkus.security.deny-unannotated=true|false` - if set to true, the access will be denied to all CDI methods
-and JAX-RS endpoints that do not have security annotations but are defined in classes that contain methods with
-security annotations. Defaults to `false`.
-
-## Security implementations
-
-Quarkus comes with several different Security extensions that provide different functionality. This functionality is
-very much a work in progress, so this list will be expanded over the coming weeks.
-
-
-.Security Extensions
-|===
-|Extension |Description
-
-|link:elytron-properties-guide.html[quarkus-elytron-security-properties-file]
-|Provides support for simples properties files that can be used for testing security. This supports both embedding user info in `application.properties` and standalone properties files.
-
-|link:security-jdbc-guide.html[quarkus-elytron-security-jdbc]
-|Provides support for authenticating via JDBC.
-
-|link:oauth2-guide.html[quarkus-elytron-security-oauth2]
-|Provides support for OAuth2 flows using Elytron. This extension will likely be deprecated soon and replaced by a reactive Vert.x version.
-
-|link:jwt-guide.html[quarkus-smallrye-jwt]
-|A Microprofile JWT implementation that provides support for authenticating using Json Web Tokens. This also allows you to inject the token and claims into the application as per the MP JWT spec.
-
-|link:oidc-guide.html[quarkus-oidc]
-|Provides support for authenticating via an OpenID Connect provider such as Keycloak.
-
-|link:keycloak-authorization-guide.html[quarkus-keycloak-authorization]
-|Provides support for a policy enforcer using Keycloak Authorization Services.
-
-
-|===
-
-Please see the linked documents above for details on how to setup the various extensions.
-
-### Authenticating Via HTTP
-
-Quarkus has two built in authentication mechanisms for HTTP based FORM and BASIC auth. This mechanism is pluggable
-however so extensions can add additional mechanisms (most notably OpenID Connect for Keycloak based auth).
-
-#### Basic Authentication
-
-To enable basic authentication set `quarkus.http.auth.basic=true`. You must also have at least one extension installed
-that provides a username/password based `IdentityProvider`, such as link:security-jdbc-guide.html[Elytron JDBC].
-
-#### Form Based Authentication
-
-Quarkus provides form based authentication that works in a similar manner to traditional Servlet form based auth. Unlike
-traditional form authentication the authenticated user is not stored in a HTTP session, as Quarkus does not provide
-clustered HTTP session support. Instead the authentication information is stored in an encrypted cookie, which can
-be read by all members of the cluster (provided they all share the same encryption key).
-
-The encryption key can be set using the `quarkus.http.auth.session.encryption-key` property, and it must be at least 16 characters
-long. This key is hashed using SHA-256 and the resulting digest is used as a key for AES-256 encryption of the cookie
-value. This cookie contains a expiry time as part of the encrypted value, so all nodes in the cluster must have their
-clocks synchronised. At one minute intervals a new cookie will be generated with an updated expiry time if the session
-is in use.
-
-The following properties can be used to configure form based auth:
-
-include::{generated-dir}/config/quarkus-http-auth-form.adoc[opts=optional, leveloffset=+1]
-
-
-### Securing Web Endpoints
+## Authorization of Web Endpoints using configuration
 
 Quarkus has an integrated plugable web security layer. If security is enabled all HTTP requests will have a permission
 check performed to make sure they are permitted to continue.
@@ -258,7 +248,19 @@ quarkus.http.auth.permission.roles2.policy=admin-policy1
 TIP: Given the above permission set, `GET /api/foo` would match both permission sets' paths,
 so would require both the `user` and `admin` roles.
 
+## Configuration
+
+There are two configuration settings that alter the RBAC behavior:
+
+- `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints will be
+denied by default. That is if the security annotations security annotations do not define the access control.
+Defaults to `false`
+- `quarkus.security.deny-unannotated=true|false` - if set to true, the access will be denied to all CDI methods
+and JAX-RS endpoints that do not have security annotations but are defined in classes that contain methods with
+security annotations. Defaults to `false`.
+
 ### Registering Security Providers
+
 When running in native mode the default behavior for Graal native image generation is to only include the main "SUN" provider
 unless you have enabled SSL, in which case all security providers are registered. If you are not using SSL, then you can selectively
 register security providers by name using the `quarkus.security.users.security-providers` property. The following example illustrates

--- a/docs/src/main/asciidoc/security-guide.adoc
+++ b/docs/src/main/asciidoc/security-guide.adoc
@@ -20,7 +20,7 @@ in order for Quarkus to know how to find the authentication information to check
 |Extension |Description
 
 |link:elytron-properties-guide.html[quarkus-elytron-security-properties-file]
-|Provides support for simples properties files that can be used for testing security. This supports both embedding user info in `application.properties` and standalone properties files.
+|Provides support for simple properties files that can be used for testing security. This supports both embedding user info in `application.properties` and standalone properties files.
 
 |link:security-jdbc-guide.html[quarkus-elytron-security-jdbc]
 |Provides support for authenticating via JDBC.
@@ -70,7 +70,7 @@ include::{generated-dir}/config/quarkus-http-auth-form.adoc[opts=optional, level
 
 ## Authorization in REST endpoints and CDI beans using annotations
 
-Quarkus comes with build in security to allow for Role-Based Access Control (link:https://en.wikipedia.org/wiki/Role-based_access_control[RBAC])
+Quarkus comes with built-in security to allow for Role-Based Access Control (link:https://en.wikipedia.org/wiki/Role-based_access_control[RBAC])
 based on the common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints and CDI beans.
 An example of an endpoint that makes use of both JAX-RS and Common Security annotations to describe and secure its endpoints is given in <<subject-example>>. Quarkus also provides
 the `io.quarkus.security.Authenticated` annotation that will permit any authenticated user to access the resource
@@ -251,7 +251,7 @@ so would require both the `user` and `admin` roles.
 
 ## Authenticated representation
 
-For every authenticated resource, you can inject an `SecurityIdentity` instance to get the authenticated identity information.
+For every authenticated resource, you can inject a `SecurityIdentity` instance to get the authenticated identity information.
 
 In some other contexts you may have other parallel representations of the same information (or parts of it) such as `SecurityContext`
 for JAX-RS or `JsonWebToken` for JWT.
@@ -261,7 +261,7 @@ for JAX-RS or `JsonWebToken` for JWT.
 There are two configuration settings that alter the RBAC behavior:
 
 - `quarkus.jaxrs.deny-uncovered=true|false` - if set to true, the access will be denied for all JAX-RS endpoints will be
-denied by default. That is if the security annotations security annotations do not define the access control.
+denied by default. That is if the security annotations do not define the access control.
 Defaults to `false`
 - `quarkus.security.deny-unannotated=true|false` - if set to true, the access will be denied to all CDI methods
 and JAX-RS endpoints that do not have security annotations but are defined in classes that contain methods with

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Config.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Config.java
@@ -12,38 +12,40 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = "oauth2", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class OAuth2Config {
     /**
-     * If the OAuth2 extension is enabled.
+     * Determine if the OAuth2 extension is enabled. Enabled by default if you include the
+     * <code>elytron-security-oauth2</code> dependency, so this would be used to disable it.
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;
 
     /**
-     * The identifier of the client on the OAuth2 Authorization Server
+     * The OAuth2 client id used to validate the token.
      */
     @ConfigItem
     public String clientId;
 
     /**
-     * The secret of the client
+     * The OAuth2 client secret used to validate the token.
      */
     @ConfigItem
     public String clientSecret;
 
     /**
-     * The URL of token introspection endpoint
+     * The OAuth2 introspection endpoint URL used to validate the token and gather the authentication claims.
      */
     @ConfigItem
     public String introspectionUrl;
 
     /**
-     * The path to a custom cert file
-     * This is not supported in native mode
+     * The OAuth2 server certificate file. <em>Warning</em>: this is not supported in native mode where the certificate
+     * must be included in the truststore used during the native image generation, see
+     * <a href="native-and-ssl-guide.html">Using SSL With Native Executables</a>.
      */
     @ConfigItem
     public Optional<String> caCertFile;
 
     /**
-     * The claim that provides the roles
+     * The claim that is used in the introspection endpoint response to load the roles.
      */
     @ConfigItem(defaultValue = "scope")
     public String roleClaim;

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/MPRealmConfig.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/MPRealmConfig.java
@@ -13,7 +13,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class MPRealmConfig {
 
     /**
-     * The authentication mechanism
+     * The realm name. This is used when generating a hashed password
      */
     @ConfigItem(defaultValue = "Quarkus")
     public String realmName;
@@ -25,17 +25,23 @@ public class MPRealmConfig {
     @ConfigItem
     public boolean plainText;
     /**
-     * If the embedded store is enabled.
+     * Determine whether security via the embedded realm is enabled.
      */
     @ConfigItem
     public boolean enabled;
 
-    /** The realm users user1=password\nuser2=password2... mapping */
-    @ConfigItem
+    /**
+     * The realm users user1=password\nuser2=password2... mapping.
+     * See <a href="#embedded-users">Embedded Users</a>.
+     */
+    @ConfigItem(defaultValueDocumentation = "none")
     public Map<String, String> users;
 
-    /** The realm roles user1=role1,role2,...\nuser2=role1,role2,... mapping */
-    @ConfigItem
+    /**
+     * The realm roles user1=role1,role2,...\nuser2=role1,role2,... mapping
+     * See <a href="#embedded-roles">Embedded Roles</a>.
+     */
+    @ConfigItem(defaultValueDocumentation = "none")
     public Map<String, String> roles;
 
     public String getRealmName() {

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/PropertiesRealmConfig.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/PropertiesRealmConfig.java
@@ -24,7 +24,7 @@ public class PropertiesRealmConfig {
     public String realmName;
 
     /**
-     * If the properties store is enabled.
+     * Determine whether security via the file realm is enabled.
      */
     @ConfigItem
     public boolean enabled;
@@ -37,13 +37,15 @@ public class PropertiesRealmConfig {
     public boolean plainText;
 
     /**
-     * The location of the users property resource
+     * Classpath resource name of properties file containing user to password mappings. See
+     * <a href="#users-properties">Users.properties</a>.
      */
     @ConfigItem(defaultValue = "users.properties")
     public String users;
 
     /**
-     * The location of the roles property file
+     * Classpath resource name of properties file containing user to role mappings. See
+     * <a href="#roles-properties">Roles.properties</a>.
      */
     @ConfigItem(defaultValue = "roles.properties")
     public String roles;

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/SecurityUsersConfig.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/SecurityUsersConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.elytron.security.runtime;
 
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -10,14 +11,16 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = "security.users", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public final class SecurityUsersConfig {
     /**
-     * The configuration for the {@linkplain org.wildfly.security.auth.realm.LegacyPropertiesSecurityRealm}
+     * Property Files Realm Configuration
      */
     @ConfigItem
+    @ConfigDocSection
     public PropertiesRealmConfig file;
     /**
-     * The configuration for the {@linkplain org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm}
+     * Embedded Realm Configuration
      */
     @ConfigItem
+    @ConfigDocSection
     public MPRealmConfig embedded;
 
 }

--- a/extensions/resteasy/deployment/src/test/resources/application-deny-jaxrs.properties
+++ b/extensions/resteasy/deployment/src/test/resources/application-deny-jaxrs.properties
@@ -1,1 +1,1 @@
-quarkus.jaxrs.deny-uncovered = true
+quarkus.security.jaxrs.deny-unannotated-endpoints = true

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/JaxRsSecurityConfig.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/JaxRsSecurityConfig.java
@@ -7,11 +7,11 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
-@ConfigRoot(name = "jaxrs", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(name = "security.jaxrs", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class JaxRsSecurityConfig {
     /**
      * if set to true, access to all JAX-RS resources will be denied by default
      */
-    @ConfigItem(name = "deny-uncovered", defaultValue = "false")
+    @ConfigItem(name = "deny-unannotated-endpoints", defaultValue = "false")
     public boolean denyJaxRs;
 }

--- a/extensions/security/deployment/src/test/resources/application-deny-unannotated.properties
+++ b/extensions/security/deployment/src/test/resources/application-deny-unannotated.properties
@@ -1,1 +1,1 @@
-quarkus.security.deny-unannotated = true
+quarkus.security.deny-unannotated-members = true

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityBuildTimeConfig.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityBuildTimeConfig.java
@@ -10,8 +10,9 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = "security", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class SecurityBuildTimeConfig {
     /**
-     * if set to true, access to all methods of beans that have any security annotations will be denied by default.
-     * E.g. if enabled, <code>methodB</code> in the following bean, will be denied.
+     * If set to true, access to all methods of beans that have any security annotations on other members will be denied by
+     * default.
+     * E.g. if enabled, in the following bean, <code>methodB</code> will be denied.
      * 
      * <pre>
      *   {@literal @}ApplicationScoped
@@ -26,7 +27,7 @@ public class SecurityBuildTimeConfig {
      *   }
      * </pre>
      */
-    @ConfigItem(name = "deny-unannotated", defaultValue = "false")
+    @ConfigItem(name = "deny-unannotated-members", defaultValue = "false")
     public boolean denyUnannotated;
 
 }


### PR DESCRIPTION
@stuartwdouglas let's do the discussion about security here then.

First, here are some doc tweaks.

Now, questions:

- Why is the security-jdbc extension not listed in the main security guide along with the other extensions: https://quarkus.io/guides/security-guide#security-implementations ?
- On the main security guide: https://quarkus.io/guides/security-guide#securing-web-endpoints presents a way to secure by path, but doesn't say how it compares to and combines with the annotation-based way?
- "Policies are pluggable so it is possible for other Quarkus extensions to provide additional policies" on the main security guide. OK, but how? Link to the extension author guide's relevant section? Or example?
- I've added examples to the rules for matching paths and methods, but while the first rule says that longer paths match first, other rules then go on to say that more specific methods match first, and I'm not sure how the two rules combine.
- Some guides use `SecurityContext` to get the identity (main guide, OAuth, JWT), OIDC uses `SecurityIdentity` and JWT uses `JsonWebToken`. I guess I understand why JWT is special, but why does OIDC have its own class and does not mention `SecurityContext`?