### PR TITLE
Avoid the re-creation of the event loops

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopSupplierBuildItem.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopSupplierBuildItem.java
@@ -5,7 +5,7 @@ import java.util.function.Supplier;
 import io.netty.channel.EventLoopGroup;
 import io.quarkus.builder.item.SimpleBuildItem;
 
-public class EventLoopSupplierBuildItem extends SimpleBuildItem {
+public final class EventLoopSupplierBuildItem extends SimpleBuildItem {
 
     private final Supplier<EventLoopGroup> mainSupplier;
     private final Supplier<EventLoopGroup> bossSupplier;

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -48,6 +48,7 @@ class VertxCoreProcessor {
         return new EventLoopCountBuildItem(recorder.calculateEventLoopThreads(vertxConfiguration));
     }
 
+    @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     EventLoopSupplierBuildItem eventLoop(VertxCoreRecorder recorder) {
         return new EventLoopSupplierBuildItem(recorder.mainSupplier(), recorder.bossSupplier());


### PR DESCRIPTION
It was missing a @BuildItem (found by @dmlloyd)