### PR TITLE
Add the zlib1g-dev package to the list of required package

### DIFF
--- a/docs/src/main/asciidoc/building-native-image-guide.adoc
+++ b/docs/src/main/asciidoc/building-native-image-guide.adoc
@@ -39,7 +39,7 @@ What does having a working C developer environment mean?
 # dnf (rpm-based)
 sudo dnf install gcc glibc-devel zlib-devel
 # Debian-based distributions:
-sudo apt-get install build-essential libz-dev
+sudo apt-get install build-essential libz-dev zlib1g-dev
 ----
 * XCode provides the required dependencies on macOS:
 +


### PR DESCRIPTION
It's been reported during the Voxxed Microservice Workshop.
This package is required to build native executables and is not installed by default on Ubuntu.