### PR TITLE
Configuration structure improvements in the Hibernate Search extension

### DIFF
--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -531,9 +531,9 @@ quarkus.hibernate-orm.sql-load-script=import.sql <4>
 
 quarkus.hibernate-search.elasticsearch.version=7 <5>
 quarkus.hibernate-search.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer <6>
-quarkus.hibernate-search.elasticsearch.automatic-indexing.synchronization.strategy=searchable <7>
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create <8>
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=yellow <9>
+quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create <7>
+quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=yellow <8>
+quarkus.hibernate-search.automatic-indexing.synchronization.strategy=searchable <9>
 ----
 <1> We won't use SSL so we disable it to have a more compact native executable.
 <2> Let's create a PostgreSQL datasource.
@@ -543,12 +543,12 @@ quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=
 It is important because there are significant differences between Elasticsearch mapping syntax depending on the version.
 Since the mapping is created at build time to reduce startup time, Hibernate Search cannot connect to the cluster to automatically detect the version.
 <6> We point to the custom `AnalysisConfigurer` which defines the configuration of our analyzers and normalizers.
-<7> This means that we wait for the entities to be searchable before considering a write complete.
-While, on a production setup, the `committed` default might be a suitable value, using `searchable` is especially important when testing as you need the entities to be searchable immediately.
-<8> Obviously, this is not for production: we drop and recreate the index every time we start the application.
-<9> We consider the `yellow` status is sufficient to connect to the Elasticsearch cluster.
+<7> Obviously, this is not for production: we drop and recreate the index every time we start the application.
+<8> We consider the `yellow` status is sufficient to connect to the Elasticsearch cluster.
 This is for testing purposes with the Elasticsearch Docker container.
 It should not be used in production.
+<9> This means that we wait for the entities to be searchable before considering a write complete.
+While, on a production setup, the `committed` default might be a suitable value, using `searchable` is especially important when testing as you need the entities to be searchable immediately.
 
 [TIP]
 For more information about the Hibernate Search extension configuration please refer to the <<configuration-reference, Configuration Reference>>.

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -95,7 +95,7 @@ class HibernateSearchElasticsearchProcessor {
         if (buildTimeConfig.additionalBackends.defaultBackend.isPresent()) {
             String defaultBackend = buildTimeConfig.additionalBackends.defaultBackend.get();
             // we have a default named backend
-            if (buildTimeConfig.elasticsearch.version.isPresent()) {
+            if (buildTimeConfig.defaultBackend.version.isPresent()) {
                 throw new ConfigurationError(
                         "quarkus.hibernate-search.elasticsearch.default-backend cannot be used in conjunction with a default backend configuration.");
             }
@@ -105,7 +105,7 @@ class HibernateSearchElasticsearchProcessor {
             }
         } else {
             // we are in the default backend case
-            if (!buildTimeConfig.elasticsearch.version.isPresent()) {
+            if (!buildTimeConfig.defaultBackend.version.isPresent()) {
                 throw new ConfigurationError(
                         "The Elasticsearch version needs to be defined via the quarkus.hibernate-search.elasticsearch.version property.");
             }
@@ -132,9 +132,9 @@ class HibernateSearchElasticsearchProcessor {
         Set<DotName> reflectiveClassCollector = new HashSet<>();
         Set<DotName> reflectiveTypeCollector = new HashSet<>();
 
-        if (buildTimeConfig.elasticsearch.analysis.configurer.isPresent()) {
+        if (buildTimeConfig.defaultBackend.analysis.configurer.isPresent()) {
             reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, false, buildTimeConfig.elasticsearch.analysis.configurer.get()));
+                    new ReflectiveClassBuildItem(true, false, buildTimeConfig.defaultBackend.analysis.configurer.get()));
         }
 
         if (buildTimeConfig.backgroundFailureHandler.isPresent()) {

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -92,15 +92,16 @@ class HibernateSearchElasticsearchProcessor {
     }
 
     private static void checkConfig(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
-        if (buildTimeConfig.defaultBackend.isPresent()) {
+        if (buildTimeConfig.additionalBackends.defaultBackend.isPresent()) {
+            String defaultBackend = buildTimeConfig.additionalBackends.defaultBackend.get();
             // we have a default named backend
             if (buildTimeConfig.elasticsearch.version.isPresent()) {
                 throw new ConfigurationError(
                         "quarkus.hibernate-search.elasticsearch.default-backend cannot be used in conjunction with a default backend configuration.");
             }
-            if (!buildTimeConfig.additionalBackends.containsKey(buildTimeConfig.defaultBackend.get())) {
+            if (!buildTimeConfig.additionalBackends.backends.containsKey(defaultBackend)) {
                 throw new ConfigurationError(
-                        "The default backend defined does not exist: " + buildTimeConfig.defaultBackend.get());
+                        "The default backend defined does not exist: " + defaultBackend);
             }
         } else {
             // we are in the default backend case
@@ -111,9 +112,9 @@ class HibernateSearchElasticsearchProcessor {
         }
 
         // we validate that the version is present for all the additional backends
-        if (!buildTimeConfig.additionalBackends.isEmpty()) {
+        if (!buildTimeConfig.additionalBackends.backends.isEmpty()) {
             List<String> additionalBackendsWithNoVersion = new ArrayList<>();
-            for (Entry<String, ElasticsearchBackendBuildTimeConfig> additionalBackendEntry : buildTimeConfig.additionalBackends
+            for (Entry<String, ElasticsearchBackendBuildTimeConfig> additionalBackendEntry : buildTimeConfig.additionalBackends.backends
                     .entrySet()) {
                 if (!additionalBackendEntry.getValue().version.isPresent()) {
                     additionalBackendsWithNoVersion.add(additionalBackendEntry.getKey());

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -20,7 +20,7 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
      */
     @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
-    public ElasticsearchBackendBuildTimeConfig elasticsearch;
+    public ElasticsearchBackendBuildTimeConfig defaultBackend;
 
     /**
      * Additional backends

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -18,23 +18,16 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
     /**
      * Default backend
      */
+    @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
     public ElasticsearchBackendBuildTimeConfig elasticsearch;
 
     /**
-     * If not using the default backend configuration, the name of the default backend that is part of the
-     * {@link #additionalBackends}.
-     */
-    @ConfigItem
-    public Optional<String> defaultBackend;
-
-    /**
      * Additional backends
      */
-    @ConfigItem(name = "elasticsearch.backends")
+    @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
-    @ConfigDocMapKey("backend-name")
-    public Map<String, ElasticsearchBackendBuildTimeConfig> additionalBackends;
+    public ElasticsearchAdditionalBackendsBuildTimeConfig additionalBackends;
 
     /**
      * The class or the name of the bean that should be notified of any failure occurring in a background process
@@ -44,6 +37,26 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
      */
     @ConfigItem
     public Optional<Class<?>> backgroundFailureHandler;
+
+    @ConfigGroup
+    public static class ElasticsearchAdditionalBackendsBuildTimeConfig {
+
+        /**
+         * Only useful when defining {@link #backends additional backends}:
+         * the name of the default backend,
+         * i.e. the backend that will be assigned to {@code @Indexed} entities
+         * that do not specify a backend explicitly through {@code @Indexed(backend = ...)}.
+         */
+        @ConfigItem
+        public Optional<String> defaultBackend;
+
+        /**
+         * Additional backends
+         */
+        @ConfigDocMapKey("backend-name")
+        public Map<String, ElasticsearchBackendBuildTimeConfig> backends;
+
+    }
 
     @ConfigGroup
     public static class ElasticsearchBackendBuildTimeConfig {

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -16,8 +16,9 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class HibernateSearchElasticsearchBuildTimeConfig {
 
     /**
-     * Configuration of the default backend.
+     * Default backend
      */
+    @ConfigDocSection
     public ElasticsearchBackendBuildTimeConfig elasticsearch;
 
     /**

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -64,14 +64,14 @@ public class HibernateSearchElasticsearchRecorder {
                 // we have a named default backend
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
                         buildTimeConfig.additionalBackends.defaultBackend.get());
-            } else if (buildTimeConfig.elasticsearch.version.isPresent()) {
+            } else if (buildTimeConfig.defaultBackend.version.isPresent()) {
                 // we use the default backend configuration
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
                         HibernateSearchElasticsearchRecorder.DEFAULT_BACKEND);
             }
 
             contributeBackendBuildTimeProperties(propertyCollector, HibernateSearchElasticsearchRecorder.DEFAULT_BACKEND,
-                    buildTimeConfig.elasticsearch);
+                    buildTimeConfig.defaultBackend);
 
             for (Entry<String, ElasticsearchBackendBuildTimeConfig> backendEntry : buildTimeConfig.additionalBackends.backends
                     .entrySet()) {

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -60,10 +60,10 @@ public class HibernateSearchElasticsearchRecorder {
                     EngineSettings.BACKGROUND_FAILURE_HANDLER,
                     buildTimeConfig.backgroundFailureHandler);
 
-            if (buildTimeConfig.defaultBackend.isPresent()) {
+            if (buildTimeConfig.additionalBackends.defaultBackend.isPresent()) {
                 // we have a named default backend
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
-                        buildTimeConfig.defaultBackend.get());
+                        buildTimeConfig.additionalBackends.defaultBackend.get());
             } else if (buildTimeConfig.elasticsearch.version.isPresent()) {
                 // we use the default backend configuration
                 addConfig(propertyCollector, EngineSettings.DEFAULT_BACKEND,
@@ -73,7 +73,7 @@ public class HibernateSearchElasticsearchRecorder {
             contributeBackendBuildTimeProperties(propertyCollector, HibernateSearchElasticsearchRecorder.DEFAULT_BACKEND,
                     buildTimeConfig.elasticsearch);
 
-            for (Entry<String, ElasticsearchBackendBuildTimeConfig> backendEntry : buildTimeConfig.additionalBackends
+            for (Entry<String, ElasticsearchBackendBuildTimeConfig> backendEntry : buildTimeConfig.additionalBackends.backends
                     .entrySet()) {
                 contributeBackendBuildTimeProperties(propertyCollector, backendEntry.getKey(), backendEntry.getValue());
             }
@@ -103,7 +103,8 @@ public class HibernateSearchElasticsearchRecorder {
 
             contributeBackendRuntimeProperties(propertyCollector, DEFAULT_BACKEND, runtimeConfig.defaultBackend);
 
-            for (Entry<String, ElasticsearchBackendRuntimeConfig> backendEntry : runtimeConfig.additionalBackends.entrySet()) {
+            for (Entry<String, ElasticsearchBackendRuntimeConfig> backendEntry : runtimeConfig.additionalBackends.backends
+                    .entrySet()) {
                 contributeBackendRuntimeProperties(propertyCollector, backendEntry.getKey(), backendEntry.getValue());
             }
         }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -21,9 +21,10 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class HibernateSearchElasticsearchRuntimeConfig {
 
     /**
-     * Configuration of the default backend.
+     * Default backend
      */
     @ConfigItem(name = "elasticsearch")
+    @ConfigDocSection
     ElasticsearchBackendRuntimeConfig defaultBackend;
 
     /**

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -30,10 +30,9 @@ public class HibernateSearchElasticsearchRuntimeConfig {
     /**
      * Additional backends
      */
-    @ConfigItem(name = "elasticsearch.backends")
+    @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
-    @ConfigDocMapKey("backend-name")
-    Map<String, ElasticsearchBackendRuntimeConfig> additionalBackends;
+    public ElasticsearchAdditionalBackendsRuntimeConfig additionalBackends;
 
     /**
      * Configuration for how entities are loaded by a search query.
@@ -46,6 +45,17 @@ public class HibernateSearchElasticsearchRuntimeConfig {
      */
     @ConfigItem
     AutomaticIndexingConfig automaticIndexing;
+
+    @ConfigGroup
+    public static class ElasticsearchAdditionalBackendsRuntimeConfig {
+
+        /**
+         * Additional backends
+         */
+        @ConfigDocMapKey("backend-name")
+        public Map<String, ElasticsearchBackendRuntimeConfig> backends;
+
+    }
 
     @ConfigGroup
     public static class ElasticsearchBackendRuntimeConfig {

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -17,19 +17,19 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(name = "hibernate-search.elasticsearch", phase = ConfigPhase.RUN_TIME)
+@ConfigRoot(name = "hibernate-search", phase = ConfigPhase.RUN_TIME)
 public class HibernateSearchElasticsearchRuntimeConfig {
 
     /**
      * Configuration of the default backend.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigItem(name = "elasticsearch")
     ElasticsearchBackendRuntimeConfig defaultBackend;
 
     /**
      * Additional backends
      */
-    @ConfigItem(name = "backends")
+    @ConfigItem(name = "elasticsearch.backends")
     @ConfigDocSection
     @ConfigDocMapKey("backend-name")
     Map<String, ElasticsearchBackendRuntimeConfig> additionalBackends;

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -10,5 +10,5 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis.configurer=io.quarkus.it.hibernate.search.elasticsearch.search.DefaultITAnalysisConfigurer
-quarkus.hibernate-search.elasticsearch.automatic-indexing.synchronization.strategy=searchable
 quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create-and-drop
+quarkus.hibernate-search.automatic-indexing.synchronization.strategy=searchable


### PR DESCRIPTION
~Based on #5202 , which should be merged first.~ => Done

1. Remove the "elasticsearch" prefix for the "query-loading" and "automatic-indexing" properties, which are not specific to Elasticsearch or to a backend in particular. This is consistent with what we already do for "default-backend" and "background-failure-handler".
2. Clearly separate the configuration of the default backend in the documentation by moving it to a separate section.
3. Move the "default-backend" property to the "additional backends" section of the documentation, since it's only useful in that case.

Please have a look at the documentation before/after to make your mind about this changeset.
Run this:

```
./mvnw clean install -DskipTests -pl docs,extensions/hibernate-search-elasticsearch/runtime,extensions/hibernate-search-elasticsearch/deployment -am && xdg-open docs/target/generated-docs/hibernate-search-elasticsearch.html
```

And compare the structure of the documentation with what we already have [here](https://quarkus.io/guides/hibernate-search-elasticsearch#configuration-reference).