### PR TITLE
Updated info about JDK version

### DIFF
--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -20,9 +20,9 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* JDK 8 installed with `JAVA_HOME` configured appropriately
 * A xref:configuring-c-development[working C development environment]
-* GraalVM version {graalvm-version} installed and  xref:configuring-graalvm[configured appropriately]
+* GraalVM version {graalvm-version} installed and xref:configuring-graalvm[configured appropriately]
 * A working container runtime (Docker, podman)
 * The code of the application developed in the link:getting-started-guide.html[Getting Started Guide].
 

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -33,7 +33,7 @@ To complete this guide, you need:
 
 * less than 15 minutes
 * an IDE
-* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* JDK 8 or 11+ installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
 
 [TIP]


### PR DESCRIPTION
Updated info about JDK version to be in sync with https://quarkus.io/get-started/ (1,2,3,4 header)

Resubmit of https://github.com/quarkusio/quarkus/pull/4837 (@gsmet fyi)