### PR TITLE
Include the original exception that caused Quarkus startup to fail

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -184,7 +184,8 @@ public class DevModeMain implements Closeable {
                 } else {
                     //we need to set this here, while we still have the correct TCCL
                     //this is so the config is still valid, and we can read HTTP config from application.properties
-                    log.error("Failed to start Quarkus, attempting to start hot replacement endpoint to recover");
+                    log.error("Failed to start Quarkus", t);
+                    log.info("Attempting to start hot replacement endpoint to recover from previous Quarkus startup failure");
                     if (runtimeUpdatesProcessor != null) {
                         runtimeUpdatesProcessor.startupFailed();
                     }


### PR DESCRIPTION
The commit here splits a log message into 2 separate messages, one to include (at `ERROR` level) the original exception that caused Quarkus startup to fail and another at `INFO` level to mention that hot replacement endpoint will be setup to handle recovery.

Should help with https://github.com/quarkusio/quarkus/issues/5058