### PR TITLE
Make sure the logs generated in integration-tests/maven are easily accessible

### DIFF
--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/verifier/RunningInvoker.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/verifier/RunningInvoker.java
@@ -1,13 +1,25 @@
 package io.quarkus.maven.it.verifier;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.shared.invoker.*;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
 import org.jutils.jprocesses.JProcesses;
 import org.jutils.jprocesses.model.ProcessInfo;
 
@@ -20,9 +32,10 @@ public class RunningInvoker extends MavenProcessInvoker {
     private final boolean debug;
     private MavenProcessInvocationResult result;
     private final File log;
-    private final PrintStreamHandler logHandler;
+    private final PrintStreamHandler outStreamHandler;
+    private final PrintStreamHandler errStreamHandler;
 
-    public RunningInvoker(File basedir, boolean debug) throws FileNotFoundException {
+    public RunningInvoker(File basedir, boolean debug) {
         this.debug = debug;
         setWorkingDirectory(basedir);
         String repo = System.getProperty("maven.repo");
@@ -31,16 +44,44 @@ public class RunningInvoker extends MavenProcessInvoker {
         }
         setLocalRepositoryDirectory(new File(repo));
         log = new File(basedir, "build-" + basedir.getName() + ".log");
-        PrintStream stream = null;
+        PrintStream outStream;
         try {
-            stream = new PrintStream(log, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            stream = new PrintStream(log);
+            outStream = createTeePrintStream(System.out, Files.newOutputStream(log.toPath()));
+        } catch (IOException ioe) {
+            outStream = System.out;
         }
-        logHandler = new PrintStreamHandler(stream, true);
-        setErrorHandler(logHandler);
-        setOutputHandler(logHandler);
-        setLogger(new PrintStreamLogger(stream, InvokerLogger.DEBUG));
+        this.outStreamHandler = new PrintStreamHandler(outStream, true);
+        setOutputHandler(this.outStreamHandler);
+
+        PrintStream errStream;
+        try {
+            errStream = createTeePrintStream(System.err, Files.newOutputStream(log.toPath()));
+        } catch (IOException ioe) {
+            errStream = System.err;
+        }
+        this.errStreamHandler = new PrintStreamHandler(errStream, true);
+        setErrorHandler(this.errStreamHandler);
+
+        setLogger(new PrintStreamLogger(outStream, debug ? InvokerLogger.DEBUG : InvokerLogger.INFO));
+    }
+
+    /**
+     * Creates a {@link PrintStream} with an underlying {@link TeeOutputStream} composed of {@code one}
+     * and {@code two} outputstreams
+     *
+     * @param one
+     * @param two
+     * @return
+     */
+    private static PrintStream createTeePrintStream(final OutputStream one, final OutputStream two) {
+        final OutputStream tee = new TeeOutputStream(one, two);
+        PrintStream stream;
+        try {
+            stream = new PrintStream(tee, true, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            stream = new PrintStream(tee, true);
+        }
+        return stream;
     }
 
     public void stop() {
@@ -81,8 +122,8 @@ public class RunningInvoker extends MavenProcessInvoker {
 
         request.setShellEnvironmentInherited(true);
         envVars.forEach(request::addShellEnvironment);
-        request.setOutputHandler(logHandler);
-        request.setErrorHandler(logHandler);
+        request.setOutputHandler(outStreamHandler);
+        request.setErrorHandler(errStreamHandler);
         this.result = (MavenProcessInvocationResult) execute(request);
         return result;
     }
@@ -93,6 +134,9 @@ public class RunningInvoker extends MavenProcessInvoker {
     }
 
     public String log() throws IOException {
+        if (log == null) {
+            return null;
+        }
         return FileUtils.readFileToString(log, "UTF-8");
     }
 


### PR DESCRIPTION
The `integration-tests/maven` has tests which launches a `mvn` process and runs various goals, to test our Maven Mojos. It uses an test framework specific class `RunningInvoker` which does the launching of the `mvn` process.

Right now, the `RunningInvoker` uses a (per test case specific) log file to redirect the logs generated by the spawned `mvn` process, to that file. There are certain (limited) number of tests that then load the log file and do string comparison to verify certain aspects of the tests. This is mostly fine. However, there are various other tests which use this same `RunningInvoker` but do not need to parse/verify the logs. With this kind of redirection, it's not easy to quickly figure out what went wrong if these tests fail, because these errors/output isn't easily viewable/accessible in our CI infrastructure logs. One such case is this PR https://github.com/quarkusio/quarkus/pull/5409 which has been running into failures against our CI, but because the log isn't "visible" in the CI logs, it wasn't easy to figure out what the problem was. Had to run this locally on a Windows setup and then get hold of the log file to see what the problem was.

With the change in this commit, the logs are made available on `System.out` and `System.err` by default and only those tests which rely on having these logs logged to a file can now optionally do so by passing `redirectToLogFile` as `true`.

This is a test framework only change and shouldn't impact regular usage of Quarkus. 