### PR TITLE
Remove duplicate dependency from integration test module

### DIFF
--- a/integration-tests/jpa-without-entity/pom.xml
+++ b/integration-tests/jpa-without-entity/pom.xml
@@ -43,10 +43,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-orm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jsonb</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This dependency is listed twice in the same module. Maven seems to not complain during a regular build, but this fails hard when trying to build subsets of the Quarkus project using Maven's `-amd` to build all dependant modules of a list of projects.