### PR TITLE
Use Maven settings with Google mirror for all CI steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
             inputs:
               goals: 'install'
               mavenOptions: $(MAVEN_OPTS)
-              options: '-DskipTests -Dno-format'
+              options: '-B --settings azure-mvn-settings.xml -DskipTests -Dno-format'
           - publish: $(MAVEN_CACHE_FOLDER)
             artifact: BuiltMavenRepo
 
@@ -185,6 +185,7 @@ stages:
             inputs:
               goals: 'verify'
               mavenOptions: $(MAVEN_OPTS)
+              options: '-B --settings azure-mvn-settings.xml'
               mavenPomFile: 'tcks/pom.xml'
 
 


### PR DESCRIPTION
Otherwise, some artifacts get loaded from Maven Central which doesn't work.

See this build for instance: https://dev.azure.com/quarkus-ci/quarkus/_build/results?buildId=10692&view=logs which timed out in the TCK check phase.