### PR TITLE
Fix Kafka test to handle empty consumer records on poll

### DIFF
--- a/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/KafkaConsumerManager.java
+++ b/integration-tests/kafka/src/main/java/io/quarkus/it/kafka/KafkaConsumerManager.java
@@ -9,6 +9,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -37,7 +38,11 @@ public class KafkaConsumerManager {
     }
 
     public String receive() {
-        return consumer.poll(Duration.ofMillis(10000)).iterator().next().value();
+        final ConsumerRecords<Integer, String> records = consumer.poll(Duration.ofMillis(60000));
+        if (records.isEmpty()) {
+            return null;
+        }
+        return records.iterator().next().value();
     }
 
 }

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -50,7 +50,7 @@ public class KafkaStreamsTest {
     private static Producer<Integer, Category> createCategoryProducer() {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
-        props.put(ProducerConfig.CLIENT_ID_CONFIG, "streams-test-producer");
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "streams-test-category-producer");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ObjectMapperSerializer.class.getName());
 


### PR DESCRIPTION
This fixes the `java.util.NoSuchElementException` exceptions that are reported in the Kafka native tests, as noted here https://github.com/quarkusio/quarkus/issues/5215.
Of course, this doesn't mean the test will still pass (since that exception was a sign that there were no messages that were consumed by the consumer). So I bumped the _maximum_ poll time to `60000` milli seconds from the current `10000` milli seconds.