### PR TITLE
Add jackson jdk8 modules

### DIFF
--- a/extensions/jackson/runtime/pom.xml
+++ b/extensions/jackson/runtime/pom.xml
@@ -19,6 +19,18 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperProducer.java
@@ -6,6 +6,9 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import io.quarkus.arc.DefaultBean;
 
@@ -17,6 +20,7 @@ public class ObjectMapperProducer {
     @Produces
     public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers) {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModules(new Jdk8Module(), new JavaTimeModule(), new ParameterNamesModule());
         for (ObjectMapperCustomizer customizer : customizers) {
             customizer.customize(objectMapper);
         }

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/Greeting.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/Greeting.java
@@ -1,14 +1,22 @@
 package io.quarkus.it.resteasy.jackson;
 
+import java.time.LocalDate;
+
 public class Greeting {
 
     private final String message;
+    private final LocalDate date;
 
-    public Greeting(String message) {
+    public Greeting(String message, LocalDate date) {
         this.message = message;
+        this.date = date;
     }
 
     public String getMessage() {
         return message;
+    }
+
+    public LocalDate getDate() {
+        return date;
     }
 }

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.resteasy.jackson;
 
+import java.time.LocalDate;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -11,6 +13,6 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Greeting hello() {
-        return new Greeting("hello");
+        return new Greeting("hello", LocalDate.of(2019, 01, 01));
     }
 }

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTest.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTest.java
@@ -16,7 +16,8 @@ class GreetingResourceTest {
                 .when().get("/greeting")
                 .then()
                 .statusCode(200)
-                .body(containsString("hello"));
+                .body(containsString("hello"))
+                .body(containsString("[2019,1,1]"));
     }
 
 }


### PR DESCRIPTION
Add by default the 3 Jackson JDK8 modues as Quarkus is JDK 8 minimum.
This adds around 100k of libraries ...

Fixes #4860

I add a LocalDate to the resteasy-jackson integration test to check that the module is enabled.

