### PR TITLE
All to disable the oidc extension

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -43,6 +43,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String REACTIVE_PG_CLIENT = "reactive-pg-client";
     public static final String REACTIVE_MYSQL_CLIENT = "reactive-mysql-client";
     public static final String NEO4J = "neo4j";
+    public static final String OIDC = "oidc";
     public static final String RESTEASY = "resteasy";
     public static final String RESTEASY_JACKSON = "resteasy-jackson";
     public static final String RESTEASY_JAXB = "resteasy-jaxb";

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/vertx/keycloak/deployment/VertxKeycloakBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/vertx/keycloak/deployment/VertxKeycloakBuildStep.java
@@ -6,6 +6,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.EnableAllSecurityServicesBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.oidc.OidcConfig;
 import io.quarkus.oidc.VertxJwtPrincipalProducer;
 import io.quarkus.oidc.VertxKeycloakRecorder;
@@ -16,11 +17,15 @@ import io.quarkus.vertx.deployment.VertxBuildItem;
 public class VertxKeycloakBuildStep {
 
     @BuildStep
-    public AdditionalBeanBuildItem beans() {
-        return AdditionalBeanBuildItem.builder().setUnremovable()
-                .addBeanClass(VertxOAuth2AuthenticationMechanism.class)
-                .addBeanClass(VertxJwtPrincipalProducer.class)
-                .addBeanClass(VertxOAuth2IdentityProvider.class).build();
+    public AdditionalBeanBuildItem beans(OidcConfig config) {
+        if (config.enabled) {
+            return AdditionalBeanBuildItem.builder().setUnremovable()
+                    .addBeanClass(VertxOAuth2AuthenticationMechanism.class)
+                    .addBeanClass(VertxJwtPrincipalProducer.class)
+                    .addBeanClass(VertxOAuth2IdentityProvider.class).build();
+        }
+
+        return null;
     }
 
     @BuildStep
@@ -32,6 +37,8 @@ public class VertxKeycloakBuildStep {
     @BuildStep
     public void setup(OidcConfig config, VertxKeycloakRecorder recorder, VertxBuildItem vertxBuildItem,
             BeanContainerBuildItem bc) {
-        recorder.setup(config, vertxBuildItem.getVertx(), bc.getValue());
+        if (config.enabled) {
+            recorder.setup(config, vertxBuildItem.getVertx(), bc.getValue());
+        }
     }
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/vertx/keycloak/deployment/VertxKeycloakBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/vertx/keycloak/deployment/VertxKeycloakBuildStep.java
@@ -17,6 +17,11 @@ import io.quarkus.vertx.deployment.VertxBuildItem;
 public class VertxKeycloakBuildStep {
 
     @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(FeatureBuildItem.OIDC);
+    }
+
+    @BuildStep
     public AdditionalBeanBuildItem beans(OidcConfig config) {
         if (config.enabled) {
             return AdditionalBeanBuildItem.builder().setUnremovable()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfig.java
@@ -11,6 +11,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class OidcConfig {
 
     /**
+     * If the OIDC extension is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
      * The base URL of the OpenID Connect (OIDC) server, for example, 'https://host:port/auth'.
      * All the other OIDC server page and service URLs are derived from this URL.
      * Note if you work with Keycloak OIDC server, make sure the base URL is in the following format:


### PR DESCRIPTION
This is done for #4619 but not sure it fixes it.
Anyway, it needs to be done because we need to be able to switch authentication implementation for dev/prod as all other authentication mechanism permits.

I also add a featurebuilditem in order the extension to shows up on the log :)