### PR TITLE
Fixes #5286 - DynamoDB: split config into build & runtime configs.

### DIFF
--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/BadInterceptor.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/BadInterceptor.java
@@ -1,0 +1,5 @@
+package io.quarkus.dynamodb.deployment;
+
+public class BadInterceptor {
+    //Empty class to represent Interceptor but not implementing ExecutionInterceptor interface.
+}

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbAsyncClientBrokenProxyConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbAsyncClientBrokenProxyConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.dynamodb.runtime.RuntimeConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
@@ -19,7 +19,7 @@ public class DynamodbAsyncClientBrokenProxyConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setExpectedException(ConfigurationError.class)
+            .setExpectedException(RuntimeConfigurationError.class)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("async-broken-proxy-config.properties", "application.properties"));
 

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbMissingInterceptorConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbMissingInterceptorConfigTest.java
@@ -8,28 +8,23 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.dynamodb.runtime.RuntimeConfigurationError;
+import io.quarkus.deployment.configuration.ConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-public class DynamodbBrokenEndpointConfigTest {
-
-    @Inject
-    DynamoDbClient sync;
+public class DynamodbMissingInterceptorConfigTest {
 
     @Inject
-    DynamoDbAsyncClient async;
+    DynamoDbAsyncClient client;
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setExpectedException(RuntimeConfigurationError.class)
+            .setExpectedException(ConfigurationError.class)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("broken-endpoint-config.properties", "application.properties"));
+                    .addAsResource("missing-interceptor-config.properties", "application.properties"));
 
     @Test
     public void test() {
-        // should not be called, deployment exception should happen first.
         Assertions.fail();
     }
 }

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbProcessCredentialsBrokenConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbProcessCredentialsBrokenConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.dynamodb.runtime.RuntimeConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -23,7 +23,7 @@ public class DynamodbProcessCredentialsBrokenConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setExpectedException(ConfigurationError.class)
+            .setExpectedException(RuntimeConfigurationError.class)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("process-credentials-broken-config.properties", "application.properties"));
 

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbStaticCredentialsBrokenConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbStaticCredentialsBrokenConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.dynamodb.runtime.RuntimeConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -23,7 +23,7 @@ public class DynamodbStaticCredentialsBrokenConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setExpectedException(ConfigurationError.class)
+            .setExpectedException(RuntimeConfigurationError.class)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("static-credentials-broken-config.properties", "application.properties"));
 

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbSyncApacheClientBrokenConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbSyncApacheClientBrokenConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.dynamodb.runtime.RuntimeConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -19,14 +19,12 @@ public class DynamodbSyncApacheClientBrokenConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setExpectedException(ConfigurationError.class)
+            .setExpectedException(RuntimeConfigurationError.class)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("sync-apache-broken-config.properties", "application.properties"));
 
     @Test
     public void test() {
-        // should not be called, deployment exception should happen first:
-        // it's illegal to use STATIC credentials resolver without access key and secret key
         Assertions.fail();
     }
 }

--- a/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbSyncApacheClientBrokenProxyConfigTest.java
+++ b/extensions/amazon-dynamodb/deployment/src/test/java/io/quarkus/dynamodb/deployment/DynamodbSyncApacheClientBrokenProxyConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.dynamodb.runtime.RuntimeConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -19,13 +19,12 @@ public class DynamodbSyncApacheClientBrokenProxyConfigTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setExpectedException(ConfigurationError.class)
+            .setExpectedException(RuntimeConfigurationError.class)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("sync-apache-broken-proxy-config.properties", "application.properties"));
 
     @Test
     public void test() {
-        // should not be called, deployment exception should happen first.
         Assertions.fail();
     }
 }

--- a/extensions/amazon-dynamodb/deployment/src/test/resources/missing-interceptor-config.properties
+++ b/extensions/amazon-dynamodb/deployment/src/test/resources/missing-interceptor-config.properties
@@ -1,0 +1,1 @@
+quarkus.dynamodb.interceptors=io.quarkus.dynamodb.deployment.BadInterceptor

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbBuildTimeConfig.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbBuildTimeConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.dynamodb.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "dynamodb", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class DynamodbBuildTimeConfig {
+
+    /**
+     * SDK client configurations
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public SdkBuildTimeConfig sdk;
+
+    /**
+     * Sync client transport configuration
+     */
+    @ConfigItem(name = "sync-client")
+    public SyncHttpClientBuildTimeConfig syncClient;
+}

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbRecorder.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/DynamodbRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.dynamodb.runtime;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -11,8 +12,15 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 @Recorder
 public class DynamodbRecorder {
 
+    public BeanContainerListener setDynamodbBuildConfig(DynamodbBuildTimeConfig buildConfig) {
+        return beanContainer -> {
+            DynamodbClientProducer producer = beanContainer.instance(DynamodbClientProducer.class);
+            producer.setBuildTimeConfig(buildConfig);
+        };
+    }
+
     public void configureRuntimeConfig(DynamodbConfig dynamodbConfig) {
-        Arc.container().instance(DynamodbClientProducer.class).get().setConfig(dynamodbConfig);
+        Arc.container().instance(DynamodbClientProducer.class).get().setRuntimeConfig(dynamodbConfig);
     }
 
     public RuntimeValue<DynamoDbClient> createClient(

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/RuntimeConfigurationError.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/RuntimeConfigurationError.java
@@ -1,0 +1,8 @@
+package io.quarkus.dynamodb.runtime;
+
+public class RuntimeConfigurationError extends RuntimeException {
+
+    public RuntimeConfigurationError(String message) {
+        super(message);
+    }
+}

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SdkBuildTimeConfig.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SdkBuildTimeConfig.java
@@ -1,0 +1,24 @@
+package io.quarkus.dynamodb.runtime;
+
+import java.util.List;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * AWS SDK specific build time configurations
+ */
+@ConfigGroup
+public class SdkBuildTimeConfig {
+    /**
+     * List of execution interceptors that will have access to read and modify the request and response objects as they are
+     * processed by the AWS SDK.
+     * <p>
+     * The list should consists of class names which implements
+     * {@code software.amazon.awssdk.core.interceptor.ExecutionInterceptor} interface.
+     *
+     * @see software.amazon.awssdk.core.interceptor.ExecutionInterceptor
+     */
+    @ConfigItem
+    public List<Class<?>> interceptors;
+}

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SdkConfig.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SdkConfig.java
@@ -2,7 +2,6 @@ package io.quarkus.dynamodb.runtime;
 
 import java.net.URI;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -43,21 +42,4 @@ public class SdkConfig {
      */
     @ConfigItem
     public Optional<Duration> apiCallAttemptTimeout;
-
-    /**
-     * List of execution interceptors that will have access to read and modify the request and response objects as they are
-     * processed by the AWS SDK.
-     * <p>
-     * The list should consists of class names which implements
-     * {@code software.amazon.awssdk.core.interceptor.ExecutionInterceptor} interface.
-     *
-     * @see software.amazon.awssdk.core.interceptor.ExecutionInterceptor
-     */
-    @ConfigItem
-    public List<Class<?>> interceptors;
-
-    public boolean isClientOverrideConfig() {
-        return apiCallTimeout.isPresent() || apiCallAttemptTimeout.isPresent()
-                || (interceptors != null && !interceptors.isEmpty());
-    }
 }

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SyncHttpClientBuildTimeConfig.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SyncHttpClientBuildTimeConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.dynamodb.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class SyncHttpClientBuildTimeConfig {
+
+    /**
+     * Type of the sync HTTP client implementation
+     */
+    @ConfigItem(defaultValue = "url")
+    public SyncClientType type;
+
+    public enum SyncClientType {
+        URL,
+        APACHE
+    }
+}

--- a/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SyncHttpClientConfig.java
+++ b/extensions/amazon-dynamodb/runtime/src/main/java/io/quarkus/dynamodb/runtime/SyncHttpClientConfig.java
@@ -10,13 +10,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
 public class SyncHttpClientConfig {
-
-    /**
-     * Type of the sync HTTP client implementation
-     */
-    @ConfigItem(defaultValue = "url")
-    public SyncClientType type;
-
     /**
      * The maximum amount of time to establish a connection before timing out.
      */
@@ -148,10 +141,5 @@ public class SyncHttpClientConfig {
             @ConfigItem
             public List<String> nonProxyHosts;
         }
-    }
-
-    public enum SyncClientType {
-        URL,
-        APACHE
     }
 }


### PR DESCRIPTION
Fix for #5286

- Extracted two properties into the build level (Interceptors & sync client type)
- Refactored validation on the build time for build time props only
- Moved runtime config validations on the processor level.

/cc @gsmet @dmlloyd 