### PR TITLE
fixes: NoSuchFileException in logs and improper caching in devmode after removing a html file

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -87,6 +87,7 @@ public class DevModeMain implements Closeable {
 
         runtimeUpdatesProcessor = setupRuntimeCompilation(context);
         if (runtimeUpdatesProcessor != null) {
+            runtimeUpdatesProcessor.checkForFileChange();
             runtimeUpdatesProcessor.checkForChangedClasses();
         }
         //TODO: we can't handle an exception on startup with hot replacement, as Undertow might not have started

--- a/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
@@ -334,6 +334,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext {
                         });
                     }
                     for (Path i : seen) {
+                        moduleResources.remove(i);
                         if (!Files.isDirectory(i)) {
                             Files.delete(i);
                         }

--- a/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/RuntimeUpdatesProcessor.java
@@ -283,7 +283,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext {
         return name.substring(lastIndexOf);
     }
 
-    private Set<String> checkForFileChange() {
+    Set<String> checkForFileChange() {
         Set<String> ret = new HashSet<>();
         for (DevModeContext.ModuleInfo module : context.getModules()) {
             final Set<Path> moduleResources = correspondingResources.computeIfAbsent(module.getName(),

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/files/StaticResourceDeletionBeforeFirstRequestTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/files/StaticResourceDeletionBeforeFirstRequestTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.resteasy.test.files;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class StaticResourceDeletionBeforeFirstRequestTest {
+
+    public static final String META_INF_RESOURCES_STATIC_RESOURCE_TXT = "META-INF/resources/static-resource.txt";
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("static resource content"), META_INF_RESOURCES_STATIC_RESOURCE_TXT));
+
+    @Test
+    public void shouldReturn404HttpStatusCode() {
+        test.deleteResourceFile(META_INF_RESOURCES_STATIC_RESOURCE_TXT); // delete the resource
+        RestAssured.when().get("/static-resource.txt").then().statusCode(404);
+    }
+}


### PR DESCRIPTION
This includes two fixes after I have rebased my work with @jmartisk initial work - https://github.com/quarkusio/quarkus/pull/5165
- **first commit** NoSuchFileException in logs as proposed by @jmartisk 
- **second commit** make sure that resource files are properly registered before first http request in dev mode. 

/cc @jmartisk I rebased on top of https://github.com/quarkusio/quarkus/pull/5165 to avoid hitting the  missing file exception fixed by your PR. 