### PR TITLE
Provide integration between RestAssured and Jackson

### DIFF
--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/Article.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/Article.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.resteasy.jackson;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+@JsonRootName("art")
+public class Article {
+
+    private String title;
+    private String description;
+    private String body;
+    private List<String> tagList;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<String> getTagList() {
+        return tagList;
+    }
+
+    public void setTagList(List<String> tagList) {
+        this.tagList = tagList;
+    }
+}

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/ArticleResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/ArticleResource.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.resteasy.jackson;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/article")
+public class ArticleResource {
+
+    @POST
+    @Consumes("application/json")
+    @Produces("application/json")
+    public Article create(Article input) {
+        return input;
+    }
+}

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/ObjectMapperConfig.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/ObjectMapperConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.resteasy.jackson;
+
+import javax.inject.Singleton;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class ObjectMapperConfig implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+        objectMapper.enable(DeserializationFeature.UNWRAP_ROOT_VALUE);
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+}

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/ArticleResourceTest.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/ArticleResourceTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.resteasy.jackson;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class ArticleResourceTest {
+
+    private static final Article CREATE_ARTICLE_REQUEST = new Article();
+    static {
+        CREATE_ARTICLE_REQUEST.setTitle("How to train your dragon");
+        CREATE_ARTICLE_REQUEST.setDescription("Ever wonder how?");
+        CREATE_ARTICLE_REQUEST.setBody("Very carefully");
+        CREATE_ARTICLE_REQUEST.setTagList(Arrays.asList("dragons", "training"));
+    }
+
+    @Test
+    public void testCreateArticle() {
+        given()
+                .when()
+                .body(CREATE_ARTICLE_REQUEST)
+                .contentType(ContentType.JSON)
+                .post("/article")
+                .then()
+                .statusCode(200)
+                .body("art.title", equalTo("How to train your dragon"))
+                .body("art.description", equalTo("Ever wonder how?"))
+                .body("art.body", equalTo("Very carefully"));
+    }
+}

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -27,6 +27,22 @@
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Needed for RestAssured -->
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredManager.java
@@ -1,18 +1,21 @@
 package io.quarkus.test.common;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
  * Utility class that sets the rest assured port to the default test port.
+ * It also configures RestAssured to use the ObjectMapper configured by the application,
+ * if there is such an ObjectMapper
  * <p>
  * This uses reflection so as to not introduce a dependency on rest-assured
  * <p>
  * TODO: do we actually want this here, or should it be in a different module?
  */
-public class RestAssuredURLManager {
+public class RestAssuredManager {
 
     private static final int DEFAULT_HTTP_PORT = 8081;
     private static final int DEFAULT_HTTPS_PORT = 8444;
@@ -20,9 +23,12 @@ public class RestAssuredURLManager {
     private static final Field portField;
     private static final Field baseURIField;
     private static final Field basePathField;
+    private static final Field configField;
+    private static Object newRestAssuredConfig;
     private int oldPort;
     private String oldBaseURI;
     private String oldBasePath;
+    private Object oldRestAssuredConfig;
 
     private final boolean useSecureConnection;
 
@@ -30,25 +36,59 @@ public class RestAssuredURLManager {
         Field p;
         Field baseURI;
         Field basePath;
+        Field config;
+        Class<?> restAssured;
         try {
-            Class<?> restAssured = Class.forName("io.restassured.RestAssured");
+            restAssured = Class.forName("io.restassured.RestAssured");
             p = restAssured.getField("port");
             p.setAccessible(true);
             baseURI = restAssured.getField("baseURI");
             baseURI.setAccessible(true);
             basePath = restAssured.getField("basePath");
             basePath.setAccessible(true);
+            config = restAssured.getField("config");
+            config.setAccessible(true);
         } catch (Exception e) {
             p = null;
             baseURI = null;
             basePath = null;
+            config = null;
         }
         portField = p;
         baseURIField = baseURI;
         basePathField = basePath;
+        configField = config;
+        newRestAssuredConfig = null;
+        if (configField != null) {
+            setNewRestAssuredConfig();
+        }
     }
 
-    public RestAssuredURLManager(boolean useSecureConnection) {
+    /**
+     * Configure RestAssured to use the application's ObjectMapper if it's set
+     */
+    private static void setNewRestAssuredConfig() {
+        try {
+            // config = RestAssuredConfig.config().objectMapperConfig(new ObjectMapperConfig().jackson2ObjectMapperFactory(new QuarkusJackson2ObjectMapperFactory());
+            Class<?> restAssuredConfigClass = Class.forName("io.restassured.config.RestAssuredConfig");
+            Method configMethod = restAssuredConfigClass.getMethod("config");
+            Object newConfig = configMethod.invoke(null);
+            Class<?> objectMapperConfigClass = Class.forName("io.restassured.config.ObjectMapperConfig");
+            Object newObjectMapperConfig = objectMapperConfigClass.newInstance();
+            Method jackson2ObjectMapperFactoryMethod = objectMapperConfigClass.getMethod("jackson2ObjectMapperFactory",
+                    Class.forName("io.restassured.path.json.mapper.factory.Jackson2ObjectMapperFactory"));
+            Object quarkusJackson2ObjectMapperFactory = Class
+                    .forName("io.quarkus.test.restassured.QuarkusJackson2ObjectMapperFactory").newInstance();
+            newObjectMapperConfig = jackson2ObjectMapperFactoryMethod.invoke(newObjectMapperConfig,
+                    quarkusJackson2ObjectMapperFactory);
+            Method objectMapperConfigMethod = restAssuredConfigClass.getMethod("objectMapperConfig",
+                    objectMapperConfigClass);
+            newRestAssuredConfig = objectMapperConfigMethod.invoke(newConfig, newObjectMapperConfig);
+        } catch (Exception e) {
+        }
+    }
+
+    public RestAssuredManager(boolean useSecureConnection) {
         this.useSecureConnection = useSecureConnection;
     }
 
@@ -56,7 +96,7 @@ public class RestAssuredURLManager {
         return ConfigProvider.getConfig().getOptionalValue(key, Integer.class).orElse(defaultValue);
     }
 
-    public void setURL() {
+    public void set() {
         if (portField != null) {
             try {
                 oldPort = (Integer) portField.get(null);
@@ -90,9 +130,17 @@ public class RestAssuredURLManager {
                 e.printStackTrace();
             }
         }
+        if ((configField != null) && newRestAssuredConfig != null) {
+            try {
+                oldRestAssuredConfig = configField.get(null);
+                configField.set(null, newRestAssuredConfig);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
-    public void clearURL() {
+    public void clear() {
         if (portField != null) {
             try {
                 portField.set(null, oldPort);
@@ -110,6 +158,13 @@ public class RestAssuredURLManager {
         if (basePathField != null) {
             try {
                 basePathField.set(null, oldBasePath);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        if ((configField != null) && newRestAssuredConfig != null) {
+            try {
+                configField.set(null, oldRestAssuredConfig);
             } catch (IllegalAccessException e) {
                 e.printStackTrace();
             }

--- a/test-framework/common/src/main/java/io/quarkus/test/restassured/QuarkusJackson2ObjectMapperFactory.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/restassured/QuarkusJackson2ObjectMapperFactory.java
@@ -1,0 +1,28 @@
+package io.quarkus.test.restassured;
+
+import java.lang.reflect.Type;
+
+import javax.enterprise.inject.spi.CDI;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
+
+/**
+ * A RestAssured Jackson2ObjectMapperFactory that pulls the ObjectMapper from CDI
+ * and delegates to the parent if no CDI bean is found
+ *
+ * It is important that this class not be referenced directly anywhere in the code so the dependencies
+ * on RestAssured and Jackson can remain optional
+ */
+public class QuarkusJackson2ObjectMapperFactory extends DefaultJackson2ObjectMapperFactory {
+
+    @Override
+    public ObjectMapper create(Type type, String s) {
+        ObjectMapper result = CDI.current().select(ObjectMapper.class).get();
+        if (result == null) {
+            super.create(type, s);
+        }
+        return result;
+    }
+}

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -55,7 +55,7 @@ import io.quarkus.runner.RuntimeRunner;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.PropertyTestUtil;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredManager;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 
@@ -82,7 +82,7 @@ public class QuarkusUnitTest
     private volatile TimerTask timeoutTask;
     private Properties customApplicationProperties;
 
-    private final RestAssuredURLManager restAssuredURLManager;
+    private final RestAssuredManager restAssuredManager;
 
     public QuarkusUnitTest setExpectedException(Class<? extends Throwable> expectedException) {
         return assertException(t -> {
@@ -100,7 +100,7 @@ public class QuarkusUnitTest
     }
 
     private QuarkusUnitTest(boolean useSecureConnection) {
-        this.restAssuredURLManager = new RestAssuredURLManager(useSecureConnection);
+        this.restAssuredManager = new RestAssuredManager(useSecureConnection);
     }
 
     public QuarkusUnitTest assertException(Consumer<Throwable> assertException) {
@@ -372,12 +372,12 @@ public class QuarkusUnitTest
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        restAssuredURLManager.clearURL();
+        restAssuredManager.clear();
     }
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        restAssuredURLManager.setURL();
+        restAssuredManager.set();
     }
 
     public Runnable getAfterUndeployListener() {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -57,7 +57,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.common.NativeImageLauncher;
 import io.quarkus.test.common.PathTestHelper;
 import io.quarkus.test.common.PropertyTestUtil;
-import io.quarkus.test.common.RestAssuredURLManager;
+import io.quarkus.test.common.RestAssuredManager;
 import io.quarkus.test.common.TestInjectionManager;
 import io.quarkus.test.common.TestInstantiator;
 import io.quarkus.test.common.TestResourceManager;
@@ -81,7 +81,7 @@ public class QuarkusTestExtension
      * run we remove them if this file exists.
      */
     private static final String CREATED_FILES = "CREATED_FILES.txt";
-    private final RestAssuredURLManager restAssuredURLManager = new RestAssuredURLManager(false);
+    private final RestAssuredManager restAssuredManager = new RestAssuredManager(false);
 
     private ExtensionState doJavaStart(ExtensionContext context, TestResourceManager testResourceManager) {
 
@@ -340,7 +340,7 @@ public class QuarkusTestExtension
         if (!failedBoot) {
             boolean nativeImageTest = context.getRequiredTestClass().isAnnotationPresent(SubstrateTest.class)
                     || context.getRequiredTestClass().isAnnotationPresent(NativeImageTest.class);
-            restAssuredURLManager.clearURL();
+            restAssuredManager.clear();
             TestScopeManager.tearDown(nativeImageTest);
         }
     }
@@ -350,7 +350,7 @@ public class QuarkusTestExtension
         if (!failedBoot) {
             boolean nativeImageTest = context.getRequiredTestClass().isAnnotationPresent(SubstrateTest.class)
                     || context.getRequiredTestClass().isAnnotationPresent(NativeImageTest.class);
-            restAssuredURLManager.setURL();
+            restAssuredManager.set();
             TestScopeManager.setup(nativeImageTest);
         }
     }


### PR DESCRIPTION
When a Quarkus application used Jackson (and therefore has configured
an ObjectMapper CDI bean), the ObjectMapper is configured to work with
RestAssured.
This makes it easy for users to reuse their Jackson configuration in tests
leaving their tests very clean and avoiding duplicate configuration.

Originally mentioned here: https://stackoverflow.com/q/58794871/2504224