### PR TITLE
Use Files.walk() within a try-with-resources statement

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -544,8 +545,8 @@ public class JarResultBuildStep {
      * @throws IOException if an error occurs
      */
     private void copyFiles(Path dir, FileSystem fs, Map<String, List<byte[]>> services) throws IOException {
-        try {
-            Files.walk(dir).forEach(new Consumer<Path>() {
+        try (Stream<Path> fileTreeElements = Files.walk(dir)) {
+            fileTreeElements.forEach(new Consumer<Path>() {
                 @Override
                 public void accept(Path path) {
                     final Path file = dir.relativize(path);


### PR DESCRIPTION
As stated in the [Files.walk()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walk(java.nio.file.Path,java.nio.file.FileVisitOption...)) Javadoc:

> API Note:
This method must be used within a try-with-resources statement or similar control structure to ensure that the stream's open directories are closed promptly after the stream's operations have completed.