### PR TITLE
infinispan-embedded - Don't let org.jgroups.protocols.DISCARD use Java Swing or AWT classes in native mode

### DIFF
--- a/extensions/infinispan-embedded/runtime/src/main/java/io/quarkus/infinispan/embedded/runtime/graal/SubstituteJGroups.java
+++ b/extensions/infinispan-embedded/runtime/src/main/java/io/quarkus/infinispan/embedded/runtime/graal/SubstituteJGroups.java
@@ -6,6 +6,7 @@ import org.jgroups.util.UUID;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 public class SubstituteJGroups {
@@ -17,4 +18,32 @@ final class SubstituteUUID {
     // Force it to null - so it can be reinitialized
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
     protected static volatile SecureRandom numberGenerator;
+}
+
+// DISCARD protocol uses swing classes
+@TargetClass(className = "org.jgroups.protocols.DISCARD")
+final class SubstituteDiscardProtocol {
+
+    @Substitute
+    public void startGui() {
+        // do nothing
+    }
+
+    @Substitute
+    public void stopGui() {
+        // do nothing
+    }
+
+    @Substitute
+    public void start() throws Exception {
+        // should call super.start() but the "super" Protocol.start() does nothing,
+        // so this empty impl is OK
+    }
+
+    @Substitute
+    public void stop() {
+        // should call super.stop() but the "super" Protocol.stop() does nothing,
+        // so this empty impl is OK
+
+    }
 }


### PR DESCRIPTION
The commit here fixes the issue noted in https://github.com/quarkusio/quarkus/issues/4830.

The `org.jgroups.protocols.DISCARD` uses Java Swing and AWT classes https://github.com/belaban/JGroups/blob/master/src/org/jgroups/protocols/DISCARD.java#L142 which aren't allowed in native mode. The commit here adds a substitution for that class to eliminate that code path.