### PR TITLE
[fixes #5323] - Only SERVICE type applications are supported

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -167,6 +167,8 @@ quarkus.oidc.credentials.secret=secret
 quarkus.keycloak.policy-enforcer.enable=true
 ----
 
+NOTE: By default, applications using the `quarkus-oidc` extension are marked as a `service` type application (see `quarkus.oidc.application-type`). This extension currently supports only such `service` type applications.
+
 == Starting and Configuring the Keycloak Server
 
 To start a Keycloak Server you can use Docker and just run the following command:

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep;
+package io.quarkus.keycloak.pep.deployment;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
@@ -7,6 +7,10 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.EnableAllSecurityServicesBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerAuthorizer;
+import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerConfig;
+import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerRecorder;
+import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.runtime.OidcConfig;
 
 public class KeycloakPolicyEnforcerBuildStep {
@@ -17,9 +21,12 @@ public class KeycloakPolicyEnforcerBuildStep {
     }
 
     @BuildStep
-    public AdditionalBeanBuildItem beans() {
-        return AdditionalBeanBuildItem.builder().setUnremovable()
-                .addBeanClass(KeycloakPolicyEnforcerAuthorizer.class).build();
+    public AdditionalBeanBuildItem beans(KeycloakPolicyEnforcerConfig config) {
+        if (config.policyEnforcer.enable) {
+            return AdditionalBeanBuildItem.builder().setUnremovable()
+                    .addBeanClass(KeycloakPolicyEnforcerAuthorizer.class).build();
+        }
+        return null;
     }
 
     @BuildStep
@@ -31,6 +38,11 @@ public class KeycloakPolicyEnforcerBuildStep {
     @BuildStep
     public void setup(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config, KeycloakPolicyEnforcerRecorder recorder,
             BeanContainerBuildItem bc) {
-        recorder.setup(oidcConfig, config, bc.getValue());
+        if (!oidcConfig.getApplicationType().equals(OidcConfig.ApplicationType.SERVICE)) {
+            throw new OIDCException("Application type [" + oidcConfig.getApplicationType() + "] not supported");
+        }
+        if (config.policyEnforcer.enable) {
+            recorder.setup(oidcConfig, config, bc.getValue());
+        }
     }
 }

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep;
+package io.quarkus.keycloak.pep.deployment;
 
 import org.keycloak.adapters.authentication.ClientCredentialsProvider;
 import org.keycloak.adapters.authentication.ClientIdAndSecretCredentialsProvider;

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep;
+package io.quarkus.keycloak.pep.runtime;
 
 import java.security.Permission;
 import java.util.HashMap;
@@ -39,7 +39,6 @@ public class KeycloakPolicyEnforcerAuthorizer
 
     @Override
     public CheckResult apply(RoutingContext routingContext, SecurityIdentity identity) {
-
         VertxHttpFacade httpFacade = new VertxHttpFacade(routingContext);
         AuthorizationContext result = delegate.authorize(httpFacade);
 

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerConfig.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep;
+package io.quarkus.keycloak.pep.runtime;
 
 import java.util.List;
 import java.util.Map;
@@ -26,7 +26,7 @@ public class KeycloakPolicyEnforcerConfig {
      * Policy enforcement configuration when using Keycloak Authorization Services
      */
     @ConfigItem
-    KeycloakConfigPolicyEnforcer policyEnforcer;
+    public KeycloakConfigPolicyEnforcer policyEnforcer;
 
     @ConfigGroup
     public static class KeycloakConfigPolicyEnforcer {
@@ -35,7 +35,7 @@ public class KeycloakPolicyEnforcerConfig {
          * Enables policy enforcement.
          */
         @ConfigItem
-        boolean enable;
+        public boolean enable;
 
         /**
          * Specifies how policies are enforced.

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep;
+package io.quarkus.keycloak.pep.runtime;
 
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.oidc.runtime.OidcConfig;

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/VertxHttpFacade.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/VertxHttpFacade.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep;
+package io.quarkus.keycloak.pep.runtime;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -20,6 +20,7 @@ import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.representations.AccessToken;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
@@ -216,7 +217,7 @@ public class VertxHttpFacade implements OIDCHttpFacade {
         }
 
         SecurityIdentity identity = user.getSecurityIdentity();
-        TokenCredential credential = identity.getCredential(TokenCredential.class);
+        TokenCredential credential = identity.getCredential(AccessTokenCredential.class);
 
         if (credential == null) {
             return null;


### PR DESCRIPTION
I'm also changing:

* Specific packages for deployment and runtime related classes
* Do not install the policy enforcer if in the configuration it is disabled
* Explicitly obtaining `AccessTokenCredential`