### PR TITLE
Fix MP Config TCKs to only exclude two failing tests

### DIFF
--- a/tcks/microprofile-config/pom.xml
+++ b/tcks/microprofile-config/pom.xml
@@ -41,6 +41,7 @@
                         <exclude>org.eclipse.microprofile.config.tck.EmptyValuesTest</exclude>
                         <!-- "testEnvironmentConfigSource" fails because of the above TCK/spec dispute -->
                         <!-- "testInjectedConfigSerializable" fails because not all ConfigSource, Converters, etc are serializable -->
+                        <!-- We have a custom version of this TCK class that excludes "testEnvironmentConfigSource" and "testInjectedConfigSerializable", allowing other tests to run -->
                         <exclude>org.eclipse.microprofile.config.tck.ConfigProviderTest</exclude>
                     </excludes>
                 </configuration>

--- a/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/CustomConfigProviderTest.java
+++ b/tcks/microprofile-config/src/test/java/io/quarkus/tck/config/CustomConfigProviderTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.tck.config;
+
+import org.eclipse.microprofile.config.tck.ConfigProviderTest;
+import org.testng.annotations.Test;
+
+public class CustomConfigProviderTest extends ConfigProviderTest {
+    @Test(enabled = false)
+    public void testEnvironmentConfigSource() {
+    }
+
+    @Test(enabled = false)
+    public void testInjectedConfigSerializable() {
+    }
+}


### PR DESCRIPTION
- Override test class to exclude the two methods, enabling the other methods on the class to execute