### PR TITLE
Avoid creating redundant instances of SecurityCheck implementations

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityCheckInstantiationUtil.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityCheckInstantiationUtil.java
@@ -1,6 +1,7 @@
 package io.quarkus.security.deployment;
 
-import static io.quarkus.gizmo.MethodDescriptor.ofConstructor;
+import static io.quarkus.gizmo.FieldDescriptor.of;
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 
 import java.util.function.Function;
 
@@ -25,12 +26,13 @@ public class SecurityCheckInstantiationUtil {
                             "Cannot use a null array to create an instance of " + RolesAllowedCheck.class.getName());
                 }
 
-                ResultHandle ctorArgs = creator.newArray(String.class, creator.load(rolesAllowed.length));
+                ResultHandle rolesAllowedArgs = creator.newArray(String.class, creator.load(rolesAllowed.length));
                 int i = 0;
                 for (String val : rolesAllowed) {
-                    creator.writeArrayValue(ctorArgs, i++, creator.load(val));
+                    creator.writeArrayValue(rolesAllowedArgs, i++, creator.load(val));
                 }
-                return creator.newInstance(ofConstructor(RolesAllowedCheck.class, String[].class), ctorArgs);
+                return creator.invokeStaticMethod(
+                        ofMethod(RolesAllowedCheck.class, "of", RolesAllowedCheck.class, String[].class), rolesAllowedArgs);
             }
         };
     }
@@ -39,7 +41,7 @@ public class SecurityCheckInstantiationUtil {
         return new Function<BytecodeCreator, ResultHandle>() {
             @Override
             public ResultHandle apply(BytecodeCreator creator) {
-                return creator.newInstance(ofConstructor(DenyAllCheck.class));
+                return creator.readStaticField(of(DenyAllCheck.class, "INSTANCE", DenyAllCheck.class));
             }
         };
     }
@@ -48,7 +50,7 @@ public class SecurityCheckInstantiationUtil {
         return new Function<BytecodeCreator, ResultHandle>() {
             @Override
             public ResultHandle apply(BytecodeCreator creator) {
-                return creator.newInstance(ofConstructor(PermitAllCheck.class));
+                return creator.readStaticField(of(PermitAllCheck.class, "INSTANCE", PermitAllCheck.class));
             }
         };
     }
@@ -57,7 +59,7 @@ public class SecurityCheckInstantiationUtil {
         return new Function<BytecodeCreator, ResultHandle>() {
             @Override
             public ResultHandle apply(BytecodeCreator creator) {
-                return creator.newInstance(ofConstructor(AuthenticatedCheck.class));
+                return creator.readStaticField(of(AuthenticatedCheck.class, "INSTANCE", AuthenticatedCheck.class));
             }
         };
     }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/AuthenticatedCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/AuthenticatedCheck.java
@@ -5,6 +5,11 @@ import io.quarkus.security.identity.SecurityIdentity;
 
 public class AuthenticatedCheck implements SecurityCheck {
 
+    public static final AuthenticatedCheck INSTANCE = new AuthenticatedCheck();
+
+    private AuthenticatedCheck() {
+    }
+
     @Override
     public void apply(SecurityIdentity identity) {
         if (identity.isAnonymous()) {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/DenyAllCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/DenyAllCheck.java
@@ -5,6 +5,12 @@ import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.SecurityIdentity;
 
 public class DenyAllCheck implements SecurityCheck {
+
+    public static final DenyAllCheck INSTANCE = new DenyAllCheck();
+
+    private DenyAllCheck() {
+    }
+
     @Override
     public void apply(SecurityIdentity identity) {
         if (identity.isAnonymous()) {

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/PermitAllCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/PermitAllCheck.java
@@ -3,6 +3,12 @@ package io.quarkus.security.runtime.interceptor.check;
 import io.quarkus.security.identity.SecurityIdentity;
 
 public class PermitAllCheck implements SecurityCheck {
+
+    public static final PermitAllCheck INSTANCE = new PermitAllCheck();
+
+    private PermitAllCheck() {
+    }
+
     @Override
     public void apply(SecurityIdentity identity) {
     }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/RolesAllowedCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/RolesAllowedCheck.java
@@ -1,16 +1,39 @@
 package io.quarkus.security.runtime.interceptor.check;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.SecurityIdentity;
 
 public class RolesAllowedCheck implements SecurityCheck {
+
+    /*
+     * The reason we want to cache RolesAllowedCheck is that it is very common
+     * to have a lot of methods using the same roles in the security check
+     * In such cases there is no need to have multiple instances of the class hanging around
+     * for the entire lifecycle of the application
+     */
+    private static final Map<List<String>, RolesAllowedCheck> CACHE = new ConcurrentHashMap<>();
+
     private final String[] allowedRoles;
 
-    public RolesAllowedCheck(String[] allowedRoles) {
+    private RolesAllowedCheck(String[] allowedRoles) {
         this.allowedRoles = allowedRoles;
+    }
+
+    public static RolesAllowedCheck of(String[] allowedRoles) {
+        return CACHE.computeIfAbsent(Arrays.asList(allowedRoles), new Function<List<String>, RolesAllowedCheck>() {
+            @Override
+            public RolesAllowedCheck apply(List<String> allowedRolesList) {
+                return new RolesAllowedCheck(allowedRolesList.toArray(new String[0]));
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
The reason we want to reuse `RolesAllowedCheck` is that it is very common
to have a lot of methods using the same roles in the security check.
In such cases there is no need to have multiple instances of the class hanging around
for the entire lifecycle of the application.