### PR TITLE
Deprecate providesCapabilities and applicationArchiveMarkers

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -15,8 +15,15 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String JACKSON = "io.quarkus.jackson";
     public static final String JSONB = "io.quarkus.jsonb";
     public static final String RESTEASY_JSON_EXTENSION = "io.quarkus.resteasy-json";
-    public static final String SECURITY = "io.quarkus.security";
+    public static final String RESTEASY = "io.quarkus.resteasy";
     public static final String JWT = "io.quarkus.jwt";
+    public static final String TIKA = "io.quarkus.tika";
+    public static final String MONGODB_PANACHE = "io.quarkus.mongodb.panache";
+    public static final String KOGITO = "io.quarkus.kogito";
+    public static final String FLYWAY = "io.quarkus.flyway";
+    public static final String SECURITY = "io.quarkus.security";
+    public static final String SECURITY_ELYTRON_OAUTH2 = "io.quarkus.elytron.security.oauth2";
+    public static final String SECURITY_ELYTRON_JDBC = "io.quarkus.elytron.security.jdbc";
 
     private final Set<String> capabilities;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
@@ -67,8 +67,14 @@ public @interface BuildStep {
      *
      * A list of capabilities that are provided by this build step.
      *
+     * This should not be used, {@link io.quarkus.deployment.builditem.CapabilityBuildItem} should just be produced
+     * directly instead.
+     *
+     * This method will be removed at some point post Quarkus 1.1.
+     *
      * @return The capabilities provided by this build step
      */
+    @Deprecated
     String[] providesCapabilities() default {};
 
     /**
@@ -77,8 +83,12 @@ public @interface BuildStep {
      * If these are present in library on the class path then the library will be indexed, and this index will be
      * used when evaluating application components.
      *
-     * TODO: this should be a different annotation?
+     * This should not be used, {@link io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem}
+     * should just be produced directly instead.
+     *
+     * This method will be removed at some point post Quarkus 1.1.
      */
+    @Deprecated
     String[] applicationArchiveMarkers() default {};
 
     /**

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -42,6 +42,7 @@ import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ObjectSubstitutionBuildItem;
@@ -83,12 +84,17 @@ public final class TestProcessor {
     TestBuildTimeConfig buildTimeConfig;
     TestBuildAndRunTimeConfig buildAndRunTimeConfig;
 
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem("io.quarkus.test-extension");
+    }
+
     /**
      * Register an extension capability and feature
      *
      * @return test-extension feature build item
      */
-    @BuildStep(providesCapabilities = "io.quarkus.test-extension")
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem("test-extension");
     }

--- a/extensions/amazon-dynamodb/deployment/src/main/java/io/quarkus/dynamodb/deployment/DynamodbProcessor.java
+++ b/extensions/amazon-dynamodb/deployment/src/main/java/io/quarkus/dynamodb/deployment/DynamodbProcessor.java
@@ -19,6 +19,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -67,7 +68,12 @@ public class DynamodbProcessor {
         return new JniBuildItem();
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_SDK_APPLICATION_ARCHIVE_MARKERS })
+    @BuildStep
+    AdditionalApplicationArchiveMarkerBuildItem marker() {
+        return new AdditionalApplicationArchiveMarkerBuildItem(AWS_SDK_APPLICATION_ARCHIVE_MARKERS);
+    }
+
+    @BuildStep
     void setup(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -55,7 +56,12 @@ public final class AmazonLambdaProcessor {
         return new FeatureBuildItem(FeatureBuildItem.AMAZON_LAMBDA);
     }
 
-    @BuildStep(applicationArchiveMarkers = { AWS_LAMBDA_EVENTS_ARCHIVE_MARKERS })
+    @BuildStep
+    AdditionalApplicationArchiveMarkerBuildItem marker() {
+        return new AdditionalApplicationArchiveMarkerBuildItem(AWS_LAMBDA_EVENTS_ARCHIVE_MARKERS);
+    }
+
+    @BuildStep
     List<AmazonLambdaBuildItem> discover(CombinedIndexBuildItem combinedIndexBuildItem,
             Optional<ProvidedAmazonLambdaHandlerBuildItem> providedLambda,
             BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemBuildProducer,

--- a/extensions/elytron-security-jdbc/deployment/src/main/java/io/quarkus/elytron/security/jdbc/deployment/ElytronSecurityJdbcProcessor.java
+++ b/extensions/elytron-security-jdbc/deployment/src/main/java/io/quarkus/elytron/security/jdbc/deployment/ElytronSecurityJdbcProcessor.java
@@ -6,10 +6,12 @@ import org.wildfly.security.auth.server.SecurityRealm;
 
 import io.quarkus.agroal.deployment.DataSourceInitializedBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
@@ -21,7 +23,12 @@ class ElytronSecurityJdbcProcessor {
 
     JdbcSecurityRealmConfig jdbc;
 
-    @BuildStep(providesCapabilities = "io.quarkus.elytron.security.jdbc")
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.SECURITY_ELYTRON_JDBC);
+    }
+
+    @BuildStep()
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.SECURITY_JDBC);
     }

--- a/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
+++ b/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
@@ -8,10 +8,12 @@ import org.wildfly.security.auth.server.SecurityRealm;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.RuntimeBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.elytron.security.deployment.ElytronTokenMarkerBuildItem;
@@ -33,7 +35,12 @@ class OAuth2DeploymentProcessor {
 
     OAuth2Config oauth2;
 
-    @BuildStep(providesCapabilities = "io.quarkus.elytron.security.oauth2")
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.SECURITY_ELYTRON_OAUTH2);
+    }
+
+    @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.SECURITY_OAUTH2);
     }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -27,10 +27,12 @@ import io.quarkus.agroal.deployment.DataSourceInitializedBuildItem;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -51,8 +53,13 @@ class FlywayProcessor {
      */
     FlywayBuildConfig flywayBuildConfig;
 
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.FLYWAY);
+    }
+
     @Record(STATIC_INIT)
-    @BuildStep(providesCapabilities = "io.quarkus.flyway")
+    @BuildStep
     void build(BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer,
             BuildProducer<FeatureBuildItem> featureProducer,
             BuildProducer<NativeImageResourceBuildItem> resourceProducer,

--- a/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
+++ b/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -54,7 +55,12 @@ public class JsonbProcessor {
     private static final DotName JSONB_TYPE_SERIALIZER = DotName.createSimple(JsonbTypeSerializer.class.getName());
     private static final DotName JSONB_TYPE_DESERIALIZER = DotName.createSimple(JsonbTypeDeserializer.class.getName());
 
-    @BuildStep(providesCapabilities = Capabilities.JSONB)
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.JSONB);
+    }
+
+    @BuildStep
     void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle,
             BuildProducer<ServiceProviderBuildItem> serviceProvider,

--- a/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
+++ b/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
@@ -41,9 +41,11 @@ import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.builder.item.BuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -61,7 +63,12 @@ public class KogitoAssetsProcessor {
     private final transient String persistenceFactoryClass = "org.kie.kogito.persistence.KogitoProcessInstancesFactory";
     private final transient String metricsClass = "org.kie.addons.monitoring.rest.MetricsResource";
 
-    @BuildStep(providesCapabilities = "io.quarkus.kogito")
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.KOGITO);
+    }
+
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(FeatureBuildItem.KOGITO);
     }

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -50,7 +51,12 @@ class NarayanaJtaProcessor {
         return new NativeImageSystemPropertyBuildItem("CoordinatorEnvironmentBean.transactionStatusManagerEnable", "false");
     }
 
-    @BuildStep(providesCapabilities = Capabilities.TRANSACTIONS)
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.TRANSACTIONS);
+    }
+
+    @BuildStep
     @Record(RUNTIME_INIT)
     public void build(NarayanaJtaRecorder recorder,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -10,10 +10,12 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
@@ -35,7 +37,12 @@ public class PanacheResourceProcessor {
 
     private static final DotName DOTNAME_OBJECT_ID = DotName.createSimple(ObjectId.class.getName());
 
-    @BuildStep(providesCapabilities = "io.quarkus.mongodb.panache")
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.MONGODB_PANACHE);
+    }
+
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(FeatureBuildItem.MONGODB_PANACHE);
     }

--- a/extensions/resteasy-jsonb/deployment/src/main/java/io/quarkus/resteasy/jsonb/deployment/ResteasyJsonbProcessor.java
+++ b/extensions/resteasy-jsonb/deployment/src/main/java/io/quarkus/resteasy/jsonb/deployment/ResteasyJsonbProcessor.java
@@ -16,6 +16,7 @@ import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
@@ -25,7 +26,12 @@ public class ResteasyJsonbProcessor {
 
     private static final DotName JSONB = DotName.createSimple(Jsonb.class.getName());
 
-    @BuildStep(providesCapabilities = { Capabilities.RESTEASY_JSON_EXTENSION })
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.RESTEASY_JSON_EXTENSION);
+    }
+
+    @BuildStep
     void build(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(FeatureBuildItem.RESTEASY_JSONB));
     }

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -6,10 +6,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.runtime.ExceptionMapperRecorder;
@@ -21,6 +23,12 @@ import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentBuildItem;
 import io.quarkus.undertow.deployment.StaticResourceFilesBuildItem;
 
 public class ResteasyBuiltinsProcessor {
+
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.RESTEASY);
+    }
+
     @BuildStep
     void setUpDenyAllJaxRs(CombinedIndexBuildItem index,
             JaxRsSecurityConfig config,

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -15,6 +15,7 @@ import io.quarkus.arc.deployment.InterceptorBindingRegistrarBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.security.runtime.IdentityProviderManagerCreator;
@@ -108,7 +109,12 @@ public class SecurityProcessor {
         return providerClasses;
     }
 
-    @BuildStep(providesCapabilities = Capabilities.SECURITY)
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.SECURITY);
+    }
+
+    @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.SECURITY);
     }

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.QuarkusConfig;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.security.deployment.JCAProviderBuildItem;
@@ -49,12 +50,17 @@ class SmallRyeJwtProcessor {
 
     SmallryeJWTConfig config;
 
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.JWT);
+    }
+
     /**
      * Register the CDI beans that are needed by the MP-JWT extension
      *
      * @param additionalBeans - producer for additional bean items
      */
-    @BuildStep(providesCapabilities = Capabilities.JWT)
+    @BuildStep
     void registerAdditionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         if (config.enabled) {
             AdditionalBeanBuildItem.Builder unremovable = AdditionalBeanBuildItem.builder().setUnremovable();

--- a/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
+++ b/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
@@ -16,10 +16,12 @@ import org.apache.tika.parser.Parser;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -53,7 +55,12 @@ public class TikaProcessor {
         recorder.initTikaParser(beanContainer.getValue(), config, getSupportedParserNames(config.parsers));
     }
 
-    @BuildStep(providesCapabilities = "io.quarkus.tika")
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.TIKA);
+    }
+
+    @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.TIKA);
     }

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -86,6 +86,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -138,7 +139,12 @@ public class UndertowBuildStep {
     @Inject
     CombinedIndexBuildItem combinedIndexBuildItem;
 
-    @BuildStep(providesCapabilities = Capabilities.SERVLET)
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.SERVLET);
+    }
+
+    @BuildStep
     public FeatureBuildItem setupCapability() {
         return new FeatureBuildItem(FeatureBuildItem.SERVLET);
     }

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/WebXmlParsingBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/WebXmlParsingBuildStep.java
@@ -30,6 +30,7 @@ import org.jboss.metadata.web.spec.WebMetaData;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 
@@ -47,7 +48,12 @@ public class WebXmlParsingBuildStep {
                 new HotDeploymentWatchedFileBuildItem(WEB_FRAGMENT_XML));
     }
 
-    @BuildStep(applicationArchiveMarkers = WEB_FRAGMENT_XML)
+    @BuildStep
+    AdditionalApplicationArchiveMarkerBuildItem marker() {
+        return new AdditionalApplicationArchiveMarkerBuildItem(WEB_FRAGMENT_XML);
+    }
+
+    @BuildStep
     WebMetadataBuildItem createWebMetadata(ApplicationArchivesBuildItem applicationArchivesBuildItem,
             Consumer<AdditionalBeanBuildItem> additionalBeanBuildItemConsumer) throws Exception {
 


### PR DESCRIPTION
These are just build items so there is really no need for them
to be given special treatment.

Also adds RESTEasy capability

Fixes #5194