### PR TITLE
Remove deprecated smallrye-open-api method overrides

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/RESTEasyExtension.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/RESTEasyExtension.java
@@ -5,32 +5,20 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.resteasy.deployment.ResteasyJaxrsConfigBuildItem;
-import io.smallrye.openapi.api.OpenApiConstants;
 import io.smallrye.openapi.runtime.scanner.DefaultAnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
-import io.smallrye.openapi.runtime.util.JandexUtil;
-import io.smallrye.openapi.runtime.util.JandexUtil.JaxRsParameterInfo;
 
 public class RESTEasyExtension extends DefaultAnnotationScannerExtension {
 
-    public static final DotName DOTNAME_QUERY_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.QueryParam");
-    public static final DotName DOTNAME_FORM_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.FormParam");
-    public static final DotName DOTNAME_COOKIE_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.CookieParam");
-    public static final DotName DOTNAME_PATH_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.PathParam");
-    public static final DotName DOTNAME_HEADER_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.HeaderParam");
-    public static final DotName DOTNAME_MATRIX_PARAM = DotName.createSimple("org.jboss.resteasy.annotations.jaxrs.MatrixParam");
     private static final DotName DOTNAME_PROVIDER = DotName.createSimple("javax.ws.rs.ext.Provider");
     private static final DotName DOTNAME_ASYNC_RESPONSE_PROVIDER = DotName
             .createSimple("org.jboss.resteasy.spi.AsyncResponseProvider");
@@ -103,73 +91,6 @@ public class RESTEasyExtension extends DefaultAnnotationScannerExtension {
                 }
             }
         }
-    }
-
-    @Override
-    public JaxRsParameterInfo getMethodParameterJaxRsInfo(MethodInfo method, int idx) {
-        AnnotationInstance jaxRsAnno = JandexUtil.getMethodParameterAnnotation(method, idx, DOTNAME_PATH_PARAM);
-        if (jaxRsAnno != null) {
-            JaxRsParameterInfo info = new JaxRsParameterInfo();
-            info.in = In.PATH;
-            info.name = JandexUtil.stringValue(jaxRsAnno, OpenApiConstants.PROP_VALUE);
-            if (info.name == null)
-                info.name = method.parameterName(idx);
-            return info;
-        }
-
-        jaxRsAnno = JandexUtil.getMethodParameterAnnotation(method, idx, DOTNAME_QUERY_PARAM);
-        if (jaxRsAnno != null) {
-            JaxRsParameterInfo info = new JaxRsParameterInfo();
-            info.in = In.QUERY;
-            info.name = JandexUtil.stringValue(jaxRsAnno, OpenApiConstants.PROP_VALUE);
-            if (info.name == null)
-                info.name = method.parameterName(idx);
-            return info;
-        }
-
-        jaxRsAnno = JandexUtil.getMethodParameterAnnotation(method, idx, DOTNAME_COOKIE_PARAM);
-        if (jaxRsAnno != null) {
-            JaxRsParameterInfo info = new JaxRsParameterInfo();
-            info.in = In.COOKIE;
-            info.name = JandexUtil.stringValue(jaxRsAnno, OpenApiConstants.PROP_VALUE);
-            if (info.name == null)
-                info.name = method.parameterName(idx);
-            return info;
-        }
-
-        jaxRsAnno = JandexUtil.getMethodParameterAnnotation(method, idx, DOTNAME_HEADER_PARAM);
-        if (jaxRsAnno != null) {
-            JaxRsParameterInfo info = new JaxRsParameterInfo();
-            info.in = In.HEADER;
-            info.name = JandexUtil.stringValue(jaxRsAnno, OpenApiConstants.PROP_VALUE);
-            if (info.name == null)
-                info.name = method.parameterName(idx);
-            return info;
-        }
-
-        return null;
-    }
-
-    @Override
-    public In parameterIn(MethodParameterInfo paramInfo) {
-        MethodInfo method = paramInfo.method();
-        short paramPosition = paramInfo.position();
-        List<AnnotationInstance> annotations = JandexUtil.getParameterAnnotations(method, paramPosition);
-        for (AnnotationInstance annotation : annotations) {
-            if (annotation.name().equals(DOTNAME_QUERY_PARAM)) {
-                return In.QUERY;
-            }
-            if (annotation.name().equals(DOTNAME_PATH_PARAM)) {
-                return In.PATH;
-            }
-            if (annotation.name().equals(DOTNAME_HEADER_PARAM)) {
-                return In.HEADER;
-            }
-            if (annotation.name().equals(DOTNAME_COOKIE_PARAM)) {
-                return In.COOKIE;
-            }
-        }
-        return null;
     }
 
     @Override


### PR DESCRIPTION
The methods `getMethodParameterJaxRsInfo` and `parameterIn` in
`RESTEasyExtension` were meant to add support for RESTEasy annotations
during the OpenAPI scan process. As support for those annotations is now
present in smallrye-open-api and the methods have been deprecated, the
overrides are no longer necessary. This change allows smallrye-open-api
to prune the methods from its API.