### PR TITLE
Fix broken native build of generated projects

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -165,7 +165,7 @@ public class NativeConfig {
     /**
      * If full stack traces are enabled in the resulting image
      */
-    @ConfigItem(defaultValue = "false")
+    @ConfigItem(defaultValue = "true")
     public boolean fullStackTraces;
 
     /**

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -187,11 +187,13 @@ public class BuildMojo extends AbstractMojo {
                             .setConfigDir(outputDirectory.toPath())
                             .setBuildSystemProperties(realProperties).build());
             Artifact original = project.getArtifact();
-            if (result.getJar().isUberJar() && result.getJar().getOriginalArtifact() != null) {
-                original.setFile(result.getJar().getOriginalArtifact().toFile());
-            }
-            if (result.getJar().isUberJar()) {
-                projectHelper.attachArtifact(project, result.getJar().getPath().toFile(), "runner");
+            if (result.getJar() != null) {
+                if (result.getJar().isUberJar() && result.getJar().getOriginalArtifact() != null) {
+                    original.setFile(result.getJar().getOriginalArtifact().toFile());
+                }
+                if (result.getJar().isUberJar()) {
+                    projectHelper.attachArtifact(project, result.getJar().getPath().toFile(), "runner");
+                }
             }
 
         } catch (AppCreatorException e) {


### PR DESCRIPTION
I honestly don't know why stacktraces need to be enabled for the generated native image to work properly.

Without this fix, the native image build of the generated (via the maven tooling) projects would fail:

1) First with a NPE
2) But even going past the NPE, the generated native image when run gave output like this:

```
Exception in thread "Thread-1" java.lang.Error: java.lang.NullPointerException
Caused by: java.lang.NullPointerException
java.lang.NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom
java.lang.NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom
2019-10-29 20:17:38,761 ERROR [io.ver.cor.imp.ContextImpl] (vert.x-eventloop-thread-0) Unhandled exception: java.lang.NullPointerException: channel

Exception in thread "main" java.lang.RuntimeException: Failed to start quarkus
Caused by: java.lang.NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom
```