### PR TITLE
Testcontainers bump to 1.12.3

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -124,7 +124,7 @@
         <caffeine.version>2.6.2</caffeine.version>
         <netty.version>4.1.42.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
-        <test-containers.version>1.12.0</test-containers.version>
+        <test-containers.version>1.12.3</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <axle-client.version>0.0.10</axle-client.version>
         <kafka-clients.version>2.2.1</kafka-clients.version>


### PR DESCRIPTION
Testcontainers bump to 1.12.3

I see trouble with RHEL7 and kafka-quickstart, seems firewall / iptable / docker related.
Testcontainers bump to 1.12.3 helps to see the cause.

1.12.0:
```
 java.lang.ExceptionInInitializerError
 	at org.acme.quarkus.sample.PriceResourceTest.<clinit>(PriceResourceTest.java:26)
```

1.12.3:
```
java.lang.ExceptionInInitializerError
	at org.acme.quarkus.sample.PriceResourceTest.<clinit>(PriceResourceTest.java:26)
Caused by: java.lang.IllegalStateException: Can not connect to Ryuk
	at org.acme.quarkus.sample.PriceResourceTest.<clinit>(PriceResourceTest.java:26)
```