### PR TITLE
Fix documentation: PT is *prepended* to duration values, not appended

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -91,7 +91,7 @@ final public class Constants {
             "\n" +
             "You can also provide duration values starting with a number.\n" +
             "In this case, if the value consists only of a number, the converter treats the value as seconds.\n" +
-            "Otherwise, `PT` is implicitly appended to the value to obtain a standard `java.time.Duration` format.\n" +
+            "Otherwise, `PT` is implicitly prepended to the value to obtain a standard `java.time.Duration` format.\n" +
             "====\n";
 
     public static final String MEMORY_SIZE_FORMAT_NOTE = "\n[NOTE]" +

--- a/docs/src/main/asciidoc/duration-format-note.adoc
+++ b/docs/src/main/asciidoc/duration-format-note.adoc
@@ -5,5 +5,5 @@ You can learn more about it in the link:https://docs.oracle.com/javase/8/docs/ap
 
 You can also provide duration values starting with a number.
 In this case, if the value consists only of a number, the converter treats the value as seconds.
-Otherwise, `PT` is implicitly appended to the value to obtain a standard `java.time.Duration` format.
+Otherwise, `PT` is implicitly prepended to the value to obtain a standard `java.time.Duration` format.
 ====


### PR DESCRIPTION
See the relevant code in DurationConverter:

```
    if (START_WITH_DIGITS.asPredicate().test(value)) {
	return Duration.parse(PERIOD_OF_TIME + value);
    }
```