### PR TITLE
Add a config property to disable Hibernate second level cache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -450,7 +450,11 @@ On top of immutable data, in certain contexts it might be acceptable to enable c
 Rather than enabling caching on mutable data, ideally a better solution would be to use a clustered cache; however at this time Quarkus doesn't provide any such implementation: feel free to get in touch and let this need known so that the team can take this into account.
 --
 
-Finally, the second-level cache can be disabled globally by setting `hibernate.cache.use_second_level_cache` to `false`; this is a setting that needs to be specified in the `persistence.xml` configuration file.
+Finally, the second-level cache can be disabled globally.
+There are two ways to do it:
+
+- by setting `quarkus.hibernate-orm.use-second-level-cache` to `false` in `application.properties`
+- by setting `hibernate.cache.use_second_level_cache` to `false` in `persistence.xml`
 
 When second-level cache is disabled, all cache annotations are ignored and all queries are run ignoring caches; this is generally useful only to diagnose issues.
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -130,6 +130,12 @@ public class HibernateOrmConfig {
     public HibernateOrmConfigLog log;
 
     /**
+     * Whether the second level cache is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useSecondLevelCache;
+
+    /**
      * Caching configuration
      */
     @ConfigDocSection

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -667,10 +667,14 @@ public final class HibernateOrmProcessor {
                 }
 
                 // Caching
-                Map<String, String> cacheConfigEntries = HibernateConfigUtil
-                        .getCacheConfigEntries(hibernateConfig);
-                for (Entry<String, String> entry : cacheConfigEntries.entrySet()) {
-                    desc.getProperties().setProperty(entry.getKey(), entry.getValue());
+                if (hibernateConfig.useSecondLevelCache) {
+                    Map<String, String> cacheConfigEntries = HibernateConfigUtil
+                            .getCacheConfigEntries(hibernateConfig);
+                    for (Entry<String, String> entry : cacheConfigEntries.entrySet()) {
+                        desc.getProperties().setProperty(entry.getKey(), entry.getValue());
+                    }
+                } else {
+                    desc.getProperties().setProperty(AvailableSettings.USE_SECOND_LEVEL_CACHE, "false");
                 }
 
                 descriptors.add(desc);


### PR DESCRIPTION
Fixes #4489

For now, I only exposed the `hibernate.cache.use_second_level_cache` Hibernate setting through the `quarkus.hibernate-orm.use-second-level-cache` Quarkus config property (which defaults to `true`), but I'm wondering if some or all of [the other settings we're enabling by default](https://github.com/quarkusio/quarkus/blob/master/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java#L333-L339) should be exposed too:

- hibernate.cache.use_reference_entries=true
- hibernate.cache.use_query_cache=true
- javax.persistence.sharedCache.mode=ENABLE_SELECTIVE