### PR TITLE
Upgrade to jackson-databind 2.9.10.1 to fix CVE

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -68,7 +68,7 @@
            is not available in Maven fast enough: -->
         <graal-sdk.version>19.2.0.1</graal-sdk.version>
         <gizmo.version>1.0.0.Alpha8</gizmo.version>
-        <jackson.version>2.9.10</jackson.version>
+        <jackson.version>2.9.10.20191020</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
         <commons-codec.version>1.11</commons-codec.version>


### PR DESCRIPTION
This upgrade will fix these new CVE-2019-16942, CVE-2019-16943, CVE-2019-17531

Unfortunatly, this version in not in the Jackson BOM 2.9.10 and there is no patch version of BOM so we have to add an explicit dependency management to it