### PR TITLE
Make build registration of security interceptors more flexible

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.resteasy.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+import static io.quarkus.resteasy.deployment.SecurityTransformerUtils.hasSecurityAnnotation;
 
 import java.util.HashSet;
 import java.util.List;
@@ -10,7 +11,6 @@ import java.util.stream.Collectors;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
-import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -41,24 +41,19 @@ public class ResteasyBuiltinsProcessor {
     void setUpDenyAllJaxRs(CombinedIndexBuildItem index,
             JaxRsSecurityConfig config,
             ResteasyDeploymentBuildItem resteasyDeployment,
-            BuildProducer<AnnotationsTransformerBuildItem> transformers,
             BuildProducer<AdditionalSecuredClassesBuildIem> additionalSecuredClasses) {
         if (config.denyJaxRs) {
             Set<ClassInfo> classes = new HashSet<>();
 
-            DenyJaxRsTransformer transformer = new DenyJaxRsTransformer(resteasyDeployment.getDeployment());
-
             List<String> resourceClasses = resteasyDeployment.getDeployment().getScannedResourceClasses();
             for (String className : resourceClasses) {
                 ClassInfo classInfo = index.getIndex().getClassByName(DotName.createSimple(className));
-                if (transformer.requiresSyntheticDenyAll(classInfo)) {
+                if (!hasSecurityAnnotation(classInfo)) {
                     classes.add(classInfo);
                 }
             }
 
             additionalSecuredClasses.produce(new AdditionalSecuredClassesBuildIem(classes));
-            transformers.produce(new AnnotationsTransformerBuildItem(transformer));
-
         }
     }
 

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalDenyingUnannotatedTransformer.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalDenyingUnannotatedTransformer.java
@@ -1,0 +1,33 @@
+package io.quarkus.security.deployment;
+
+import static io.quarkus.security.deployment.SecurityTransformerUtils.DENY_ALL;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationTarget;
+
+import io.quarkus.arc.processor.AnnotationsTransformer;
+
+public class AdditionalDenyingUnannotatedTransformer implements AnnotationsTransformer {
+
+    private final Set<String> classNames;
+
+    public AdditionalDenyingUnannotatedTransformer(Collection<String> classNames) {
+        this.classNames = new HashSet<>(classNames);
+    }
+
+    @Override
+    public boolean appliesTo(AnnotationTarget.Kind kind) {
+        return kind == org.jboss.jandex.AnnotationTarget.Kind.CLASS;
+    }
+
+    @Override
+    public void transform(TransformationContext context) {
+        String className = context.getTarget().asClass().name().toString();
+        if (classNames.contains(className)) {
+            context.transform().add(DENY_ALL).done();
+        }
+    }
+}

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalSecurityCheckBuildItem.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalSecurityCheckBuildItem.java
@@ -1,0 +1,31 @@
+package io.quarkus.security.deployment;
+
+import java.util.function.Function;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ResultHandle;
+
+/**
+ * Used as an integration point when extensions need to customize the security behavior of a bean
+ */
+public final class AdditionalSecurityCheckBuildItem extends MultiBuildItem {
+
+    private final MethodInfo methodInfo;
+    private final Function<BytecodeCreator, ResultHandle> function;
+
+    public AdditionalSecurityCheckBuildItem(MethodInfo methodInfo, Function<BytecodeCreator, ResultHandle> function) {
+        this.methodInfo = methodInfo;
+        this.function = function;
+    }
+
+    public MethodInfo getMethodInfo() {
+        return methodInfo;
+    }
+
+    public Function<BytecodeCreator, ResultHandle> getSecurityCheckResultHandleCreator() {
+        return function;
+    }
+}

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/DotNames.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/DotNames.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.deployment;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.security.Authenticated;
+
+public final class DotNames {
+
+    public static final DotName ROLES_ALLOWED = DotName.createSimple(RolesAllowed.class.getName());
+    public static final DotName AUTHENTICATED = DotName.createSimple(Authenticated.class.getName());
+    public static final DotName DENY_ALL = DotName.createSimple(DenyAll.class.getName());
+    public static final DotName PERMIT_ALL = DotName.createSimple(PermitAll.class.getName());
+
+    private DotNames() {
+    }
+}

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityCheckInstantiationUtil.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityCheckInstantiationUtil.java
@@ -1,0 +1,64 @@
+package io.quarkus.security.deployment;
+
+import static io.quarkus.gizmo.MethodDescriptor.ofConstructor;
+
+import java.util.function.Function;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.security.runtime.interceptor.check.AuthenticatedCheck;
+import io.quarkus.security.runtime.interceptor.check.DenyAllCheck;
+import io.quarkus.security.runtime.interceptor.check.PermitAllCheck;
+import io.quarkus.security.runtime.interceptor.check.RolesAllowedCheck;
+
+public class SecurityCheckInstantiationUtil {
+
+    private SecurityCheckInstantiationUtil() {
+    }
+
+    public static Function<BytecodeCreator, ResultHandle> rolesAllowedSecurityCheck(final String[] rolesAllowed) {
+        return new Function<BytecodeCreator, ResultHandle>() {
+            @Override
+            public ResultHandle apply(BytecodeCreator creator) {
+                if ((rolesAllowed == null)) {
+                    throw new IllegalStateException(
+                            "Cannot use a null array to create an instance of " + RolesAllowedCheck.class.getName());
+                }
+
+                ResultHandle ctorArgs = creator.newArray(String.class, creator.load(rolesAllowed.length));
+                int i = 0;
+                for (String val : rolesAllowed) {
+                    creator.writeArrayValue(ctorArgs, i++, creator.load(val));
+                }
+                return creator.newInstance(ofConstructor(RolesAllowedCheck.class, String[].class), ctorArgs);
+            }
+        };
+    }
+
+    public static Function<BytecodeCreator, ResultHandle> denyAllSecurityCheck() {
+        return new Function<BytecodeCreator, ResultHandle>() {
+            @Override
+            public ResultHandle apply(BytecodeCreator creator) {
+                return creator.newInstance(ofConstructor(DenyAllCheck.class));
+            }
+        };
+    }
+
+    public static Function<BytecodeCreator, ResultHandle> permitAllSecurityCheck() {
+        return new Function<BytecodeCreator, ResultHandle>() {
+            @Override
+            public ResultHandle apply(BytecodeCreator creator) {
+                return creator.newInstance(ofConstructor(PermitAllCheck.class));
+            }
+        };
+    }
+
+    public static Function<BytecodeCreator, ResultHandle> authenticatedSecurityCheck() {
+        return new Function<BytecodeCreator, ResultHandle>() {
+            @Override
+            public ResultHandle apply(BytecodeCreator creator) {
+                return creator.newInstance(ofConstructor(AuthenticatedCheck.class));
+            }
+        };
+    }
+}

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityCheckStorageBuilder.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityCheckStorageBuilder.java
@@ -6,27 +6,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.annotation.security.DenyAll;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
-
-import io.quarkus.security.Authenticated;
-import io.quarkus.security.runtime.interceptor.check.AuthenticatedCheck;
-import io.quarkus.security.runtime.interceptor.check.DenyAllCheck;
-import io.quarkus.security.runtime.interceptor.check.PermitAllCheck;
-import io.quarkus.security.runtime.interceptor.check.RolesAllowedCheck;
 import io.quarkus.security.runtime.interceptor.check.SecurityCheck;
 
 public class SecurityCheckStorageBuilder {
     private final Map<MethodDescription, SecurityCheck> securityChecks = new HashMap<>();
 
-    public void registerAnnotation(String aClass,
+    public void registerCheck(String className,
             String methodName,
             String[] parameterTypes,
-            String securityAnnotation,
-            String[] value) {
-        securityChecks.put(new MethodDescription(aClass, methodName, parameterTypes),
-                determineCheck(securityAnnotation, value));
+            SecurityCheck securityCheck) {
+        securityChecks.put(new MethodDescription(className, methodName, parameterTypes), securityCheck);
     }
 
     public SecurityCheckStorage create() {
@@ -40,23 +29,7 @@ public class SecurityCheckStorageBuilder {
         };
     }
 
-    private SecurityCheck determineCheck(String securityAnnotation, String[] value) {
-        if (DenyAll.class.getName().equals(securityAnnotation)) {
-            return new DenyAllCheck();
-        }
-        if (RolesAllowed.class.getName().equals(securityAnnotation)) {
-            return new RolesAllowedCheck(value);
-        }
-        if (PermitAll.class.getName().equals(securityAnnotation)) {
-            return new PermitAllCheck();
-        }
-        if (Authenticated.class.getName().equals(securityAnnotation)) {
-            return new AuthenticatedCheck();
-        }
-        throw new IllegalArgumentException("Unsupported security check " + securityAnnotation);
-    }
-
-    private String[] typesAsStrings(Class[] parameterTypes) {
+    private String[] typesAsStrings(Class<?>[] parameterTypes) {
         String[] result = new String[parameterTypes.length];
         for (int i = 0; i < parameterTypes.length; i++) {
             result[i] = parameterTypes[i].getName();
@@ -69,8 +42,8 @@ public class SecurityCheckStorageBuilder {
         private final String methodName;
         private final String[] parameterTypes;
 
-        public MethodDescription(String aClass, String methodName, String[] parameterTypes) {
-            this.className = aClass;
+        public MethodDescription(String className, String methodName, String[] parameterTypes) {
+            this.className = className;
             this.methodName = methodName;
             this.parameterTypes = parameterTypes;
         }

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredClassesBuildIem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredClassesBuildIem.java
@@ -7,6 +7,9 @@ import org.jboss.jandex.ClassInfo;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Contains classes that need to have @DenyAll on all methods that don't have security annotations
+ */
 public final class AdditionalSecuredClassesBuildIem extends MultiBuildItem {
     public final Collection<ClassInfo> additionalSecuredClasses;
 


### PR DESCRIPTION
This is done by allowing the registration of arbitrary
SecurityCheck implementations.
Furthermore the use of the AnnotationStore is hidden so as
to not give the impression that it's a feature that magically
makes security annotations work

This change paves the way for #5225 and more related improvements
in the future