### PR TITLE
refactor: rename META_INF_SERVICES to META_INF_RESOURCES in ResteasyHotReplacementSetup

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/devmode/ResteasyHotReplacementSetup.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/devmode/ResteasyHotReplacementSetup.java
@@ -11,15 +11,15 @@ import io.quarkus.resteasy.runtime.standalone.ResteasyStandaloneRecorder;
 
 public class ResteasyHotReplacementSetup implements HotReplacementSetup {
 
-    public static final String META_INF_SERVICES = "META-INF/resources";
+    public static final String META_INF_RESOURCES = "META-INF/resources";
 
     @Override
     public void setupHotDeployment(HotReplacementContext context) {
         List<Path> resources = new ArrayList<>();
-        for (Path i : context.getResourcesDir()) {
-            Path resolved = i.resolve(META_INF_SERVICES);
-            if (Files.exists(resolved)) {
-                resources.add(resolved);
+        for (Path resourceDir : context.getResourcesDir()) {
+            Path resource = resourceDir.resolve(META_INF_RESOURCES);
+            if (Files.exists(resource)) {
+                resources.add(resource);
             }
         }
         ResteasyStandaloneRecorder.setHotDeploymentResources(resources);


### PR DESCRIPTION
I noticed the typo when I was going around trying to fix something. While I was there, I did some
all around clean ups of variable naming
