### PR TITLE
CDI guide: add method removal documentation

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -470,12 +470,22 @@ An unused bean:
 * does not declare any producer which is eligible for injection to any injection point,
 * is not directly eligible for injection into any `javax.enterprise.inject.Instance` or `javax.inject.Provider` injection point
 
+This optimization applies to all forms of bean declarations: bean class, producer method, producer field.
+
 Users can instruct the container to not remove any of their specific beans (even if they satisfy all the rules specified above) by annotating them with `io.quarkus.arc.Unremovable`.
+This annotation can be placed on the types, producer methods, and producer fields.
  
 Furthermore, extensions can eliminate possible false positives by producing `UnremovableBeanBuildItem`.
 
 Finally, Quarkus provides a middle ground for the bean removal optimization where application beans are never removed whether or not they are unused,
 while the optimization proceeds normally for non application classes. To use this mode, set `quarkus.arc.remove-unused-beans` to `fwk` or `framework`.
+
+In order to see more information about which beans are being removed,
+you can enable additional logging via the following line in your `application.properties`.
+
+----
+quarkus.log.category."io.quarkus.arc.producer".level=DEBUG
+----
 
 [[default_beans]]
 == Default Beans

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Unremovable.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Unremovable.java
@@ -7,7 +7,19 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the bean marked with this annotation should never be removed by Arc
- * even if it has no known injection points
+ * even if it's considered unused.
+ *
+ * An unused bean:
+ * <ul>
+ * <li>is not a built-in bean or an interceptor</li>
+ * <li>is not eligible for injection to any injection point,</li>
+ * <li>is not excluded by any extension,</li>
+ * <li>does not have a name,</li>
+ * <li>does not declare an observer,</li>
+ * <li>does not declare any producer which is eligible for injection to any injection point,</li>
+ * <li>is not directly eligible for injection into any `javax.enterprise.inject.Instance` or `javax.inject.Provider` injection
+ * point</li>
+ * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD })


### PR DESCRIPTION
Add to the CDI documentation the fact tha Arc also remove method that produces beans, not just beans, and that @Unremovable can be used on methods.

Also adds a line explaining how to debug removal issues