### PR TITLE
Replacing quarkus.properties with quarkus.platform.version

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigDefinition.java
@@ -71,6 +71,9 @@ public class ConfigDefinition extends CompoundConfigType {
             .asList(QUARKUS_NAMESPACE + ".live-reload.password", QUARKUS_NAMESPACE + ".live-reload.url",
                     QUARKUS_NAMESPACE + ".debug.generated-classes-dir", QUARKUS_NAMESPACE + ".debug.reflection",
                     QUARKUS_NAMESPACE + ".build.skip",
+                    QUARKUS_NAMESPACE + ".platform.group-id",
+                    QUARKUS_NAMESPACE + ".platform.artifact-id",
+                    QUARKUS_NAMESPACE + ".platform.version",
                     QUARKUS_NAMESPACE + ".version", QUARKUS_NAMESPACE + ".profile", QUARKUS_NAMESPACE + ".test.profile",
                     QUARKUS_NAMESPACE + ".test.native-image-wait-time",
                     QUARKUS_NAMESPACE + ".test.native-image-profile");

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusVersion}"
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}"
     }
 }
 

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -1,3 +1,4 @@
 quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
+quarkusPluginVersion = ${plugin_version}

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/pom.xml-template.ftl
@@ -12,7 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
+        <quarkus.platform.artifact-id>${bom_artifactId}</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>${bom_groupId}</quarkus.platform.group-id>
+        <quarkus.platform.version>${bom_version}</quarkus.platform.version>
+        <quarkus-plugin.version>${plugin_version}</quarkus-plugin.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
     </properties>
@@ -20,9 +23,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${bom_groupId}</groupId>
-                <artifactId>${bom_artifactId}</artifactId>
-                <version>${bom_version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -54,7 +57,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusVersion}"
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}"
     }
 }
 

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
@@ -1,3 +1,4 @@
 quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
+quarkusPluginVersion = ${plugin_version}

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -12,7 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
+        <quarkus.platform.artifact-id>${bom_artifactId}</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>${bom_groupId}</quarkus.platform.group-id>
+        <quarkus.platform.version>${bom_version}</quarkus.platform.version>
+        <quarkus-plugin.version>${plugin_version}</quarkus-plugin.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <kotlin.version>${kotlin_version}</kotlin.version>
@@ -21,9 +24,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${plugin_groupId}</groupId>
-                <artifactId>${bom_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -61,7 +64,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/build.gradle-template.ftl
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusVersion}"
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}"
     }
 }
 

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/gradle.properties-template.ftl
@@ -1,3 +1,4 @@
 quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
+quarkusPluginVersion = ${plugin_version}

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/pom.xml-template.ftl
@@ -12,7 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
+        <quarkus.platform.artifact-id>${bom_artifactId}</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>${bom_groupId}</quarkus.platform.group-id>
+        <quarkus.platform.version>${bom_version}</quarkus.platform.version>
+        <quarkus-plugin.version>${plugin_version}</quarkus-plugin.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <scala.version>${scala_version}</scala.version>
@@ -22,9 +25,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${plugin_groupId}</groupId>
-                <artifactId>${bom_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -67,7 +70,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/CreateProject.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/CreateProject.java
@@ -14,7 +14,7 @@ import static io.quarkus.generators.ProjectGenerator.QUARKUS_VERSION;
 import static io.quarkus.generators.ProjectGenerator.SOURCE_TYPE;
 import static io.quarkus.maven.utilities.MojoUtils.getBomGroupId;
 import static io.quarkus.maven.utilities.MojoUtils.getBomArtifactId;
-import static io.quarkus.maven.utilities.MojoUtils.getBomVersionForTemplate;
+import static io.quarkus.maven.utilities.MojoUtils.getBomVersion;
 import static io.quarkus.maven.utilities.MojoUtils.getPluginVersion;
 import static io.quarkus.maven.utilities.MojoUtils.getQuarkusVersion;
 
@@ -111,7 +111,7 @@ public class CreateProject {
         context.put(PROJECT_VERSION, version);
         context.put(BOM_GROUP_ID, getBomGroupId());
         context.put(BOM_ARTIFACT_ID, getBomArtifactId());
-        context.put(BOM_VERSION, getBomVersionForTemplate(getBuildFile().getPlatformBomVersionExpression()));
+        context.put(BOM_VERSION, getBomVersion());
         context.put(QUARKUS_VERSION, getQuarkusVersion());
         context.put(SOURCE_TYPE, sourceType);
         context.put(BUILD_FILE, getBuildFile());

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/BuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/BuildFile.java
@@ -32,8 +32,6 @@ public abstract class BuildFile implements Closeable {
         this.buildTool = buildTool;
     }
 
-    public abstract String getPlatformBomVersionExpression();
-
     protected void write(String fileName, String content) throws IOException {
         writer.write(fileName, content);
     }
@@ -46,8 +44,8 @@ public abstract class BuildFile implements Closeable {
                 dep = extension.toDependency(true);
             } else {
                 dep = extension.toDependency(false);
-                if(getProperty(MojoUtils.QUARKUS_VERSION_PROPERTY_NAME) != null) {
-                    dep.setVersion(MojoUtils.QUARKUS_VERSION_PROPERTY);
+                if(getProperty(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_VERSION_NAME) != null) {
+                    dep.setVersion(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_VERSION_VALUE);
                 }
             }
             addDependencyInBuildFile(dep);

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -31,11 +31,6 @@ public class GradleBuildFile extends BuildFile {
     }
 
     @Override
-    public String getPlatformBomVersionExpression() {
-        return MojoUtils.getBomVersion();
-    }
-
-    @Override
     public void close() throws IOException {
         write(SETTINGS_GRADLE_PATH, getModel().getSettingsContent());
         write(BUILD_GRADLE_PATH, getModel().getBuildContent());
@@ -108,7 +103,7 @@ public class GradleBuildFile extends BuildFile {
             res.append("    resolutionStrategy {").append(System.lineSeparator());
             res.append("        eachPlugin {").append(System.lineSeparator());
             res.append("            if (requested.id.id == 'io.quarkus') {").append(System.lineSeparator());
-            res.append("                useModule(\"io.quarkus:quarkus-gradle-plugin:${quarkusVersion}\")")
+            res.append("                useModule(\"io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}\")")
                     .append(System.lineSeparator());
             res.append("            }").append(System.lineSeparator());
             res.append("        }").append(System.lineSeparator());
@@ -124,8 +119,8 @@ public class GradleBuildFile extends BuildFile {
 
     private void completeProperties() throws IOException {
         Properties props = getModel().getPropertiesContent();
-        if (props.getProperty("quarkusVersion") == null) {
-            props.setProperty("quarkusVersion", getPluginVersion());
+        if (props.getProperty("quarkusPluginVersion") == null) {
+            props.setProperty("quarkusPluginVersion", getPluginVersion());
         }
         if(props.getProperty("quarkusPlatformGroupId") == null) {
             props.setProperty("quarkusPlatformGroupId", MojoUtils.getBomGroupId());

--- a/independent-projects/tools/common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
@@ -46,8 +46,24 @@ public class MojoUtils {
     public static final String KOTLIN_EXTENSION_NAME = "kotlin";
     public static final String SCALA_EXTENSION_NAME = "scala";
 
-    public static final String QUARKUS_VERSION_PROPERTY_NAME = "quarkus.version";
-    public static final String QUARKUS_VERSION_PROPERTY = "${" + QUARKUS_VERSION_PROPERTY_NAME + "}";
+    public static final String TEMPLATE_PROPERTY_QUARKUS_VERSION_NAME = "quarkus.version";
+    public static final String TEMPLATE_PROPERTY_QUARKUS_VERSION_VALUE = toPropExpr(TEMPLATE_PROPERTY_QUARKUS_VERSION_NAME);
+
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLATFORM_GROUP_ID_NAME = "quarkus.platform.group-id";
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLATFORM_GROUP_ID_VALUE = toPropExpr(TEMPLATE_PROPERTY_QUARKUS_PLATFORM_GROUP_ID_NAME);
+
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_NAME = "quarkus.platform.artifact-id";
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE = toPropExpr(TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_NAME);
+
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_NAME = "quarkus.platform.version";
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE = toPropExpr(TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_NAME);
+
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_NAME = "quarkus-plugin.version";
+    public static final String TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE = toPropExpr(TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_NAME);
+
+    private static String toPropExpr(String name) {
+        return "${" + name + "}";
+    }
 
     private static Properties properties;
 
@@ -108,15 +124,6 @@ public class MojoUtils {
 
     public static String getBomVersion() {
         return getPlatformDescriptor().getBomVersion();
-    }
-
-    public static String getBomVersionForTemplate(String defaultValue) {
-        final String v = getBomVersion();
-        if(v.equals(getQuarkusVersion())) {
-            // this might not always work but at this point we're assuming the bom is coming from Quarkus itself
-            return defaultValue;
-        }
-        return v;
     }
 
     public static String getQuarkusVersion() {
@@ -249,6 +256,13 @@ public class MojoUtils {
     }
 
     public static void write(Model model, OutputStream fileOutputStream) throws IOException {
+        final Properties props = model.getProperties();
+        // until we can preserve the user ordering, it's better to stick to the alphabetical one
+        if (!props.isEmpty() && !(props instanceof SortedProperties)) {
+            final Properties sorted = new SortedProperties();
+            sorted.putAll(props);
+            model.setProperties(sorted);
+        }
         try (OutputStream stream = fileOutputStream) {
             new MavenXpp3Writer().write(stream, model);
         }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/maven/utilities/SortedProperties.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/maven/utilities/SortedProperties.java
@@ -1,0 +1,16 @@
+package io.quarkus.maven.utilities;
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+class SortedProperties extends Properties {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Set<Object> keySet()
+    {
+       return new TreeSet<Object>(super.keySet());
+    }
+}

--- a/independent-projects/tools/common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
@@ -9,5 +9,4 @@ public interface ToolsConstants {
 
     String DEFAULT_PLATFORM_BOM_GROUP_ID = IO_QUARKUS;
     String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-universe-bom";
-
 }

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/CreateProjectTest.java
@@ -138,7 +138,7 @@ public class CreateProjectTest {
         Assertions.assertTrue(createProject.doCreateProject(new HashMap<>()));
 
         assertThat(contentOf(pom, "UTF-8"))
-                .contains(getPluginArtifactId(), QUARKUS_VERSION_PROPERTY, getPluginGroupId());
+                .contains(getPluginArtifactId(), TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE, getPluginGroupId());
         assertThat(new File(testDir, "src/main/java")).isDirectory();
         assertThat(new File(testDir, "src/test/java")).isDirectory();
 
@@ -154,7 +154,7 @@ public class CreateProjectTest {
         });
 
         assertThat(contentOf(new File(testDir, "pom.xml"), "UTF-8"))
-                .containsIgnoringCase(getBomArtifactId());
+                .contains(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE);
 
     }
 
@@ -179,7 +179,7 @@ public class CreateProjectTest {
         Assertions.assertTrue(createProject.doCreateProject(new HashMap<>()));
 
         assertThat(contentOf(pom, "UTF-8"))
-                .contains(getPluginArtifactId(), QUARKUS_VERSION_PROPERTY, getPluginGroupId());
+                .contains(getPluginArtifactId(), TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE, getPluginGroupId());
         assertThat(new File(testDir, "src/main/java")).isDirectory();
         assertThat(new File(testDir, "src/test/java")).isDirectory();
 
@@ -221,7 +221,7 @@ public class CreateProjectTest {
         Assertions.assertTrue(createProject.doCreateProject(new HashMap<>()));
 
         assertThat(contentOf(pom, "UTF-8"))
-                .contains(getPluginArtifactId(), QUARKUS_VERSION_PROPERTY, getPluginGroupId());
+                .contains(getPluginArtifactId(), TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE, getPluginGroupId());
         assertThat(new File(testDir, "src/main/java")).isDirectory();
         assertThat(new File(testDir, "src/test/java")).isDirectory();
 
@@ -263,7 +263,7 @@ public class CreateProjectTest {
         assertThat(new File(testDir, "src/main/java/org/acme/MyApplication.java")).doesNotExist();
 
         assertThat(contentOf(pom, "UTF-8"))
-                .contains(getPluginArtifactId(), QUARKUS_VERSION_PROPERTY, getPluginGroupId());
+                .contains(getPluginArtifactId(), TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE, getPluginGroupId());
         assertThat(new File(testDir, "src/main/java")).isDirectory();
         assertThat(new File(testDir, "src/test/java")).isDirectory();
 
@@ -271,7 +271,7 @@ public class CreateProjectTest {
         assertThat(new File(testDir, "src/main/resources/META-INF/resources/index.html")).exists();
 
         assertThat(contentOf(new File(testDir, "pom.xml"), "UTF-8"))
-                .containsIgnoringCase(MojoUtils.QUARKUS_VERSION_PROPERTY);
+                .contains(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE);
 
     }
 

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/ListExtensionsTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/ListExtensionsTest.java
@@ -36,7 +36,7 @@ public class ListExtensionsTest {
 
         FileProjectWriter writer = new FileProjectWriter(pom.getParentFile());
         new CreateProject(writer)
-                .groupId(getPluginGroupId())
+                .groupId("org.acme")
                 .artifactId("add-extension-test")
                 .version("0.0.1-SNAPSHOT")
                 .doCreateProject(context);
@@ -69,7 +69,7 @@ public class ListExtensionsTest {
         FileProjectWriter writer = new FileProjectWriter(pomFile.getParentFile());
 
         new CreateProject(writer)
-                .groupId(getPluginGroupId())
+        .groupId("org.acme")
                 .artifactId("add-extension-test")
                 .version("0.0.1-SNAPSHOT")
                 .doCreateProject(context);
@@ -95,7 +95,7 @@ public class ListExtensionsTest {
         FileProjectWriter writer = new FileProjectWriter(pomFile.getParentFile());
 
         new CreateProject(writer)
-                .groupId(getPluginGroupId())
+                .groupId("org.acme")
                 .artifactId("add-extension-test")
                 .version("0.0.1-SNAPSHOT")
                 .doCreateProject(context);
@@ -166,7 +166,7 @@ public class ListExtensionsTest {
         FileProjectWriter writer = new FileProjectWriter(pomFile.getParentFile());
 
         new CreateProject(writer)
-                .groupId(getPluginGroupId())
+                .groupId("org.acme")
                 .artifactId("add-extension-test")
                 .version("0.0.1-SNAPSHOT")
                 .doCreateProject(context);
@@ -199,7 +199,7 @@ public class ListExtensionsTest {
         FileProjectWriter writer = new FileProjectWriter(pomFile.getParentFile());
 
         new CreateProject(writer)
-                .groupId(getPluginGroupId())
+        .groupId("org.acme")
                 .artifactId("add-extension-test")
                 .version("0.0.1-SNAPSHOT")
                 .doCreateProject(context);

--- a/independent-projects/tools/common/src/test/java/io/quarkus/generators/rest/BasicRestProjectGeneratorTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/generators/rest/BasicRestProjectGeneratorTest.java
@@ -1,14 +1,14 @@
 package io.quarkus.generators.rest;
 
+import static io.quarkus.generators.ProjectGenerator.BOM_VERSION;
 import static io.quarkus.generators.ProjectGenerator.CLASS_NAME;
 import static io.quarkus.generators.ProjectGenerator.IS_SPRING;
 import static io.quarkus.generators.ProjectGenerator.PACKAGE_NAME;
 import static io.quarkus.generators.ProjectGenerator.PROJECT_ARTIFACT_ID;
 import static io.quarkus.generators.ProjectGenerator.PROJECT_GROUP_ID;
 import static io.quarkus.generators.ProjectGenerator.PROJECT_VERSION;
-import static io.quarkus.generators.ProjectGenerator.QUARKUS_VERSION;
 import static io.quarkus.generators.ProjectGenerator.SOURCE_TYPE;
-import static io.quarkus.maven.utilities.MojoUtils.getPluginVersion;
+import static io.quarkus.maven.utilities.MojoUtils.getBomVersion;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.cli.commands.writer.ProjectWriter;
 import io.quarkus.generators.SourceType;
+import io.quarkus.maven.utilities.MojoUtils;
 
 class BasicRestProjectGeneratorTest {
 
@@ -45,7 +46,7 @@ class BasicRestProjectGeneratorTest {
             .put(PROJECT_GROUP_ID, "org.example")
             .put(PROJECT_ARTIFACT_ID, "quarkus-app")
             .put(PROJECT_VERSION, "0.0.1-SNAPSHOT")
-            .put(QUARKUS_VERSION, getPluginVersion())
+            .put(BOM_VERSION, getBomVersion())
             .put(SOURCE_TYPE, SourceType.JAVA)
             .put(PACKAGE_NAME, "org.example")
             .put(CLASS_NAME, "ExampleResource")
@@ -96,7 +97,7 @@ class BasicRestProjectGeneratorTest {
                 argThat(argument -> argument.contains("<groupId>org.example</groupId>")
                         && argument.contains("<artifactId>quarkus-app</artifactId")
                         && argument.contains("<version>0.0.1-SNAPSHOT</version>")
-                        && argument.contains("<quarkus.version>" + getPluginVersion() + "</quarkus.version>")));
+                        && argument.contains("<" + MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_NAME + ">" + MojoUtils.getPluginVersion())));// + "</" + MojoUtils.TEMPLATE_QUARKUS_PLATFORM_VERSION_NAME + ">")));
         verify(mockWriter, times(1)).write(eq("src/main/java/org/example/ExampleResource.java"),
                 argThat(argument -> argument.contains("@Path(\"/hello\")")));
         verify(mockWriter, times(1)).write(eq("src/test/java/org/example/ExampleResourceTest.java"), anyString());

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/build.gradle-template.ftl
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusVersion}"
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}"
     }
 }
 

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -1,3 +1,4 @@
 quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
+quarkusPluginVersion = ${plugin_version}

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/pom.xml-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/java/pom.xml-template.ftl
@@ -12,7 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
+        <quarkus.platform.artifact-id>${bom_artifactId}</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>${bom_groupId}</quarkus.platform.group-id>
+        <quarkus.platform.version>${bom_version}</quarkus.platform.version>
+        <quarkus-plugin.version>${plugin_version}</quarkus-plugin.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
     </properties>
@@ -20,9 +23,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${bom_groupId}</groupId>
-                <artifactId>${bom_artifactId}</artifactId>
-                <version>${bom_version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -54,7 +57,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -95,7 +98,7 @@
                     <plugin>
                         <groupId>${plugin_groupId}</groupId>
                         <artifactId>${plugin_artifactId}</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${quarkus-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusVersion}"
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}"
     }
 }
 

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
@@ -1,3 +1,4 @@
 quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
+quarkusPluginVersion = ${plugin_version}

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -12,7 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
+        <quarkus.platform.artifact-id>${bom_artifactId}</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>${bom_groupId}</quarkus.platform.group-id>
+        <quarkus.platform.version>${bom_version}</quarkus.platform.version>
+        <quarkus-plugin.version>${plugin_version}</quarkus-plugin.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <kotlin.version>${kotlin_version}</kotlin.version>
@@ -21,9 +24,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${plugin_groupId}</groupId>
-                <artifactId>${bom_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -61,7 +64,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -138,7 +141,7 @@
                     <plugin>
                         <groupId>${plugin_groupId}</groupId>
                         <artifactId>${plugin_artifactId}</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${quarkus-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/build.gradle-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/build.gradle-template.ftl
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusVersion}"
+        classpath "io.quarkus:quarkus-gradle-plugin:${quarkusPluginVersion}"
     }
 }
 

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/gradle.properties-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/gradle.properties-template.ftl
@@ -1,3 +1,4 @@
 quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
+quarkusPluginVersion = ${plugin_versin}

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/pom.xml-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/scala/pom.xml-template.ftl
@@ -12,7 +12,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.version>${quarkus_version}</quarkus.version>
+        <quarkus.platform.artifact-id>${bom_artifactId}</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>${bom_groupId}</quarkus.platform.group-id>
+        <quarkus.platform.version>${bom_version}</quarkus.platform.version>
+        <quarkus-plugin.version>${plugin_version}</quarkus-plugin.version>
         <compiler-plugin.version>${compiler_plugin_version}</compiler-plugin.version>
         <surefire-plugin.version>${surefire_plugin_version}</surefire-plugin.version>
         <scala.version>${scala_version}</scala.version>
@@ -22,9 +25,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${plugin_groupId}</groupId>
-                <artifactId>${bom_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -67,7 +70,7 @@
             <plugin>
                 <groupId>${plugin_groupId}</groupId>
                 <artifactId>${plugin_artifactId}</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -139,7 +142,7 @@
                     <plugin>
                         <groupId>${plugin_groupId}</groupId>
                         <artifactId>${plugin_artifactId}</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${quarkus-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinCreateMavenProjectIT.java
+++ b/integration-tests/kotlin/src/test/java/io/quarkus/kotlin/maven/it/KotlinCreateMavenProjectIT.java
@@ -55,10 +55,11 @@ public class KotlinCreateMavenProjectIT extends MojoTestBase {
         Model model = loadPom(testDir);
         final DependencyManagement dependencyManagement = model.getDependencyManagement();
         final List<Dependency> dependencies = dependencyManagement.getDependencies();
-        assertThat(dependencies.stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                && d.getVersion().equalsIgnoreCase("${quarkus.version}")
-                && d.getScope().equalsIgnoreCase("import")
-                && d.getType().equalsIgnoreCase("pom"))).isTrue();
+        assertThat(dependencies.stream()
+                .anyMatch(d -> d.getArtifactId().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE)
+                        && d.getVersion().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE)
+                        && d.getScope().equalsIgnoreCase("import")
+                        && d.getType().equalsIgnoreCase("pom"))).isTrue();
 
         assertThat(
                 model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("quarkus-resteasy")

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/AddExtensionIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/AddExtensionIT.java
@@ -16,7 +16,6 @@ import io.quarkus.maven.utilities.MojoUtils;
 
 class AddExtensionIT extends MojoTestBase {
 
-    private static final String QUARKUS_VERSION = "${quarkus.version}";
     private static final String QUARKUS_GROUPID = "io.quarkus";
     private static final String VERTX_ARTIFACT_ID = "quarkus-vertx";
     private static final String COMMONS_IO = "commons-io";
@@ -34,7 +33,6 @@ class AddExtensionIT extends MojoTestBase {
         Dependency expected = new Dependency();
         expected.setGroupId(QUARKUS_GROUPID);
         expected.setArtifactId(VERTX_ARTIFACT_ID);
-        expected.setVersion(QUARKUS_VERSION);
         assertThat(contains(model.getDependencies(), expected)).isTrue();
     }
 
@@ -48,7 +46,6 @@ class AddExtensionIT extends MojoTestBase {
         Dependency expected1 = new Dependency();
         expected1.setGroupId(QUARKUS_GROUPID);
         expected1.setArtifactId(VERTX_ARTIFACT_ID);
-        expected1.setVersion(QUARKUS_VERSION);
         Dependency expected2 = new Dependency();
         expected2.setGroupId(COMMONS_IO);
         expected2.setArtifactId(COMMONS_IO);
@@ -68,7 +65,6 @@ class AddExtensionIT extends MojoTestBase {
         Dependency expected = new Dependency();
         expected.setGroupId(QUARKUS_GROUPID);
         expected.setArtifactId(VERTX_ARTIFACT_ID);
-        expected.setVersion(QUARKUS_VERSION);
         assertThat(contains(model.getDependencies(), expected)).isTrue();
     }
 
@@ -83,7 +79,6 @@ class AddExtensionIT extends MojoTestBase {
         Dependency expected1 = new Dependency();
         expected1.setGroupId(QUARKUS_GROUPID);
         expected1.setArtifactId(VERTX_ARTIFACT_ID);
-        expected1.setVersion(QUARKUS_VERSION);
         Dependency expected2 = new Dependency();
         expected2.setGroupId(COMMONS_IO);
         expected2.setArtifactId(COMMONS_IO);
@@ -93,12 +88,12 @@ class AddExtensionIT extends MojoTestBase {
     }
 
     private boolean contains(List<Dependency> dependencies, Dependency expected) {
-        return dependencies.stream().anyMatch(dep -> dep.getGroupId().equalsIgnoreCase(expected.getGroupId())
-                && dep.getArtifactId().equalsIgnoreCase(expected.getArtifactId())
-                && dep.getVersion().equalsIgnoreCase(expected.getVersion())
-                && (dep.getScope() == null || dep.getScope().equalsIgnoreCase(expected.getScope()))
+        return dependencies.stream().anyMatch(dep -> dep.getGroupId().equals(expected.getGroupId())
+                && dep.getArtifactId().equals(expected.getArtifactId())
+                && (dep.getVersion() == null && expected.getVersion() == null || dep.getVersion().equals(expected.getVersion()))
+                && (dep.getScope() == null || dep.getScope().equals(expected.getScope()))
                 && dep.isOptional() == expected.isOptional()
-                && dep.getType().equalsIgnoreCase(expected.getType()));
+                && dep.getType().equals(expected.getType()));
     }
 
     private void addExtension(boolean plural, String ext)

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -62,10 +62,11 @@ public class CreateProjectMojoIT extends MojoTestBase {
         Model model = loadPom(testDir);
         final DependencyManagement dependencyManagement = model.getDependencyManagement();
         final List<Dependency> dependencies = dependencyManagement.getDependencies();
-        assertThat(dependencies.stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                && d.getVersion().equalsIgnoreCase("${quarkus.version}")
-                && d.getScope().equalsIgnoreCase("import")
-                && d.getType().equalsIgnoreCase("pom"))).isTrue();
+        assertThat(dependencies.stream()
+                .anyMatch(d -> d.getArtifactId().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE)
+                        && d.getVersion().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE)
+                        && d.getScope().equals("import")
+                        && d.getType().equals("pom"))).isTrue();
 
         assertThat(
                 model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("quarkus-resteasy")
@@ -84,7 +85,8 @@ public class CreateProjectMojoIT extends MojoTestBase {
 
         assertThat(new File(testDir, "pom.xml")).isFile();
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
-                .contains(MojoUtils.getPluginGroupId(), MojoUtils.QUARKUS_VERSION_PROPERTY, MojoUtils.getPluginGroupId());
+                .contains(MojoUtils.getPluginArtifactId(), MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE,
+                        MojoUtils.getPluginGroupId());
         assertThat(new File(testDir, "src/main/java")).isDirectory();
 
         assertThat(new File(testDir, "src/main/resources/application.properties")).exists();
@@ -95,10 +97,10 @@ public class CreateProjectMojoIT extends MojoTestBase {
 
         Model model = loadPom(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
-                .anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                        && d.getVersion().equalsIgnoreCase("${quarkus.version}")
-                        && d.getScope().equalsIgnoreCase("import")
-                        && d.getType().equalsIgnoreCase("pom"))).isTrue();
+                .anyMatch(d -> d.getArtifactId().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE)
+                        && d.getVersion().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE)
+                        && d.getScope().equals("import")
+                        && d.getType().equals("pom"))).isTrue();
 
         assertThat(model.getDependencies()).isEmpty();
 
@@ -137,7 +139,7 @@ public class CreateProjectMojoIT extends MojoTestBase {
         properties.put("className", "org.acme.MyResource.java");
         setup(properties);
 
-        check(new File(testDir, "pom.xml"), "quarkus.version");
+        check(new File(testDir, "pom.xml"), MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_NAME);
 
         assertThat(new File(testDir, "src/main/java")).isDirectory();
 
@@ -170,10 +172,10 @@ public class CreateProjectMojoIT extends MojoTestBase {
 
         Model model = loadPom(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
-                .anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                        && d.getVersion().equalsIgnoreCase("${quarkus.version}")
-                        && d.getScope().equalsIgnoreCase("import")
-                        && d.getType().equalsIgnoreCase("pom"))).isTrue();
+                .anyMatch(d -> d.getArtifactId().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE)
+                        && d.getVersion().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE)
+                        && d.getScope().equals("import")
+                        && d.getType().equals("pom"))).isTrue();
 
         assertThat(
                 model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("quarkus-resteasy")
@@ -207,10 +209,10 @@ public class CreateProjectMojoIT extends MojoTestBase {
 
         Model model = loadPom(testDir);
         assertThat(model.getDependencyManagement().getDependencies().stream()
-                .anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                        && d.getVersion().equalsIgnoreCase("${quarkus.version}")
-                        && d.getScope().equalsIgnoreCase("import")
-                        && d.getType().equalsIgnoreCase("pom"))).isTrue();
+                .anyMatch(d -> d.getArtifactId().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE)
+                        && d.getVersion().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE)
+                        && d.getScope().equals("import")
+                        && d.getType().equals("pom"))).isTrue();
 
         assertThat(
                 model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("quarkus-resteasy")

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -90,12 +90,11 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         // Edit the pom.xml.
         File source = new File(testDir, "pom.xml");
-        filter(source, ImmutableMap.of("<dependencies>", "<dependencies>\n" +
+        filter(source, ImmutableMap.of("<!-- insert test dependencies here -->",
                 "        <dependency>\n" +
-                "            <groupId>io.quarkus</groupId>\n" +
-                "            <artifactId>quarkus-smallrye-openapi</artifactId>\n" +
-                "            <version>${quarkus.version}</version>\n" +
-                "        </dependency>"));
+                        "            <groupId>io.quarkus</groupId>\n" +
+                        "            <artifactId>quarkus-smallrye-openapi</artifactId>\n" +
+                        "        </dependency>"));
 
         // Wait until we get "uuid"
         await()

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/PackageIT.java
@@ -55,8 +55,10 @@ public class PackageIT extends MojoTestBase {
 
     private void ensureManifestOfJarIsReadableByJarInputStream(File jar) throws IOException {
         try (InputStream fileInputStream = new FileInputStream(jar)) {
-            Manifest manifest = new JarInputStream(fileInputStream).getManifest();
-            assertThat(manifest).isNotNull();
+            try (JarInputStream stream = new JarInputStream(fileInputStream)) {
+                Manifest manifest = stream.getManifest();
+                assertThat(manifest).isNotNull();
+            }
         }
     }
 

--- a/integration-tests/maven/src/test/resources/projects/classic-no-undertow/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic-no-undertow/pom.xml
@@ -6,36 +6,47 @@
   <artifactId>acme</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>@project.version@</quarkus.version>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>${quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
-        <groupId>@project.groupId@</groupId>
-        <artifactId>@project.artifactId@</artifactId>
-        <version>${quarkus.version}</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -52,9 +63,9 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>@project.groupId@</groupId>
-            <artifactId>@project.artifactId@</artifactId>
-            <version>${quarkus.version}</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus-plugin.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/integration-tests/maven/src/test/resources/projects/classic-noconfig/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic-noconfig/pom.xml
@@ -6,51 +6,55 @@
   <artifactId>acme</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>@project.version@</quarkus.version>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
-      <artifactId>quarkus-arc</artifactId>
-      <version>${quarkus.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-undertow-websockets</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>3.1.0</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>${quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
-        <groupId>@project.groupId@</groupId>
-        <artifactId>@project.artifactId@</artifactId>
-        <version>${quarkus.version}</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -67,9 +71,9 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>@project.groupId@</groupId>
-            <artifactId>@project.artifactId@</artifactId>
-            <version>${quarkus.version}</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus-plugin.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/integration-tests/maven/src/test/resources/projects/classic/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic/pom.xml
@@ -6,51 +6,56 @@
   <artifactId>acme</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>@project.version@</quarkus.version>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
+    <!-- insert test dependencies here -->
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
-      <artifactId>quarkus-arc</artifactId>
-      <version>${quarkus.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-undertow-websockets</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>3.1.0</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>${quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
-        <groupId>@project.groupId@</groupId>
-        <artifactId>@project.artifactId@</artifactId>
-        <version>${quarkus.version}</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -67,9 +72,9 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>@project.groupId@</groupId>
-            <artifactId>@project.artifactId@</artifactId>
-            <version>${quarkus.version}</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus-plugin.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/integration-tests/maven/src/test/resources/projects/custom-packaging-app/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/custom-packaging-app/pom.xml
@@ -10,6 +10,10 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -17,11 +21,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>@project.version@</version>
-        <type>pom</type>
-        <scope>import</scope>
+      <groupId>${quarkus.platform.group-id}</groupId>
+      <artifactId>${quarkus.platform.artifact-id}</artifactId>
+      <version>${quarkus.platform.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -31,7 +35,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-         <version>@project.version@</version>
+         <version>${quarkus-plugin.version}</version>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/maven/src/test/resources/projects/custom-packaging-plugin/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/custom-packaging-plugin/pom.xml
@@ -11,6 +11,10 @@
   <packaging>maven-plugin</packaging>
 
   <properties>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -18,9 +22,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>@project.version@</version>
+      <groupId>${quarkus.platform.group-id}</groupId>
+      <artifactId>${quarkus.platform.artifact-id}</artifactId>
+      <version>${quarkus.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/pom.xml
@@ -8,7 +8,10 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>@project.version@</quarkus.version>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -23,9 +26,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>@project.groupId@</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -33,9 +36,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>@project.groupId@</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/rest/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/rest/pom.xml
@@ -15,7 +15,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>@project.groupId@</groupId>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
     </dependencies>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/runner/pom.xml
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>@project.groupId@</groupId>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
@@ -28,7 +28,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>@project.groupId@</groupId>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -79,7 +79,7 @@
                     <plugin>
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus.version}</version>
+                        <version>${quarkus-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/integration-tests/maven/src/test/resources/projects/uberjar-check/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/uberjar-check/pom.xml
@@ -6,41 +6,51 @@
   <artifactId>acme</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <quarkus.version>@project.version@</quarkus.version>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.version>@project.version@</quarkus.platform.version>
+    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
-      <version>${quarkus.version}</version>
     </dependency>
     <dependency>
-      <groupId>@project.groupId@</groupId>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>${quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
-        <groupId>@project.groupId@</groupId>
-        <artifactId>@project.artifactId@</artifactId>
-        <version>${quarkus.version}</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -57,9 +67,9 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>@project.groupId@</groupId>
-            <artifactId>@project.artifactId@</artifactId>
-            <version>${quarkus.version}</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus-plugin.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/integration-tests/scala/src/test/java/io/quarkus/scala/maven/it/ScalaCreateMavenProjectIT.java
+++ b/integration-tests/scala/src/test/java/io/quarkus/scala/maven/it/ScalaCreateMavenProjectIT.java
@@ -55,10 +55,11 @@ public class ScalaCreateMavenProjectIT extends MojoTestBase {
         Model model = loadPom(testDir);
         final DependencyManagement dependencyManagement = model.getDependencyManagement();
         final List<Dependency> dependencies = dependencyManagement.getDependencies();
-        assertThat(dependencies.stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase(MojoUtils.getBomArtifactId())
-                && d.getVersion().equalsIgnoreCase("${quarkus.version}")
-                && d.getScope().equalsIgnoreCase("import")
-                && d.getType().equalsIgnoreCase("pom"))).isTrue();
+        assertThat(dependencies.stream()
+                .anyMatch(d -> d.getArtifactId().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_VALUE)
+                        && d.getVersion().equals(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_VALUE)
+                        && d.getScope().equalsIgnoreCase("import")
+                        && d.getType().equalsIgnoreCase("pom"))).isTrue();
 
         assertThat(
                 model.getDependencies().stream().anyMatch(d -> d.getArtifactId().equalsIgnoreCase("quarkus-resteasy")

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/assertions/SetupVerifier.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/assertions/SetupVerifier.java
@@ -54,14 +54,17 @@ public class SetupVerifier {
 
         //Check if the properties have been set correctly
         Properties properties = model.getProperties();
-        assertThat(properties.containsKey("quarkus.version")).isTrue();
+        assertThat(properties.containsKey(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_GROUP_ID_NAME)).isTrue();
+        assertThat(properties.containsKey(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_ARTIFACT_ID_NAME)).isTrue();
+        assertThat(properties.containsKey(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLATFORM_VERSION_NAME)).isTrue();
+        assertThat(properties.containsKey(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_NAME)).isTrue();
 
         // Check plugin is set
         Plugin plugin = maybe.orElseThrow(() -> new AssertionError("Plugin expected"));
         assertThat(plugin).isNotNull().satisfies(p -> {
-            assertThat(p.getArtifactId()).isEqualTo(MojoUtils.getPluginArtifactId());
-            assertThat(p.getGroupId()).isEqualTo(MojoUtils.getPluginGroupId());
-            assertThat(p.getVersion()).isEqualTo(MojoUtils.QUARKUS_VERSION_PROPERTY);
+            assertThat(p.getArtifactId()).isEqualTo("quarkus-maven-plugin");
+            assertThat(p.getGroupId()).isEqualTo("io.quarkus");
+            assertThat(p.getVersion()).isEqualTo(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_VALUE);
         });
 
         // Check build execution Configuration
@@ -104,6 +107,7 @@ public class SetupVerifier {
         Properties projectProps = project.getProperties();
         assertNotNull(projectProps);
         assertFalse(projectProps.isEmpty());
-        assertEquals(MojoUtils.getPluginVersion(), projectProps.getProperty("quarkus.version"));
+        assertEquals(MojoUtils.getPluginVersion(),
+                projectProps.getProperty(MojoUtils.TEMPLATE_PROPERTY_QUARKUS_PLUGIN_VERSION_NAME));
     }
 }


### PR DESCRIPTION
...and quarkus-plugin.version in Maven templates and quarkusVersion with quarkusPluginVersion in the Gradle ones, also adding quarkus.platform.group-is and quarkus.platform.artifact-id to pom.xml templates and sorting of properties before persisting pom.xml.

Fixes #4744 