### PR TITLE
Rename Postgres to PostgreSQL

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -46,7 +46,7 @@ public class Fruit {
 
 [TIP]
 ====
-Do you need a ready-to-use Postgres server to try out the examples?
+Do you need a ready-to-use PostgreSQL server to try out the examples?
 
 [source,shell]
 ----
@@ -56,7 +56,7 @@ docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name qua
 
 == Installing
 
-=== Reactive Postgres Client extension
+=== Reactive PostgreSQL Client extension
 
 First, make sure your project has the `quarkus-reactive-pg-client` extension enabled.
 If you are creating a new project, set the `extensions` parameter as follows:
@@ -86,7 +86,7 @@ Otherwise, you can manually add this to the dependencies section of your `pom.xm
 </dependency>
 ----
 
-NOTE: In this guide, we will use the Axle API of the Reactive Postgres Client.
+NOTE: In this guide, we will use the Axle API of the Reactive PostgreSQL Client.
 Read the link:using-vertx.html[Using Eclipse Vert.x] guide to understand the differences between the callback, RxJava and Axle based APIs.
 
 === JSON Binding
@@ -109,11 +109,11 @@ If you prefer not to use the command line, manually add this to the dependencies
 </dependency>
 ----
 
-Of course, this is only a requirement for this guide, not any application using the Reactive Postgres Client.
+Of course, this is only a requirement for this guide, not any application using the Reactive PostgreSQL Client.
 
 == Configuring
 
-The Reactive Postgres Client can be configured with standard Quarkus datasource properties:
+The Reactive PostgreSQL Client can be configured with standard Quarkus datasource properties:
 
 [source]
 .src/main/resources/application.properties
@@ -124,7 +124,7 @@ quarkus.datasource.password=quarkus_test
 ----
 
 IMPORTANT: The eagle eyes among you might have noticed the `url` prefix is different from usual JDBC urls.
-It is required to use the `vertx-reactive:` prefix otherwise the Reactive Postgres Client extension will not use the `quarkus.datasource.url` config property.
+It is required to use the `vertx-reactive:` prefix otherwise the Reactive PostgreSQL Client extension will not use the `quarkus.datasource.url` config property.
 
 With that you may create your `FruitResource` skeleton and `@Inject` a `io.vertx.axle.pgclient.PgPool` instance:
 
@@ -276,7 +276,7 @@ Lastly, open your browser and navigate to http://localhost:8080/fruits, you shou
 
 === Prepared queries
 
-The Reactive Postgres Client can also prepare queries and take parameters that are replaced in the SQL statement at execution time:
+The Reactive PostgreSQL Client can also prepare queries and take parameters that are replaced in the SQL statement at execution time:
 
 [source,java]
 ----
@@ -383,7 +383,7 @@ We will use https://jquery.com/[jQuery] to simplify interactions with the backen
 <html>
 <head>
     <meta charset="utf-8"/>
-    <title>Reactive Postgres Client - Quarkus</title>
+    <title>Reactive PostgreSQL Client - Quarkus</title>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"
             integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script type="application/javascript" src="fruits.js"></script>
@@ -464,7 +464,7 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 |===
 |Database |Extension name |Pool class name
 
-|Postgres
+|PostgreSQL
 |`quarkus-reactive-pg-client`
 |`io.vertx.axle.pgclient.PgPool`
 

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
 
-    <name>Quarkus - Reactive Postgres Client - Deployment</name>
+    <name>Quarkus - Reactive PostgreSQL Client - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/reactive-pg-client/pom.xml
+++ b/extensions/reactive-pg-client/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>quarkus-reactive-pg-client-parent</artifactId>
     <packaging>pom</packaging>
 
-    <name>Quarkus - Reactive Postgres Client</name>
+    <name>Quarkus - Reactive PostgreSQL Client</name>
 
     <modules>
         <module>deployment</module>

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>quarkus-reactive-pg-client</artifactId>
 
-    <name>Quarkus - Reactive Postgres Client - Runtime</name>
+    <name>Quarkus - Reactive PostgreSQL Client - Runtime</name>
     <description>A reactive client for the PostgreSQL database</description>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Rename Postgres to PostgreSQL

https://vertx.io/docs/vertx-pg-client/js/ is referring to Reactive PostgreSQL Client, not Reactive Postgres Client.