### PR TITLE
Persistent attributes of a Panache entity should not be generated when using Jackson

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>jakarta.json.bind-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -7,6 +7,8 @@ import java.util.stream.Stream;
 import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.Transient;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
@@ -74,6 +76,8 @@ public abstract class PanacheEntityBase {
      * @return true if this entity is persistent in the database.
      */
     @JsonbTransient
+    // @JsonIgnore is here to avoid serialization of this property with jackson
+    @JsonIgnore
     public boolean isPersistent() {
         return JpaOperations.isPersistent(this);
     }

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>quarkus-test-h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -1,9 +1,13 @@
 package io.quarkus.it.panache;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
@@ -48,5 +52,24 @@ public class PanacheFunctionalityTest {
     @Test
     public void testBug5274() {
         RestAssured.when().get("/test/5274").then().body(is("OK"));
+    }
+
+    /**
+     * This test is disabled in native mode as there is no interaction with the quarkus integration test endpoint.
+     */
+    @DisabledOnNativeImage
+    @Test
+    public void jacksonDeserilazationIgnoresPersitantAttribute() throws JsonProcessingException {
+        // set Up
+        Person person = new Person();
+        person.name = "max";
+        // do
+        ObjectMapper objectMapper = new ObjectMapper();
+        String personAsString = objectMapper.writeValueAsString(person);
+        // check 
+        // hence no 'persistence'-attribute
+        assertEquals(
+                "{\"id\":null,\"name\":\"max\",\"uniqueName\":null,\"address\":null,\"status\":null,\"dogs\":[],\"serialisationTrick\":1}",
+                personAsString);
     }
 }


### PR DESCRIPTION
When using JSONB the the method *isPersistent()* in PanacheEntityBase is ignored from JSONB and does not produce the *persistant*-attribute. This was fixed in https://github.com/FroMage/quarkus/commit/86edaa10eba0da2c1052566d752a257068da2b0f
But if Jackson is used, the *persistant*-attribute is still generated. 

This PR tackles this issue.

This is my first PR in an open source project and I do not know if i mess things up....