### PR TITLE
Updated mailer docs with option for google password auth , issue #4510

### DIFF
--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -234,6 +234,7 @@ With TLS:
 
 [source]
 ----
+quarkus.mailer.auth-methods=DIGEST-MD5 CRAM-SHA256 CRAM-SHA1 CRAM-MD5 PLAIN LOGIN
 quarkus.mailer.from=YOUREMAIL@gmail.com
 quarkus.mailer.host=smtp.gmail.com
 quarkus.mailer.port=587
@@ -245,7 +246,8 @@ quarkus.mailer.password=YOURGENERATEDAPPLICATIONPASSWORD
 Or with SSL:
 
 [source]
-----
+---- 
+quarkus.mailer.auth-methods=DIGEST-MD5 CRAM-SHA256 CRAM-SHA1 CRAM-MD5 PLAIN LOGIN
 quarkus.mailer.from=YOUREMAIL@gmail.com
 quarkus.mailer.host=smtp.gmail.com
 quarkus.mailer.port=465
@@ -253,6 +255,8 @@ quarkus.mailer.ssl=true
 quarkus.mailer.username=YOUREMAIL@gmail.com
 quarkus.mailer.password=YOURGENERATEDAPPLICATIONPASSWORD
 ----
+
+Note: the `quarkus.mailer.auth-methods` configuration option is needed for the quarkus mailer to support password auth with google. By default both the mailer and google default to XOAUTH2 which requires registering an application, getting tokens, etc. 
 
 == Using SSL with native executables
 

--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -256,7 +256,11 @@ quarkus.mailer.username=YOUREMAIL@gmail.com
 quarkus.mailer.password=YOURGENERATEDAPPLICATIONPASSWORD
 ----
 
-Note: the `quarkus.mailer.auth-methods` configuration option is needed for the quarkus mailer to support password auth with google. By default both the mailer and google default to XOAUTH2 which requires registering an application, getting tokens, etc. 
+[NOTE]
+====
+The `quarkus.mailer.auth-methods` configuration option is needed for the Quarkus mailer to support password authentication with Gmail.
+By default both the mailer and Gmail default to `XOAUTH2` which requires registering an application, getting tokens, etc.
+====
 
 == Using SSL with native executables
 


### PR DESCRIPTION
By default, the vertx mail client and google both default to XOAUTH2 and that method needs to be disabled in order for password authentication (with app passwords to work)

Addresses issue https://github.com/quarkusio/quarkus/issues/4510

Otherwise, gmail fails with the dreaded:
> AUTH XOAUTH2 failed 535-5.7.8 Username and Password not accepted. Learn more at
535 5.7.8  https://support.google.com/mail/?p=BadCredentials n5sm9432005qke.74 - gsmtp