### PR TITLE
issue 4791 Do not open ports at build time (disable TSM)

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -84,7 +84,7 @@
         <hibernate-validator.version>6.1.0.Final</hibernate-validator.version>
         <hibernate-orm.version>5.4.8.Final</hibernate-orm.version>
         <hibernate-search.version>6.0.0.Beta2</hibernate-search.version>
-        <narayana.version>5.9.8.Final</narayana.version>
+        <narayana.version>5.10.0.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.7</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>

--- a/extensions/narayana-stm/runtime/pom.xml
+++ b/extensions/narayana-stm/runtime/pom.xml
@@ -18,6 +18,10 @@
             <groupId>org.jboss.narayana.stm</groupId>
             <artifactId>stm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/narayana-stm/runtime/src/main/java/io/quarkus/narayana/stm/runtime/NarayanaSTMRecorder.java
+++ b/extensions/narayana-stm/runtime/src/main/java/io/quarkus/narayana/stm/runtime/NarayanaSTMRecorder.java
@@ -1,0 +1,13 @@
+package io.quarkus.narayana.stm.runtime;
+
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class NarayanaSTMRecorder {
+    public void disableTransactionStatusManager() {
+        arjPropertyManager.getCoordinatorEnvironmentBean()
+                .setTransactionStatusManagerEnable(false);
+    }
+}


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/issues/4791

The fix disables the Narayana TransactionStatusManager during native image build and at runtime since it is not needed (and opens ports resulting in unexpected log messages during native image build).
