### PR TITLE
Fix native image doc inconsistency

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -13,11 +13,58 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class NativeConfig {
 
     /**
-     * If errors should be reported at runtime. This is a more relaxed setting, however it is not recommended as it means
-     * your application may fail at runtime if an unsupported feature is used by accident
+     * Additional arguments to pass to the build process
+     */
+    @ConfigItem
+    public List<String> additionalBuildArgs;
+
+    /**
+     * If the HTTP url handler should be enabled, allowing you to do URL.openConnection() for HTTP URLs
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enableHttpUrlHandler;
+
+    /**
+     * If the HTTPS url handler should be enabled, allowing you to do URL.openConnection() for HTTPS URLs
      */
     @ConfigItem(defaultValue = "false")
-    public boolean reportErrorsAtRuntime;
+    public boolean enableHttpsUrlHandler;
+
+    /**
+     * If all security services should be added to the native image
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableAllSecurityServices;
+
+    /**
+     * If JNI should be enabled
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableJni;
+
+    /**
+     * If all character sets should be added to the native image. This increases image size
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean addAllCharsets;
+
+    /**
+     * The location of the Graal distribution
+     */
+    @ConfigItem(defaultValue = "${GRAALVM_HOME:}")
+    public String graalvmHome;
+
+    /**
+     * The location of the JDK
+     */
+    @ConfigItem(defaultValue = "${java.home}")
+    public File javaHome;
+
+    /**
+     * The default maximum old generation size of the native image
+     */
+    @ConfigItem
+    public Optional<String> nativeImageXmx;
 
     /**
      * If debug symbols should be included
@@ -45,24 +92,6 @@ public class NativeConfig {
     public boolean cleanupServer;
 
     /**
-     * If the HTTP url handler should be enabled, allowing you to do URL.openConnection() for HTTP URLs
-     */
-    @ConfigItem(defaultValue = "true")
-    public boolean enableHttpUrlHandler;
-
-    /**
-     * If the HTTPS url handler should be enabled, allowing you to do URL.openConnection() for HTTPS URLs
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableHttpsUrlHandler;
-
-    /**
-     * If all security services should be added to the native image
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableAllSecurityServices;
-
-    /**
      * This will report on the size of the retained heap after image build
      */
     @ConfigItem(defaultValue = "false")
@@ -88,29 +117,11 @@ public class NativeConfig {
     public boolean enableFallbackImages;
 
     /**
-     * The location of the Graal distribution
-     */
-    @ConfigItem(defaultValue = "${GRAALVM_HOME:}")
-    public String graalvmHome;
-
-    /**
-     * The location of the JDK
-     */
-    @ConfigItem(defaultValue = "${java.home}")
-    public File javaHome;
-
-    /**
      * If the native image server should be used. This can speed up compilation but can result in changes not always
      * being picked up due to cache invalidation not working 100%
      */
     @ConfigItem(defaultValue = "false")
     public boolean enableServer;
-
-    /**
-     * If JNI should be enabled
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableJni;
 
     /**
      * If all META-INF/services entries should be automatically registered
@@ -123,12 +134,6 @@ public class NativeConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean dumpProxies;
-
-    /**
-     * The default maximum old generation size of the native image
-     */
-    @ConfigItem
-    public Optional<String> nativeImageXmx;
 
     /**
      * If this build should be done using a container runtime. If this is set docker will be used by default,
@@ -175,20 +180,15 @@ public class NativeConfig {
     public boolean enableReports;
 
     /**
-     * Additional arguments to pass to the build process
-     */
-    @ConfigItem
-    public List<String> additionalBuildArgs;
-
-    /**
-     * If all character sets should be added to the native image. This increases image size
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean addAllCharsets;
-
-    /**
      * If exceptions should be reported with a full stack trace
      */
     @ConfigItem(defaultValue = "true")
     public boolean reportExceptionStackTraces;
+
+    /**
+     * If errors should be reported at runtime. This is a more relaxed setting, however it is not recommended as it means
+     * your application may fail at runtime if an unsupported feature is used by accident.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean reportErrorsAtRuntime;
 }

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -144,7 +144,12 @@ If you have generated the application from the previous tutorial, you can find i
 
 [TIP]
 ====
-You can provide custom options for `native-image` command using `<additionalBuildArgs>` configuration element which can have multiple `<additionalBuildArg>` child elements.
+You can provide custom options for the `native-image` command using the `<quarkus.native.additional-build-args>` property.
+Multiple options may be separated by a comma.
+
+Another possibility is to include the `quarkus.native.additional-build-args` configuration property in your `application.properties`.
+
+You can find more information about how to configure the native image building process in the <<configuration-reference>> section below.
 ====
 
 We use a profile because, you will see very soon, packaging the native executable takes a _few_ minutes. You could
@@ -375,6 +380,7 @@ If you need SSL support in your native executable, you can easily include the ne
 Please see link:native-and-ssl.html#working-with-containers[our Using SSL With Native Executables guide] for more information.
 ====
 
+[[configuration-reference]]
 == Configuring the Native Image
 
 There are a lot of different configuration options that can affect how the native image is generated.

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Building Quarkus apps with Maven
+= Quarkus - Building applications with Maven
 
 include::./attributes.adoc[]
 
@@ -396,24 +396,12 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 <profiles>
     <profile> <3>
         <id>native</id>
+        <properties> <4>
+            <quarkus.package.type>native</quarkus.package.type>
+        </properties>
         <build>
             <plugins>
-                <plugin> <3>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-maven-plugin</artifactId>
-                    <version>${quarkus.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>native-image</goal>
-                            </goals>
-                            <configuration>
-                                <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin> <4>
+                <plugin> <5>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${surefire-plugin.version}</version>
@@ -438,9 +426,10 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 ----
 
 <1> Optionally use a BOM file to omit the version of the different Quarkus dependencies.
-<2> Use the Quarkus Maven plugin that will hook into the build process
-<3> Use a native profile and plugin to activate GraalVM compilation
-<4> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@NativeImageTest` will be run against the native executable. See the link:building-native-image.html[Native executable guide] for more info.
+<2> Use the Quarkus Maven plugin that will hook into the build process.
+<3> Use a specific `native` profile for native executable building.
+<4> Enable the `native` package type. The build will therefore produce a native executable.
+<5> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@NativeImageTest` will be run against the native executable. See the link:building-native-image.html[Native executable guide] for more info.
 
 [[uber-jar-maven]]
 === Uber-Jar Creation
@@ -455,6 +444,16 @@ option, this takes a comma seperated list of entries to ignore.
 Uber-Jar creation by default excludes link:https://docs.oracle.com/javase/tutorial/deployment/jar/intro.html[signature files] that might be present in the dependencies of the application.
 
 Uber-Jar's final name is configurable via a Maven's build settings `finalName` option.
+
+[[configuration-reference]]
+== Configuring the Project Output
+
+There are a several configuration options that will define what the output of your project build will be.
+These are provided in `application.properties` the same as any other config property.
+
+The properties are shown below:
+
+include::{generated-dir}/config/quarkus-core-package-config.adoc[opts=optional]
 
 [[custom-test-configuration-profile]]
 === Custom test configuration profile in JVM mode

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -53,25 +53,23 @@ Now, let's tell the `native-image` executable about this configuration file by t
 
 [source,xml]
 ----
-<plugin>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-maven-plugin</artifactId>
-    <version>${version.quarkus}</version>
-    <executions>
-        <execution>
-            <goals>
-                <goal>native-image</goal>
-            </goals>
-            <configuration>
-                <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                <additionalBuildArgs>
-                    <additionalBuildArg>-H:ResourceConfigurationFiles=${project.basedir}/resources-config.json</additionalBuildArg>
-                </additionalBuildArgs>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
+<profiles>
+    <profile>
+        <id>native</id>
+        <properties>
+            <quarkus.package.type>native</quarkus.package.type>
+            <quarkus.native.additional-build-args>-H:ResourceConfigurationFiles=${project.basedir}/resources-config.json</quarkus.native.additional-build-args>
+        </properties>
+    </profile>
+</profiles>
 ----
+
+[TIP]
+====
+Multiple options may be separated by a comma.
+
+Another possibility is to include the `quarkus.native.additional-build-args` configuration property in your `application.properties`.
+====
 
 When using Gradle, we need to configure the additional build arguments in the plugin configuration:
 
@@ -199,25 +197,23 @@ Now, let's tell the `native-image` executable about this configuration file by t
 
 [source,xml]
 ----
-<plugin>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-maven-plugin</artifactId>
-    <version>${version.quarkus}</version>
-    <executions>
-        <execution>
-            <goals>
-                <goal>native-image</goal>
-            </goals>
-            <configuration>
-                <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                <additionalBuildArgs>
-                    <additionalBuildArg>-H:ReflectionConfigurationFiles=${project.basedir}/reflection-config.json</additionalBuildArg>
-                </additionalBuildArgs>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
+<profiles>
+    <profile>
+        <id>native</id>
+        <properties>
+            <quarkus.package.type>native</quarkus.package.type>
+            <quarkus.native.additional-build-args>-H:ReflectionConfigurationFiles=${project.basedir}/reflection-config.json</quarkus.native.additional-build-args>
+        </properties>
+    </profile>
+</profiles>
 ----
+
+[TIP]
+====
+Multiple options may be separated by a comma.
+
+Another possibility is to include the `quarkus.native.additional-build-args` configuration property in your `application.properties`.
+====
 
 When using Gradle, we need to configure the additional build arguments in the plugin configuration:
 


### PR DESCRIPTION
Fixes #5111

@geoand @gastaldi  I'm not totally sure of what should be adjusted for Gradle but I would appreciate if one of you could have a look at what I did here and see if we need something similar for the Gradle parts of the documentation (we probably do).

Note: the change in the config file is just about reordering the options so that the most useful ones are at the top of the documentation.