### PR TITLE
refactor(LogConfig): Remove optional @DefaultConverter

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -98,10 +98,10 @@ public class ExecutorRecorder {
                                 final List<Runnable> runnables = executor.shutdownNow();
                                 if (!runnables.isEmpty()) {
                                     log.warnf("Thread pool shutdown failed: discarding %d tasks, %d threads still running",
-                                            Integer.valueOf(runnables.size()), Integer.valueOf(executor.getActiveCount()));
+                                            runnables.size(), executor.getActiveCount());
                                 } else {
                                     log.warnf("Thread pool shutdown failed: %d threads still running",
-                                            Integer.valueOf(executor.getActiveCount()));
+                                            executor.getActiveCount());
                                 }
                                 break;
                             }
@@ -111,7 +111,7 @@ public class ExecutorRecorder {
                                 final int queueSize = executor.getQueueSize();
                                 final Thread[] runningThreads = executor.getRunningThreads();
                                 log.infof("Awaiting thread pool shutdown; %d thread(s) running with %d task(s) waiting",
-                                        Integer.valueOf(runningThreads.length), Integer.valueOf(queueSize));
+                                        runningThreads.length, queueSize);
                                 // make sure no threads are stuck in {@code exit()}
                                 int realWaiting = runningThreads.length;
                                 for (Thread thr : runningThreads) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -5,7 +5,6 @@ import java.util.logging.Level;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.DefaultConverter;
 
 @ConfigGroup
 public class ConsoleConfig {
@@ -25,7 +24,6 @@ public class ConsoleConfig {
     /**
      * The console log level
      */
-    @DefaultConverter
     @ConfigItem(defaultValue = "ALL")
     Level level;
 
@@ -33,7 +31,7 @@ public class ConsoleConfig {
      * If the console logging should be in color. If undefined quarkus takes
      * best guess based on operating system and environment.
      */
-    @ConfigItem()
+    @ConfigItem
     Optional<Boolean> color;
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -6,7 +6,6 @@ import java.util.logging.Level;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.DefaultConverter;
 import io.quarkus.runtime.configuration.MemorySize;
 
 @ConfigGroup
@@ -32,7 +31,6 @@ public class FileConfig {
     /**
      * The level of logs to be written into the file.
      */
-    @DefaultConverter
     @ConfigItem(defaultValue = "ALL")
     Level level;
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/SyslogConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/SyslogConfig.java
@@ -21,6 +21,7 @@ public class SyslogConfig {
     boolean enable;
 
     /**
+     *
      * The IP address and port of the syslog server
      */
     @ConfigItem(defaultValue = "localhost:514")
@@ -60,13 +61,13 @@ public class SyslogConfig {
      * Set to {@code true} if the message being sent should be prefixed with the size of the message
      */
     @ConfigItem
-    public boolean useCountingFraming;
+    boolean useCountingFraming;
 
     /**
      * Set to {@code true} if the message should be truncated
      */
     @ConfigItem(defaultValue = "true")
-    public boolean truncate;
+    boolean truncate;
 
     /**
      * Enables or disables blocking when attempting to reconnect a

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -942,7 +942,6 @@ public class FileConfig {
     /**
      * The level of logs to be written into the file.
      */
-    @DefaultConverter
     @ConfigItem(defaultValue = "ALL")
     Level level;
 


### PR DESCRIPTION
Hi @dmlloyd, 
According to [writing extensions guide](https://quarkus.io/guides/writing-extensions) we should use `@DefaultConverter` if we have one, i thought that this is the case of `Level.class` && `InetSocketAddress`. 

Thanks