### PR TITLE
Reduce CI load on failing PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
               options: '-B --settings azure-mvn-settings.xml -DskipTests=true -Dno-format -DskipDocs'
 
   #This stage builds the Quarkus artifacts needed for native image testing
-  - stage: build_artifact_for_native_stage
+  - stage: initial_jdk8_stage
     displayName: 'Build for Native'
     dependsOn: cache_maven_repo_stage
     jobs:
@@ -98,34 +98,14 @@ stages:
         pool:
           vmImage: 'Ubuntu 16.04'
         steps:
-          - task: CacheBeta@0 #we know the very first job will have restored or created this, so this will never write built artifacts to the cache
-            inputs:
-              key: maven | bom/runtime/pom.xml
-              path: $(Pipeline.Workspace)/.m2/repository/
-              securityNamespace: cache
-            displayName: Restore Maven Cache
-
-          - task: Maven@3
-            displayName: 'Maven Build'
-            inputs:
-              goals: 'install'
-              mavenOptions: $(MAVEN_OPTS)
-              options: '-B --settings azure-mvn-settings.xml -DskipTests -Dno-format'
+          - template: ci-templates/jvm-build-steps.yaml
           - publish: $(MAVEN_CACHE_FOLDER)
             artifact: BuiltMavenRepo
 
   - stage: run_jvm_tests_stage
     displayName: 'Run JVM Tests'
-    dependsOn: cache_maven_repo_stage
+    dependsOn: initial_jdk8_stage
     jobs:
-
-      - job: Build_JDK8_Linux
-        displayName: 'Build JDK8 Linux'
-        timeoutInMinutes: 60
-        pool:
-          vmImage: 'Ubuntu 16.04'
-        steps:
-          - template: ci-templates/jvm-build-steps.yaml
 
       - job: Windows_Build
         displayName: 'Windows JVM Build'
@@ -191,7 +171,7 @@ stages:
 
   - stage: run_native_tests_stage
     displayName: 'Native Tests'
-    dependsOn: build_artifact_for_native_stage
+    dependsOn: initial_jdk8_stage
     jobs:
       - template: ci-templates/native-build-steps.yaml
         parameters:


### PR DESCRIPTION
This PR changes the staging of CI jobs to not run native tests
if the JVM tests fail. It also removes the dedicated 'build for
native' job, and instead uses the results of the JDK8 build
to run the native build, further reducing the load.