### PR TITLE
Change of logGuessedPath to split message to 2 lines and have fixed label length

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
@@ -130,16 +130,10 @@ public class NativeImageLauncher implements Closeable {
     }
 
     private static void logGuessedPath(String guessedPath) {
-        String errorString = "\n=native.image.path was not set, making a guess that  " + guessedPath
-                + " is the correct native image=";
-        for (int i = 0; i < errorString.length(); ++i) {
-            System.err.print("=");
-        }
-        System.err.println(errorString);
-        for (int i = 0; i < errorString.length(); ++i) {
-            System.err.print("=");
-        }
-        System.err.println();
+        System.err.println("======================================================================================");
+        System.err.println("  native.image.path was not set, making a guess for the correct path of native image");
+        System.err.println("  guessed path: " + guessedPath);
+        System.err.println("======================================================================================");
     }
 
     private void waitForQuarkus() {


### PR DESCRIPTION
Change of logGuessedPath to split message to 2 lines and have fixed `=` label length

The main reason for this change is that I didn't like very long line of `=`.

Proposed version:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.acme.quickstart.NativeGreetingResourceIT
======================================================================================
  native.image.path was not set, making a guess for the correct path of native image
  guessed path: /Users/rsvoboda/tmp/getting-started/target/getting-started-1.0-SNAPSHOT-runner
======================================================================================
```

Current version:
```
[INFO] -------------------------------------------------------
[INFO] T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.acme.quickstart.NativeGreetingResourceIT
=======================================================================================
===============================================================================
=native.image.path was not set, making a guess that  /Users/rsvoboda/tmp/getting-started/
target/getting-started-1.0-SNAPSHOT-runner is the correct native image=
=======================================================================================
===============================================================================
```

To see this message use getting started sample or any other Quarkus app and run
```
mvn verify -Dnative
mvn failsafe:integration-test
```