### PR TITLE
Fix delegation usage in ResumingRouter

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/router/RouterEventTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/router/RouterEventTest.java
@@ -36,6 +36,7 @@ public class RouterEventTest {
 
         RestAssured.given()
                 .body("An example body")
+                .contentType("text/plain")
                 .post("/post")
                 .then()
                 .body(is("An example body"));
@@ -50,6 +51,7 @@ public class RouterEventTest {
             counter++;
             router.get("/boom").handler(ctx -> ctx.response().setStatusCode(200).end("ok"));
             Route post = router.post("/post");
+            post.consumes("text/plain");
             post.handler(BodyHandler.create());
             post.handler(ctx -> ctx.response().end(ctx.getBody()));
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ResumingRouter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ResumingRouter.java
@@ -1,7 +1,10 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
@@ -181,33 +184,41 @@ public class ResumingRouter implements Router {
 
     @Override
     public Route patchWithRegex(String regex) {
-        return delegate.patchWithRegex(regex);
+        return new ResumingRoute(delegate.patchWithRegex(regex));
     }
 
     @Override
     public List<Route> getRoutes() {
-        return delegate.getRoutes();
+        return Optional.ofNullable(delegate.getRoutes())
+                .map(List::stream)
+                .orElseGet(Stream::empty)
+                .map(ResumingRoute::new)
+                .collect(Collectors.toList());
     }
 
     @Override
     public Router clear() {
-        return delegate.clear();
+        delegate.clear();
+        return this;
     }
 
     @Override
     public Router mountSubRouter(String mountPoint, Router subRouter) {
-        return delegate.mountSubRouter(mountPoint, subRouter);
+        delegate.mountSubRouter(mountPoint, subRouter);
+        return this;
     }
 
     @Override
     @Deprecated
     public Router exceptionHandler(Handler<Throwable> exceptionHandler) {
-        return delegate.exceptionHandler(exceptionHandler);
+        delegate.exceptionHandler(exceptionHandler);
+        return this;
     }
 
     @Override
     public Router errorHandler(int statusCode, Handler<RoutingContext> errorHandler) {
-        return delegate.errorHandler(statusCode, errorHandler);
+        delegate.errorHandler(statusCode, errorHandler);
+        return this;
     }
 
     @Override
@@ -221,9 +232,9 @@ public class ResumingRouter implements Router {
     }
 
     @Override
-
     public Router modifiedHandler(Handler<Router> handler) {
-        return delegate.modifiedHandler(handler);
+        delegate.modifiedHandler(handler);
+        return this;
     }
 
     @Override
@@ -240,82 +251,98 @@ public class ResumingRouter implements Router {
 
         @Override
         public Route method(HttpMethod method) {
-            return route.method(method);
+            route.method(method);
+            return this;
         }
 
         @Override
         public Route path(String path) {
-            return route.path(path);
+            route.path(path);
+            return this;
         }
 
         @Override
         public Route pathRegex(String path) {
-            return route.pathRegex(path);
+            route.pathRegex(path);
+            return this;
         }
 
         @Override
         public Route produces(String contentType) {
-            return route.produces(contentType);
+            route.produces(contentType);
+            return this;
         }
 
         @Override
         public Route consumes(String contentType) {
-            return route.consumes(contentType);
+            route.consumes(contentType);
+            return this;
         }
 
         @Override
         public Route order(int order) {
-            return route.order(order);
+            route.order(order);
+            return this;
         }
 
         @Override
         public Route last() {
-            return route.last();
+            route.last();
+            return this;
         }
 
         @Override
         public Route handler(Handler<RoutingContext> requestHandler) {
-            return route.handler(new ResumeHandler(requestHandler));
+            route.handler(new ResumeHandler(requestHandler));
+            return this;
         }
 
         @Override
         public Route blockingHandler(Handler<RoutingContext> requestHandler) {
-            return route.blockingHandler(new ResumeHandler(requestHandler));
+            route.blockingHandler(new ResumeHandler(requestHandler));
+            return this;
         }
 
         @Override
         public Route subRouter(Router subRouter) {
-            return route.subRouter(subRouter);
+            route.subRouter(subRouter);
+            return this;
         }
 
         @Override
         public Route blockingHandler(Handler<RoutingContext> requestHandler, boolean ordered) {
-            return route.blockingHandler(new ResumeHandler(requestHandler), ordered);
+            route.blockingHandler(new ResumeHandler(requestHandler), ordered);
+            return this;
         }
 
         @Override
         public Route failureHandler(Handler<RoutingContext> failureHandler) {
-            return route.failureHandler(new ResumeHandler(failureHandler));
+            route.failureHandler(new ResumeHandler(failureHandler));
+            return this;
         }
 
         @Override
         public Route remove() {
-            return route.remove();
+            route.remove();
+            return this;
         }
 
         @Override
         public Route disable() {
-            return route.disable();
+            route.disable();
+            return this;
         }
 
         @Override
         public Route enable() {
-            return route.enable();
+            route.enable();
+            return this;
         }
 
         @Override
         public Route useNormalisedPath(boolean useNormalisedPath) {
-            return route.useNormalisedPath(useNormalisedPath);
+            route.useNormalisedPath(useNormalisedPath);
+            return this;
         }
 
         @Override
@@ -335,7 +362,8 @@ public class ResumingRouter implements Router {
 
         @Override
         public Route setRegexGroupsNames(List<String> groups) {
-            return route.setRegexGroupsNames(groups);
+            route.setRegexGroupsNames(groups);
+            return this;
         }
     }
 }

--- a/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
+++ b/extensions/vertx-web/deployment/src/test/java/io/quarkus/vertx/web/SimpleRouteTest.java
@@ -20,6 +20,7 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.vertx.ConsumeEvent;
 import io.restassured.RestAssured;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
@@ -43,6 +44,8 @@ public class SimpleRouteTest {
         RestAssured.when().delete("/delete").then().statusCode(200).body(is("deleted"));
         RestAssured.when().get("/routes").then().statusCode(200)
                 .body(Matchers.containsString("/hello-event-bus"));
+        RestAssured.given().contentType("text/plain").body("world")
+                .post("/body").then().body(is("Hello world!"));
     }
 
     static class SimpleBean {
@@ -69,6 +72,11 @@ public class SimpleRouteTest {
         @Route(path = "/delete", methods = DELETE)
         void deleteHttpMethod(RoutingExchange exchange) {
             exchange.ok("deleted");
+        }
+
+        @Route(path = "/body", methods = HttpMethod.POST, consumes = "text/plain")
+        void post(RoutingContext context) {
+            context.response().setStatusCode(200).end("Hello " + context.getBodyAsString() + "!");
         }
 
     }


### PR DESCRIPTION
I found a bug with vertx-http, in a case like this 
```
    router.post("/hi/bug")
    	    .consumes("application/json")
	    .handler(BodyHandler.create())
            .handler(rc -> rc.response().end("Hi from router"));
```

my requests was getting stuck and never returned.
After further investigation I found that the class `ResumingRouter` https://github.com/quarkusio/quarkus/blob/master/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ResumingRouter.java wasn't properly implemented and after the call to `consumes(...` the underliying router was returned instead of the `ResumingRouter`, this lead into the unexpected behaviour I described above but many other things could be affected.

I have a reproducer for this error here https://github.com/famartinrh/quarkus-with-vertx-web
It can be easily tested running 
`curl -v -H "Content-Type:application/json" -X POST localhost:8080/hi/bug -d "hello world"`

This PR fixes the incorrected implementation of the delegation in the class `ResumingRouter` and adds some modifications to related tests to cover the usecase

Special thanks to my mate @juazugas for helping me with the troubleshooting