### PR TITLE
Set a higher timeout for MicroProfile TCK runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,7 +150,7 @@ stages:
               jdk: '1.12'
 
       - job: Run_TCKs
-        timeoutInMinutes: 45
+        timeoutInMinutes: 60
         pool:
           vmImage: 'Ubuntu 16.04'
         steps:


### PR DESCRIPTION
It got cancelled quite a couple of times lately.