### PR TITLE
Remove private field injection from within our own extensions.

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/CDIDelegatingTransactionManager.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/CDIDelegatingTransactionManager.java
@@ -35,7 +35,7 @@ public class CDIDelegatingTransactionManager implements TransactionManager, Seri
      */
     @Inject
     @Initialized(TransactionScoped.class)
-    private Event<Transaction> transactionScopeInitialized;
+    Event<Transaction> transactionScopeInitialized;
 
     /**
      * An {@link Event} that can {@linkplain Event#fire(Object) fire}
@@ -43,7 +43,7 @@ public class CDIDelegatingTransactionManager implements TransactionManager, Seri
      */
     @Inject
     @BeforeDestroyed(TransactionScoped.class)
-    private Event<Object> transactionScopeBeforeDestroyed;
+    Event<Object> transactionScopeBeforeDestroyed;
 
     /**
      * An {@link Event} that can {@linkplain Event#fire(Object) fire}
@@ -51,7 +51,7 @@ public class CDIDelegatingTransactionManager implements TransactionManager, Seri
      */
     @Inject
     @Destroyed(TransactionScoped.class)
-    private Event<Object> transactionScopeDestroyed;
+    Event<Object> transactionScopeDestroyed;
 
     /**
      * Delegating transaction manager call to com.arjuna.ats.jta.{@link com.arjuna.ats.jta.TransactionManager}

--- a/extensions/resteasy-jackson/runtime/src/main/java/io/quarkus/resteasy/jackson/runtime/QuarkusObjectMapperContextResolver.java
+++ b/extensions/resteasy-jackson/runtime/src/main/java/io/quarkus/resteasy/jackson/runtime/QuarkusObjectMapperContextResolver.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class QuarkusObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
 
     @Inject
-    private ObjectMapper objectMapper;
+    ObjectMapper objectMapper;
 
     @Override
     public ObjectMapper getContext(Class<?> type) {

--- a/extensions/resteasy-jsonb/runtime/src/main/java/io/quarkus/resteasy/jsonb/runtime/QuarkusJsonbContextResolver.java
+++ b/extensions/resteasy-jsonb/runtime/src/main/java/io/quarkus/resteasy/jsonb/runtime/QuarkusJsonbContextResolver.java
@@ -14,7 +14,7 @@ import javax.ws.rs.ext.Provider;
 public class QuarkusJsonbContextResolver implements ContextResolver<Jsonb> {
 
     @Inject
-    private Jsonb jsonb;
+    Jsonb jsonb;
 
     @Override
     public Jsonb getContext(Class<?> type) {

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/CodecRegistrationTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/CodecRegistrationTest.java
@@ -136,7 +136,7 @@ public class CodecRegistrationTest {
 
     }
 
-    private static class EventBusConsumers {
+    static class EventBusConsumers {
 
         private List<String> address1 = new CopyOnWriteArrayList<>();
         private List<String> address2 = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
These can lead to debug log warning about unrecommended usage of private fields.