### PR TITLE
Feature/cdi agroal datasource listeners

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -267,20 +267,20 @@ public abstract class AbstractDataSourceProducer {
             }
         }
     }
-    
+
     /**
      * Wrapper to facilitate filtering & sorting of applicable CDI produced AgroalDataSourceListeners
      */
     private class PrioritizedDataSourceListenerWrapper implements Comparable<PrioritizedDataSourceListenerWrapper> {
         final AgroalDataSourceListener listener;
         final int priority;
-        final String dataSource;
+        final String dataSourceName;
 
         PrioritizedDataSourceListenerWrapper(final AgroalDataSourceListener listener, final int priority,
                 final String dataSourceName) {
             this.listener = listener;
             this.priority = priority;
-            this.dataSource = dataSourceName;
+            this.dataSourceName = dataSourceName;
         }
 
         PrioritizedDataSourceListenerWrapper(final Bean<AgroalDataSourceListener> listener) {
@@ -291,11 +291,11 @@ public abstract class AbstractDataSourceProducer {
             this.priority = p != null ? p.value() : Interceptor.Priority.APPLICATION;
 
             io.quarkus.agroal.DataSource ds = listener.getBeanClass().getAnnotation(io.quarkus.agroal.DataSource.class);
-            this.dataSource = ds != null ? ds.value() : null;
+            this.dataSourceName = ds != null ? ds.value() : null;
         }
 
         boolean appliesTo(final String dataSourceNamed) {
-            return dataSource == null || dataSource.equals(dataSourceNamed);
+            return dataSourceName == null || dataSourceName.equals(dataSourceNamed);
         }
 
         @Override

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -6,9 +6,14 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.annotation.PreDestroy;
+import javax.annotation.Priority;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
+import javax.interceptor.Interceptor;
 import javax.sql.DataSource;
 import javax.sql.XADataSource;
 import javax.transaction.TransactionManager;
@@ -17,6 +22,7 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import org.jboss.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration.ConnectionValidator;
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
@@ -44,6 +50,9 @@ public abstract class AbstractDataSourceProducer {
 
     @Inject
     public TransactionSynchronizationRegistry transactionSynchronizationRegistry;
+
+    @Inject
+    public BeanManager beanManager;
 
     public DataSourceBuildTimeConfig getDefaultBuildTimeConfig() {
         return buildTimeConfig.defaultDataSource;
@@ -209,9 +218,21 @@ public abstract class AbstractDataSourceProducer {
             }
         }
 
+        // Identify AgroalDataSourceListener beans and filter appropriately to this dataSourceName.
+        List<PrioritizedDataSourceListenerWrapper> listeners = beanManager.getBeans(AgroalDataSourceListener.class).stream()
+                .map(beanDef -> new PrioritizedDataSourceListenerWrapper((Bean<AgroalDataSourceListener>) beanDef))
+                .filter(pds -> pds.appliesTo(dataSourceName))
+                .collect(Collectors.toList());
+
+        // Add the default event logging listener..
+        listeners.add(new PrioritizedDataSourceListenerWrapper(
+                new AgroalEventLoggingListener(dataSourceName), 0, dataSourceName));
+
         // Explicit reference to bypass reflection need of the ServiceLoader used by AgroalDataSource#from
         AgroalDataSource dataSource = new io.agroal.pool.DataSource(dataSourceConfiguration.get(),
-                new AgroalEventLoggingListener(dataSourceName));
+                listeners.stream().sorted().map(listenersWrapper -> listenersWrapper.listener)
+                        .toArray(size -> new AgroalDataSourceListener[size]));
+
         log.debugv("Started data source {0} connected to {1}", dataSource, url);
 
         this.dataSources.add(dataSource);
@@ -244,6 +265,42 @@ public abstract class AbstractDataSourceProducer {
             if (dataSource != null) {
                 dataSource.close();
             }
+        }
+    }
+
+    /**
+     * Wrapper to facilitate filtering & sorting of applicable CDI produced AgroalDataSourceListeners
+     */
+    private class PrioritizedDataSourceListenerWrapper implements Comparable<PrioritizedDataSourceListenerWrapper> {
+        final AgroalDataSourceListener listener;
+        final int priority;
+        final String dataSourceName;
+
+        PrioritizedDataSourceListenerWrapper(final AgroalDataSourceListener listener, final int priority,
+                final String dataSourceName) {
+            this.listener = listener;
+            this.priority = priority;
+            this.dataSourceName = dataSourceName;
+        }
+
+        PrioritizedDataSourceListenerWrapper(final Bean<AgroalDataSourceListener> listener) {
+            this.listener = (AgroalDataSourceListener) beanManager.getReference(listener, listener.getBeanClass(),
+                    beanManager.createCreationalContext(listener));
+
+            Priority p = listener.getBeanClass().getAnnotation(Priority.class);
+            this.priority = p != null ? p.value() : Interceptor.Priority.APPLICATION;
+
+            io.quarkus.agroal.DataSource ds = listener.getBeanClass().getAnnotation(io.quarkus.agroal.DataSource.class);
+            this.dataSourceName = ds != null ? ds.value() : null;
+        }
+
+        boolean appliesTo(final String dataSourceNamed) {
+            return dataSourceName == null || dataSourceName.equals(dataSourceNamed);
+        }
+
+        @Override
+        public int compareTo(final PrioritizedDataSourceListenerWrapper o) {
+            return Integer.compare(this.priority, o.priority);
         }
     }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -283,7 +283,7 @@ public abstract class AbstractDataSourceProducer {
             this.dataSource = dataSourceName;
         }
 
-        PrioritizedDataSourceListenerWrapper(Bean<AgroalDataSourceListener> listener) {
+        PrioritizedDataSourceListenerWrapper(final Bean<AgroalDataSourceListener> listener) {
             this.listener = (AgroalDataSourceListener) beanManager.getReference(listener, listener.getBeanClass(),
                     beanManager.createCreationalContext(listener));
 
@@ -299,7 +299,7 @@ public abstract class AbstractDataSourceProducer {
         }
 
         @Override
-        public int compareTo(PrioritizedDataSourceListenerWrapper o) {
+        public int compareTo(final PrioritizedDataSourceListenerWrapper o) {
             return Integer.compare(this.priority, o.priority);
         }
     }


### PR DESCRIPTION
To help foster discussion on #5381 here's a quick first-pass at implementing the CDI run-time bits.

There's some things here I'm not proud of or thrilled with, like cribbing the Interceptor.Priority constants.

From an Agroal perspective, I also haven't checked the Agroal listener invocation order on things like `onConnectionAcquire()` and `onConnectionReturn()`.

In my (private closed source) use-case, this is working fantastically.

If you could all steer me in the right directions here with regards to documentation and testing, I'll be happy to contribute additional changes.