### PR TITLE
mongodb-client: Make it possible to override default providers

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -100,9 +100,10 @@ public class MongoClientRecorder {
                 .automatic(true)
                 .conventions(Conventions.DEFAULT_CONVENTIONS)
                 .build();
-        providers.add(pojoCodecProvider);
-        CodecRegistry registry = CodecRegistries.fromRegistries(defaultCodecRegistry,
-                CodecRegistries.fromProviders(providers));
+        CodecRegistry registry = CodecRegistries.fromRegistries(
+                CodecRegistries.fromProviders(providers),
+                defaultCodecRegistry,
+                CodecRegistries.fromProviders(Collections.singletonList(pojoCodecProvider)));
         settings.codecRegistry(registry);
 
         config.applicationName.ifPresent(settings::applicationName);


### PR DESCRIPTION
Make it possible to override the default codec providers by changing the order in the codec registry created during initalization.

In my case I wanted to a use different UuidCoded instead of the default legacy one.