### PR TITLE
Minor text edit - add space after text "single" and Lambda ResourceHander (..single[ ]com.amazonaws...)

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -106,7 +106,7 @@ public class AmazonLambdaRecorder {
                 }
             } else if (unamedHandlerClasses.size() > 1) {
                 throw new RuntimeException(
-                        "Multiple handler classes, either specify the quarkus.lambda.handler property, or make sure there is only a single"
+                        "Multiple handler classes, either specify the quarkus.lambda.handler property, or make sure there is only a single "
                                 + RequestHandler.class.getName() + " implementation in the deployment");
             } else {
                 handlerClass = unamedHandlerClasses.get(0);


### PR DESCRIPTION
Caused by: java.lang.RuntimeException: Multiple handler classes, either specify the quarkus.lambda.handler property, or make sure there is only a **singlecom**.amazonaws.services.lambda.runtime.RequestHandler implementation in the deployment
        at io.quarkus.amazon.lambda.runtime.AmazonLambdaRecorder.chooseHandlerClass(AmazonLambdaRecorder.java:110)
        at io.quarkus.deployment.steps.AmazonLambdaProcessor$recordHandlerClass23.deploy_0(AmazonLambdaProcessor$recordHandlerClass23.zig:165)
        at io.quarkus.deployment.steps.AmazonLambdaProcessor$recordHandlerClass23.deploy(AmazonLambdaProcessor$recordHandlerClass23.zig:36)
        at io.quarkus.runner.ApplicationImpl2.doStart(ApplicationImpl2.zig:179)
