### PR TITLE
fix(vertx): do not log a warning about missing json support when vertx extension is present

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.arc.processor.AnnotationStore;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.GizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -51,6 +52,11 @@ class VertxProcessor {
     @Inject
     BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
 
+    @BuildStep(providesCapabilities = Capabilities.RESTEASY_JSON_EXTENSION)
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FeatureBuildItem.VERTX);
+    }
+
     @BuildStep
     AdditionalBeanBuildItem registerBean() {
         return AdditionalBeanBuildItem.unremovableOf(VertxProducer.class);
@@ -59,13 +65,11 @@ class VertxProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     VertxBuildItem build(CoreVertxBuildItem internalVertx, VertxRecorder recorder, BeanContainerBuildItem beanContainer,
-            BuildProducer<FeatureBuildItem> feature,
             List<EventConsumerBusinessMethodItem> messageConsumerBusinessMethods,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             AnnotationProxyBuildItem annotationProxy, LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown,
             BuildProducer<ServiceStartBuildItem> serviceStart,
             List<MessageCodecBuildItem> codecs, RecorderContext recorderContext) {
-        feature.produce(new FeatureBuildItem(FeatureBuildItem.VERTX));
         Map<String, ConsumeEvent> messageConsumerConfigurations = new HashMap<>();
         ClassOutput classOutput = new GizmoAdaptor(generatedClass, true);
         for (EventConsumerBusinessMethodItem businessMethod : messageConsumerBusinessMethods) {


### PR DESCRIPTION
Vert.x also provides a JSON implementation so no warning should be emitted

Fixes #5614

/cc @geoand @gsmet 