### PR TITLE
Log the dev mode JVM startup command at INFO level

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -616,8 +616,8 @@ public class DevMojo extends AbstractMojo {
         }
 
         public void run() throws Exception {
-            // Display the launch command line in debug mode
-            getLog().debug("Launching JVM with command line: " + args.toString());
+            // Display the launch command line in dev mode
+            getLog().info("Launching JVM with command line: " + args.toString());
             ProcessBuilder pb = new ProcessBuilder(args.toArray(new String[0]));
             pb.redirectError(ProcessBuilder.Redirect.INHERIT);
             pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);


### PR DESCRIPTION
The dev mode JVM startup command is currently logged at `DEBUG` level (in Maven DevMojo). I think logging this at `INFO` will be more useful since it prints out useful information on what arguments etc are being passed to the JVM launch command. That can sometimes help identifying any obvious issues while debugging issues like https://github.com/quarkusio/quarkus/issues/5359.
Furthermore, this log message is logged only once when the JVM is launched. So I don't think changing this to INFO will end up polluting the logs.

BTW, the gradle version of dev mode already prints this detail at "INFO" level by using System.out.println.
