### PR TITLE
Translate Windows-Style path in volume mounting

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.util.FileUtil;
 
 public class NativeImageBuildStep {
 
@@ -82,8 +83,12 @@ public class NativeImageBuildStep {
             String containerRuntime = nativeConfig.containerRuntime.orElse("docker");
             // E.g. "/usr/bin/docker run -v {{PROJECT_DIR}}:/project --rm quarkus/graalvm-native-image"
             nativeImage = new ArrayList<>();
-            Collections.addAll(nativeImage, containerRuntime, "run", "-v",
-                    outputDir.toAbsolutePath() + ":/project:z");
+
+            String outputPath = outputDir.toAbsolutePath().toString();
+            if (IS_WINDOWS) {
+                outputPath = FileUtil.translateToVolumePath(outputPath);
+            }
+            Collections.addAll(nativeImage, containerRuntime, "run", "-v", outputPath + ":/project:z");
 
             if (IS_LINUX) {
                 if ("docker".equals(containerRuntime)) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java
@@ -8,6 +8,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FileUtil {
 
@@ -47,5 +50,31 @@ public class FileUtil {
             out.write(buf, 0, r);
         }
         return out.toByteArray();
+    }
+
+    /**
+     * Translates a file path from the Windows Style to a syntax accepted by Docker,
+     * so that volumes be safely mounted in both Docker for Windows and the legacy
+     * Docker Toolbox.
+     * <p>
+     * <code>docker run -v //c/foo/bar:/somewhere (...)</code>
+     * <p>
+     * You should only use this method on Windows-style paths, and not Unix-style
+     * paths.
+     * 
+     * @see https://github.com/quarkusio/quarkus/issues/5360
+     * @param windowsStylePath A path formatted in Windows-style, e.g. "C:\foo\bar".
+     * @return A translated path accepted by Docker, e.g. "//c/foo/bar".
+     */
+    public static String translateToVolumePath(String windowsStylePath) {
+        String translated = windowsStylePath.replace('\\', '/');
+        Pattern p = Pattern.compile("^(\\w)(?:$|:(/)?(.*))");
+        Matcher m = p.matcher(translated);
+        if (m.matches()) {
+            String slash = Optional.ofNullable(m.group(2)).orElse("/");
+            String path = Optional.ofNullable(m.group(3)).orElse("");
+            return "//" + m.group(1).toLowerCase() + slash + path;
+        }
+        return translated;
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/FileUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/FileUtilTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.deployment.util;
+
+import static io.quarkus.deployment.util.FileUtil.translateToVolumePath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class FileUtilTest {
+
+    @Test
+    public void testTranslateToVolumePath() {
+        // Windows-Style paths are formatted.
+        assertEquals("//c/", translateToVolumePath("C"));
+        assertEquals("//c/", translateToVolumePath("C:"));
+        assertEquals("//c/", translateToVolumePath("C:\\"));
+        assertEquals("//c/Users", translateToVolumePath("C:\\Users"));
+        assertEquals("//c/Users/Quarkus/lambdatest-1.0-SNAPSHOT-native-image-source-jar",
+                translateToVolumePath("C:\\Users\\Quarkus\\lambdatest-1.0-SNAPSHOT-native-image-source-jar"));
+
+        // Side effect for Unix-style path.
+        assertEquals("//c/Users/Quarkus", translateToVolumePath("c:/Users/Quarkus"));
+
+        // Side effects for fancy inputs - for the sake of documentation.
+        assertEquals("something/bizarre", translateToVolumePath("something\\bizarre"));
+        assertEquals("something.bizarre", translateToVolumePath("something.bizarre"));
+    }
+
+}


### PR DESCRIPTION
# Rationale

There are two distributions of Docker which can be installed on Windows: the legacy "Docker Toolbox", which runs on Virtualbox, and the more recent "Docker for Windows", which runs on Hyper-V.

The mounting of volumes on the legacy Docker Toolbox requires a certain formatting of windows paths. This PR provides the required path translation.

I could only test on Windows 10 Home Edition, with the Docker Toolbox. I have not made any regression testing on Windows 10 with Docker For Windows, nor Mac or Linux, as I don't own any machine with these environments.

Note that the build still reports an error on the assembly, which seems of no consequence:
`[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /`

See https://github.com/quarkusio/quarkus/issues/5360

# Tested locally (Windows 10 Home Edition, with Docker Toolbox).

Install the new plugin:
`mvn install`

Create a sample projet:
`mvn archetype:generate -DarchetypeGroupId=io.quarkus  -DarchetypeArtifactId=quarkus-amazon-lambda-archetype -DarchetypeVersion=1.0.0.CR1`

Update the pom.xml of the project:
`<quarkus.version>999-SNAPSHOT</quarkus.version>`

Start the Docker Machine (legacy Docker Toolbox):
`docker-machine start`

Build:
`mvn clean package -Dnative=true -Dnative-image.docker-build=true`

Native Build log provided below. There's an error reported by the assembly, but seemingly not relevant.

Deploy locally (based on https://github.com/quarkusio/quarkus/pull/5377/files):
`sam local invoke --template sam.native.yml --event payload.json`

# Native Build log
```
[INFO] Scanning for projects...
[INFO]
[INFO] --------------------< io.elegie.quarkus:lambdatest >--------------------
[INFO] Building lambdatest 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ lambdatest ---
[INFO] Deleting C:\Users\Elegie\springyme_quarkus\lambdatest\target
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ lambdatest ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ lambdatest ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 5 source files to C:\Users\Elegie\springyme_quarkus\lambdatest\target\classes
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ lambdatest ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory C:\Users\Elegie\springyme_quarkus\lambdatest\src\test\resources
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ lambdatest ---
[INFO] Changes detected - recompiling the module!
[INFO]
[INFO] --- maven-surefire-plugin:2.22.0:test (default-test) @ lambdatest ---
[INFO]
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ lambdatest ---
[INFO] Building jar: C:\Users\Elegie\springyme_quarkus\lambdatest\target\lambdatest-1.0-SNAPSHOT.jar
[INFO]
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:build (default) @ lambdatest ---
[INFO] [org.jboss.threads] JBoss Threads version 3.0.0.Final
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building fat jar: C:\Users\Elegie\springyme_quarkus\lambdatest\target\lambdatest-1.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 2217ms
[INFO]
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:native-image (default) @ lambdatest ---
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building native image source jar: C:\Users\Elegie\springyme_quarkus\lambdatest\target\lambdatest-1.0-SNAPSHOT-native-image-source-jar\lambdatest-1.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from C:\Users\Elegie\springyme_quarkus\lambdatest\target\lambdatest-1.0-SNAPSHOT-native-image-source-jar\lambdatest-1.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on OpenJDK 64-Bit Server VM
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] docker run -v //c/Users/Elegie/springyme_quarkus/lambdatest/target/lambdatest-1.0-SNAPSHOT-native-image-source-jar:/project:z --rm quay.io/quarkus/ubi-quarkus-native-image:19.2.1 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime -jar lambdatest-1.0-SNAPSHOT-runner.jar -J-Djava.util.concurrent.ForkJoinPool.common.parallelism=1 -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-JNI -H:-UseServiceLoaderFeature -H:+StackTrace lambdatest-1.0-SNAPSHOT-runner
Build on Server(pid: 22, port: 35519)*
[lambdatest-1.0-SNAPSHOT-runner:22]    classlist:   7,477.13 ms
[lambdatest-1.0-SNAPSHOT-runner:22]        (cap):   2,506.07 ms
[lambdatest-1.0-SNAPSHOT-runner:22]        setup:   5,804.98 ms
21:28:32,744 INFO  [org.jbo.threads] JBoss Threads version 3.0.0.Final
[lambdatest-1.0-SNAPSHOT-runner:22]   (typeflow):  29,296.39 ms
[lambdatest-1.0-SNAPSHOT-runner:22]    (objects):  13,699.08 ms
[lambdatest-1.0-SNAPSHOT-runner:22]   (features):     505.64 ms
[lambdatest-1.0-SNAPSHOT-runner:22]     analysis:  44,208.52 ms
[lambdatest-1.0-SNAPSHOT-runner:22]     (clinit):     656.04 ms
[lambdatest-1.0-SNAPSHOT-runner:22]     universe:   1,831.01 ms
[lambdatest-1.0-SNAPSHOT-runner:22]      (parse):   8,003.72 ms
[lambdatest-1.0-SNAPSHOT-runner:22]     (inline):  10,102.64 ms
[lambdatest-1.0-SNAPSHOT-runner:22]    (compile):  50,126.19 ms
[lambdatest-1.0-SNAPSHOT-runner:22]      compile:  70,029.60 ms
[lambdatest-1.0-SNAPSHOT-runner:22]        image:   3,276.24 ms
[lambdatest-1.0-SNAPSHOT-runner:22]        write:   1,477.43 ms
[lambdatest-1.0-SNAPSHOT-runner:22]      [total]: 134,407.67 ms
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 161453ms
[INFO]
[INFO] --- maven-assembly-plugin:3.1.0:single (zip-assembly) @ lambdatest ---
[INFO] Reading assembly descriptor: src/assembly/zip.xml
[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
[INFO] Building zip: C:\Users\Elegie\springyme_quarkus\lambdatest\target\function.zip
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:49 min
[INFO] Finished at: 2019-11-13T22:30:32+01:00
[INFO] ------------------------------------------------------------------------
```
# sam.native.yml
```
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Globals:
  Function:
    Timeout: 5
Resources:
  QuarkusSam:
    Type: AWS::Serverless::Function
    Properties:
      Handler: not.used.in.provided.runtime
      Runtime: provided
      CodeUri: target/function.zip
      MemorySize: 128
      Policies: AWSLambdaBasicExecutionRole
      Timeout: 15
      Environment:
        Variables:
          DISABLE_SIGNAL_HANDLERS: true
```

# Local Invocation log
```
C:\Users\Elegie\springyme_quarkus\lambdatest>sam local invoke --template sam.native.yml --event payload.json
Invoking not.used.in.provided.runtime (provided)
2019-11-13 22:43:10 Found credentials in shared credentials file: ~/.aws/credentials
Decompressing C:\Users\Elegie\springyme_quarkus\lambdatest\target\function.zip

Fetching lambci/lambda:provided Docker container image......
Mounting C:\Users\Elegie\AppData\Local\Temp\tmp4pkc1cmb as /var/task:ro,delegated inside runtime container
2019-11-13 21:43:12,095 INFO  [io.quarkus] (main) lambdatest 1.0-SNAPSHOT (running on Quarkus 999-SNAPSHOT) started in 0.114s.
2019-11-13 21:43:12,111 INFO  [io.quarkus] (main) Profile prod activated.
2019-11-13 21:43:12,111 INFO  [io.quarkus] (main) Installed features: [amazon-lambda, cdi]
START RequestId: a0225029-cae1-1b62-0c1c-bcde852b6e77 Version: $LATEST
END RequestId: a0225029-cae1-1b62-0c1c-bcde852b6e77
REPORT RequestId: a0225029-cae1-1b62-0c1c-bcde852b6e77  Init Duration: 185.10 ms        Duration: 16.55 ms      Billed Duration: 100 ms                                                                                                     Memory Size: 128 MB      Max Memory Used: 14 MB
{"result":"hello Bill","requestId":"a0225029-cae1-1b62-0c1c-bcde852b6e77"}
```