### PR TITLE
Upgrade to Hibernate Search 6.0.0.Beta2

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -77,13 +77,13 @@
         <javax.el-impl.version>3.0.1-b11</javax.el-impl.version>
         <hibernate-validator.version>6.1.0.Alpha6</hibernate-validator.version>
         <hibernate-orm.version>5.4.7.Final</hibernate-orm.version>
-        <hibernate-search.version>6.0.0.Beta1</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Beta2</hibernate-search.version>
         <narayana.version>5.9.8.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.6</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
-        <elasticsearch-rest-client.version>7.3.0</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.4.0</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.13</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Maven plugin versions -->
         <elasticsearch-maven-plugin.version>6.14</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.3.1</elasticsearch-server.version>
+        <elasticsearch-server.version>7.4.0</elasticsearch-server.version>
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->

--- a/docs/src/main/asciidoc/hibernate-search-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-guide.adoc
@@ -593,7 +593,7 @@ Let's use Docker to start one of each:
 
 [source, shell]
 ----
-docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.3.1
+docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.4.0
 ----
 
 [source, shell]

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -136,6 +136,11 @@ class HibernateSearchElasticsearchProcessor {
                     new ReflectiveClassBuildItem(true, false, buildTimeConfig.elasticsearch.analysis.configurer.get()));
         }
 
+        if (buildTimeConfig.backgroundFailureHandler.isPresent()) {
+            reflectiveClass.produce(
+                    new ReflectiveClassBuildItem(true, false, buildTimeConfig.backgroundFailureHandler.get()));
+        }
+
         for (DotName fieldAnnotation : FIELD_ANNOTATIONS) {
             for (AnnotationInstance fieldAnnotationInstance : index.getAnnotations(fieldAnnotation)) {
                 AnnotationTarget annotationTarget = fieldAnnotationInstance.target();

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -35,6 +35,15 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
     @ConfigDocMapKey("backend-name")
     public Map<String, ElasticsearchBackendBuildTimeConfig> additionalBackends;
 
+    /**
+     * The class or the name of the bean that should be notified of any failure occurring in a background process
+     * (mainly index operations).
+     * <p>
+     * Must implement {@link org.hibernate.search.engine.reporting.FailureHandler}.
+     */
+    @ConfigItem
+    public Optional<Class<?>> backgroundFailureHandler;
+
     @ConfigGroup
     public static class ElasticsearchBackendBuildTimeConfig {
         /**

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -56,6 +56,10 @@ public class HibernateSearchElasticsearchRecorder {
             addConfig(propertyCollector, HibernateOrmMapperSpiSettings.REFLECTION_STRATEGY,
                     HibernateOrmReflectionStrategyName.JAVA_LANG_REFLECT);
 
+            addConfig(propertyCollector,
+                    EngineSettings.BACKGROUND_FAILURE_HANDLER,
+                    buildTimeConfig.backgroundFailureHandler);
+
             if (buildTimeConfig.defaultBackend.isPresent()) {
                 // we have a named default backend
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -53,8 +53,7 @@ public class HibernateSearchElasticsearchRecorder {
 
         @Override
         public void contributeBootProperties(BiConsumer<String, Object> propertyCollector) {
-            // Use the radical only as a workaround for https://hibernate.atlassian.net/browse/HSEARCH-3734
-            addConfig(propertyCollector, HibernateOrmMapperSpiSettings.Radicals.REFLECTION_STRATEGY,
+            addConfig(propertyCollector, HibernateOrmMapperSpiSettings.REFLECTION_STRATEGY,
                     HibernateOrmReflectionStrategyName.JAVA_LANG_REFLECT);
 
             if (buildTimeConfig.defaultBackend.isPresent()) {


### PR DESCRIPTION
This upgrades to Hibernate Search 6.0.0.Beta2 and adds a configuration option to allow the customization of the background failure handler introduced in Beta2.