### PR TITLE
issue-4099 Introduce the ability to show root-cause first in exception stacktraces on error pages

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/devmode/ReplacementDebugPage.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/devmode/ReplacementDebugPage.java
@@ -1,8 +1,5 @@
 package io.quarkus.deployment.devmode;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 import io.quarkus.runtime.TemplateHtmlBuilder;
 
 /**
@@ -14,16 +11,9 @@ public class ReplacementDebugPage {
         TemplateHtmlBuilder builder = new TemplateHtmlBuilder("Error restarting Quarkus", exception.getClass().getName(),
                 generateHeaderMessage(exception));
 
-        builder.stack(generateStackTrace(exception));
+        builder.stack(exception);
 
         return builder.toString();
-    }
-
-    private static String generateStackTrace(final Throwable exception) {
-        StringWriter stringWriter = new StringWriter();
-        exception.printStackTrace(new PrintWriter(stringWriter));
-
-        return stringWriter.toString().trim();
     }
 
     private static String generateHeaderMessage(final Throwable exception) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
@@ -1,0 +1,116 @@
+package io.quarkus.runtime.util;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ */
+public class ExceptionUtil {
+
+    /**
+     * Returns the string representation of the stacktrace of the passed {@code exception}
+     *
+     * @param exception
+     * @return
+     */
+    public static String generateStackTrace(final Throwable exception) {
+        if (exception == null) {
+            return null;
+        }
+        final StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+
+        return stringWriter.toString().trim();
+    }
+
+    /**
+     * Returns a "upside down" stacktrace of the {@code exception} with the root
+     * cause showing up first in the stacktrace.
+     * <em>Note:</em> This is a relatively expensive method because it creates additional
+     * exceptions and manipulates their stacktraces. Care should be taken to determine whether
+     * usage of this method is necessary.
+     *
+     * @param exception The exception
+     * @return
+     */
+    public static String rootCauseFirstStackTrace(final Throwable exception) {
+        if (exception == null) {
+            return null;
+        }
+        // create an exception chain with the root cause being at element 0
+        final List<Throwable> exceptionChain = new ArrayList<>();
+        Throwable curr = exception;
+        while (curr != null) {
+            exceptionChain.add(0, curr);
+            curr = curr.getCause();
+        }
+        Throwable prevStrippedCause = null;
+        Throwable modifiedRoot = null;
+        // We reverse the stacktrace as follows:
+        // - Iterate the exception chain that we created, which has the root cause at element 0
+        // - for each exception in this chain
+        //      - create a new "copy" C1 of that exception
+        //      - create a new copy C2 of the "next" exception in the chain with its cause stripped off
+        //      - C1.initCause(C2)
+        //      - keep track of the copy C1 of the first element in the exception chain. That C1, lets call
+        //        it RC1, will be the modified representation of the root cause on which if printStackTrace()
+        //        is called, then it will end up printing stacktrace in reverse order (because of the way we
+        //        fiddled around with its causes and other details)
+        // - Finally, replace the occurrences of "Caused by:" string the in the stacktrace to "Resulted in:"
+        //   to better phrase the reverse stacktrace representation.
+        for (int i = 0; i < exceptionChain.size(); i++) {
+            final Throwable x = prevStrippedCause == null ? stripCause(exceptionChain.get(0)) : prevStrippedCause;
+            if (i != exceptionChain.size() - 1) {
+                final Throwable strippedCause = stripCause(exceptionChain.get(i + 1));
+                x.initCause(strippedCause);
+                prevStrippedCause = strippedCause;
+            }
+            if (i == 0) {
+                modifiedRoot = x;
+            }
+        }
+        return generateStackTrace(modifiedRoot).replace("Caused by:", "Resulted in:");
+    }
+
+    /**
+     * Creates and returns a new {@link Throwable} which has the following characteristics:
+     * <ul>
+     * <li>The {@code cause} of the Throwable hasn't yet been {@link Throwable#initCause(Throwable) inited}
+     * and thus can be "inited" later on if needed
+     * </li>
+     * <li>
+     * The stacktrace elements of the Throwable have been set to the stacktrace elements of the passed
+     * {@code t}. That way, any call to {@link Throwable#printStackTrace(PrintStream)} for example
+     * will print the stacktrace of the passed {@code t}
+     * </li>
+     * </ul>
+     *
+     * @param t The exception
+     * @return
+     */
+    private static Throwable stripCause(final Throwable t) {
+        final Throwable stripped = delegatingToStringThrowable(t);
+        stripped.setStackTrace(t.getStackTrace());
+        return stripped;
+    }
+
+    /**
+     * Creates and returns a new {@link Throwable} whose {@link Throwable#toString()} has been
+     * overridden to call the {@code toString()} method of the passed {@code t}.
+     *
+     * @param t The exception
+     * @return
+     */
+    private static Throwable delegatingToStringThrowable(final Throwable t) {
+        return new Throwable() {
+            @Override
+            public String toString() {
+                return t.toString();
+            }
+        };
+    }
+}

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/ExceptionUtilTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/ExceptionUtilTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.runtime.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class ExceptionUtilTest {
+
+    /**
+     * Tests the {@link ExceptionUtil#rootCauseFirstStackTrace(Throwable)} method
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testReversed() throws Exception {
+        final Throwable ex = generateException();
+        final String rootCauseFirst = ExceptionUtil.rootCauseFirstStackTrace(ex);
+        assertNotNull(rootCauseFirst, "Stacktrace was null");
+        assertTrue(rootCauseFirst.contains("Resulted in:"),
+                "Stacktrace doesn't contain the \"Resulted in:\" string");
+        assertFalse(rootCauseFirst.contains("Caused by:"), "Stacktrace contains the \"Caused by:\" string");
+        final String[] lines = rootCauseFirst.split("\n");
+        final String firstLine = lines[0];
+        assertTrue(firstLine.startsWith(NumberFormatException.class.getName() + ": For input string: \"23.23232\""),
+                "Unexpected root cause");
+        final List<String> expectedResultedIns = new ArrayList<>();
+        expectedResultedIns.add(IllegalArgumentException.class.getName() + ": Incorrect param");
+        expectedResultedIns.add(IOException.class.getName() + ": Request processing failed");
+        expectedResultedIns.add(IOError.class.getName());
+        expectedResultedIns.add(RuntimeException.class.getName() + ": Unexpected exception");
+        for (final String line : lines) {
+            if (!line.startsWith("Resulted in:")) {
+                continue;
+            }
+            final String expected = expectedResultedIns.remove(0);
+            assertTrue(line.startsWith("Resulted in: " + expected), "Unexpected stacktrace element '" + line + "'");
+        }
+        assertTrue(expectedResultedIns.isEmpty(), "Reversed stacktrace is missing certain elements");
+    }
+
+    private Throwable generateException() {
+        try {
+            try {
+                Integer.parseInt("23.23232");
+            } catch (NumberFormatException nfe) {
+                throw new IllegalArgumentException("Incorrect param", nfe);
+            }
+        } catch (IllegalArgumentException iae) {
+            try {
+                throw new IOException("Request processing failed", iae);
+            } catch (IOException e) {
+                try {
+                    throw new IOError(e);
+                } catch (IOError ie) {
+                    return new RuntimeException("Unexpected exception", ie);
+                }
+            }
+        }
+        throw new RuntimeException("Should not reach here");
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ErrorServletTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ErrorServletTestCase.java
@@ -23,7 +23,7 @@ public class ErrorServletTestCase {
         RestAssured.when().get("/error").then()
                 .statusCode(500)
                 .body(containsString("<h1 class=\"container\">Internal Server Error</h1>"))
-                .body(containsString("<div class=\"trace\">"));
+                .body(containsString("<div id=\"stacktrace\">"));
     }
 
     @Test

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusErrorServlet.java
@@ -27,7 +27,8 @@ public class QuarkusErrorServlet extends HttpServlet {
         if (errorMessage != null) {
             details = errorMessage;
         }
-        if (Boolean.parseBoolean(getInitParameter(SHOW_STACK)) && exception != null) {
+        final boolean showStack = Boolean.parseBoolean(getInitParameter(SHOW_STACK));
+        if (showStack && exception != null) {
             details = generateHeaderMessage(exception, uuid == null ? null : uuid.toString());
             stack = generateStackTrace(exception);
 
@@ -47,7 +48,11 @@ public class QuarkusErrorServlet extends HttpServlet {
             //We default to HTML representation
             resp.setContentType("text/html");
             resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
-            resp.getWriter().write(new TemplateHtmlBuilder("Internal Server Error", details, details).stack(stack).toString());
+            final TemplateHtmlBuilder htmlBuilder = new TemplateHtmlBuilder("Internal Server Error", details, details);
+            if (showStack && exception != null) {
+                htmlBuilder.stack(exception);
+            }
+            resp.getWriter().write(htmlBuilder.toString());
         }
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/QuarkusErrorHandler.java
@@ -62,7 +62,11 @@ public class QuarkusErrorHandler implements Handler<RoutingContext> {
         } else {
             //We default to HTML representation
             event.response().headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
-            event.response().end(new TemplateHtmlBuilder("Internal Server Error", details, details).stack(stack).toString());
+            final TemplateHtmlBuilder htmlBuilder = new TemplateHtmlBuilder("Internal Server Error", details, details);
+            if (showStack && exception != null) {
+                htmlBuilder.stack(exception);
+            }
+            event.response().end(htmlBuilder.toString());
         }
     }
 


### PR DESCRIPTION
The commit here adds an enhancement that was requested in https://github.com/quarkusio/quarkus/issues/4099.

What this change does is, it "reverses" the stacktrace of the exception that is being displayed on the Quarkus error page. Once reversed, the root cause of the exception will show up first and then its "successor" and so on.

For example, imagine this "original" exception stacktrace:

```
org.jboss.resteasy.spi.UnhandledException: java.lang.NumberFormatException: For input string: "232.232"
	at org.jboss.resteasy.core.ExceptionHandler.handleApplicationException(ExceptionHandler.java:106)
	at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:372)
	at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:209)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:496)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:252)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:153)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:363)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:156)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:238)
	at io.quarkus.resteasy.runtime.standalone.RequestDispatcher.service(RequestDispatcher.java:69)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:104)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatchRequestContext(VertxRequestHandler.java:83)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.lambda$handle$0(VertxRequestHandler.java:70)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NumberFormatException: For input string: "232.232"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.acme.blah.ExampleResource.hello(ExampleResource.java:21)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:151)
	at org.jboss.resteasy.core.MethodInjectorImpl.lambda$invoke$3(MethodInjectorImpl.java:122)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602)
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614)
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983)
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:110)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:122)
	at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:594)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:468)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:421)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:363)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:423)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:391)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invoke$1(ResourceMethodInvoker.java:365)
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:981)
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2124)
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:110)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:365)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:477)
	... 14 more
```
Once reversed, this stacktrace will now up as:

```
java.lang.NumberFormatException: For input string: "232.232"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.acme.blah.ExampleResource.hello(ExampleResource.java:21)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:151)
	at org.jboss.resteasy.core.MethodInjectorImpl.lambda$invoke$3(MethodInjectorImpl.java:122)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602)
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614)
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983)
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:110)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:122)
	at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:594)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:468)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:421)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:363)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:423)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:391)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invoke$1(ResourceMethodInvoker.java:365)
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:981)
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2124)
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:110)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:365)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:477)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:252)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:153)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:363)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:156)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:238)
	at io.quarkus.resteasy.runtime.standalone.RequestDispatcher.service(RequestDispatcher.java:69)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:104)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatchRequestContext(VertxRequestHandler.java:83)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.lambda$handle$0(VertxRequestHandler.java:70)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
Resulted in: org.jboss.resteasy.spi.UnhandledException: java.lang.NumberFormatException: For input string: "232.232"
	at org.jboss.resteasy.core.ExceptionHandler.handleApplicationException(ExceptionHandler.java:106)
	at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:372)
	at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:209)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:496)
	... 14 more
```

Our error pages will show the reversed (root-cause first) exception stacktraces by default. There's a visible/prominent message which states:
```
The stacktrace below has been reversed to show the root cause first. Click Here to see the original stacktrace
```
The "Click Here" link when clicked will show the exception stacktrace in the original format.

I decided to keep this (Javascript based) toggle to let users decide which representation they prefer.

The only thing that I kind of dislike is that I had to introduce the requirement of having javascript enabled (to provide this toggling). I tend to avoid allowing javascripts by default on random pages, but I guess for something like this use case, this is OK?

If anyone is interested to visualize this feature, I think for now, you can download this html file https://gist.github.com/jaikiran/fcc0798708e13e0144be7082493db06d and just open it locally in a browser and see how it looks.  That was generated from a Quarkus application, which had this change and which threw an error while serving a REST endpoint