### PR TITLE
Upgrade to Hibernate Validator 6.1.0.Final, RESTEasy 4.4.0.CR1 and move to Jakarta artifacts

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -52,15 +52,15 @@
         <jakarta.json.version>1.1.6</jakarta.json.version>
         <jakarta.json.bind-api.version>1.0.2</jakarta.json.bind-api.version>
         <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
+        <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
+        <jakarta.security.jaspi-api.version>1.1.3</jakarta.security.jaspi-api.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
         <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
-        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
+        <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
         <jaxb-runtime.version>2.3.3-b01</jaxb-runtime.version>
-        <javax.security.jacc-api.version>1.0.2.Final</javax.security.jacc-api.version>
-        <javax.security.jaspi-api.version>1.0.2.Final</javax.security.jaspi-api.version>
-        <jboss-jaxrs-api_2.1_spec.version>1.0.2.Final</jboss-jaxrs-api_2.1_spec.version>
-        <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
+        <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
+        <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
         <asm.version>7.1</asm.version>
         <commons-io.version>2.6</commons-io.version>
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
@@ -1197,9 +1197,14 @@
                 <version>${jakarta.interceptor-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>${javax.ws.rs-api.version}</version>
+                <groupId>org.jboss.spec.javax.xml.bind</groupId>
+                <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+                <version>${jboss-jaxb-api_2.3_spec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+                <version>${jboss-jaxrs-api_2.1_spec.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
@@ -1447,25 +1452,19 @@
                 <version>${jaxb-runtime.version}</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${jakarta.xml.bind-api.version}</version>
+                <groupId>jakarta.security.jacc</groupId>
+                <artifactId>jakarta.security.jacc-api</artifactId>
+                <version>${jakarta.security.jacc-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.spec.javax.security.jacc</groupId>
-                <artifactId>jboss-jacc-api_1.5_spec</artifactId>
-                <version>${javax.security.jacc-api.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.spec.javax.servlet</groupId>
-                        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>jakarta.security.auth.message</groupId>
+                <artifactId>jakarta.security.auth.message-api</artifactId>
+                <version>${jakarta.security.jaspi-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.spec.javax.security.auth.message</groupId>
-                <artifactId>jboss-jaspi-api_1.1_spec</artifactId>
-                <version>${javax.security.jaspi-api.version}</version>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
+                <version>${jakarta.websocket-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
@@ -1634,21 +1633,6 @@
                 <type>pom</type>
             </dependency>
 
-            <dependency>
-                <groupId>org.jboss.spec.javax.servlet</groupId>
-                <artifactId>jboss-servlet-api_4.0_spec</artifactId>
-                <version>${jboss-servlet-api_4.0_spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.transaction</groupId>
-                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-                <version>${jboss-transaction-api_1.2_spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.ws.rs</groupId>
-                <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-                <version>${jboss-jaxrs-api_2.1_spec.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.jboss.threads</groupId>
                 <artifactId>jboss-threads</artifactId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -75,7 +75,7 @@
         <validation-api.version>2.0.1.Final</validation-api.version>
         <classmate.version>1.3.4</classmate.version>
         <javax.el-impl.version>3.0.1-b11</javax.el-impl.version>
-        <hibernate-validator.version>6.1.0.Alpha6</hibernate-validator.version>
+        <hibernate-validator.version>6.1.0.Final</hibernate-validator.version>
         <hibernate-orm.version>5.4.7.Final</hibernate-orm.version>
         <hibernate-search.version>6.0.0.Beta2</hibernate-search.version>
         <narayana.version>5.9.8.Final</narayana.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -59,6 +59,8 @@
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
         <jaxb-runtime.version>2.3.3-b01</jaxb-runtime.version>
+        <!-- just for test dependency convergence -->
+        <jaxb-api.version>2.3.1</jaxb-api.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
         <asm.version>7.1</asm.version>
@@ -912,8 +914,8 @@
                         <artifactId>activation</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
                     </exclusion>
                     <exclusion>
                         <!-- https://github.com/quarkusio/quarkus/issues/1991 -->
@@ -925,6 +927,11 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -43,18 +43,25 @@
         <smallrye-converter-api.version>1.0.10</smallrye-converter-api.version>
         <smallrye-reactive-messaging.version>1.0.8</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.20.9</swagger-ui.version>
-        <javax.activation.version>1.1.1</javax.activation.version>
-        <javax.inject.version>1</javax.inject.version>
-        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <jakarta.activation.version>1.2.1</jakarta.activation.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>
+        <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
+        <jakarta.inject-api.version>1.0</jakarta.inject-api.version>
+        <jakarta.interceptor-api.version>1.2.5</jakarta.interceptor-api.version>
+        <jakarta.json.version>1.1.6</jakarta.json.version>
+        <jakarta.json.bind-api.version>1.0.2</jakarta.json.bind-api.version>
+        <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
+        <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
+        <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
+        <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
+        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
+        <jaxb-runtime.version>2.3.3-b01</jaxb-runtime.version>
         <javax.security.jacc-api.version>1.0.2.Final</javax.security.jacc-api.version>
         <javax.security.jaspi-api.version>1.0.2.Final</javax.security.jaspi-api.version>
-        <javax.json.version>1.1.4</javax.json.version>
-        <javax.json.bind-api.version>1.0</javax.json.bind-api.version>
-        <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
         <jboss-jaxrs-api_2.1_spec.version>1.0.2.Final</jboss-jaxrs-api_2.1_spec.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <asm.version>7.1</asm.version>
-        <cdi-api.version>2.0.SP1</cdi-api.version>
         <commons-io.version>2.6</commons-io.version>
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
         <maven-core.version>3.5.4</maven-core.version>
@@ -72,9 +79,7 @@
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.13</commons-codec.version>
-        <validation-api.version>2.0.1.Final</validation-api.version>
         <classmate.version>1.3.4</classmate.version>
-        <javax.el-impl.version>3.0.1-b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Final</hibernate-validator.version>
         <hibernate-orm.version>5.4.7.Final</hibernate-orm.version>
         <hibernate-search.version>6.0.0.Beta2</hibernate-search.version>
@@ -82,7 +87,6 @@
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.6</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <elasticsearch-rest-client.version>7.4.0</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.13</rxjava.version>
@@ -100,7 +104,6 @@
         <httpcore.version>4.4.11</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>
         <quartz.version>2.3.1</quartz.version>
-        <jakarta-activation.version>1.2.1</jakarta-activation.version>
         <h2.version>1.4.197</h2.version>  <!-- keep 1.4.197 as newer versions have severe regressions -->
         <postgresql-jdbc.version>42.2.6</postgresql-jdbc.version>
         <mariadb-jdbc.version>2.4.4</mariadb-jdbc.version>
@@ -165,7 +168,6 @@
         <jna.version>5.3.1</jna.version>
         <antlr.version>4.7.2</antlr.version>
         <quarkus-security.version>1.0.0.Beta1</quarkus-security.version>
-        <javax.interceptor-api.version>1.2</javax.interceptor-api.version>
         <keycloak.version>7.0.1</keycloak.version>
     </properties>
 
@@ -805,7 +807,7 @@
             <dependency>
                 <groupId>com.sun.activation</groupId>
                 <artifactId>jakarta.activation</artifactId>
-                <version>${jakarta-activation.version}</version>
+                <version>${jakarta.activation.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jaegertracing</groupId>
@@ -908,6 +910,10 @@
                     <exclusion>
                         <groupId>javax.activation</groupId>
                         <artifactId>activation</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
                     </exclusion>
                     <exclusion>
                         <!-- https://github.com/quarkusio/quarkus/issues/1991 -->
@@ -1151,35 +1157,44 @@
                 <version>${sundr.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${javax.activation.version}</version>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>${javax.inject.version}</version>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${javax.annotation-api.version}</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
-                <version>${javax.persistence-api.version}</version>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${jakarta.persistence-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${validation-api.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
             </dependency>
-
             <dependency>
-                <groupId>javax.interceptor</groupId>
-                <artifactId>javax.interceptor-api</artifactId>
-                <version>${javax.interceptor-api.version}</version>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${jakarta.transaction-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${jakarta.interceptor-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -1404,14 +1419,7 @@
                 <artifactId>yasson</artifactId>
                 <version>${yasson.version}</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>org.glassfish</groupId>
-                        <artifactId>jakarta.json</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>jakarta.json.bind</groupId>
-                        <artifactId>jakarta.json.bind-api</artifactId>
-                    </exclusion>
+                    <!-- The API is coming with the impl -->
                     <exclusion>
                         <groupId>jakarta.json</groupId>
                         <artifactId>jakarta.json-api</artifactId>
@@ -1420,40 +1428,28 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-                <version>${javax.el-impl.version}</version>
+                <artifactId>jakarta.el</artifactId>
+                <version>${jakarta.el-impl.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.json</artifactId>
-                <version>${javax.json.version}</version>
+                <artifactId>jakarta.json</artifactId>
+                <version>${jakarta.json.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.json.bind</groupId>
-                <artifactId>javax.json.bind-api</artifactId>
-                <version>${javax.json.bind-api.version}</version>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${jakarta.json.bind-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${javax.xml.bind.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>javax.activation-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>${jaxb-runtime.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${javax.xml.bind.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>javax.activation-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.security.jacc</groupId>
@@ -1587,11 +1583,11 @@
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-json-binding-provider</artifactId>
                 <version>${resteasy.version}</version>
-                <!-- In javax.json 1.1.4, the API is included in the impl jar -->
+                <!-- In jakarta.json 1.1.6, the API is included in the impl jar -->
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.json</groupId>
-                        <artifactId>javax.json-api</artifactId>
+                        <groupId>jakarta.json</groupId>
+                        <artifactId>jakarta.json-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1599,13 +1595,6 @@
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jaxb-provider</artifactId>
                 <version>${resteasy.version}</version>
-                <exclusions>
-                    <!-- The JBoss JAXB API artifact is used instead -->
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
@@ -1794,9 +1783,9 @@
                 <version>${slf4j-jboss-logging.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>${cdi-api.version}</version>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.enterprise.cdi-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -53,7 +53,7 @@
         <jakarta.json.bind-api.version>1.0.2</jakarta.json.bind-api.version>
         <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
         <jakarta.security.jacc-api.version>1.6.1</jakarta.security.jacc-api.version>
-        <jakarta.security.jaspi-api.version>1.1.3</jakarta.security.jaspi-api.version>
+        <jakarta.security.auth.message-api.version>1.1.3</jakarta.security.auth.message-api.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
         <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
@@ -1466,7 +1466,7 @@
             <dependency>
                 <groupId>jakarta.security.auth.message</groupId>
                 <artifactId>jakarta.security.auth.message-api</artifactId>
-                <version>${jakarta.security.jaspi-api.version}</version>
+                <version>${jakarta.security.auth.message-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.websocket</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <aesh.version>1.11</aesh.version>
         <jandex.version>2.1.1.Final</jandex.version>
-        <resteasy.version>4.3.1.Final</resteasy.version>
+        <resteasy.version>4.4.0.CR1</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>
         <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>
         <opentracing-web-servlet-filter.version>0.2.3</opentracing-web-servlet-filter.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -256,6 +256,10 @@
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
                                         </excludes>
+                                        <includes>
+                                            <!-- this is for REST Assured -->
+                                            <include>javax.xml.bind:jaxb-api:*:*:test</include>
+                                        </includes>
                                     </bannedDependencies>
                                 </rules>
                             </configuration>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -193,11 +193,9 @@
                                     </requireMavenVersion>
                                     <bannedDependencies>
                                         <excludes>
-                                            <!-- Use javax.annotation-api -->
-                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec
-                                            </exclude>
-                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec
-                                            </exclude>
+                                            <!-- Use Jakarta artifacts -->
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
                                             <!-- use our jboss-logmanager -->
                                             <exclude>org.jboss.logging:jboss-logmanager</exclude>
                                             <!-- We don't want all the API's in one jar-->
@@ -210,11 +208,24 @@
                                             <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
                                             <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
                                             <!-- The API is packaged by the implementation-->
-                                            <exclude>javax.json:javax.json-api</exclude>
-                                            <!-- Do not use Jakarta APIs for JSON -->
-                                            <exclude>org.glassfish:jakarta.json</exclude>
-                                            <exclude>jakarta.json.bind:jakarta.json.bind-api</exclude>
                                             <exclude>jakarta.json:jakarta.json-api</exclude>
+                                            <!-- Exclude javax dependencies in favor of Jakarta -->
+                                            <exclude>javax.activation:activation</exclude>
+                                            <exclude>javax.activation:javax.activation-api</exclude>
+                                            <exclude>javax.annotation:javax.annotation-api</exclude>
+                                            <exclude>javax.enterprise:cdi-api</exclude>
+                                            <exclude>javax.inject:javax.inject</exclude>
+                                            <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>org.glassfish:javax.json</exclude>
+                                            <exclude>org.glassfish:javax.el</exclude>
+                                            <exclude>javax.persistence:javax.persistence-api</exclude>
+                                            <exclude>javax.persistence:persistence-api</exclude>
+                                            <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
+                                            <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.transaction:jta</exclude>
+                                            <exclude>javax.transaction:javax.transaction-api</exclude>
+                                            <exclude>javax.validation:validation-api</exclude>
+                                            <exclude>javax.xml.bind:jaxb-api</exclude>
                                             <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
                                             <exclude>io.netty:netty-all</exclude>
                                             <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -216,6 +216,7 @@
                                             <exclude>javax.enterprise:cdi-api</exclude>
                                             <exclude>javax.inject:javax.inject</exclude>
                                             <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>javax.json.bind:javax.json.bind-api</exclude>
                                             <exclude>org.glassfish:javax.json</exclude>
                                             <exclude>org.glassfish:javax.el</exclude>
                                             <exclude>javax.persistence:javax.persistence-api</exclude>
@@ -227,6 +228,7 @@
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>
                                             <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <exclude>javax.websocket:javax.websocket-api</exclude>
                                             <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
                                             <!-- use our jboss-logmanager -->
                                             <exclude>org.jboss.logging:jboss-logmanager</exclude>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -193,22 +193,22 @@
                                     </requireMavenVersion>
                                     <bannedDependencies>
                                         <excludes>
-                                            <!-- Use Jakarta artifacts -->
+                                            <!-- Use Jakarta artifacts instead of JBoss specific ones -->
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
-                                            <!-- use our jboss-logmanager -->
-                                            <exclude>org.jboss.logging:jboss-logmanager</exclude>
-                                            <!-- We don't want all the API's in one jar-->
-                                            <exclude>javax:javaee-api</exclude>
-                                            <!-- Prevent incompatible config from coming in -->
-                                            <exclude>org.wildfly.client:wildfly-client-config</exclude>
-                                            <!-- Use Jakarta Activation -->
-                                            <exclude>javax.activation:javax-activation-api</exclude>
-                                            <exclude>javax.activation:activation</exclude>
-                                            <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
-                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
-                                            <!-- The API is packaged by the implementation-->
-                                            <exclude>jakarta.json:jakarta.json-api</exclude>
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec</exclude>
+                                            <!-- except for these 2 for now as most of the RESTEasy optional artifacts depend on them
+                                            <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec</exclude>
+                                            -->
+                                            <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                                            <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
                                             <!-- Exclude javax dependencies in favor of Jakarta -->
                                             <exclude>javax.activation:activation</exclude>
                                             <exclude>javax.activation:javax.activation-api</exclude>
@@ -226,6 +226,17 @@
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>
                                             <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                                            <!-- use our jboss-logmanager -->
+                                            <exclude>org.jboss.logging:jboss-logmanager</exclude>
+                                            <!-- We don't want all the API's in one jar-->
+                                            <exclude>javax:javaee-api</exclude>
+                                            <!-- Prevent incompatible config from coming in -->
+                                            <exclude>org.wildfly.client:wildfly-client-config</exclude>
+                                            <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
+                                            <!-- The API is packaged by the implementation-->
+                                            <exclude>jakarta.json:jakarta.json-api</exclude>
                                             <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
                                             <exclude>io.netty:netty-all</exclude>
                                             <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -222,6 +222,7 @@
                                             <exclude>javax.persistence:persistence-api</exclude>
                                             <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
                                             <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.servlet:javax.servlet-api</exclude>
                                             <exclude>javax.transaction:jta</exclude>
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>

--- a/core/creator/src/main/java/io/quarkus/creator/curator/Curator.java
+++ b/core/creator/src/main/java/io/quarkus/creator/curator/Curator.java
@@ -47,7 +47,7 @@ public class Curator {
 
     public static CurateOutcome run(CuratedApplicationCreator ctx) throws AppCreatorException {
 
-        log.info("provideOutcome depsOrigin=" + ctx.getDepsOrigin() + ", versionUpdate=" + ctx.getUpdate()
+        log.debug("provideOutcome depsOrigin=" + ctx.getDepsOrigin() + ", versionUpdate=" + ctx.getUpdate()
                 + ", versionUpdateNumber="
                 + ctx.getUpdateNumber());
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/index/ClassPathArtifactResolverTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/index/ClassPathArtifactResolverTestCase.java
@@ -17,7 +17,7 @@ public class ClassPathArtifactResolverTestCase {
 
     @Test
     public void testMultipleGroupArtifact() throws Exception {
-        assertNotNull(RESOLVER.getArtifact("javax.annotation", "javax.annotation-api", null));
+        assertNotNull(RESOLVER.getArtifact("jakarta.annotation", "jakarta.annotation-api", null));
     }
 
     @Test

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -16,16 +16,30 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/core/test-extension/deployment/pom.xml
+++ b/core/test-extension/deployment/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.quarkus.http</groupId>
-            <artifactId>quarkus-http-servlet</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>
         </dependency>

--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -44,8 +44,8 @@
         </dependency>
         <!-- Don't rely on JDK JAXB so code compiles and runs under both JDK8/11 -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
@@ -55,7 +55,7 @@
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
         </dependency>
-</dependencies>
+    </dependencies>
 
     <build>
         <plugins>

--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -37,6 +37,16 @@
         <dependency>
             <groupId>io.quarkus.http</groupId>
             <artifactId>quarkus-http-servlet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -44,12 +54,18 @@
         </dependency>
         <!-- Don't rely on JDK JAXB so code compiles and runs under both JDK8/11 -->
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -39,6 +39,24 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
@@ -47,6 +65,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -116,7 +140,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
 
         <!-- extensions reader -->

--- a/devtools/platform-descriptor-json-plugin/pom.xml
+++ b/devtools/platform-descriptor-json-plugin/pom.xml
@@ -49,7 +49,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
 
         <!-- extensions reader -->

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -49,8 +49,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -61,12 +61,12 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.security.jacc</groupId>
-            <artifactId>jboss-jacc-api_1.5_spec</artifactId>
+            <groupId>jakarta.security.jacc</groupId>
+            <artifactId>jakarta.security.jacc-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.security.auth.message</groupId>
-            <artifactId>jboss-jaspi-api_1.1_spec</artifactId>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -49,6 +49,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.security.jacc</groupId>

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -57,12 +57,12 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.security.jacc</groupId>
-            <artifactId>jboss-jacc-api_1.5_spec</artifactId>
+            <groupId>jakarta.security.jacc</groupId>
+            <artifactId>jakarta.security.jacc-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.security.auth.message</groupId>
-            <artifactId>jboss-jaspi-api_1.1_spec</artifactId>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -45,6 +45,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.security.jacc</groupId>

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -75,6 +75,17 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <exclusions>
+                <exclusion>
+                    <groupId>javax.persistence</groupId>
+                    <artifactId>javax.persistence-api</artifactId>
+                </exclusion>
 
                 <!-- Javassist is never used in Quarkus -->
                 <exclusion>
@@ -57,8 +61,11 @@
                     <groupId>javax.activation</groupId>
                     <artifactId>javax.activation-api</artifactId>
                 </exclusion>
-
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -39,6 +39,10 @@
                     <groupId>javax.persistence</groupId>
                     <artifactId>javax.persistence-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
 
                 <!-- Javassist is never used in Quarkus -->
                 <exclusion>
@@ -66,6 +70,10 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -57,7 +57,17 @@
                     <groupId>org.jboss.marshalling</groupId>
                     <artifactId>jboss-marshalling-osgi</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>
+                        jboss-transaction-api_1.2_spec
+                    </artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/infinispan-embedded/runtime/pom.xml
+++ b/extensions/infinispan-embedded/runtime/pom.xml
@@ -29,6 +29,18 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>
+                        jboss-transaction-api_1.2_spec
+                    </artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>

--- a/extensions/jaeger/deployment/pom.xml
+++ b/extensions/jaeger/deployment/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>quarkus-jaeger</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -22,6 +22,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
+        <!-- Don't rely on the JDK impl to be present as it's not present in JDK 11+ -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.xml.bind</groupId>
             <artifactId>jboss-jaxb-api_2.3_spec</artifactId>

--- a/extensions/jsonb/runtime/pom.xml
+++ b/extensions/jsonb/runtime/pom.xml
@@ -17,10 +17,13 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <exclusions>
+                <!-- this is a "module" dependency and dependency management does not work correctly -->
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jsonp/runtime/pom.xml
+++ b/extensions/jsonp/runtime/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/keycloak-authorization/runtime/pom.xml
+++ b/extensions/keycloak-authorization/runtime/pom.xml
@@ -37,6 +37,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -29,6 +29,24 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -56,10 +56,6 @@
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-integration</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -29,6 +29,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-context-propagation-jta</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>javax.transaction-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -37,6 +37,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -30,8 +30,8 @@
             <artifactId>quarkus-panache-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/extensions/rest-client/runtime/pom.xml
+++ b/extensions/rest-client/runtime/pom.xml
@@ -30,6 +30,18 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client-microprofile</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.interceptor</groupId>
+                    <artifactId>
+                        jboss-interceptors-api_1.2_spec
+                    </artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/extensions/resteasy-jackson/runtime/pom.xml
+++ b/extensions/resteasy-jackson/runtime/pom.xml
@@ -25,6 +25,16 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/resteasy-jaxb/runtime/pom.xml
+++ b/extensions/resteasy-jaxb/runtime/pom.xml
@@ -25,6 +25,16 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/resteasy-server-common/runtime/pom.xml
+++ b/extensions/resteasy-server-common/runtime/pom.xml
@@ -27,8 +27,8 @@
             <artifactId>quarkus-resteasy-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/resteasy/runtime/pom.xml
+++ b/extensions/resteasy/runtime/pom.xml
@@ -16,8 +16,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpRequest.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpRequest.java
@@ -41,6 +41,7 @@ public class VertxHttpRequest extends BaseHttpRequest {
     protected ResteasyHttpHeaders httpHeaders;
     protected SynchronousDispatcher dispatcher;
     protected String httpMethod;
+    protected String remoteHost;
     protected InputStream inputStream;
     protected Map<String, Object> attributes = new HashMap<String, Object>();
     protected VertxHttpResponse response;
@@ -53,6 +54,7 @@ public class VertxHttpRequest extends BaseHttpRequest {
             ResteasyHttpHeaders httpHeaders,
             ResteasyUriInfo uri,
             String httpMethod,
+            String remoteHost,
             SynchronousDispatcher dispatcher,
             VertxHttpResponse response,
             boolean is100ContinueExpected) {
@@ -63,6 +65,7 @@ public class VertxHttpRequest extends BaseHttpRequest {
         this.dispatcher = dispatcher;
         this.httpHeaders = httpHeaders;
         this.httpMethod = httpMethod;
+        this.remoteHost = remoteHost;
         this.executionContext = new VertxExecutionContext(this, response, dispatcher);
     }
 
@@ -121,6 +124,16 @@ public class VertxHttpRequest extends BaseHttpRequest {
     @Override
     public HttpHeaders getHttpHeaders() {
         return httpHeaders;
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return remoteHost;
+    }
+
+    @Override
+    public String getRemoteAddress() {
+        return remoteHost;
     }
 
     @Override

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -96,7 +96,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
             VertxHttpResponse vertxResponse = new VertxHttpResponse(request, dispatcher.getProviderFactory(),
                     request.method(), allocator, output);
             VertxHttpRequest vertxRequest = new VertxHttpRequest(ctx, headers, uriInfo, request.rawMethod(),
-                    dispatcher.getDispatcher(), vertxResponse, false);
+                    request.remoteAddress().host(), dispatcher.getDispatcher(), vertxResponse, false);
             vertxRequest.setInputStream(is);
             try {
                 ResteasyContext.pushContext(SecurityContext.class, new QuarkusResteasySecurityContext(request));

--- a/extensions/scheduler/runtime/pom.xml
+++ b/extensions/scheduler/runtime/pom.xml
@@ -43,8 +43,8 @@
       </exclusions>
     </dependency>
     <dependency>
-       <groupId>org.jboss.spec.javax.transaction</groupId>
-       <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+       <groupId>jakarta.transaction</groupId>
+       <artifactId>jakarta.transaction-api</artifactId>
        <!--
           TODO: Make this an optional dependency?
           Graal compiler not happy with broken classpaths

--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -19,8 +19,8 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>
@@ -29,6 +29,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/security/test-utils/pom.xml
+++ b/extensions/security/test-utils/pom.xml
@@ -21,6 +21,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/smallrye-context-propagation/runtime/pom.xml
+++ b/extensions/smallrye-context-propagation/runtime/pom.xml
@@ -17,6 +17,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-context-propagation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -32,7 +32,23 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/smallrye-health/runtime/pom.xml
+++ b/extensions/smallrye-health/runtime/pom.xml
@@ -18,6 +18,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-health</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -15,10 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-jwt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
         </dependency>
@@ -34,6 +30,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp-deployment</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt</artifactId>

--- a/extensions/smallrye-jwt/runtime/pom.xml
+++ b/extensions/smallrye-jwt/runtime/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>quarkus-jsonp</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/extensions/smallrye-jwt/runtime/pom.xml
+++ b/extensions/smallrye-jwt/runtime/pom.xml
@@ -18,6 +18,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -53,16 +53,16 @@
             <artifactId>quarkus-jsonp</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -25,6 +25,16 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-opentracing</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -42,7 +42,15 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -54,7 +54,15 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -38,7 +38,15 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -1,62 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <parent>
-      <artifactId>quarkus-smallrye-reactive-messaging-parent</artifactId>
-      <groupId>io.quarkus</groupId>
-      <version>999-SNAPSHOT</version>
-      <relativePath>../</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-
-   <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
-   <name>Quarkus - SmallRye Reactive Messaging - Runtime</name>
-   <description>Asynchronous messaging for Reactive Streams</description>
-   <dependencies>
-      <dependency>
-         <groupId>io.quarkus</groupId>
-         <artifactId>quarkus-arc</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.quarkus</groupId>
-         <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.quarkus</groupId>
-         <artifactId>quarkus-vertx-core</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.smallrye.reactive</groupId>
-         <artifactId>smallrye-reactive-messaging-provider</artifactId>
-         <exclusions>
-            <exclusion>
-               <groupId>com.fasterxml.jackson.core</groupId>
-               <artifactId>jackson-core</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-   </dependencies>
-
-   <build>
-      <plugins>
-         <plugin>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-smallrye-reactive-messaging-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
+    <name>Quarkus - SmallRye Reactive Messaging - Runtime</name>
+    <description>Asynchronous messaging for Reactive Streams</description>
+    <dependencies>
+        <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-         </plugin>
-         <plugin>
-           <artifactId>maven-compiler-plugin</artifactId>
-           <configuration>
-             <annotationProcessorPaths>
-               <path>
-                 <groupId>io.quarkus</groupId>
-                 <artifactId>quarkus-extension-processor</artifactId>
-                 <version>${project.version}</version>
-               </path>
-             </annotationProcessorPaths>
-           </configuration>
-         </plugin>
-      </plugins>
-   </build>
-
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-provider</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/extensions/spring-web/runtime/pom.xml
+++ b/extensions/spring-web/runtime/pom.xml
@@ -22,6 +22,16 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-spring-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -33,11 +33,19 @@
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>

--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -29,7 +29,15 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -30,6 +30,18 @@
         <dependency>
             <groupId>io.quarkus.http</groupId>
             <artifactId>quarkus-http-websockets-jsr</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.websocket</groupId>
+                    <artifactId>
+                        jboss-websocket-api_1.1_spec
+                    </artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/undertow/deployment/pom.xml
+++ b/extensions/undertow/deployment/pom.xml
@@ -16,6 +16,16 @@
         <dependency>
             <groupId>io.quarkus.http</groupId>
             <artifactId>quarkus-http-servlet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -25,6 +25,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.substratevm</groupId>
@@ -33,6 +43,16 @@
         <dependency>
             <groupId>io.quarkus.http</groupId>
             <artifactId>quarkus-http-servlet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.http</groupId>

--- a/extensions/undertow/spi/pom.xml
+++ b/extensions/undertow/spi/pom.xml
@@ -16,6 +16,16 @@
         <dependency>
             <groupId>io.quarkus.http</groupId>
             <artifactId>quarkus-http-servlet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -21,6 +21,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -29,6 +29,16 @@
         <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -35,15 +35,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Versions -->
-        <version.cdi>2.0.SP1</version.cdi>
+        <version.cdi>2.0.2</version.cdi>
         <version.jandex>2.1.1.Final</version.jandex>
         <version.junit5>5.5.2</version.junit5>
         <version.maven>3.5.4</version.maven>
         <version.assertj>3.12.2</version.assertj>
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
-        <version.javax-annotation>1.3.2</version.javax-annotation>
+        <version.jakarta-annotation>1.3.5</version.jakarta-annotation>
         <version.gizmo>1.0.0.Alpha8</version.gizmo>
-        <version.jpa>2.2</version.jpa>
+        <version.jpa>2.2.3</version.jpa>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
 
@@ -70,8 +70,8 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${version.cdi}</version>
             </dependency>
 
@@ -122,15 +122,15 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${version.javax-annotation}</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${version.jakarta-annotation}</version>
                 <!-- scope>provided</scope -->
             </dependency>
 
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
                 <version>${version.jpa}</version>
                 <scope>test</scope>
             </dependency>
@@ -166,9 +166,26 @@
                                 <rules>
                                     <bannedDependencies>
                                         <excludes>
-                                            <!-- Use javax.annotation-api -->
+                                            <!-- Use jakarta.annotation-api -->
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
+                                            <!-- Use Jakarta dependencies -->
+                                            <exclude>javax.activation:activation</exclude>
+                                            <exclude>javax.activation:javax.activation-api</exclude>
+                                            <exclude>javax.annotation:javax.annotation-api</exclude>
+                                            <exclude>javax.enterprise:cdi-api</exclude>
+                                            <exclude>javax.inject:javax.inject</exclude>
+                                            <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>org.glassfish:javax.json</exclude>
+                                            <exclude>org.glassfish:javax.el</exclude>
+                                            <exclude>javax.persistence:javax.persistence-api</exclude>
+                                            <exclude>javax.persistence:persistence-api</exclude>
+                                            <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
+                                            <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.transaction:jta</exclude>
+                                            <exclude>javax.transaction:javax.transaction-api</exclude>
+                                            <exclude>javax.validation:validation-api</exclude>
+                                            <exclude>javax.xml.bind:jaxb-api</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -166,10 +166,23 @@
                                 <rules>
                                     <bannedDependencies>
                                         <excludes>
-                                            <!-- Use jakarta.annotation-api -->
+                                            <!-- Use Jakarta artifacts instead of JBoss specific ones -->
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
-                                            <!-- Use Jakarta dependencies -->
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec</exclude>
+                                            <!-- except for these 2 for now as most of the RESTEasy optional artifacts depend on them
+                                            <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec</exclude>
+                                            -->
+                                            <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                                            <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
+                                            <!-- Exclude javax dependencies in favor of Jakarta -->
                                             <exclude>javax.activation:activation</exclude>
                                             <exclude>javax.activation:javax.activation-api</exclude>
                                             <exclude>javax.annotation:javax.annotation-api</exclude>
@@ -186,6 +199,35 @@
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>
                                             <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                                            <!-- use our jboss-logmanager -->
+                                            <exclude>org.jboss.logging:jboss-logmanager</exclude>
+                                            <!-- We don't want all the API's in one jar-->
+                                            <exclude>javax:javaee-api</exclude>
+                                            <!-- Prevent incompatible config from coming in -->
+                                            <exclude>org.wildfly.client:wildfly-client-config</exclude>
+                                            <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
+                                            <!-- The API is packaged by the implementation-->
+                                            <exclude>jakarta.json:jakarta.json-api</exclude>
+                                            <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
+                                            <exclude>io.netty:netty-all</exclude>
+                                            <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
+                                            <exclude>log4j:log4j</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                                            <!-- Ban commons-logging (use org.jboss.logging:commons-logging-jboss-logging instead) -->
+                                            <exclude>commons-logging:commons-logging</exclude>
+                                            <exclude>commons-logging:commons-logging-api</exclude>
+                                            <exclude>org.springframework:spring-jcl</exclude>
+                                            <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <exclude>org.slf4j:slf4j-simple</exclude>
+                                            <exclude>org.slf4j:slf4j-nop</exclude>
+                                            <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                            <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                            <exclude>org.slf4j:slf4j-log4j13</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -195,6 +195,7 @@
                                             <exclude>javax.persistence:persistence-api</exclude>
                                             <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
                                             <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.servlet:javax.servlet-api</exclude>
                                             <exclude>javax.transaction:jta</exclude>
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -189,6 +189,7 @@
                                             <exclude>javax.enterprise:cdi-api</exclude>
                                             <exclude>javax.inject:javax.inject</exclude>
                                             <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>javax.json.bind:javax.json.bind-api</exclude>
                                             <exclude>org.glassfish:javax.json</exclude>
                                             <exclude>org.glassfish:javax.el</exclude>
                                             <exclude>javax.persistence:javax.persistence-api</exclude>
@@ -200,6 +201,7 @@
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>
                                             <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <exclude>javax.websocket:javax.websocket-api</exclude>
                                             <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
                                             <!-- use our jboss-logmanager -->
                                             <exclude>org.jboss.logging:jboss-logmanager</exclude>

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -22,8 +22,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
 
         <dependency>
@@ -42,8 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/runtime/pom.xml
+++ b/independent-projects/arc/runtime/pom.xml
@@ -17,13 +17,13 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -36,8 +36,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
 
         <dependency>

--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -18,10 +18,17 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -70,6 +70,14 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -230,10 +230,23 @@
                                 <rules>
                                     <bannedDependencies>
                                         <excludes>
-                                            <!-- Use javax.annotation-api -->
+                                            <!-- Use Jakarta artifacts instead of JBoss specific ones -->
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
-                                            <!-- Use Jakarta dependencies -->
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec</exclude>
+                                            <!-- except for these 2 for now as most of the RESTEasy optional artifacts depend on them
+                                            <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec</exclude>
+                                            -->
+                                            <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                                            <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
+                                            <!-- Exclude javax dependencies in favor of Jakarta -->
                                             <exclude>javax.activation:activation</exclude>
                                             <exclude>javax.activation:javax.activation-api</exclude>
                                             <exclude>javax.annotation:javax.annotation-api</exclude>
@@ -247,8 +260,37 @@
                                             <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
                                             <exclude>javax.servlet:servlet-api</exclude>
                                             <exclude>javax.transaction:jta</exclude>
+                                            <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>
                                             <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <!-- use our jboss-logmanager -->
+                                            <exclude>org.jboss.logging:jboss-logmanager</exclude>
+                                            <!-- We don't want all the API's in one jar-->
+                                            <exclude>javax:javaee-api</exclude>
+                                            <!-- Prevent incompatible config from coming in -->
+                                            <exclude>org.wildfly.client:wildfly-client-config</exclude>
+                                            <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
+                                            <!-- The API is packaged by the implementation-->
+                                            <exclude>jakarta.json:jakarta.json-api</exclude>
+                                            <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
+                                            <exclude>io.netty:netty-all</exclude>
+                                            <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
+                                            <exclude>log4j:log4j</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                                            <!-- Ban commons-logging (use org.jboss.logging:commons-logging-jboss-logging instead) -->
+                                            <exclude>commons-logging:commons-logging</exclude>
+                                            <exclude>commons-logging:commons-logging-api</exclude>
+                                            <exclude>org.springframework:spring-jcl</exclude>
+                                            <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <exclude>org.slf4j:slf4j-simple</exclude>
+                                            <exclude>org.slf4j:slf4j-nop</exclude>
+                                            <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                            <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                            <exclude>org.slf4j:slf4j-log4j13</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -253,6 +253,7 @@
                                             <exclude>javax.enterprise:cdi-api</exclude>
                                             <exclude>javax.inject:javax.inject</exclude>
                                             <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>javax.json.bind:javax.json.bind-api</exclude>
                                             <exclude>org.glassfish:javax.json</exclude>
                                             <exclude>org.glassfish:javax.el</exclude>
                                             <exclude>javax.persistence:javax.persistence-api</exclude>
@@ -264,6 +265,8 @@
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>
                                             <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <exclude>javax.websocket:javax.websocket-api</exclude>
+                                            <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
                                             <!-- use our jboss-logmanager -->
                                             <exclude>org.jboss.logging:jboss-logmanager</exclude>
                                             <!-- We don't want all the API's in one jar-->

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -259,6 +259,7 @@
                                             <exclude>javax.persistence:persistence-api</exclude>
                                             <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
                                             <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.servlet:javax.servlet-api</exclude>
                                             <exclude>javax.transaction:jta</exclude>
                                             <exclude>javax.transaction:javax.transaction-api</exclude>
                                             <exclude>javax.validation:validation-api</exclude>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -31,10 +31,13 @@
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
         <maven-resolver.version>1.1.1</maven-resolver.version>
         <maven-wagon.version>3.0.0</maven-wagon.version>
+        <plexus-cypher.version>1.7</plexus-cypher.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jackson.version>2.9.10</jackson.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
+        <jakarta.inject-api.version>1.0</jakarta.inject-api.version>
     </properties>
     <modules>
         <module>core</module>
@@ -63,6 +66,16 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>${maven-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -73,6 +86,12 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${maven-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -91,18 +110,42 @@
                         <groupId>javax.annotation</groupId>
                         <artifactId>jsr250-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${javax.annotation-api.version}</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.enterprise.cdi-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-resolver-provider</artifactId>
                 <version>${maven-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -190,6 +233,22 @@
                                             <!-- Use javax.annotation-api -->
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
                                             <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
+                                            <!-- Use Jakarta dependencies -->
+                                            <exclude>javax.activation:activation</exclude>
+                                            <exclude>javax.activation:javax.activation-api</exclude>
+                                            <exclude>javax.annotation:javax.annotation-api</exclude>
+                                            <exclude>javax.enterprise:cdi-api</exclude>
+                                            <exclude>javax.inject:javax.inject</exclude>
+                                            <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>org.glassfish:javax.json</exclude>
+                                            <exclude>org.glassfish:javax.el</exclude>
+                                            <exclude>javax.persistence:javax.persistence-api</exclude>
+                                            <exclude>javax.persistence:persistence-api</exclude>
+                                            <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
+                                            <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.transaction:jta</exclude>
+                                            <exclude>javax.validation:validation-api</exclude>
+                                            <exclude>javax.xml.bind:jaxb-api</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/independent-projects/tools/common/pom.xml
+++ b/independent-projects/tools/common/pom.xml
@@ -38,10 +38,30 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.http</groupId>

--- a/independent-projects/tools/common/pom.xml
+++ b/independent-projects/tools/common/pom.xml
@@ -66,6 +66,26 @@
         <dependency>
             <groupId>io.quarkus.http</groupId>
             <artifactId>quarkus-http-websockets-jsr</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.websocket</groupId>
+                    <artifactId>
+                        jboss-websocket-api_1.1_spec
+                    </artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -40,6 +40,7 @@
         <assertj.version>3.13.2</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jackson.version>2.9.10</jackson.version>
+        <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <junit.version>5.5.2</junit.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <maven-core.version>3.5.4</maven-core.version>
@@ -90,6 +91,11 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.enterprise.cdi-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -144,6 +150,84 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- Use javax.annotation-api -->
+                                        <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec
+                                        </exclude>
+                                        <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec
+                                        </exclude>
+                                        <!-- use our jboss-logmanager -->
+                                        <exclude>org.jboss.logging:jboss-logmanager</exclude>
+                                        <!-- We don't want all the API's in one jar-->
+                                        <exclude>javax:javaee-api</exclude>
+                                        <!-- Prevent incompatible config from coming in -->
+                                        <exclude>org.wildfly.client:wildfly-client-config</exclude>
+                                        <!-- Use Jakarta Activation -->
+                                        <exclude>javax.activation:javax-activation-api</exclude>
+                                        <exclude>javax.activation:activation</exclude>
+                                        <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
+                                        <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
+                                        <!-- The API is packaged by the implementation-->
+                                        <exclude>jakarta.json:jakarta.json-api</exclude>
+                                        <!-- Exclude javax dependencies in favor of Jakarta -->
+                                        <exclude>javax.activation:activation</exclude>
+                                        <exclude>javax.activation:javax.activation-api</exclude>
+                                        <exclude>javax.annotation:javax.annotation-api</exclude>
+                                        <exclude>javax.enterprise:cdi-api</exclude>
+                                        <exclude>javax.inject:javax.inject</exclude>
+                                        <exclude>javax.json:javax.json-api</exclude>
+                                        <exclude>org.glassfish:javax.json</exclude>
+                                        <exclude>org.glassfish:javax.el</exclude>
+                                        <exclude>javax.persistence:javax.persistence-api</exclude>
+                                        <exclude>javax.persistence:persistence-api</exclude>
+                                        <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
+                                        <exclude>javax.servlet:servlet-api</exclude>
+                                        <exclude>javax.transaction:jta</exclude>
+                                        <exclude>javax.transaction:javax.transaction-api</exclude>
+                                        <exclude>javax.validation:validation-api</exclude>
+                                        <exclude>javax.xml.bind:jaxb-api</exclude>
+                                        <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
+                                        <exclude>io.netty:netty-all</exclude>
+                                        <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
+                                        <exclude>log4j:log4j</exclude>
+                                        <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                                        <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                                        <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                                        <!-- Ban commons-logging (use org.jboss.logging:commons-logging-jboss-logging instead) -->
+                                        <exclude>commons-logging:commons-logging</exclude>
+                                        <exclude>commons-logging:commons-logging-api</exclude>
+                                        <exclude>org.springframework:spring-jcl</exclude>
+                                        <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                                        <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                        <exclude>org.slf4j:slf4j-simple</exclude>
+                                        <exclude>org.slf4j:slf4j-nop</exclude>
+                                        <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                        <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                        <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -198,6 +198,7 @@
                                         <exclude>javax.enterprise:cdi-api</exclude>
                                         <exclude>javax.inject:javax.inject</exclude>
                                         <exclude>javax.json:javax.json-api</exclude>
+                                        <exclude>javax.json.bind:javax.json.bind-api</exclude>
                                         <exclude>org.glassfish:javax.json</exclude>
                                         <exclude>org.glassfish:javax.el</exclude>
                                         <exclude>javax.persistence:javax.persistence-api</exclude>
@@ -209,6 +210,7 @@
                                         <exclude>javax.transaction:javax.transaction-api</exclude>
                                         <exclude>javax.validation:validation-api</exclude>
                                         <exclude>javax.xml.bind:jaxb-api</exclude>
+                                        <exclude>javax.websocket:javax.websocket-api</exclude>
                                         <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
                                         <!-- use our jboss-logmanager -->
                                         <exclude>org.jboss.logging:jboss-logmanager</exclude>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -41,6 +41,8 @@
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jackson.version>2.9.10</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
+        <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
+        <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
         <junit.version>5.5.2</junit.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <maven-core.version>3.5.4</maven-core.version>
@@ -96,6 +98,16 @@
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${jakarta.enterprise.cdi-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
+                <version>${jakarta.websocket-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -163,24 +175,22 @@
                             <rules>
                                 <bannedDependencies>
                                     <excludes>
-                                        <!-- Use javax.annotation-api -->
-                                        <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec
-                                        </exclude>
-                                        <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec
-                                        </exclude>
-                                        <!-- use our jboss-logmanager -->
-                                        <exclude>org.jboss.logging:jboss-logmanager</exclude>
-                                        <!-- We don't want all the API's in one jar-->
-                                        <exclude>javax:javaee-api</exclude>
-                                        <!-- Prevent incompatible config from coming in -->
-                                        <exclude>org.wildfly.client:wildfly-client-config</exclude>
-                                        <!-- Use Jakarta Activation -->
-                                        <exclude>javax.activation:javax-activation-api</exclude>
-                                        <exclude>javax.activation:activation</exclude>
-                                        <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
-                                        <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
-                                        <!-- The API is packaged by the implementation-->
-                                        <exclude>jakarta.json:jakarta.json-api</exclude>
+                                        <!-- Use Jakarta artifacts instead of JBoss specific ones -->
+                                        <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec</exclude>
+                                        <!-- except for these 2 for now as most of the RESTEasy optional artifacts depend on them
+                                        <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</exclude>
+                                        <exclude>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec</exclude>
+                                        -->
+                                        <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                                        <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
                                         <!-- Exclude javax dependencies in favor of Jakarta -->
                                         <exclude>javax.activation:activation</exclude>
                                         <exclude>javax.activation:javax.activation-api</exclude>
@@ -198,6 +208,17 @@
                                         <exclude>javax.transaction:javax.transaction-api</exclude>
                                         <exclude>javax.validation:validation-api</exclude>
                                         <exclude>javax.xml.bind:jaxb-api</exclude>
+                                        <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                                        <!-- use our jboss-logmanager -->
+                                        <exclude>org.jboss.logging:jboss-logmanager</exclude>
+                                        <!-- We don't want all the API's in one jar-->
+                                        <exclude>javax:javaee-api</exclude>
+                                        <!-- Prevent incompatible config from coming in -->
+                                        <exclude>org.wildfly.client:wildfly-client-config</exclude>
+                                        <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
+                                        <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
+                                        <!-- The API is packaged by the implementation-->
+                                        <exclude>jakarta.json:jakarta.json-api</exclude>
                                         <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
                                         <exclude>io.netty:netty-all</exclude>
                                         <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -204,6 +204,7 @@
                                         <exclude>javax.persistence:persistence-api</exclude>
                                         <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
                                         <exclude>javax.servlet:servlet-api</exclude>
+                                        <exclude>javax.servlet:javax.servlet-api</exclude>
                                         <exclude>javax.transaction:jta</exclude>
                                         <exclude>javax.transaction:javax.transaction-api</exclude>
                                         <exclude>javax.validation:validation-api</exclude>

--- a/integration-tests/common-jpa-entities/pom.xml
+++ b/integration-tests/common-jpa-entities/pom.xml
@@ -16,8 +16,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/elytron-security-oauth2/pom.xml
+++ b/integration-tests/elytron-security-oauth2/pom.xml
@@ -44,6 +44,16 @@
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/integration-tests/elytron-security-oauth2/pom.xml
+++ b/integration-tests/elytron-security-oauth2/pom.xml
@@ -58,14 +58,12 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>build</goal>
                         </goals>
-                        <configuration>
-                            <uberJar>true</uberJar>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -31,11 +31,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jaxb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
+            <artifactId>quarkus-resteasy-jaxb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -30,7 +30,7 @@
         <!-- EL implementation -->
         <dependency>
            <groupId>org.glassfish</groupId>
-           <artifactId>javax.el</artifactId>
+           <artifactId>jakarta.el</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/integration-tests/jgit/pom.xml
+++ b/integration-tests/jgit/pom.xml
@@ -51,7 +51,15 @@
                     <groupId>org.eclipse.jgit</groupId>
                     <artifactId>org.eclipse.jgit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/integration-tests/shared-library/pom.xml
+++ b/integration-tests/shared-library/pom.xml
@@ -18,8 +18,8 @@
     </description>
     <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/tcks/microprofile-context-propagation/pom.xml
+++ b/tcks/microprofile-context-propagation/pom.xml
@@ -57,6 +57,24 @@
             <groupId>org.eclipse.microprofile.context-propagation</groupId>
             <artifactId>microprofile-context-propagation-tck</artifactId>
             <version>${microprofile-context-propagation.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>javax.transaction-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/tcks/microprofile-health/pom.xml
+++ b/tcks/microprofile-health/pom.xml
@@ -50,6 +50,10 @@
                     <artifactId>javax.json-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
@@ -58,6 +62,10 @@
                     <artifactId>activation</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/tcks/microprofile-metrics/rest/pom.xml
+++ b/tcks/microprofile-metrics/rest/pom.xml
@@ -53,7 +53,15 @@
                     <groupId>org.jboss.shrinkwrap.resolver</groupId>
                     <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -67,6 +67,10 @@
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -76,6 +80,10 @@
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -59,7 +59,23 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/tcks/microprofile-opentracing/base/pom.xml
+++ b/tcks/microprofile-opentracing/base/pom.xml
@@ -53,6 +53,24 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -75,7 +75,15 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-servlets</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/test-framework/junit5-internal/pom.xml
+++ b/test-framework/junit5-internal/pom.xml
@@ -49,8 +49,8 @@
             <artifactId>quarkus-test-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -26,7 +26,23 @@
                     <groupId>com.squareup.okhttp3</groupId>
                     <artifactId>okhttp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/test-framework/vault/pom.xml
+++ b/test-framework/vault/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
 
         <!-- resolve conflict on visible-assertions that depends on jna 5.2.0 instead of 5.3.1 for testcontainers 1.12.0 -->

--- a/test-framework/vault/pom.xml
+++ b/test-framework/vault/pom.xml
@@ -32,6 +32,24 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <version>${test-containers.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <!-- resolve conflict on visible-assertions that depends on jna 5.2.0 instead of 5.3.1 for testcontainers 1.12.0 -->


### PR DESCRIPTION
I moved most of the artifacts to Jakarta but not all as RESTEasy optional dependencies are heavily relying on two JBoss API spec artifacts for JAX-RS and JAXB (but not entirely consistently, I will report that). These 2 artifacts were updated to Jakarta.

Note that I added a lot of exclusions to be sure we don't have any duplicates: we had a few duplications present in the current code base.

I have another branch with a complete move to Jakarta but:
- it adds a lot more exclusions + explicit dependencies as JAX-RS and JAXB are injected in a lot of places
- every time you add an optional RESTEasy dependencies (typically the one for RX-Java2), you end up with duplicate artifacts (or requires exclusions + explicit dependencies)
So I thought this was the best compromise for now.

Draft status for now as we need to discuss this.

@FroMage could you have a look at https://github.com/quarkusio/quarkus/pull/4907/commits/e9af116176410384c00b13114e78d5529dbaa44e#diff-806baf513aab8570dfd629e9eaff1dadR136 , I'm not entirely sure where I should get the remote address from. Usually the header don't provide the really remote one so I was wondering exactly what you had in mind? Note that I might have missed something in Vert.x.