### PR TITLE
Jetty removal, leftover from Camel extensions

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -148,7 +148,6 @@
         <jprocesses.version>1.6.5</jprocesses.version>
         <jboss-logmanager.version>1.0.4</jboss-logmanager.version>
         <jgit.version>5.5.1.201910021850-r</jgit.version>
-        <jetty.version>9.4.19.v20190610</jetty.version>
         <flyway.version>6.0.6</flyway.version>
         <yasson.version>1.0.5</yasson.version>
         <neo4j-java-driver.version>4.0.0-beta03</neo4j-java-driver.version>
@@ -2292,49 +2291,6 @@
                 <artifactId>jProcesses</artifactId>
                 <version>${jprocesses.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-client</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util-ajax</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-io</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlets</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-
-
-
             <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>swagger-ui</artifactId>


### PR DESCRIPTION
Jetty removal from BOM, leftover from Camel extensions

Jetty is still transitively used in testing of integration-tests/jgit, but I don't think we need to be worried about it.
```
...
[INFO] +- org.arquillian.smart.testing:git-rules:jar:0.0.10:test
[INFO] |  +- junit:junit:jar:4.12:test
[INFO] |  |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] |  +- org.eclipse.jgit:org.eclipse.jgit.http.server:jar:5.5.1.201910021850-r:test
[INFO] |  \- org.eclipse.jetty:jetty-servlet:jar:9.4.6.v20170531:test
[INFO] |     \- org.eclipse.jetty:jetty-security:jar:9.4.6.v20170531:test
[INFO] |        \- org.eclipse.jetty:jetty-server:jar:9.4.6.v20170531:test
[INFO] |           +- org.eclipse.jetty:jetty-http:jar:9.4.6.v20170531:test
[INFO] |           |  \- org.eclipse.jetty:jetty-util:jar:9.4.6.v20170531:test
[INFO] |           \- org.eclipse.jetty:jetty-io:jar:9.4.6.v20170531:test
```