### PR TITLE
Use platform for project create

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -83,13 +83,13 @@ public class CreateProjectMojo extends AbstractMojo {
     @Parameter(property = "projectVersion")
     private String projectVersion;
 
-    @Parameter(property = "bomGroupId", defaultValue = CreateUtils.DEFAULT_PLATFORM_BOM_GROUP_ID)
+    @Parameter(property = "platformGroupId", defaultValue = CreateUtils.DEFAULT_PLATFORM_BOM_GROUP_ID)
     private String bomGroupId;
 
-    @Parameter(property = "bomArtifactId", defaultValue = CreateUtils.DEFAULT_PLATFORM_BOM_ARTIFACT_ID)
+    @Parameter(property = "platformArtifactId", defaultValue = CreateUtils.DEFAULT_PLATFORM_BOM_ARTIFACT_ID)
     private String bomArtifactId;
 
-    @Parameter(property = "bomVersion", required = false)
+    @Parameter(property = "platformVersion", required = false)
     private String bomVersion;
 
     @Parameter(property = "path")
@@ -149,6 +149,7 @@ public class CreateProjectMojo extends AbstractMojo {
             bomVersion = CreateUtils.resolvePluginInfo(getClass()).getVersion();
         }
 
+        // We assume platform specified by user refers to a BOM.
         final QuarkusPlatformDescriptor platform = QuarkusJsonPlatformDescriptorResolver.newInstance()
                 .setMessageWriter(new MojoMessageWriter(getLog()))
                 .setArtifactResolver(new BootstrapAppModelResolver(mvn))

--- a/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/QuarkusJsonPlatformDescriptorResolver.java
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/QuarkusJsonPlatformDescriptorResolver.java
@@ -278,14 +278,15 @@ public class QuarkusJsonPlatformDescriptorResolver {
         try {
             log.debug("Attempting to resolve Quarkus JSON platform descriptor as %s", jsonArtifact);
             return loadFromFile(artifactResolver.resolve(jsonArtifact));
-        } catch (Throwable e) {
+        } catch (Exception e) {
+            log.debug("Failed to resolve %s due to %s", jsonArtifact, e);
             // it didn't work, now we are trying artifactId-descriptor-json
             final AppArtifact fallbackArtifact = new AppArtifact(jsonArtifact.getGroupId(), jsonArtifact.getArtifactId() + "-descriptor-json", null, "json", jsonArtifact.getVersion());
             log.debug("Attempting to resolve Quarkus JSON platform descriptor as %s", fallbackArtifact);
             try {
                 return loadFromFile(artifactResolver.resolve(fallbackArtifact));
-            } catch (Throwable e1) {
-                throw new IllegalStateException("Failed to resolve the JSON descriptor artifact as " + jsonArtifact);
+            } catch (Exception e1) {
+                throw new IllegalStateException("Failed to resolve the JSON descriptor artifact as " + jsonArtifact, e);
             }
         }
     }


### PR DESCRIPTION
Why:

 * instead of referring to platform as a bom go back to use platform
   as in future it is not all enforced by a bom.

This change addreses the need by:

 * rollback bomXXX change
 * change use of Throwable to Exception as if Throwable happens
   we have worse problems.