### PR TITLE
Set the lower boundary of the default range for Quarkus platforms to 1.0.0.CR2

### DIFF
--- a/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/QuarkusJsonPlatformDescriptorResolver.java
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/main/java/io/quarkus/platform/descriptor/resolver/json/QuarkusJsonPlatformDescriptorResolver.java
@@ -46,7 +46,7 @@ import io.quarkus.platform.tools.ToolsUtils;
  */
 public class QuarkusJsonPlatformDescriptorResolver {
 
-    private static final String DEFAULT_QUARKUS_PLATFORM_VERSION_RANGE = "[0.28.1,2)";
+    private static final String DEFAULT_QUARKUS_PLATFORM_VERSION_RANGE = "[1.0.0.CR2,2)";
     private static final String DEFAULT_NON_QUARKUS_VERSION_RANGE = "[0,)";
     public static final String PROP_PLATFORM_JSON_GROUP_ID = "quarkus.platform.json.groupId";
     public static final String PROP_PLATFORM_JSON_ARTIFACT_ID = "quarkus.platform.json.artifactId";

--- a/independent-projects/tools/platform-descriptor-resolver-json/src/test/java/io/quarkus/platform/descriptor/resolver/json/test/QuarkusJsonPlatformDescriptorResolverTest.java
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/test/java/io/quarkus/platform/descriptor/resolver/json/test/QuarkusJsonPlatformDescriptorResolverTest.java
@@ -56,22 +56,22 @@ public class QuarkusJsonPlatformDescriptorResolverTest extends ResolverSetupClea
 
     protected void doSetup() throws Exception {
 
-        final TsArtifact quarkusCore = new TsArtifact(IO_QUARKUS, QUARKUS_CORE_ARTIFACT_ID, null, "jar", "0.28.5");
+        final TsArtifact quarkusCore = new TsArtifact(IO_QUARKUS, QUARKUS_CORE_ARTIFACT_ID, null, "jar", "1.0.0.CR50");
         install(quarkusCore, newJar().getPath(workDir));
 
-        final TsArtifact quarkusPlatformDescriptorJson = new TsArtifact(IO_QUARKUS, "quarkus-platform-descriptor-json", null, "jar", "0.28.5");
+        final TsArtifact quarkusPlatformDescriptorJson = new TsArtifact(IO_QUARKUS, "quarkus-platform-descriptor-json", null, "jar", "1.0.0.CR50");
         install(quarkusPlatformDescriptorJson, newJar().getPath(workDir));
 
         // install a few universe versions with the default GA
-        installDefaultUniverse(quarkusCore, "0.28.5");
-        installDefaultUniverse(quarkusCore, "0.28.6");
-        installDefaultUniverse(quarkusCore, "0.28.7");
+        installDefaultUniverse(quarkusCore, "1.0.0.CR50");
+        installDefaultUniverse(quarkusCore, "1.0.0.CR60");
+        installDefaultUniverse(quarkusCore, "1.0.0.CR70");
 
         // install a universe with a custom GA and JSON descriptor with `-descriptor-json` suffix
-        TsArtifact universeBom = new TsArtifact(DEFAULT_PLATFORM_BOM_GROUP_ID, "other-universe", null, "pom", "0.28.8")
+        TsArtifact universeBom = new TsArtifact(DEFAULT_PLATFORM_BOM_GROUP_ID, "other-universe", null, "pom", "1.0.0.CR80")
                 .addManagedDependency(new TsDependency(quarkusCore));
         install(universeBom);
-        final TsArtifact universeJson = new TsArtifact(DEFAULT_PLATFORM_BOM_GROUP_ID, "other-universe" + "-descriptor-json", null, "json", "0.28.8")
+        final TsArtifact universeJson = new TsArtifact(DEFAULT_PLATFORM_BOM_GROUP_ID, "other-universe" + "-descriptor-json", null, "json", "1.0.0.CR80")
                 .setContent(new TestPlatformJsonDescriptorProvider(universeBom));
         install(universeJson);
 
@@ -80,33 +80,33 @@ public class QuarkusJsonPlatformDescriptorResolverTest extends ResolverSetupClea
     @Test
     public void testResolve() throws Exception {
         final QuarkusPlatformDescriptor platform = newResolver().resolve();
-        assertDefaultPlatform(platform, "0.28.7");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        assertDefaultPlatform(platform, "1.0.0.CR70");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromJsonVersion() throws Exception {
-        final QuarkusPlatformDescriptor platform = newResolver().resolveFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, "0.28.6");
-        assertDefaultPlatform(platform, "0.28.6");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        final QuarkusPlatformDescriptor platform = newResolver().resolveFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, "1.0.0.CR60");
+        assertDefaultPlatform(platform, "1.0.0.CR60");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromJsonFile() throws Exception {
-        final Path jsonPath = resolver.resolve(new AppArtifact(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, null, "json", "0.28.5"));
+        final Path jsonPath = resolver.resolve(new AppArtifact(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, null, "json", "1.0.0.CR50"));
         final QuarkusPlatformDescriptor platform = newResolver().resolveFromJson(jsonPath);
-        assertDefaultPlatform(platform, "0.28.5");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        assertDefaultPlatform(platform, "1.0.0.CR50");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromBomWithDescriptorJsonPrefix() throws Exception {
-        final QuarkusPlatformDescriptor platform = newResolver().resolveFromBom(DEFAULT_PLATFORM_BOM_GROUP_ID, "other-universe", "0.28.8");
+        final QuarkusPlatformDescriptor platform = newResolver().resolveFromBom(DEFAULT_PLATFORM_BOM_GROUP_ID, "other-universe", "1.0.0.CR80");
         assertNotNull(platform);
         assertEquals(ToolsConstants.IO_QUARKUS, platform.getBomGroupId());
         assertEquals("other-universe", platform.getBomArtifactId());
-        assertEquals("0.28.8", platform.getBomVersion());
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        assertEquals("1.0.0.CR80", platform.getBomVersion());
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
@@ -115,36 +115,36 @@ public class QuarkusJsonPlatformDescriptorResolverTest extends ResolverSetupClea
         assertNotNull(platform);
         assertEquals(ToolsConstants.IO_QUARKUS, platform.getBomGroupId());
         assertEquals("other-universe", platform.getBomArtifactId());
-        assertEquals("0.28.8", platform.getBomVersion());
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        assertEquals("1.0.0.CR80", platform.getBomVersion());
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromLatestJson() throws Exception {
         final QuarkusPlatformDescriptor platform = newResolver().resolveLatestFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, null);
-        assertDefaultPlatform(platform, "0.28.7");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        assertDefaultPlatform(platform, "1.0.0.CR70");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromLatestJsonWithRange() throws Exception {
-        final QuarkusPlatformDescriptor platform = newResolver().resolveLatestFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, "[0,0.28.6]");
-        assertDefaultPlatform(platform, "0.28.6");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        final QuarkusPlatformDescriptor platform = newResolver().resolveLatestFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, "[0,1.0.0.CR60]");
+        assertDefaultPlatform(platform, "1.0.0.CR60");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromLatestBom() throws Exception {
         final QuarkusPlatformDescriptor platform = newResolver().resolveLatestFromBom(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, null);
-        assertDefaultPlatform(platform, "0.28.7");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        assertDefaultPlatform(platform, "1.0.0.CR70");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     @Test
     public void testResolveFromLatestBomWithRange() throws Exception {
-        final QuarkusPlatformDescriptor platform = newResolver().resolveLatestFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, "[0,0.28.6]");
-        assertDefaultPlatform(platform, "0.28.6");
-        assertEquals("0.28.5", platform.getQuarkusVersion());
+        final QuarkusPlatformDescriptor platform = newResolver().resolveLatestFromJson(DEFAULT_PLATFORM_BOM_GROUP_ID, DEFAULT_PLATFORM_BOM_ARTIFACT_ID, "[0,1.0.0.CR60]");
+        assertDefaultPlatform(platform, "1.0.0.CR60");
+        assertEquals("1.0.0.CR50", platform.getQuarkusVersion());
     }
 
     private void installDefaultUniverse(final TsArtifact quarkusCore, String platformVersion) {


### PR DESCRIPTION
Due to recently introduced changes in the project templates used for project generation and updates, it'll be safe to move the lower boundary of the default range of Quarkus platforms discovered by the tooling to the upcoming version 1.0.0.CR2.
Note that 1.0.0.CR2 has not yet been released, so the SNAPSHOT version of the tooling will now be falling back to the bundled version of the platform (which is based on quarkus-bom, SNAPSHOT) until 1.0.0.CR2 has been released and available in the remote repos.