### PR TITLE
add mappedBy to remove build warning in Spring Data JPA ITs

### DIFF
--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
@@ -8,6 +8,7 @@ import java.util.Random;
 
 import javax.json.bind.annotation.JsonbDateFormat;
 import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -118,7 +119,8 @@ public class Person {
         @Column(name = "zip_code")
         private String zipCode;
 
-        @OneToMany
+        @JsonbTransient
+        @OneToMany(mappedBy = "address")
         private List<Person> people;
 
         public Long getId() {


### PR DESCRIPTION
The following warnings were observed
```
[org.hib.byt.enh.int.byt.BiDirectionalAssociationHandler] (main) Bi-directional association not managed for field [io.quarkus.it.spring.data.jpa.Person$Address#people]: Could not find target field in [io.quarkus.it.spring.data.jpa.Person]
[org.hib.byt.enh.int.byt.BiDirectionalAssociationHandler] (main) Bi-directional association not managed for field [io.quarkus.it.spring.data.jpa.Person#address]: Could not find target field in [io.quarkus.it.spring.data.jpa.Person.Address]
```