### PR TITLE
If start fails make sure to shutdown server

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -96,6 +96,11 @@ public class VertxHttpRecorder {
     }
 
     public static void startServerAfterFailedStart() {
+        if (closeTask != null) {
+            //it is possible start failed after the server was started
+            //we shut it down in this case, as we have no idea what state it is in
+            shutDownDevMode();
+        }
         VertxConfiguration vertxConfiguration = new VertxConfiguration();
         ConfigInstantiator.handleObject(vertxConfiguration);
         VertxCoreRecorder.initializeWeb(vertxConfiguration);


### PR DESCRIPTION
It's possible start can fail after the server
has started in dev mode. We need to make sure it
is shut down to recover properly.

Possible fix for #4815