### PR TITLE
Work around an issue in vertx where getting remote/client SocketAddress of the request leads to a NPE

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/LazyHostSupplier.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/LazyHostSupplier.java
@@ -2,10 +2,13 @@ package io.quarkus.resteasy.runtime.standalone;
 
 import java.util.Objects;
 
+import org.jboss.logging.Logger;
+
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
 
 final class LazyHostSupplier {
+    private static final Logger logger = Logger.getLogger(LazyHostSupplier.class.getName());
 
     private final HttpServerRequest request;
     private String remoteHost = null;
@@ -20,7 +23,17 @@ final class LazyHostSupplier {
         if (initialized) {
             return this.remoteHost;
         } else {
-            SocketAddress socketAddress = request.remoteAddress();
+            SocketAddress socketAddress = null;
+            try {
+                socketAddress = request.remoteAddress();
+            } catch (NullPointerException npe) {
+                // ideally there shouldn't be an exception for this call.
+                // This is just to workaround a current issue in vertx
+                // https://github.com/quarkusio/quarkus/issues/5247
+                // https://github.com/eclipse-vertx/vert.x/issues/3181
+                // TODO: remove this workaround once vertx issue is resolved
+                logger.debug("Ignoring exception that occurred when obtaining remote address of request " + request, npe);
+            }
             // client address may not be available with VirtualHttp;
             this.remoteHost = socketAddress != null ? socketAddress.host() : null;
             initialized = true;


### PR DESCRIPTION
The commit in this PR works around the vertx issue https://github.com/eclipse-vertx/vert.x/issues/3181.

The existing code in this class already seems capable of handling `null` value for a remote address, since it already had:
```
String host = socketAddress != null ? socketAddress.host() : null;
```
So I think it should be fine to consider `host` as `null` when we run into an exception and ignore it.