### PR TITLE
Add resteasy capability

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -14,6 +14,7 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String TRANSACTIONS = "io.quarkus.transactions";
     public static final String JACKSON = "io.quarkus.jackson";
     public static final String JSONB = "io.quarkus.jsonb";
+    public static final String RESTEASY = "io.quarkus.resteasy";
     public static final String RESTEASY_JSON_EXTENSION = "io.quarkus.resteasy-json";
     public static final String SECURITY = "io.quarkus.security";
     public static final String JWT = "io.quarkus.jwt";

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
@@ -51,7 +51,7 @@ public class ResteasyServletProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(providesCapabilities = Capabilities.RESTEASY)
     public void build(
             Capabilities capabilities,
             Optional<ResteasyServerConfigBuildItem> resteasyServerConfig,

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -56,7 +56,7 @@ public class ResteasyStandaloneBuildStep {
 
     }
 
-    @BuildStep()
+    @BuildStep(providesCapabilities = Capabilities.RESTEASY)
     @Record(STATIC_INIT)
     public void staticInit(ResteasyStandaloneRecorder recorder,
             Capabilities capabilities,


### PR DESCRIPTION
In camel-quarkus we do enable some features or behaviors according to
the presence of resteasy and as today the conditions is the presence
of the quarkus-resteasy extension (checked by lookgin at what features
are on the classpath using FeatureBuildItems). 

This PR introduces a new capability "resteasy" that can be used by our
code instead of basing our conditional on extension names.