### PR TITLE
Make RESTEasy standalone use correct TCCL in dev mode

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -47,7 +47,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
         this.vertx = vertx;
         this.beanContainer = beanContainer;
         this.dispatcher = new RequestDispatcher((SynchronousDispatcher) deployment.getDispatcher(),
-                deployment.getProviderFactory(), null);
+                deployment.getProviderFactory(), null, Thread.currentThread().getContextClassLoader());
         this.rootPath = rootPath;
         this.allocator = allocator;
         Instance<CurrentIdentityAssociation> association = CDI.current().select(CurrentIdentityAssociation.class);


### PR DESCRIPTION
RESTEasy is using the original RuntimeClassLoader, which
causes all kinds of hot replacement problems.

Fixes #4957