### PR TITLE
fix command line that scaffold gradle project

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -24,7 +24,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=my-artifactId \
     -DprojectVersion=my-version \
     -DclassName="org.my.group.MyResource" \
-    -Dextensions="resteasy-jsonb"
+    -Dextensions="resteasy-jsonb" \
     -DbuildTool=gradle
 ----
 


### PR DESCRIPTION
Because copying/pasting the Gradle project scaffolding command line was generating a maven project. A simple ` \` was missing.