### PR TITLE
mongodb-client: Make it possible to override default providers

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -90,21 +90,21 @@ public class MongoClientRecorder {
             settings.applyConnectionString(connectionString);
         }
 
-        List<CodecProvider> providers = new ArrayList<>();
-        if (!codecProviders.isEmpty()) {
-            providers.addAll(getCodecProviders(codecProviders));
+        List<CodecRegistry> registries = new ArrayList<>();
+        List<CodecProvider> foundProviders = getCodecProviders(codecProviders);
+        if (!foundProviders.isEmpty()) {
+            registries.add(CodecRegistries.fromProviders(foundProviders));
         }
+        registries.add(defaultCodecRegistry);
+
         // add pojo codec provider with automatic capabilities
         // it always needs to be the last codec provided
         CodecProvider pojoCodecProvider = PojoCodecProvider.builder()
                 .automatic(true)
                 .conventions(Conventions.DEFAULT_CONVENTIONS)
                 .build();
-        CodecRegistry registry = CodecRegistries.fromRegistries(
-                CodecRegistries.fromProviders(providers),
-                defaultCodecRegistry,
-                CodecRegistries.fromProviders(Collections.singletonList(pojoCodecProvider)));
-        settings.codecRegistry(registry);
+        registries.add(CodecRegistries.fromProviders(Collections.singletonList(pojoCodecProvider)));
+        settings.codecRegistry(CodecRegistries.fromRegistries(registries));
 
         config.applicationName.ifPresent(settings::applicationName);
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -100,9 +100,10 @@ public class MongoClientRecorder {
                 .automatic(true)
                 .conventions(Conventions.DEFAULT_CONVENTIONS)
                 .build();
-        providers.add(pojoCodecProvider);
-        CodecRegistry registry = CodecRegistries.fromRegistries(defaultCodecRegistry,
-                CodecRegistries.fromProviders(providers));
+        CodecRegistry registry = CodecRegistries.fromRegistries(
+                CodecRegistries.fromProviders(providers),
+                defaultCodecRegistry,
+                CodecRegistries.fromProviders(Collections.singletonList(pojoCodecProvider)));
         settings.codecRegistry(registry);
 
         config.applicationName.ifPresent(settings::applicationName);


### PR DESCRIPTION
Make it possible to override the default codec providers by changing the order in the codec registry created during initalization.

In my case I wanted to a use different UuidCoded instead of the default.