### PR TITLE
Don't add the "--rm" option to "docker run" command, of native-image, too early

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -82,7 +82,7 @@ public class NativeImageBuildStep {
             // E.g. "/usr/bin/docker run -v {{PROJECT_DIR}}:/project --rm quarkus/graalvm-native-image"
             nativeImage = new ArrayList<>();
             Collections.addAll(nativeImage, nativeConfig.containerRuntime, "run", "-v",
-                    outputDir.toAbsolutePath() + ":/project:z", "--rm");
+                    outputDir.toAbsolutePath() + ":/project:z");
 
             if (IS_LINUX) {
                 if ("docker".equals(nativeConfig.containerRuntime)) {
@@ -101,7 +101,7 @@ public class NativeImageBuildStep {
                 // publish the debug port onto the host if asked for
                 nativeImage.add("--publish=" + DEBUG_BUILD_PROCESS_PORT + ":" + DEBUG_BUILD_PROCESS_PORT);
             }
-            nativeImage.add(nativeConfig.builderImage);
+            Collections.addAll(nativeImage, "--rm", nativeConfig.builderImage);
         } else {
             if (IS_LINUX) {
                 noPIE = detectNoPIE();


### PR DESCRIPTION
The commit here fixes an issue where the `--rm` option to `docker run` command during native image generation, is added too early. This causes issues when the native image is passed addtional `containerRuntimeOptions` for example the below one:

```
<containerRuntimeOptions>--name=hello</containerRuntimeOptions>
```
This ends up generating a command of the form:
```
docker run -v quarkus/integration-tests/infinispan-embedded/target/quarkus-integration-test-xxx-999-SNAPSHOT-native-image-source-jar:/project:z --rm --name=hello quay.io/quarkus/ubi-quarkus-native-image:19.2.0.1 ...
```
notice that after `--rm`, the additional container runtime option(s) get added instead of the image name.

This commit fixes that issue and the above command now gets correctly created as:

```
docker run -v quarkus/integration-tests/infinispan-embedded/target/quarkus-integration-test-xxx-999-SNAPSHOT-native-image-source-jar:/project:z --name=hello --rm quay.io/quarkus/ubi-quarkus-native-image:19.2.0.1
```