### PR TITLE
Replace `mvn` with `./mvnw` whenever possible

### DIFF
--- a/docs/src/main/asciidoc/async-message-passing.adoc
+++ b/docs/src/main/asciidoc/async-message-passing.adoc
@@ -222,7 +222,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="vertx"
 ----
 
-You can already start the application in _dev mode_ using `mvn compile quarkus:dev`.
+You can already start the application in _dev mode_ using `./mvnw compile quarkus:dev`.
 
 Then, creates a new JAX-RS resource with the following content:
 

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1507,7 +1507,7 @@ memory in a runtime class loader. To have these classes written out to disk for 
 
 [source,shell]
 ----
-mvn clean install -Dquarkus.debug.generated-classes-dir=./target/app-generated-classes
+./mvnw clean install -Dquarkus.debug.generated-classes-dir=./target/app-generated-classes
 ----
 
 ==== Multi-module Maven Projects and the Development Mode
@@ -2212,7 +2212,7 @@ You can also use the `@asciidoclet` tag as shown above.
 
 Generating the documentation is easy:
 
- * Running `mvn clean install -DskipTests -DskipITs` will do.
+ * Running `./mvnw clean install -DskipTests -DskipITs` will do.
  * You  can either do it globally or in a specific extension directory (e.g. `extensions/mailer`).
 
 The documentation is generated in the global `target/asciidoc/generated/config/` located at the root of the project.

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -66,7 +66,7 @@ Importing the `smallrye-health` extension directly exposes three REST endpoints:
  
 To check that the `smallrye-health` extension is working as expected:
 
-* start your Quarkus application with `mvn compile quarkus:dev`
+* start your Quarkus application with `./mvnw compile quarkus:dev`
 * access the `http://localhost:8080/health/live` endpoint using your browser or 
 `curl http://localhost:8080/health/live`
 

--- a/docs/src/main/asciidoc/infinispan-client-guide.adoc
+++ b/docs/src/main/asciidoc/infinispan-client-guide.adoc
@@ -19,7 +19,7 @@ Once you have your Quarkus project configured you can add the `infinispan-client
 to your project by running the following from the command line in your project base directory.
 
 [source]
-mvn quarkus:add-extension -Dextensions="infinispan-client"
+./mvnw quarkus:add-extension -Dextensions="infinispan-client"
 
 This will add the following to your pom.xml
 

--- a/docs/src/main/asciidoc/infinispan-embedded-guide.adoc
+++ b/docs/src/main/asciidoc/infinispan-embedded-guide.adoc
@@ -16,7 +16,7 @@ After you set up your Quarkus project, run the following command from the base d
 
 [source]
 ----
-mvn quarkus:add-extension -Dextensions="infinispan-embedded"
+./mvnw quarkus:add-extension -Dextensions="infinispan-embedded"
 ----
 
 The command adds the following dependency to your `pom.xml`:

--- a/docs/src/main/asciidoc/jgit.adoc
+++ b/docs/src/main/asciidoc/jgit.adoc
@@ -18,7 +18,7 @@ to your project by running the following command in your project base directory.
 
 [source,bash]
 ----
-mvn quarkus:add-extension -Dextensions="jgit"
+./mvnw quarkus:add-extension -Dextensions="jgit"
 ----
 
 This will add the following to your pom.xml:

--- a/docs/src/main/asciidoc/kafka-streams-guide.adoc
+++ b/docs/src/main/asciidoc/kafka-streams-guide.adoc
@@ -24,7 +24,7 @@ It is recommended, that you have read the {quickstarts-tree-url}/kafka-quickstar
 
 [NOTE]
 ====
-The Quarkus extension for Kafka Streams allows for very fast turnaround times during development by supporting the Quarkus Dev Mode (e.g. via `mvn compile quarkus:dev`).
+The Quarkus extension for Kafka Streams allows for very fast turnaround times during development by supporting the Quarkus Dev Mode (e.g. via `./mvnw compile quarkus:dev`).
 After changing the code of your Kafka Streams topology, the application will automatically be reloaded when the next input message arrives.
 
 A recommended development set-up is to have some producer which creates test messages on the processed topic(s) in fixed intervals, e.g. every second and observe the streaming application's output topic(s) using a tool such as `kafkacat`.

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -22,7 +22,7 @@ Once you have your Quarkus project configured you can add the `kubernetes-client
 to your project by running the following command in your project base directory.
 
 [source]
-mvn quarkus:add-extension -Dextensions="kubernetes-client"
+./mvnw quarkus:add-extension -Dextensions="kubernetes-client"
 
 This will add the following to your pom.xml:
 

--- a/docs/src/main/asciidoc/kubernetes-resources.adoc
+++ b/docs/src/main/asciidoc/kubernetes-resources.adoc
@@ -60,7 +60,7 @@ quarkus.kubernetes.group=yourDockerUsername # this is optional and defaults to y
 quarkus.application.name=test-quarkus-app # this is also optional and defaults to the project name if not set
 ----
 
-and following the execution of `mvn package` you will notice amongst the other files that are created, two files named
+and following the execution of `./mvnw package` you will notice amongst the other files that are created, two files named
 `kubernetes.json` and `kubernetes.yaml` in the `target/kubernetes/` directory.
 
 If you look at either file you will see that it contains both a Kubernetes `Deployment` and a `Service`.

--- a/docs/src/main/asciidoc/neo4j-guide.adoc
+++ b/docs/src/main/asciidoc/neo4j-guide.adoc
@@ -145,7 +145,7 @@ If you have an already created project, the `neo4j` extension can be added to an
 
 [source,shell]
 ----
-mvn quarkus:add-extension -Dextensions="neo4j"
+./mvnw quarkus:add-extension -Dextensions="neo4j"
 ----
 
 Otherwise, you can manually add this to the dependencies section of your `pom.xml` file:
@@ -248,7 +248,7 @@ Now start Quarkus in `dev` mode with:
 
 [source, shell]
 ----
-mvn compile quarkus:dev
+./mvnw compile quarkus:dev
 ----
 
 and retrieve the endpoint like this

--- a/docs/src/main/asciidoc/oauth2-guide.adoc
+++ b/docs/src/main/asciidoc/oauth2-guide.adoc
@@ -137,7 +137,7 @@ and you should see output similar to:
 .quarkus:dev Output
 [source,shell]
 ----
-$ mvn clean compile quarkus:dev
+$ ./mvnw clean compile quarkus:dev
 [INFO] Scanning for projects...
 [INFO] 
 [INFO] ---------------------< org.acme:using-oauth2-rbac >---------------------

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -73,7 +73,7 @@ If you have an already created project, the `reactive-pg-client` extension can b
 
 [source,shell]
 ----
-mvn quarkus:add-extension -Dextensions="reactive-pg-client"
+./mvnw quarkus:add-extension -Dextensions="reactive-pg-client"
 ----
 
 Otherwise, you can manually add this to the dependencies section of your `pom.xml` file:
@@ -96,7 +96,7 @@ Consequently, you also need to add the `quarkus-resteasy-jsonb` extension:
 
 [source,shell]
 ----
-mvn quarkus:add-extension -Dextensions="resteasy-jsonb"
+./mvnw quarkus:add-extension -Dextensions="resteasy-jsonb"
 ----
 
 If you prefer not to use the command line, manually add this to the dependencies section of your `pom.xml` file:
@@ -264,7 +264,7 @@ Now start Quarkus in `dev` mode with:
 
 [source, shell]
 ----
-mvn compile quarkus:dev
+./mvnw compile quarkus:dev
 ----
 
 Lastly, open your browser and navigate to http://localhost:8080/fruits, you should see:

--- a/docs/src/main/asciidoc/tests-with-coverage-guide.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage-guide.adoc
@@ -232,7 +232,7 @@ We're now able to distinguish unit tests and integration tests. Now, let's bind 
 ----
 
 NOTE: This way, the `QuarkusTest` instances will be executed as part of the `integration-test` build phase while the other JUnit tests will still be ran during the `test` phase.
-You can run all the tests with the command `mvn clean verify` (and you will notice that two tests are ran in different phases).
+You can run all the tests with the command `./mvnw clean verify` (and you will notice that two tests are ran in different phases).
 
 == Measuring the coverage of JUnit tests using JaCoCo
 
@@ -275,7 +275,7 @@ It is now time to introduce JaCoCo to measure the coverage. The straightforward 
     </build>
 ----
 
-NOTE: If you run `mvn clean test` the coverage information will be collected during the execution of the unit tests in the file `jacoco.exec`.
+NOTE: If you run `./mvnw clean test` the coverage information will be collected during the execution of the unit tests in the file `jacoco.exec`.
 
 == Measuring separately the coverage of each test type
 
@@ -345,7 +345,7 @@ We also need to generate a separate report for each test execution. Let's adjust
 
 == The coverage does not seem to correspond to the reality
 
-You can now run the tests: `mvn clean verify` As explained earlier, it will run the unit tests first, then the integration tests. And finally, it will generate two separate reports. First a report of the coverage of the unit tests in `target/site/jacoco-ut` then a report of the coverage of the integration tests in `target/site/jacoco-it`.
+You can now run the tests: `./mvnw clean verify` As explained earlier, it will run the unit tests first, then the integration tests. And finally, it will generate two separate reports. First a report of the coverage of the unit tests in `target/site/jacoco-ut` then a report of the coverage of the integration tests in `target/site/jacoco-it`.
 
 Given the content of `GreetingResourceTest`, `GreetingResource` should have been covered. But when we open the report `target/site/jacoco-it/index.html`, the class `GreetingResource` is reported with 0% of coverage. But the fact that `GreetingService` is reported as covered shows that the test execution was actually recorded. How come?
 

--- a/docs/src/main/asciidoc/tika-guide.adoc
+++ b/docs/src/main/asciidoc/tika-guide.adoc
@@ -83,7 +83,7 @@ to your project by running the following command in your project base directory.
 
 [source,bash]
 ----
-mvn quarkus:add-extension -Dextensions="tika,resteasy"
+./mvnw quarkus:add-extension -Dextensions="tika,resteasy"
 ----
 
 This will add the following to your pom.xml:
@@ -187,7 +187,7 @@ and you should see output similar to:
 .quarkus:dev Output
 [source,shell]
 ----
-$ mvn clean compile quarkus:dev
+$ ./mvnw clean compile quarkus:dev
 [INFO] Scanning for projects...
 [INFO]
 INFO] --------------------< org.acme.example:apache-tika >--------------------


### PR DESCRIPTION
There was a mix of `mvn` and `./mvnw` commands in the doc (with a majority of `./mvnw`).

I think `./mvnw` should be used whenever possible.