### PR TITLE
Update Kotlin and Scala gradle templates to match Java template

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}")
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/build.gradle-template.ftl
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}")
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -192,7 +192,9 @@ public class GradleBuildFile extends BuildFile {
 
     @Override
     protected boolean containsBOM() throws IOException {
-        return getModel().getBuildContent().contains("enforcedPlatform(\"${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:");
+    	String buildContent = getModel().getBuildContent();
+        return buildContent.contains("enforcedPlatform(\"${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:")
+        		|| buildContent.contains("enforcedPlatform(\"" + MojoUtils.getBomGroupId() + ":" + MojoUtils.getBomArtifactId() + ":");
     }
 
     @Override


### PR DESCRIPTION
Fixes #5251

The quarkus platform bom has changed a bit from `quarkus-bom` to `quarkus-universe-bom`, and additionally the Java templates have been updated to use properties instead of hardcoded values. The code in `io.quarkus.cli.commands.file.GradleBuildFile.containsBOM()` depends on these properties being used.

This PR does 2 things:
1. Updates the Kotlin and Scala templates to use the variables for the bom
2. Adds toleration to the resolved property variables in case we ever decide to not use properties or if this code gets called after the properties have been completed

I couldn't write a good test for this issue in this repo, so I have opened a PR in the code.quarkus repo here:
https://github.com/quarkusio/code.quarkus.io/pull/226

*NOTE TO REVIEWER:*
Please also view the corresponding code.quarkus PR with this PR