### PR TITLE
Update SmallRye Metrics to 2.3.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -33,7 +33,7 @@
         <microprofile-rest-client.version>1.3.4</microprofile-rest-client.version>
         <smallrye-config.version>1.3.9</smallrye-config.version>
         <smallrye-health.version>2.1.0</smallrye-health.version>
-        <smallrye-metrics.version>2.3.0</smallrye-metrics.version>
+        <smallrye-metrics.version>2.3.1</smallrye-metrics.version>
         <smallrye-open-api.version>1.1.20</smallrye-open-api.version>
         <smallrye-opentracing.version>1.3.2</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>2.1.2</smallrye-fault-tolerance.version>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/5071
No other changes between 2.3.0 and 2.3.1 so this should be very safe