### PR TITLE
fix: remove unsupported native-image flags

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -92,18 +92,6 @@ public class NativeConfig {
     public boolean cleanupServer;
 
     /**
-     * This will report on the size of the retained heap after image build
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableRetainedHeapReporting;
-
-    /**
-     * This enables reporting of the code size of the native image
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean enableCodeSizeReporting;
-
-    /**
      * If isolates should be enabled
      */
     @ConfigItem(defaultValue = "true")

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -232,12 +232,7 @@ public class NativeImageBuildStep {
             if (!noPIE.isEmpty()) {
                 command.add("-H:NativeLinkerOption=" + noPIE);
             }
-            if (nativeConfig.enableRetainedHeapReporting) {
-                command.add("-H:+PrintRetainedHeapHistogram");
-            }
-            if (nativeConfig.enableCodeSizeReporting) {
-                command.add("-H:+PrintCodeSizeReport");
-            }
+
             if (!nativeConfig.enableIsolates) {
                 command.add("-H:-SpawnIsolates");
             }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -44,11 +44,7 @@ public class QuarkusNative extends QuarkusTask {
 
     private boolean enableAllSecurityServices;
 
-    private boolean enableRetainedHeapReporting;
-
     private boolean enableIsolates;
-
-    private boolean enableCodeSizeReporting;
 
     private String graalvmHome = System.getenv("GRAALVM_HOME");
 
@@ -189,17 +185,6 @@ public class QuarkusNative extends QuarkusTask {
 
     @Optional
     @Input
-    public boolean isEnableRetainedHeapReporting() {
-        return enableRetainedHeapReporting;
-    }
-
-    @Option(description = "Specify if retained heap reporting should be enabled", option = "enable-retained-heap-reporting")
-    public void setEnableRetainedHeapReporting(boolean enableRetainedHeapReporting) {
-        this.enableRetainedHeapReporting = enableRetainedHeapReporting;
-    }
-
-    @Optional
-    @Input
     public boolean isEnableIsolates() {
         return enableIsolates;
     }
@@ -207,17 +192,6 @@ public class QuarkusNative extends QuarkusTask {
     @Option(description = "Report errors at runtime", option = "enable-isolates")
     public void setEnableIsolates(boolean enableIsolates) {
         this.enableIsolates = enableIsolates;
-    }
-
-    @Optional
-    @Input
-    public boolean isEnableCodeSizeReporting() {
-        return enableCodeSizeReporting;
-    }
-
-    @Option(description = "Report errors at runtime", option = "enable-code-size-reporting")
-    public void setEnableCodeSizeReporting(boolean enableCodeSizeReporting) {
-        this.enableCodeSizeReporting = enableCodeSizeReporting;
     }
 
     @Optional
@@ -464,14 +438,12 @@ public class QuarkusNative extends QuarkusTask {
                 }
                 configs.add("quarkus.native.dump-proxies", dumpProxies);
                 configs.add("quarkus.native.enable-all-security-services", enableAllSecurityServices);
-                configs.add("quarkus.native.enable-code-size-reporting", enableCodeSizeReporting);
                 configs.add("quarkus.native.enable-fallback-images", enableFallbackImages);
                 configs.add("quarkus.native.enable-https-url-handler", enableHttpsUrlHandler);
 
                 configs.add("quarkus.native.enable-http-url-handler", enableHttpUrlHandler);
                 configs.add("quarkus.native.enable-isolates", enableIsolates);
                 configs.add("quarkus.native.enable-jni", enableJni);
-                configs.add("quarkus.native.enable-retained-heap-reporting", enableRetainedHeapReporting);
 
                 configs.add("quarkus.native.enable-server", enableServer);
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -92,13 +92,7 @@ public class NativeImageMojo extends AbstractMojo {
     private Boolean enableAllSecurityServices;
 
     @Parameter
-    private Boolean enableRetainedHeapReporting;
-
-    @Parameter
     private Boolean enableIsolates;
-
-    @Parameter
-    private Boolean enableCodeSizeReporting;
 
     @Parameter(defaultValue = "${env.GRAALVM_HOME}")
     private String graalvmHome;
@@ -365,9 +359,6 @@ public class NativeImageMojo extends AbstractMojo {
                 if (enableAllSecurityServices != null) {
                     configs.add("quarkus.native.enable-all-security-services", enableAllSecurityServices.toString());
                 }
-                if (enableCodeSizeReporting != null) {
-                    configs.add("quarkus.native.enable-code-size-reporting", enableCodeSizeReporting.toString());
-                }
                 if (enableFallbackImages != null) {
                     configs.add("quarkus.native.enable-fallback-images", enableFallbackImages.toString());
                 }
@@ -383,12 +374,11 @@ public class NativeImageMojo extends AbstractMojo {
                 if (enableJni != null) {
                     configs.add("quarkus.native.enable-jni", enableJni.toString());
                 }
-                if (enableRetainedHeapReporting != null) {
-                    configs.add("quarkus.native.enable-retained-heap-reporting", enableRetainedHeapReporting.toString());
-                }
+
                 if (enableServer != null) {
                     configs.add("quarkus.native.enable-server", enableServer.toString());
                 }
+
                 if (enableVMInspection != null) {
                     configs.add("quarkus.native.enable-vm-inspection", enableVMInspection.toString());
                 }
@@ -396,13 +386,13 @@ public class NativeImageMojo extends AbstractMojo {
                     configs.add("quarkus.native.full-stack-traces", fullStackTraces.toString());
                 }
                 if (graalvmHome != null && !graalvmHome.trim().isEmpty()) {
-                    configs.add("quarkus.native.graalvm-home", graalvmHome.toString());
+                    configs.add("quarkus.native.graalvm-home", graalvmHome);
                 }
                 if (javaHome != null && !javaHome.toString().isEmpty()) {
                     configs.add("quarkus.native.java-home", javaHome.toString());
                 }
                 if (nativeImageXmx != null && !nativeImageXmx.trim().isEmpty()) {
-                    configs.add("quarkus.native.native-image-xmx", nativeImageXmx.toString());
+                    configs.add("quarkus.native.native-image-xmx", nativeImageXmx);
                 }
                 if (reportErrorsAtRuntime != null) {
                     configs.add("quarkus.native.report-errors-at-runtime", reportErrorsAtRuntime.toString());

--- a/integration-tests/artemis-core/pom.xml
+++ b/integration-tests/artemis-core/pom.xml
@@ -120,10 +120,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/artemis-jms/pom.xml
+++ b/integration-tests/artemis-jms/pom.xml
@@ -120,10 +120,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/elytron-security-oauth2/pom.xml
+++ b/integration-tests/elytron-security-oauth2/pom.xml
@@ -120,10 +120,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/elytron-security/pom.xml
+++ b/integration-tests/elytron-security/pom.xml
@@ -109,10 +109,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -131,10 +131,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                 </configuration>

--- a/integration-tests/hibernate-search-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-elasticsearch/pom.xml
@@ -184,10 +184,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Protean Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -121,10 +121,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                 </configuration>

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -104,7 +104,7 @@
                 </plugins>
             </build>
         </profile>
-    
+
         <profile>
             <id>native-image</id>
             <activation>
@@ -147,10 +147,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -147,10 +147,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -99,7 +99,7 @@
                 </plugins>
             </build>
         </profile>
-    
+
         <profile>
             <id>native-image</id>
             <activation>
@@ -142,10 +142,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                 </configuration>

--- a/integration-tests/jsonb/pom.xml
+++ b/integration-tests/jsonb/pom.xml
@@ -97,10 +97,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -133,10 +133,6 @@
                                 <configuration>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/keycloak-authorization/pom.xml
+++ b/integration-tests/keycloak-authorization/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
     </properties>
-  
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -164,10 +164,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
@@ -207,8 +203,8 @@
                                             <KEYCLOAK_USER>admin</KEYCLOAK_USER>
                                             <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
                                             <JAVA_OPTS>
-                                                -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m                                                      -Djava.net.preferIPv4Stack=true 
-                                                -Djava.awt.headless=true  
+                                                -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m                                                      -Djava.net.preferIPv4Stack=true
+                                                -Djava.awt.headless=true
                                                 -Dkeycloak.profile.feature.upload_scripts=enabled
                                             </JAVA_OPTS>
                                         </env>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -242,10 +242,6 @@
                                     <addAllCharsets>true</addAllCharsets>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>
                             </execution>

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -18,7 +18,7 @@
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
         <htmlunit.version>2.36.0</htmlunit.version>
     </properties>
-  
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -187,10 +187,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
     </properties>
-  
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -170,10 +170,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>

--- a/integration-tests/test-extension/pom.xml
+++ b/integration-tests/test-extension/pom.xml
@@ -102,10 +102,6 @@
                 <configuration>
                   <cleanupServer>true</cleanupServer>
                   <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                    <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                    <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                  -->
                   <graalvmHome>${graalvmHome}</graalvmHome>
                 </configuration>
               </execution>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -171,10 +171,6 @@
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
-                                    <!-- Requires Quarkus Graal fork to work, will fail otherwise
-                                      <enableRetainedHeapReporting>true</enableRetainedHeapReporting>
-                                      <enableCodeSizeReporting>true</enableCodeSizeReporting>
-                                    -->
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                     <enableJni>false</enableJni>
                                 </configuration>


### PR DESCRIPTION
This remove the enableRetainedHeapReporting i.e -H:+PrintRetainedHeapHistogram and
enableCodeSizeReporting i.e -H:+PrintCodeSizeReport

fixes #5324