### PR TITLE
Decouple Spring Web from quarkus-undertow

### DIFF
--- a/docs/src/main/asciidoc/spring-web-guide.adoc
+++ b/docs/src/main/asciidoc/spring-web-guide.adoc
@@ -236,6 +236,7 @@ The following method return types are supported:
 
 In addition to the method parameters that can be annotated with the appropriate Spring Web annotations from the previous table,
 `javax.servlet.http.HttpServletRequest` and `javax.servlet.http.HttpServletResponse` are also supported.
+For this to function however, users need to add the `quarkus-undertow` dependency.
 
 
 == Important Technical Note

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyDeploymentCustomizerBuildItem.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyDeploymentCustomizerBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.server.common.deployment;
+
+import java.util.function.Consumer;
+
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that is meant to customize the RESTEasy Deployment before it has been finalized
+ * This gives extensions to ability to add stuff to the Deployment
+ */
+public final class ResteasyDeploymentCustomizerBuildItem extends MultiBuildItem {
+
+    private final Consumer<ResteasyDeployment> consumer;
+
+    public ResteasyDeploymentCustomizerBuildItem(Consumer<ResteasyDeployment> consumer) {
+        this.consumer = consumer;
+    }
+
+    public Consumer<ResteasyDeployment> getConsumer() {
+        return consumer;
+    }
+}

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -158,6 +158,7 @@ public class ResteasyServerCommonProcessor {
             List<AdditionalJaxRsResourceDefiningAnnotationBuildItem> additionalJaxRsResourceDefiningAnnotations,
             List<AdditionalJaxRsResourceMethodAnnotationsBuildItem> additionalJaxRsResourceMethodAnnotations,
             List<AdditionalJaxRsResourceMethodParamAnnotations> additionalJaxRsResourceMethodParamAnnotations,
+            List<ResteasyDeploymentCustomizerBuildItem> deploymentCustomizers,
             JaxrsProvidersToRegisterBuildItem jaxrsProvidersToRegisterBuildItem,
             CombinedIndexBuildItem combinedIndexBuildItem,
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem) throws Exception {
@@ -276,6 +277,11 @@ public class ResteasyServerCommonProcessor {
         }
         resteasyInitParameters.put("resteasy.injector.factory", QuarkusInjectorFactory.class.getName());
         deployment.setInjectorFactoryClass(QuarkusInjectorFactory.class.getName());
+
+        // apply all customizers
+        for (ResteasyDeploymentCustomizerBuildItem deploymentCustomizer : deploymentCustomizers) {
+            deploymentCustomizer.getConsumer().accept(deployment);
+        }
 
         if (commonConfig.gzip.enabled) {
             resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_GZIP_MAX_INPUT,

--- a/extensions/spring-web/deployment/pom.xml
+++ b/extensions/spring-web/deployment/pom.xml
@@ -33,7 +33,13 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow-deployment</artifactId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -4,6 +4,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -11,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Providers;
@@ -25,6 +27,7 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.resteasy.core.MediaTypeMap;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.resteasy.spi.metadata.SpringResourceBuilder;
 import org.jboss.resteasy.spring.web.ResponseEntityFeature;
 import org.jboss.resteasy.spring.web.ResponseStatusFeature;
@@ -45,6 +48,7 @@ import io.quarkus.resteasy.common.deployment.ResteasyCommonProcessor;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.runtime.ExceptionMapperRecorder;
 import io.quarkus.resteasy.runtime.NonJaxRsClassMappings;
+import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentCustomizerBuildItem;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceDefiningAnnotationBuildItem;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodAnnotationsBuildItem;
 import io.quarkus.resteasy.server.common.spi.AdditionalJaxRsResourceMethodParamAnnotations;
@@ -138,7 +142,8 @@ public class SpringWebProcessor {
     @BuildStep
     public void process(BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<ServletInitParamBuildItem> initParamProducer) {
+            BuildProducer<ServletInitParamBuildItem> initParamProducer,
+            BuildProducer<ResteasyDeploymentCustomizerBuildItem> deploymentCustomizerProducer) {
 
         final IndexView index = beanArchiveIndexBuildItem.getIndex();
         final Collection<AnnotationInstance> annotations = index.getAnnotations(REST_CONTROLLER_ANNOTATION);
@@ -153,10 +158,19 @@ public class SpringWebProcessor {
             classNames.add(annotation.target().asClass().toString());
         }
 
+        // initialize the init params that will be used in case of servlet
         initParamProducer.produce(
                 new ServletInitParamBuildItem(
                         ResteasyContextParameters.RESTEASY_SCANNED_RESOURCE_CLASSES_WITH_BUILDER,
                         SpringResourceBuilder.class.getName() + ":" + String.join(",", classNames)));
+        // customize the deployment that will be used in case of RESTEasy standalone
+        deploymentCustomizerProducer.produce(new ResteasyDeploymentCustomizerBuildItem(new Consumer<ResteasyDeployment>() {
+            @Override
+            public void accept(ResteasyDeployment resteasyDeployment) {
+                resteasyDeployment.getScannedResourceClassesWithBuilder().put(SpringResourceBuilder.class.getName(),
+                        new ArrayList<>(classNames));
+            }
+        }));
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, SpringResourceBuilder.class.getName()));
     }

--- a/extensions/spring-web/deployment/src/test/java/io/quarkus/spring/web/test/SimpleSpringController.java
+++ b/extensions/spring-web/deployment/src/test/java/io/quarkus/spring/web/test/SimpleSpringController.java
@@ -1,0 +1,15 @@
+package io.quarkus.spring.web.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/simple")
+public class SimpleSpringController {
+
+    @GetMapping
+    public String hello() {
+        return "hello";
+    }
+}

--- a/extensions/spring-web/deployment/src/test/java/io/quarkus/spring/web/test/SimpleSpringControllerTest.java
+++ b/extensions/spring-web/deployment/src/test/java/io/quarkus/spring/web/test/SimpleSpringControllerTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.spring.web.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SimpleSpringControllerTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SimpleSpringController.class));
+
+    @Test
+    public void testRootResource() {
+        when().get("/simple").then().body(is("hello"));
+    }
+
+}

--- a/extensions/spring-web/runtime/pom.xml
+++ b/extensions/spring-web/runtime/pom.xml
@@ -20,10 +20,6 @@
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-spring-web</artifactId>
         </dependency>

--- a/integration-tests/spring-web/pom.xml
+++ b/integration-tests/spring-web/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Spring Web can now use standalone RESTEasy when no Servlet capabilities are needed