### PR TITLE
Entity-less native compilation failures

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -107,6 +107,16 @@ public final class HibernateOrmProcessor {
      */
     HibernateOrmConfig hibernateConfig;
 
+    // We do our own enhancement during the compilation phase, so disable any
+    // automatic entity enhancement by Hibernate ORM
+    // This has to happen before Hibernate ORM classes are initialized: see
+    // org.hibernate.cfg.Environment#BYTECODE_PROVIDER_INSTANCE
+    @BuildStep
+    public SystemPropertyBuildItem enforceDisableRuntimeEnhancer() {
+        return new SystemPropertyBuildItem(AvailableSettings.BYTECODE_PROVIDER,
+                org.hibernate.cfg.Environment.BYTECODE_PROVIDER_NAME_NONE);
+    }
+
     @BuildStep
     List<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles(LaunchModeBuildItem launchMode) {
         List<HotDeploymentWatchedFileBuildItem> watchedFiles = new ArrayList<>();

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -170,12 +170,13 @@ public final class HibernateOrmProcessor {
         // remember how to run the enhancers later
         domainObjectsProducer.produce(domainObjects);
 
-        if (!hasEntities(domainObjects, nonJpaModelBuildItems)) {
+        final boolean enableORM = hasEntities(domainObjects, nonJpaModelBuildItems);
+        recorder.callHibernateFeatureInit(enableORM);
+
+        if (!enableORM) {
             // we can bail out early
             return;
         }
-
-        recorder.callHibernateFeatureInit();
 
         // handle the implicit persistence unit
         List<ParsedPersistenceXmlDescriptor> allDescriptors = new ArrayList<>(explicitDescriptors.size() + 1);

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/Hibernate.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/Hibernate.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.orm.runtime;
 
-import org.hibernate.cfg.AvailableSettings;
 import org.jboss.logging.Logger;
 
 public class Hibernate {
@@ -9,13 +8,6 @@ public class Hibernate {
         // Override the JPA persistence unit resolver so to use our custom boot
         // strategy:
         PersistenceProviderSetup.registerPersistenceProvider();
-
-        // We do our own enhancement during the compilation phase, so disable any
-        // automatic entity enhancement by Hibernate ORM
-        // This has to happen before Hibernate ORM classes are initialized: see
-        // org.hibernate.cfg.Environment#BYTECODE_PROVIDER_INSTANCE
-        System.setProperty(AvailableSettings.BYTECODE_PROVIDER,
-                org.hibernate.cfg.Environment.BYTECODE_PROVIDER_NAME_NONE);
     }
 
     public static void featureInit(boolean enabled) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/Hibernate.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/Hibernate.java
@@ -18,8 +18,10 @@ public class Hibernate {
                 org.hibernate.cfg.Environment.BYTECODE_PROVIDER_NAME_NONE);
     }
 
-    public static void featureInit() {
-        Logger.getLogger("org.hibernate.quarkus.feature").debug("Hibernate Features Enabled");
+    public static void featureInit(boolean enabled) {
+        if (enabled) {
+            Logger.getLogger("org.hibernate.quarkus.feature").debug("Hibernate Features Enabled");
+        }
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -30,8 +30,13 @@ public class HibernateOrmRecorder {
         Logger.getLogger("io.quarkus.hibernate.orm").debugf("List of entities found by Quarkus deployment:%n%s", entities);
     }
 
-    public void callHibernateFeatureInit() {
-        Hibernate.featureInit();
+    /**
+     * The feature needs to be initialized, even if it's not enabled.
+     *
+     * @param enabled Set to false if it's not being enabled, to log appropriately.
+     */
+    public void callHibernateFeatureInit(boolean enabled) {
+        Hibernate.featureInit(enabled);
     }
 
     public BeanContainerListener initializeJpa(boolean jtaEnabled) {

--- a/integration-tests/jpa-without-entity/pom.xml
+++ b/integration-tests/jpa-without-entity/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-jpa-without-entity</artifactId>
+
+    <name>Quarkus - Integration Tests - JPA without entities</name>
+    <description>Verifies against odd problems which manifest when there are no entities</description>
+    <dependencies>
+        <!-- Include the JPA extensions
+            but we'll intentionally not use it:
+            verify that this is ok -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+
+        <!-- All other test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
+                                    <debugBuildProcess>false</debugBuildProcess>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
+
+</project>

--- a/integration-tests/jpa-without-entity/src/main/java/org/test/HelloResource.java
+++ b/integration-tests/jpa-without-entity/src/main/java/org/test/HelloResource.java
@@ -1,0 +1,16 @@
+package org.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/y")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/jpa-without-entity/src/test/java/org/test/HelloResourceTest.java
+++ b/integration-tests/jpa-without-entity/src/test/java/org/test/HelloResourceTest.java
@@ -1,0 +1,22 @@
+package org.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class HelloResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+                .when().get("/y")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
+    }
+
+}

--- a/integration-tests/jpa-without-entity/src/test/java/org/test/NativeHelloResourceIT.java
+++ b/integration-tests/jpa-without-entity/src/test/java/org/test/NativeHelloResourceIT.java
@@ -1,0 +1,9 @@
+package org.test;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeHelloResourceIT extends HelloResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -85,6 +85,7 @@
         <module>narayana-jta</module>
         <module>elytron-security-jdbc</module>
         <module>vertx-graphql</module>
+        <module>jpa-without-entity</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Fixes #2482 and Fixes #5262 

The culprit was the fact that when there's no entities, we'd bail out early.

In fact we'd abort a little too early, as it would by-pass setting a couple of key static fields which I had intentionally crafted to guide the code analysis of the native-image compiler.

Example symptoms include issues which seem related to entirely different components, such as:

```
Trace:
	at parsing java.lang.System$2.getConstantPool(System.java:1227)
Call path from entry point to java.lang.System$2.getConstantPool(Class):
	at java.lang.System$2.getConstantPool(System.java:1227)
	at sun.reflect.annotation.TypeAnnotationParser.parseAllTypeAnnotations(TypeAnnotationParser.java:323)
	at sun.reflect.annotation.TypeAnnotationParser.fetchBounds(TypeAnnotationParser.java:299)
	at sun.reflect.annotation.TypeAnnotationParser.parseAnnotatedBounds(TypeAnnotationParser.java:244)
	at sun.reflect.annotation.TypeAnnotationParser.parseAnnotatedBounds(TypeAnnotationParser.java:237)
	at sun.reflect.generics.reflectiveObjects.TypeVariableImpl.getAnnotatedBounds(TypeVariableImpl.java:241)
	at com.oracle.svm.reflect.TypeVariable_getAnnotatedBounds_88ea462da2b17ea45028db307519aaeeec9a4036_776.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.resteasy.core.ContextParameterInjector$GenericDelegatingProxy.invoke(ContextParameterInjector.java:118)
	at com.sun.proxy.$Proxy225.hashCode(Unknown Source)
	at java.util.HashMap.hash(HashMap.java:339)
	at java.util.HashMap.get(HashMap.java:557)
```


I've also seen this manifest as failures around:
 - JTA logging system, which defines an illegal invocationhandler during initialization
 - Various Byte Buddy helpers doing illegal stuff like reading annotation parameters in `toString()`, `equals()` and `hashcode` implementations
 - the RESTEasy default invocation handler attempting to define a class
 - (unexplained) attempts to load `javax/security/jacc/PolicyContextException`
 - failure as it would reach `io.undertow.protocols.alpn.OpenSSLAlpnProvider.setProtocols`
 - .. !

The most puzzling failure I got was this one:

```
        at java.lang.reflect.Method.invoke(Method.java:498)
        at javax.enterprise.util.AnnotationLiteral.invoke(AnnotationLiteral.java:288)
        at javax.enterprise.util.AnnotationLiteral.getMemberValue(AnnotationLiteral.java:276)
        at javax.enterprise.util.AnnotationLiteral.toString(AnnotationLiteral.java:135)
        at java.lang.String.valueOf(String.java:2994)
        at java.lang.StringBuilder.append(StringBuilder.java:131)
        at com.oracle.svm.core.amd64.AMD64CPUFeatureAccess.verifyHostSupportsArchitecture
```

at which I almost gave up :1234: :confused: 