### PR TITLE
Explicitly add the `cd` command to navigate into the generated directory

### DIFF
--- a/docs/src/main/asciidoc/amqp-guide.adoc
+++ b/docs/src/main/asciidoc/amqp-guide.adoc
@@ -48,6 +48,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=amqp-quickstart \
     -Dextensions="amqp"
+cd amqp-quickstart
 ----
 
 This command generates a Maven project, importing the Reactive Messaging and AMQP connector extensions.

--- a/docs/src/main/asciidoc/application-configuration-guide.adoc
+++ b/docs/src/main/asciidoc/application-configuration-guide.adoc
@@ -39,6 +39,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=config-quickstart \
     -DclassName="org.acme.config.GreetingResource" \
     -Dpath="/greeting"
+cd config-quickstart
 ----
 
 It generates:

--- a/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
+++ b/docs/src/main/asciidoc/application-lifecycle-events-guide.adoc
@@ -44,6 +44,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=lifecycle-quickstart \
     -DclassName="org.acme.events.GreetingResource" \
     -Dpath="/hello"
+cd lifecycle-quickstart
 ----
 
 It generates:

--- a/docs/src/main/asciidoc/artemis-jms-guide.adoc
+++ b/docs/src/main/asciidoc/artemis-jms-guide.adoc
@@ -45,6 +45,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=jms-quickstart \
     -Dextensions="artemis-jms"
+cd jms-quickstart
 ----
 
 This command generates a Maven project, importing the Artemis JMS extension.

--- a/docs/src/main/asciidoc/async-message-passing.adoc
+++ b/docs/src/main/asciidoc/async-message-passing.adoc
@@ -31,6 +31,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vertx-quickstart \
     -Dextensions="vertx"
+cd vertx-quickstart
 ----
 
 If you have an already created project, the `vertx` extension can be added to an existing Quarkus project with
@@ -218,8 +219,9 @@ First create a new project using:
 ----
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
-    -DprojectArtifactId=vertx-quickstart \
+    -DprojectArtifactId=vertx-http-quickstart \
     -Dextensions="vertx"
+cd vertx-http-quickstart
 ----
 
 You can already start the application in _dev mode_ using `./mvnw compile quarkus:dev`.

--- a/docs/src/main/asciidoc/datasource-guide.adoc
+++ b/docs/src/main/asciidoc/datasource-guide.adoc
@@ -42,6 +42,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=agroal-quickstart \
     -DclassName="org.acme.datasource.GreetingResource" \
     -Dpath="/hello"
+cd agroal-quickstart
 ----
 
 This will generate:

--- a/docs/src/main/asciidoc/dynamodb-guide.adoc
+++ b/docs/src/main/asciidoc/dynamodb-guide.adoc
@@ -104,6 +104,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.dynamodb.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jsonb,dynamodb"
+cd dynamodb-quickstart
 ----
 
 This command generates a Maven structure importing the RESTEasy/JAX-RS and DynamoDB Client extensions.

--- a/docs/src/main/asciidoc/extension-authors-guide.adoc
+++ b/docs/src/main/asciidoc/extension-authors-guide.adoc
@@ -1700,6 +1700,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jsonb"
+cd rest-json
 ----
 
 ==== Bean Defining Annotations

--- a/docs/src/main/asciidoc/fault-tolerance-guide.adoc
+++ b/docs/src/main/asciidoc/fault-tolerance-guide.adoc
@@ -52,6 +52,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.faulttolerance.CoffeeResource" \
     -Dpath="/coffee" \
     -Dextensions="smallrye-fault-tolerance, resteasy-jsonb"
+cd microprofile-fault-tolerance-quickstart
 ----
 
 This command generates a Maven structure, importing the extensions for RESTEasy/JAX-RS

--- a/docs/src/main/asciidoc/getting-started-guide.adoc
+++ b/docs/src/main/asciidoc/getting-started-guide.adoc
@@ -80,6 +80,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=getting-started \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello"
+cd getting-started
 ----
 
 It generates the following in  `./getting-started`:

--- a/docs/src/main/asciidoc/health-guide.adoc
+++ b/docs/src/main/asciidoc/health-guide.adoc
@@ -51,6 +51,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-health-quickstart \
     -Dextensions="health"
+cd microprofile-health-quickstart
 ----
 
 This command generates a Maven project, importing the `smallrye-health` extension 

--- a/docs/src/main/asciidoc/hibernate-search-guide.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-guide.adoc
@@ -63,6 +63,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.hibernate.search.elasticsearch.LibraryResource" \
     -Dpath="/library" \
     -Dextensions="hibernate-orm-panache, hibernate-search-elasticsearch, resteasy-jsonb, jdbc-postgresql"
+cd hibernate-search-elasticsearch-quickstart
 ----
 
 This command generates a Maven structure importing the following extensions:

--- a/docs/src/main/asciidoc/jwt-guide.adoc
+++ b/docs/src/main/asciidoc/jwt-guide.adoc
@@ -63,6 +63,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.jwt.TokenSecuredResource" \
     -Dpath="/secured" \
     -Dextensions="resteasy-jsonb, jwt"
+cd security-jwt-quickstart
 ----
 
 This command generates the Maven project with a REST endpoint and imports the `smallrye-jwt` extension, which includes the {mp-jwt} support.

--- a/docs/src/main/asciidoc/kafka-guide.adoc
+++ b/docs/src/main/asciidoc/kafka-guide.adoc
@@ -49,6 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kafka-quickstart \
     -Dextensions="kafka"
+cd kafka-quickstart
 ----
 
 This command generates a Maven project, importing the Reactive Messaging and Kafka connector extensions.

--- a/docs/src/main/asciidoc/keycloak-authorization-guide.adoc
+++ b/docs/src/main/asciidoc/keycloak-authorization-guide.adoc
@@ -72,6 +72,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-keycloak-authorization-quickstart \
     -Dextensions="oidc, keycloak-authorization, resteasy-jsonb"
+cd security-keycloak-authorization-quickstart
 ----
 
 This command generates a Maven project, importing the `keycloak-authorization` extension which is an implementation of a Keycloak Adapter for Quarkus applications and provides all the necessary capabilities to integrate with a Keycloak Server and perform bearer token authorization.

--- a/docs/src/main/asciidoc/kogito-guide.adoc
+++ b/docs/src/main/asciidoc/kogito-guide.adoc
@@ -79,6 +79,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-quickstart \
     -Dextensions="kogito"
+cd kogito-quickstart
 ----
 
 This command generates a Maven project, importing the `kogito` extension

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -34,6 +34,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.GreetingResource" \
     -Dpath="/greeting" \
     -Dextensions="kotlin,resteasy-jsonb"
+cd kotlin-quickstart
 ----
 
 When adding `kotlin` to the extensions list, the Maven plugin will generate a project that is properly

--- a/docs/src/main/asciidoc/kubernetes-resources.adoc
+++ b/docs/src/main/asciidoc/kubernetes-resources.adoc
@@ -31,6 +31,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.GreetingResource" \
     -Dpath="/greeting" \
     -Dextensions="kubernetes"
+cd kubernetes-quickstart
 ----
 
 == Enable Kubernetes support

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -61,8 +61,8 @@ The following table lists the attributes you can pass to the `create` command:
 If you decide to generate a REST resource (using the `className` attribute), the endpoint is exposed at: `http://localhost:8080/$path`.
 If you use the default `path`, the URL is: http://localhost:8080/hello.
 
-The project is either generated in the current directory or in a directory named after the passed artifactId.
-If the current directory is empty, the project is generated in-place.
+The project is generated in a directory named after the passed artifactId.
+If the directory already exists, the generation fails.
 
 A pair of Dockerfiles for native and jvm mode are also generated in `src/main/docker`.
 Instructions to build the image and run the container are written in those Dockerfiles.

--- a/docs/src/main/asciidoc/metrics-guide.adoc
+++ b/docs/src/main/asciidoc/metrics-guide.adoc
@@ -50,6 +50,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=microprofile-metrics-quickstart \
     -Dextensions="metrics"
+cd microprofile-metrics-quickstart
 ----
 
 This command generates a Maven project, importing the `smallrye-metrics` extension which is an implementation of the MicroProfile Metrics specification used in Quarkus.

--- a/docs/src/main/asciidoc/mongo-guide.adoc
+++ b/docs/src/main/asciidoc/mongo-guide.adoc
@@ -49,6 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jsonb,mongodb-client"
+cd mongodb-quickstart
 ----
 
 This command generates a Maven structure importing the RESTEasy/JAX-RS, JSON-B and MongoDB Client extensions.

--- a/docs/src/main/asciidoc/mongodb-panache-guide.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache-guide.adoc
@@ -69,6 +69,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.mongodb.panache.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jsonb,mongodb-panache"
+cd mongodb-panache-quickstart
 ----
 
 This command generates a Maven structure importing the RESTEasy/JAX-RS, JSON-B and MongoDB with Panache extensions.

--- a/docs/src/main/asciidoc/neo4j-guide.adoc
+++ b/docs/src/main/asciidoc/neo4j-guide.adoc
@@ -128,6 +128,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=neo4j-quickstart \
     -Dextensions="neo4j,resteasy-jsonb"
+cd neo4j-quickstart
 ----
 
 It generates:

--- a/docs/src/main/asciidoc/oauth2-guide.adoc
+++ b/docs/src/main/asciidoc/oauth2-guide.adoc
@@ -37,6 +37,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.oauth2.TokenSecuredResource" \
     -Dpath="/secured" \
     -Dextensions="resteasy-jsonb, security-oauth2"
+cd security-oauth2-quickstart
 ----
 
 This command generates the Maven project with a REST endpoint and imports the `elytron-security-oauth2` extension, which includes the OAuth2 opaque token support.

--- a/docs/src/main/asciidoc/oidc-guide.adoc
+++ b/docs/src/main/asciidoc/oidc-guide.adoc
@@ -58,6 +58,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-openid-connect-quickstart \
     -Dextensions="oidc, resteasy-jsonb"
+cd security-openid-connect-quickstart
 ----
 
 This command generates a Maven project, importing the `keycloak` extension

--- a/docs/src/main/asciidoc/oidc-web-app-guide.adoc
+++ b/docs/src/main/asciidoc/oidc-web-app-guide.adoc
@@ -52,6 +52,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-openid-connect-web-authentication-quickstart \
     -Dextensions="oidc"
+cd security-openid-connect-web-authentication-quickstart
 ----
 
 == Configuring the application

--- a/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui-guide.adoc
@@ -45,6 +45,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.openapi.swaggerui.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jsonb"
+cd openapi-swaggerui-quickstart
 ----
 
 This command generates the Maven project with a `/fruits` REST endpoint.

--- a/docs/src/main/asciidoc/opentracing-guide.adoc
+++ b/docs/src/main/asciidoc/opentracing-guide.adoc
@@ -47,6 +47,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.opentracing.TracedResource" \
     -Dpath="/hello" \
     -Dextensions="opentracing"
+cd opentracing-quickstart
 ----
 
 This command generates the Maven project with a REST endpoint and imports the `smallrye-opentracing` extension, which

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -67,6 +67,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=reactive-pg-client-quickstart \
     -Dextensions="reactive-pg-client"
+cd reactive-pg-client-quickstart
 ----
 
 If you have an already created project, the `reactive-pg-client` extension can be added to an existing Quarkus project with the `add-extension` command:

--- a/docs/src/main/asciidoc/rest-client-guide.adoc
+++ b/docs/src/main/asciidoc/rest-client-guide.adoc
@@ -40,6 +40,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.restclient.CountriesResource" \
     -Dpath="/country" \
     -Dextensions="rest-client, resteasy-jsonb"
+cd rest-client-quickstart
 ----
 
 This command generates the Maven project with a REST endpoint and imports the `rest-client` and `resteasy-jsonb` extensions.

--- a/docs/src/main/asciidoc/rest-client-multipart-guide.adoc
+++ b/docs/src/main/asciidoc/rest-client-multipart-guide.adoc
@@ -43,6 +43,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.restclient.multipart.MultipartClientResource" \
     -Dpath="/client" \
     -Dextensions="rest-client, resteasy"
+cd rest-client-multipart-quickstart
 ----
 
 This command generates the Maven project with a REST endpoint and imports the `rest-client` and `resteasy` extensions.

--- a/docs/src/main/asciidoc/rest-json-guide.adoc
+++ b/docs/src/main/asciidoc/rest-json-guide.adoc
@@ -47,6 +47,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jsonb"
+cd rest-json-quickstart
 ----
 
 This command generates a Maven structure importing the RESTEasy/JAX-RS and http://json-b.net/[JSON-B] extensions.
@@ -61,6 +62,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jackson"
+cd rest-json-quickstart
 ----
 
 == Creating your first JSON REST service

--- a/docs/src/main/asciidoc/scheduled-guide.adoc
+++ b/docs/src/main/asciidoc/scheduled-guide.adoc
@@ -49,6 +49,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.scheduling.CountResource" \
     -Dpath="/count" \
     -Dextensions="scheduler"
+cd scheduler-quickstart
 ----
 
 It generates:

--- a/docs/src/main/asciidoc/security-jdbc-guide.adoc
+++ b/docs/src/main/asciidoc/security-jdbc-guide.adoc
@@ -50,6 +50,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=security-jdbc-quickstart \
     -Dextensions="elytron-security-jdbc, jdbc-postgresql, resteasy"
+cd security-jdbc-quickstart
 ----
 
 [NOTE]

--- a/docs/src/main/asciidoc/sending-emails.adoc
+++ b/docs/src/main/asciidoc/sending-emails.adoc
@@ -35,6 +35,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=sending-email-quickstart \
     -Dextensions="mailer"
+cd sending-email-quickstart
 ----
 
 If you already have an existing project, add the `mailer` extension:

--- a/docs/src/main/asciidoc/spring-data-jpa-guide.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa-guide.adoc
@@ -40,6 +40,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.spring.data.jpa.FruitResource" \
     -Dpath="/greeting" \
     -Dextensions="spring-data-jpa,resteasy-jsonb,quarkus-jdbc-postgresql"
+cd spring-data-jpa-quickstart
 ----
 
 This command generates a Maven project with a REST endpoint and imports the `spring-data-jpa` extension.

--- a/docs/src/main/asciidoc/spring-di-guide.adoc
+++ b/docs/src/main/asciidoc/spring-di-guide.adoc
@@ -42,6 +42,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.spring.di.GreeterResource" \
     -Dpath="/greeting" \
     -Dextensions="spring-di"
+cd spring-di-quickstart
 ----
 
 This command generates a Maven project with a REST endpoint and imports the `spring-di` extension.

--- a/docs/src/main/asciidoc/spring-web-guide.adoc
+++ b/docs/src/main/asciidoc/spring-web-guide.adoc
@@ -42,6 +42,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.spring.web.GreetingController" \
     -Dpath="/greeting" \
     -Dextensions="spring-web"
+cd spring-web-quickstart
 ----
 
 This command generates a Maven project with a REST endpoint and imports the `spring-web` extension.

--- a/docs/src/main/asciidoc/tests-with-coverage-guide.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage-guide.adoc
@@ -58,6 +58,7 @@ Let's start from an empty application created with the Quarkus Maven plugin:
 mvn io.quarkus:quarkus-maven-plugin:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=tests-with-coverage-quickstart
+cd tests-with-coverage-quickstart
 ----
 
 Now we'll be adding all the elements necessary to have an application that is properly covered with tests.

--- a/docs/src/main/asciidoc/tika-guide.adoc
+++ b/docs/src/main/asciidoc/tika-guide.adoc
@@ -74,6 +74,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.quickstart.tika.TikaParserResource" \
     -Dpath="/parse" \
     -Dextensions="tika,resteasy"
+cd tika-quickstart
 ----
 
 This command generates a Maven project, importing the `tika` and `resteasy` extensions.

--- a/docs/src/main/asciidoc/using-vertx.adoc
+++ b/docs/src/main/asciidoc/using-vertx.adoc
@@ -26,6 +26,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vertx-quickstart \
     -Dextensions="vertx"
+cd vertx-quickstart
 ----
 
 If you have an already created project, the `vertx` extension can be added to an existing Quarkus project with

--- a/docs/src/main/asciidoc/validation-guide.adoc
+++ b/docs/src/main/asciidoc/validation-guide.adoc
@@ -50,6 +50,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.validation.BookResource" \
     -Dpath="/books" \
     -Dextensions="resteasy-jsonb, hibernate-validator"
+cd validation-quickstart
 ----
 
 This command generates a Maven structure importing the RESTEasy/JAX-RS, JSON-B and Hibernate Validator/Bean Validation extensions.

--- a/docs/src/main/asciidoc/vault-guide.adoc
+++ b/docs/src/main/asciidoc/vault-guide.adoc
@@ -246,6 +246,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello" \
     -Dextensions="vault,hibernate-orm,jdbc-postgresql"
+cd vault-quickstart
 ----
 
 Configure access to vault from the `{config-file}`:

--- a/docs/src/main/asciidoc/websocket-guide.adoc
+++ b/docs/src/main/asciidoc/websocket-guide.adoc
@@ -46,6 +46,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=websockets-quickstart \
     -Dextensions="undertow-websockets"
+cd websockets-quickstart
 ----
 
 This command generates the Maven project (without any classes) and import the `undertow-websockets` extension.


### PR DESCRIPTION
Now that the project generation always creates a new directory (named after the artifactId), we can explicitly add the `cd` instructions in the guides.

This was discussed with @maxandersen.  