### PR TITLE
RESTEasy standalone - handle @ApplicationPath value correctly

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationPathHttpRootTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationPathHttpRootTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.resteasy.test.root;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test a combination of application path and http root path.
+ */
+public class ApplicationPathHttpRootTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class, HelloApp.class)
+                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
+
+    @Test
+    public void testResources() {
+        // Note that /foo is added automatically by RestAssuredURLManager 
+        RestAssured.when().get("/hello/world").then().body(Matchers.is("hello world"));
+        RestAssured.when().get("/world").then().statusCode(404);
+    }
+
+    @Path("world")
+    public static class HelloResource {
+
+        @GET
+        public String hello() {
+            return "hello world";
+        }
+
+    }
+
+    @ApplicationPath("hello")
+    public static class HelloApp extends Application {
+
+    }
+
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationPathTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/root/ApplicationPathTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.test.root;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ApplicationPathTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class, HelloApp.class));
+
+    @Test
+    public void testResources() {
+        RestAssured.when().get("/hello/world").then().body(Matchers.is("hello world"));
+        RestAssured.when().get("/world").then().statusCode(404);
+    }
+
+    @Path("world")
+    public static class HelloResource {
+
+        @GET
+        public String hello() {
+            return "hello world";
+        }
+
+    }
+
+    @ApplicationPath("hello")
+    public static class HelloApp extends Application {
+
+    }
+
+}

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -34,7 +34,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
 
     protected final Vertx vertx;
     protected final RequestDispatcher dispatcher;
-    protected final String servletMappingPrefix;
+    protected final String rootPath;
     protected final BufferAllocator allocator;
     protected final BeanContainer beanContainer;
     protected final CurrentIdentityAssociation association;
@@ -42,13 +42,13 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
     public VertxRequestHandler(Vertx vertx,
             BeanContainer beanContainer,
             ResteasyDeployment deployment,
-            String servletMappingPrefix,
+            String rootPath,
             BufferAllocator allocator) {
         this.vertx = vertx;
         this.beanContainer = beanContainer;
         this.dispatcher = new RequestDispatcher((SynchronousDispatcher) deployment.getDispatcher(),
                 deployment.getProviderFactory(), null);
-        this.servletMappingPrefix = servletMappingPrefix;
+        this.rootPath = rootPath;
         this.allocator = allocator;
         Instance<CurrentIdentityAssociation> association = CDI.current().select(CurrentIdentityAssociation.class);
         this.association = association.isResolvable() ? association.get() : null;
@@ -90,7 +90,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
         try {
             Context ctx = vertx.getOrCreateContext();
             HttpServerRequest request = routingContext.request();
-            ResteasyUriInfo uriInfo = VertxUtil.extractUriInfo(request, servletMappingPrefix);
+            ResteasyUriInfo uriInfo = VertxUtil.extractUriInfo(request, rootPath);
             ResteasyHttpHeaders headers = VertxUtil.extractHttpHeaders(request);
             HttpServerResponse response = request.response();
             VertxHttpResponse vertxResponse = new VertxHttpResponse(request, dispatcher.getProviderFactory(),

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
@@ -44,6 +44,11 @@ public class VertxUtil {
             uriString = protocol + "://" + host + uri;
         }
 
+        // ResteasyUriInfo expects a context path to start with a "/" character
+        if (!contextPath.startsWith("/")) {
+            contextPath = "/" + contextPath;
+        }
+
         return new ResteasyUriInfo(uriString, contextPath);
     }
 


### PR DESCRIPTION
- application path value does not have to start with a slash
- resource should not be served from both the root and the app path
- resolves #4787

IMPL NOTE: We register the delegating handler in the default route (matches `HttpBuildTimeConfig.path`) for a JAX-RS root resource path of a default value `/`. However, for any other value we do register the handler in a special route that matches the root resource path. In fact, we register two routes that share the same handler. For example, for the JAX-RS root resource path `/foo` we register two routes, first matches `/foo` (exact match) and the second one matches `/foo/*`. And the reason is that otherwise the resources would be served from both the root and the app path - see the issue description for an example.