### PR TITLE
RegisterRestclient configkey: improve error message and add documentation

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -141,6 +141,24 @@ The default scope can also be defined on the interface.
 
 Note that `org.acme.restclient.CountriesService` _must_ match the fully qualified name of the `CountriesService` interface we created in the previous section.
 
+To facilitate the configuration, you can use the `@RegisterRestClient` `configKey` property that allows to use another configuration root than the fully qualified name of your interface.
+
+[source, java]
+----
+
+@RegisterRestClient(configKey="country-api")
+public interface CountriesService {
+    [...]
+}
+----
+
+[source,properties]
+----
+# Your configuration properties
+country-api/mp-rest/url=https://restcountries.eu/rest #
+country-api/mp-rest/scope=javax.inject.Singleton # /
+----
+
 == Update the JAX-RS resource
 
 Open the `src/main/java/org/acme/restclient/CountriesResource.java` file and update it with the following content:

--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -189,8 +189,11 @@ public class RestClientBase {
                 && !propertyOptional.isPresent()) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Unable to determine the proper baseUrl/baseUri. Consider registering using @RegisterRestClient(baseUri=\"someuri\", configKey=\"orkey\"), or by adding '%s' to your Quarkus configuration",
-                            propertyPrefix));
+                            "Unable to determine the proper baseUrl/baseUri. " +
+                                    "Consider registering using @RegisterRestClient(baseUri=\"someuri\"), @RegisterRestClient(configKey=\"orkey\"), "
+                                    +
+                                    "or by adding '%s' or '%s' to your Quarkus configuration",
+                            String.format(REST_URL_FORMAT, propertyPrefix), String.format(REST_URI_FORMAT, propertyPrefix)));
         }
         String baseUrl = propertyOptional.orElse(baseUriFromAnnotation);
 


### PR DESCRIPTION
Fixes #5619

I provides a better error message (the default one makes me think there is a bug:) ).

I add some documentation because this is really a usefull feature.

I didn't document the `baseUrl` annotation property because I don't think it something a user should use ...