### PR TITLE
Ensure that Security annotation are always placed on non-final methods

### DIFF
--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/SecurityAnnotationOnFinalMethodTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/SecurityAnnotationOnFinalMethodTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.security.test.cdi;
+
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SecurityAnnotationOnFinalMethodTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SomeBean.class))
+            .setExpectedException(DeploymentException.class);
+
+    @Inject
+    SomeBean simpleBean;
+
+    @Test
+    public void test() {
+        // should not be called, deployment exception should happen first.
+        Assertions.fail();
+    }
+
+    @Singleton
+    public static class SomeBean {
+
+        @RolesAllowed("admin")
+        public final void someMethod() {
+
+        }
+    }
+}


### PR DESCRIPTION
We need security annotations to result in the creation of an interceptor
which is not possible when a method is final.
The default behavior of Arc to simply warn about the final method is not
good enough for security annotations because it could cause methods
that should have been secure to not be by a simple oversight.

Fixes: #5051

A note on the implementation: I went for a simple approach here instead of introducing some more build items and tying deeper into Arc since IMHO that would require us to handle other Arc warnings in a uniform manner instead of having a specific implementation for interceptors  