### PR TITLE
Move to use metadata section in extensions manifest

### DIFF
--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,6 +1,8 @@
-
 {
-    "name": "Quarkus - Core",
-    "labels": [
+  "name": "Quarkus - Core",
+  "metadata": {
+    "keywords": [
+      
     ]
+  }
 }

--- a/extensions/agroal/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/agroal/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Agroal - Database connection pool",
-    "labels": [
-        "agroal",
-        "database-connection-pool"
+  "name": "Agroal - Database connection pool",
+  "metadata": {
+    "keywords": [
+      "agroal",
+      "database-connection-pool"
     ]
+  }
 }

--- a/extensions/amazon-dynamodb/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/amazon-dynamodb/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "Amazon DynamoDB client",
-    "labels": [
-        "dynamodb",
-        "dynamo",
-        "aws",
-        "amazon"
+  "name": "Amazon DynamoDB client",
+  "metadata": {
+    "keywords": [
+      "dynamodb",
+      "dynamo",
+      "aws",
+      "amazon"
     ]
+  }
 }

--- a/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "AWS Lambda",
-    "labels": [
-        "lambda",
-        "aws",
-        "amazon"
+  "name": "AWS Lambda",
+  "metadata": {
+    "keywords": [
+      "lambda",
+      "aws",
+      "amazon"
     ]
+  }
 }

--- a/extensions/arc/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/arc/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,12 +1,13 @@
-
 {
-    "name": "ArC",
-    "shortName": "CDI",
-    "labels": [
-        "arc",
-        "cdi",
-        "dependency-injection",
-        "di"
-    ],
-    "guide": "https://quarkus.io/guides/cdi-reference"
+  "name": "ArC",
+  "shortName": "CDI",
+  "guide": "https://quarkus.io/guides/cdi-reference",
+  "metadata": {
+    "keywords": [
+      "arc",
+      "cdi",
+      "dependency-injection",
+      "di"
+    ]
+  }
 }

--- a/extensions/artemis-core/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/artemis-core/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Artemis Core",
-    "labels": [
-        "artemis-core",
-        "artemis"
+  "name": "Artemis Core",
+  "metadata": {
+    "keywords": [
+      "artemis-core",
+      "artemis"
     ]
+  }
 }

--- a/extensions/artemis-jms/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/artemis-jms/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Artemis JMS",
-    "labels": [
-        "artemis-jms",
-        "artemis"
+  "name": "Artemis JMS",
+  "metadata": {
+    "keywords": [
+      "artemis-jms",
+      "artemis"
     ]
+  }
 }

--- a/extensions/elytron-security-jdbc/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/elytron-security-jdbc/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "Elytron Security JDBC Realm",
-    "labels": [
-        "security",
-        "jdbc"
-    ],
-    "guide": "https://quarkus.io/guides/security-jdbc-guide"
+  "name": "Elytron Security JDBC Realm",
+  "guide": "https://quarkus.io/guides/security-jdbc-guide",
+  "metadata": {
+    "keywords": [
+      "security",
+      "jdbc"
+    ]
+  }
 }

--- a/extensions/elytron-security-oauth2/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/elytron-security-oauth2/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Elytron Security OAuth 2.0",
-    "labels": [
-        "security",
-        "oauth2"
+  "name": "Elytron Security OAuth 2.0",
+  "metadata": {
+    "keywords": [
+      "security",
+      "oauth2"
     ]
+  }
 }

--- a/extensions/elytron-security-properties-file/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/elytron-security-properties-file/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Properties File based Security",
-    "labels": [
-        "security"
-    ],
-    "guide": "https://quarkus.io/guides/elytron-properties-guide"
+  "name": "Properties File based Security",
+  "guide": "https://quarkus.io/guides/elytron-properties-guide",
+  "metadata": {
+    "keywords": [
+      "security"
+    ]
+  }
 }

--- a/extensions/flyway/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/flyway/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "Flyway",
-    "labels": [
-        "flyway",
-        "database",
-        "data"
-    ],
-    "guide": "https://quarkus.io/guides/flyway-guide"
+  "name": "Flyway",
+  "guide": "https://quarkus.io/guides/flyway-guide",
+  "metadata": {
+    "keywords": [
+      "flyway",
+      "database",
+      "data"
+    ]
+  }
 }

--- a/extensions/hibernate-orm/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/hibernate-orm/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "Hibernate ORM",
-    "shortName": "JPA",
-    "labels": [
-        "hibernate-orm",
-        "jpa",
-        "hibernate"
-    ],
-    "guide": "https://quarkus.io/guides/hibernate-orm-guide"
+  "name": "Hibernate ORM",
+  "shortName": "JPA",
+  "guide": "https://quarkus.io/guides/hibernate-orm-guide",
+  "metadata": {
+    "keywords": [
+      "hibernate-orm",
+      "jpa",
+      "hibernate"
+    ]
+  }
 }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,12 +1,13 @@
-
 {
-    "name": "Hibernate Search + Elasticsearch",
-    "labels": [
-        "hibernate-search-elasticsearch",
-        "search",
-        "full-text",
-        "hibernate",
-        "elasticsearch"
-    ],
-    "guide": "https://quarkus.io/guides/hibernate-search-guide"
+  "name": "Hibernate Search + Elasticsearch",
+  "guide": "https://quarkus.io/guides/hibernate-search-guide",
+  "metadata": {
+    "keywords": [
+      "hibernate-search-elasticsearch",
+      "search",
+      "full-text",
+      "hibernate",
+      "elasticsearch"
+    ]
+  }
 }

--- a/extensions/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "Hibernate Validator",
-    "shortName": "bean validation",
-    "labels": [
-        "hibernate-validator",
-        "bean-validation",
-        "validation"
-    ],
-    "guide": "https://quarkus.io/guides/validation-guide"
+  "name": "Hibernate Validator",
+  "shortName": "bean validation",
+  "guide": "https://quarkus.io/guides/validation-guide",
+  "metadata": {
+    "keywords": [
+      "hibernate-validator",
+      "bean-validation",
+      "validation"
+    ]
+  }
 }

--- a/extensions/infinispan-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/infinispan-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "Infinispan Client",
-    "labels": [
-        "infinispan-client",
-        "data-grid-client",
-        "infinispan"
-    ],
-    "guide": "https://quarkus.io/guides/infinispan-client-guide"
+  "name": "Infinispan Client",
+  "guide": "https://quarkus.io/guides/infinispan-client-guide",
+  "metadata": {
+    "keywords": [
+      "infinispan-client",
+      "data-grid-client",
+      "infinispan"
+    ]
+  }
 }

--- a/extensions/infinispan-embedded/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/infinispan-embedded/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "Infinispan Embedded",
-    "labels": [
-        "infinispan"
+  "name": "Infinispan Embedded",
+  "metadata": {
+    "keywords": [
+      "infinispan"
     ]
+  }
 }

--- a/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Jackson",
-    "labels": [
-        "jackson",
-        "json"
+  "name": "Jackson",
+  "metadata": {
+    "keywords": [
+      "jackson",
+      "json"
     ]
+  }
 }

--- a/extensions/jaeger/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jaeger/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "Security",
-    "labels": [
-        "security"
+  "name": "Security",
+  "metadata": {
+    "keywords": [
+      "security"
     ]
+  }
 }

--- a/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-h2/jdbc-h2-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "JDBC Driver - H2",
-    "labels": [
-        "jdbc-h2",
-        "jdbc",
-        "h2"
+  "name": "JDBC Driver - H2",
+  "metadata": {
+    "keywords": [
+      "jdbc-h2",
+      "jdbc",
+      "h2"
     ]
+  }
 }

--- a/extensions/jdbc/jdbc-mariadb/jdbc-mariadb-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-mariadb/jdbc-mariadb-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "JDBC Driver - MariaDB",
-    "labels": [
-        "jdbc-mariadb",
-        "jdbc",
-        "mariadb"
+  "name": "JDBC Driver - MariaDB",
+  "metadata": {
+    "keywords": [
+      "jdbc-mariadb",
+      "jdbc",
+      "mariadb"
     ]
+  }
 }

--- a/extensions/jdbc/jdbc-mssql/jdbc-mssql-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-mssql/jdbc-mssql-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "JDBC Driver - Microsoft SQL Server",
-    "labels": [
-        "jdbc-mssql",
-        "jdbc",
-        "mssql",
-        "sql-server"
+  "name": "JDBC Driver - Microsoft SQL Server",
+  "metadata": {
+    "keywords": [
+      "jdbc-mssql",
+      "jdbc",
+      "mssql",
+      "sql-server"
     ]
+  }
 }

--- a/extensions/jdbc/jdbc-mysql/jdbc-mysql-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-mysql/jdbc-mysql-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "JDBC Driver - MySQL",
-    "labels": [
-        "jdbc-mysql",
-        "jdbc",
-        "mysql"
+  "name": "JDBC Driver - MySQL",
+  "metadata": {
+    "keywords": [
+      "jdbc-mysql",
+      "jdbc",
+      "mysql"
     ]
+  }
 }

--- a/extensions/jdbc/jdbc-postgresql/jdbc-postgresql-runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jdbc/jdbc-postgresql/jdbc-postgresql-runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "JDBC Driver - PostgreSQL",
-    "labels": [
-        "jdbc-postgresql",
-        "jdbc",
-        "postgresql"
+  "name": "JDBC Driver - PostgreSQL",
+  "metadata": {
+    "keywords": [
+      "jdbc-postgresql",
+      "jdbc",
+      "postgresql"
     ]
+  }
 }

--- a/extensions/jgit/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jgit/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "JGit",
-    "labels": [
-        "git"
+  "name": "JGit",
+  "metadata": {
+    "keywords": [
+      "git"
     ]
+  }
 }

--- a/extensions/jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "JSON-B",
-    "labels": [
-        "jsonb",
-        "json-b",
-        "json"
-    ],
-    "guide": "https://quarkus.io/guides/rest-json-guide"
+  "name": "JSON-B",
+  "guide": "https://quarkus.io/guides/rest-json-guide",
+  "metadata": {
+    "keywords": [
+      "jsonb",
+      "json-b",
+      "json"
+    ]
+  }
 }

--- a/extensions/jsonp/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/jsonp/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "JSON-P",
-    "labels": [
-        "jsonp",
-        "json-p",
-        "json"
+  "name": "JSON-P",
+  "metadata": {
+    "keywords": [
+      "jsonp",
+      "json-p",
+      "json"
     ]
+  }
 }

--- a/extensions/kafka-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kafka-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "Apache Kafka Client",
-    "labels": [
-        "kafka"
+  "name": "Apache Kafka Client",
+  "metadata": {
+    "keywords": [
+      "kafka"
     ]
+  }
 }

--- a/extensions/kafka-streams/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kafka-streams/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Apache Kafka Streams",
-    "labels": [
-        "kafka",
-        "kafka-streams"
+  "name": "Apache Kafka Streams",
+  "metadata": {
+    "keywords": [
+      "kafka",
+      "kafka-streams"
     ]
+  }
 }

--- a/extensions/kogito/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kogito/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "Kogito",
-    "labels": [
-        "kogito",
-        "drools",
-        "jbpm"
-    ],
-    "guide": "https://quarkus.io/guides/kogito-guide"
+  "name": "Kogito",
+  "guide": "https://quarkus.io/guides/kogito-guide",
+  "metadata": {
+    "keywords": [
+      "kogito",
+      "drools",
+      "jbpm"
+    ]
+  }
 }

--- a/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Kotlin",
-    "labels": [
-        "kotlin"
-    ],
-    "guide": "https://quarkus.io/guides/kotlin"
+  "name": "Kotlin",
+  "guide": "https://quarkus.io/guides/kotlin",
+  "metadata": {
+    "keywords": [
+      "kotlin"
+    ]
+  }
 }

--- a/extensions/kubernetes-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kubernetes-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "Kubernetes Client",
-    "labels": [
-        "kubernetes-client"
+  "name": "Kubernetes Client",
+  "metadata": {
+    "keywords": [
+      "kubernetes-client"
     ]
+  }
 }

--- a/extensions/kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/kubernetes/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Kubernetes",
-    "labels": [
-        "kubernetes"
-    ],
-    "guide": "https://quarkus.io/guides/kubernetes-guide"
+  "name": "Kubernetes",
+  "guide": "https://quarkus.io/guides/kubernetes-guide",
+  "metadata": {
+    "keywords": [
+      "kubernetes"
+    ]
+  }
 }

--- a/extensions/mailer/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/mailer/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "Mailer",
-    "labels": [
-        "mail",
-        "mailer"
-    ],
-    "guide": "https://quarkus.io/guides/sending-emails"
+  "name": "Mailer",
+  "guide": "https://quarkus.io/guides/sending-emails",
+  "metadata": {
+    "keywords": [
+      "mail",
+      "mailer"
+    ]
+  }
 }

--- a/extensions/mongodb-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/mongodb-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "MongoDB client",
-    "labels": [
-        "mongo",
-        "mongodb",
-        "nosql",
-        "datastore"
+  "name": "MongoDB client",
+  "metadata": {
+    "keywords": [
+      "mongo",
+      "mongodb",
+      "nosql",
+      "datastore"
     ]
+  }
 }

--- a/extensions/narayana-jta/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/narayana-jta/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,14 +1,15 @@
-
 {
-    "name": "Narayana JTA - Transaction manager",
-    "labels": [
-        "narayana-jta",
-        "narayana",
-        "jta",
-        "transactions",
-        "transaction",
-        "tx",
-        "txs"
-    ],
-    "guide": "https://quarkus.io/guides/transaction-guide"
+  "name": "Narayana JTA - Transaction manager",
+  "guide": "https://quarkus.io/guides/transaction-guide",
+  "metadata": {
+    "keywords": [
+      "narayana-jta",
+      "narayana",
+      "jta",
+      "transactions",
+      "transaction",
+      "tx",
+      "txs"
+    ]
+  }
 }

--- a/extensions/narayana-stm/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/narayana-stm/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,15 +1,16 @@
-
 {
-    "name": "Narayana STM - Software Transactional Memory",
-    "labels": [
-        "narayana-stm",
-        "narayana",
-        "stm",
-        "transactions",
-        "transaction",
-        "software-transactional-memory",
-        "tx",
-        "txs"
-    ],
-    "guide": "https://quarkus.io/guides/stm-guide"
+  "name": "Narayana STM - Software Transactional Memory",
+  "guide": "https://quarkus.io/guides/stm-guide",
+  "metadata": {
+    "keywords": [
+      "narayana-stm",
+      "narayana",
+      "stm",
+      "transactions",
+      "transaction",
+      "software-transactional-memory",
+      "tx",
+      "txs"
+    ]
+  }
 }

--- a/extensions/neo4j/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/neo4j/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "Neo4j client",
-    "labels": [
-        "neo4j",
-        "graph",
-        "nosql",
-        "datastore"
+  "name": "Neo4j client",
+  "metadata": {
+    "keywords": [
+      "neo4j",
+      "graph",
+      "nosql",
+      "datastore"
     ]
+  }
 }

--- a/extensions/oidc/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/oidc/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "OpenID Connect",
-    "labels": [
-        "oauth2",
-        "openid-connect"
-    ],
-    "guide": "https://quarkus.io/guides/oidc-guide"
+  "name": "OpenID Connect",
+  "guide": "https://quarkus.io/guides/oidc-guide",
+  "metadata": {
+    "keywords": [
+      "oauth2",
+      "openid-connect"
+    ]
+  }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "Hibernate ORM with Panache",
-    "labels": [
-        "hibernate-orm-panache",
-        "panache",
-        "hibernate",
-        "jpa"
-    ],
-    "guide": "https://quarkus.io/guides/hibernate-orm-panache-guide"
+  "name": "Hibernate ORM with Panache",
+  "guide": "https://quarkus.io/guides/hibernate-orm-panache-guide",
+  "metadata": {
+    "keywords": [
+      "hibernate-orm-panache",
+      "panache",
+      "hibernate",
+      "jpa"
+    ]
+  }
 }

--- a/extensions/panache/mongodb-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/panache/mongodb-panache/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "MongoDB with Panache",
-    "labels": [
-        "mongo",
-        "mongodb",
-        "nosql",
-        "datastore",
-        "panache"
+  "name": "MongoDB with Panache",
+  "metadata": {
+    "keywords": [
+      "mongo",
+      "mongodb",
+      "nosql",
+      "datastore",
+      "panache"
     ]
+  }
 }

--- a/extensions/reactive-mysql-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-mysql-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,13 +1,14 @@
-
 {
-    "name": "Reactive MySQL client",
-    "labels": [
-        "eclipse-vert.x",
-        "vertx",
-        "vert.x",
-        "reactive",
-        "database",
-        "data",
-        "mysql"
+  "name": "Reactive MySQL client",
+  "metadata": {
+    "keywords": [
+      "eclipse-vert.x",
+      "vertx",
+      "vert.x",
+      "reactive",
+      "database",
+      "data",
+      "mysql"
     ]
+  }
 }

--- a/extensions/reactive-pg-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-pg-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,13 +1,14 @@
-
 {
-    "name": "Reactive PostgreSQL client",
-    "labels": [
-        "eclipse-vert.x",
-        "vertx",
-        "vert.x",
-        "reactive",
-        "database",
-        "data",
-        "postgresql"
+  "name": "Reactive PostgreSQL client",
+  "metadata": {
+    "keywords": [
+      "eclipse-vert.x",
+      "vertx",
+      "vert.x",
+      "reactive",
+      "database",
+      "data",
+      "postgresql"
     ]
+  }
 }

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,13 +1,14 @@
-
 {
-    "name": "SmallRye Reactive Streams Operators",
-    "shortName": "reactive streams",
-    "labels": [
-        "smallrye-reactive-streams-operators",
-        "smallrye-reactive-streams",
-        "reactive-streams-operators",
-        "reactive-streams",
-        "microprofile-reactive-streams",
-        "reactive"
+  "name": "SmallRye Reactive Streams Operators",
+  "shortName": "reactive streams",
+  "metadata": {
+    "keywords": [
+      "smallrye-reactive-streams-operators",
+      "smallrye-reactive-streams",
+      "reactive-streams-operators",
+      "reactive-streams",
+      "microprofile-reactive-streams",
+      "reactive"
     ]
+  }
 }

--- a/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/reactive-streams-operators/smallrye-reactive-type-converters/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,12 +1,13 @@
-
 {
-    "name": "SmallRye Reactive Type Converters",
-    "labels": [
-        "smallrye-reactive-type-converters",
-        "reactive-type-converters",
-        "reactive-streams-operators",
-        "reactive-streams",
-        "microprofile-reactive-streams",
-        "reactive"
+  "name": "SmallRye Reactive Type Converters",
+  "metadata": {
+    "keywords": [
+      "smallrye-reactive-type-converters",
+      "reactive-type-converters",
+      "reactive-streams-operators",
+      "reactive-streams",
+      "microprofile-reactive-streams",
+      "reactive"
     ]
+  }
 }

--- a/extensions/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "REST Client",
-    "labels": [
-        "rest-client",
-        "web-client",
-        "microprofile-rest-client"
-    ],
-    "guide": "https://quarkus.io/guides/rest-client-guide"
+  "name": "REST Client",
+  "guide": "https://quarkus.io/guides/rest-client-guide",
+  "metadata": {
+    "keywords": [
+      "rest-client",
+      "web-client",
+      "microprofile-rest-client"
+    ]
+  }
 }

--- a/extensions/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,13 +1,14 @@
-
 {
-    "name": "RESTEasy Jackson",
-    "labels": [
-        "resteasy-jackson",
-        "jaxrs-json",
-        "resteasy-json",
-        "resteasy",
-        "jaxrs",
-        "json",
-        "jackson"
+  "name": "RESTEasy Jackson",
+  "metadata": {
+    "keywords": [
+      "resteasy-jackson",
+      "jaxrs-json",
+      "resteasy-json",
+      "resteasy",
+      "jaxrs",
+      "json",
+      "jackson"
     ]
+  }
 }

--- a/extensions/resteasy-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/resteasy-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,14 +1,15 @@
-
 {
-    "name": "RESTEasy JSON-B",
-    "labels": [
-        "resteasy-jsonb",
-        "jaxrs-json",
-        "resteasy-json",
-        "resteasy",
-        "jaxrs",
-        "json",
-        "jsonb"
-    ],
-    "guide": "https://quarkus.io/guides/rest-json-guide"
+  "name": "RESTEasy JSON-B",
+  "guide": "https://quarkus.io/guides/rest-json-guide",
+  "metadata": {
+    "keywords": [
+      "resteasy-jsonb",
+      "jaxrs-json",
+      "resteasy-json",
+      "resteasy",
+      "jaxrs",
+      "json",
+      "jsonb"
+    ]
+  }
 }

--- a/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,12 +1,13 @@
-
 {
-    "name": "RESTEasy JAX-RS",
-    "shortName": "jax-rs",
-    "labels": [
-        "resteasy",
-        "jaxrs",
-        "web",
-        "rest"
-    ],
-    "guide": "https://quarkus.io/guides/rest-json-guide"
+  "name": "RESTEasy JAX-RS",
+  "shortName": "jax-rs",
+  "guide": "https://quarkus.io/guides/rest-json-guide",
+  "metadata": {
+    "keywords": [
+      "resteasy",
+      "jaxrs",
+      "web",
+      "rest"
+    ]
+  }
 }

--- a/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "Scala",
-    "labels": [
-        "scala"
+  "name": "Scala",
+  "metadata": {
+    "keywords": [
+      "scala"
     ]
+  }
 }

--- a/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "Scheduler - tasks",
-    "labels": [
-        "scheduler",
-        "tasks",
-        "periodic-tasks"
-    ],
-    "guide": "https://quarkus.io/guides/scheduled-guide"
+  "name": "Scheduler - tasks",
+  "guide": "https://quarkus.io/guides/scheduled-guide",
+  "metadata": {
+    "keywords": [
+      "scheduler",
+      "tasks",
+      "periodic-tasks"
+    ]
+  }
 }

--- a/extensions/security/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/security/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,7 +1,8 @@
-
 {
-    "name": "Jaeger",
-    "labels": [
-        "jaeger"
+  "name": "Jaeger",
+  "metadata": {
+    "keywords": [
+      "jaeger"
     ]
+  }
 }

--- a/extensions/smallrye-context-propagation/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-context-propagation/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,12 +1,13 @@
-
 {
-    "name": "SmallRye Context Propagation",
-    "shortName": "context propagation",
-    "labels": [
-        "smallrye-context-propagation",
-        "microprofile-context-propagation",
-        "context-propagation",
-        "context",
-        "reactive"
+  "name": "SmallRye Context Propagation",
+  "shortName": "context propagation",
+  "metadata": {
+    "keywords": [
+      "smallrye-context-propagation",
+      "microprofile-context-propagation",
+      "context-propagation",
+      "context",
+      "reactive"
     ]
+  }
 }

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "SmallRye Fault Tolerance",
-    "labels": [
-        "smallrye-fault-tolerance",
-        "fault-tolerance",
-        "microprofile-fault-tolerance",
-        "circuit-breaker",
-        "bulkhead"
+  "name": "SmallRye Fault Tolerance",
+  "metadata": {
+    "keywords": [
+      "smallrye-fault-tolerance",
+      "fault-tolerance",
+      "microprofile-fault-tolerance",
+      "circuit-breaker",
+      "bulkhead"
     ]
+  }
 }

--- a/extensions/smallrye-health/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-health/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,13 +1,14 @@
-
 {
-    "name": "SmallRye Health",
-    "shortName": "health",
-    "labels": [
-        "smallrye-health",
-        "health-check",
-        "health",
-        "microprofile-health",
-        "microprofile-health-check"
-    ],
-    "guide": "https://quarkus.io/guides/health-guide"
+  "name": "SmallRye Health",
+  "shortName": "health",
+  "guide": "https://quarkus.io/guides/health-guide",
+  "metadata": {
+    "keywords": [
+      "smallrye-health",
+      "health-check",
+      "health",
+      "microprofile-health",
+      "microprofile-health-check"
+    ]
+  }
 }

--- a/extensions/smallrye-jwt/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-jwt/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "SmallRye JWT",
-    "labels": [
-        "smallrye-jwt",
-        "jwt",
-        "json-web-token",
-        "rbac"
-    ],
-    "guide": "https://quarkus.io/guides/jwt-guide"
+  "name": "SmallRye JWT",
+  "guide": "https://quarkus.io/guides/jwt-guide",
+  "metadata": {
+    "keywords": [
+      "smallrye-jwt",
+      "jwt",
+      "json-web-token",
+      "rbac"
+    ]
+  }
 }

--- a/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,13 +1,14 @@
-
 {
-    "name": "SmallRye Metrics",
-    "shortName": "metrics",
-    "labels": [
-        "smallrye-metrics",
-        "metrics",
-        "metric",
-        "prometheus",
-        "monitoring"
-    ],
-    "guide": "https://quarkus.io/guides/metrics-guide"
+  "name": "SmallRye Metrics",
+  "shortName": "metrics",
+  "guide": "https://quarkus.io/guides/metrics-guide",
+  "metadata": {
+    "keywords": [
+      "smallrye-metrics",
+      "metrics",
+      "metric",
+      "prometheus",
+      "monitoring"
+    ]
+  }
 }

--- a/extensions/smallrye-openapi/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-openapi/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "SmallRye OpenAPI",
-    "labels": [
-        "smallrye-openapi",
-        "openapi",
-        "open-api"
-    ],
-    "guide": "https://quarkus.io/guides/openapi-swaggerui-guide"
+  "name": "SmallRye OpenAPI",
+  "guide": "https://quarkus.io/guides/openapi-swaggerui-guide",
+  "metadata": {
+    "keywords": [
+      "smallrye-openapi",
+      "openapi",
+      "open-api"
+    ]
+  }
 }

--- a/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,12 +1,13 @@
-
 {
-    "name": "SmallRye OpenTracing",
-    "labels": [
-        "smallrye-opentracing",
-        "opentracing",
-        "tracing",
-        "distributed-tracing",
-        "jaeger"
-    ],
-    "guide": "https://quarkus.io/guides/opentracing-guide"
+  "name": "SmallRye OpenTracing",
+  "guide": "https://quarkus.io/guides/opentracing-guide",
+  "metadata": {
+    "keywords": [
+      "smallrye-opentracing",
+      "opentracing",
+      "tracing",
+      "distributed-tracing",
+      "jaeger"
+    ]
+  }
 }

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "SmallRye Reactive Messaging - AMQP Connector",
-    "labels": [
-        "amqp",
-        "reactive-amqp"
-    ],
-    "guide": "https://quarkus.io/guides/amqp-guide"
+  "name": "SmallRye Reactive Messaging - AMQP Connector",
+  "guide": "https://quarkus.io/guides/amqp-guide",
+  "metadata": {
+    "keywords": [
+      "amqp",
+      "reactive-amqp"
+    ]
+  }
 }

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "SmallRye Reactive Messaging - Kafka Connector",
-    "shortName": "kafka",
-    "labels": [
-        "kafka",
-        "reactive-kafka"
-    ],
-    "guide": "https://quarkus.io/guides/kafka-guide"
+  "name": "SmallRye Reactive Messaging - Kafka Connector",
+  "shortName": "kafka",
+  "guide": "https://quarkus.io/guides/kafka-guide",
+  "metadata": {
+    "keywords": [
+      "kafka",
+      "reactive-kafka"
+    ]
+  }
 }

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "SmallRye Reactive Messaging - MQTT Connector",
-    "labels": [
-        "mqtt",
-        "reactive-mqtt"
+  "name": "SmallRye Reactive Messaging - MQTT Connector",
+  "metadata": {
+    "keywords": [
+      "mqtt",
+      "reactive-mqtt"
     ]
+  }
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,10 +1,11 @@
-
 {
-    "name": "SmallRye Reactive Messaging",
-    "labels": [
-        "smallrye-reactive-messaging",
-        "reactive-messaging",
-        "reactive"
-    ],
-    "guide": "https://quarkus.io/guides/async-message-passing"
+  "name": "SmallRye Reactive Messaging",
+  "guide": "https://quarkus.io/guides/async-message-passing",
+  "metadata": {
+    "keywords": [
+      "smallrye-reactive-messaging",
+      "reactive-messaging",
+      "reactive"
+    ]
+  }
 }

--- a/extensions/spring-data-jpa/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/spring-data-jpa/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Quarkus Extension for Spring Data JPA API",
-    "labels": [
-        "spring-data"
-    ],
-    "guide": "https://quarkus.io/guides/spring-data-jpa-guide"
+  "name": "Quarkus Extension for Spring Data JPA API",
+  "guide": "https://quarkus.io/guides/spring-data-jpa-guide",
+  "metadata": {
+    "keywords": [
+      "spring-data"
+    ]
+  }
 }

--- a/extensions/spring-di/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/spring-di/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Quarkus Extension for Spring DI API",
-    "labels": [
-        "spring-di"
-    ],
-    "guide": "https://quarkus.io/guides/spring-di-guide"
+  "name": "Quarkus Extension for Spring DI API",
+  "guide": "https://quarkus.io/guides/spring-di-guide",
+  "metadata": {
+    "keywords": [
+      "spring-di"
+    ]
+  }
 }

--- a/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/spring-web/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Quarkus Extension for Spring Web API",
-    "labels": [
-        "spring-web"
-    ],
-    "guide": "https://quarkus.io/guides/spring-web-guide"
+  "name": "Quarkus Extension for Spring Web API",
+  "guide": "https://quarkus.io/guides/spring-web-guide",
+  "metadata": {
+    "keywords": [
+      "spring-web"
+    ]
+  }
 }

--- a/extensions/swagger-ui/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/swagger-ui/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Swagger UI",
-    "labels": [
-        "swagger-ui"
-    ],
-    "guide": "https://quarkus.io/guides/openapi-swaggerui-guide"
+  "name": "Swagger UI",
+  "guide": "https://quarkus.io/guides/openapi-swaggerui-guide",
+  "metadata": {
+    "keywords": [
+      "swagger-ui"
+    ]
+  }
 }

--- a/extensions/tika/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/tika/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,9 @@
-
 {
-    "name": "Apache Tika",
-    "labels": [
-        "tika",
-        "parser"
+  "name": "Apache Tika",
+  "metadata": {
+    "keywords": [
+      "tika",
+      "parser"
     ]
+  }
 }

--- a/extensions/undertow-websockets/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/undertow-websockets/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,14 +1,15 @@
-
 {
-    "name": "Undertow WebSockets",
-    "shortName": "websockets",
-    "labels": [
-        "undertow-websockets",
-        "undertow-websocket",
-        "websocket",
-        "websockets",
-        "web-socket",
-        "web-sockets"
-    ],
-    "guide": "https://quarkus.io/guides/websocket-guide"
+  "name": "Undertow WebSockets",
+  "shortName": "websockets",
+  "guide": "https://quarkus.io/guides/websocket-guide",
+  "metadata": {
+    "keywords": [
+      "undertow-websockets",
+      "undertow-websocket",
+      "websocket",
+      "websockets",
+      "web-socket",
+      "web-sockets"
+    ]
+  }
 }

--- a/extensions/undertow/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/undertow/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,9 +1,10 @@
-
 {
-    "name": "Undertow Servlet",
-    "shortName": "servlet",
-    "labels": [
-        "undertow",
-        "servlet"
+  "name": "Undertow Servlet",
+  "shortName": "servlet",
+  "metadata": {
+    "keywords": [
+      "undertow",
+      "servlet"
     ]
+  }
 }

--- a/extensions/vault/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/vault/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,8 +1,10 @@
 {
-    "name": "Vault",
-    "labels": [
-        "vault",
-        "security"
-    ],
-    "guide": "https://quarkus.io/guides/vault-guide"
+  "name": "Vault",
+  "guide": "https://quarkus.io/guides/vault-guide",
+  "metadata": {
+    "keywords": [
+      "vault",
+      "security"
+    ]
+  }
 }

--- a/extensions/vertx-core/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/vertx-core/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,11 @@
-
 {
-
-    "name": "Eclipse Vert.x - Core",
-    "labels": [
-        "eclipse-vert.x",
-        "vertx",
-        "vert.x",
-        "reactive"
+  "name": "Eclipse Vert.x - Core",
+  "metadata": {
+    "keywords": [
+      "eclipse-vert.x",
+      "vertx",
+      "vert.x",
+      "reactive"
     ]
+  }
 }

--- a/extensions/vertx-http/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/vertx-http/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "Eclipse Vert.x - HTTP",
-    "labels": [
-        "eclipse-vert.x",
-        "vertx",
-        "vert.x",
-        "reactive",
-        "vertx-http"
+  "name": "Eclipse Vert.x - HTTP",
+  "metadata": {
+    "keywords": [
+      "eclipse-vert.x",
+      "vertx",
+      "vert.x",
+      "reactive",
+      "vertx-http"
     ]
+  }
 }

--- a/extensions/vertx/runtime/src/main/resources/META-INF/quarkus-extension.json
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/quarkus-extension.json
@@ -1,11 +1,12 @@
-
 {
-    "name": "Eclipse Vert.x",
-    "labels": [
-        "eclipse-vert.x",
-        "vertx",
-        "vert.x",
-        "reactive"
-    ],
-    "guide": "https://quarkus.io/guides/using-vertx"
+  "name": "Eclipse Vert.x",
+  "guide": "https://quarkus.io/guides/using-vertx",
+  "metadata": {
+    "keywords": [
+      "eclipse-vert.x",
+      "vertx",
+      "vert.x",
+      "reactive"
+    ]
+  }
 }

--- a/independent-projects/tools/platform-descriptor-api/pom.xml
+++ b/independent-projects/tools/platform-descriptor-api/pom.xml
@@ -18,5 +18,10 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/dependencies/Extension.java
+++ b/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/dependencies/Extension.java
@@ -1,7 +1,10 @@
 package io.quarkus.dependencies;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -24,14 +27,15 @@ public class Extension {
 
     private String name;
     private String description;
-    private boolean internal = false;
-    private String[] labels;
     private String guide;
-
+    private boolean unlisted;
+    
     private String simplifiedArtifactId;
     private static final Pattern QUARKUS_PREFIX = Pattern.compile("^quarkus-");
     private String shortName;
 
+    private Map<String, Object> metadata = new HashMap<String, Object>(3);
+    
     public Extension() {
         // Use by mapper.
     }
@@ -98,11 +102,15 @@ public class Extension {
     }
 
     public String[] getLabels() {
-        return labels;
+    	List<String> keywords = (List<String>) getMetadata().get("keywords");
+    	if(keywords != null) {
+    		return (String[]) keywords.toArray(new String[keywords.size()]);
+    	}
+    	return null;
     }
 
     public Extension setLabels(String[] labels) {
-        this.labels = labels;
+        getMetadata().put("keywords", Arrays.asList(labels));
         return this;
     }
 
@@ -124,17 +132,18 @@ public class Extension {
         return this;
     }
 
-    public boolean isInternal() {
-        return internal;
+    public Map<String, Object> getMetadata() {
+    	return metadata;
     }
-
-    public Extension setInternal(boolean internal) {
-        this.internal = internal;
-        return this;
+    
+    public Extension setMetadata(Map<String, Object> metadata) {
+    	this.metadata = metadata;
+    	return this;
     }
-
+    
     public List<String> labels() {
         List<String> list = new ArrayList<>();
+        String[] labels = getLabels();
         if (labels != null) {
             list.addAll(Stream.of(labels).map(String::toLowerCase).collect(Collectors.toList()));
         }
@@ -228,6 +237,11 @@ public class Extension {
         return true;
     }
 
+    public Extension setGuide(String guide) {
+    	this.guide = guide;
+    	return this;
+    }
+    
     public String getGuide() {
         return guide;
     }
@@ -243,4 +257,12 @@ public class Extension {
         this.shortName = shortName;
         return this;
     }
+
+	public boolean isUnlisted() {
+		return unlisted;
+	}
+
+	public void setUnlisted(boolean unlisted) {
+		this.unlisted = unlisted;
+	}
 }

--- a/independent-projects/tools/platform-descriptor-api/src/test/java/io/quarkus/dependencies/test/ExtensionSerializerTest.java
+++ b/independent-projects/tools/platform-descriptor-api/src/test/java/io/quarkus/dependencies/test/ExtensionSerializerTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.dependencies.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.dependencies.Extension;
+
+class ExtensionSerializerTest {
+
+	@Test
+	void testLegacyLabelsMapToKeywords() {
+		Extension e = new Extension();
+		
+		String[] input = new String[] { "what", "not", "to", "do"};
+		
+		e.setLabels(input);
+		
+		List<String> list = (List<String>) e.getMetadata().get("keywords");
+		
+		assertNotNull(list);	
+		assertArrayEquals(input, list.toArray(new String[0]));
+		assertArrayEquals(input,e.getLabels());
+	}
+
+}


### PR DESCRIPTION
Why:

 * to have an openended set of data we can use in aggregation
   and UI's.
 * labels notion caused too much ambiguity; move to more explicit keywords.

This change addreses the need by:

 * add metadata to Extension.java
 * have extension mojo "migrate" all existing extensions
 * move labels to use keywords

note: existing code still uses keywords. Follow fix will be done to
remove the old extensions.json together with notion of labels.