### PR TITLE
Use same ResumingRouter in CDI as in Observes events.

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UserRouteRegistrationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UserRouteRegistrationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http;
 
+import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -15,6 +16,7 @@ import io.quarkus.runtime.StartupEvent;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
 
 public class UserRouteRegistrationTest {
 
@@ -27,6 +29,7 @@ public class UserRouteRegistrationTest {
     public void test() {
         assertThat(RestAssured.get("/observes").asString()).isEqualTo("observers - ok");
         assertThat(RestAssured.get("/inject").asString()).isEqualTo("inject - ok");
+        assertThat(given().body("test").contentType("text/plain").post("/body").asString()).isEqualTo("test");
     }
 
     @ApplicationScoped
@@ -47,6 +50,8 @@ public class UserRouteRegistrationTest {
         public void register(@Observes StartupEvent ignored) {
             router.route("/inject").handler(rc -> rc.response().end("inject - ok"));
             router.route().failureHandler(rc -> rc.failure().printStackTrace());
+            router.route("/body").consumes("text/plain").handler(BodyHandler.create())
+                    .handler(rc -> rc.response().end(rc.getBodyAsString()));
         }
 
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -181,8 +181,9 @@ public class VertxHttpRecorder {
 
         filterList.addAll(filters.getFilters());
 
-        // Then, fire the router
-        event.select(Router.class).fire(new ResumingRouter(router));
+        // Then, fire the resuming router
+        ResumingRouter resumingRouter = new ResumingRouter(router);
+        event.select(Router.class).fire(resumingRouter);
 
         for (Filter filter : filterList) {
             if (filter.getHandler() != null) {
@@ -195,7 +196,7 @@ public class VertxHttpRecorder {
             defaultRouteHandler.accept(router.route().order(10_000));
         }
 
-        container.instance(RouterProducer.class).initialize(router);
+        container.instance(RouterProducer.class).initialize(resumingRouter);
         router.route().last().failureHandler(new QuarkusErrorHandler(launchMode.isDevOrTest()));
 
         if (rootPath.equals("/")) {

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/VertxProducerResource.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/VertxProducerResource.java
@@ -1,7 +1,9 @@
 package io.quarkus.it.vertx;
 
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -28,6 +30,19 @@ public class VertxProducerResource {
             throw new NullPointerException("router instance should have been injected");
         }
         return "vert.x has been injected";
+    }
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
+    public String testBody(String body) {
+        if (vertx == null) {
+            throw new NullPointerException("vert.x instance should have been injected");
+        }
+        if (router == null) {
+            throw new NullPointerException("router instance should have been injected");
+        }
+        return body;
     }
 
 }

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceTest.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceTest.java
@@ -2,10 +2,12 @@ package io.quarkus.it.vertx;
 
 import static io.restassured.RestAssured.get;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 
 @QuarkusTest
 public class VertxProducerResourceTest {
@@ -13,6 +15,12 @@ public class VertxProducerResourceTest {
     @Test
     public void testInjection() {
         get("/").then().body(containsString("vert.x has been injected"));
+    }
+
+    @Test
+    public void testInjectedRouter() {
+        RestAssured.given().contentType("text/plain").body("Hello world!")
+                .post("/").then().body(is("Hello world!"));
     }
 
     @Test


### PR DESCRIPTION
In vertx-http the router passed in `@Observes Router` events is a ResumingRouter, this is because it's needed to resume the http request after the root handler first pauses it... However the router we were using in CDI was the directly vertx router so user code defining routes in a router got from injection would get missbehaviours receiving the request body...
As per the docs we don't show the usage of the router getting it from injection but because we use it this way in some of our tests I think we should fix that and pass the ResumingRouter instance to CDI.