### PR TITLE
Generate documentation file for config group

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -54,8 +54,18 @@ final public class Constants {
             .get(System.getProperties().getProperty("maven.multiModuleProjectDirectory")
                     + Constants.DOCS_SRC_MAIN_ASCIIDOC_GENERATED);
     public static final File GENERATED_DOCS_DIR = GENERATED_DOCS_PATH.toFile();
+
+    /**
+     * Holds the list of configuration items / configuration sections of each configuration roots.
+     */
     public static final File ALL_CR_GENERATED_DOC = GENERATED_DOCS_PATH
             .resolve("all-configuration-roots-generated-doc.properties").toFile();
+
+    /**
+     * Holds the list of computed file names and the list of configuration roots of this extension
+     */
+    public static final File EXTENSION_CONFIGURATION_ROOT_LIST = GENERATED_DOCS_PATH
+            .resolve("extensions-configuration-roots-list.properties").toFile();
 
     public static final String DURATION_NOTE_ANCHOR = "duration-note-anchor";
     public static final String MEMORY_SIZE_NOTE_ANCHOR = "memory-size-note-anchor";

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -66,9 +65,9 @@ import org.jboss.jdeparser.JSources;
 import org.jboss.jdeparser.JType;
 import org.jboss.jdeparser.JTypes;
 
-import io.quarkus.annotation.processor.generate_doc.ConfigDocItem;
 import io.quarkus.annotation.processor.generate_doc.ConfigDocItemScanner;
 import io.quarkus.annotation.processor.generate_doc.ConfigDocWriter;
+import io.quarkus.annotation.processor.generate_doc.ScannedConfigDocsItemHolder;
 
 public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
@@ -236,9 +235,12 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         }
 
         try {
-            final Map<String, List<ConfigDocItem>> extensionConfigurationItems = configDocItemScanner
+            final ScannedConfigDocsItemHolder scannedConfigDocsItemHolder = configDocItemScanner
                     .scanExtensionsConfigurationItems(javaDocProperties);
-            configDocWriter.writeExtensionConfigDocumentation(extensionConfigurationItems);
+
+            configDocWriter.writeExtensionConfigDocumentation(scannedConfigDocsItemHolder.getAllConfigItemsPerExtension(),
+                    true); // generate extension doc with search engine activate
+            configDocWriter.writeExtensionConfigDocumentation(scannedConfigDocsItemHolder.getConfigGroupConfigItems(), false); // generate config group docs with search engine deactivated
         } catch (IOException e) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to generate extension doc: " + e);
             return;

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
@@ -1,0 +1,284 @@
+package io.quarkus.annotation.processor.generate_doc;
+
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getJavaDocSiteLink;
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getKnownGenericType;
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.hyphenate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+import io.quarkus.annotation.processor.Constants;
+
+class ConfigDoItemFinder {
+
+    private static final String NAMED_MAP_CONFIG_ITEM_FORMAT = ".\"%s\"";
+    private final JavaDocParser javaDocParser = new JavaDocParser();
+    private final ScannedConfigDocsItemHolder holder = new ScannedConfigDocsItemHolder();
+
+    private final Set<ConfigRootInfo> configRoots;
+    private final Map<String, TypeElement> configGroups;
+    private final Properties javaDocProperties;
+
+    public ConfigDoItemFinder(Set<ConfigRootInfo> configRoots, Map<String, TypeElement> configGroups,
+            Properties javaDocProperties) {
+        this.configRoots = configRoots;
+        this.configGroups = configGroups;
+        this.javaDocProperties = javaDocProperties;
+    }
+
+    /**
+     * Find configuration items from current encountered configuration roots
+     */
+    ScannedConfigDocsItemHolder findInMemoryConfigurationItems() {
+        for (ConfigRootInfo configRootInfo : configRoots) {
+            final TypeElement element = configRootInfo.getClazz();
+            /**
+             * Config sections will start at level 2 i.e the section title will be prefixed with
+             * ('='* (N + 1)) where N is section level.
+             */
+            final int sectionLevel = 2;
+            final List<ConfigDocItem> configDocItems = recursivelyFindConfigItems(element, configRootInfo.getName(),
+                    configRootInfo.getConfigPhase(), false, sectionLevel);
+            holder.addToAllConfigItems(configRootInfo.getClazz().getQualifiedName().toString(), configDocItems);
+        }
+
+        return holder;
+    }
+
+    /**
+     * Recursively find config item found in a config root given as {@link Element}
+     *
+     * @param element - root element
+     * @param parentName - root name
+     * @param configPhase - configuration phase see {@link ConfigPhase}
+     * @param withinAMap - indicates if a a key is within a map or is a map configuration key
+     * @param sectionLevel - section sectionLevel
+     */
+    private List<ConfigDocItem> recursivelyFindConfigItems(Element element, String parentName,
+            ConfigPhase configPhase, boolean withinAMap, int sectionLevel) {
+        List<ConfigDocItem> configDocItems = new ArrayList<>();
+        for (Element enclosedElement : element.getEnclosedElements()) {
+            if (!enclosedElement.getKind().isField()) {
+                continue;
+            }
+
+            boolean isStaticField = enclosedElement
+                    .getModifiers()
+                    .stream()
+                    .anyMatch(Modifier.STATIC::equals);
+
+            if (isStaticField) {
+                continue;
+            }
+
+            String name = Constants.EMPTY;
+            String defaultValue = Constants.NO_DEFAULT;
+            String defaultValueDoc = Constants.EMPTY;
+            final TypeMirror typeMirror = enclosedElement.asType();
+            String type = typeMirror.toString();
+            List<String> acceptedValues = null;
+            Element configGroup = configGroups.get(type);
+            ConfigDocSection configSection = null;
+            boolean isConfigGroup = configGroup != null;
+            final TypeElement clazz = (TypeElement) element;
+            final String fieldName = enclosedElement.getSimpleName().toString();
+            final String javaDocKey = clazz.getQualifiedName().toString() + Constants.DOT + fieldName;
+            final List<? extends AnnotationMirror> annotationMirrors = enclosedElement.getAnnotationMirrors();
+            final String rawJavaDoc = javaDocProperties.getProperty(javaDocKey);
+
+            String hyphenatedFieldName = hyphenate(fieldName);
+            String configDocMapKey = hyphenatedFieldName;
+
+            for (AnnotationMirror annotationMirror : annotationMirrors) {
+                String annotationName = annotationMirror.getAnnotationType().toString();
+                if (annotationName.equals(Constants.ANNOTATION_CONFIG_ITEM)
+                        || annotationName.equals(Constants.ANNOTATION_CONFIG_DOC_MAP_KEY)) {
+                    for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror
+                            .getElementValues().entrySet()) {
+                        final String key = entry.getKey().toString();
+                        final String value = entry.getValue().getValue().toString();
+                        if (annotationName.equals(Constants.ANNOTATION_CONFIG_DOC_MAP_KEY) && "value()".equals(key)) {
+                            configDocMapKey = value;
+                        } else if (annotationName.equals(Constants.ANNOTATION_CONFIG_ITEM)) {
+                            if ("name()".equals(key)) {
+                                switch (value) {
+                                    case Constants.HYPHENATED_ELEMENT_NAME:
+                                        name = parentName + Constants.DOT + hyphenatedFieldName;
+                                        break;
+                                    case Constants.PARENT:
+                                        name = parentName;
+                                        break;
+                                    default:
+                                        name = parentName + Constants.DOT + value;
+                                }
+                            } else if ("defaultValue()".equals(key)) {
+                                defaultValue = value;
+                            } else if ("defaultValueDocumentation()".equals(key)) {
+                                defaultValueDoc = value;
+                            }
+                        }
+                    }
+                } else if (annotationName.equals(Constants.ANNOTATION_CONFIG_DOC_SECTION)) {
+                    final JavaDocParser.SectionHolder sectionHolder = javaDocParser.parseConfigSection(rawJavaDoc,
+                            sectionLevel);
+
+                    configSection = new ConfigDocSection();
+                    configSection.setWithinAMap(withinAMap);
+                    configSection.setConfigPhase(configPhase);
+                    configSection.setSectionDetails(sectionHolder.details);
+                    configSection.setSectionDetailsTitle(sectionHolder.title);
+                    configSection.setName(parentName + Constants.DOT + hyphenatedFieldName);
+                }
+            }
+
+            if (name.isEmpty()) {
+                name = parentName + Constants.DOT + hyphenatedFieldName;
+            }
+
+            if (Constants.NO_DEFAULT.equals(defaultValue)) {
+                defaultValue = Constants.EMPTY;
+            }
+            if (Constants.EMPTY.equals(defaultValue)) {
+                defaultValue = defaultValueDoc;
+            }
+
+            if (isConfigGroup) {
+                List<ConfigDocItem> groupConfigItems = recordConfigItemsFromConfigGroup(configPhase, name, configGroup,
+                        configSection, withinAMap, sectionLevel);
+                configDocItems.addAll(groupConfigItems);
+            } else {
+                final ConfigDocKey configDocKey = new ConfigDocKey();
+                configDocKey.setWithinAMap(withinAMap);
+                boolean optional = false;
+                boolean list = false;
+                if (!typeMirror.getKind().isPrimitive()) {
+                    DeclaredType declaredType = (DeclaredType) typeMirror;
+                    TypeElement typeElement = (TypeElement) declaredType.asElement();
+                    Name qualifiedName = typeElement.getQualifiedName();
+                    optional = qualifiedName.toString().startsWith("java.util.Optional");
+                    list = qualifiedName.contentEquals("java.util.List");
+
+                    List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
+                    if (!typeArguments.isEmpty()) {
+                        // FIXME: this is super dodgy: we should check the type!!
+                        if (typeArguments.size() == 2) {
+                            final String mapKey = String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey);
+                            type = typeArguments.get(1).toString();
+                            configGroup = configGroups.get(type);
+                            name += mapKey;
+
+                            if (configGroup != null) {
+                                name += String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey);
+                                List<ConfigDocItem> groupConfigItems = recordConfigItemsFromConfigGroup(configPhase, name,
+                                        configGroup, configSection, true, sectionLevel);
+                                configDocItems.addAll(groupConfigItems);
+                                continue;
+                            } else {
+                                configDocKey.setWithinAMap(true);
+                            }
+                        } else {
+                            // FIXME: this is for Optional<T> and List<T>
+                            TypeMirror realTypeMirror = typeArguments.get(0);
+                            type = simpleTypeToString(realTypeMirror);
+
+                            if (isEnumType(realTypeMirror)) {
+                                acceptedValues = extractEnumValues(realTypeMirror);
+                            }
+                        }
+                    } else {
+                        type = simpleTypeToString(declaredType);
+                        if (isEnumType(declaredType)) {
+                            acceptedValues = extractEnumValues(declaredType);
+                        }
+                    }
+                }
+
+                final String configDescription = javaDocParser.parseConfigDescription(rawJavaDoc);
+
+                configDocKey.setKey(name);
+                configDocKey.setType(type);
+                configDocKey.setConfigPhase(configPhase);
+                configDocKey.setDefaultValue(defaultValue);
+                configDocKey.setOptional(optional);
+                configDocKey.setList(list);
+                configDocKey.setConfigDoc(configDescription);
+                configDocKey.setAcceptedValues(acceptedValues);
+                configDocKey.setJavaDocSiteLink(getJavaDocSiteLink(type));
+                ConfigDocItem configDocItem = new ConfigDocItem();
+                configDocItem.setConfigDocKey(configDocKey);
+                configDocItems.add(configDocItem);
+            }
+        }
+
+        return configDocItems;
+    }
+
+    private List<ConfigDocItem> recordConfigItemsFromConfigGroup(ConfigPhase configPhase, String name, Element configGroup,
+            ConfigDocSection configSection, boolean withinAMap, int sectionLevel) {
+        final List<ConfigDocItem> groupConfigItems;
+        final List<ConfigDocItem> configDocItems = new ArrayList<>();
+
+        if (configSection != null) {
+            final ConfigDocItem configDocItem = new ConfigDocItem();
+            configDocItem.setConfigDocSection(configSection);
+            configDocItems.add(configDocItem);
+            groupConfigItems = recursivelyFindConfigItems(configGroup, name, configPhase, withinAMap,
+                    sectionLevel + 1);
+            configSection.addConfigDocItems(groupConfigItems);
+        } else {
+            groupConfigItems = recursivelyFindConfigItems(configGroup, name, configPhase, withinAMap, sectionLevel);
+            configDocItems.addAll(groupConfigItems);
+        }
+
+        String configGroupName = configGroup.asType().toString();
+        List<ConfigDocItem> previousConfigGroupConfigItems = holder.getConfigGroupConfigItems().get(configGroupName);
+        if (previousConfigGroupConfigItems == null) {
+            holder.addConfigGroupItems(configGroupName, groupConfigItems);
+        } else {
+            previousConfigGroupConfigItems.addAll(configDocItems);
+        }
+
+        return configDocItems;
+    }
+
+    private String simpleTypeToString(TypeMirror typeMirror) {
+        if (typeMirror.getKind().isPrimitive()) {
+            return typeMirror.toString();
+        }
+
+        final String knownGenericType = getKnownGenericType((DeclaredType) typeMirror);
+        return knownGenericType != null ? knownGenericType : typeMirror.toString();
+    }
+
+    private List<String> extractEnumValues(TypeMirror realTypeMirror) {
+        Element declaredTypeElement = ((DeclaredType) realTypeMirror).asElement();
+        List<String> acceptedValues = new ArrayList<>();
+
+        for (Element field : declaredTypeElement.getEnclosedElements()) {
+            if (field.getKind() == ElementKind.ENUM_CONSTANT) {
+                acceptedValues.add(DocGeneratorUtil.hyphenateEnumValue(field.getSimpleName().toString()));
+            }
+        }
+
+        return acceptedValues;
+    }
+
+    private boolean isEnumType(TypeMirror realTypeMirror) {
+        return realTypeMirror instanceof DeclaredType
+                && ((DeclaredType) realTypeMirror).asElement().getKind() == ElementKind.ENUM;
+    }
+}

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
@@ -1,8 +1,7 @@
 package io.quarkus.annotation.processor.generate_doc;
 
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.computeConfigGroupDocFileName;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.computeExtensionDocFileName;
-import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getJavaDocSiteLink;
-import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getKnownGenericType;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.hyphenate;
 
 import java.io.BufferedReader;
@@ -10,7 +9,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -21,15 +19,9 @@ import java.util.regex.Matcher;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,10 +30,8 @@ import io.quarkus.annotation.processor.Constants;
 
 final public class ConfigDocItemScanner {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String NAMED_MAP_CONFIG_ITEM_FORMAT = ".\"%s\"";
     private static final String IO_QUARKUS_TEST_EXTENSION_PACKAGE = "io.quarkus.extest.";
 
-    private final JavaDocParser javaDocParser = new JavaDocParser();
     private final Set<ConfigRootInfo> configRoots = new HashSet<>();
     private final Set<String> processorClassMembers = new HashSet<>();
     private final Map<String, TypeElement> configGroups = new HashMap<>();
@@ -109,14 +99,20 @@ final public class ConfigDocItemScanner {
     }
 
     /**
-     * Return a Map structure which contains extension name as key and generated doc value.
+     * Return a data structure which contains two maps of config items.
+     * 1. A map of all extensions config items accessible via
+     * {@link ScannedConfigDocsItemHolder#getAllConfigItemsPerExtension()}
+     * 2. a map of all config groups config items accessible via {@link ScannedConfigDocsItemHolder#getConfigGroupConfigItems()}
      */
-    public Map<String, List<ConfigDocItem>> scanExtensionsConfigurationItems(Properties javaDocProperties)
+    public ScannedConfigDocsItemHolder scanExtensionsConfigurationItems(Properties javaDocProperties)
             throws IOException {
 
-        final Map<String, List<ConfigDocItem>> inMemoryConfigurationItems = findInMemoryConfigurationItems(javaDocProperties);
+        ConfigDoItemFinder configDoItemFinder = new ConfigDoItemFinder(configRoots, configGroups, javaDocProperties);
+        ScannedConfigDocsItemHolder inMemoryScannedItemsHolder = configDoItemFinder.findInMemoryConfigurationItems();
 
-        if (!inMemoryConfigurationItems.isEmpty()) {
+        Map<String, List<ConfigDocItem>> inMemoryConfigItemsForConfigRoot = inMemoryScannedItemsHolder
+                .getAllConfigItemsPerExtension();
+        if (!inMemoryConfigItemsForConfigRoot.isEmpty()) {
             if (!Constants.GENERATED_DOCS_DIR.exists()) {
                 Constants.GENERATED_DOCS_DIR.mkdirs();
             }
@@ -134,8 +130,8 @@ final public class ConfigDocItemScanner {
             }
         }
 
-        if (!inMemoryConfigurationItems.isEmpty()) {
-            for (Map.Entry<String, List<ConfigDocItem>> entry : inMemoryConfigurationItems.entrySet()) {
+        if (!inMemoryConfigItemsForConfigRoot.isEmpty()) {
+            for (Map.Entry<String, List<ConfigDocItem>> entry : inMemoryConfigItemsForConfigRoot.entrySet()) {
                 String serializableConfigRootDoc = OBJECT_MAPPER.writeValueAsString(entry.getValue());
                 allExtensionGeneratedDocs.put(entry.getKey(), serializableConfigRootDoc);
             }
@@ -149,10 +145,10 @@ final public class ConfigDocItemScanner {
             }
         }
 
-        final Map<String, List<ConfigDocItem>> foundExtensionConfigurationItems = new HashMap<>();
+        final ScannedConfigDocsItemHolder foundExtensionConfigurationItems = new ScannedConfigDocsItemHolder();
 
         for (String member : processorClassMembers) {
-            List<ConfigDocItem> configDocItems = inMemoryConfigurationItems.get(member);
+            List<ConfigDocItem> configDocItems = inMemoryConfigItemsForConfigRoot.get(member);
             if (configDocItems == null) {
                 final String serializedContent = allExtensionGeneratedDocs.getProperty(member);
                 if (serializedContent == null) {
@@ -163,13 +159,19 @@ final public class ConfigDocItemScanner {
             }
 
             final String fileName = computeExtensionDocFileName(member);
-            final List<ConfigDocItem> existingConfigDocItems = foundExtensionConfigurationItems.get(fileName);
+            final List<ConfigDocItem> existingConfigDocItems = foundExtensionConfigurationItems.getConfigItemsByName(fileName);
 
             if (existingConfigDocItems == null) {
-                foundExtensionConfigurationItems.put(fileName, configDocItems);
+                foundExtensionConfigurationItems.addToAllConfigItems(fileName, configDocItems);
             } else {
                 DocGeneratorUtil.appendConfigItemsIntoExistingOnes(existingConfigDocItems, configDocItems);
             }
+        }
+
+        Map<String, List<ConfigDocItem>> configItemsPerConfigGroup = inMemoryScannedItemsHolder.getConfigGroupConfigItems();
+        for (Map.Entry<String, List<ConfigDocItem>> entry : configItemsPerConfigGroup.entrySet()) {
+            final String extensionDocFileName = computeConfigGroupDocFileName(entry.getKey());
+            foundExtensionConfigurationItems.addConfigGroupItems(extensionDocFileName, entry.getValue());
         }
 
         return foundExtensionConfigurationItems;
@@ -211,243 +213,9 @@ final public class ConfigDocItemScanner {
         return foundExtensionConfigurationItems;
     }
 
-    /**
-     * Find configuration items from current encountered configuration roots
-     */
-    private Map<String, List<ConfigDocItem>> findInMemoryConfigurationItems(Properties javaDocProperties) {
-        final Map<String, List<ConfigDocItem>> configOutput = new HashMap<>();
-
-        for (ConfigRootInfo configRootInfo : configRoots) {
-            final TypeElement element = configRootInfo.getClazz();
-            final List<ConfigDocItem> configDocItems = new ArrayList<>();
-            /**
-             * Config sections will start at level 2 i.e the section title will be prefixed with
-             * ('='* (N + 1)) where N is section level.
-             */
-            final int sectionLevel = 2;
-            recordConfigItems(configDocItems, element, configRootInfo.getName(), configRootInfo.getConfigPhase(),
-                    javaDocProperties, false, sectionLevel);
-            configOutput.put(configRootInfo.getClazz().getQualifiedName().toString(), configDocItems);
-        }
-
-        return configOutput;
-    }
-
-    /**
-     * Recursively record config item found in a config root given as {@link Element}
-     *
-     * @param configDocItems - all found config items
-     * @param element - root element
-     * @param parentName - root name
-     * @param configPhase - configuration phase see {@link ConfigPhase}
-     * @param javaDocProperties - java doc
-     * @param withinAMap - indicates if a a key is within a map or is a map configuration key
-     * @param sectionLevel - section sectionLevel
-     */
-    private void recordConfigItems(List<ConfigDocItem> configDocItems, Element element, String parentName,
-            ConfigPhase configPhase, Properties javaDocProperties, boolean withinAMap, int sectionLevel) {
-        for (Element enclosedElement : element.getEnclosedElements()) {
-            if (!enclosedElement.getKind().isField()) {
-                continue;
-            }
-
-            boolean isStaticField = enclosedElement
-                    .getModifiers()
-                    .stream()
-                    .anyMatch(Modifier.STATIC::equals);
-
-            if (isStaticField) {
-                continue;
-            }
-
-            String name = Constants.EMPTY;
-            String defaultValue = Constants.NO_DEFAULT;
-            String defaultValueDoc = Constants.EMPTY;
-            final TypeMirror typeMirror = enclosedElement.asType();
-            String type = typeMirror.toString();
-            List<String> acceptedValues = null;
-            Element configGroup = configGroups.get(type);
-            ConfigDocSection configSection = null;
-            boolean isConfigGroup = configGroup != null;
-            final TypeElement clazz = (TypeElement) element;
-            final String fieldName = enclosedElement.getSimpleName().toString();
-            final String javaDocKey = clazz.getQualifiedName().toString() + Constants.DOT + fieldName;
-            final List<? extends AnnotationMirror> annotationMirrors = enclosedElement.getAnnotationMirrors();
-            final String rawJavaDoc = javaDocProperties.getProperty(javaDocKey);
-
-            String hyphenatedFieldName = hyphenate(fieldName);
-            String configDocMapKey = hyphenatedFieldName;
-
-            for (AnnotationMirror annotationMirror : annotationMirrors) {
-                String annotationName = annotationMirror.getAnnotationType().toString();
-                if (annotationName.equals(Constants.ANNOTATION_CONFIG_ITEM)
-                        || annotationName.equals(Constants.ANNOTATION_CONFIG_DOC_MAP_KEY)) {
-                    for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror
-                            .getElementValues().entrySet()) {
-                        final String key = entry.getKey().toString();
-                        final String value = entry.getValue().getValue().toString();
-                        if (annotationName.equals(Constants.ANNOTATION_CONFIG_DOC_MAP_KEY) && "value()".equals(key)) {
-                            configDocMapKey = value;
-                        } else if (annotationName.equals(Constants.ANNOTATION_CONFIG_ITEM)) {
-                            if ("name()".equals(key)) {
-                                switch (value) {
-                                    case Constants.HYPHENATED_ELEMENT_NAME:
-                                        name = parentName + Constants.DOT + hyphenatedFieldName;
-                                        break;
-                                    case Constants.PARENT:
-                                        name = parentName;
-                                        break;
-                                    default:
-                                        name = parentName + Constants.DOT + value;
-                                }
-                            } else if ("defaultValue()".equals(key)) {
-                                defaultValue = value;
-                            } else if ("defaultValueDocumentation()".equals(key)) {
-                                defaultValueDoc = value;
-                            }
-                        }
-                    }
-                } else if (annotationName.equals(Constants.ANNOTATION_CONFIG_DOC_SECTION)) {
-                    final JavaDocParser.SectionHolder sectionHolder = javaDocParser.parseConfigSection(rawJavaDoc,
-                            sectionLevel);
-
-                    configSection = new ConfigDocSection();
-                    configSection.setWithinAMap(withinAMap);
-                    configSection.setConfigPhase(configPhase);
-                    configSection.setSectionDetails(sectionHolder.details);
-                    configSection.setSectionDetailsTitle(sectionHolder.title);
-                    configSection.setName(parentName + Constants.DOT + hyphenatedFieldName);
-                }
-            }
-
-            if (name.isEmpty()) {
-                name = parentName + Constants.DOT + hyphenatedFieldName;
-            }
-
-            if (Constants.NO_DEFAULT.equals(defaultValue)) {
-                defaultValue = Constants.EMPTY;
-            }
-            if (Constants.EMPTY.equals(defaultValue)) {
-                defaultValue = defaultValueDoc;
-            }
-
-            if (isConfigGroup) {
-                recordSectionConfigItems(configDocItems, configPhase, javaDocProperties, name, configGroup, configSection,
-                        withinAMap, sectionLevel);
-            } else {
-                final ConfigDocKey configDocKey = new ConfigDocKey();
-                configDocKey.setWithinAMap(withinAMap);
-                boolean optional = false;
-                boolean list = false;
-                if (!typeMirror.getKind().isPrimitive()) {
-                    DeclaredType declaredType = (DeclaredType) typeMirror;
-                    TypeElement typeElement = (TypeElement) declaredType.asElement();
-                    Name qualifiedName = typeElement.getQualifiedName();
-
-                    if (qualifiedName.contentEquals("java.util.Optional")
-                            || qualifiedName.contentEquals("java.util.OptionalInt")
-                            || qualifiedName.contentEquals("java.util.OptionalDouble")
-                            || qualifiedName.contentEquals("java.util.OptionalLong")) {
-                        optional = true;
-                    } else if (qualifiedName.contentEquals("java.util.List")) {
-                        list = true;
-                    }
-                    List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
-                    if (!typeArguments.isEmpty()) {
-                        // FIXME: this is super dodgy: we should check the type!!
-                        if (typeArguments.size() == 2) {
-                            final String mapKey = String.format(NAMED_MAP_CONFIG_ITEM_FORMAT, configDocMapKey);
-                            type = typeArguments.get(1).toString();
-                            configGroup = configGroups.get(type);
-                            name += mapKey;
-
-                            if (configGroup != null) {
-                                recordSectionConfigItems(configDocItems, configPhase, javaDocProperties, name, configGroup,
-                                        configSection, true, sectionLevel);
-                                continue;
-                            } else {
-                                configDocKey.setWithinAMap(true);
-                            }
-                        } else {
-                            // FIXME: this is for Optional<T> and List<T>
-                            TypeMirror realTypeMirror = typeArguments.get(0);
-                            type = simpleTypeToString(realTypeMirror);
-
-                            if (isEnumType(realTypeMirror)) {
-                                acceptedValues = extractEnumValues(realTypeMirror);
-                            }
-                        }
-                    } else {
-                        type = simpleTypeToString(declaredType);
-                        if (isEnumType(declaredType)) {
-                            acceptedValues = extractEnumValues(declaredType);
-                        }
-                    }
-                }
-
-                final String configDescription = javaDocParser.parseConfigDescription(rawJavaDoc);
-
-                configDocKey.setKey(name);
-                configDocKey.setType(type);
-                configDocKey.setConfigPhase(configPhase);
-                configDocKey.setDefaultValue(defaultValue);
-                configDocKey.setOptional(optional);
-                configDocKey.setList(list);
-                configDocKey.setConfigDoc(configDescription);
-                configDocKey.setAcceptedValues(acceptedValues);
-                configDocKey.setJavaDocSiteLink(getJavaDocSiteLink(type));
-                ConfigDocItem configDocItem = new ConfigDocItem();
-                configDocItem.setConfigDocKey(configDocKey);
-                configDocItems.add(configDocItem);
-            }
-        }
-    }
-
-    private void recordSectionConfigItems(List<ConfigDocItem> configDocItems, ConfigPhase configPhase,
-            Properties javaDocProperties,
-            String name, Element configGroup, ConfigDocSection configSection, boolean withinAMap, int sectionLevel) {
-        if (configSection != null) {
-            final ConfigDocItem configDocItem = new ConfigDocItem();
-            configDocItem.setConfigDocSection(configSection);
-            configDocItems.add(configDocItem);
-            recordConfigItems(configSection.getConfigDocItems(), configGroup, name, configPhase, javaDocProperties, withinAMap,
-                    sectionLevel + 1);
-        } else {
-            recordConfigItems(configDocItems, configGroup, name, configPhase, javaDocProperties, withinAMap, sectionLevel);
-        }
-    }
-
-    private String simpleTypeToString(TypeMirror typeMirror) {
-        if (typeMirror.getKind().isPrimitive()) {
-            return typeMirror.toString();
-        }
-
-        final String knownGenericType = getKnownGenericType((DeclaredType) typeMirror);
-        return knownGenericType != null ? knownGenericType : typeMirror.toString();
-    }
-
-    private List<String> extractEnumValues(TypeMirror realTypeMirror) {
-        Element declaredTypeElement = ((DeclaredType) realTypeMirror).asElement();
-        List<String> acceptedValues = new ArrayList<>();
-
-        for (Element field : declaredTypeElement.getEnclosedElements()) {
-            if (field.getKind() == ElementKind.ENUM_CONSTANT) {
-                acceptedValues.add(DocGeneratorUtil.hyphenateEnumValue(field.getSimpleName().toString()));
-            }
-        }
-
-        return acceptedValues;
-    }
-
-    private boolean isEnumType(TypeMirror realTypeMirror) {
-        return realTypeMirror instanceof DeclaredType
-                && ((DeclaredType) realTypeMirror).asElement().getKind() == ElementKind.ENUM;
-    }
-
     @Override
     public String toString() {
         return "ConfigDocItemScanner{" +
-                "javaDocParser=" + javaDocParser +
                 ", configRoots=" + configRoots +
                 ", processorClassMembers=" + processorClassMembers +
                 ", configGroups=" + configGroups +

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
@@ -9,6 +9,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -29,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.annotation.processor.Constants;
 
 final public class ConfigDocItemScanner {
+    private static final String EXTENSION_LIST_SEPARATOR = ",";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String IO_QUARKUS_TEST_EXTENSION_PACKAGE = "io.quarkus.extest.";
 
@@ -107,74 +110,169 @@ final public class ConfigDocItemScanner {
     public ScannedConfigDocsItemHolder scanExtensionsConfigurationItems(Properties javaDocProperties)
             throws IOException {
 
-        ConfigDoItemFinder configDoItemFinder = new ConfigDoItemFinder(configRoots, configGroups, javaDocProperties);
-        ScannedConfigDocsItemHolder inMemoryScannedItemsHolder = configDoItemFinder.findInMemoryConfigurationItems();
+        final ConfigDoItemFinder configDoItemFinder = new ConfigDoItemFinder(configRoots, configGroups, javaDocProperties);
+        final ScannedConfigDocsItemHolder inMemoryScannedItemsHolder = configDoItemFinder.findInMemoryConfigurationItems();
 
-        Map<String, List<ConfigDocItem>> inMemoryConfigItemsForConfigRoot = inMemoryScannedItemsHolder
-                .getAllConfigItemsPerExtension();
-        if (!inMemoryConfigItemsForConfigRoot.isEmpty()) {
-            if (!Constants.GENERATED_DOCS_DIR.exists()) {
-                Constants.GENERATED_DOCS_DIR.mkdirs();
-            }
-
-            if (!Constants.ALL_CR_GENERATED_DOC.exists()) {
-                Constants.ALL_CR_GENERATED_DOC.createNewFile();
-            }
+        if (!inMemoryScannedItemsHolder.isEmpty()) {
+            createOutputFolder();
         }
 
-        final Properties allExtensionGeneratedDocs = new Properties();
+        final Properties allExtensionGeneratedDocs = loadAllExtensionConfigItemsParConfigRoot();
+        final Properties configurationRootsParExtensionFileName = loadExtensionConfigRootList();
+
+        if (!inMemoryScannedItemsHolder.isEmpty()) {
+            updateScannedExtensionArtifactFiles(inMemoryScannedItemsHolder, allExtensionGeneratedDocs,
+                    configurationRootsParExtensionFileName);
+        }
+
+        Map<String, List<ConfigDocItem>> allConfigItemsPerExtension = computeAllExtensionConfigItems(inMemoryScannedItemsHolder,
+                allExtensionGeneratedDocs, configurationRootsParExtensionFileName);
+        Map<String, List<ConfigDocItem>> configGroupConfigItems = computeConfigGroupFilesNames(inMemoryScannedItemsHolder);
+
+        return new ScannedConfigDocsItemHolder(allConfigItemsPerExtension, configGroupConfigItems);
+    }
+
+    private void createOutputFolder() throws IOException {
+        if (!Constants.GENERATED_DOCS_DIR.exists()) {
+            Constants.GENERATED_DOCS_DIR.mkdirs();
+        }
+
+        if (!Constants.ALL_CR_GENERATED_DOC.exists()) {
+            Constants.ALL_CR_GENERATED_DOC.createNewFile();
+        }
+
+        if (!Constants.EXTENSION_CONFIGURATION_ROOT_LIST.exists()) {
+            Constants.EXTENSION_CONFIGURATION_ROOT_LIST.createNewFile();
+        }
+    }
+
+    /**
+     * Loads the list of configuration items per configuration root
+     * 
+     * @return
+     * @throws IOException
+     */
+    private Properties loadAllExtensionConfigItemsParConfigRoot() throws IOException {
+        Properties allExtensionGeneratedDocs = new Properties();
         if (Constants.ALL_CR_GENERATED_DOC.exists()) {
             try (BufferedReader bufferedReader = Files.newBufferedReader(Constants.ALL_CR_GENERATED_DOC.toPath(),
                     StandardCharsets.UTF_8)) {
                 allExtensionGeneratedDocs.load(bufferedReader);
             }
         }
+        return allExtensionGeneratedDocs;
+    }
 
-        if (!inMemoryConfigItemsForConfigRoot.isEmpty()) {
-            for (Map.Entry<String, List<ConfigDocItem>> entry : inMemoryConfigItemsForConfigRoot.entrySet()) {
-                String serializableConfigRootDoc = OBJECT_MAPPER.writeValueAsString(entry.getValue());
-                allExtensionGeneratedDocs.put(entry.getKey(), serializableConfigRootDoc);
-            }
-
-            /**
-             * Update stored generated config doc for each configuration root
-             */
-            try (BufferedWriter bufferedWriter = Files.newBufferedWriter(Constants.ALL_CR_GENERATED_DOC.toPath(),
+    /**
+     * Loads the list of comma separated configuration roots per extension file name
+     * 
+     * @return
+     * @throws IOException
+     */
+    private Properties loadExtensionConfigRootList() throws IOException {
+        Properties configurationRootsParExtensionFileName = new Properties();
+        if (Constants.EXTENSION_CONFIGURATION_ROOT_LIST.exists()) {
+            try (BufferedReader bufferedReader = Files.newBufferedReader(
+                    Constants.EXTENSION_CONFIGURATION_ROOT_LIST.toPath(),
                     StandardCharsets.UTF_8)) {
-                allExtensionGeneratedDocs.store(bufferedWriter, Constants.EMPTY);
+                configurationRootsParExtensionFileName.load(bufferedReader);
             }
         }
 
-        final ScannedConfigDocsItemHolder foundExtensionConfigurationItems = new ScannedConfigDocsItemHolder();
+        return configurationRootsParExtensionFileName;
+    }
 
-        for (String member : processorClassMembers) {
-            List<ConfigDocItem> configDocItems = inMemoryConfigItemsForConfigRoot.get(member);
-            if (configDocItems == null) {
-                final String serializedContent = allExtensionGeneratedDocs.getProperty(member);
-                if (serializedContent == null) {
-                    continue;
-                }
-                configDocItems = OBJECT_MAPPER.readValue(serializedContent, new TypeReference<List<ConfigDocItem>>() {
-                });
+    /**
+     * Update extensions config roots. We need to gather the complete list of configuration roots of an extension
+     * when generating the documentation.
+     */
+    private void updateConfigurationRootsList(Properties configurationRootsParExtensionFileName,
+            Map.Entry<String, List<ConfigDocItem>> entry) {
+        String extensionFileName = DocGeneratorUtil.computeExtensionDocFileName(entry.getKey());
+        String extensionList = configurationRootsParExtensionFileName
+                .computeIfAbsent(extensionFileName, (key) -> entry.getKey()).toString();
+        if (!extensionList.contains(entry.getKey())) {
+            configurationRootsParExtensionFileName.put(extensionFileName,
+                    extensionList + EXTENSION_LIST_SEPARATOR + entry.getKey());
+        }
+    }
+
+    private void updateScannedExtensionArtifactFiles(ScannedConfigDocsItemHolder inMemoryScannedItemsHolder,
+            Properties allExtensionGeneratedDocs, Properties configurationRootsParExtensionFileName) throws IOException {
+        for (Map.Entry<String, List<ConfigDocItem>> entry : inMemoryScannedItemsHolder.getAllConfigItemsPerExtension()
+                .entrySet()) {
+            String serializableConfigRootDoc = OBJECT_MAPPER.writeValueAsString(entry.getValue());
+            allExtensionGeneratedDocs.put(entry.getKey(), serializableConfigRootDoc);
+            updateConfigurationRootsList(configurationRootsParExtensionFileName, entry);
+        }
+
+        /**
+         * Update stored list of extensions configuration roots
+         */
+        try (BufferedWriter bufferedWriter = Files.newBufferedWriter(Constants.EXTENSION_CONFIGURATION_ROOT_LIST.toPath(),
+                StandardCharsets.UTF_8)) {
+            configurationRootsParExtensionFileName.store(bufferedWriter, Constants.EMPTY);
+        }
+
+        /**
+         * Update stored generated config doc for each configuration root
+         */
+        try (BufferedWriter bufferedWriter = Files.newBufferedWriter(Constants.ALL_CR_GENERATED_DOC.toPath(),
+                StandardCharsets.UTF_8)) {
+            allExtensionGeneratedDocs.store(bufferedWriter, Constants.EMPTY);
+        }
+    }
+
+    /**
+     * returns a Map of with extension generated file name and the list of its associated config items.
+     */
+    private Map<String, List<ConfigDocItem>> computeAllExtensionConfigItems(
+            ScannedConfigDocsItemHolder inMemoryScannedItemsHolder, Properties allExtensionGeneratedDocs,
+            Properties configurationRootsParExtensionFileName) throws IOException {
+        Map<String, List<ConfigDocItem>> configItemsParExtensionFileNames = new HashMap<>();
+
+        Set<String> extensionFileNamesToGenerate = processorClassMembers
+                .stream()
+                .filter(allExtensionGeneratedDocs::containsKey)
+                .map(member -> computeExtensionDocFileName(member))
+                .collect(Collectors.toSet());
+
+        for (String extensionFileName : extensionFileNamesToGenerate) {
+            String extensionConfigRootsProperty = configurationRootsParExtensionFileName.getProperty(extensionFileName);
+            if (extensionConfigRootsProperty == null || Constants.EMPTY.equals(extensionConfigRootsProperty.trim())) {
+                continue;
             }
 
-            final String fileName = computeExtensionDocFileName(member);
-            final List<ConfigDocItem> existingConfigDocItems = foundExtensionConfigurationItems.getConfigItemsByName(fileName);
+            String[] extensionConfigRoots = extensionConfigRootsProperty.split(EXTENSION_LIST_SEPARATOR);
+            for (String configRoot : extensionConfigRoots) {
+                List<ConfigDocItem> configDocItems = inMemoryScannedItemsHolder.getAllConfigItemsPerExtension().get(configRoot);
+                if (configDocItems == null) {
+                    String serializedContent = allExtensionGeneratedDocs.getProperty(configRoot);
+                    configDocItems = OBJECT_MAPPER.readValue(serializedContent, new TypeReference<List<ConfigDocItem>>() {
+                    });
+                }
 
-            if (existingConfigDocItems == null) {
-                foundExtensionConfigurationItems.addToAllConfigItems(fileName, configDocItems);
-            } else {
+                final List<ConfigDocItem> existingConfigDocItems = configItemsParExtensionFileNames
+                        .computeIfAbsent(extensionFileName, (key) -> new ArrayList<>());
                 DocGeneratorUtil.appendConfigItemsIntoExistingOnes(existingConfigDocItems, configDocItems);
             }
         }
 
-        Map<String, List<ConfigDocItem>> configItemsPerConfigGroup = inMemoryScannedItemsHolder.getConfigGroupConfigItems();
-        for (Map.Entry<String, List<ConfigDocItem>> entry : configItemsPerConfigGroup.entrySet()) {
-            final String extensionDocFileName = computeConfigGroupDocFileName(entry.getKey());
-            foundExtensionConfigurationItems.addConfigGroupItems(extensionDocFileName, entry.getValue());
+        return configItemsParExtensionFileNames;
+    }
+
+    /**
+     * returns a Map of with config group generated file name and the list of its associated config items.
+     */
+    private Map<String, List<ConfigDocItem>> computeConfigGroupFilesNames(
+            ScannedConfigDocsItemHolder inMemoryScannedItemsHolder) {
+        Map<String, List<ConfigDocItem>> configItemsParConfigGroupFileNames = new HashMap<>();
+        for (Map.Entry<String, List<ConfigDocItem>> entry : inMemoryScannedItemsHolder.getConfigGroupConfigItems().entrySet()) {
+            String extensionDocFileName = computeConfigGroupDocFileName(entry.getKey());
+            configItemsParConfigGroupFileNames.put(extensionDocFileName, entry.getValue());
         }
 
-        return foundExtensionConfigurationItems;
+        return configItemsParConfigGroupFileNames;
     }
 
     /**

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocWriter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocWriter.java
@@ -14,29 +14,32 @@ final public class ConfigDocWriter {
     private final DocFormatter summaryTableDocFormatter = new SummaryTableDocFormatter();
 
     /**
-     * Write extension configuration AsciiDoc format in `{root}/target/asciidoc/generated/config/`
+     * Write configuration in AsciiDoc format in `{root}/target/asciidoc/generated/config/` directory
      */
-    public void writeExtensionConfigDocumentation(Map<String, List<ConfigDocItem>> extensionsConfigurations)
+    public void writeExtensionConfigDocumentation(Map<String, List<ConfigDocItem>> extensionsConfigurations,
+            boolean withSearchActivated)
             throws IOException {
         for (Map.Entry<String, List<ConfigDocItem>> entry : extensionsConfigurations.entrySet()) {
             final List<ConfigDocItem> configDocItems = entry.getValue();
-            final String extensionFileName = entry.getKey();
+            final String fileName = entry.getKey();
 
             sort(configDocItems);
-            String anchorPrefix = extensionFileName;
-            if (extensionFileName.endsWith(".adoc"))
+            String anchorPrefix = fileName;
+            if (fileName.endsWith(Constants.ADOC_EXTENSION)) {
                 anchorPrefix = anchorPrefix.substring(0, anchorPrefix.length() - 5);
+            }
 
-            generateDocumentation(Constants.GENERATED_DOCS_PATH.resolve(extensionFileName), anchorPrefix + "_", configDocItems);
+            generateDocumentation(Constants.GENERATED_DOCS_PATH.resolve(fileName), anchorPrefix + "_", withSearchActivated,
+                    configDocItems);
         }
     }
 
     /**
-     * Write all extension configuration AsciiDoc format in `{root}/target/asciidoc/generated/config/`
+     * Write all extension configuration in AsciiDoc format in `{root}/target/asciidoc/generated/config/` directory
      */
     public void writeAllExtensionConfigDocumentation(List<ConfigDocItem> allItems)
             throws IOException {
-        generateDocumentation(Constants.GENERATED_DOCS_PATH.resolve("all-config.adoc"), "", allItems);
+        generateDocumentation(Constants.GENERATED_DOCS_PATH.resolve("all-config.adoc"), "", true, allItems);
     }
 
     /**
@@ -63,18 +66,20 @@ final public class ConfigDocWriter {
      * @param configDocItems
      * @throws IOException
      */
-    private void generateDocumentation(Path targetPath, String initialAnchorPrefix, List<ConfigDocItem> configDocItems)
+    private void generateDocumentation(Path targetPath, String initialAnchorPrefix, boolean activateSearch,
+            List<ConfigDocItem> configDocItems)
             throws IOException {
         try (Writer writer = Files.newBufferedWriter(targetPath)) {
-            summaryTableDocFormatter.format(writer, initialAnchorPrefix, configDocItems);
+            summaryTableDocFormatter.format(writer, initialAnchorPrefix, activateSearch, configDocItems);
 
             boolean hasDuration = false, hasMemory = false;
             for (ConfigDocItem item : configDocItems) {
-                if (item.hasDurationInformationNote())
+                if (item.hasDurationInformationNote()) {
                     hasDuration = true;
-                if (item.hasMemoryInformationNote())
+                }
+                if (item.hasMemoryInformationNote()) {
                     hasMemory = true;
-
+                }
             }
             if (hasDuration) {
                 writer.append(Constants.DURATION_FORMAT_NOTE);

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
@@ -61,7 +61,8 @@ interface DocFormatter {
         return string.toLowerCase();
     }
 
-    void format(Writer writer, String initialAnchorPrefix, List<ConfigDocItem> configDocItems) throws IOException;
+    void format(Writer writer, String initialAnchorPrefix, boolean activateSearch, List<ConfigDocItem> configDocItems)
+            throws IOException;
 
     void format(Writer writer, ConfigDocKey configDocKey) throws IOException;
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ScannedConfigDocsItemHolder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ScannedConfigDocsItemHolder.java
@@ -5,10 +5,17 @@ import java.util.List;
 import java.util.Map;
 
 final public class ScannedConfigDocsItemHolder {
-    private final Map<String, List<ConfigDocItem>> allConfigItemsPerExtension = new HashMap<>();
-    private final Map<String, List<ConfigDocItem>> configGroupConfigItems = new HashMap<>();
+    private final Map<String, List<ConfigDocItem>> allConfigItemsPerExtension;
+    private final Map<String, List<ConfigDocItem>> configGroupConfigItems;
 
     public ScannedConfigDocsItemHolder() {
+        this(new HashMap<>(), new HashMap<>());
+    }
+
+    public ScannedConfigDocsItemHolder(Map<String, List<ConfigDocItem>> allConfigItemsPerExtension,
+            Map<String, List<ConfigDocItem>> configGroupConfigItems) {
+        this.allConfigItemsPerExtension = allConfigItemsPerExtension;
+        this.configGroupConfigItems = configGroupConfigItems;
     }
 
     public Map<String, List<ConfigDocItem>> getAllConfigItemsPerExtension() {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ScannedConfigDocsItemHolder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ScannedConfigDocsItemHolder.java
@@ -1,0 +1,33 @@
+package io.quarkus.annotation.processor.generate_doc;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final public class ScannedConfigDocsItemHolder {
+    private final Map<String, List<ConfigDocItem>> allConfigItemsPerExtension = new HashMap<>();
+    private final Map<String, List<ConfigDocItem>> configGroupConfigItems = new HashMap<>();
+
+    public ScannedConfigDocsItemHolder() {
+    }
+
+    public Map<String, List<ConfigDocItem>> getAllConfigItemsPerExtension() {
+        return allConfigItemsPerExtension;
+    }
+
+    public Map<String, List<ConfigDocItem>> getConfigGroupConfigItems() {
+        return configGroupConfigItems;
+    }
+
+    public void addToAllConfigItems(String configRootName, List<ConfigDocItem> configDocItems) {
+        allConfigItemsPerExtension.put(configRootName, configDocItems);
+    }
+
+    public void addConfigGroupItems(String configGroupName, List<ConfigDocItem> configDocItems) {
+        configGroupConfigItems.put(configGroupName, configDocItems);
+    }
+
+    public boolean isEmpty() {
+        return allConfigItemsPerExtension.isEmpty();
+    }
+}

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -8,22 +8,25 @@ import io.quarkus.annotation.processor.Constants;
 
 final class SummaryTableDocFormatter implements DocFormatter {
     private static final String TABLE_CLOSING_TAG = "\n|===";
+    public static final String SEARCHABLE_TABLE_CLASS = ".searchable"; // a css class indicating if a table is searchable
+    public static final String CONFIGURATION_TABLE_CLASS = ".configuration-reference";
     private static final String TABLE_ROW_FORMAT = "\n\na|%s [[%s]]`link:#%s[%s]`\n\n[.description]\n--\n%s\n--|%s %s\n|%s\n";
     private static final String TABLE_SECTION_ROW_FORMAT = "\n\nh|[[%s]]link:#%s[%s]\nh|Type\nh|Default";
-    private static final String TABLE_HEADER_FORMAT = "[.configuration-legend]%s\n[.configuration-reference, cols=\"80,.^10,.^10\"]\n|===";
+    private static final String TABLE_HEADER_FORMAT = "[.configuration-legend]%s\n[%s, cols=\"80,.^10,.^10\"]\n|===";
     //    private static final String MORE_INFO_ABOUT_SECTION_FORMAT = "link:#%s[icon:plus-circle[], title=More information about %s]";
 
     private String anchorPrefix = "";
 
     /**
-     * Generate configuration keys in table format.
-     * Generated table will contain a key column that points to the long descriptive format.
-     *
-     * @param configDocItems
+     * Generate configuration keys in table format with search engine activated or not.
+     * Useful when we want to optionally activate or deactivate search engine
      */
     @Override
-    public void format(Writer writer, String initialAnchorPrefix, List<ConfigDocItem> configDocItems) throws IOException {
-        final String tableHeaders = String.format(TABLE_HEADER_FORMAT, Constants.CONFIG_PHASE_LEGEND);
+    public void format(Writer writer, String initialAnchorPrefix, boolean activateSearch, List<ConfigDocItem> configDocItems)
+            throws IOException {
+        String searchableClass = activateSearch ? SEARCHABLE_TABLE_CLASS : Constants.EMPTY;
+        String tableClasses = CONFIGURATION_TABLE_CLASS + searchableClass;
+        final String tableHeaders = String.format(TABLE_HEADER_FORMAT, Constants.CONFIG_PHASE_LEGEND, tableClasses);
         writer.append(tableHeaders);
         anchorPrefix = initialAnchorPrefix;
 

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
@@ -4,6 +4,7 @@ import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.AGRO
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.OFFICIAL_JAVA_DOC_BASE_LINK;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.VERTX_JAVA_DOC_SITE;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.appendConfigItemsIntoExistingOnes;
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.computeConfigGroupDocFileName;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.computeExtensionDocFileName;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getJavaDocSiteLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,7 +123,7 @@ public class DocGeneratorUtilTest {
     }
 
     @Test
-    public void shouldReturnConfigRootName() {
+    public void shouldReturnConfigRootNameWhenComputingExtensionName() {
         String configRoot = "org.acme.ConfigRoot";
         String expected = "org.acme.ConfigRoot.adoc";
         String fileName = computeExtensionDocFileName(configRoot);
@@ -148,7 +149,7 @@ public class DocGeneratorUtilTest {
     }
 
     @Test
-    public void shouldGuessArtifactId() {
+    public void shouldGuessArtifactIdWhenComputingExtensionName() {
         String configRoot = "io.quarkus.agroal.Config";
         String expected = "quarkus-agroal.adoc";
         String fileName = computeExtensionDocFileName(configRoot);
@@ -162,6 +163,39 @@ public class DocGeneratorUtilTest {
         configRoot = "io.quarkus.extension.name.BuildTimeConfig";
         expected = "quarkus-extension-name.adoc";
         fileName = computeExtensionDocFileName(configRoot);
+        assertEquals(expected, fileName);
+    }
+
+    @Test
+    public void shouldUseHyphenatedClassNameWithoutRuntimeOrDeploymentNamespaceWhenComputingConfigGroupFileName() {
+        String configRoot = "ClassName";
+        String expected = "config-group-class-name.adoc";
+        String fileName = computeConfigGroupDocFileName(configRoot);
+        assertEquals(expected, fileName);
+
+        configRoot = "io.quarkus.agroal.ConfigGroup";
+        expected = "quarkus-agroal-config-group.adoc";
+        fileName = computeConfigGroupDocFileName(configRoot);
+        assertEquals(expected, fileName);
+
+        configRoot = "io.quarkus.agroal.runtime.ClassName";
+        expected = "quarkus-agroal-config-group-class-name.adoc";
+        fileName = computeConfigGroupDocFileName(configRoot);
+        assertEquals(expected, fileName);
+
+        configRoot = "io.quarkus.keycloak.deployment.RealmConfig";
+        expected = "quarkus-keycloak-config-group-realm-config.adoc";
+        fileName = computeConfigGroupDocFileName(configRoot);
+        assertEquals(expected, fileName);
+
+        configRoot = "io.quarkus.extension.deployment.BuildTimeConfig";
+        expected = "quarkus-extension-config-group-build-time-config.adoc";
+        fileName = computeConfigGroupDocFileName(configRoot);
+        assertEquals(expected, fileName);
+
+        configRoot = "io.quarkus.extension.deployment.name.BuildTimeConfig";
+        expected = "quarkus-extension-config-group-name-build-time-config.adoc";
+        fileName = computeConfigGroupDocFileName(configRoot);
         assertEquals(expected, fileName);
     }
 

--- a/docs/src/main/asciidoc/javascript/config.js
+++ b/docs/src/main/asciidoc/javascript/config.js
@@ -10,20 +10,23 @@ if(tables){
     var idx = 0;
     for (var table of tables) {
         var caption = table.previousElementSibling;
-        var input = document.createElement("input");
-        input.setAttribute("type", "search");
-        input.setAttribute("placeholder", "filter configuration");
-        input.id = "config-search-"+(idx++);
-        caption.children.item(0).appendChild(input);
-        input.addEventListener("keyup", initiateSearch);
-        input.addEventListener("input", initiateSearch);
-        inputs[input.id] = {"table": table};
-        var descriptions = table.querySelectorAll(".description");
-        if(descriptions){
+        if (table.classList.contains('searchable')) { // activate search engine only when needed
+          var input = document.createElement("input");
+          input.setAttribute("type", "search");
+          input.setAttribute("placeholder", "filter configuration");
+          input.id = "config-search-"+(idx++);
+          caption.children.item(0).appendChild(input);
+          input.addEventListener("keyup", initiateSearch);
+          input.addEventListener("input", initiateSearch);
+          inputs[input.id] = {"table": table};
+          var descriptions = table.querySelectorAll(".description");
+          if(descriptions){
             for (description of descriptions){
-                makeCollapsible(input, description);
+              makeCollapsible(input, description);
             }
+          }
         }
+
         var rowIdx = 0;
         for (var row of table.querySelectorAll("tr")) {
             var heads = row.querySelectorAll("th");
@@ -58,7 +61,7 @@ function highlight(element, text){
         var elementText = n.nodeValue;
         if(elementText == undefined)
             continue;
-        var elementTextLC = elementText.toLowerCase(); 
+        var elementTextLC = elementText.toLowerCase();
         var index = elementTextLC.indexOf(text);
         if(index != -1
            && acceptTextForSearch(n)){
@@ -153,10 +156,10 @@ function reinstallClickHandlers(input, table){
             var decoration = content.lastElementChild;
             var iconDecoration = decoration.children.item(0);
             var collapsibleSpan = decoration.children.item(1);
-            var collapsibleHandler = makeCollapsibleHandler(input, descDiv, td, row, 
-                                                            collapsibleSpan, 
+            var collapsibleHandler = makeCollapsibleHandler(input, descDiv, td, row,
+                                                            collapsibleSpan,
                                                             iconDecoration);
-        
+
             row.addEventListener("click", collapsibleHandler);
         }
     }
@@ -206,7 +209,7 @@ function applySearch(table, search, autoExpand){
         if(!search){
             row.style.removeProperty("display");
             // recollapse when searching is over
-            if(autoExpand 
+            if(autoExpand
                 && row.classList.contains("row-collapsible")
                 && !row.classList.contains("row-collapsed"))
                 row.click();
@@ -268,7 +271,7 @@ function makeCollapsible(input, descDiv){
         collapsibleSpan.appendChild(document.createTextNode("Show more"));
         descDecoration.appendChild(collapsibleSpan);
 
-        var collapsibleHandler = makeCollapsibleHandler(input, descDiv, td, row, 
+        var collapsibleHandler = makeCollapsibleHandler(input, descDiv, td, row,
                                                         collapsibleSpan,
                                                         iconDecoration);
 
@@ -284,10 +287,10 @@ function makeCollapsible(input, descDiv){
 
 };
 
-function makeCollapsibleHandler(input, descDiv, td, row, 
+function makeCollapsibleHandler(input, descDiv, td, row,
     collapsibleSpan,
     iconDecoration) {
-    
+
     return function(event) {
         var target = event.target;
         if( (target.localName == 'a' || getAncestor(target, "a"))) {

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -66,7 +66,7 @@ is in use.
 
 The following properties can be used to configure form based auth:
 
-include::{generated-dir}/config/quarkus-http-auth-form.adoc[opts=optional, leveloffset=+1]
+include::{generated-dir}/config/quarkus-vertx-http-config-group-form-auth-config.adoc[opts=optional, leveloffset=+1]
 
 ## Authorization in REST endpoints and CDI beans using annotations
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2363,6 +2363,15 @@ This is simple, include the generated documentation in your guide:
 \include::{generated-dir}/config/quarkus-your-extension.adoc[opts=optional, leveloffset=+1]
 ----
 
+If you are interested in including the generated documentation for the config group, you can use the include statement below
+[source,asciidoc]
+----
+\include::{generated-dir}/config/hyphenated-config-group-class-name-with-runtime-or-deployment-namespace-replaced-by-config-group-namespace.adoc[opts=optional, leveloffset=+1]
+----
+
+For example, the `io.quarkus.vertx.http.runtime.FormAuthConfig` configuration group will be generated in a file named `quarkus-vertx-http-config-group-form-auth-config.adoc`.
+
+
 A few recommendations:
 
  * `opts=optional` is mandatory as we don't want the build to fail if only part of the configuration documentation has been generated


### PR DESCRIPTION
**1st commit:**
Make it possible to generate a file par config group. 

**2nd commit:** 
use the generated file for `FormAuthConfig` to avoid the usage of an inexistant file which  was generating the following warning
```
asciidoctor: INFO: security-guide.adoc: line 69: optional include dropped because include file not found: target/asciidoc/generated/config/quarkus-http-auth-form.adoc 
```

**3rd commit:**
Resolves https://github.com/quarkusio/quarkus/issues/5097