### PR TITLE
Changed Gradle project templates to use the platform BOM properties, …

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile "io.quarkus:quarkus-bootstrap-core:${version}"
     compile "io.quarkus:quarkus-devtools-common:${version}"
     compile "io.quarkus:quarkus-platform-descriptor-json:${version}"
+    compile "io.quarkus:quarkus-platform-descriptor-resolver-json:${version}"
     compile "io.quarkus:quarkus-development-mode:${version}"
     compile "io.quarkus:quarkus-creator:${version}"
     compile "org.gradle:gradle-tooling-api:5.5.1"

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -66,6 +66,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-platform-descriptor-json</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-platform-descriptor-resolver-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/GradleDependencyArtifact.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/GradleDependencyArtifact.java
@@ -1,0 +1,117 @@
+package io.quarkus.gradle;
+
+import org.gradle.api.artifacts.DependencyArtifact;
+
+public class GradleDependencyArtifact implements DependencyArtifact {
+
+    private String classifier;
+    private String extension;
+    private String name;
+    private String type;
+    private String url;
+
+    @Override
+    public String getClassifier() {
+        return classifier;
+    }
+
+    @Override
+    public String getExtension() {
+        return extension;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public void setClassifier(String arg0) {
+        this.classifier = arg0;
+    }
+
+    @Override
+    public void setExtension(String arg0) {
+        this.extension = arg0;
+    }
+
+    @Override
+    public void setName(String arg0) {
+        this.name = arg0;
+    }
+
+    @Override
+    public void setType(String arg0) {
+        this.type = arg0;
+    }
+
+    @Override
+    public void setUrl(String arg0) {
+        this.url = arg0;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((classifier == null) ? 0 : classifier.hashCode());
+        result = prime * result + ((extension == null) ? 0 : extension.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((url == null) ? 0 : url.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        GradleDependencyArtifact other = (GradleDependencyArtifact) obj;
+        if (classifier == null) {
+            if (other.classifier != null)
+                return false;
+        } else if (!classifier.equals(other.classifier))
+            return false;
+        if (extension == null) {
+            if (other.extension != null)
+                return false;
+        } else if (!extension.equals(other.extension))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        if (url == null) {
+            if (other.url != null)
+                return false;
+        } else if (!url.equals(other.url))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "GradleDepArtifact [classifier=" + classifier + ", extension=" + extension + ", name=" + name + ", type=" + type
+                + ", url=" + url + "]";
+    }
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusExtDependency.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusExtDependency.java
@@ -1,6 +1,9 @@
 package io.quarkus.gradle;
 
+import java.util.Set;
+
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.AbstractExternalModuleDependency;
@@ -21,12 +24,23 @@ public class QuarkusExtDependency extends AbstractExternalModuleDependency {
     }
 
     @Override
+    public Set<DependencyArtifact> getArtifacts() {
+        return super.getArtifacts();
+    }
+
+    @Override
     public ExternalModuleDependency copy() {
-        return new QuarkusExtDependency(group, name, version, configuration);
+        QuarkusExtDependency copy = new QuarkusExtDependency(group, name, version, configuration);
+        final Set<DependencyArtifact> artifacts = getArtifacts();
+        for (DependencyArtifact a : artifacts) {
+            copy.addArtifact(a);
+        }
+        return copy;
     }
 
     @Override
     public boolean contentEquals(Dependency arg0) {
+        new Exception("contentEquals " + arg0).printStackTrace();
         return true;
     }
 }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/GradleMessageWriter.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/GradleMessageWriter.java
@@ -1,0 +1,39 @@
+package io.quarkus.gradle.tasks;
+
+import org.gradle.api.logging.Logger;
+
+import io.quarkus.platform.tools.MessageWriter;
+
+public class GradleMessageWriter implements MessageWriter {
+
+    private final Logger logger;
+
+    public GradleMessageWriter(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void debug(String arg0) {
+        logger.debug(arg0);
+    }
+
+    @Override
+    public void error(String arg0) {
+        logger.error(arg0);
+    }
+
+    @Override
+    public void info(String arg0) {
+        logger.info(arg0);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void warn(String arg0) {
+        logger.warn(arg0);
+    }
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusAddExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusAddExtension.java
@@ -17,7 +17,7 @@ import io.quarkus.cli.commands.writer.FileProjectWriter;
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
  */
-public class QuarkusAddExtension extends QuarkusTask {
+public class QuarkusAddExtension extends QuarkusPlatformTask {
 
     public QuarkusAddExtension() {
         super("Adds Quarkus extensions specified by the user to the project.");
@@ -37,6 +37,9 @@ public class QuarkusAddExtension extends QuarkusTask {
 
     @TaskAction
     public void addExtension() {
+
+        setupPlatformDescriptor();
+
         Set<String> extensionsSet = new HashSet<>(getExtensionsToAdd());
         try {
             new AddExtensions(new GradleBuildFile(new FileProjectWriter(getProject().getProjectDir())))
@@ -45,5 +48,4 @@ public class QuarkusAddExtension extends QuarkusTask {
             throw new GradleException("Failed to add extensions " + getExtensionsToAdd(), e);
         }
     }
-
 }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
@@ -1,6 +1,5 @@
 package io.quarkus.gradle.tasks;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.gradle.api.GradleException;
@@ -16,13 +15,13 @@ import io.quarkus.gradle.GradleBuildFileFromConnector;
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
  */
-public class QuarkusListExtensions extends QuarkusTask {
+public class QuarkusListExtensions extends QuarkusPlatformTask {
 
     private boolean all = true;
 
     private String format = "concise";
 
-    private String searchPattern = null;
+    private String searchPattern;
 
     @Optional
     @Input
@@ -63,13 +62,16 @@ public class QuarkusListExtensions extends QuarkusTask {
 
     @TaskAction
     public void listExtensions() {
+
+        setupPlatformDescriptor();
+
         try {
-            new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(new File(getPath())))).listExtensions(
-                    isAll(),
-                    getFormat(), getSearchPattern());
+            new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(getProject().getProjectDir())))
+                    .listExtensions(
+                            isAll(),
+                            getFormat(), getSearchPattern());
         } catch (IOException e) {
             throw new GradleException("Unable to list extensions", e);
         }
     }
-
 }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -1,0 +1,60 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.descriptor.resolver.json.QuarkusJsonPlatformDescriptorResolver;
+import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
+
+public class QuarkusPlatformTask extends QuarkusTask {
+
+    QuarkusPlatformTask(String description) {
+        super(description);
+    }
+
+    protected void setupPlatformDescriptor() {
+
+        if (QuarkusPlatformConfig.hasGlobalDefault()) {
+            return;
+        }
+
+        final Path currentDir = getProject().getProjectDir().toPath();
+
+        final Path gradlePropsPath = currentDir.resolve("gradle.properties");
+        if (Files.exists(gradlePropsPath)) {
+            final Properties props = new Properties();
+            try (InputStream is = Files.newInputStream(gradlePropsPath)) {
+                props.load(is);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to load " + gradlePropsPath, e);
+            }
+
+            final QuarkusPlatformDescriptor platform = QuarkusJsonPlatformDescriptorResolver.newInstance()
+                    .setArtifactResolver(extension().resolveAppModel())
+                    .setBomVersion(
+                            getRequiredProperty(props, "quarkusPlatformBomGroupId"),
+                            getRequiredProperty(props, "quarkusPlatformBomArtifactId"),
+                            getRequiredProperty(props, "quarkusPlatformBomVersion"))
+                    .setMessageWriter(new GradleMessageWriter(getProject().getLogger()))
+                    .resolve();
+
+            QuarkusPlatformConfig.defaultConfigBuilder().setPlatformDescriptor(platform).build();
+
+        } else {
+            getProject().getLogger()
+                    .warn("Failed to locate " + gradlePropsPath + " to determine the Quarkus Platform BOM coordinates");
+        }
+    }
+
+    private static String getRequiredProperty(Properties props, String name) {
+        final String value = props.getProperty(name);
+        if (value == null) {
+            throw new IllegalStateException("Required property " + name + " is missing from gradle.properties");
+        }
+        return value;
+    }
+}

--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
@@ -27,6 +27,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.dependencies.Extension;
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
@@ -76,10 +77,8 @@ public class ValidateExtensionsJsonMojo extends AbstractMojo {
         }
 
         final QuarkusPlatformDescriptor descriptor = QuarkusJsonPlatformDescriptorResolver.newInstance()
-                .setPlatformJsonGroupId(jsonGroupId)
-                .setPlatformJsonArtifactId(jsonArtifactId)
-                .setPlatformJsonVersion(jsonVersion)
-                .setMavenArtifactResolver(mvn)
+                .setJsonVersion(jsonGroupId, jsonArtifactId, jsonVersion)
+                .setArtifactResolver(new BootstrapAppModelResolver(mvn))
                 .resolve();
 
         final DefaultArtifact bomArtifact = new DefaultArtifact(descriptor.getBomGroupId(),

--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptor.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptor.java
@@ -39,6 +39,10 @@ public class QuarkusJsonPlatformDescriptor implements QuarkusPlatformDescriptor 
         bomVersion = bom.version;
     }
 
+    public void setQuarkusCoreVersion(String quarkusVersion) {
+        this.quarkusVersion = quarkusVersion;
+    }
+
     public void setExtensions(List<Extension> extensions) {
         this.extensions = extensions;
     }

--- a/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderImpl.java
+++ b/devtools/platform-descriptor-json/src/main/java/io/quarkus/platform/descriptor/loader/json/impl/QuarkusJsonPlatformDescriptorLoaderImpl.java
@@ -4,11 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.maven.model.Dependency;
-import org.eclipse.aether.artifact.DefaultArtifact;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,9 +15,6 @@ import io.quarkus.platform.descriptor.loader.json.QuarkusJsonPlatformDescriptorL
 
 public class QuarkusJsonPlatformDescriptorLoaderImpl
         implements QuarkusJsonPlatformDescriptorLoader<QuarkusJsonPlatformDescriptor> {
-
-    private static final String IO_QUARKUS = "io.quarkus";
-    private static final String QUARKUS_CORE_ARTIFACT_ID = "quarkus-core";
 
     @Override
     public QuarkusJsonPlatformDescriptor load(final QuarkusJsonPlatformDescriptorLoaderContext context) {
@@ -43,38 +35,8 @@ public class QuarkusJsonPlatformDescriptorLoaderImpl
                     }
                 });
 
-        final DefaultArtifact platformBom = new DefaultArtifact(platform.getBomGroupId(), platform.getBomArtifactId(), null,
-                "pom", platform.getBomVersion());
-        String quarkusVersion = null;
-        try {
-            final List<Dependency> managedDeps = context.getArtifactResolver().getManagedDependencies(platformBom.getGroupId(),
-                    platformBom.getArtifactId(), platformBom.getVersion());
-            final List<Dependency> convertedDeps = new ArrayList<>(managedDeps.size());
-            for (Dependency dep : managedDeps) {
-                final org.apache.maven.model.Dependency converted = new org.apache.maven.model.Dependency();
-                convertedDeps.add(converted);
-                converted.setGroupId(dep.getGroupId());
-                converted.setArtifactId(dep.getArtifactId());
-                converted.setVersion(dep.getVersion());
-                converted.setClassifier(dep.getClassifier());
-                converted.setType(dep.getType());
-                converted.setScope(dep.getScope());
-                converted.setOptional(dep.isOptional());
-                // exclusions aren't added yet
-
-                if (dep.getArtifactId().equals(QUARKUS_CORE_ARTIFACT_ID)
-                        && dep.getGroupId().equals(IO_QUARKUS)) {
-                    quarkusVersion = dep.getVersion();
-                }
-            }
-            platform.setManagedDependencies(convertedDeps);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to read descriptor of " + platformBom, e);
-        }
-
-        if (quarkusVersion == null) {
-            throw new RuntimeException("Failed to determine the Quarkus version for the platform " + platformBom);
-        }
+        platform.setManagedDependencies(context.getArtifactResolver().getManagedDependencies(platform.getBomGroupId(),
+                platform.getBomArtifactId(), null, "pom", platform.getBomVersion()));
 
         final Path classOrigin;
         try {
@@ -92,7 +54,6 @@ public class QuarkusJsonPlatformDescriptorLoaderImpl
         }
         platform.setResourceLoader(resourceLoader);
 
-        platform.setQuarkusVersion(quarkusVersion);
         platform.setMessageWriter(context.getMessageWriter());
 
         return platform;

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${bom_groupId}:${bom_artifactId}:${bom_version}")
+    implementation enforcedPlatform("${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -1,1 +1,3 @@
-quarkusVersion = ${quarkus_version}
+quarkusPlatformBomGroupId = ${bom_groupId}
+quarkusPlatformBomArtifactId = ${bom_artifactId}
+quarkusPlatformBomVersion = ${bom_version}

--- a/devtools/platform-descriptor-json/src/test/java/io/quarkus/platform/descriptor/tests/PlatformDescriptorLoaderTest.java
+++ b/devtools/platform-descriptor-json/src/test/java/io/quarkus/platform/descriptor/tests/PlatformDescriptorLoaderTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -41,26 +41,17 @@ class PlatformDescriptorLoaderTest {
                 return new ArtifactResolver() {
 
                     @Override
-                    public List<Dependency> getManagedDependencies(String groupId, String artifactId,
-                            String version) {
-                        List<Dependency> lx = new ArrayList<Dependency>();
-
-                        Dependency core = new Dependency();
-                        core.setArtifactId("quarkus-core");
-                        core.setGroupId("io.quarkus");
-                        core.setVersion("I don't care!");
-                        lx.add(core);
-                        return lx;
+                    public <T> T process(String groupId, String artifactId, String classifier, String type, String version,
+                            Function<Path, T> processor) {
+                        throw new UnsupportedOperationException();
                     }
 
                     @Override
-                    public <T> T process(String groupId, String artifactId, String classifier, String type,
-                            String version, Function<Path, T> processor) {
-                        // TODO Auto-generated method stub
-                        return null;
+                    public List<Dependency> getManagedDependencies(String groupId, String artifactId, String classifier,
+                            String type, String version) {
+                        return Collections.emptyList();
                     }
                 };
-
             }
 
             @Override

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/AppModelResolver.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/AppModelResolver.java
@@ -113,4 +113,14 @@ public interface AppModelResolver {
      * @throws AppModelResolverException  in case of a failure
      */
     String getLatestVersion(AppArtifact artifact, String upToVersion, boolean inclusive) throws AppModelResolverException;
+
+    /**
+     * Resolves the latest version from the specified range. The version of the artifact is ignored.
+     *
+     * @param appArtifact  the artifact
+     * @param range  the version range
+     * @return  the latest version of the artifact from the range or null, if no version was found for the specified range
+     * @throws AppModelResolverException  in case of a failure
+     */
+    String getLatestVersionFromRange(AppArtifact appArtifact, String range) throws AppModelResolverException;
 }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/writer/FileProjectWriter.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/writer/FileProjectWriter.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package io.quarkus.cli.commands.writer;
 
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * ProjectWriter implementation to create direct files in the file system.
@@ -51,13 +50,13 @@ public class FileProjectWriter implements ProjectWriter {
 
     @Override
     public void write(String path, String content) throws IOException {
-        final Path outputPath = Paths.get(root + "/" + path);
+        final Path outputPath = root.toPath().resolve(path);
         Files.write(outputPath, content.getBytes("UTF-8"));
     }
 
     @Override
     public byte[] getContent(String path) throws IOException {
-        return Files.readAllBytes(Paths.get(root + "/" + path));
+        return Files.readAllBytes(root.toPath().resolve(path));
     }
 
     @Override

--- a/independent-projects/tools/common/src/main/java/io/quarkus/generators/rest/BasicRestProjectGenerator.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/generators/rest/BasicRestProjectGenerator.java
@@ -100,8 +100,10 @@ public class BasicRestProjectGenerator implements ProjectGenerator {
                     gav = new String[3];
                     for (String buildFile : buildTool.getBuildFiles()) {
                         if (writer.exists(buildFile)) {
-                            ByteArrayInputStream buildFileInputStream = new ByteArrayInputStream(writer.getContent(buildFile));
-                            gav = MojoUtils.readGavFromSettingsGradle(buildFileInputStream, gav);
+                            try (ByteArrayInputStream buildFileInputStream = new ByteArrayInputStream(
+                                    writer.getContent(buildFile))) {
+                                gav = MojoUtils.readGavFromSettingsGradle(buildFileInputStream, gav);
+                            }
                         }
                     }
                 }
@@ -120,7 +122,7 @@ public class BasicRestProjectGenerator implements ProjectGenerator {
                 final String resourceType)
                 throws IOException {
             if (!writer.exists(outputFilePath)) {
-                String path = templateName;//templateName.startsWith("/") ? templateName : "/" + templateName;
+                String path = templateName;
                 String template = QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor().getTemplate(path);
                 if (template == null) {
                     throw new IOException("Template resource is missing: " + path);

--- a/independent-projects/tools/common/src/main/java/io/quarkus/platform/descriptor/loader/json/ArtifactResolver.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/platform/descriptor/loader/json/ArtifactResolver.java
@@ -8,11 +8,11 @@ import org.apache.maven.model.Dependency;
 
 public interface ArtifactResolver {
 
-    List<Dependency> getManagedDependencies(String groupId, String artifactId, String version);
-
     default <T> T process(String groupId, String artifactId, String version, Function<Path, T> processor) {
         return process(groupId, artifactId, null, "jar", version, processor);
     }
 
     <T> T process(String groupId, String artifactId, String classifier, String type, String version, Function<Path, T> processor);
+
+    List<Dependency> getManagedDependencies(String groupId, String artifactId, String classifier, String type, String version);
 }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
@@ -8,6 +8,6 @@ public interface ToolsConstants {
     String QUARKUS_CORE_ARTIFACT_ID = "quarkus-core";
 
     String DEFAULT_PLATFORM_BOM_GROUP_ID = IO_QUARKUS;
-    String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-platform-bom";
+    String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-universe-bom";
 
 }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/platform/tools/config/QuarkusPlatformConfig.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/platform/tools/config/QuarkusPlatformConfig.java
@@ -2,8 +2,6 @@ package io.quarkus.platform.tools.config;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
-import java.util.concurrent.atomic.AtomicReference;
-
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import io.quarkus.platform.descriptor.loader.QuarkusPlatformDescriptorLoader;
 import io.quarkus.platform.descriptor.loader.QuarkusPlatformDescriptorLoaderContext;
@@ -105,7 +103,7 @@ public class QuarkusPlatformConfig {
         }
     }
 
-    private static final AtomicReference<QuarkusPlatformConfig> defaultConfig = new AtomicReference<>();
+    private static final ThreadLocal<QuarkusPlatformConfig> defaultConfig = new ThreadLocal<>();
 
     private final MessageWriter log;
     private final QuarkusPlatformDescriptor platformDescr;

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -105,7 +107,15 @@ public class CreateProjectTest {
                 .containsIgnoringCase("io.quarkus:quarkus-gradle-plugin");
 
         assertThat(contentOf(new File(testDir, "build.gradle"), "UTF-8"))
-                .containsIgnoringCase(getBomArtifactId());
+                .contains("${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}");
+
+        final Properties props = new Properties();
+        try(InputStream is = Files.newInputStream(testDir.toPath().resolve("gradle.properties"))) {
+            props.load(is);
+        }
+        Assertions.assertEquals(getBomGroupId(), props.get("quarkusPlatformBomGroupId"));
+        Assertions.assertEquals(getBomArtifactId(), props.get("quarkusPlatformBomArtifactId"));
+        Assertions.assertEquals(getBomVersion(), props.get("quarkusPlatformBomVersion"));
     }
 
     @Test

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${bom_groupId}:${bom_artifactId}:${bom_version}")
+    implementation enforcedPlatform("${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -1,1 +1,3 @@
-quarkusVersion = ${quarkus_version}
+quarkusPlatformBomGroupId = ${bom_groupId}
+quarkusPlatformBomArtifactId = ${bom_artifactId}
+quarkusPlatformBomVersion = ${bom_version}

--- a/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/tools/DefaultMessageWriter.java
+++ b/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/tools/DefaultMessageWriter.java
@@ -15,8 +15,9 @@ public class DefaultMessageWriter implements MessageWriter {
         this.out = out;
     }
 
-    public void setDebugEnabled(boolean debugEnabled) {
+    public DefaultMessageWriter setDebugEnabled(boolean debugEnabled) {
         this.debug = debugEnabled;
+        return this;
     }
 
     @Override

--- a/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/demo/JsonDescriptorResolverDemo.java
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/demo/JsonDescriptorResolverDemo.java
@@ -13,12 +13,11 @@ public class JsonDescriptorResolverDemo {
 
         final QuarkusPlatformDescriptor platform = QuarkusJsonPlatformDescriptorResolver.newInstance()
                 .setMessageWriter(log)
-                .setPlatformJsonArtifactId("quarkus-bom-descriptor-json")
+                .setJsonArtifactId("quarkus-bom-descriptor-json")
                 .resolve();
 
         log.info("Platform BOM: " + platform.getBomGroupId() + ":" + platform.getBomArtifactId() + ":" + platform.getBomVersion());
         log.info("Extensions total: " + platform.getExtensions().size());
-        log.info("Managed deps total: " + platform.getManagedDependencies().size());
 
         log.info(platform.getTemplate("templates/basic-rest/java/resource-template.ftl"));
     }


### PR DESCRIPTION
…made Gradle list and add extensions commands to use the correct platform descriptor, enhanced JSON descriptor resolver to determine the JSON artifact corresponding to the specified BOM coords, enhanced Gradle AppModelResolver impl, fixes related to resolution of the latest platform version

@maxandersen @gastaldi I think this PR is good enough for Gradle support. I tested it with the custom built universe which includes Camel too. Specifically, it's about list and add extensions.

QuarkusJsonPlatformDescriptorResolver class is probably going to be used in a similar manner in the Maven case. Except that I'll still need to fallback to the classpath discovery of resources in case we are offline.