### PR TITLE
Set default encoding as UTF-8 for static resources

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
@@ -114,6 +114,7 @@ public class ResteasyStandaloneRecorder {
                         staticHandler.setCachingEnabled(false);
                         staticHandler.setAllowRootFileSystemAccess(true);
                         staticHandler.setWebRoot(root);
+                        staticHandler.setDefaultContentEncoding("UTF-8");
                         return staticHandler;
                     }
                 });
@@ -132,7 +133,8 @@ public class ResteasyStandaloneRecorder {
             ThreadLocalHandler staticHandler = new ThreadLocalHandler(new Supplier<Handler<RoutingContext>>() {
                 @Override
                 public Handler<RoutingContext> get() {
-                    return StaticHandler.create(META_INF_RESOURCES);
+                    return StaticHandler.create(META_INF_RESOURCES)
+                            .setDefaultContentEncoding("UTF-8");
                 }
             });
             handlers.add(ctx -> {


### PR DESCRIPTION
Fixes #4891

I wonder if this should be configurable at some point but having the default as UTF-8 for the time being is still an improvement.