### PR TITLE
Creation extension command needs artifactIdPrefix

### DIFF
--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -358,6 +358,7 @@ cd quarkus
 cd extensions
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
     -Dquarkus.artifactIdBase=my-ext \
+    -Dquarkus.artifactIdPrefix=quarkus- \
     -Dquarkus.nameBase="My Extension"
 ----
 
@@ -392,7 +393,6 @@ Note that the parameters of the mojo that will be constant for all the extension
            mvn quarkus:create-extension -N -Dquarkus.artifactIdBase=my-ext -Dquarkus.nameBase="My Extension"
     -->
     <configuration>
-        <artifactIdPrefix>quarkus-</artifactIdPrefix>
         <namePrefix xml:space="preserve">Quarkus - </namePrefix>
         <runtimeBomPath>../bom/runtime/pom.xml</runtimeBomPath>
         <deploymentBomPath>../bom/deployment/pom.xml</deploymentBomPath>


### PR DESCRIPTION
The parameters that will be constant for all the extensions are configured in extensions/pom.xml. This config introduces a build dependency on the maven plugin  which leads to an ordering that prevents the tooling to include the generated JSON platform descriptor so has been `commented`. 
Thus, the command to add a new extension to the Quarkus source tree needs to pass also the `artifactIdPrefix` otherwise an error is raised.
Here is the stacktrace:
```
mvn io.quarkus:quarkus-maven-plugin:0.27.0:create-extension -N \
                                                            -Dquarkus.artifactIdBase=my-ext \
                                                            -Dquarkus.nameBase="My Extension"
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< io.quarkus:quarkus-parent >----------------------
[INFO] Building Quarkus - Parent pom 999-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:0.27.0:create-extension (default-cli) @ quarkus-parent ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.770 s
[INFO] Finished at: 2019-10-31T09:02:33+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:0.27.0:create-extension (default-cli) on project quarkus-parent: Either artifactId or both artifactIdPrefix and artifactIdBase must be specified; found: artifactId=[null], artifactIdPrefix=[null], artifactIdBase[my-ext] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```
Could you please take a look @geoand or forward this PR to someone else?