### PR TITLE
Use ThreadLocal to store the global value only for gradle add and list

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusAddExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusAddExtension.java
@@ -39,8 +39,11 @@ public class QuarkusAddExtension extends QuarkusPlatformTask {
 
     @TaskAction
     public void addExtension() {
-        setupPlatformDescriptor();
+        execute();
+    }
 
+    @Override
+    protected void doExecute() {
         Set<String> extensionsSet = getExtensionsToAdd()
                 .stream()
                 .flatMap(ext -> stream(ext.split(",")))

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
@@ -62,9 +62,11 @@ public class QuarkusListExtensions extends QuarkusPlatformTask {
 
     @TaskAction
     public void listExtensions() {
+        execute();
+    }
 
-        setupPlatformDescriptor();
-
+    @Override
+    protected void doExecute() {
         try {
             new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(getProject().getProjectDir())))
                     .listExtensions(


### PR DESCRIPTION
… extensions tasks, otherwise the default global config should use a static field

Here is the story. Originally, I'd use a static field to share the default config (it's ugly and will be re-worked after 1.0) but then I realized it doesn't work for Gradle. Specifically, add and list extensions (only these two commands use the platform). Apparently, the tasks are initialized once and re-used accross projects. So, I switched to the ThreadLocal as a holder (and didn't properly clean it up). Which in its turn created a problem for code.quarkus.io with a thread pool in the background.

This change introduces an option how to share the default config: thread local or static field. Thread local and proper cleanup is used for Gradle add and list extensions. Maven Mojos are using the static field. code.quarkus.io will use the static field.