### PR TITLE
Remove the warning about not having undertow

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
@@ -62,9 +62,6 @@ public class ResteasyServletProcessor {
             BuildProducer<ServletInitParamBuildItem> servletInitParameters,
             ResteasyInjectionReadyBuildItem resteasyInjectionReady) throws Exception {
         if (!capabilities.isCapabilityPresent(Capabilities.SERVLET)) {
-            // todo remove this info message after this is in the wild a few releases
-            log.info("Resteasy running without servlet container.");
-            log.info("- Add quarkus-undertow to run Resteasy within a servlet container");
             return;
         }
         feature.produce(new FeatureBuildItem(FeatureBuildItem.RESTEASY));


### PR DESCRIPTION
That's definitely not something we want to keep for the next releases.

_Not sure it's something we want to merge right away for this release but I want it for the next one so I prefer creating it now to not forget about it._