### PR TITLE
Bean that has a bound interceptor must not declare final methods

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -19,7 +19,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.enterprise.inject.spi.DefinitionException;
+import javax.enterprise.inject.spi.DeploymentException;
 import javax.enterprise.inject.spi.InterceptionType;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -405,8 +407,10 @@ public class BeanInfo implements InjectionTargetInfo {
         if (disposer != null) {
             disposer.init(errors);
         }
-        interceptedMethods.putAll(initInterceptedMethods());
-        lifecycleInterceptors.putAll(initLifecycleInterceptors());
+        interceptedMethods.putAll(initInterceptedMethods(errors));
+        if (errors.isEmpty()) {
+            lifecycleInterceptors.putAll(initLifecycleInterceptors());
+        }
     }
 
     protected String getType() {
@@ -421,7 +425,7 @@ public class BeanInfo implements InjectionTargetInfo {
         }
     }
 
-    private Map<MethodInfo, InterceptionInfo> initInterceptedMethods() {
+    private Map<MethodInfo, InterceptionInfo> initInterceptedMethods(List<Throwable> errors) {
         if (!isInterceptor() && isClassBean()) {
             Map<MethodInfo, InterceptionInfo> interceptedMethods = new HashMap<>();
             Map<MethodKey, Set<AnnotationInstance>> candidates = new HashMap<>();
@@ -434,7 +438,14 @@ public class BeanInfo implements InjectionTargetInfo {
                 }
             }
 
-            Methods.addInterceptedMethodCandidates(beanDeployment, target.get().asClass(), candidates, classLevelBindings);
+            Set<MethodInfo> finalMethods = Methods.addInterceptedMethodCandidates(beanDeployment, target.get().asClass(),
+                    candidates, classLevelBindings);
+            if (!finalMethods.isEmpty()) {
+                errors.add(new DeploymentException(String.format(
+                        "Intercepted methods of the bean %s may not be declared final:\n\t- %s", getBeanClass(),
+                        finalMethods.stream().map(Object::toString).sorted().collect(Collectors.joining("\n\t- ")))));
+                return Collections.emptyMap();
+            }
 
             for (Entry<MethodKey, Set<AnnotationInstance>> entry : candidates.entrySet()) {
                 List<InterceptorInfo> interceptors = beanDeployment.getInterceptorResolver()

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIgnoredTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIgnoredTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.arc.test.clientproxy.finalmethod;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.io.IOException;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class FinalMethodIgnoredTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Moo.class);
+
+    @Test
+    public void testProducer() throws IOException {
+        Moo moo = Arc.container().instance(Moo.class).get();
+        assertTrue(moo instanceof ClientProxy);
+        assertEquals(0, moo.getVal());
+        assertEquals(10, ((Moo) ((ClientProxy) moo).arc_contextualInstance()).val);
+    }
+
+    @ApplicationScoped
+    static class Moo {
+
+        private int val;
+
+        @PostConstruct
+        void init() {
+            this.val = 10;
+        }
+
+        // will return 0 if invoked upon a client proxy
+        final int getVal() {
+            return val;
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/finalmethod/FinalInterceptedMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/finalmethod/FinalInterceptedMethodTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.arc.test.interceptors.finalmethod;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.interceptors.Simple;
+import javax.annotation.Priority;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Singleton;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class FinalInterceptedMethodTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Simple.class, SimpleBean.class,
+            SimpleInterceptor.class).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        Throwable t = container.getFailure();
+        assertNotNull(t);
+        assertTrue(t instanceof DeploymentException);
+        assertTrue(t.getMessage().contains("foo"));
+        assertTrue(t.getMessage().contains("bar"));
+    }
+
+    @Simple
+    @Singleton
+    static class SimpleBean {
+
+        final String foo() {
+            return "foo";
+        }
+
+        final void bar() {
+        }
+
+    }
+
+    @Simple
+    @Priority(1)
+    @Interceptor
+    static class SimpleInterceptor {
+
+        @AroundInvoke
+        Object mySuperCoolAroundInvoke(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/finalmethod/FinalNonInterceptedMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/finalmethod/FinalNonInterceptedMethodTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.test.interceptors.finalmethod;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.interceptors.Simple;
+import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
+import javax.inject.Singleton;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class FinalNonInterceptedMethodTest {
+
+    static final String VAL = "ping";
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Simple.class, SimpleBean.class,
+            SimpleInterceptor.class);
+
+    @Test
+    public void testInvocation() {
+        SimpleBean bean = Arc.container().instance(SimpleBean.class).get();
+        assertEquals(VAL, bean.foo());
+        assertEquals("a" + VAL, bean.bar());
+    }
+
+    @Singleton
+    static class SimpleBean {
+
+        private String val;
+
+        @PostConstruct
+        void init() {
+            val = VAL;
+        }
+
+        // This method is final but not intercepted = OK
+        final String foo() {
+            return val;
+        }
+
+        @Simple
+        String bar() {
+            return val;
+        }
+
+    }
+
+    @Simple
+    @Priority(1)
+    @Interceptor
+    static class SimpleInterceptor {
+
+        @AroundInvoke
+        Object mySuperCoolAroundInvoke(InvocationContext ctx) throws Exception {
+            return "a" + ctx.proceed();
+        }
+    }
+
+}


### PR DESCRIPTION
- otherwise a deployment exception is thrown
- final methods declared on bean classes that require client proxies are
ignored though