### PR TITLE
Provides Optional support inside Hibernate with Panache and MongoDB with Panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -161,6 +161,10 @@ List<Person> allPersons = Person.listAll();
 // finding a specific person by ID
 person = Person.findById(personId);
 
+// finding a specific person by ID via an Optional
+Optional<Person> optional = Person.findByIdOptional(personId);
+person = optional.orElseThrow(() -> NotFoundException());
+
 // finding all living persons
 List<Person> livingPersons = Person.list("status", Status.Alive);
 

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -163,7 +163,7 @@ person = Person.findById(personId);
 
 // finding a specific person by ID via an Optional
 Optional<Person> optional = Person.findByIdOptional(personId);
-person = optional.orElseThrow(() -> NotFoundException());
+person = optional.orElseThrow(() -> new NotFoundException());
 
 // finding all living persons
 List<Person> livingPersons = Person.list("status", Status.Alive);

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -196,6 +196,10 @@ List<Person> allPersons = Person.listAll();
 // finding a specific person by ID
 person = Person.findById(personId);
 
+// finding a specific person by ID via an Optional
+Optional<Person> optional = Person.findByIdOptional(personId);
+person = optional.orElseThrow(() -> new NotFoundException());
+
 // finding all living persons
 List<Person> livingPersons = Person.list("status", Status.Alive);
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.orm.panache;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.json.bind.annotation.JsonbTransient;
@@ -112,6 +113,29 @@ public abstract class PanacheEntityBase {
      */
     @GenerateBridge(targetReturnTypeErased = true)
     public static <T extends PanacheEntityBase> T findById(Object id, LockModeType lockModeType) {
+        throw JpaOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Find an entity of this type by ID.
+     *
+     * @param id the ID of the entity to find.
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     */
+    @GenerateBridge
+    public static <T extends PanacheEntityBase> Optional<T> findByIdOptional(Object id) {
+        throw JpaOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Find an entity of this type by ID.
+     *
+     * @param id the ID of the entity to find.
+     * @param lockModeType the locking strategy to be used when retrieving the entity.
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     */
+    @GenerateBridge
+    public static <T extends PanacheEntityBase> Optional<T> findByIdOptional(Object id, LockModeType lockModeType) {
         throw JpaOperations.implementationInjectionMissing();
     }
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.panache;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.persistence.LockModeType;
@@ -164,6 +165,15 @@ public interface PanacheQuery<Entity> {
     public <T extends Entity> T firstResult();
 
     /**
+     * Returns the first result of the current page index. This ignores the current page size to fetch
+     * a single result.
+     *
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     * @see #singleResultOptional()
+     */
+    public <T extends Entity> Optional<T> firstResultOptional();
+
+    /**
      * Executes this query for the current page and return a single result.
      * 
      * @return the single result (throws if there is not exactly one)
@@ -172,4 +182,13 @@ public interface PanacheQuery<Entity> {
      * @see #firstResult()
      */
     public <T extends Entity> T singleResult();
+
+    /**
+     * Executes this query for the current page and return a single result.
+     *
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     * @throws NonUniqueResultException if there are more than one result
+     * @see #firstResultOptional()
+     */
+    public <T extends Entity> Optional<T> singleResultOptional();
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheRepositoryBase.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.orm.panache;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.persistence.LockModeType;
@@ -110,6 +111,28 @@ public interface PanacheRepositoryBase<Entity, Id> {
      */
     @GenerateBridge(targetReturnTypeErased = true)
     public default Entity findById(Id id, LockModeType lockModeType) {
+        throw JpaOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Find an entity of this type by ID.
+     *
+     * @param id the ID of the entity to find.
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     */
+    @GenerateBridge
+    public default Optional<Entity> findByIdOptional(Id id) {
+        throw JpaOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Find an entity of this type by ID.
+     *
+     * @param id the ID of the entity to find.
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     */
+    @GenerateBridge
+    public default Optional<Entity> findByIdOptional(Id id, LockModeType lockModeType) {
         throw JpaOperations.implementationInjectionMissing();
     }
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -3,6 +3,7 @@ package io.quarkus.hibernate.orm.panache.runtime;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
@@ -199,6 +200,14 @@ public class JpaOperations {
 
     public static Object findById(Class<?> entityClass, Object id, LockModeType lockModeType) {
         return getEntityManager().find(entityClass, id, lockModeType);
+    }
+
+    public static Optional<?> findByIdOptional(Class<?> entityClass, Object id) {
+        return Optional.ofNullable(findById(entityClass, id));
+    }
+
+    public static Optional<?> findByIdOptional(Class<?> entityClass, Object id, LockModeType lockModeType) {
+        return Optional.ofNullable(findById(entityClass, id, lockModeType));
     }
 
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Object... params) {

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -10,8 +10,6 @@ import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.Query;
 
-import com.arjuna.ats.internal.jdbc.drivers.modifiers.list;
-
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Page;
 

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
@@ -2,6 +2,7 @@ package io.quarkus.mongodb.panache;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.bson.Document;
@@ -82,6 +83,17 @@ public abstract class PanacheMongoEntityBase {
      */
     @GenerateBridge(targetReturnTypeErased = true)
     public static <T extends PanacheMongoEntityBase> T findById(Object id) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Find an entity of this type by ID.
+     *
+     * @param id the ID of the entity to find.
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     */
+    @GenerateBridge
+    public static <T extends PanacheMongoEntityBase> Optional<T> findByIdOptional(Object id) {
         throw MongoOperations.implementationInjectionMissing();
     }
 

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
@@ -2,6 +2,7 @@ package io.quarkus.mongodb.panache;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.bson.Document;
@@ -88,6 +89,17 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      */
     @GenerateBridge(targetReturnTypeErased = true)
     public default Entity findById(Id id) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Find an entity of this type by ID.
+     *
+     * @param id the ID of the entity to find.
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     */
+    @GenerateBridge
+    public default Optional<Entity> findByIdOptional(Id id) {
         throw MongoOperations.implementationInjectionMissing();
     }
 

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
@@ -1,6 +1,7 @@
 package io.quarkus.mongodb.panache;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import io.quarkus.panache.common.Page;
@@ -148,10 +149,29 @@ public interface PanacheQuery<Entity> {
     public <T extends Entity> T firstResult();
 
     /**
+     * Returns the first result of the current page index. This ignores the current page size to fetch
+     * a single result.
+     *
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     * @see #singleResultOptional()
+     */
+    public <T extends Entity> Optional<T> firstResultOptional();
+
+    /**
      * Executes this query for the current page and return a single result.
      * 
-     * @return the single result (throws if there is not exactly one)
+     * @return the single result
+     * @throws PanacheQueryException if there is not exactly one result.
      * @see #firstResult()
      */
     public <T extends Entity> T singleResult();
+
+    /**
+     * Executes this query for the current page and return a single result.
+     *
+     * @return if found, an optional containing the entity, else <code>Optional.empty()</code>.
+     * @throws PanacheQueryException if there is more than one result.
+     * @see #firstResultOptional()
+     */
+    public <T extends Entity> Optional<T> singleResultOptional();
 }

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoOperations.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -280,6 +281,10 @@ public class MongoOperations {
     public static Object findById(Class<?> entityClass, Object id) {
         MongoCollection collection = mongoCollection(entityClass);
         return collection.find(new Document(ID, id)).first();
+    }
+
+    public static Optional findByIdOptional(Class<?> entityClass, Object id) {
+        return Optional.ofNullable(findById(entityClass, id));
     }
 
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Object... params) {

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.mongodb.panache.runtime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.bson.Document;
@@ -12,6 +13,7 @@ import com.mongodb.client.MongoCursor;
 
 import io.quarkus.mongodb.panache.PanacheQuery;
 import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.exception.PanacheQueryException;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     private MongoCollection collection;
@@ -134,13 +136,29 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     }
 
     @Override
+    public <T extends Entity> Optional<T> firstResultOptional() {
+        return Optional.ofNullable(firstResult());
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T extends Entity> T singleResult() {
         List<T> list = list();
         if (list.isEmpty() || list.size() > 1) {
-            throw new RuntimeException("There should be only one result");//TODO use proper exception
+            throw new PanacheQueryException("There should be only one result");
         }
 
         return list.get(0);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Entity> Optional<T> singleResultOptional() {
+        List<T> list = list();
+        if (list.size() > 1) {
+            throw new PanacheQueryException("There should be no more than one result");
+        }
+
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
     }
 }

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/exception/PanacheQueryException.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/exception/PanacheQueryException.java
@@ -1,0 +1,7 @@
+package io.quarkus.panache.common.exception;
+
+public class PanacheQueryException extends RuntimeException {
+    public PanacheQueryException(String s) {
+        super(s);
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -138,7 +138,15 @@ public class TestEndpoint {
         Assertions.assertEquals(person, byId);
         Assertions.assertEquals("Person<" + person.id + ">", byId.toString());
 
+        byId = Person.<Person> findByIdOptional(person.id).get();
+        Assertions.assertEquals(person, byId);
+        Assertions.assertEquals("Person<" + person.id + ">", byId.toString());
+
         byId = Person.findById(person.id, LockModeType.PESSIMISTIC_READ);
+        Assertions.assertEquals(person, byId);
+        Assertions.assertEquals("Person<" + person.id + ">", byId.toString());
+
+        byId = Person.<Person> findByIdOptional(person.id, LockModeType.PESSIMISTIC_READ).get();
         Assertions.assertEquals(person, byId);
         Assertions.assertEquals("Person<" + person.id + ">", byId.toString());
 
@@ -184,6 +192,8 @@ public class TestEndpoint {
         }
 
         Assertions.assertNotNull(Person.findAll().firstResult());
+
+        Assertions.assertNotNull(Person.findAll().firstResultOptional().get());
 
         Assertions.assertEquals(7, Person.deleteAll());
 
@@ -333,7 +343,11 @@ public class TestEndpoint {
         } catch (NoResultException x) {
         }
 
+        Assertions.assertFalse(personDao.findAll().singleResultOptional().isPresent());
+
         Assertions.assertNull(personDao.findAll().firstResult());
+
+        Assertions.assertFalse(personDao.findAll().firstResultOptional().isPresent());
 
         Person person = makeSavedPersonDao();
         Assertions.assertNotNull(person.id);
@@ -363,6 +377,7 @@ public class TestEndpoint {
 
         Assertions.assertEquals(person, personDao.findAll().firstResult());
         Assertions.assertEquals(person, personDao.findAll().singleResult());
+        Assertions.assertEquals(person, personDao.findAll().singleResultOptional().get());
 
         persons = personDao.find("name = ?1", "stef").list();
         Assertions.assertEquals(1, persons.size());
@@ -413,11 +428,18 @@ public class TestEndpoint {
 
         Assertions.assertEquals(person, personDao.find("name", "stef").firstResult());
         Assertions.assertEquals(person, personDao.find("name", "stef").singleResult());
+        Assertions.assertEquals(person, personDao.find("name", "stef").singleResultOptional().get());
 
         Person byId = personDao.findById(person.id);
         Assertions.assertEquals(person, byId);
 
+        byId = personDao.findByIdOptional(person.id).get();
+        Assertions.assertEquals(person, byId);
+
         byId = personDao.findById(person.id, LockModeType.PESSIMISTIC_READ);
+        Assertions.assertEquals(person, byId);
+
+        byId = personDao.findByIdOptional(person.id, LockModeType.PESSIMISTIC_READ).get();
         Assertions.assertEquals(person, byId);
 
         personDao.delete(person);

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookEntityResource.java
@@ -70,6 +70,12 @@ public class BookEntityResource {
     }
 
     @GET
+    @Path("/optional/{id}")
+    public BookEntity getBookOptional(@PathParam("id") String id) {
+        return BookEntity.<BookEntity> findByIdOptional(new ObjectId(id)).orElseThrow(() -> new NotFoundException());
+    }
+
+    @GET
     @Path("/search/{author}")
     public List<BookEntity> getBooksByAuthor(@PathParam("author") String author) {
         return BookEntity.list("author", author);
@@ -86,7 +92,7 @@ public class BookEntityResource {
         return BookEntity
                 .find("{'creationDate': {$gte: ?1}, 'creationDate': {$lte: ?2}}", LocalDate.parse(dateFrom),
                         LocalDate.parse(dateTo))
-                .firstResult();
+                .<BookEntity> firstResultOptional().orElseThrow(() -> new NotFoundException());
     }
 
     @GET

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/book/BookRepositoryResource.java
@@ -73,6 +73,12 @@ public class BookRepositoryResource {
     }
 
     @GET
+    @Path("/optional/{id}")
+    public Book getBookOptional(@PathParam("id") String id) {
+        return bookRepository.findByIdOptional(new ObjectId(id)).orElseThrow(() -> new NotFoundException());
+    }
+
+    @GET
     @Path("/search/{author}")
     public List<Book> getBooksByAuthor(@PathParam("author") String author) {
         return bookRepository.list("author", author);
@@ -89,7 +95,7 @@ public class BookRepositoryResource {
         return bookRepository
                 .find("{'creationDate': {$gte: ?1}, 'creationDate': {$lte: ?2}}", LocalDate.parse(dateFrom),
                         LocalDate.parse(dateTo))
-                .firstResult();
+                .firstResultOptional().orElseThrow(() -> new NotFoundException());
     }
 
     @GET

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -42,8 +42,8 @@ import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 
 @QuarkusTest
-class BookResourceTest {
-    private static final Logger LOGGER = Logger.getLogger(BookResourceTest.class);
+class MongodbPanacheResourceTest {
+    private static final Logger LOGGER = Logger.getLogger(MongodbPanacheResourceTest.class);
     private static final TypeRef<List<BookDTO>> LIST_OF_BOOK_TYPE_REF = new TypeRef<List<BookDTO>>() {
     };
     private static final TypeRef<List<Person>> LIST_OF_PERSON_TYPE_REF = new TypeRef<List<Person>>() {
@@ -195,8 +195,13 @@ class BookResourceTest {
 
         //check that the title has been updated and the transient description ignored
         book = get(endpoint + "/" + book.getId().toString()).as(BookDTO.class);
+        Assertions.assertNotNull(book);
         Assertions.assertEquals("Notre-Dame de Paris 2", book.getTitle());
         Assertions.assertNull(book.getTransientDescription());
+
+        //test findByIdOptional
+        book = get(endpoint + "/optional/" + book.getId().toString()).as(BookDTO.class);
+        Assertions.assertNotNull(book);
 
         //delete a book
         response = RestAssured

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/NativeBookResourceIT.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/NativeBookResourceIT.java
@@ -3,6 +3,6 @@ package io.quarkus.it.mongodb.panache;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-class NativeBookResourceIT extends BookResourceTest {
+class NativeBookResourceIT extends MongodbPanacheResourceTest {
 
 }


### PR DESCRIPTION
Fixes #1368

This is a draft PR as when #5583 is merged we will want to consider also having overload for with `LockModeType` for `findByIdOptional`.

cc @FroMage and @emmanuelbernard 