### PR TITLE
Fix NPE when processing a @WebServlet which has additional annotations other than @ServletSecurity

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -347,9 +347,9 @@ public class UndertowBuildStep {
                 // Map the @ServletSecurity annotations
                 if (webMetaData.getAnnotations() != null) {
                     for (AnnotationMetaData amd : webMetaData.getAnnotations()) {
-                        if (amd.getClassName().equals(servlet.getServletClass())) {
+                        final ServletSecurityMetaData ssmd = amd.getServletSecurity();
+                        if (ssmd != null && amd.getClassName().equals(servlet.getServletClass())) {
                             // Process the @ServletSecurity into metadata
-                            ServletSecurityMetaData ssmd = amd.getServletSecurity();
                             ServletSecurityInfo securityInfo = new ServletSecurityInfo();
                             securityInfo.setEmptyRoleSemantic(
                                     ssmd.getEmptyRoleSemantic() == EmptyRoleSemanticType.DENY ? DENY : PERMIT);

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServlet.java
@@ -1,0 +1,29 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.annotation.security.RunAs;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+@WebServlet(urlPatterns = AnnotatedServlet.SERVLET_ENDPOINT)
+// we aren't really interested in testing the RunAs feature, instead this is there to reproduce
+// a NPE https://github.com/quarkusio/quarkus/issues/5293
+@RunAs("dummy")
+public class AnnotatedServlet extends HttpServlet {
+
+    public static final String SERVLET_ENDPOINT = "/plainAnnotatedServlet";
+
+    public static final String OK_RESPONSE = "Success";
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().write(OK_RESPONSE);
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServletTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServletTestCase.java
@@ -1,0 +1,35 @@
+package io.quarkus.undertow.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ *
+ */
+public class AnnotatedServletTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AnnotatedServlet.class));
+
+    /**
+     * Tests the issue noted in https://github.com/quarkusio/quarkus/issues/5293
+     * where {@code UndertowBuildStep} would throw an NPE when the annotated servlet
+     * had additional annotation(s) but not the {@code @ServletSecurity} annotation
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNPE() throws Exception {
+        when().get(AnnotatedServlet.SERVLET_ENDPOINT).then()
+                .statusCode(200)
+                .body(is(AnnotatedServlet.OK_RESPONSE));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/5293

This commit adds a check to see if `@ServletSecurity` annotation is indeed present, before starting to process its details. This also includes a test case which reproduces the issue and verifies the fix.