### PR TITLE
Add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,15 @@
+ADOPTERS
+========
+
+PUBLIC REFERENCES
+-----------------
+
+This document lists the organizations that use Quarkus based on public information available in blog posts and videos. 
+If any organization would like get added or removed please make a pull request by following these guidelines:
+
+* Please don't include your organization's logo or other trademarked material
+* Add a reference (link to a public blog post, video, slides, etc) mentioning that Quarkus is used
+
+| Organization |  Reference |
+|--------------|------------|
+|GoWithFlow    | https://quarkus.io/blog/gowithflow-chooses-quarkus-to-deliver-fast-to-production/ |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ pr:
       - docs/src/main/asciidoc/images/*
       - README.md
       - CONTRIBUTING.md
+      - ADOPTERS.md
       - LICENSE.txt
       - dco.txt
       - .github/ISSUE_TEMPLATE/*.md


### PR DESCRIPTION
Based on the conversation in Zulip with @maxandersen, and based on https://github.com/keycloak/keycloak/blob/master/ADOPTERS.md, this PR adds an `ADOPTERS.md` file containing a list of organizations that publicly use Quarkus 

/cc @emmanuelbernard @maxandersen @cescoffier