### PR TITLE
Fix the application-type property in the OIDC web authentication guide

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -65,7 +65,7 @@ The OpenID Connect extension allows you to define the configuration using the `a
 ----
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=frontend
-quarkus.oidc.client-type=web-app
+quarkus.oidc.application-type=web-app
 
 ----
 


### PR DESCRIPTION
Starting with the most urgent fix, would like to discuss the need for configuring the permissions first