### PR TITLE
Cleanup platformBomXXX and templates

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -37,9 +37,9 @@ public class QuarkusPlatformTask extends QuarkusTask {
                     .setArtifactResolver(extension().resolveAppModel())
                     .setMessageWriter(new GradleMessageWriter(getProject().getLogger()))
                     .resolveFromBom(
-                            getRequiredProperty(props, "quarkusPlatformBomGroupId"),
-                            getRequiredProperty(props, "quarkusPlatformBomArtifactId"),
-                            getRequiredProperty(props, "quarkusPlatformBomVersion"));
+                            getRequiredProperty(props, "quarkusPlatformGroupId"),
+                            getRequiredProperty(props, "quarkusPlatformArtifactId"),
+                            getRequiredProperty(props, "quarkusPlatformVersion"));
 
             QuarkusPlatformConfig.defaultConfigBuilder().setPlatformDescriptor(platform).build();
 

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}")
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -1,3 +1,3 @@
-quarkusPlatformBomGroupId = ${bom_groupId}
-quarkusPlatformBomArtifactId = ${bom_artifactId}
-quarkusPlatformBomVersion = ${bom_version}
+quarkusPlatformGroupId = ${bom_groupId}
+quarkusPlatformArtifactId = ${bom_artifactId}
+quarkusPlatformVersion = ${bom_version}

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
@@ -1,1 +1,3 @@
-quarkusVersion = ${quarkus_version}
+quarkusPlatformGroupId = ${bom_groupId}
+quarkusPlatformArtifactId = ${bom_artifactId}
+quarkusPlatformVersion = ${bom_version}

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/gradle.properties-template.ftl
@@ -1,1 +1,3 @@
-quarkusVersion = ${quarkus_version}
+quarkusPlatformGroupId = ${bom_groupId}
+quarkusPlatformArtifactId = ${bom_artifactId}
+quarkusPlatformVersion = ${bom_version}

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -73,7 +73,7 @@ public class GradleBuildFile extends BuildFile {
         if (!containsBOM()) {
             res.append(System.lineSeparator());
             res.append("dependencies {").append(System.lineSeparator());
-            res.append("    implementation enforcedPlatform(\"${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}\")")
+            res.append("    implementation enforcedPlatform(\"${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}\")")
                     .append(System.lineSeparator());
             res.append("    implementation 'io.quarkus:quarkus-resteasy'").append(System.lineSeparator());
             res.append("    testImplementation 'io.quarkus:quarkus-junit5'").append(System.lineSeparator());
@@ -127,14 +127,14 @@ public class GradleBuildFile extends BuildFile {
         if (props.getProperty("quarkusVersion") == null) {
             props.setProperty("quarkusVersion", getPluginVersion());
         }
-        if(props.getProperty("quarkusPlatformBomGroupId") == null) {
-            props.setProperty("quarkusPlatformBomGroupId", MojoUtils.getBomGroupId());
+        if(props.getProperty("quarkusPlatformGroupId") == null) {
+            props.setProperty("quarkusPlatformGroupId", MojoUtils.getBomGroupId());
         }
-        if(props.getProperty("quarkusPlatformBomArtifactId") == null) {
-            props.setProperty("quarkusPlatformBomArtifactId", MojoUtils.getBomArtifactId());
+        if(props.getProperty("quarkusPlatformArtifactId") == null) {
+            props.setProperty("quarkusPlatformArtifactId", MojoUtils.getBomArtifactId());
         }
-        if(props.getProperty("quarkusPlatformBomVersion") == null) {
-            props.setProperty("quarkusPlatformBomVersion", MojoUtils.getBomVersion());
+        if(props.getProperty("quarkusPlatformVersion") == null) {
+            props.setProperty("quarkusPlatformVersion", MojoUtils.getBomVersion());
         }
     }
 
@@ -192,7 +192,7 @@ public class GradleBuildFile extends BuildFile {
 
     @Override
     protected boolean containsBOM() throws IOException {
-        return getModel().getBuildContent().contains("enforcedPlatform(\"${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:");
+        return getModel().getBuildContent().contains("enforcedPlatform(\"${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:");
     }
 
     @Override

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
@@ -107,15 +107,15 @@ public class CreateProjectTest {
                 .containsIgnoringCase("io.quarkus:quarkus-gradle-plugin");
 
         assertThat(contentOf(new File(testDir, "build.gradle"), "UTF-8"))
-                .contains("${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}");
+                .contains("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}");
 
         final Properties props = new Properties();
         try(InputStream is = Files.newInputStream(testDir.toPath().resolve("gradle.properties"))) {
             props.load(is);
         }
-        Assertions.assertEquals(getBomGroupId(), props.get("quarkusPlatformBomGroupId"));
-        Assertions.assertEquals(getBomArtifactId(), props.get("quarkusPlatformBomArtifactId"));
-        Assertions.assertEquals(getBomVersion(), props.get("quarkusPlatformBomVersion"));
+        Assertions.assertEquals(getBomGroupId(), props.get("quarkusPlatformGroupId"));
+        Assertions.assertEquals(getBomArtifactId(), props.get("quarkusPlatformArtifactId"));
+        Assertions.assertEquals(getBomVersion(), props.get("quarkusPlatformVersion"));
     }
 
     @Test

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformBomGroupId}:${quarkusPlatformBomArtifactId}:${quarkusPlatformBomVersion}")
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -1,3 +1,3 @@
-quarkusPlatformBomGroupId = ${bom_groupId}
-quarkusPlatformBomArtifactId = ${bom_artifactId}
-quarkusPlatformBomVersion = ${bom_version}
+quarkusPlatformGroupId = ${bom_groupId}
+quarkusPlatformArtifactId = ${bom_artifactId}
+quarkusPlatformVersion = ${bom_version}

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}")
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
@@ -1,1 +1,3 @@
-quarkusVersion = ${quarkus_version}
+quarkusPlatformGroupId = ${bom_groupId}
+quarkusPlatformArtifactId = ${bom_artifactId}
+quarkusPlatformVersion = ${bom_version}

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}")
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/gradle.properties-template.ftl
@@ -1,1 +1,3 @@
-quarkusVersion = ${quarkus_version}
+quarkusPlatformGroupId = ${bom_groupId}
+quarkusPlatformArtifactId = ${bom_artifactId}
+quarkusPlatformVersion = ${bom_version}


### PR DESCRIPTION
Why:

 * maven and gradle uses various different spelling and casing of
   quarkusPlatformBomXXX

This change addreses the need by:

 * search and replace to consistently use `quarkusPlatformXXX` (i.e not bom)
   references as the data is intended to be used to resolve the "platform"
   rather than a specific resource.
 * Future improvements can be done in pom.xml and gradle build files to
   allow overrides but changing that this close to release I evaluated as
   being a bad idea :)