### PR TITLE
Get path of project-dir via correct API

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
@@ -1,6 +1,5 @@
 package io.quarkus.gradle.tasks;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.gradle.api.GradleException;
@@ -64,9 +63,10 @@ public class QuarkusListExtensions extends QuarkusTask {
     @TaskAction
     public void listExtensions() {
         try {
-            new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(new File(getPath())))).listExtensions(
-                    isAll(),
-                    getFormat(), getSearchPattern());
+            new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(this.getProject().getProjectDir())))
+                    .listExtensions(
+                            isAll(),
+                            getFormat(), getSearchPattern());
         } catch (IOException e) {
             throw new GradleException("Unable to list extensions", e);
         }


### PR DESCRIPTION
Fixes #4705 .
The correct path to the gradle project is provided so the exception is no longer printed.
But it now prints messages like
`Found null dependency:org.gradle.plugins.ide.internal.tooling.eclipse.DefaultEclipseExternalDependency@195a6ec8`

I assume there is still a larger body or work required here. Happy to help if someone can guide me what is the current- and target-state of the codebase here.