### PR TITLE
open config doc's type javadocs in new tab

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -45,7 +45,7 @@ final class SummaryTableDocFormatter implements DocFormatter {
             typeContent = configDocKey.computeTypeSimpleName();
             final String javaDocLink = configDocKey.getJavaDocSiteLink();
             if (!javaDocLink.isEmpty()) {
-                typeContent = String.format("link:%s[%s]\n", javaDocLink, typeContent);
+                typeContent = String.format("link:%s[%s,window=\"_blank\"]\n", javaDocLink, typeContent);
             }
         }
         if (configDocKey.isList()) {


### PR DESCRIPTION
A minor one to open the JavaDoc link of config Type in a new tab instead of the current tab.

/cc @gsmet @FroMage 