### PR TITLE
Minor OIDC guide update add version to keycloak

### DIFF
--- a/docs/src/main/asciidoc/oidc-guide.adoc
+++ b/docs/src/main/asciidoc/oidc-guide.adoc
@@ -161,7 +161,7 @@ To start a Keycloak Server you can use Docker and just run the following command
 
 [source,bash]
 ----
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:7.0.0
 ----
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].

--- a/docs/src/main/asciidoc/oidc-web-app-guide.adoc
+++ b/docs/src/main/asciidoc/oidc-web-app-guide.adoc
@@ -76,7 +76,7 @@ To start a Keycloak Server you can use Docker and just run the following command
 
 [source,bash]
 ----
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:7.0.0
 ----
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].


### PR DESCRIPTION
Keycloak from version 7.0.1 does not support loading custom JS on endpoints. hence the the guides fail loading quarkus-realm.json
Keycloak Release notes: https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-7-0-1-final
Example offending line in quarkus-realm.json: https://github.com/quarkusio/quarkus-quickstarts/blob/master/using-openid-connect/config/quarkus-realm.json#L475

This PR makes the use of the keycloak tag 7.0.0 explicitly. 




