### PR TITLE
Rename @SubstrateTest to @NativeImageTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/test/TestScopeSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/test/TestScopeSetup.java
@@ -2,7 +2,7 @@ package io.quarkus.deployment.test;
 
 public interface TestScopeSetup {
 
-    void setup(boolean isSubstrateTest);
+    void setup(boolean isNativeImageTest);
 
-    void tearDown(boolean isSubstrateTest);
+    void tearDown(boolean isNativeImageTest);
 }

--- a/devtools/gradle/src/test/resources/gradle-project/build.gradle
+++ b/devtools/gradle/src/test/resources/gradle-project/build.gradle
@@ -30,6 +30,6 @@ test {
     dependsOn 'cleanTest'
     useJUnitPlatform()
 
-    // @SubstrateTest and JVM mode tests can't be mixed in the same run
+    // @NativeImageTest and JVM mode tests can't be mixed in the same run
     forkEvery 1
 }

--- a/devtools/maven/src/main/resources/create-extension-templates/IT.java
+++ b/devtools/maven/src/main/resources/create-extension-templates/IT.java
@@ -1,8 +1,8 @@
 package [=javaPackageBase].it;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class [=artifactIdBaseCamelCase]IT extends [=artifactIdBaseCamelCase]Test {
 
 }

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/native-test-resource-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/native-test-resource-template.ftl
@@ -1,8 +1,8 @@
 package ${package_name};
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class Native${class_name}IT extends ${class_name}Test {
 
     // Execute the same tests but in native mode.

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/native-test-resource-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/native-test-resource-template.ftl
@@ -1,6 +1,6 @@
 package ${package_name}
 
-import io.quarkus.test.junit.SubstrateTest
+import io.quarkus.test.junit.NativeImageTest
 
-@SubstrateTest
+@NativeImageTest
 open class Native${class_name}IT : ${class_name}Test()

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/native-test-resource-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/native-test-resource-template.ftl
@@ -1,6 +1,6 @@
 package ${package_name}
 
-import io.quarkus.test.junit.SubstrateTest
+import io.quarkus.test.junit.NativeImageTest
 
-@SubstrateTest
+@NativeImageTest
 class Native${class_name}IT extends ${class_name}Test

--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -193,9 +193,9 @@ Then, open the `src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java`
 package org.acme.quickstart;
 
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest // <1>
+@NativeImageTest // <1>
 public class NativeGreetingResourceIT extends GreetingResourceTest { // <2>
 
     // Run the same tests
@@ -254,7 +254,7 @@ you can only test via HTTP calls. Your test code does not actually run natively,
 that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
 
 If you share your test class between JVM and native executions like we advise above, you can mark certain tests
-with the `@DisabledOnSubstrate` annotation in order to only run them on the JVM.
+with the `@DisabledOnNativeImage` annotation in order to only run them on the JVM.
 
 == Creating a container
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -354,7 +354,7 @@ There are a few system properties that can be used to tune the bootstrap of the 
 
 == Native Executable Testing
 
-It is also possible to test native executables using `@SubstrateTest`. This supports all the features mentioned in this
+It is also possible to test native executables using `@NativeImageTest`. This supports all the features mentioned in this
 guide except injecting into tests (and the native executable runs in a separate non-JVM process this is not really possible).
 
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -440,7 +440,7 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 <1> Optionally use a BOM file to omit the version of the different Quarkus dependencies.
 <2> Use the Quarkus Maven plugin that will hook into the build process
 <3> Use a native profile and plugin to activate GraalVM compilation
-<4> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@SubstrateTest` will be run against the native executable. See the link:building-native-image-guide.html[Native executable guide] for more info.
+<4> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@NativeImageTest` will be run against the native executable. See the link:building-native-image-guide.html[Native executable guide] for more info.
 
 [[uber-jar-maven]]
 === Uber-Jar Creation

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcTestRequestScopeProvider.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcTestRequestScopeProvider.java
@@ -11,8 +11,8 @@ public class ArcTestRequestScopeProvider implements TestScopeSetup {
     private static final Logger LOGGER = Logger.getLogger(ArcTestRequestScopeProvider.class);
 
     @Override
-    public void setup(boolean isSubstrateTest) {
-        if (isSubstrateTest) {
+    public void setup(boolean isNativeImageTest) {
+        if (isNativeImageTest) {
             return;
         }
         ArcContainer container = Arc.container();
@@ -25,8 +25,8 @@ public class ArcTestRequestScopeProvider implements TestScopeSetup {
     }
 
     @Override
-    public void tearDown(boolean isSubstrateTest) {
-        if (isSubstrateTest) {
+    public void tearDown(boolean isNativeImageTest) {
+        if (isNativeImageTest) {
             return;
         }
         ArcContainer container = Arc.container();

--- a/integration-tests/amazon-dynamodb/src/test/java/io/quarkus/it/dynamodb/DynamoDbFunctionalityITCase.java
+++ b/integration-tests/amazon-dynamodb/src/test/java/io/quarkus/it/dynamodb/DynamoDbFunctionalityITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.dynamodb;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class DynamoDbFunctionalityITCase extends DynamoDbFunctionalityTest {
 }

--- a/integration-tests/amazon-lambda-http-it/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda-http-it/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisConsumerITCase.java
+++ b/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisConsumerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.artemis;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ArtemisConsumerITCase extends ArtemisConsumerTest {
 
 }

--- a/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisProducerITCase.java
+++ b/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisProducerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.artemis;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ArtemisProducerITCase extends ArtemisProducerTest {
 
 }

--- a/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisConsumerITCase.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisConsumerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.artemis;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ArtemisConsumerITCase extends ArtemisConsumerTest {
 
 }

--- a/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisProducerITCase.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisProducerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.artemis;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ArtemisProducerITCase extends ArtemisProducerTest {
 
 }

--- a/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/BaseAuthIT.java
+++ b/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/BaseAuthIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.resteasy.elytron;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class BaseAuthIT extends BaseAuthTest {
 }

--- a/integration-tests/elytron-security-jdbc/src/test/java/io/quarkus/elytron/security/jdbc/it/ElytronSecurityJdbcIT.java
+++ b/integration-tests/elytron-security-jdbc/src/test/java/io/quarkus/elytron/security/jdbc/it/ElytronSecurityJdbcIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.elytron.security.jdbc.it;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class ElytronSecurityJdbcIT extends ElytronSecurityJdbcTest {
 
 }

--- a/integration-tests/elytron-security-oauth2/src/test/java/io/quarkus/it/elytron/oauth2/ElytronOauth2ExtensionResourceITCase.java
+++ b/integration-tests/elytron-security-oauth2/src/test/java/io/quarkus/it/elytron/oauth2/ElytronOauth2ExtensionResourceITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.elytron.oauth2;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class ElytronOauth2ExtensionResourceITCase extends ElytronOauth2ExtensionResourceTestCase {
 
 }

--- a/integration-tests/elytron-security/src/test/java/io/quarkus/it/elytron/JCAITCase.java
+++ b/integration-tests/elytron-security/src/test/java/io/quarkus/it/elytron/JCAITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.elytron;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JCAITCase extends JCATestCase {
 }

--- a/integration-tests/elytron-security/src/test/java/io/quarkus/it/elytron/X500PrincipalUtilITCase.java
+++ b/integration-tests/elytron-security/src/test/java/io/quarkus/it/elytron/X500PrincipalUtilITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.elytron;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class X500PrincipalUtilITCase extends X500PrincipalUtilTestCase {
 }

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthIT.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.undertow.elytron;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class BaseAuthIT extends BaseAuthTest {
 }

--- a/integration-tests/flyway/src/test/java/io/quarkus/it/flyway/FlywayFunctionalityNativeIT.java
+++ b/integration-tests/flyway/src/test/java/io/quarkus/it/flyway/FlywayFunctionalityNativeIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.flyway;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class FlywayFunctionalityNativeIT extends FlywayFunctionalityTest {
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityInGraalITCase.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.panache;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various Panache operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class PanacheFunctionalityInGraalITCase extends PanacheFunctionalityTest {
 
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnSubstrate;
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -39,7 +39,7 @@ public class PanacheFunctionalityTest {
                         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><person><id>666</id><name>Eddie</name><serialisationTrick>1</serialisationTrick><status>DECEASED</status></person>"));
     }
 
-    @DisabledOnSubstrate
+    @DisabledOnNativeImage
     @Test
     public void testPanacheInTest() {
         Assertions.assertEquals(0, Person.count());

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/ElasticsearchClientInGraalIT.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/ElasticsearchClientInGraalIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibernate.search.elasticsearch;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ElasticsearchClientInGraalIT extends ElasticsearchClientTest {
 
 }

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/HibernateSearchInGraalIT.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/HibernateSearchInGraalIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.hibernate.search.elasticsearch;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class HibernateSearchInGraalIT extends HibernateSearchTest {
 
 }

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityInGraalITCase.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.hibernate.validator;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various Bean Validation operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class HibernateValidatorFunctionalityInGraalITCase extends HibernateValidatorFunctionalityTest {
 
 }

--- a/integration-tests/infinispan-cache-jpa/src/test/java/io/quarkus/it/infinispan/cache/jpa/InfinispanCacheJPAFunctionalityInGraalITCase.java
+++ b/integration-tests/infinispan-cache-jpa/src/test/java/io/quarkus/it/infinispan/cache/jpa/InfinispanCacheJPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.infinispan.cache.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class InfinispanCacheJPAFunctionalityInGraalITCase extends InfinispanCacheJPAFunctionalityTest {
 
 }

--- a/integration-tests/infinispan-client/src/test/java/io/quarkus/it/infinispan/client/InfinispanClientFunctionalityInGraalITCase.java
+++ b/integration-tests/infinispan-client/src/test/java/io/quarkus/it/infinispan/client/InfinispanClientFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.infinispan.client;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author William Burns
  */
-@SubstrateTest
+@NativeImageTest
 public class InfinispanClientFunctionalityInGraalITCase extends InfinispanClientFunctionalityTest {
 
 }

--- a/integration-tests/infinispan-embedded/src/test/java/io/quarkus/it/infinispan/embedded/InfinispanEmbeddedFunctionalityInGraalITCase.java
+++ b/integration-tests/infinispan-embedded/src/test/java/io/quarkus/it/infinispan/embedded/InfinispanEmbeddedFunctionalityInGraalITCase.java
@@ -1,13 +1,13 @@
 package io.quarkus.it.infinispan.embedded;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author William Burns
  */
 @QuarkusTestResource(InfinispanEmbeddedTestResource.class)
-@SubstrateTest
+@NativeImageTest
 public class InfinispanEmbeddedFunctionalityInGraalITCase extends InfinispanEmbeddedFunctionalityTest {
 
 }

--- a/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/InheritedModelWithBuilderResourceIT.java
+++ b/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/InheritedModelWithBuilderResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.reproducer;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class InheritedModelWithBuilderResourceIT extends InheritedModelWithBuilderResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/ModelWithBuilderResourceIT.java
+++ b/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/ModelWithBuilderResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.reproducer;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ModelWithBuilderResourceIT extends ModelWithBuilderResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/ModelWithSerializerAndDeserializerOnFieldResourceIT.java
+++ b/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/ModelWithSerializerAndDeserializerOnFieldResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.reproducer;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ModelWithSerializerAndDeserializerOnFieldResourceIT extends ModelWithSerializerAndDeserializerOnFieldResourceTest {
 
 }

--- a/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/RegisteredPojoModelResourceIT.java
+++ b/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/RegisteredPojoModelResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.reproducer;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class RegisteredPojoModelResourceIT extends RegisteredPojoModelResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/jgit/src/test/java/io/quarkus/it/jgit/NativeJGitIT.java
+++ b/integration-tests/jgit/src/test/java/io/quarkus/it/jgit/NativeJGitIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.jgit;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeJGitIT extends JGitTest {
 }

--- a/integration-tests/jpa-derby/src/test/java/io/quarkus/it/jpa/derby/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-derby/src/test/java/io/quarkus/it/jpa/derby/JPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.derby;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 
 }

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/JPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.h2;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 
 }

--- a/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-mariadb/src/test/java/io/quarkus/it/jpa/mariadb/JPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.mariadb;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 
 }

--- a/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-mssql/src/test/java/io/quarkus/it/jpa/mssql/JPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.mssql;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 
 }

--- a/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-mysql/src/test/java/io/quarkus/it/jpa/mysql/JPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.mysql;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 
 }

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.postgresql;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various JPA operations running in native mode
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 
 }

--- a/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAReflectionInGraalITCase.java
+++ b/integration-tests/jpa-postgresql/src/test/java/io/quarkus/it/jpa/postgresql/JPAReflectionInGraalITCase.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 import io.restassured.RestAssured;
 
 /**
@@ -12,7 +12,7 @@ import io.restassured.RestAssured;
  *
  * @author Emmanuel Bernard emmanuel@hibernate.org
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAReflectionInGraalITCase {
 
     @Test

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/JPAConfigurationlessTestInGraalITCase.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/JPAConfigurationlessTestInGraalITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.jpa.configurationless;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JPAConfigurationlessTestInGraalITCase extends JPAConfigurationlessTest {
 
 }

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/JPAElementCollectionInGraalITCase.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/JPAElementCollectionInGraalITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.jpa.configurationless;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JPAElementCollectionInGraalITCase extends JPAElementCollectionTest {
 
 }

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/JPALoadScriptTestInGraalITCase.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/configurationless/JPALoadScriptTestInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.jpa.configurationless;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author Emmanuel Bernard emmanuel@hibernate.org
  */
 
-@SubstrateTest
+@NativeImageTest
 public class JPALoadScriptTestInGraalITCase extends JPALoadScriptTest {
 }

--- a/integration-tests/jsonb/src/test/java/io/quarkus/it/jsonb/ModelWithSerializerAndDeserializerOnFieldResourceIT.java
+++ b/integration-tests/jsonb/src/test/java/io/quarkus/it/jsonb/ModelWithSerializerAndDeserializerOnFieldResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.jsonb;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ModelWithSerializerAndDeserializerOnFieldResourceIT extends ModelWithSerializerAndDeserializerOnFieldResourceTest {
 
 }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerITCase.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaConsumerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.kafka;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class KafkaConsumerITCase extends KafkaConsumerTest {
 
 }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerITCase.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaProducerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.kafka;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class KafkaProducerITCase extends KafkaProducerTest {
 
 }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsITCase.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.kafka.streams;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class KafkaStreamsITCase extends KafkaStreamsTest {
 
 }

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerInGraalITCase.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerInGraalITCase.java
@@ -1,12 +1,12 @@
 package io.quarkus.it.keycloak;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusTestResource(KeycloakTestResource.class)
-@SubstrateTest
+@NativeImageTest
 public class PolicyEnforcerInGraalITCase extends PolicyEnforcerTest {
 }

--- a/integration-tests/kogito-maven/src/test/resources/projects/simple-kogito/src/test/java/org/acme/kogito/PersonProcessInGraalIT.java
+++ b/integration-tests/kogito-maven/src/test/resources/projects/simple-kogito/src/test/java/org/acme/kogito/PersonProcessInGraalIT.java
@@ -1,8 +1,8 @@
 package org.acme.kogito;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class PersonProcessInGraalIT extends PersonProcessTest {
 
 }

--- a/integration-tests/kogito/src/test/java/io/quarkus/it/kogito/drools/DroolsTestIT.java
+++ b/integration-tests/kogito/src/test/java/io/quarkus/it/kogito/drools/DroolsTestIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.kogito.drools;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class DroolsTestIT extends DroolsTest {
 }

--- a/integration-tests/kogito/src/test/java/io/quarkus/it/kogito/jbpm/OrdersProcessTestIT.java
+++ b/integration-tests/kogito/src/test/java/io/quarkus/it/kogito/jbpm/OrdersProcessTestIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.kogito.jbpm;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class OrdersProcessTestIT extends OrdersProcessTest {
 }

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTestIT.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTestIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.kubernetes.client;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class KubernetesClientTestIT extends KubernetesClientTest {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/CharacterSetSupportITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/CharacterSetSupportITCase.java
@@ -4,10 +4,10 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 import io.restassured.RestAssured;
 
-@SubstrateTest
+@NativeImageTest
 public class CharacterSetSupportITCase {
 
     @Test

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ConfigPropertiesITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ConfigPropertiesITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ConfigPropertiesITCase extends ConfigPropertiesTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ContextPropagationITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ContextPropagationITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ContextPropagationITCase extends ContextPropagationTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/CoreReflectionInGraalITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/CoreReflectionInGraalITCase.java
@@ -4,10 +4,10 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 import io.restassured.RestAssured;
 
-@SubstrateTest
+@NativeImageTest
 public class CoreReflectionInGraalITCase {
 
     @Test

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/CustomConfigSourceITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/CustomConfigSourceITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class CustomConfigSourceITCase extends CustomConfigSourceTestCase {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DataSourceTransactionITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DataSourceTransactionITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class DataSourceTransactionITCase extends DataSourceTransactionTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DatasourceITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DatasourceITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class DatasourceITCase extends DatasourceTestCase {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ExternalIndexITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ExternalIndexITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ExternalIndexITCase extends ExternalIndexTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/FaultToleranceITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/FaultToleranceITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class FaultToleranceITCase extends FaultToleranceTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthCheckTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthCheckTestCase.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.wildfly.common.Assert;
 
 import io.quarkus.it.health.SimpleHealthCheck;
+import io.quarkus.test.junit.NativeImageTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.SubstrateTest;
 
@@ -22,6 +23,7 @@ public class HealthCheckTestCase {
     @Test
     public void testInjection() {
         Assumptions.assumeFalse(getClass().isAnnotationPresent(SubstrateTest.class));
+        Assumptions.assumeFalse(getClass().isAnnotationPresent(NativeImageTest.class));
         Assert.assertTrue(checkks.call().getState() == HealthCheckResponse.State.UP);
     }
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class HealthITCase extends HealthTestCase {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JPABootstrapITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JPABootstrapITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JPABootstrapITCase extends JPABootstrapTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JPAReflectionInGraalITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JPAReflectionInGraalITCase.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 import io.restassured.RestAssured;
 
 /**
@@ -12,7 +12,7 @@ import io.restassured.RestAssured;
  *
  * @author Emmanuel Bernard emmanuel@hibernate.org
  */
-@SubstrateTest
+@NativeImageTest
 public class JPAReflectionInGraalITCase {
 
     @Test

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JPAUserTypeITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JPAUserTypeITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JPAUserTypeITCase extends JPAUserTypeTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JaxRSITCase extends JaxRSTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxbITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxbITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JaxbITCase extends JaxbTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class MetricsITCase extends MetricsTestCase {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsInheritanceITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsInheritanceITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class MetricsInheritanceITCase extends MetricsInheritanceTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsOnClassITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsOnClassITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class MetricsOnClassITCase extends MetricsOnClassTestCase {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MicroProfileConfigITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MicroProfileConfigITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class MicroProfileConfigITCase extends MicroProfileConfigTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author Ken Finnigan
  */
-@SubstrateTest
+@NativeImageTest
 public class OpenApiITCase extends OpenApiTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/OpenTracingITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/OpenTracingITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class OpenTracingITCase extends OpenTracingTestCase {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ProfileManagerITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ProfileManagerITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ProfileManagerITCase extends ProfileManagerTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RBACAccessInGraalITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RBACAccessInGraalITCase.java
@@ -1,10 +1,10 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
-@SubstrateTest
+@NativeImageTest
 public class RBACAccessInGraalITCase extends RBACAccessTest {
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ReactiveStreamsOperatorsITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ReactiveStreamsOperatorsITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ReactiveStreamsOperatorsITCase extends ReactiveStreamsOperatorsTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RequestScopeITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RequestScopeITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class RequestScopeITCase extends RequestScopeTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class RestClientITCase extends RestClientTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ServletITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ServletITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ServletITCase extends ServletTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SwaggerUIITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SwaggerUIITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class SwaggerUIITCase extends SwaggerUITestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TransactionITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TransactionITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class TransactionITCase extends TransactionTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ValidatorITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ValidatorITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class ValidatorITCase extends ValidatorTestCase {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.main;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class WebsocketITCase extends WebsocketTestCase {
 
 }

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/test/java/org/acme/my/project/itest/it/ItestIT.java
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/src/test/java/org/acme/my/project/itest/it/ItestIT.java
@@ -1,8 +1,8 @@
 package org.acme.my.project.itest.it;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class ItestIT extends ItestTest {
 
 }

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/NativeBookResourceIT.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/NativeBookResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.mongodb;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class NativeBookResourceIT extends BookResourceTest {
 
 }

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/NativeBookResourceIT.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/NativeBookResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.mongodb.panache;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class NativeBookResourceIT extends BookResourceTest {
 
 }

--- a/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityInGraalITCase.java
+++ b/integration-tests/neo4j/src/test/java/io/quarkus/it/neo4j/Neo4jFunctionalityInGraalITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.neo4j;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Test various Neo4j operations running in native mode.
  */
-@SubstrateTest
+@NativeImageTest
 public class Neo4jFunctionalityInGraalITCase extends Neo4jFunctionalityTest {
 
 }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowInGraalITCase.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowInGraalITCase.java
@@ -3,13 +3,13 @@ package io.quarkus.it.keycloak;
 import org.junit.jupiter.api.Disabled;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusTestResource(KeycloakTestResource.class)
-@SubstrateTest
+@NativeImageTest
 @Disabled("While figuring out how to have different application.properties for different tests")
 public class CodeFlowInGraalITCase extends CodeFlowTest {
 }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.keycloak;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 @QuarkusTestResource(KeycloakTestResource.class)
-@SubstrateTest
+@NativeImageTest
 public class BearerTokenAuthorizationInGraalITCase extends BearerTokenAuthorizationTest {
 }

--- a/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/NativeFruitsEndpointIT.java
+++ b/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/NativeFruitsEndpointIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.reactive.mysql.client;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeFruitsEndpointIT extends FruitsEndpointTest {
 
     // Runs the same tests as the parent class

--- a/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/NativeFruitsEndpointIT.java
+++ b/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/NativeFruitsEndpointIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.reactive.pg.client;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeFruitsEndpointIT extends FruitsEndpointTest {
 
     // Runs the same tests as the parent class

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTestIT.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTestIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.resteasy.jackson;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 class GreetingResourceTestIT extends GreetingResourceTest {
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/BookResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/BookResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class BookResourceIT extends BookResourceTest {
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CatResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class CatResourceIT extends CatResourceTest {
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CountryResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/CountryResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class CountryResourceIT extends CountryResourceTest {
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/MovieResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/MovieResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class MovieResourceIT extends MovieResourceTest {
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PersonResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PersonResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class PersonResourceIT extends PersonResourceTest {
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PostResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PostResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.spring.data.jpa;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class PostResourceIT extends PostResourceTest {
 
 }

--- a/integration-tests/spring-di/src/test/java/io/quarkus/it/spring/InjectedSpringBeansResourceIT.java
+++ b/integration-tests/spring-di/src/test/java/io/quarkus/it/spring/InjectedSpringBeansResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class InjectedSpringBeansResourceIT extends InjectedSpringBeansResourceTest {
 }

--- a/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerIT.java
+++ b/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/SpringControllerIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.spring.web;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class SpringControllerIT extends SpringControllerTest {
 }

--- a/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ExtensionITCase.java
+++ b/integration-tests/test-extension/src/test/java/io/quarkus/it/extension/ExtensionITCase.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.extension;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * Native image tests
  */
-@SubstrateTest
+@NativeImageTest
 public class ExtensionITCase extends ExtensionTestCase {
 
 }

--- a/integration-tests/tika/src/test/java/io/quarkus/it/tika/NativeTikaEmbeddedContentIT.java
+++ b/integration-tests/tika/src/test/java/io/quarkus/it/tika/NativeTikaEmbeddedContentIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.tika;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeTikaEmbeddedContentIT extends TikaEmbeddedContentTest {
 }

--- a/integration-tests/tika/src/test/java/io/quarkus/it/tika/NativeTikaParserIT.java
+++ b/integration-tests/tika/src/test/java/io/quarkus/it/tika/NativeTikaParserIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.tika;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeTikaParserIT extends TikaParserTest {
 }

--- a/integration-tests/tika/src/test/java/io/quarkus/it/tika/NativeTikaPdfInvoiceIT.java
+++ b/integration-tests/tika/src/test/java/io/quarkus/it/tika/NativeTikaPdfInvoiceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.tika;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeTikaPdfInvoiceIT extends TikaPdfInvoiceTest {
 }

--- a/integration-tests/vault-app/src/test/java/io/quarkus/it/vault/VaultInGraalITCase.java
+++ b/integration-tests/vault-app/src/test/java/io/quarkus/it/vault/VaultInGraalITCase.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
-@SubstrateTest
+@NativeImageTest
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 @DisabledOnOs(OS.WINDOWS)
 public class VaultInGraalITCase extends VaultTest {

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/NettyMainEventLoopGroupResourceIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/NettyMainEventLoopGroupResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.vertx;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NettyMainEventLoopGroupResourceIT extends NettyMainEventLoopGroupResourceTest {
 
 }

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.vertx;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class VertxProducerResourceIT extends VertxProducerResourceTest {
 
 }

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/EventBusIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/EventBusIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.vertx;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class EventBusIT extends EventBusTest {
 
 }

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/JsonReaderIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/JsonReaderIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.vertx;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class JsonReaderIT extends JsonReaderTest {
 
 }

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/JsonWriterIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/JsonWriterIT.java
@@ -1,11 +1,11 @@
 package io.quarkus.it.vertx;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
 /**
  * @author Thomas Segismont
  */
-@SubstrateTest
+@NativeImageTest
 public class JsonWriterIT extends JsonWriterTest {
 
 }

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VertxProducerResourceIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VertxProducerResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.vertx;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class VertxProducerResourceIT extends VertxProducerResourceTest {
 
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestScopeManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestScopeManager.java
@@ -16,15 +16,15 @@ public class TestScopeManager {
         }
     }
 
-    public static void setup(boolean isSubstrateTest) {
+    public static void setup(boolean isNativeImageTest) {
         for (TestScopeSetup i : SCOPE_MANAGERS) {
-            i.setup(isSubstrateTest);
+            i.setup(isNativeImageTest);
         }
     }
 
-    public static void tearDown(boolean isSubstrateTest) {
+    public static void tearDown(boolean isNativeImageTest) {
         for (TestScopeSetup i : SCOPE_MANAGERS) {
-            i.tearDown(isSubstrateTest);
+            i.tearDown(isNativeImageTest);
         }
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisabledOnNativeImage.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisabledOnNativeImage.java
@@ -6,14 +6,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * @deprecated Use {@link DisabledOnNativeImage} instead.
- */
-@Deprecated
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface DisabledOnSubstrate {
+public @interface DisabledOnNativeImage {
     /**
      * Reason for disabling this test
      */

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisabledOnNativeImageCondition.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisabledOnNativeImageCondition.java
@@ -14,31 +14,26 @@ import org.junit.platform.commons.util.StringUtils;
 
 import io.quarkus.test.junit.QuarkusTestExtension.ExtensionState;
 
-/**
- * @deprecated Use {@link DisabledOnNativeImageCondition} instead.
- *
- */
-@Deprecated
-public class DisabledOnSubstrateCondition implements ExecutionCondition {
+public class DisabledOnNativeImageCondition implements ExecutionCondition {
 
     private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult
-            .enabled("@DisabledOnSubstrate is not present");
+            .enabled("@DisabledOnNativeImage is not present");
 
     /**
-     * Containers/tests are disabled if {@code @DisabledOnSubstrate} is present on the test
-     * class or method and we're running on Substrate.
+     * Containers/tests are disabled if {@code @DisabledOnNativeImage} is present on the test
+     * class or method and we're running on a native image.
      */
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
         Optional<AnnotatedElement> element = context.getElement();
-        Optional<DisabledOnSubstrate> disabled = findAnnotation(element, DisabledOnSubstrate.class);
+        Optional<DisabledOnNativeImage> disabled = findAnnotation(element, DisabledOnNativeImage.class);
         if (disabled.isPresent()) {
             Store store = context.getStore(Namespace.GLOBAL);
             ExtensionState state = (ExtensionState) store.get(ExtensionState.class.getName());
-            if (state != null && state.isSubstrate()) {
-                String reason = disabled.map(DisabledOnSubstrate::value)
+            if (state != null && state.isNativeImage()) {
+                String reason = disabled.map(DisabledOnNativeImage::value)
                         .filter(StringUtils::isNotBlank)
-                        .orElseGet(() -> element.get() + " is @DisabledOnSubstrate");
+                        .orElseGet(() -> element.get() + " is @DisabledOnNativeImage");
                 return ConditionEvaluationResult.disabled(reason);
             }
         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeImageTest.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeImageTest.java
@@ -20,13 +20,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * run, it is expected that the JVM tests will be standard unit tests that are
  * executed by surefire, while the native image tests will be integration tests
  * executed by failsafe.
- * 
- * @deprecated Use {@link NativeImageTest} instead.
  *
  */
-@Deprecated
 @Target(ElementType.TYPE)
-@ExtendWith({ QuarkusTestExtension.class, DisabledOnSubstrateCondition.class })
+@ExtendWith({ QuarkusTestExtension.class, DisabledOnNativeImageCondition.class })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SubstrateTest {
+public @interface NativeImageTest {
 }


### PR DESCRIPTION
Fixes #4989 

The `FinalFieldReflectionInGraalITCase` test still uses the deprecated `@SubstrateTest` annotation on purpose to make sure the deprecated tests still work.