### PR TITLE
Support * Wildcard for quarkus.http.cors.origins

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -127,13 +127,13 @@ following properties will be applied before passing the request on to its actual
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.http.cors.origins||The comma-separated list of origins allowed for CORS. The filter allows any origin if this is not
-set.
-|quarkus.http.cors.methods||The comma-separated list of HTTP methods allowed for CORS. The filter allows any method if this is
-not set.
-|quarkus.http.cors.headers||The comma-separated list of HTTP headers allowed for CORS. The filter allows any header if this is
-not set.
-|quarkus.http.cors.exposed-headers||The comma-separated list of HTTP headers exposed in CORS.
+|quarkus.http.cors.origins|*|The comma-separated list of origins allowed for CORS. The filter allows any origin if this is not set or set to '*'.
+|quarkus.http.cors.methods|*|The comma-separated list of HTTP methods allowed for CORS. The filter allows any method if this is
+not set or set to '*'.
+|quarkus.http.cors.headers|*|The comma-separated list of HTTP headers allowed for CORS. The filter allows any header if this is
+not set or set to '*'.
+|quarkus.http.cors.exposed-headers|*|The comma-separated list of HTTP headers exposed in CORS. The filter allows any headers to be exposed if this is
+not set or set to '*'.
 |quarkus.http.cors.access-control-max-age||The duration (see note below) indicating how long the results of a pre-flight request can be cached.
 This value will be returned in a `Access-Control-Max-Age` response header.
 |===

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
@@ -18,7 +18,7 @@ import io.quarkus.vertx.http.security.PathHandler;
 import io.quarkus.vertx.http.security.TestIdentityController;
 import io.quarkus.vertx.http.security.TestIdentityProvider;
 
-public class CoresSecurityTestCase {
+public class CORSSecurityTestCase {
 
     private static final String APP_PROPS = "" +
             "quarkus.http.cors=true\n" +

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
@@ -1,0 +1,149 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.security.PathHandler;
+import io.quarkus.vertx.http.security.TestIdentityController;
+import io.quarkus.vertx.http.security.TestIdentityProvider;
+
+public class CORSWildcardSecurityTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.cors=true\n" +
+            "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.policy.r1.roles-allowed=test\n" +
+            "quarkus.http.auth.permission.roles1.paths=/test\n" +
+            "quarkus.http.auth.permission.roles1.policy=r1\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<JavaArchive>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, PathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("test", "test", "test").add("user", "user", "user");
+    }
+
+    @Test
+    @DisplayName("Handles a preflight CORS request correctly")
+    public void corsPreflightTest() {
+        String origin = "http://custom.origin.quarkus";
+        String methods = "GET,POST";
+        String headers = "X-Custom";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "test")
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "wrongpassword")
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("user", "user")
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+    }
+
+    @Test
+    @DisplayName("Handles a direct CORS request correctly")
+    public void corsNoPreflightTest() {
+        String origin = "http://custom.origin.quarkus";
+        String methods = "GET,POST";
+        String headers = "X-Custom";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .log().headers()
+                .get("/test").then()
+                .statusCode(401)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "test")
+                .log().headers()
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers)
+                .body(Matchers.equalTo("test:/test"));
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("test", "wrongpassword")
+                .log().headers()
+                .get("/test").then()
+                .statusCode(401)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("user", "user")
+                .log().headers()
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Headers", headers);
+    }
+}


### PR DESCRIPTION
The star wildcard for the origins means, that any origin can access the service.
Previosly, this behavior could only be achieved by leaving the config property out completly.
Now you can either not set the origins config property, or use "*".

Adjust the documentation for * origins.
Fix naming of one of the tests.

fixes #5422