### PR TITLE
Maven plugin's devmode doesn't take into account versions overridden through system properties or profiles

### DIFF
--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -21,12 +21,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.maven.wagon</groupId>
-                    <artifactId>wagon-provider-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -59,10 +53,6 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-invoker</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <exclusions>
@@ -72,21 +62,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-toolchain</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptions.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptions.java
@@ -1,0 +1,141 @@
+package io.quarkus.bootstrap.resolver.maven.options;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.quarkus.bootstrap.util.PropertyUtils;
+
+/**
+ * This class resolves relevant Maven command line options in case it's called
+ * from a Maven build process. Maven internally uses org.apache.commons.cli.* API
+ * besides Maven-specific API. This class locates the Maven's lib directory that
+ * was used to launch the build process and loads the necessary classes from that
+ * lib directory.
+ */
+public class BootstrapMavenOptions {
+
+    public static Map<String, Object> parse(String cmdLine) {
+        if(cmdLine == null) {
+            return Collections.emptyMap();
+        }
+        final String[] args = cmdLine.split("\\s+");
+        if(args.length == 0) {
+            return Collections.emptyMap();
+        }
+
+        final String mavenHome = PropertyUtils.getProperty("maven.home");
+        if(mavenHome == null) {
+            return invokeParser(Thread.currentThread().getContextClassLoader(), args);
+        }
+
+        final Path mvnLib = Paths.get(mavenHome).resolve("lib");
+        if (!Files.exists(mvnLib)) {
+            throw new IllegalStateException("Maven lib dir does not exist: " + mvnLib);
+        }
+        final URL[] urls;
+        try {
+            final List<URL> list = Files.list(mvnLib).map(p -> {
+                try {
+                    return p.toUri().toURL();
+                } catch (MalformedURLException e) {
+                    throw new IllegalStateException("Failed to translate " + p + " to URL", e);
+                }
+            }).collect(Collectors.toCollection(ArrayList::new));
+            list.add(getClassOrigin(BootstrapMavenOptions.class).toUri().toURL());
+            urls = list.toArray(new URL[list.size()]);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create a URL list out of " + mvnLib + " content", e);
+        }
+        final ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+        try (URLClassLoader ucl = new URLClassLoader(urls, null)) {
+            Thread.currentThread().setContextClassLoader(ucl);
+            return invokeParser(ucl, args);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to close URL classloader", e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalCl);
+        }
+    }
+
+    public static BootstrapMavenOptions newInstance(String cmdLine) {
+        return new BootstrapMavenOptions(parse(cmdLine));
+    }
+
+    private final Map<String, Object> options;
+
+    private BootstrapMavenOptions(Map<String, Object> options) {
+        this.options = options;
+    }
+
+    public boolean hasOption(String name) {
+        return options.containsKey(name);
+    }
+
+    public String getOptionValue(String name) {
+        final Object o = options.get(name);
+        return o == null ? null : o.toString();
+    }
+
+    public String[] getOptionValues(String name) {
+        final Object o = options.get(name);
+        return o == null ? null : (String[]) o;
+    }
+
+    public boolean isEmpty() {
+        return options.isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> invokeParser(ClassLoader cl, String[] args) {
+        try {
+            final Class<?> parserCls = cl.loadClass("io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptionsParser");
+            final Method parseMethod = parserCls.getMethod("parse", String[].class);
+            return (Map<String, Object>) parseMethod.invoke(null, (Object) args);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse command line arguments " + Arrays.asList(args), e);
+        }
+    }
+
+    /**
+     * Returns the JAR or the root directory that contains the class file that is on the
+     * classpath of the context classloader
+     */
+    public static Path getClassOrigin(Class<?> cls) throws IOException {
+        return getResourceOrigin(cls.getClassLoader(), cls.getName().replace('.', '/') + ".class");
+    }
+
+    public static Path getResourceOrigin(ClassLoader cl, final String name) throws IOException {
+        URL url = cl.getResource(name);
+        if (url == null) {
+            throw new IOException("Failed to locate the origin of " + name);
+        }
+        String classLocation = url.toExternalForm();
+        if (url.getProtocol().equals("jar")) {
+            classLocation = classLocation.substring(4, classLocation.length() - name.length() - 2);
+        } else {
+            classLocation = classLocation.substring(0, classLocation.length() - name.length());
+        }
+        return urlSpecToPath(classLocation);
+    }
+
+    private static Path urlSpecToPath(String urlSpec) throws IOException {
+        try {
+            return Paths.get(new URL(urlSpec).toURI());
+        } catch (Throwable e) {
+            throw new IOException(
+                    "Failed to create an instance of " + Path.class.getName() + " from " + urlSpec, e);
+        }
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptionsParser.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptionsParser.java
@@ -1,0 +1,58 @@
+package io.quarkus.bootstrap.resolver.maven.options;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+import org.apache.maven.cli.CLIManager;
+
+public class BootstrapMavenOptionsParser {
+
+    public static Map<String, Object> parse(String[] args) {
+        final CommandLine cmdLine;
+        try {
+            cmdLine = new CLIManager().parse(args);
+        } catch (ParseException e) {
+            throw new IllegalStateException("Failed to parse Maven command line arguments", e);
+        }
+
+        final Map<String, Object> map = new HashMap<>();
+        put(cmdLine, map, CLIManager.ALTERNATE_USER_SETTINGS);
+        put(cmdLine, map, CLIManager.ALTERNATE_GLOBAL_SETTINGS);
+        put(cmdLine, map, CLIManager.ACTIVATE_PROFILES);
+
+        putBoolean(cmdLine, map, CLIManager.SUPRESS_SNAPSHOT_UPDATES);
+        putBoolean(cmdLine, map, CLIManager.UPDATE_SNAPSHOTS);
+        putBoolean(cmdLine, map, CLIManager.CHECKSUM_FAILURE_POLICY);
+        putBoolean(cmdLine, map, CLIManager.CHECKSUM_WARNING_POLICY);
+
+        return map;
+    }
+
+    private static void put(CommandLine cmdLine, Map<String, Object> map, char name) {
+        put(map, String.valueOf(name), cmdLine.getOptionValue(name));
+    }
+
+    private static void put(CommandLine cmdLine, Map<String, Object> map, String name) {
+        put(map, name, cmdLine.getOptionValue(name));
+    }
+
+    private static void putBoolean(CommandLine cmdLine, Map<String, Object> map, char name) {
+        if(cmdLine.hasOption(name)) {
+            map.put(String.valueOf(name), Boolean.TRUE.toString());
+        }
+    }
+
+    private static void putBoolean(CommandLine cmdLine, Map<String, Object> map, String name) {
+        if(cmdLine.hasOption(name)) {
+            map.put(name, Boolean.TRUE.toString());
+        }
+    }
+
+    private static void put(Map<String, Object> map, String name, final Object value) {
+        if(value != null) {
+            map.put(name, value);
+        }
+    }
+}

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -38,6 +38,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -99,12 +103,6 @@
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-platform-descriptor-json</artifactId>
                         <version>${project.version}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>org.apache.maven</groupId>
-                                <artifactId>*</artifactId>
-                            </exclusion>
-                        </exclusions>
                     </dependency>
                     <dependency>
                         <groupId>io.quarkus</groupId>


### PR DESCRIPTION
For some reason the pom provided by the LocalWorkspace instance is not interpolated by Maven.

It is also important to use MojoExecutor API to invoke `compile` on the project instead of using the Maven Invoker because MojoExecutor will share the reactor with the dev mojo that can later be re-used as the workspace reader.

Fixes #4289 

Also enables a workaround for #3539 by adding `maven.home` system property set by Maven launcher to propagate the Maven home dir to Quarkus bootstrap used in the tests. E.g.
````
      <plugin>
        <artifactId>maven-surefire-plugin</artifactId>
        <version>${surefire-plugin.version}</version>
        <configuration>
          <systemProperties>
            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
            <maven.home>${maven.home}</maven.home>
          </systemProperties>
        </configuration>
      </plugin>
````