### PR TITLE
Test scenario for expired bearer tokens

### DIFF
--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -1,9 +1,11 @@
 package io.quarkus.it.keycloak;
 
 import static io.quarkus.it.keycloak.KeycloakRealmResourceManager.getAccessToken;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
@@ -107,5 +109,16 @@ public class BearerTokenAuthorizationTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello World"));
+    }
+
+    @Test
+    public void testExpiredBearerToken() throws InterruptedException {
+        String token = getAccessToken("alice");
+
+        await()
+                .pollDelay(3, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS).until(
+                        () -> RestAssured.given().auth().oauth2(token).when()
+                                .get("/api/users/me").thenReturn().statusCode() == 403);
     }
 }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -68,6 +68,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         realm.setEnabled(true);
         realm.setUsers(new ArrayList<>());
         realm.setClients(new ArrayList<>());
+        realm.setAccessTokenLifespan(3);
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();


### PR DESCRIPTION
I'm afraid we have some thread blocks that should be watched closely in order to avoid impacting CI execution. Any suggestion about how to better test scenarios where we need to stop execution for a while in order to check expirations and invalidations based on time would be appreciated.

Maybe introducing some utility class that we can potentially use to check and force a time ...