### PR TITLE
#5023 Add additional metadata to MANIFEST.MF

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ApplicationInfoBuildItem.java
@@ -4,7 +4,7 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class ApplicationInfoBuildItem extends SimpleBuildItem {
 
-    private static final String UNSET_VALUE = "<<unset>>";
+    public static final String UNSET_VALUE = "<<unset>>";
 
     private final String name;
     private final String version;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/ManifestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/ManifestConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.deployment.pkg;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ManifestConfig {
+
+    /**
+     * If the Implementation information should be included in the runner jar's MANIFEST.MF.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean addImplementationEntries;
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -26,6 +26,12 @@ public class PackageConfig {
     public boolean uberJar;
 
     /**
+     * Manifest configuration of the runner jar.
+     */
+    @ConfigItem
+    public ManifestConfig manifest;
+
+    /**
      * The entry point of the application. In most cases this should not be modified.
      */
     @ConfigItem(defaultValue = "io.quarkus.runner.GeneratedMain")


### PR DESCRIPTION
Added two additional information to MANIFEST.MF

```
Implementation-Title:  ${appArtifact.artifactId}
Implementation-Version: ${appArtifact.version}
```

The fields are only added to the manifest if the addDefaultImplementationEntries is set to true

```xml
     <plugin>
        <groupId>io.quarkus</groupId>
        <artifactId>quarkus-maven-plugin</artifactId>
        <version>${quarkus.version}</version>
        <configuration>
            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
        </configuration>
        <executions>
          <execution>
            <goals>
              <goal>build</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
```

fix for [#5023](https://github.com/quarkusio/quarkus/issues/5023)