### PR TITLE
fix (#5174): Add sundrio exclusion in kubernetes extension.

### DIFF
--- a/extensions/kubernetes/deployment/pom.xml
+++ b/extensions/kubernetes/deployment/pom.xml
@@ -23,6 +23,10 @@
             <classifier>noapt</classifier>
             <exclusions>
                 <exclusion>
+                    <groupId>io.sundr</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
@@ -33,6 +37,10 @@
             <artifactId>openshift-annotations</artifactId>
             <classifier>noapt</classifier>
             <exclusions>
+                <exclusion>
+                    <groupId>io.sundr</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>


### PR DESCRIPTION
Should fix #5174 by exclusion all `sundrio` dependencies that bring in the VelocityTransformer and other annotation processors.