### PR TITLE
Unlist unlisted in list-extensions

### DIFF
--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensions.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensions.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.maven.model.Dependency;
 
@@ -55,7 +56,9 @@ public class AddExtensions {
         if (matchesNameOrArtifactId.size() == 1) {
             return new SelectionResult(matchesNameOrArtifactId, true);
         }
-
+        
+        extensions = extensions.stream().filter(e -> !e.isUnlisted()).collect(Collectors.toList());
+        
         // Try short names
         Set<Extension> matchesShortName = extensions.stream().filter(extension -> matchesShortName(extension, q))
                 .collect(Collectors.toSet());
@@ -192,6 +195,7 @@ public class AddExtensions {
         List<Dependency> dependenciesFromBom = getDependenciesFromBom();
 
         List<Extension> registry = MojoUtils.loadExtensions();
+
         for (String query : extensions) {
 
             if (query.contains(":")) {

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ListExtensions.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ListExtensions.java
@@ -35,6 +35,7 @@ public class ListExtensions {
         final Map<String, Dependency> installed = findInstalled();
 
         Stream<Extension> extensionsStream = loadExtensions().stream();
+        extensionsStream = extensionsStream.filter(e -> filterUnlisted(e));
         if (search != null && !"*".equalsIgnoreCase(search)) {
             final Pattern searchPattern = Pattern.compile(".*" + search + ".*", Pattern.CASE_INSENSITIVE);
             extensionsStream = extensionsStream.filter(e -> filterBySearch(searchPattern, e));
@@ -81,6 +82,10 @@ public class ListExtensions {
                         "pom.xml or use `./mvnw quarkus:add-extension -Dextensions=\"artifactId\"`");
             }
         }
+    }
+
+    private boolean filterUnlisted(Extension e) {
+        return !e.getMetadata().containsKey("unlisted");
     }
 
     public Map<String, Dependency> findInstalled() throws IOException {

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddExtensionsSelectTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddExtensionsSelectTest.java
@@ -119,4 +119,29 @@ class AddExtensionsSelectTest {
         Assertions.assertTrue(matches.iterator().next().getArtifactId().equalsIgnoreCase("quarkus-foo"));
     }
 
+    @Test
+    void testListedVsUnlisted() {
+        Extension e1 = new Extension("org.acme", "quarkus-foo-unlisted", "1.0")
+                .setName("some complex seo unaware name")
+                .setShortName("foo")
+                .setKeywords(new String[] { "foo", "bar" }).addMetadata("unlisted", "true");
+        
+        Extension e2 = new Extension("org.acme", "quarkus-foo-bar", "1.0")
+                .setName("some foo bar")
+                .setKeywords(new String[] { "foo", "bar", "baz" }).addMetadata("unlisted", "false");
+        Extension e3 = new Extension("org.acme", "quarkus-foo-baz", "1.0")
+                .setName("unrelated")
+                .setKeywords(new String[] { "foo" });
+
+        List<Extension> extensions = asList(e1, e2, e3);
+        Collections.shuffle(extensions);
+        SelectionResult matches = AddExtensions.select("quarkus-foo", extensions, true);
+        Assertions.assertEquals(2, matches.getExtensions().size());
+
+        matches = AddExtensions.select("quarkus-foo-unlisted", extensions, true);
+        Assertions.assertEquals(1, matches.getExtensions().size());
+
+    }
+    
+    
 }

--- a/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/dependencies/Extension.java
+++ b/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/dependencies/Extension.java
@@ -294,10 +294,30 @@ public class Extension {
     }
 
     public boolean isUnlisted() {
-        return (boolean) getMetadata().get(MD_UNLISTED);
-    }
+        Object val = getMetadata().get(MD_UNLISTED);
+        if (val==null) {
+            return false;
+        } else if (val instanceof Boolean) {
+            return ((Boolean) val).booleanValue();
+        } else if (val instanceof String) {
+            return Boolean.valueOf((String)val);
+        }
+        
+        return false;
+     }
 
     public void setUnlisted(boolean unlisted) {
         getMetadata().put(MD_UNLISTED, Boolean.valueOf(unlisted));
     }
+
+    public Extension addMetadata(String key, Object value) {
+       getMetadata().put(key,value);
+       return this;
+        
+    }
+    
+    public Extension removeMetadata(String key) {
+        getMetadata().remove(key);
+        return this;
+     }
 }


### PR DESCRIPTION
jaeger was being listed via listExtensions.

With this fix any extension with a "unlisted" key in metadata gets unlisted.
i.e. the mere presence of the key makes it unlisted.