### PR TITLE
CORS headers may not be sent on 403

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
@@ -11,6 +11,11 @@ import io.vertx.ext.web.RoutingContext;
  */
 public final class FilterBuildItem extends MultiBuildItem {
 
+    //predefined system priorities
+    public static final int CORS = 300;
+    public static final int AUTHENTICATION = 200;
+    public static final int AUTHORIZATION = 100;
+
     private final Handler<RoutingContext> handler;
     private final int priority;
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -88,8 +88,10 @@ public class HttpSecurityProcessor {
             beanProducer
                     .produce(AdditionalBeanBuildItem.builder().setUnremovable().addBeanClass(HttpAuthenticator.class)
                             .addBeanClass(HttpAuthorizer.class).build());
-            filterBuildItemBuildProducer.produce(new FilterBuildItem(recorder.authenticationMechanismHandler(), 200));
-            filterBuildItemBuildProducer.produce(new FilterBuildItem(recorder.permissionCheckHandler(), 100));
+            filterBuildItemBuildProducer
+                    .produce(new FilterBuildItem(recorder.authenticationMechanismHandler(), FilterBuildItem.AUTHENTICATION));
+            filterBuildItemBuildProducer
+                    .produce(new FilterBuildItem(recorder.permissionCheckHandler(), FilterBuildItem.AUTHORIZATION));
 
             if (!buildTimeConfig.auth.permissions.isEmpty()) {
                 beanContainerListenerBuildItemBuildProducer

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -48,7 +48,7 @@ class VertxHttpProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     FilterBuildItem cors(CORSRecorder recorder, HttpConfiguration configuration) {
-        return new FilterBuildItem(recorder.corsHandler(configuration), 100);
+        return new FilterBuildItem(recorder.corsHandler(configuration), FilterBuildItem.CORS);
     }
 
     @BuildStep

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CoresSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CoresSecurityTestCase.java
@@ -1,0 +1,149 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.PathHandler;
+import io.quarkus.vertx.http.security.TestIdentityController;
+import io.quarkus.vertx.http.security.TestIdentityProvider;
+
+public class CoresSecurityTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.cors=true\n" +
+            "quarkus.http.cors.methods=GET, OPTIONS, POST\n" +
+            "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.policy.r1.roles-allowed=test\n" +
+            "quarkus.http.auth.permission.roles1.paths=/test\n" +
+            "quarkus.http.auth.permission.roles1.policy=r1\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<JavaArchive>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class).addClasses(TestIdentityProvider.class, PathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("test", "test", "test").add("user", "user", "user");
+    }
+
+    @Test
+    @DisplayName("Handles a preflight CORS request correctly")
+    public void corsPreflightTest() {
+        String origin = "http://custom.origin.quarkus";
+        String methods = "GET,POST";
+        String headers = "X-Custom";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "test")
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "wrongpassword")
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("user", "user")
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+    }
+
+    @Test
+    @DisplayName("Handles a direct CORS request correctly")
+    public void corsNoPreflightTest() {
+        String origin = "http://custom.origin.quarkus";
+        String methods = "GET,POST";
+        String headers = "X-Custom";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .log().headers()
+                .get("/test").then()
+                .statusCode(401)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "test")
+                .log().headers()
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers)
+                .body(Matchers.equalTo("test:/test"));
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "wrongpassword")
+                .log().headers()
+                .get("/test").then()
+                .statusCode(401)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("user", "user")
+                .log().headers()
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/TestIdentityController.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/TestIdentityController.java
@@ -15,7 +15,7 @@ public class TestIdentityController {
         return new Builder();
     }
 
-    static class Builder {
+    public static class Builder {
         public Builder add(String username, String password, String... roles) {
             idenitities.put(username, new TestIdentity(username, password, roles));
             return this;


### PR DESCRIPTION
The authorization and CORS handlers had the same priority,
which means sometimes CORS headers would not be sent on a
403 response.