### PR TITLE
Fix PanacheQuery.firstResult()

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -127,8 +127,8 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public <T extends Entity> T firstResult() {
-        List<T> list = list();
         jpaQuery.setMaxResults(1);
+        List<T> list = jpaQuery.getResultList();
         return list.isEmpty() ? null : list.get(0);
     }
 


### PR DESCRIPTION
Fixes #5589

PanacheQuery.firstResult() calls `setMaxResults` too late so it is not taken into account