### PR TITLE
Use a specific Keycloak docker image tag to run the integration tests

### DIFF
--- a/ci-templates/native-build-steps.yaml
+++ b/ci-templates/native-build-steps.yaml
@@ -36,7 +36,7 @@ jobs:
       - script: docker run --rm --publish 8000:8000 --name build-dynamodb -d amazon/dynamodb-local:1.11.477
         displayName: 'start dynamodb'
     - ${{ if eq(parameters.keycloak, 'true') }}:
-        - script: docker run --rm --publish 8180:8080 --name build-keycloak  -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e JAVA_OPTS="-server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dkeycloak.profile.feature.upload_scripts=enabled" -d quay.io/keycloak/keycloak
+        - script: docker run --rm --publish 8180:8080 --name build-keycloak  -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e JAVA_OPTS="-server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dkeycloak.profile.feature.upload_scripts=enabled" -d quay.io/keycloak/keycloak:7.0.1
           displayName: 'start keycloak'
     - ${{ if eq(parameters.mysql, 'true') }}:
       - bash: |


### PR DESCRIPTION
<s>The commit here temporarily disables the `BearerTokenAuthorizationTest` since it has been failing consistently in recent runs causing CI failures for other unrleated PRs. 

Once the real issue is fixed, this can then be re-enabled.</s>

The PR has now been updated to use `7.0.1` of Keycloak docker image to run these tests, instead of the "latest" which since the past 2 days has now moved to 8.0.0 and has been causing failures in the Keycloak related tests.

