### PR TITLE
Register response.closeHandler() in VertxBlockingOutput and test for clients closing connections

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxOutputStream.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxOutputStream.java
@@ -66,12 +66,13 @@ public class VertxOutputStream extends OutputStream {
                 rem -= toWrite;
                 idx += toWrite;
                 if (!buffer.isWritable()) {
-                    response.writeBlocking(buffer, false);
+                    ByteBuf tmpBuf = buffer;
                     this.pooledBuffer = buffer = allocator.allocateBuffer();
+                    response.writeBlocking(tmpBuf, false);
                 }
             }
         } catch (Exception e) {
-            if (buffer != null) {
+            if (buffer != null && buffer.refCnt() > 0) {
                 buffer.release();
             }
             throw new IOException(e);


### PR DESCRIPTION
There is a race cond accessing `waitingForDrain` in `VertxBlockingOutput.awaitWriteable()`, where `request.response().drainHandler()` can be called from a seperate thread, but access to the private boolean `waitingForDrain` is not guarded in `request.response().drainHandler()` . 

I have used the same locking pattern used for `request.response().exceptionHandler()` and `request.response().endHandler()`.

However, I have concerns that this could result in a deadlock  if we are holding the intrinsic lock on request.connection() `VertxBlockingOutput.awaitWriteable()` and a call to `request.response().drainHandler()` in a seperate thread would block waiting for the lock.

Would it be better for `waitingForDrain` to be defined as `volatile`?