### PR TITLE
integration-tests - Use the right version of quarkus-maven-plugin in the native profile

### DIFF
--- a/integration-tests/amazon-lambda/pom.xml
+++ b/integration-tests/amazon-lambda/pom.xml
@@ -86,6 +86,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/artemis-core/pom.xml
+++ b/integration-tests/artemis-core/pom.xml
@@ -110,6 +110,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/artemis-jms/pom.xml
+++ b/integration-tests/artemis-jms/pom.xml
@@ -110,6 +110,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/elytron-security-jdbc/pom.xml
+++ b/integration-tests/elytron-security-jdbc/pom.xml
@@ -91,6 +91,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/elytron-security-oauth2/pom.xml
+++ b/integration-tests/elytron-security-oauth2/pom.xml
@@ -102,6 +102,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/elytron-security/pom.xml
+++ b/integration-tests/elytron-security/pom.xml
@@ -99,6 +99,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/flyway/pom.xml
+++ b/integration-tests/flyway/pom.xml
@@ -104,6 +104,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/hibernate-search-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-elasticsearch/pom.xml
@@ -171,6 +171,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -108,6 +108,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -155,6 +155,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/infinispan-embedded/pom.xml
+++ b/integration-tests/infinispan-embedded/pom.xml
@@ -126,6 +126,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jgit/pom.xml
+++ b/integration-tests/jgit/pom.xml
@@ -101,6 +101,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa-derby/pom.xml
+++ b/integration-tests/jpa-derby/pom.xml
@@ -100,6 +100,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa-h2/pom.xml
+++ b/integration-tests/jpa-h2/pom.xml
@@ -100,6 +100,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -134,6 +134,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -138,6 +138,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -134,6 +134,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -129,6 +129,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jpa/pom.xml
+++ b/integration-tests/jpa/pom.xml
@@ -97,6 +97,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/jsonb/pom.xml
+++ b/integration-tests/jsonb/pom.xml
@@ -87,6 +87,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -123,6 +123,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -231,6 +231,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/narayana-stm/pom.xml
+++ b/integration-tests/narayana-stm/pom.xml
@@ -60,6 +60,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/neo4j/pom.xml
+++ b/integration-tests/neo4j/pom.xml
@@ -159,6 +159,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -112,6 +112,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -153,6 +154,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/test-extension/pom.xml
+++ b/integration-tests/test-extension/pom.xml
@@ -92,6 +92,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${project.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/integration-tests/tika/pom.xml
+++ b/integration-tests/tika/pom.xml
@@ -104,6 +104,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -156,6 +156,7 @@
                     <plugin>
                         <groupId>${project.groupId}</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
                         <executions>
                             <execution>
                                 <id>native-image</id>


### PR DESCRIPTION
The commit here should fix the issue reported in https://github.com/quarkusio/quarkus/issues/4836. 

Ideally, I think, the parent pom.xml of the integration tests should probably dictate this in `pluginManagement` for the `native` profile too. But I couldn't get that working. Nor do I see any conclusive documentation that the `pluginManagement` for profiles is supported from the parent pom.xml. So at least for now, this goes directly in the `vault-app`'s `native` profile in pom.xml