### PR TITLE
Move to jsonb and jackson dependencies for mongodb with panache

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache/runtime/pom.xml
@@ -34,14 +34,14 @@
         <!-- But needed to provides default serializer/deserializer for JsonB -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-jsonb</artifactId>
             <optional>true</optional>
         </dependency>
         <!-- This is optional to avoid pulling libraries if jackson is not on the path-->
         <!-- But needed to provides default serializer/deserializer for Jackson -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-jackson</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Move to jsonb and jackson dependencies instead of the resteasy ones. Reasteasy was previously needed as we provided jaxrs providers but now that we use Jsonb/Jackson new customization mechanism it is no longuer needed.

Also simplifies a little the producing of the Jackson module.