### PR TITLE
Load transformed bean in correct CL

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/TransformedArchiveBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/TransformedArchiveBuildItem.java
@@ -1,0 +1,43 @@
+package io.quarkus.deployment.builditem;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.ApplicationArchive;
+
+/**
+ * Represents all archives that contain classes that need to be transformed.
+ *
+ * In an environment that is using {@link io.quarkus.runner.RuntimeClassLoader} all classes
+ * from these archives need to be loaded by the RuntimeClassLoader. They also need to be treated
+ * as application classes, so all beans and other resources derived from them must also be loaded
+ * into the same class loader.
+ */
+public final class TransformedArchiveBuildItem extends SimpleBuildItem {
+
+    private final List<ApplicationArchive> applicationArchives;
+    private final Map<String, Path> classFileToPath;
+    private final Set<String> classes;
+
+    public TransformedArchiveBuildItem(List<ApplicationArchive> applicationArchives, Map<String, Path> classFileToPath,
+            Set<String> applicationJavaClassNames) {
+        this.applicationArchives = applicationArchives;
+        this.classFileToPath = classFileToPath;
+        this.classes = applicationJavaClassNames;
+    }
+
+    public List<ApplicationArchive> getApplicationArchives() {
+        return applicationArchives;
+    }
+
+    public Map<String, Path> getClassFileToPath() {
+        return classFileToPath;
+    }
+
+    public Set<String> getClasses() {
+        return classes;
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
@@ -48,14 +48,14 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
     /**
      *
      * @param beanDeployment
-     * @param annotationLiterals
      * @return a collection of resources
      */
     Collection<Resource> generate(String name, BeanDeployment beanDeployment,
             ComputingCache<Key, Literal> annotationLiteralsCache) {
         List<Resource> resources = new ArrayList<>();
         annotationLiteralsCache.forEachEntry((key, literal) -> {
-            ResourceClassOutput classOutput = new ResourceClassOutput(literal.isApplicationClass);
+            ResourceClassOutput classOutput = new ResourceClassOutput(literal.isApplicationClass,
+                    DotName.createSimple(literal.className));
             createSharedAnnotationLiteral(classOutput, key, literal);
             resources.addAll(classOutput.getResources());
         });

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -140,7 +140,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         boolean isApplicationClass = applicationClassPredicate.test(bean.getImplClazz().name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
-                name -> name.equals(generatedName) ? SpecialType.BEAN : null);
+                bean.getBeanClass(), name -> name.equals(generatedName) ? SpecialType.BEAN : null);
 
         // Foo_Bean implements InjectableBean<T>
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
@@ -243,7 +243,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         boolean isApplicationClass = applicationClassPredicate.test(beanClass.name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
-                name -> name.equals(generatedName) ? SpecialType.BEAN : null);
+                bean.getBeanClass(), name -> name.equals(generatedName) ? SpecialType.BEAN : null);
 
         // Foo_Bean implements InjectableBean<T>
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
@@ -339,7 +339,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
-                name -> name.equals(generatedName) ? SpecialType.BEAN : null);
+                bean.getBeanClass(), name -> name.equals(generatedName) ? SpecialType.BEAN : null);
 
         // Foo_Bean implements InjectableBean<T>
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)
@@ -425,7 +425,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         boolean isApplicationClass = applicationClassPredicate.test(declaringClass.name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
-                name -> name.equals(generatedName) ? SpecialType.BEAN : null);
+                bean.getBeanClass(), name -> name.equals(generatedName) ? SpecialType.BEAN : null);
 
         // Foo_Bean implements InjectableBean<T>
         ClassCreator beanCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -58,7 +58,8 @@ public class ClientProxyGenerator extends AbstractGenerator {
      */
     Collection<Resource> generate(BeanInfo bean, String beanClassName, ReflectionRegistration reflectionRegistration) {
 
-        ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()));
+        ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()),
+                bean.getBeanClass());
 
         Type providerType = bean.getProviderType();
         ClassInfo providerClass = getClassByName(bean.getDeployment().getIndex(), providerType.name());

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -59,7 +59,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
     Collection<Resource> generate(String name, BeanDeployment beanDeployment, Map<BeanInfo, String> beanToGeneratedName,
             Map<ObserverInfo, String> observerToGeneratedName) {
 
-        ResourceClassOutput classOutput = new ResourceClassOutput(true);
+        ResourceClassOutput classOutput = new ResourceClassOutput(true, null);
 
         String generatedName = SETUP_PACKAGE + "." + name + COMPONENTS_PROVIDER_SUFFIX;
         ClassCreator componentsProvider = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -70,7 +70,7 @@ public class InterceptorGenerator extends BeanGenerator {
 
         boolean isApplicationClass = applicationClassPredicate.test(interceptor.getBeanClass());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
-                name -> name.equals(generatedName) ? SpecialType.INTERCEPTOR_BEAN : null);
+                interceptor.getBeanClass(), name -> name.equals(generatedName) ? SpecialType.INTERCEPTOR_BEAN : null);
 
         // MyInterceptor_Bean implements InjectableInterceptor<T>
         ClassCreator interceptorCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -101,7 +101,7 @@ public class ObserverGenerator extends AbstractGenerator {
 
         boolean isApplicationClass = applicationClassPredicate.test(observer.getObserverMethod().declaringClass().name());
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
-                name -> name.equals(generatedName) ? SpecialType.OBSERVER : null);
+                observer.getDeclaringBean().getBeanClass(), name -> name.equals(generatedName) ? SpecialType.OBSERVER : null);
 
         // Foo_Observer_fooMethod_hash implements ObserverMethod<T>
         ClassCreator observerCreator = ClassCreator.builder().classOutput(classOutput).className(generatedName)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ResourceClassOutput.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ResourceClassOutput.java
@@ -6,6 +6,7 @@ import io.quarkus.gizmo.ClassOutput;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import org.jboss.jandex.DotName;
 
 /**
  *
@@ -16,22 +17,25 @@ public class ResourceClassOutput implements ClassOutput {
     private final List<Resource> resources = new ArrayList<>();
 
     private final boolean applicationClass;
+    private final DotName associatedClassName;
 
     private final Function<String, SpecialType> specialTypeFunction;
 
-    public ResourceClassOutput(boolean applicationClass) {
-        this(applicationClass, null);
+    public ResourceClassOutput(boolean applicationClass, DotName associatedClassName) {
+        this(applicationClass, associatedClassName, null);
     }
 
-    public ResourceClassOutput(boolean applicationClass, Function<String, SpecialType> specialTypeFunction) {
+    public ResourceClassOutput(boolean applicationClass, DotName associatedClassName,
+            Function<String, SpecialType> specialTypeFunction) {
         this.applicationClass = applicationClass;
+        this.associatedClassName = associatedClassName;
         this.specialTypeFunction = specialTypeFunction;
     }
 
     @Override
     public void write(String name, byte[] data) {
         resources.add(ResourceImpl.javaClass(name, data, specialTypeFunction != null ? specialTypeFunction.apply(name) : null,
-                applicationClass));
+                applicationClass, associatedClassName));
     }
 
     List<Resource> getResources() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ResourceImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ResourceImpl.java
@@ -6,6 +6,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.jboss.jandex.DotName;
 
 /**
  *
@@ -13,10 +14,9 @@ import java.nio.file.Path;
  */
 class ResourceImpl implements ResourceOutput.Resource {
 
-    private final boolean applicationClass;
-
-    static Resource javaClass(String name, byte[] data, SpecialType specialType, boolean applicationClass) {
-        return new ResourceImpl(applicationClass, name, data, Type.JAVA_CLASS, specialType);
+    static Resource javaClass(String name, byte[] data, SpecialType specialType, boolean applicationClass,
+            DotName associatedClassName) {
+        return new ResourceImpl(applicationClass, name, data, Type.JAVA_CLASS, specialType, associatedClassName);
 
     }
 
@@ -25,7 +25,7 @@ class ResourceImpl implements ResourceOutput.Resource {
     }
 
     static Resource serviceProvider(String name, byte[] data, SpecialType specialType) {
-        return new ResourceImpl(true, name, data, Type.SERVICE_PROVIDER, specialType);
+        return new ResourceImpl(true, name, data, Type.SERVICE_PROVIDER, specialType, null);
     }
 
     private final String name;
@@ -36,17 +36,27 @@ class ResourceImpl implements ResourceOutput.Resource {
 
     private final SpecialType specialType;
 
-    private ResourceImpl(boolean applicationClass, String name, byte[] data, Type type, SpecialType specialType) {
+    private final boolean applicationClass;
+    private final DotName associatedClassName;
+
+    private ResourceImpl(boolean applicationClass, String name, byte[] data, Type type, SpecialType specialType,
+            DotName associatedClassName) {
         this.applicationClass = applicationClass;
         this.name = name;
         this.data = data;
         this.type = type;
         this.specialType = specialType;
+        this.associatedClassName = associatedClassName;
     }
 
     @Override
     public boolean isApplicationClass() {
         return applicationClass;
+    }
+
+    @Override
+    public DotName getAssociatedClassName() {
+        return associatedClassName;
     }
 
     @Override

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ResourceOutput.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ResourceOutput.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.processor;
 
 import java.io.File;
 import java.io.IOException;
+import org.jboss.jandex.DotName;
 
 /**
  * Represents a generated resource.
@@ -15,6 +16,8 @@ public interface ResourceOutput {
     interface Resource {
 
         boolean isApplicationClass();
+
+        DotName getAssociatedClassName();
 
         File writeTo(File directory) throws IOException;
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -94,7 +94,8 @@ public class SubclassGenerator extends AbstractGenerator {
      */
     Collection<Resource> generate(BeanInfo bean, String beanClassName, ReflectionRegistration reflectionRegistration) {
 
-        ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()));
+        ResourceClassOutput classOutput = new ResourceClassOutput(applicationClassPredicate.test(bean.getBeanClass()),
+                bean.getBeanClass());
 
         Type providerType = bean.getProviderType();
         ClassInfo providerClass = getClassByName(bean.getDeployment().getIndex(), providerType.name());


### PR DESCRIPTION
If a class is part of a transformed archive then it will
be loaded by the RuntimeClassLoader, which means that all
beans associated with this class must also be loaded by
the RuntimeClassLoader.

Fixes #5015

Note that this has been manually verified, but does not include a test, as a test would require multiple additional maven modules to be created.