### PR TITLE
Introduce UnsafeAccessedFieldBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsafeAccessedFieldBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsafeAccessedFieldBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.deployment.builditem.nativeimage;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class UnsafeAccessedFieldBuildItem extends MultiBuildItem {
+
+    final String declaringClass;
+    final String fieldName;
+
+    public UnsafeAccessedFieldBuildItem(String declaringClass, String fieldName) {
+        this.declaringClass = declaringClass;
+        this.fieldName = fieldName;
+    }
+
+    public String getDeclaringClass() {
+        return declaringClass;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.netty.deployment;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -21,6 +23,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.netty.BossEventLoopGroup;
 import io.quarkus.netty.MainEventLoopGroup;
 import io.quarkus.netty.runtime.NettyRecorder;
@@ -176,5 +179,13 @@ class NettyProcessor {
     public RuntimeReinitializedClassBuildItem reinitScheduledFutureTask() {
         return new RuntimeReinitializedClassBuildItem(
                 "io.quarkus.netty.runtime.graal.Holder_io_netty_util_concurrent_ScheduledFutureTask");
+    }
+
+    // TODO: Remove this when netty.version is 4.1.43.Final or greater.
+    @BuildStep
+    public List<UnsafeAccessedFieldBuildItem> unsafeAccessedFields() {
+        return Arrays.asList(
+                new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "selectedKeys"),
+                new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "publicSelectedKeys"));
     }
 }


### PR DESCRIPTION
This PR introduces the GraalVM `allowUnsafeAccess` support for fields through the Quarkus reflection registration API.

It was created to fix one the GraalVM `19.3.0` requirements mentioned in #4218. It makes the Netty upgrade to `4.1.43.Final` optional.

cc @gsmet, @cescoffier 