### PR TITLE
Don't delegate to parent CL for "leaking" dependencies from build system

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/DefineClassVisibleURLClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/DefineClassVisibleURLClassLoader.java
@@ -2,6 +2,8 @@ package io.quarkus.bootstrap;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A wrapper around URLClassLoader whose only purpose is to expose defineClass
@@ -10,11 +12,48 @@ import java.net.URLClassLoader;
  */
 public class DefineClassVisibleURLClassLoader extends URLClassLoader {
 
+    private static final List<String> KNOWN_LEAKING_PACKAGES_FROM_PARENT_CL = Arrays.asList(
+            "org.apache.commons.lang3", // commons-lang3 used internally by gradle
+            "com.google.common" // guava added by maven internals
+    );
+
     public DefineClassVisibleURLClassLoader(URL[] urls, ClassLoader parent) {
         super(urls, parent);
     }
 
     public Class<?> visibleDefineClass(String name, byte[] b, int off, int len) throws ClassFormatError {
         return super.defineClass(name, b, off, len);
+    }
+
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        boolean lookup = false;
+        for (String prefix : KNOWN_LEAKING_PACKAGES_FROM_PARENT_CL) {
+            if (name.startsWith(prefix)) {
+                lookup = true;
+                break;
+            }
+        }
+
+        // The parent classloader can introduce plenty of build system dependencies (like commons-lang3 or guava)
+        // Which could be incompatible with what the user dependencies specify
+        // The temporary solution is to not delegate to parent class loader for dependencies that are known
+        // to leak in from the build system.
+        // The solution is pretty bad and should be views as temporary until a proper solution
+        // (like the one proposed here: https://github.com/quarkusio/quarkus/issues/770)
+        if (lookup) {
+            Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass == null) {
+                try {
+                    loadedClass = findClass(name);
+                } catch (ClassNotFoundException ignored) {
+                }
+
+                if (loadedClass == null) {
+                    loadedClass = super.loadClass(name);
+                }
+            }
+            return loadedClass;
+        }
+        return super.loadClass(name);
     }
 }


### PR DESCRIPTION
Fixes: #4767 

Would be great to have #4579 in so some new integration tests could be added with known problematic cases.

The problem is caused because the parent CL (defined [here](https://github.com/quarkusio/quarkus/blob/master/core/creator/src/main/java/io/quarkus/creator/phase/augment/AugmentTask.java#L162)) contains all the classes of the build system. 
This solution is pretty bad and should be temporary until a proper solution
like #770 is implemented.