### PR TITLE
docs: change servlet to route in swagger-ui path documentation since the endpoint is not served by servlets anymore

### DIFF
--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -203,7 +203,7 @@ public class SwaggerUiProcessor {
     @ConfigRoot
     static final class SwaggerUiConfig {
         /**
-         * The path of the swagger-ui servlet.
+         * The path where Swagger UI is available.
          * <p>
          * The value `/` is not allowed as it blocks the application from serving anything else.
          */


### PR DESCRIPTION
I was going through the documentation and found this one. 

/cc @gsmet @geoand 