### PR TITLE
Work around JDK bug to produce JAR files with proper CRC32 entries

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.pkg.steps;
 
+import static io.quarkus.bootstrap.util.ZipUtils.wrapForJDK8232879;
+
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -368,7 +370,7 @@ public class JarResultBuildStep {
             for (TransformedClassesBuildItem.TransformedClass i : transformed) {
                 Path target = runnerZipFs.getPath(i.getFileName());
                 handleParent(runnerZipFs, i.getFileName(), seen);
-                try (OutputStream out = Files.newOutputStream(target)) {
+                try (final OutputStream out = wrapForJDK8232879(Files.newOutputStream(target))) {
                     out.write(i.getData());
                 }
                 seen.put(i.getFileName(), "Current Application");
@@ -382,7 +384,7 @@ public class JarResultBuildStep {
             if (Files.exists(target)) {
                 continue;
             }
-            try (OutputStream os = Files.newOutputStream(target)) {
+            try (final OutputStream os = wrapForJDK8232879(Files.newOutputStream(target))) {
                 os.write(i.getClassData());
             }
         }
@@ -396,7 +398,7 @@ public class JarResultBuildStep {
             if (i.getName().startsWith("META-INF/services")) {
                 services.computeIfAbsent(i.getName(), (u) -> new ArrayList<>()).add(i.getClassData());
             } else {
-                try (OutputStream os = Files.newOutputStream(target)) {
+                try (final OutputStream os = wrapForJDK8232879(Files.newOutputStream(target))) {
                     os.write(i.getClassData());
                 }
             }
@@ -405,7 +407,7 @@ public class JarResultBuildStep {
         copyFiles(appArchives.getRootArchive().getArchiveRoot(), runnerZipFs, services);
 
         for (Map.Entry<String, List<byte[]>> entry : services.entrySet()) {
-            try (OutputStream os = Files.newOutputStream(runnerZipFs.getPath(entry.getKey()))) {
+            try (final OutputStream os = wrapForJDK8232879(Files.newOutputStream(runnerZipFs.getPath(entry.getKey())))) {
                 for (byte[] i : entry.getValue()) {
                     os.write(i);
                     os.write('\n');
@@ -483,7 +485,7 @@ public class JarResultBuildStep {
             }
         }
         attributes.put(Attributes.Name.MAIN_CLASS, config.mainClass);
-        try (OutputStream os = Files.newOutputStream(manifestPath)) {
+        try (final OutputStream os = wrapForJDK8232879(Files.newOutputStream(manifestPath))) {
             manifest.write(os);
         }
     }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/ZipUtils.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/util/ZipUtils.java
@@ -1,6 +1,7 @@
 package io.quarkus.bootstrap.util;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
@@ -168,4 +169,46 @@ public class ZipUtils {
              throw new IOException("Failed to create a new filesystem for " + path, ioe);
          }
      }
+
+    /**
+     * This is a hack to get past the <a href="https://bugs.openjdk.java.net/browse/JDK-8232879">JDK-8232879</a>
+     * issue which causes CRC errors when writing out data to (jar) files using ZipFileSystem.
+     * TODO: Get rid of this method as soon as JDK-8232879 gets fixed and released in a public version
+     *
+     * @param original The original outputstream which will be wrapped into a new outputstream
+     *                 that delegates to this one.
+     * @return
+     */
+    public static OutputStream wrapForJDK8232879(final OutputStream original) {
+        return new OutputStream() {
+            @Override
+            public void write(final byte[] b) throws IOException {
+                original.write(b);
+            }
+
+            @Override
+            public void write(final byte[] b, final int off, final int len) throws IOException {
+                original.write(b, off, len);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                original.flush();
+            }
+
+            @Override
+            public void close() throws IOException {
+                original.close();
+            }
+
+            @Override
+            public void write(final int b) throws IOException {
+                // we call the 3 arg write(...) method here, instead
+                // of the single arg one to bypass the JDK-8232879 issue
+                final byte[] buf = new byte[1];
+                buf[0] = (byte) (b & 0xff);
+                this.write(buf, 0, 1);
+            }
+        };
+    }
 }


### PR DESCRIPTION
The commit here introduces a workaround to fix the issue noted in https://github.com/quarkusio/quarkus/issues/4782.

The root cause of the issue resides in recent versions of Java itself and needs to come in as a fix for https://bugs.openjdk.java.net/browse/JDK-8232879. Until that happens and the fix is available in (all) prominent recent versions of Java, the workaround in this commit should allow users to user Quarkus with recent Java versions on platforms like google cloud (which is where the user seems to have run into issues)