### PR TITLE
chore: add missing MongoDB guide in mongo extension descriptor yaml file

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mongodb-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
   - "mongodb"
   - "nosql"
   - "datastore"
+  guide: "https://quarkus.io/guides/mongodb"
   categories:
   - "data"
   status: "preview"

--- a/extensions/panache/mongodb-panache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/panache/mongodb-panache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,6 +7,7 @@ metadata:
   - "nosql"
   - "datastore"
   - "panache"
+  guide: "https://quarkus.io/guides/mongodb-panache"
   categories:
   - "data"
   status: "preview"


### PR DESCRIPTION
We have this https://quarkus.io/guides/mongodb  and https://quarkus.io/guides/mongodb-panache guides. So let's add them :-)

