### PR TITLE
Include the original exception that caused classloading to fail

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
@@ -67,7 +67,7 @@ public class ConfigRecorder {
         try {
             return Class.forName(className, true, cl);
         } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Unable to load the config property type: " + className);
+            throw new IllegalStateException("Unable to load the config property type: " + className, e);
         }
     }
 


### PR DESCRIPTION
This is a very trivial change to include the original exception that caused the classloading to fail. 