### PR TITLE
Ensure that final methods don't prevent CDI interceptors from being applied

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -50,6 +50,16 @@ public class ArcConfig {
     @ConfigItem(defaultValue = "true")
     public boolean autoInjectFields;
 
+    /**
+     * If set to true, Arc will transform the bytecode of beans containing methods that need to be proxyable
+     * but have been declared as final. The transformation is simply a matter of removing final.
+     * This ensures that a proxy can be created properly.
+     * If the value is set to false, then an exception is thrown at build time indicating
+     * that a proxy could not be created because a method was final.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean removeFinalForProxyableMethods;
+
     public final boolean isRemoveUnusedBeansFieldValid() {
         return ALLOWED_REMOVE_UNUSED_BEANS_VALUES.contains(removeUnusedBeans.toLowerCase());
     }

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/BeanWithSecuredFinalMethod.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/BeanWithSecuredFinalMethod.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.test.cdi;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Singleton;
+
+@Singleton
+public class BeanWithSecuredFinalMethod {
+
+    @RolesAllowed("admin")
+    public final String securedMethod() {
+        return "accessibleForAdminOnly";
+    }
+
+    @DenyAll
+    public final String otherSecuredMethod(String input) {
+        return "denied";
+    }
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/SecurityAnnotationOnFinalMethodTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/SecurityAnnotationOnFinalMethodTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.security.test.cdi;
+
+import static io.quarkus.security.test.cdi.SecurityTestUtils.assertFailureFor;
+import static io.quarkus.security.test.cdi.SecurityTestUtils.assertSuccess;
+import static io.quarkus.security.test.utils.IdentityMock.ADMIN;
+import static io.quarkus.security.test.utils.IdentityMock.ANONYMOUS;
+import static io.quarkus.security.test.utils.IdentityMock.USER;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.test.utils.AuthData;
+import io.quarkus.security.test.utils.IdentityMock;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SecurityAnnotationOnFinalMethodTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanWithSecuredFinalMethod.class, IdentityMock.class,
+                            AuthData.class, SecurityTestUtils.class));
+
+    @Inject
+    BeanWithSecuredFinalMethod bean;
+
+    @Test
+    public void shouldRestrictAccessToSpecificRole() {
+        assertFailureFor(() -> bean.securedMethod(), UnauthorizedException.class, ANONYMOUS);
+        assertSuccess(() -> bean.securedMethod(), "accessibleForAdminOnly", ADMIN);
+    }
+
+    @Test
+    public void shouldFailToAccessCompletely() {
+        assertFailureFor(() -> bean.otherSecuredMethod("whatever"), UnauthorizedException.class, ANONYMOUS);
+        assertFailureFor(() -> bean.otherSecuredMethod("whatever"), ForbiddenException.class, USER, ADMIN);
+    }
+
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/SecurityAnnotationOnFinalMethodWithDisableFinalRemovalTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/SecurityAnnotationOnFinalMethodWithDisableFinalRemovalTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.security.test.cdi;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.AuthData;
+import io.quarkus.security.test.utils.IdentityMock;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SecurityAnnotationOnFinalMethodWithDisableFinalRemovalTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanWithSecuredFinalMethod.class, IdentityMock.class,
+                            AuthData.class, SecurityTestUtils.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.arc.remove-final-for-proxyable-methods=false"),
+                            "application.properties"))
+            .setExpectedException(DeploymentException.class);
+
+    @Inject
+    BeanWithSecuredFinalMethod bean;
+
+    @Test
+    public void test() {
+        // should never be executed since the application should not be built
+        fail();
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BytecodeTransformer.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BytecodeTransformer.java
@@ -1,0 +1,24 @@
+package io.quarkus.arc.processor;
+
+import java.util.function.BiFunction;
+import org.objectweb.asm.ClassVisitor;
+
+public class BytecodeTransformer {
+
+    final String classToTransform;
+    final BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction;
+
+    public BytecodeTransformer(String classToTransform,
+            BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction) {
+        this.classToTransform = classToTransform;
+        this.visitorFunction = visitorFunction;
+    }
+
+    public String getClassToTransform() {
+        return classToTransform;
+    }
+
+    public BiFunction<String, ClassVisitor, ClassVisitor> getVisitorFunction() {
+        return visitorFunction;
+    }
+}

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -38,7 +38,7 @@ public class TypesTest {
                 Collections.emptyMap(),
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,
-                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList()),
+                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), false),
                 resolvedTypeVariables::put);
         assertEquals(3, bazTypes.size());
         assertTrue(bazTypes.contains(Type.create(bazName, Kind.CLASS)));
@@ -55,7 +55,7 @@ public class TypesTest {
         Set<Type> fooTypes = Types.getClassBeanTypeClosure(fooClass,
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,
-                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList()));
+                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), false));
         assertEquals(2, fooTypes.size());
         for (Type t : fooTypes) {
             if (t.kind().equals(Kind.PARAMETERIZED_TYPE)) {
@@ -71,7 +71,7 @@ public class TypesTest {
         Set<Type> producerMethodTypes = Types.getProducerMethodTypeClosure(producerMethod,
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,
-                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList()));
+                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), false));
         assertEquals(1, producerMethodTypes.size());
 
         // Object is the sole type
@@ -79,7 +79,7 @@ public class TypesTest {
         Set<Type> producerFieldTypes = Types.getProducerFieldTypeClosure(producerField,
                 new BeanDeployment(index, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                         Collections.emptyList(), null,
-                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList()));
+                        false, Collections.emptyList(), Collections.emptyMap(), Collections.emptyList(), false));
         assertEquals(1, producerFieldTypes.size());
     }
 


### PR DESCRIPTION
We need security annotations to result in the creation of an interceptor
which is not possible when a method is final.
The solution we follow is to remove the final modifier from methods
that need intercepting.
This is now configurable with the default value true, meaning that
Arc will remove the final flag. If the value is set to false
Arc throws an exception at build time.

Fixes: #5051

Provides an alternative implementation to #5089 (which has now been closed) based on [this](https://github.com/quarkusio/quarkus/pull/5089#discussion_r341386797) comment