### PR TITLE
fix: use unique key name when generating config section anchor

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -87,7 +87,7 @@ final class SummaryTableDocFormatter implements DocFormatter {
 
     @Override
     public void format(Writer writer, ConfigDocSection configDocSection) throws IOException {
-        String anchor = anchorPrefix + getAnchor(configDocSection.getSectionDetailsTitle());
+        String anchor = anchorPrefix + getAnchor(configDocSection.getName());
         final String sectionRow = String.format(TABLE_SECTION_ROW_FORMAT, anchor, anchor,
                 configDocSection.getSectionDetailsTitle());
         writer.append(sectionRow);

--- a/docs/src/main/java/io/quarkus/docs/generation/AllConfigGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AllConfigGenerator.java
@@ -170,6 +170,7 @@ public class AllConfigGenerator {
             ConfigDocSection header = new ConfigDocSection();
             header.setSectionDetailsTitle(entry.getKey());
             header.setAnchorPrefix(artifactIdsByName.get(entry.getKey()));
+            header.setName(artifactIdsByName.get(entry.getKey()));
             allItems.add(new ConfigDocItem(header, null));
             // add all the configs for this extension
             allItems.addAll(configDocItems);


### PR DESCRIPTION
The issue was reported here - https://github.com/quarkusio/quarkus/pull/4529#issuecomment-551883480

@geoand @dufoli this should fix the doc building issue for https://github.com/quarkusio/quarkus/pull/4529. Can you please confirm? Thanks


