### PR TITLE
add hibernate-jpamodelgen to bom

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1812,6 +1812,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-jpamodelgen</artifactId>
+                <version>${hibernate-orm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
                 <artifactId>quarkus-local-cache</artifactId>
                 <version>${hibernate-quarkus-local-cache.version}</version>
             </dependency>


### PR DESCRIPTION
To generate the static metamodel, e.g. for criteria queries, the
hibernate-jpamodelgen dependency must be added.

Adding the dependency in the dependency management section of the
bom makes it easier to keep the versions of hibernate and the
metamodel generator in sync.

Each project using the metamodel still needs to add an explicit 
dependency as in
```
<dependencies>
   ...
    <dependency>
        <groupId>org.hibernate</groupId>
        <artifactId>hibernate-jpamodelgen</artifactId>
    </dependency>
</dependencies>
```