### PR TITLE
Provide a way to set the TCCL in @BuildStep

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildStep.java
@@ -104,4 +104,20 @@ public @interface BuildStep {
      * @return the supplier class array
      */
     Class<? extends BooleanSupplier>[] onlyIfNot() default {};
+
+    /**
+     * If this is set to true then the build step will be run with a TCCL that can load user
+     * classes from the deployment in a transformer safe way.
+     *
+     * This ClassLoader will only last for the life of the augmentation run, and then will be discarded,
+     * these classes will be loaded again in a different class loader on startup. This means that loading
+     * a class during augmentation does not stop it from being transformed when running in dev or test
+     * mode.
+     *
+     * The ClassLoader will be the one provided by {@link io.quarkus.deployment.builditem.DeploymentClassLoaderBuildItem},
+     * and an implicit dependency on this build item will be created.
+     *
+     * @return <code>true</code> if this build step wants to load deployment classes
+     */
+    boolean loadsApplicationClasses() default false;
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -34,7 +34,8 @@ public class ClassTransformingBuildStep {
 
     private static final Logger log = Logger.getLogger(ClassTransformingBuildStep.class);
 
-    @BuildStep
+    //we specify loadsApplicationClasses=true in case the transformation process attempts to load app classes
+    @BuildStep(loadsApplicationClasses = true)
     TransformedClassesBuildItem handleClassTransformation(List<BytecodeTransformerBuildItem> bytecodeTransformerBuildItems,
             ApplicationArchivesBuildItem appArchives) throws ExecutionException, InterruptedException {
         if (bytecodeTransformerBuildItems.isEmpty()) {

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -41,7 +41,6 @@ import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.DeploymentClassLoaderBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -195,15 +194,14 @@ public class SmallRyeReactiveMessagingProcessor {
                         new BeanClassAnnotationExclusion(io.quarkus.smallrye.reactivemessaging.deployment.DotNames.OUTGOING)));
     }
 
-    @BuildStep
+    @BuildStep(loadsApplicationClasses = true)
     @Record(STATIC_INIT)
     public void build(SmallRyeReactiveMessagingRecorder recorder, RecorderContext recorderContext,
             BeanContainerBuildItem beanContainer,
             List<MediatorBuildItem> mediatorMethods,
             List<EmitterBuildItem> emitterFields,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            DeploymentClassLoaderBuildItem deploymentClassLoaderBuildItem) {
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
 
         List<QuarkusMediatorConfiguration> configurations = new ArrayList<>(mediatorMethods.size());
 
@@ -232,7 +230,7 @@ public class SmallRyeReactiveMessagingProcessor {
 
             try {
                 QuarkusMediatorConfiguration mediatorConfiguration = QuarkusMediatorConfigurationUtil.create(methodInfo, bean,
-                        generatedInvokerName, recorderContext, deploymentClassLoaderBuildItem.getClassLoader());
+                        generatedInvokerName, recorderContext, Thread.currentThread().getContextClassLoader());
                 configurations.add(mediatorConfiguration);
             } catch (IllegalArgumentException e) {
                 throw new DeploymentException(e); // needed to pass the TCK


### PR DESCRIPTION
This allows for the TCCL to automatically set the TCCL
in a build step. We can't do it for everyone as the metadata
needed to build this CL is created by @BuildStep methods.

Any build step that needs to load application classes should
use this flag to get a transformation safe ClassLoader.