### PR TITLE
Ensure kubernetes.group and kubernetes.registry are used

### DIFF
--- a/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/src/main/resources/application.properties
+++ b/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/src/main/resources/application.properties
@@ -4,3 +4,5 @@ kubernetes.labels[0].key=foo
 kubernetes.labels[0].value=bar
 kubernetes.env-vars[0].name=MY_ENV_VAR
 kubernetes.env-vars[0].value=SOMEVALUE
+kubernetes.group=grp
+kubernetes.registry=quay.io

--- a/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/verify.groovy
+++ b/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/verify.groovy
@@ -26,3 +26,6 @@ Container container = deployment.spec.template.spec.containers.get(0)
 EnvVar env = container.env.find{e -> e.name == "MY_ENV_VAR"}
 assert env != null
 assert env.value == "SOMEVALUE"
+
+//Check the image
+assert deployment.spec.template.spec.containers[0].image == "quay.io/grp/kubernetes-with-application-properties:0.1-SNAPSHOT"


### PR DESCRIPTION
This is just a quick fix around some Dekorate issues. Once Dekorate itself
properly handles these cases, the workaround (but not the test) should
be removed

Fixes: #5135