### PR TITLE
fix: remove build warning by making injected spring data jpa fragments protected in a generated repository

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
@@ -163,7 +163,7 @@ public class SpringDataRepositoryCreator {
         for (String customImplClassName : customImplClassNames) {
             FieldCreator customClassField = repositoryImpl
                     .getFieldCreator("customImplClass" + (i + 1), customImplClassName)
-                    .setModifiers(Modifier.PRIVATE);
+                    .setModifiers(Modifier.PROTECTED); // done to prevent warning during the build
             customClassField.addAnnotation(Inject.class);
 
             customImplNameToFieldDescriptor.put(customImplClassName,


### PR DESCRIPTION
This was causing the following warning:
```
[INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:
- @Inject field io.quarkus.it.spring.data.jpa.PersonRepository_bcb609283abd593bd6e8ce51955e38a20ba9d528Impl#customImplClass1,
- @Inject field io.quarkus.it.spring.data.jpa.PersonRepository_bcb609283abd593bd6e8ce51955e38a20ba9d528Impl#customImplClass2
```

