### PR TITLE
Add exception handler description in Spring web docs

### DIFF
--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -233,12 +233,29 @@ The following method return types are supported:
 * POJO classes which will be serialized via JSON
 * `org.springframework.http.ResponseEntity`
 
-=== Controller method return types
+=== Controller method parameter types
 
 In addition to the method parameters that can be annotated with the appropriate Spring Web annotations from the previous table,
 `javax.servlet.http.HttpServletRequest` and `javax.servlet.http.HttpServletResponse` are also supported.
 For this to function however, users need to add the `quarkus-undertow` dependency.
 
+=== Exception handler method return types
+
+The following method return types are supported:
+
+* `org.springframework.http.ResponseEntity`
+* `java.util.Map` 
+
+Other return types mentioned in the Spring `https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/ExceptionHandler.html[ExceptionHandler javadoc]` are not supported.
+
+=== Exception handler method parameter types
+
+The following parameter types are supported, in arbitrary order:
+
+* An exception argument: declared as a general `Exception` or as a more specific exception. This also serves as a mapping hint if the annotation itself does not narrow the exception types through its `value()`.
+* Request and/or response objects (typically from the Servlet API). You may choose any specific request/response type, e.g. `ServletRequest` / `HttpServletRequest`. To use Servlet API, the `quarkus-undertow` dependency needs to be added.
+ 
+Other parameter types mentioned in the Spring `https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/ExceptionHandler.html[ExceptionHandler javadoc]` are not supported.
 
 == Important Technical Note
 


### PR DESCRIPTION
Mentioned in issue #4042, added sections for exception handlers. This PR should be clean finally when #4042  and #5374 are resolved. 