### PR TITLE
Fix a race condition on Kafka Streams hot reload

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -448,7 +448,7 @@ In MongoDB with Panache the ID are defined by a field named `id` of the `org.bso
 but if you want ot customize them, once again we have you covered.
 
 You can specify your own ID strategy by extending `PanacheMongoEntityBase` instead of `PanacheMongoEntity`. Then
-you just declare whatever ID you want as a public field by annotating it by @BsonId:
+you just declare whatever ID you want as a public field by annotating it by `@BsonId`:
 
 [source,java]
 ----

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsHotReplacementSetup.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsHotReplacementSetup.java
@@ -12,7 +12,7 @@ public class KafkaStreamsHotReplacementSetup implements HotReplacementSetup {
     private static final long TWO_SECONDS = 2000;
 
     private HotReplacementContext context;
-    private long nextUpdate;
+    private volatile long nextUpdate;
     private final Executor executor = Executors.newSingleThreadExecutor();
 
     @Override


### PR DESCRIPTION
This PR fixes a race condition on the kafka-stream hot replacement setup.

Some kind of double-locked idiom was used without a volatile field.
After discussion with @cescoffier about this, I moe the implementation to use an `AtomicLong` instead.

Tested OK manually using the integration test (no test added).

I take the liberty to also add a small fix to the mongodb-panache guide to avoid creating a separate PR for this. I can remove this comit and create a separate PR if needed.