### PR TITLE
chore: Option -DskipTests also covers maven invoker tests.

### DIFF
--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -52,7 +52,7 @@
           <cloneClean>true</cloneClean>
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
-          <skipInvocation>${maven.test.skip}</skipInvocation>
+          <skipInvocation>${skipTests}</skipInvocation>
           <streamLogs>true</streamLogs>
           <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
         </configuration>

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -52,7 +52,7 @@
                     <settingsFile>src/it/settings.xml</settingsFile>
                     <postBuildHookScript>verify</postBuildHookScript>
                     <addTestClassPath>true</addTestClassPath>
-                    <skipInvocation>${maven.test.skip}</skipInvocation>
+                    <skipInvocation>${skipTests}</skipInvocation>
                     <streamLogs>true</streamLogs>
                     <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
                 </configuration>


### PR DESCRIPTION
Currently when using `-DskipTests` all tests are excluded.
All?
Not all, there are still two modules that are using `maven-invoker-plugin`. These integration tests do run even when `-DskipTests` is used.

This pull request changes the `maven-invoker-plugin` coniguration so that invoker tests are skiped when using `-DskipTests`.