### PR TITLE
Fix the Infinispan Embedded guide: it breaks the website build

### DIFF
--- a/docs/src/main/asciidoc/infinispan-embedded.adoc
+++ b/docs/src/main/asciidoc/infinispan-embedded.adoc
@@ -3,8 +3,10 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-include::./attributes.adoc[]
 = Quarkus - Infinispan Embedded
+
+include::./attributes.adoc[]
+
 Infinispan is an elastically scalable in-memory data store that you can embed
 directly in your application.
 


### PR DESCRIPTION
You need new lines after the title, otherwise they are considered metadata.

Also the title must be the very first element.