### PR TITLE
close handlers and free all associated resources.

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -146,7 +146,7 @@
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.0.1</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
-        <jboss-logmanager.version>1.0.3</jboss-logmanager.version>
+        <jboss-logmanager.version>1.0.4</jboss-logmanager.version>
         <jgit.version>5.5.1.201910021850-r</jgit.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
         <flyway.version>6.0.6</flyway.version>

--- a/core/runtime/src/main/java/io/quarkus/runtime/Timing.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Timing.java
@@ -1,8 +1,11 @@
 package io.quarkus.runtime;
 
 import java.math.BigDecimal;
+import java.util.logging.Handler;
 
 import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.logging.InitialConfigurator;
 
 /**
  * Class that is responsible for printing out timing results.
@@ -79,6 +82,17 @@ public class Timing {
                 (UNSET_VALUE.equals(name) || name == null || name.trim().isEmpty()) ? "Quarkus" : name,
                 secondsRepresentation);
         bootStopTime = -1;
+
+        /**
+         * We can safely close log handlers after stop time has been printed.
+         */
+        Handler[] handlers = InitialConfigurator.DELAYED_HANDLER.clearHandlers();
+        for (Handler handler : handlers) {
+            try {
+                handler.close();
+            } catch (Throwable ignored) {
+            }
+        }
     }
 
     public static BigDecimal convertToBigDecimalSeconds(final long timeNanoSeconds) {


### PR DESCRIPTION
I noticed that the handlers were never closed while trying to figure out the causes for
https://github.com/quarkusio/quarkus/issues/5522.

Fixes https://github.com/quarkusio/quarkus/issues/5522
