### PR TITLE
Make sure hot deployment works after a failed server start in an application with non-default http port

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
@@ -4,11 +4,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -28,19 +31,33 @@ import io.smallrye.config.SmallRyeConfig;
 public class ConfigInstantiator {
 
     private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+    // certain well-known classname suffixes that we support
+    private static Set<String> supportedClassNameSuffix;
+
+    static {
+        final Set<String> suffixes = new HashSet<>();
+        suffixes.add("Config");
+        suffixes.add("Configuration");
+        supportedClassNameSuffix = Collections.unmodifiableSet(suffixes);
+    }
 
     public static void handleObject(Object o) {
-        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
-        Class cls = o.getClass();
-        String name = dashify(cls.getSimpleName().substring(0, cls.getSimpleName().length() - "Config".length()));
+        final SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
+        final Class cls = o.getClass();
+        final String clsNameSuffix = getClassNameSuffix(o);
+        if (clsNameSuffix == null) {
+            // unsupported object type
+            return;
+        }
+        final String name = dashify(cls.getSimpleName().substring(0, cls.getSimpleName().length() - clsNameSuffix.length()));
         handleObject("quarkus." + name, o, config);
     }
 
     private static void handleObject(String prefix, Object o, SmallRyeConfig config) {
 
         try {
-            Class cls = o.getClass();
-            if (!cls.getName().endsWith("Config") && !cls.getName().endsWith("Configuration")) {
+            final Class cls = o.getClass();
+            if (!isClassNameSuffixSupported(o)) {
                 return;
             }
             for (Field field : cls.getDeclaredFields()) {
@@ -110,14 +127,48 @@ public class ConfigInstantiator {
         }
     }
 
+    //    Configuration keys are normally derived from the field names that they are tied to.
+    //    This is done by de-camel-casing the name and then joining the segments with hyphens (-).
+    //    Some examples:
+    //    bindAddress becomes bind-address
+    //    keepAliveTime becomes keep-alive-time
+    //    requestDNSTimeout becomes request-dns-timeout
     private static String dashify(String substring) {
-        StringBuilder ret = new StringBuilder();
-        for (char i : substring.toCharArray()) {
-            if (i >= 'A' && i <= 'Z') {
+        final StringBuilder ret = new StringBuilder();
+        final char[] chars = substring.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            final char c = chars[i];
+            if (i != 0 && i != (chars.length - 1) && c >= 'A' && c <= 'Z') {
                 ret.append('-');
             }
-            ret.append(Character.toLowerCase(i));
+            ret.append(Character.toLowerCase(c));
         }
         return ret.toString();
+    }
+
+    private static String getClassNameSuffix(final Object o) {
+        if (o == null) {
+            return null;
+        }
+        final String klassName = o.getClass().getName();
+        for (final String supportedSuffix : supportedClassNameSuffix) {
+            if (klassName.endsWith(supportedSuffix)) {
+                return supportedSuffix;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isClassNameSuffixSupported(final Object o) {
+        if (o == null) {
+            return false;
+        }
+        final String klassName = o.getClass().getName();
+        for (final String supportedSuffix : supportedClassNameSuffix) {
+            if (klassName.endsWith(supportedSuffix)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -99,7 +99,12 @@ public class VertxHttpRecorder {
         if (closeTask != null) {
             //it is possible start failed after the server was started
             //we shut it down in this case, as we have no idea what state it is in
+            final Handler<RoutingContext> prevHotReplacementHandler = hotReplacementHandler;
             shutDownDevMode();
+            // reset back to the older hot replacement handler, so that it can be used
+            // to watch any artifacts that need hot deployment to fix the reason which caused
+            // the server start to fail
+            hotReplacementHandler = prevHotReplacementHandler;
         }
         VertxConfiguration vertxConfiguration = new VertxConfiguration();
         ConfigInstantiator.handleObject(vertxConfiguration);


### PR DESCRIPTION
This should fix the issue reported in https://github.com/quarkusio/quarkus/issues/4815

This includes 2 commits - one which fixes the parsing of the configuration options in `ConfigInstantiator` which was resulting in not using the configured port in case of failed start. This `ConfigInstantiator` is only used in this specific failed server start case and for limited use case and thus explains why such a basic issue wasn't noticed in this one so far.
The second commit in this PR includes a change in `VertxHttpRecorder` to make sure the hot deployment handler is setup even after the server failed to start.

Given the nature of this change, there isn't any easy way to add a test to this one. I have manually tried a bunch of use cases with this change. That includes, using non-default http port and then starting Quarkus such that it fails during startup and then updating the application.propreties to make sure the change fixes the startup and then issuing a request to it. Went fine. Have also tried the usual successful cases and those too went fine.