### PR TITLE
Remove reference to deleted artifactId quarkus-undertow-common-substitutions

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -532,11 +532,6 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-undertow-common-substitutions</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
…tutions

This fixes the build, currently broken.