### PR TITLE
ZipResourceLoader fix to compile with Java 13

### DIFF
--- a/independent-projects/tools/common/src/main/java/io/quarkus/platform/descriptor/loader/json/ZipResourceLoader.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/platform/descriptor/loader/json/ZipResourceLoader.java
@@ -19,7 +19,7 @@ public class ZipResourceLoader implements ResourceLoader {
 
     @Override
     public <T> T loadResource(String name, ResourceInputStreamConsumer<T> consumer) throws IOException {
-        try(FileSystem fs = FileSystems.newFileSystem(zip, null)) {
+        try(FileSystem fs = FileSystems.newFileSystem(zip, (ClassLoader) null)) {
             final Path p = fs.getPath("/", name);
             if(!Files.exists(p)) {
                 throw new IOException("Failed to locate " + name + " in " + zip);


### PR DESCRIPTION
ZipResourceLoader fix to compile with Java 13

https://docs.oracle.com/en/java/javase/13/docs/api/java.base/java/nio/file/FileSystems.html#newFileSystem(java.nio.file.Path,java.util.Map) is new in Java 13