### PR TITLE
Added BeanArchiveIndexBuildItem to be used for searching for secured classes

### DIFF
--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/ext/CDIAccessGeneratedBeanTest.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/ext/CDIAccessGeneratedBeanTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.security.test.cdi.ext;
+
+import static io.quarkus.security.test.cdi.SecurityTestUtils.assertFailureFor;
+import static io.quarkus.security.test.utils.IdentityMock.ANONYMOUS;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.test.cdi.SecurityTestUtils;
+import io.quarkus.security.test.utils.IdentityMock;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CDIAccessGeneratedBeanTest {
+
+    @Inject
+    GeneratedBean generatedBean;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(IdentityMock.class,
+                            SecurityTestUtils.class,
+                            GeneratedBean.class,
+                            GenereateBeanBuildStep.class));
+
+    @Test
+    public void shouldFailToAccessForbidden() {
+        assertFailureFor(() -> generatedBean.secured(), UnauthorizedException.class, ANONYMOUS);
+
+    }
+
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/ext/GeneratedBean.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/ext/GeneratedBean.java
@@ -1,0 +1,6 @@
+package io.quarkus.security.test.cdi.ext;
+
+public interface GeneratedBean {
+
+    void secured();
+}

--- a/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/ext/GenereateBeanBuildStep.java
+++ b/extensions/security/deployment/src/test/java/io/quarkus/security/test/cdi/ext/GenereateBeanBuildStep.java
@@ -1,0 +1,36 @@
+package io.quarkus.security.test.cdi.ext;
+
+import javax.annotation.security.DenyAll;
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.MethodCreator;
+
+public class GenereateBeanBuildStep {
+
+    @BuildStep
+    public void generateSecuredBean(BuildProducer<GeneratedBeanBuildItem> generatedBeans) {
+
+        ClassOutput beansClassOutput = new ClassOutput() {
+            @Override
+            public void write(String name, byte[] data) {
+                generatedBeans.produce(new GeneratedBeanBuildItem(name, data));
+            }
+        };
+        ClassCreator creator = ClassCreator.builder().className("io.quarkus.security.test.GeneratedBean")
+                .interfaces(io.quarkus.security.test.cdi.ext.GeneratedBean.class)
+                .classOutput(beansClassOutput).build();
+
+        creator.addAnnotation(ApplicationScoped.class);
+
+        MethodCreator method = creator.getMethodCreator("secured", void.class);
+        method.returnValue(method.loadNull());
+        method.addAnnotation(DenyAll.class);
+
+        creator.close();
+    }
+}


### PR DESCRIPTION
…classes

generated classes such as REST resources that are intended to be secured (using `@RolesAllowed` annotation) are not processed by security extension and by that they are left unprotected. 

This PR introduces use of BeanArchiveIndexBuildItem to get hold of all the classes including generated.

@michalszynkiewicz tagging you as we just discussed over the topic, thanks for the help on this.