### PR TITLE
Also configure the Surefire plugin in the Maven IT

### DIFF
--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -111,6 +111,19 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--suppress MavenModelInspection -->
+                        <maven.home>${maven.home}</maven.home>
+                        <maven.repo>${settings.localRepository}</maven.repo>
+                        <project.version>${project.version}</project.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Otherwise, we can't build the release as the tests do not point to the locally configured repository and the platform cannot resolve the bom.