### PR TITLE
Documentation : Jackson Java 8 modules and a small correction

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -480,11 +480,11 @@ Furthermore, extensions can eliminate possible false positives by producing `Unr
 Finally, Quarkus provides a middle ground for the bean removal optimization where application beans are never removed whether or not they are unused,
 while the optimization proceeds normally for non application classes. To use this mode, set `quarkus.arc.remove-unused-beans` to `fwk` or `framework`.
 
-In order to see more information about which beans are being removed,
-you can enable additional logging via the following line in your `application.properties`.
+When using the dev mode (running `mvn clean compile quarkus:dev`), you can see more information about which beans are being removed
+by enabling additional logging via the following line in your `application.properties`.
 
 ----
-quarkus.log.category."io.quarkus.arc.producer".level=DEBUG
+quarkus.log.category."io.quarkus.arc.processor".level=DEBUG
 ----
 
 [[default_beans]]

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1629,7 +1629,7 @@ The class augmentation step of Quarkus generates classes for various purposes. S
 classes/bytecode to debug or understand an issue. Classes that are related to application augmentation are currently held in
 memory in a runtime class loader.
 
-When using the dev mode (running `mvn clean compile quarkus:dev) you can have these classes written out to disk for inspection, for this, you need to specify the
+When using the dev mode (running `mvn clean compile quarkus:dev`) you can have these classes written out to disk for inspection, for this, you need to specify the
 `quarkus.debug.generated-classes-dir` system property, for example:
 
 [source,shell]

--- a/docs/src/main/asciidoc/rest-json-guide.adoc
+++ b/docs/src/main/asciidoc/rest-json-guide.adoc
@@ -63,6 +63,8 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dextensions="resteasy-jackson"
 ----
 
+To improve user experience, Quarkus registers the three Jackson https://github.com/FasterXML/jackson-modules-java8[Java 8 modules] so you don't need to do it manually.
+
 == Creating your first JSON REST service
 
 In this example, we will create an application to manage a list of fruits.


### PR DESCRIPTION
Fix a small documentation error.

Add a reference to the Java 8 modules that Quarkus automatically add in the rest json guide.