### PR TITLE
Lazily recompute Inet4Address, Inet6Address and CidrAddress fields at runtime

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigurationSetup.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigurationSetup.java
@@ -77,6 +77,7 @@ import io.quarkus.runtime.configuration.HyphenateEnumConverter;
 import io.quarkus.runtime.configuration.NameIterator;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.runtime.configuration.SimpleConfigurationProviderResolver;
+import io.quarkus.runtime.graal.InetRunTime;
 import io.smallrye.config.Converters;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
@@ -820,5 +821,10 @@ public class ConfigurationSetup {
 
     ) {
 
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitializedClass() {
+        return new RuntimeInitializedClassBuildItem(InetRunTime.class.getName());
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/CidrAddressSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/CidrAddressSubstitutions.java
@@ -1,0 +1,91 @@
+package io.quarkus.runtime.graal;
+
+import java.net.InetAddress;
+
+import org.wildfly.common.net.CidrAddress;
+import org.wildfly.common.net.Inet;
+
+import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.InjectAccessors;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.runtime.graal.Target_org_wildfly_common_net_CidrAddress.CidrAddressUtil;
+
+/*
+ * The following substitutions are required because of a new restriction in GraalVM 19.3.0 that prohibits the presence of
+ * java.net.Inet4Address and java.net.Inet6Address in the image heap. Each field annotated with @InjectAccessors is lazily
+ * recomputed at runtime on first access while CidrAddress.class can still be initialized during the native image build.
+ */
+@TargetClass(CidrAddress.class)
+final class Target_org_wildfly_common_net_CidrAddress {
+
+    @Alias
+    private Target_org_wildfly_common_net_CidrAddress(InetAddress networkAddress, int netmaskBits) {
+    }
+
+    @Alias
+    @InjectAccessors(Inet4AnyCidrAccessor.class)
+    public static CidrAddress INET4_ANY_CIDR;
+
+    @Alias
+    @InjectAccessors(Inet6AnyCidrAccessor.class)
+    public static CidrAddress INET6_ANY_CIDR;
+
+    static class CidrAddressUtil {
+        static CidrAddress newInstance(InetAddress networkAddress, int netmaskBits) {
+            return SubstrateUtil.cast(new Target_org_wildfly_common_net_CidrAddress(networkAddress, netmaskBits),
+                    CidrAddress.class);
+        }
+    }
+}
+
+class Inet4AnyCidrAccessor {
+
+    private static volatile CidrAddress INET4_ANY_CIDR;
+
+    static CidrAddress get() {
+        CidrAddress result = INET4_ANY_CIDR;
+        if (result == null) {
+            // Lazy initialization on first access.
+            result = initializeOnce();
+        }
+        return result;
+    }
+
+    private static synchronized CidrAddress initializeOnce() {
+        CidrAddress result = INET4_ANY_CIDR;
+        if (result != null) {
+            // Double-checked locking is OK because INSTANCE is volatile.
+            return result;
+        }
+        result = CidrAddressUtil.newInstance(Inet.INET4_ANY, 0);
+        INET4_ANY_CIDR = result;
+        return result;
+    }
+}
+
+class Inet6AnyCidrAccessor {
+
+    private static volatile CidrAddress INET6_ANY_CIDR;
+
+    static CidrAddress get() {
+        CidrAddress result = INET6_ANY_CIDR;
+        if (result == null) {
+            // Lazy initialization on first access.
+            result = initializeOnce();
+        }
+        return result;
+    }
+
+    private static synchronized CidrAddress initializeOnce() {
+        CidrAddress result = INET6_ANY_CIDR;
+        if (result != null) {
+            // Double-checked locking is OK because INSTANCE is volatile.
+            return result;
+        }
+        result = CidrAddressUtil.newInstance(Inet.INET6_ANY, 0);
+        INET6_ANY_CIDR = result;
+        return result;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/InetRunTime.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/InetRunTime.java
@@ -1,0 +1,14 @@
+package io.quarkus.runtime.graal;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+
+import org.wildfly.common.net.Inet;
+
+public class InetRunTime {
+    public static final Inet4Address INET4_ANY = Inet.getInet4Address(0, 0, 0, 0);
+    public static final Inet4Address INET4_LOOPBACK = Inet.getInet4Address(127, 0, 0, 1);
+    public static final Inet4Address INET4_BROADCAST = Inet.getInet4Address(255, 255, 255, 255);
+    public static final Inet6Address INET6_ANY = Inet.getInet6Address(0, 0, 0, 0, 0, 0, 0, 0);
+    public static final Inet6Address INET6_LOOPBACK = Inet.getInet6Address(0, 0, 0, 0, 0, 0, 0, 1);
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/InetSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/InetSubstitutions.java
@@ -1,0 +1,69 @@
+package io.quarkus.runtime.graal;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+
+import org.wildfly.common.net.Inet;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.InjectAccessors;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/*
+ * The following substitutions are required because of a new restriction in GraalVM 19.3.0 that prohibits the presence of
+ * java.net.Inet4Address and java.net.Inet6Address in the image heap. Each field annotated with @InjectAccessors is lazily
+ * recomputed at runtime on first access while Inet.class can still be initialized during the native image build.
+ */
+@TargetClass(Inet.class)
+final class Target_org_wildfly_common_net_Inet {
+
+    @Alias
+    @InjectAccessors(Inet4AnyAccessor.class)
+    public static Inet4Address INET4_ANY;
+
+    @Alias
+    @InjectAccessors(Inet4LoopbackAccessor.class)
+    public static Inet4Address INET4_LOOPBACK;
+
+    @Alias
+    @InjectAccessors(Inet4BroadcastAccessor.class)
+    public static Inet4Address INET4_BROADCAST;
+
+    @Alias
+    @InjectAccessors(Inet6AnyAccessor.class)
+    public static Inet6Address INET6_ANY;
+
+    @Alias
+    @InjectAccessors(Inet6LoopbackAccessor.class)
+    public static Inet6Address INET6_LOOPBACK;
+}
+
+final class Inet4AnyAccessor {
+    static Inet4Address get() {
+        return InetRunTime.INET4_ANY;
+    }
+}
+
+final class Inet4LoopbackAccessor {
+    static Inet4Address get() {
+        return InetRunTime.INET4_LOOPBACK;
+    }
+}
+
+final class Inet4BroadcastAccessor {
+    static Inet4Address get() {
+        return InetRunTime.INET4_BROADCAST;
+    }
+}
+
+final class Inet6AnyAccessor {
+    static Inet6Address get() {
+        return InetRunTime.INET6_ANY;
+    }
+}
+
+final class Inet6LoopbackAccessor {
+    static Inet6Address get() {
+        return InetRunTime.INET6_LOOPBACK;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/config/MicroProfileConfigResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/config/MicroProfileConfigResource.java
@@ -6,6 +6,7 @@ import javax.ws.rs.Path;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.wildfly.common.net.CidrAddress;
 
 /**
  * Test some MicroProfile config primitives.
@@ -18,6 +19,9 @@ public class MicroProfileConfigResource {
 
     @ConfigProperty(name = "microprofile.custom.value")
     MicroProfileCustomValue value;
+
+    @ConfigProperty(name = "microprofile.cidr-address")
+    CidrAddress cidrAddress;
 
     @Inject
     Config config;
@@ -35,5 +39,11 @@ public class MicroProfileConfigResource {
     @Path("/get-custom-value")
     public String getCustomValue() {
         return Integer.toString(value.getNumber());
+    }
+
+    @GET
+    @Path("/get-cidr-address")
+    public String getCidrAddress() {
+        return cidrAddress.getNetworkAddress().getHostAddress();
     }
 }

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -26,6 +26,7 @@ names=quarkus,redhat
 schedulerservice.cron.expr=0/10 * * * * ?
 
 microprofile.custom.value = 456
+microprofile.cidr-address=10.0.0.20/24
 configproperties.message=Hello
 configproperties.other=1
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MicroProfileConfigTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MicroProfileConfigTestCase.java
@@ -25,4 +25,11 @@ public class MicroProfileConfigTestCase {
                 .when().get("/microprofile-config/get-custom-value")
                 .then().body(is("456"));
     }
+
+    @Test
+    public void testCidrAddress() {
+        RestAssured
+                .when().get("/microprofile-config/get-cidr-address")
+                .then().body(is("10.0.0.0"));
+    }
 }


### PR DESCRIPTION
This PR is related to #4218 

It can be merged into master before GraalVM 19.3.0 is available.