### PR TITLE
Tip fix - additionalBuildArgs

### DIFF
--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -144,7 +144,7 @@ If you have generated the application from the previous tutorial, you can find i
 
 [TIP]
 ====
-You can provide additional options for `native-image` command using `quarkus.native.additional-build-args=foo,bar` in `application.properties`. Provided options have to be `,` separated.
+You can provide custom options for `native-image` command using `<additionalBuildArgs>` configuration element which can have multiple `<additionalBuildArg>` child elements.
 ====
 
 We use a profile because, you will see very soon, packaging the native executable takes a _few_ minutes. You could


### PR DESCRIPTION
Fix for tip about additionalBuildArgs in native image guide