### PR TITLE
Security JPA implementation

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -614,6 +614,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-security-jpa-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-security-test-utils</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -742,6 +742,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-security-jpa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-vault</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -25,6 +25,7 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String SECURITY_ELYTRON_OAUTH2 = "io.quarkus.elytron.security.oauth2";
     public static final String SECURITY_ELYTRON_JDBC = "io.quarkus.elytron.security.jdbc";
     public static final String SECURITY_ELYTRON_LDAP = "io.quarkus.elytron.security.ldap";
+    public static final String SECURITY_JPA = "io.quarkus.security.jpa";
     public static final String QUARTZ = "io.quarkus.quartz";
     public static final String METRICS = "io.quarkus.metrics";
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -62,6 +62,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String SECURITY = "security";
     public static final String SECURITY_JDBC = "security-jdbc";
     public static final String SECURITY_LDAP = "security-ldap";
+    public static final String SECURITY_JPA = "security-jpa";
     public static final String SECURITY_PROPERTIES_FILE = "security-properties-file";
     public static final String SECURITY_OAUTH2 = "security-oauth2";
     public static final String SERVLET = "servlet";

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -1,0 +1,360 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Using Security from JPA
+
+include::./attributes.adoc[]
+
+This guide demonstrates how your Quarkus application can use a database to store your user identities with 
+link:hibernate-orm[Hibernate ORM] or link:hibernate-orm-panache[Hibernate ORM with Panache].
+
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* less than 15 minutes
+* an IDE
+* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* Apache Maven 3.5.3+
+
+== Architecture
+
+In this example, we build a very simple microservice which offers three endpoints:
+
+* `/api/public`
+* `/api/users/me`
+* `/api/admin`
+
+The `/api/public` endpoint can be accessed anonymously.
+The `/api/admin` endpoint is protected with RBAC (Role-Based Access Control) where only users granted with the `admin` role can access. At this endpoint, we use the `@RolesAllowed` annotation to declaratively enforce the access constraint.
+The `/api/users/me` endpoint is also protected with RBAC (Role-Based Access Control) where only users granted with the `user` role can access. As a response, it returns a JSON document with details about the user.
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `security-jpa-quickstart` {quickstarts-tree-url}/security-jpa-quickstart[directory].
+
+== Creating the Maven Project
+
+First, we need a new project. Create a new project with the following command:
+
+[source, subs=attributes+]
+----
+mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=security-jpa-quickstart \
+    -Dextensions="security-jpa, jdbc-postgresql, resteasy, hibernate-orm-panache"
+cd security-jpa-quickstart
+----
+
+[NOTE]
+====
+Don't forget to add the database connector library of choice. Here we are using PostgreSQL as identity store.
+====
+
+This command generates a Maven project, importing the `security-jpa` extension
+which allows you to map your security source to JPA entities.
+
+== Writing the application
+
+Let's start by implementing the `/api/public` endpoint. As you can see from the source code below, it is just a regular JAX-RS resource:
+
+[source,java]
+----
+package org.acme.security.jpa;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/api/public")
+public class PublicResource {
+
+    @GET
+    @PermitAll
+    @Produces(MediaType.TEXT_PLAIN)
+    public String publicResource() {
+        return "public";
+   }
+}
+----
+
+The source code for the `/api/admin` endpoint is also very simple. The main difference here is that we are using a `@RolesAllowed` annotation to make sure that only users granted with the `admin` role can access the endpoint:
+
+
+[source,java]
+----
+package org.acme.security.jpa;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/api/admin")
+public class AdminResource {
+
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String adminResource() {
+         return "admin";
+    }
+}
+----
+
+Finally, let's consider the `/api/users/me` endpoint. As you can see from the source code below, we are trusting only users with the `user` role.
+We are using `SecurityContext` to get access to the current authenticated Principal and we return the user's name. This information is loaded from the database.
+
+[source,java]
+----
+package org.acme.security.jpa;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/api/users")
+public class UserResource {
+
+    @GET
+    @RolesAllowed("user")
+    @Path("/me")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String me(@Context SecurityContext securityContext) {
+        return securityContext.getUserPrincipal().getName();
+    }
+}
+----
+
+=== Defining our user entity
+
+We can now describe how our security information is stored in our model by adding a few annotations to our `User` entity:
+
+[source,java]
+----
+package org.acme.security.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.security.common.BcryptUtil;
+import io.quarkus.security.jpa.Password;
+import io.quarkus.security.jpa.Roles;
+import io.quarkus.security.jpa.UserDefinition;
+import io.quarkus.security.jpa.Username;
+
+@Entity
+@Table(name = "test_user")
+@UserDefinition <1>
+public class User extends PanacheEntity {
+    @Username <2>
+    public String username;
+    @Password <3>
+    public String password;
+    @Roles <4>
+    public String role;
+    
+    /**
+     * Adds a new user in the database
+     * @param username the user name
+     * @param password the unencrypted password (it will be encrypted with bcrypt)
+     * @param role the comma-separated roles
+     */
+    public static void add(String username, String password, String role) { <5>
+        User user = new User();
+        user.username = username;
+        user.password = BcryptUtil.bcryptHash(password);
+        user.role = role;
+        user.persist();
+    }
+}
+
+----
+
+The `security-jpa` extension is only initialized if there is a single entity annotated with `@UserDefinition`.
+
+<1> This annotation must be present on a single entity. It can be a regular Hibernate ORM entity or a Hibernate ORM with Panache entity as in this example.
+<2> This indicates the field used for the user name.
+<3> This indicates the field used for the password. This defaults to using bcrypt hashed passwords, but you can also configure it for clear text passwords.
+<4> This indicates the comma-separated list of roles added to the target Principal representation attributes.
+<5> This method allows us to add users while hashing the password with the proper bcrypt hash.
+
+=== Configuring the Application
+
+The `security-jpa` extension requires at least one datasource to access to your database.
+
+[source,properties]
+----
+quarkus.datasource.url=jdbc:postgresql:security_jpa
+quarkus.datasource.driver=org.postgresql.Driver
+quarkus.datasource.username=quarkus
+quarkus.datasource.password=quarkus
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+----
+
+In our context, we are using PostgreSQL as identity store. The database schema is created by Hibernate ORM automatically
+on startup (change this in production) and we initialise the database with users and roles in the `Startup` class:
+
+[source,java]
+----
+package org.acme.security.jpa;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+
+import io.quarkus.runtime.StartupEvent;
+
+
+@Singleton
+public class Startup {
+    @Transactional
+    public void loadUsers(@Observes StartupEvent evt) {
+        // reset and load all test users
+        User.deleteAll();
+        User.add("admin", "admin", "admin");
+        User.add("user", "user", "user");
+    }
+}
+----
+
+[NOTE]
+====
+It is probably useless but we kindly remind you that you must not store clear-text passwords in production environments ;-).
+As a result, the `security-jpa` defaults to using bcrypt-hashed passwords.
+====
+
+== Testing the Application
+
+The application is now protected and the identities are provided by our database.
+The very first thing to check is to ensure the anonymous access works.
+
+[source,shell]
+----
+$ curl -i -X GET http://localhost:8080/api/public
+HTTP/1.1 200 OK
+Content-Length: 6
+Content-Type: text/plain;charset=UTF-8
+
+public%
+----
+
+Now, let's try a to hit a protected resource anonymously.
+
+[source,shell]
+----
+$ curl -i -X GET http://localhost:8080/api/admin
+HTTP/1.1 401 Unauthorized
+Content-Length: 14
+Content-Type: text/html;charset=UTF-8
+
+Not authorized%
+----
+
+So far so good, now let's try with an allowed user.
+
+[source,shell]
+----
+$ curl -i -X GET -u admin:admin http://localhost:8080/api/admin
+HTTP/1.1 200 OK
+Content-Length: 5
+Content-Type: text/plain;charset=UTF-8
+
+admin%
+----
+By providing the `admin:admin` credentials, the extension authenticated the user and loaded their roles.
+The `admin` user is authorized to access to the protected resources.
+
+The user `admin` should be forbidden to access a resource protected with `@RolesAllowed("user")` because it doesn't have this role.
+[source,shell]
+----
+$ curl -i -X GET -u admin:admin http://localhost:8080/api/users/me
+HTTP/1.1 403 Forbidden
+Content-Length: 34
+Content-Type: text/html;charset=UTF-8
+
+Forbidden%
+----
+
+Finally, using the user `user` works and the security context contains the principal details (username for instance).
+[source,shell]
+----
+curl -i -X GET -u user:user http://localhost:8080/api/users/me
+HTTP/1.1 200 OK
+Content-Length: 4
+Content-Type: text/plain;charset=UTF-8
+
+user%
+----
+
+== Supported model types
+
+- The `@UserDefinition` class must be a JPA entity (with Panache or not).
+- The `@Username` and `@Password` field types must be of type `String`.
+- The `@Roles` field must either be of type `String` or `Collection<String>` or alternately a `Collection<X>` where `X` is an entity class with one `String` field annotated with the `@RolesValue` annotation.
+- Each `String` role element type will be parsed as a comma-separated list of roles.
+
+== Storing roles in another entity
+
+You can also store roles in another entity:
+
+[source,java]
+----
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class User extends PanacheEntity {
+    @Username
+    public String name;
+
+    @Password
+    public String pass;
+
+    @ManyToMany
+    @Roles
+    public List<Role> roles = new ArrayList<>();
+}
+
+@Entity
+public class Role extends PanacheEntity {
+
+    @ManyToMany(mappedBy = "roles")
+    public List<ExternalRolesUserEntity> users;
+
+    @RolesValue
+    public String role;
+}
+----
+
+== Password storage and hashing
+
+By default, we consider passwords to be stored hashed with https://en.wikipedia.org/wiki/Bcrypt[bcrypt] under the 
+https://en.wikipedia.org/wiki/Crypt_(C)[Modular Crypt Format] (MCF).
+
+When you need to create such a hashed password we provide the convenient `String BcryptUtil.bcryptHash(String password)`
+function, which defaults to creating a random salt and hashing in 10 iterations (though you can specify the iterations and salt
+too).
+
+NOTE: with MCF you don't need dedicated columns to store the hashing algo, the iterations count or the salt because
+they're all stored in the hashed value.
+
+WARN: you can also store passwords in clear text with `@Password(PasswordType.CLEAR)` but we strongly recommend against
+it in production.

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -22,6 +22,9 @@ in order for Quarkus to know how to find the authentication information to check
 |link:security-properties[quarkus-elytron-security-properties-file]
 |Provides support for simple properties files that can be used for testing security. This supports both embedding user info in `application.properties` and standalone properties files.
 
+|link:security-jpa[quarkus-security-jpa]
+|Provides support for authenticating via JPA.
+
 |link:security-jdbc[quarkus-elytron-security-jdbc]
 |Provides support for authenticating via JDBC.
 

--- a/extensions/elytron-security-common/deployment/pom.xml
+++ b/extensions/elytron-security-common/deployment/pom.xml
@@ -18,6 +18,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/QuarkusSecurityCommonProcessor.java
+++ b/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/QuarkusSecurityCommonProcessor.java
@@ -1,0 +1,38 @@
+package io.quarkus.elytron.security.common.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import io.quarkus.elytron.security.common.runtime.ElytronCommonRecorder;
+
+public class QuarkusSecurityCommonProcessor {
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitBcryptUtil() {
+        // this holds a SecureRandom static var that needs to be initialised at run time
+        return new RuntimeInitializedClassBuildItem(BcryptUtil.class.getName());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void registerPasswordProvider(ElytronCommonRecorder recorder, ShutdownContextBuildItem shutdownContextBuildItem) {
+        recorder.registerPasswordProvider(shutdownContextBuildItem);
+    }
+
+    /**
+     * Register the Elytron-provided password factory SPI implementation
+     *
+     * @param classes producer factory for ReflectiveClassBuildItems
+     */
+    @BuildStep
+    void services(BuildProducer<ReflectiveClassBuildItem> classes) {
+        String[] allClasses = {
+                "org.wildfly.security.password.impl.PasswordFactorySpiImpl",
+        };
+        classes.produce(new ReflectiveClassBuildItem(true, false, allClasses));
+    }
+}

--- a/extensions/elytron-security-common/runtime/pom.xml
+++ b/extensions/elytron-security-common/runtime/pom.xml
@@ -25,6 +25,15 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-credential</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-password-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/elytron-security-common/runtime/src/main/java/io/quarkus/elytron/security/common/BcryptUtil.java
+++ b/extensions/elytron-security-common/runtime/src/main/java/io/quarkus/elytron/security/common/BcryptUtil.java
@@ -1,0 +1,92 @@
+package io.quarkus.elytron.security.common;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Objects;
+
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.BCryptPassword;
+import org.wildfly.security.password.spec.EncryptablePasswordSpec;
+import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
+import org.wildfly.security.password.util.ModularCrypt;
+
+/**
+ * Utility class used to produce bcrypt hashes using the Modular Crypt Format.
+ */
+public class BcryptUtil {
+
+    private static final SecureRandom random = new SecureRandom();
+    private static final WildFlyElytronPasswordProvider provider = new WildFlyElytronPasswordProvider();
+
+    /**
+     * Produces a Modular Crypt Format bcrypt hash of the given password, using a generated salt and 10 iterations.
+     * 
+     * @param password the password to hash
+     * @return the Modular Crypt Format bcrypt hash of the given password
+     * @throws NullPointerException if the password is null
+     */
+    public static String bcryptHash(String password) {
+        return bcryptHash(password, 10);
+    }
+
+    /**
+     * Produces a Modular Crypt Format bcrypt hash of the given password, using a generated salt and the specified iteration
+     * count.
+     * 
+     * @param password the password to hash
+     * @param iterationCount the number of iterations to use while hashing
+     * @return the Modular Crypt Format bcrypt hash of the given password
+     * @throws NullPointerException if the password is null
+     * @throws IllegalArgumentException if the iterationCount parameter is negative or zero
+     */
+    public static String bcryptHash(String password, int iterationCount) {
+        byte[] salt = new byte[BCryptPassword.BCRYPT_SALT_SIZE];
+        random.nextBytes(salt);
+        return bcryptHash(password, iterationCount, salt);
+    }
+
+    /**
+     * Produces a Modular Crypt Format bcrypt hash of the given password, using the specified salt and the specified iteration
+     * count.
+     * 
+     * @param password the password to hash
+     * @param iterationCount the number of iterations to use while hashing
+     * @param salt the salt to use while hashing
+     * @return the Modular Crypt Format bcrypt hash of the given password
+     * @throws NullPointerException if the password or salt are null
+     * @throws IllegalArgumentException if the iterationCount parameter is negative or zero, or if the salt length is not equal
+     *         to 16
+     */
+    public static String bcryptHash(String password, int iterationCount, byte[] salt) {
+        if (iterationCount <= 0) {
+            throw new IllegalArgumentException("Iteration count must be greater than zero");
+        }
+        Objects.requireNonNull(password, "password is required");
+        Objects.requireNonNull(salt, "salt is required");
+        if (salt.length != BCryptPassword.BCRYPT_SALT_SIZE) {
+            throw new IllegalArgumentException("Salt length must be exactly " + BCryptPassword.BCRYPT_SALT_SIZE + " bytes");
+        }
+
+        PasswordFactory passwordFactory;
+        try {
+            passwordFactory = PasswordFactory.getInstance(BCryptPassword.ALGORITHM_BCRYPT, provider);
+        } catch (NoSuchAlgorithmException e) {
+            // can't really happen
+            throw new RuntimeException(e);
+        }
+
+        IteratedSaltedPasswordAlgorithmSpec iteratedAlgorithmSpec = new IteratedSaltedPasswordAlgorithmSpec(iterationCount,
+                salt);
+        EncryptablePasswordSpec encryptableSpec = new EncryptablePasswordSpec(password.toCharArray(), iteratedAlgorithmSpec);
+
+        try {
+            BCryptPassword original = (BCryptPassword) passwordFactory.generatePassword(encryptableSpec);
+            return ModularCrypt.encodeAsString(original);
+        } catch (InvalidKeySpecException e) {
+            // can't really happen
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/elytron-security-common/runtime/src/main/java/io/quarkus/elytron/security/common/runtime/ElytronCommonRecorder.java
+++ b/extensions/elytron-security-common/runtime/src/main/java/io/quarkus/elytron/security/common/runtime/ElytronCommonRecorder.java
@@ -1,0 +1,33 @@
+package io.quarkus.elytron.security.common.runtime;
+
+import java.security.Security;
+
+import org.jboss.logging.Logger;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Recorder;
+
+/**
+ * The runtime security recorder class that provides methods for creating RuntimeValues for the deployment security objects.
+ */
+@Recorder
+public class ElytronCommonRecorder {
+    static final Logger log = Logger.getLogger(ElytronCommonRecorder.class);
+
+    /**
+     * As of Graal 19.3.0 this has to be registered at runtime, due to a bug.
+     *
+     * 19.3.1 should fix this, see https://github.com/oracle/graal/issues/1883
+     */
+    public void registerPasswordProvider(ShutdownContext shutdownContext) {
+        WildFlyElytronPasswordProvider provider = new WildFlyElytronPasswordProvider();
+        Security.addProvider(provider);
+        shutdownContext.addShutdownTask(new Runnable() {
+            @Override
+            public void run() {
+                Security.removeProvider(provider.getName());
+            }
+        });
+    }
+}

--- a/extensions/elytron-security-common/runtime/src/test/java/io/quarkus/elytron/security/common/runtime/BcryptUtilTest.java
+++ b/extensions/elytron-security-common/runtime/src/test/java/io/quarkus/elytron/security/common/runtime/BcryptUtilTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.elytron.security.common.runtime;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.security.spec.InvalidKeySpecException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.util.ModularCrypt;
+
+import io.quarkus.elytron.security.common.BcryptUtil;
+
+public class BcryptUtilTest {
+
+    static {
+        Security.addProvider(new WildFlyElytronPasswordProvider());
+    }
+
+    @Test
+    public void testHashesTheRightPassword() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        String testPassword = "fubar";
+
+        String testPasswordHash = BcryptUtil.bcryptHash(testPassword);
+
+        PasswordGuessEvidence correctPasswordEvidence = new PasswordGuessEvidence(testPassword.toCharArray());
+        PasswordGuessEvidence incorrectPasswordEvidence = new PasswordGuessEvidence("stef".toCharArray());
+        PasswordCredential producedPasswordCredential = new PasswordCredential(ModularCrypt.decode(testPasswordHash));
+        Assertions.assertTrue(producedPasswordCredential.verify(correctPasswordEvidence));
+        Assertions.assertFalse(producedPasswordCredential.verify(incorrectPasswordEvidence));
+    }
+
+    @Test
+    public void testHashesTheSameHash() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        String adminKnownBcrypt = "$2a$10$YP9QWYOpxRNCNquTzCjRIuEpc.MiVPTjlMIZHNqHKckKN8FK9Xyh2";
+        byte[] knownSalt = new byte[] { 105, 31, -46, 97, -92, 43, -51, 51, -60, 62, -52, 21, -44, 73, 83, 43 };
+        String adminProducedBcrypt = BcryptUtil.bcryptHash("admin", 10, knownSalt);
+        Assertions.assertEquals(adminKnownBcrypt, adminProducedBcrypt);
+    }
+}

--- a/extensions/elytron-security/deployment/src/main/java/io/quarkus/elytron/security/deployment/ElytronDeploymentProcessor.java
+++ b/extensions/elytron-security/deployment/src/main/java/io/quarkus/elytron/security/deployment/ElytronDeploymentProcessor.java
@@ -12,8 +12,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.elytron.security.runtime.DefaultRoleDecoder;
 import io.quarkus.elytron.security.runtime.ElytronPasswordIdentityProvider;
 import io.quarkus.elytron.security.runtime.ElytronRecorder;
@@ -39,19 +37,6 @@ import io.quarkus.runtime.RuntimeValue;
  */
 class ElytronDeploymentProcessor {
     private static final Logger log = Logger.getLogger(ElytronDeploymentProcessor.class.getName());
-
-    /**
-     * Register the Elytron-provided password factory SPI implementation
-     *
-     * @param classes producer factory for ReflectiveClassBuildItems
-     */
-    @BuildStep
-    void services(BuildProducer<ReflectiveClassBuildItem> classes) {
-        String[] allClasses = {
-                "org.wildfly.security.password.impl.PasswordFactorySpiImpl",
-        };
-        classes.produce(new ReflectiveClassBuildItem(true, false, allClasses));
-    }
 
     @BuildStep
     void addBeans(BuildProducer<AdditionalBeanBuildItem> beans, List<ElytronPasswordMarkerBuildItem> pw,
@@ -97,12 +82,6 @@ class ElytronDeploymentProcessor {
             return new SecurityDomainBuildItem(securityDomain);
         }
         return null;
-    }
-
-    @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
-    public void registerPasswordProvider(ElytronRecorder recorder, ShutdownContextBuildItem shutdownContextBuildItem) {
-        recorder.registerPasswordProvider(shutdownContextBuildItem);
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
@@ -26,6 +26,7 @@ import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.deployment.EntityField;
 import io.quarkus.panache.common.deployment.EntityModel;
 import io.quarkus.panache.common.deployment.MetamodelInfo;
+import io.quarkus.panache.common.deployment.PanacheEntityClassesBuildItem;
 import io.quarkus.panache.common.deployment.PanacheFieldAccessEnhancer;
 import io.quarkus.panache.common.deployment.PanacheRepositoryEnhancer;
 
@@ -60,7 +61,8 @@ public final class PanacheResourceProcessor {
     void build(CombinedIndexBuildItem index,
             ApplicationIndexBuildItem applicationIndex,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
-            HibernateEnhancersRegisteredBuildItem hibernateMarker) throws Exception {
+            HibernateEnhancersRegisteredBuildItem hibernateMarker,
+            BuildProducer<PanacheEntityClassesBuildItem> entityClasses) throws Exception {
 
         PanacheJpaRepositoryEnhancer daoEnhancer = new PanacheJpaRepositoryEnhancer(index.getIndex());
         Set<String> daoClasses = new HashSet<>();
@@ -99,6 +101,9 @@ public final class PanacheResourceProcessor {
         }
         for (String modelClass : modelClasses) {
             transformers.produce(new BytecodeTransformerBuildItem(modelClass, modelEnhancer));
+        }
+        if (!modelClasses.isEmpty()) {
+            entityClasses.produce(new PanacheEntityClassesBuildItem(modelClasses));
         }
 
         MetamodelInfo<EntityModel<EntityField>> modelInfo = modelEnhancer.getModelInfo();

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -45,6 +45,7 @@ import io.quarkus.mongodb.panache.PanacheMongoRecorder;
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
 import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
 import io.quarkus.mongodb.panache.ProjectionFor;
+import io.quarkus.panache.common.deployment.PanacheEntityClassesBuildItem;
 import io.quarkus.panache.common.deployment.PanacheFieldAccessEnhancer;
 import io.quarkus.panache.common.deployment.PanacheRepositoryEnhancer;
 
@@ -118,7 +119,8 @@ public class PanacheResourceProcessor {
             ApplicationIndexBuildItem applicationIndex,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass) throws Exception {
+            BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
+            BuildProducer<PanacheEntityClassesBuildItem> entityClasses) throws Exception {
 
         PanacheMongoRepositoryEnhancer daoEnhancer = new PanacheMongoRepositoryEnhancer(index.getIndex());
         Set<String> daoClasses = new HashSet<>();
@@ -176,6 +178,9 @@ public class PanacheResourceProcessor {
 
             // Register for building the property mapping cache
             propertyMappingClass.produce(new PropertyMappingClassBuildStep(modelClass));
+        }
+        if (!modelClasses.isEmpty()) {
+            entityClasses.produce(new PanacheEntityClassesBuildItem(modelClasses));
         }
 
         if (!modelEnhancer.entities.isEmpty()) {

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityClassesBuildItem.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityClassesBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.panache.common.deployment;
+
+import java.util.Set;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Build item to indicate that those classes are Panache-enhanced and will get
+ * getters/setters generated for public fields, even if they're not visible in the index.
+ */
+public final class PanacheEntityClassesBuildItem extends MultiBuildItem {
+    private Set<String> entityClasses;
+
+    public PanacheEntityClassesBuildItem(Set<String> entityClasses) {
+        this.entityClasses = entityClasses;
+    }
+
+    public Set<String> getEntityClasses() {
+        return entityClasses;
+    }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -97,6 +97,7 @@
 
         <!-- Security -->
         <module>security</module>
+        <module>security-jpa</module>
         <module>elytron-security-common</module>
         <module>elytron-security</module>
         <module>elytron-security-jdbc</module>

--- a/extensions/security-jpa/deployment/pom.xml
+++ b/extensions/security-jpa/deployment/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-security-jpa-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-security-jpa-deployment</artifactId>
+    <name>Quarkus - Security JPA - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-panache-common-deployment</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Hibernate ORM specific dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JDBC driver dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/JpaSecurityDefinition.java
+++ b/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/JpaSecurityDefinition.java
@@ -1,0 +1,132 @@
+package io.quarkus.security.jpa.deployment;
+
+import java.lang.reflect.Modifier;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+import io.quarkus.deployment.bean.JavaBeanUtil;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+public class JpaSecurityDefinition {
+    public static class FieldOrMethod {
+        public final FieldInfo field;
+        public final MethodInfo getter;
+
+        public FieldOrMethod(FieldInfo field, MethodInfo getter) {
+            this.field = field;
+            this.getter = getter;
+        }
+
+        public AnnotationInstance annotation(DotName annotationName) {
+            if (field != null) {
+                return field.annotation(annotationName);
+            }
+            return getter.annotation(annotationName);
+        }
+
+        public String name() {
+            if (field != null) {
+                return field.name();
+            }
+            return JavaBeanUtil.getPropertyNameFromGetter(getter.name());
+        }
+
+        public ResultHandle readValue(BytecodeCreator methodCreator, AssignableResultHandle userVar) {
+            // favour the getter
+            if (getter != null) {
+                return methodCreator.invokeVirtualMethod(MethodDescriptor.of(getter), userVar);
+            }
+            return methodCreator.readInstanceField(FieldDescriptor.of(field), userVar);
+        }
+
+        public Type type() {
+            // FIXME: this doesn't work with generics-inherited types
+            if (field != null) {
+                return field.type();
+            }
+            return getter.returnType();
+        }
+    }
+
+    public final FieldOrMethod username;
+    public final FieldOrMethod password;
+    public final FieldOrMethod roles;
+    public final ClassInfo annotatedClass;
+
+    public JpaSecurityDefinition(Index index,
+            ClassInfo annotatedClass,
+            boolean isPanache,
+            AnnotationTarget usernameFieldOrMethod,
+            AnnotationTarget passwordFieldOrMethod,
+            AnnotationTarget rolesFieldOrMethod) {
+        this.annotatedClass = annotatedClass;
+        this.username = getFieldOrMethod(index, annotatedClass, usernameFieldOrMethod, isPanache);
+        this.password = getFieldOrMethod(index, annotatedClass, passwordFieldOrMethod, isPanache);
+        this.roles = getFieldOrMethod(index, annotatedClass, rolesFieldOrMethod, isPanache);
+    }
+
+    public static FieldOrMethod getFieldOrMethod(Index index, ClassInfo annotatedClass,
+            AnnotationTarget annotatedFieldOrMethod, boolean isPanache) {
+        switch (annotatedFieldOrMethod.kind()) {
+            case FIELD:
+                // try to find a getter for this field
+                FieldInfo field = annotatedFieldOrMethod.asField();
+                return new FieldOrMethod(field,
+                        findGetter(index, annotatedClass, field, Modifier.isPublic(field.flags()) && isPanache));
+            case METHOD:
+                // skip the field entirely
+                return new FieldOrMethod(null, annotatedFieldOrMethod.asMethod());
+            default:
+                throw new IllegalArgumentException(
+                        "annotatedFieldOrMethod must be a field or method: " + annotatedFieldOrMethod);
+        }
+    }
+
+    // FIXME: in order to check for the getter type we need to apply type parameters, that's too complex so assume it matches
+    private static MethodInfo findGetter(Index index, ClassInfo annotatedClass, FieldInfo field, boolean isPanache) {
+        // if it's a panache field, we won't see the getter but it will be there
+        String methodName = "get" + JavaBeanUtil.capitalize(field.name());
+        if (isPanache) {
+            return MethodInfo.create(field.declaringClass(), methodName, new Type[0], field.type(), (short) Modifier.PUBLIC);
+        }
+        return findGetter(index, annotatedClass, methodName);
+    }
+
+    private static MethodInfo findGetter(Index index, ClassInfo annotatedClass, String methodName) {
+        MethodInfo method = annotatedClass.method(methodName);
+        if (method != null) {
+            return method;
+        }
+        DotName superName = annotatedClass.superName();
+        if (superName != null && !superName.equals(QuarkusSecurityJpaProcessor.DOTNAME_OBJECT)) {
+            ClassInfo superClass = index.getClassByName(superName);
+            if (superClass != null) {
+                method = findGetter(index, superClass, methodName);
+                if (method != null) {
+                    return method;
+                }
+            }
+        }
+        for (DotName interfaceName : annotatedClass.interfaceNames()) {
+            ClassInfo interf = index.getClassByName(interfaceName);
+            if (interf != null) {
+                method = findGetter(index, interf, methodName);
+                if (method != null) {
+                    return method;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/QuarkusSecurityJpaProcessor.java
+++ b/extensions/security-jpa/deployment/src/main/java/io/quarkus/security/jpa/deployment/QuarkusSecurityJpaProcessor.java
@@ -1,0 +1,345 @@
+package io.quarkus.security.jpa.deployment;
+
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.hibernate.Session;
+import org.hibernate.SimpleNaturalIdLoadAccess;
+import org.hibernate.annotations.NaturalId;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+
+import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
+import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.panache.common.deployment.PanacheEntityClassesBuildItem;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.Password;
+import io.quarkus.security.jpa.PasswordType;
+import io.quarkus.security.jpa.Roles;
+import io.quarkus.security.jpa.RolesValue;
+import io.quarkus.security.jpa.UserDefinition;
+import io.quarkus.security.jpa.Username;
+import io.quarkus.security.jpa.deployment.JpaSecurityDefinition.FieldOrMethod;
+import io.quarkus.security.jpa.runtime.JpaIdentityProvider;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+class QuarkusSecurityJpaProcessor {
+
+    static final DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
+
+    private static final DotName DOTNAME_STRING = DotName.createSimple(String.class.getName());
+    private static final DotName DOTNAME_LIST = DotName.createSimple(List.class.getName());
+    private static final DotName DOTNAME_SET = DotName.createSimple(Set.class.getName());
+    private static final DotName DOTNAME_COLLECTION = DotName.createSimple(Collection.class.getName());
+
+    private static final DotName DOTNAME_NATURAL_ID = DotName.createSimple(NaturalId.class.getName());
+
+    private static final DotName DOTNAME_USER_DEFINITION = DotName.createSimple(UserDefinition.class.getName());
+    private static final DotName DOTNAME_USERNAME = DotName.createSimple(Username.class.getName());
+    private static final DotName DOTNAME_PASSWORD = DotName.createSimple(Password.class.getName());
+    private static final DotName DOTNAME_ROLES = DotName.createSimple(Roles.class.getName());
+    private static final DotName DOTNAME_ROLES_VALUE = DotName.createSimple(RolesValue.class.getName());
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FeatureBuildItem.SECURITY_JPA);
+    }
+
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.SECURITY_JPA);
+    }
+
+    @BuildStep
+    void configureJpaAuthConfig(ApplicationIndexBuildItem index,
+            BuildProducer<UnremovableBeanBuildItem> unremovable,
+            BuildProducer<GeneratedBeanBuildItem> beanProducer,
+            List<PanacheEntityClassesBuildItem> panacheEntityClasses) throws Exception {
+
+        // Generate an IdentityProvider if we have a @UserDefinition
+        List<AnnotationInstance> userDefinitions = index.getIndex().getAnnotations(DOTNAME_USER_DEFINITION);
+        if (userDefinitions.size() > 1) {
+            throw new RuntimeException("You can only annotate one class with @UserDefinition");
+        } else if (!userDefinitions.isEmpty()) {
+            ClassInfo userDefinitionClass = userDefinitions.get(0).target().asClass();
+            AnnotationTarget annotatedUsername = getSingleAnnotatedElement(index.getIndex(), DOTNAME_USERNAME);
+            // FIXME: check that it's in the same class hierarchy
+            // FIXME: look up fields with default names? name, username…
+            AnnotationTarget annotatedPassword = getSingleAnnotatedElement(index.getIndex(), DOTNAME_PASSWORD);
+            AnnotationTarget annotatedRoles = getSingleAnnotatedElement(index.getIndex(), DOTNAME_ROLES);
+            Set<String> panacheEntities = collectPanacheEntities(panacheEntityClasses);
+            // collect associated getters if required
+            JpaSecurityDefinition jpaSecurityDefinition = new JpaSecurityDefinition(index.getIndex(),
+                    userDefinitionClass,
+                    isPanache(userDefinitionClass, panacheEntities),
+                    annotatedUsername,
+                    annotatedPassword,
+                    annotatedRoles);
+            AnnotationInstance passAnnotation = jpaSecurityDefinition.password.annotation(DOTNAME_PASSWORD);
+            AnnotationValue passwordType = passAnnotation.value();
+            generateIdentityProvider(index.getIndex(), jpaSecurityDefinition,
+                    passwordType != null ? passwordType.asEnum() : PasswordType.MCF.name(),
+                    beanProducer, panacheEntities);
+        }
+    }
+
+    private boolean isPanache(ClassInfo annotatedClass, Set<String> panacheEntities) {
+        return panacheEntities.contains(annotatedClass.name().toString());
+    }
+
+    private Set<String> collectPanacheEntities(List<PanacheEntityClassesBuildItem> panacheEntityClassesBuildItems) {
+        Set<String> modelClasses = new HashSet<>();
+        for (PanacheEntityClassesBuildItem panacheEntityClasses : panacheEntityClassesBuildItems) {
+            modelClasses.addAll(panacheEntityClasses.getEntityClasses());
+        }
+        return modelClasses;
+    }
+
+    private AnnotationTarget getSingleAnnotatedElement(Index index, DotName annotation) {
+        List<AnnotationInstance> annotations = index.getAnnotations(annotation);
+        if (annotations.isEmpty()) {
+            return null;
+        } else if (annotations.size() > 1) {
+            throw new RuntimeException("You can only annotate one field or method with @" + annotation);
+        }
+        return annotations.get(0).target();
+    }
+
+    private void generateIdentityProvider(Index index, JpaSecurityDefinition jpaSecurityDefinition, String passwordType,
+            BuildProducer<GeneratedBeanBuildItem> beanProducer, Set<String> panacheClasses) {
+        GeneratedBeanGizmoAdaptor gizmoAdaptor = new GeneratedBeanGizmoAdaptor(beanProducer);
+
+        String name = jpaSecurityDefinition.annotatedClass.name() + "__JpaIdentityProviderImpl";
+        try (ClassCreator classCreator = ClassCreator.builder()
+                .className(name)
+                .superClass(JpaIdentityProvider.class)
+                .classOutput(gizmoAdaptor)
+                .build()) {
+            classCreator.addAnnotation(Singleton.class);
+            try (MethodCreator methodCreator = classCreator.getMethodCreator("authenticate", SecurityIdentity.class,
+                    EntityManager.class, UsernamePasswordAuthenticationRequest.class)) {
+                methodCreator.setModifiers(Modifier.PUBLIC);
+
+                ResultHandle username = methodCreator.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(UsernamePasswordAuthenticationRequest.class, "getUsername", String.class),
+                        methodCreator.getMethodParam(1));
+
+                // two strategies, depending on whether the username is natural id
+                AnnotationInstance naturalIdAnnotation = jpaSecurityDefinition.username.annotation(DOTNAME_NATURAL_ID);
+                ResultHandle user;
+                if (naturalIdAnnotation != null) {
+                    // Session session = em.unwrap(Session.class);
+                    ResultHandle session = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(EntityManager.class, "unwrap", Object.class, Class.class),
+                            methodCreator.getMethodParam(0),
+                            methodCreator.loadClass(Session.class));
+                    // SimpleNaturalIdLoadAccess<PlainUserEntity> naturalIdLoadAccess = session.bySimpleNaturalId(PlainUserEntity.class);
+                    ResultHandle naturalIdLoadAccess = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(Session.class, "bySimpleNaturalId",
+                                    SimpleNaturalIdLoadAccess.class, Class.class),
+                            methodCreator.checkCast(session, Session.class),
+                            methodCreator.loadClass(jpaSecurityDefinition.annotatedClass.name().toString()));
+                    // PlainUserEntity user = naturalIdLoadAccess.load(request.getUsername());
+                    user = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(SimpleNaturalIdLoadAccess.class, "load",
+                                    Object.class, Object.class),
+                            naturalIdLoadAccess, username);
+                } else {
+                    // Query query = entityManager.createQuery("FROM Entity WHERE field = :name")
+                    String hql = "FROM " + jpaSecurityDefinition.annotatedClass.simpleName() + " WHERE "
+                            + jpaSecurityDefinition.username.name() + " = :name";
+                    ResultHandle query = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(EntityManager.class, "createQuery", Query.class, String.class),
+                            methodCreator.getMethodParam(0), methodCreator.load(hql));
+                    // query.setParameter("name", request.getUsername())
+                    ResultHandle query2 = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(Query.class, "setParameter", Query.class, String.class, Object.class),
+                            query, methodCreator.load("name"), username);
+
+                    // UserEntity user = getSingleUser(query2);
+                    user = methodCreator.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(name, "getSingleUser", Object.class, Query.class),
+                            methodCreator.getThis(), query2);
+                }
+
+                String declaringClassName = jpaSecurityDefinition.annotatedClass.name().toString();
+                String declaringClassTypeDescriptor = "L" + declaringClassName.replace('.', '/') + ";";
+                AssignableResultHandle userVar = methodCreator.createVariable(declaringClassTypeDescriptor);
+                methodCreator.assign(userVar, methodCreator.checkCast(user, declaringClassName));
+
+                // if(user == null) return null;
+                try (BytecodeCreator trueBranch = methodCreator.ifNull(userVar).trueBranch()) {
+                    trueBranch.returnValue(trueBranch.loadNull());
+                }
+
+                // :pass = user.pass | user.getPass()
+                ResultHandle pass = jpaSecurityDefinition.password.readValue(methodCreator, userVar);
+                String getPasswordMethod;
+                if (passwordType == null) {
+                    passwordType = PasswordType.MCF.name();
+                }
+                switch (PasswordType.valueOf(passwordType)) {
+                    case CLEAR:
+                        getPasswordMethod = "getClearPassword";
+                        break;
+                    case MCF:
+                        getPasswordMethod = "getMcfPassword";
+                        break;
+                    default:
+                        throw new RuntimeException("Unknown password type: " + passwordType);
+                }
+                // :getPasswordMethod(:pass);
+                ResultHandle storedPassword = methodCreator.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(name, getPasswordMethod, org.wildfly.security.password.Password.class,
+                                String.class),
+                        methodCreator.getThis(), pass);
+
+                // Builder builder = checkPassword(storedPassword, request);
+                ResultHandle builder = methodCreator.invokeVirtualMethod(MethodDescriptor.ofMethod(name, "checkPassword",
+                        QuarkusSecurityIdentity.Builder.class,
+                        org.wildfly.security.password.Password.class,
+                        UsernamePasswordAuthenticationRequest.class),
+                        methodCreator.getThis(),
+                        storedPassword, methodCreator.getMethodParam(1));
+                AssignableResultHandle builderVar = methodCreator.createVariable(QuarkusSecurityIdentity.Builder.class);
+                methodCreator.assign(builderVar, builder);
+
+                ResultHandle role = jpaSecurityDefinition.roles.readValue(methodCreator, userVar);
+                // role: user.getRole()
+                boolean handledRole = false;
+                Type rolesType = jpaSecurityDefinition.roles.type();
+                switch (rolesType.kind()) {
+                    case ARRAY:
+                        // FIXME: support non-JPA-backed array roles?
+                        break;
+                    case CLASS:
+                        if (rolesType.name().equals(DOTNAME_STRING)) {
+                            // addRoles(builder, :role)
+                            methodCreator.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(name, "addRoles", void.class,
+                                            QuarkusSecurityIdentity.Builder.class, String.class),
+                                    methodCreator.getThis(),
+                                    builderVar,
+                                    role);
+                            handledRole = true;
+                        }
+                        break;
+                    case PARAMETERIZED_TYPE:
+                        DotName roleType = rolesType.name();
+                        if (roleType.equals(DOTNAME_LIST)
+                                || roleType.equals(DOTNAME_COLLECTION)
+                                || roleType.equals(DOTNAME_SET)) {
+                            Type elementType = rolesType.asParameterizedType().arguments().get(0);
+                            String elementClassName = elementType.name().toString();
+                            String elementClassTypeDescriptor = "L" + elementClassName.replace('.', '/') + ";";
+                            FieldOrMethod rolesFieldOrMethod;
+                            if (!elementType.name().equals(DOTNAME_STRING)) {
+                                ClassInfo roleClass = index.getClassByName(elementType.name());
+                                if (roleClass == null) {
+                                    throw new RuntimeException(
+                                            "The role element type must be indexed by Jandex: " + elementType);
+                                }
+                                AnnotationTarget annotatedRolesValue = getSingleAnnotatedElement(index, DOTNAME_ROLES_VALUE);
+                                rolesFieldOrMethod = JpaSecurityDefinition.getFieldOrMethod(index, roleClass,
+                                        annotatedRolesValue, isPanache(roleClass, panacheClasses));
+                                if (rolesFieldOrMethod == null) {
+                                    throw new RuntimeException(
+                                            "Missing @RoleValue annotation on (non-String) role element type: " + elementType);
+                                }
+                            } else {
+                                rolesFieldOrMethod = null;
+                            }
+                            // for(:elementType roleElement : :role){
+                            //    ret.addRoles(:role.roleField);
+                            //    // or for String collections:
+                            //    ret.addRoles(:role);
+                            // }
+                            foreach(methodCreator, role, elementClassTypeDescriptor, (creator, var) -> {
+                                ResultHandle roleElement;
+                                if (rolesFieldOrMethod != null) {
+                                    roleElement = rolesFieldOrMethod.readValue(creator, var);
+                                } else {
+                                    roleElement = var;
+                                }
+                                creator.invokeVirtualMethod(
+                                        MethodDescriptor.ofMethod(name, "addRoles", void.class,
+                                                QuarkusSecurityIdentity.Builder.class, String.class),
+                                        methodCreator.getThis(),
+                                        builderVar,
+                                        roleElement);
+                            });
+                            handledRole = true;
+                        }
+                        break;
+                }
+                if (!handledRole) {
+                    throw new RuntimeException("Unsupported @Roles field/getter type: " + rolesType);
+                }
+
+                // return builder.build()
+                methodCreator.returnValue(methodCreator.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(QuarkusSecurityIdentity.Builder.class,
+                                "build",
+                                QuarkusSecurityIdentity.class),
+                        builderVar));
+            }
+        }
+    }
+
+    private void foreach(MethodCreator method, ResultHandle iterable, String type,
+            BiConsumer<BytecodeCreator, AssignableResultHandle> body) {
+        ResultHandle iterator = method.invokeInterfaceMethod(
+                MethodDescriptor.ofMethod(Iterable.class, "iterator", Iterator.class),
+                iterable);
+        try (BytecodeCreator loop = method.createScope()) {
+            ResultHandle hasNextValue = loop.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(Iterator.class, "hasNext", boolean.class),
+                    iterator);
+
+            BranchResult hasNextBranch = loop.ifNonZero(hasNextValue);
+            try (BytecodeCreator hasNext = hasNextBranch.trueBranch()) {
+                ResultHandle next = hasNext.invokeInterfaceMethod(
+                        MethodDescriptor.ofMethod(Iterator.class, "next", Object.class),
+                        iterator);
+
+                AssignableResultHandle var = hasNext.createVariable(type);
+                hasNext.assign(var, next);
+
+                body.accept(hasNext, var);
+                hasNext.continueScope(loop);
+            }
+            try (BytecodeCreator doesNotHaveNext = hasNextBranch.falseBranch()) {
+                doesNotHaveNext.breakScope(loop);
+            }
+        }
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/BCryptUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/BCryptUserEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.security.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class BCryptUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password
+    public String pass;
+
+    @Roles
+    public String role;
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/BcryptPasswordMapperTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/BcryptPasswordMapperTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BcryptPasswordMapperTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(BCryptUserEntity.class)
+                    .addAsResource("bcrypt-password-mapper/import.sql", "import.sql")
+                    .addAsResource("bcrypt-password-mapper/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/CustomIdentityProviderConfigurationTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/CustomIdentityProviderConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CustomIdentityProviderConfigurationTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(PlainUserEntity.class)
+                    .addClass(UserEntityIdentityProvider.class)
+                    .addAsResource("minimal-config/import.sql", "import.sql")
+                    .addAsResource("minimal-config/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ExternalRolesUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ExternalRolesUserEntity.java
@@ -1,0 +1,43 @@
+package io.quarkus.security.jpa;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class ExternalRolesUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @ManyToMany
+    @Roles
+    public List<RoleEntity> roles = new ArrayList<>();
+
+    public List<RoleEntity> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<RoleEntity> roles) {
+        this.roles = roles;
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/JpaSecurityRealmTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/JpaSecurityRealmTest.java
@@ -1,0 +1,143 @@
+package io.quarkus.security.jpa;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+/**
+ * Tests of BASIC authentication mechanism with the minimal config required
+ */
+public abstract class JpaSecurityRealmTest {
+
+    protected static Class[] testClasses = {
+            SingleRoleSecuredServlet.class, TestApplication.class, RolesEndpointClassLevel.class,
+            ParametrizedPathsResource.class, SubjectExposingResource.class
+    };
+
+    // Basic @ServletSecurity tests
+    @Test()
+    public void testSecureAccessFailure() {
+        RestAssured.when().get("/servlet-secured").then()
+                .statusCode(401);
+    }
+
+    @Test()
+    public void testSecureRoleFailure() {
+        RestAssured.given().auth().preemptive().basic("noRoleUser", "noRoleUser")
+                .when().get("/servlet-secured").then()
+                .statusCode(403);
+    }
+
+    @Test()
+    public void testSecureAccessSuccess() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/servlet-secured").then()
+                .statusCode(200);
+    }
+
+    /**
+     * Test access a secured jaxrs resource without any authentication. should see 401 error code.
+     */
+    @Test
+    public void testJaxrsGetFailure() {
+        RestAssured.when().get("/jaxrs-secured/roles-class").then()
+                .statusCode(401);
+    }
+
+    /**
+     * Test access a secured jaxrs resource with authentication, but no authorization. should see 403 error code.
+     */
+    @Test
+    public void testJaxrsGetRoleFailure() {
+        RestAssured.given().auth().preemptive().basic("noRoleUser", "noRoleUser")
+                .when().get("/jaxrs-secured/roles-class").then()
+                .statusCode(403);
+    }
+
+    /**
+     * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
+     */
+    @Test
+    public void testJaxrsGetRoleSuccess() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/jaxrs-secured/roles-class").then()
+                .statusCode(200);
+    }
+
+    /**
+     * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
+     */
+    @Test
+    public void testJaxrsPathAdminRoleSuccess() {
+        RestAssured.given().auth().preemptive().basic("admin", "admin")
+                .when().get("/jaxrs-secured/parameterized-paths/my/banking/admin").then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testJaxrsPathAdminRoleFailure() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/jaxrs-secured/parameterized-paths/my/banking/admin").then()
+                .statusCode(403);
+    }
+
+    /**
+     * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
+     */
+    @Test
+    public void testJaxrsPathUserRoleSuccess() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/jaxrs-secured/parameterized-paths/my/banking/view").then()
+                .statusCode(200);
+    }
+
+    /**
+     * Test access a secured jaxrs resource with authentication, and authorization. should see 200 success code.
+     */
+    @Test
+    public void testJaxrsUserRoleSuccess() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/jaxrs-secured/subject/secured").then()
+                .statusCode(200)
+                .body(equalTo("user"));
+    }
+
+    @Test
+    public void testJaxrsInjectedPrincipalSuccess() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/jaxrs-secured/subject/principal-secured").then()
+                .statusCode(200)
+                .body(equalTo("user"));
+    }
+
+    /**
+     * Test access a @PermitAll secured jaxrs resource without any authentication. should see a 200 success code.
+     */
+    @Test
+    public void testJaxrsGetPermitAll() {
+        RestAssured.when().get("/jaxrs-secured/subject/unsecured").then()
+                .statusCode(200)
+                .body(equalTo("anonymous"));
+    }
+
+    /**
+     * Test access a @DenyAll secured jaxrs resource without authentication. should see a 401 success code.
+     */
+    @Test
+    public void testJaxrsGetDenyAllWithoutAuth() {
+        RestAssured.when().get("/jaxrs-secured/subject/denied").then()
+                .statusCode(401);
+    }
+
+    /**
+     * Test access a @DenyAll secured jaxrs resource with authentication. should see a 403 success code.
+     */
+    @Test
+    public void testJaxrsGetDenyAllWithAuth() {
+        RestAssured.given().auth().preemptive().basic("user", "user")
+                .when().get("/jaxrs-secured/subject/denied").then()
+                .statusCode(403);
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MinimalConfigurationTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MinimalConfigurationTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MinimalConfigurationTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(MinimalUserEntity.class)
+                    .addAsResource("minimal-config/import.sql", "import.sql")
+                    .addAsResource("minimal-config/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MinimalUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MinimalUserEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.security.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class MinimalUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @Roles
+    public String role;
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleEntitiesConfigurationTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleEntitiesConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleEntitiesConfigurationTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(ExternalRolesUserEntity.class)
+                    .addClass(RoleEntity.class)
+                    .addAsResource("multiple-entities/import.sql", "import.sql")
+                    .addAsResource("multiple-entities/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesInCollectionConfigurationTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesInCollectionConfigurationTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleRolesInCollectionConfigurationTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(MultipleRolesInCollectionUserEntity.class)
+                    .addAsResource("multiple-roles-in-collection/import.sql", "import.sql")
+                    .addAsResource("multiple-roles-in-collection/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesInCollectionUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesInCollectionUserEntity.java
@@ -1,0 +1,44 @@
+package io.quarkus.security.jpa;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class MultipleRolesInCollectionUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @CollectionTable(name = "test_role", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "role_name")
+    @ElementCollection
+    @Roles
+    public List<String> roles = new ArrayList<>();
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleRolesTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(MultipleRolesUserEntity.class)
+                    .addAsResource("multiple-roles/import.sql", "import.sql")
+                    .addAsResource("multiple-roles/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/MultipleRolesUserEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.security.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class MultipleRolesUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @Roles
+    public String roles;
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/NaturalIdConfigurationTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/NaturalIdConfigurationTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NaturalIdConfigurationTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(NaturalIdUserEntity.class)
+                    .addAsResource("minimal-config/import.sql", "import.sql")
+                    .addAsResource("minimal-config/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/NaturalIdUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/NaturalIdUserEntity.java
@@ -1,0 +1,30 @@
+package io.quarkus.security.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.NaturalId;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class NaturalIdUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @Username
+    @NaturalId
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @Roles
+    public String role;
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheEntitiesConfigurationTest.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheEntitiesConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PanacheEntitiesConfigurationTest extends JpaSecurityRealmTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addClass(PanacheUserEntity.class)
+                    .addClass(PanacheRoleEntity.class)
+                    .addAsResource("multiple-entities/import.sql", "import.sql")
+                    .addAsResource("multiple-entities/application.properties", "application.properties"));
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheRoleEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheRoleEntity.java
@@ -1,0 +1,23 @@
+package io.quarkus.security.jpa;
+
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Table(name = "test_role")
+@Entity
+public class PanacheRoleEntity extends PanacheEntity {
+
+    @ManyToMany(mappedBy = "roles")
+    public List<PanacheUserEntity> users;
+
+    @Column(name = "role_name")
+    @RolesValue
+    public String role;
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheUserEntity.java
@@ -1,0 +1,31 @@
+package io.quarkus.security.jpa;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@UserDefinition
+@Table(name = "test_user")
+@Entity
+public class PanacheUserEntity extends PanacheEntity {
+    @Column(name = "username")
+    @Username
+    public String name;
+
+    @Column(name = "password")
+    @Password(PasswordType.CLEAR)
+    public String pass;
+
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @ManyToMany
+    @Roles
+    public List<PanacheRoleEntity> roles = new ArrayList<>();
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ParametrizedPathsResource.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ParametrizedPathsResource.java
@@ -1,0 +1,26 @@
+package io.quarkus.security.jpa;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+@Path("/parameterized-paths")
+public class ParametrizedPathsResource {
+    @GET
+    @Path("/my/{path}/admin")
+    @RolesAllowed("admin")
+    public String admin(@PathParam("path") String path) {
+        return "Admin accessed " + path;
+    }
+
+    @GET
+    @Path("/my/{path}/view")
+    @RolesAllowed("user")
+    public String view(@PathParam("path") String path) {
+        return "View accessed " + path;
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PlainUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PlainUserEntity.java
@@ -1,0 +1,26 @@
+package io.quarkus.security.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.NaturalId;
+
+@Table(name = "test_user")
+@Entity
+public class PlainUserEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Column(name = "username")
+    @NaturalId
+    public String name;
+
+    @Column(name = "password")
+    public String pass;
+
+    public String role;
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/RoleEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/RoleEntity.java
@@ -1,0 +1,26 @@
+package io.quarkus.security.jpa;
+
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
+@Table(name = "test_role")
+@Entity
+public class RoleEntity {
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @ManyToMany(mappedBy = "roles")
+    public List<ExternalRolesUserEntity> users;
+
+    @Column(name = "role_name")
+    @RolesValue
+    public String role;
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/RolesEndpointClassLevel.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/RolesEndpointClassLevel.java
@@ -1,0 +1,20 @@
+package io.quarkus.security.jpa;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+/**
+ * Test JAXRS endpoint with RolesAllowed specified at the class level
+ */
+@Path("/roles-class")
+@RolesAllowed("user")
+public class RolesEndpointClassLevel {
+    @GET
+    public String echo(@Context SecurityContext sec) {
+        return "Hello " + sec.getUserPrincipal().getName();
+    }
+
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SingleRoleSecuredServlet.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SingleRoleSecuredServlet.java
@@ -1,0 +1,24 @@
+package io.quarkus.security.jpa;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Basic secured servlet test target
+ */
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "user" }))
+@WebServlet(name = "SingleRoleSecuredServlet", urlPatterns = "/servlet-secured", initParams = {
+        @WebInitParam(name = "message", value = "A secured message") })
+public class SingleRoleSecuredServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().write(getInitParameter("message"));
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SubjectExposingResource.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/SubjectExposingResource.java
@@ -1,0 +1,57 @@
+package io.quarkus.security.jpa;
+
+import java.security.Principal;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("subject")
+public class SubjectExposingResource {
+
+    @Inject
+    Principal principal;
+
+    @GET
+    @RolesAllowed("user")
+    @Path("secured")
+    public String getSubjectSecured(@Context SecurityContext sec) {
+        Principal user = sec.getUserPrincipal();
+        String name = user != null ? user.getName() : "anonymous";
+        return name;
+    }
+
+    @GET
+    @RolesAllowed("user")
+    @Path("principal-secured")
+    public String getPrincipalSecured(@Context SecurityContext sec) {
+        if (principal == null) {
+            throw new IllegalStateException("No injected principal");
+        }
+        String name = principal.getName();
+        return name;
+    }
+
+    @GET
+    @Path("unsecured")
+    @PermitAll
+    public String getSubjectUnsecured(@Context SecurityContext sec) {
+        Principal user = sec.getUserPrincipal();
+        String name = user != null ? user.getName() : "anonymous";
+        return name;
+    }
+
+    @DenyAll
+    @GET
+    @Path("denied")
+    public String getSubjectDenied(@Context SecurityContext sec) {
+        Principal user = sec.getUserPrincipal();
+        String name = user != null ? user.getName() : "anonymous";
+        return name;
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/TestApplication.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/TestApplication.java
@@ -1,0 +1,11 @@
+package io.quarkus.security.jpa;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+@ApplicationPath("/jaxrs-secured")
+public class TestApplication extends Application {
+    // intentionally left empty
+}

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/UserEntityIdentityProvider.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/UserEntityIdentityProvider.java
@@ -1,0 +1,41 @@
+package io.quarkus.security.jpa;
+
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+
+import org.hibernate.Session;
+import org.hibernate.SimpleNaturalIdLoadAccess;
+import org.wildfly.security.password.Password;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.jpa.runtime.JpaIdentityProvider;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+@Singleton
+public class UserEntityIdentityProvider extends JpaIdentityProvider {
+
+    @Override
+    public SecurityIdentity authenticate(EntityManager em,
+            UsernamePasswordAuthenticationRequest request) {
+
+        Session session = em.unwrap(Session.class);
+        SimpleNaturalIdLoadAccess<PlainUserEntity> naturalIdLoadAccess = session.bySimpleNaturalId(PlainUserEntity.class);
+        PlainUserEntity user = naturalIdLoadAccess.load(request.getUsername());
+        //        Query query = em.createQuery("FROM PlainUserEntity WHERE name = :name");
+        //        query.setParameter("name", request.getUsername());
+        //        PlainUserEntity user = getSingleUser(query);
+        if (user == null)
+            return null;
+
+        // for MCF:
+        //               Password storedPassword = getMcfPasword(user.pass);
+        // for clear:
+        Password storedPassword = getClearPassword(user.pass);
+
+        QuarkusSecurityIdentity.Builder builder = checkPassword(storedPassword, request);
+
+        addRoles(builder, user.role);
+        return builder.build();
+    }
+}

--- a/extensions/security-jpa/deployment/src/test/resources/bcrypt-password-mapper/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/bcrypt-password-mapper/application.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.url=jdbc:h2:mem:bcrypt-password-mapper'
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/bcrypt-password-mapper/import.sql
+++ b/extensions/security-jpa/deployment/src/test/resources/bcrypt-password-mapper/import.sql
@@ -1,0 +1,3 @@
+INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', '$2y$10$YP9QWYOpxRNCNquTzCjRIuEpc.MiVPTjlMIZHNqHKckKN8FK9Xyh2', 'admin');
+INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','$2y$10$jXnruhr78D/6pTwWl82zGebMerVodgJLlISr8Ek4xptMWx8H9iruG', 'user');
+INSERT INTO test_user (id, username, password, role) VALUES (3, 'noRoleUser','$2y$10$Hmy.4PDoQscwM8vlNUPYE.9q.VfQFrNMi75N/ukn7xz08KM4IyoPa', '');

--- a/extensions/security-jpa/deployment/src/test/resources/minimal-config/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/minimal-config/application.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.url=jdbc:h2:mem:minimal-config'
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/minimal-config/import.sql
+++ b/extensions/security-jpa/deployment/src/test/resources/minimal-config/import.sql
@@ -1,0 +1,3 @@
+INSERT INTO test_user (id, username, password, role) VALUES (1, 'admin', 'admin', 'admin');
+INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','user', 'user');
+INSERT INTO test_user (id, username, password, role) VALUES (3, 'noRoleUser','noRoleUser', '');

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-entities/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-entities/application.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.url=jdbc:h2:mem:multiple-queries'
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.log.sql=true
+

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-entities/import.sql
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-entities/import.sql
@@ -1,0 +1,9 @@
+INSERT INTO test_user (id, username, password) VALUES (1, 'admin', 'admin');
+INSERT INTO test_user (id, username, password) VALUES (2, 'user','user');
+INSERT INTO test_user (id, username, password) VALUES (3, 'noRoleUser','noRoleUser');
+
+INSERT INTO test_role (id, role_name) VALUES (1, 'admin');
+INSERT INTO test_role (id, role_name) VALUES (2, 'user');
+
+INSERT INTO test_user_role (user_id, role_id) VALUES (1, 1);
+INSERT INTO test_user_role (user_id, role_id) VALUES (2, 2);

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-roles-in-collection/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-roles-in-collection/application.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.url=jdbc:h2:mem:multiple-queries'
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.log.sql=true
+

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-roles-in-collection/import.sql
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-roles-in-collection/import.sql
@@ -1,0 +1,6 @@
+INSERT INTO test_user (id, username, password) VALUES (1, 'admin', 'admin');
+INSERT INTO test_user (id, username, password) VALUES (2, 'user','user');
+INSERT INTO test_user (id, username, password) VALUES (3, 'noRoleUser','noRoleUser');
+
+INSERT INTO test_role (user_id, role_name) VALUES (1, 'admin');
+INSERT INTO test_role (user_id, role_name) VALUES (2, 'user');

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-roles/application.properties
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-roles/application.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.url=jdbc:h2:mem:custom-role-decoder'
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.log.sql=true

--- a/extensions/security-jpa/deployment/src/test/resources/multiple-roles/import.sql
+++ b/extensions/security-jpa/deployment/src/test/resources/multiple-roles/import.sql
@@ -1,0 +1,3 @@
+INSERT INTO test_user (id, username, password, roles) VALUES (1, 'admin', 'admin', 'admin, user');
+INSERT INTO test_user (id, username, password, roles) VALUES (2, 'user','user', 'user,tester');
+INSERT INTO test_user (id, username, password, roles) VALUES (3, 'noRoleUser','noRoleUser', '');

--- a/extensions/security-jpa/pom.xml
+++ b/extensions/security-jpa/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-security-jpa-parent</artifactId>
+    <name>Quarkus - Security JPA</name>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/security-jpa/runtime/pom.xml
+++ b/extensions/security-jpa/runtime/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-security-jpa-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-security-jpa</artifactId>
+    <name>Quarkus - Security JPA - Runtime</name>
+    <description>Secure your applications with username/password stored in a database via JPA</description>
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/Password.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/Password.java
@@ -1,0 +1,25 @@
+package io.quarkus.security.jpa;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Indicates that this field or property should be used as a source of password for security. Only
+ * supports the {@link String} type.
+ * </p>
+ * <p>
+ * Defaults to considering the password as hashed with bcrypt in the Modular Crypt Format.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Password {
+    /**
+     * Sets the password storage type. defaults to {@link PasswordType#MCF}.
+     */
+    PasswordType value() default PasswordType.MCF;
+}

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/PasswordType.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/PasswordType.java
@@ -1,0 +1,15 @@
+package io.quarkus.security.jpa;
+
+/**
+ * Describes how the password is hashed in the database.
+ */
+public enum PasswordType {
+    /**
+     * The password is stored hashed using bcrypt in the Modular Crypt Format.
+     */
+    MCF,
+    /**
+     * The password is stored in clear text. Do not use in production.
+     */
+    CLEAR;
+}

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/Roles.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/Roles.java
@@ -1,0 +1,24 @@
+package io.quarkus.security.jpa;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collection;
+
+/**
+ * <p>
+ * Indicates that this field or property should be used as a source of roles for security.
+ * Supports the {@link String} type, or a {@code Collection<String>} or a {@link Collection} of
+ * entities with a field or getter annotated with {@link RolesValue}.
+ * </p>
+ * <p>
+ * Each role element is considered a comma-separated list of roles.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Roles {
+
+}

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/RolesValue.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/RolesValue.java
@@ -1,0 +1,23 @@
+package io.quarkus.security.jpa;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Indicates that this field or property should be used as a source of roles for security when you store
+ * roles in a separate table from your user entity.
+ * Supports only the {@link String} type.
+ * </p>
+ * <p>
+ * Each role element is considered a comma-separated list of roles.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RolesValue {
+
+}

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/UserDefinition.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/UserDefinition.java
@@ -1,0 +1,19 @@
+package io.quarkus.security.jpa;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that this entity class should be used as a source of identity information. At most one
+ * entity can have that annotation in an application. The entity must contain fields or properties annotated
+ * with the {@link Username}, {@link Password} and {@link Roles} annotations.
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface UserDefinition {
+
+}

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/Username.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/Username.java
@@ -1,0 +1,18 @@
+package io.quarkus.security.jpa;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that this field or property should be used as a source of user name for security. Only
+ * supports the {@link String} type.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Username {
+
+}

--- a/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/JpaIdentityProvider.java
+++ b/extensions/security-jpa/runtime/src/main/java/io/quarkus/security/jpa/runtime/JpaIdentityProvider.java
@@ -1,0 +1,110 @@
+package io.quarkus.security.jpa.runtime;
+
+import java.security.spec.InvalidKeySpecException;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.hibernate.FlushMode;
+import org.jboss.logging.Logger;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.util.ModularCrypt;
+
+import io.quarkus.hibernate.orm.runtime.JPAConfig;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity.Builder;
+
+public abstract class JpaIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+    private static Logger log = Logger.getLogger(JpaIdentityProvider.class);
+
+    @Inject
+    JPAConfig jpaConfig;
+
+    @Override
+    public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+        return UsernamePasswordAuthenticationRequest.class;
+    }
+
+    @Override
+    public CompletionStage<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest request,
+            AuthenticationRequestContext context) {
+        return context.runBlocking(new Supplier<SecurityIdentity>() {
+            @Override
+            public SecurityIdentity get() {
+                // FIXME: unit name
+                EntityManager em = jpaConfig.getEntityManagerFactory(null).createEntityManager();
+                ((org.hibernate.Session) em).setHibernateFlushMode(FlushMode.MANUAL);
+                ((org.hibernate.Session) em).setDefaultReadOnly(true);
+                try {
+                    return authenticate(em, request);
+                } catch (SecurityException e) {
+                    log.debug("Authentication failed", e);
+                    throw new AuthenticationFailedException();
+                } finally {
+                    em.close();
+                }
+            }
+        });
+    }
+
+    public abstract SecurityIdentity authenticate(EntityManager em,
+            UsernamePasswordAuthenticationRequest request);
+
+    protected Builder checkPassword(Password storedPassword, UsernamePasswordAuthenticationRequest request) {
+        PasswordGuessEvidence sentPasswordEvidence = new PasswordGuessEvidence(request.getPassword().getPassword());
+        PasswordCredential storedPasswordCredential = new PasswordCredential(storedPassword);
+        if (!storedPasswordCredential.verify(sentPasswordEvidence)) {
+            throw new AuthenticationFailedException();
+        }
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(new QuarkusPrincipal(request.getUsername()));
+        builder.addCredential(request.getPassword());
+        return builder;
+    }
+
+    protected void addRoles(Builder builder, String roles) {
+        if (roles.indexOf(',') != -1) {
+            for (String role : roles.split(",")) {
+                builder.addRole(role.trim());
+            }
+        } else {
+            builder.addRole(roles.trim());
+        }
+    }
+
+    protected <T> T getSingleUser(Query query) {
+        @SuppressWarnings("unchecked")
+        List<T> results = (List<T>) query.getResultList();
+        if (results.isEmpty())
+            return null;
+        if (results.size() > 1)
+            throw new AuthenticationFailedException();
+        return results.get(0);
+    }
+
+    protected Password getClearPassword(String pass) {
+        return ClearPassword.createRaw("clear", pass.toCharArray());
+    }
+
+    protected Password getMcfPassword(String pass) {
+        try {
+            return ModularCrypt.decode(pass);
+        } catch (InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/security-jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/security-jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: "Security JPA"
+metadata:
+  keywords:
+  - "security"
+  - "jpa"
+  - "orm"
+  - "panache"
+  guide: "https://quarkus.io/guides/security-jpa"
+  categories:
+  - "security"
+  status: "preview"


### PR DESCRIPTION
This is for #4347, and it's Almost Done™ (Famous Last Words©).

You can define your security user entity like this:

```java
@UserDefinition
@Entity
public class PanacheUserEntity extends PanacheEntity {
    @Username
    public String name;

    @Password
    public String pass;

    @Roles
    public String roles;
}
```

Or with multiple tables for roles:

```java
@UserDefinition
@Entity
public class PanacheUserEntity extends PanacheEntity {
    @Username
    public String name;

    @Password
    public String pass;

    @ManyToMany
    @Roles
    public List<PanacheRoleEntity> roles = new ArrayList<>();
}

@Entity
public class PanacheRoleEntity extends PanacheEntity {

    @ManyToMany(mappedBy = "roles")
    public List<PanacheUserEntity> users;

    @RolesValue
    public String role;

}
```

- Supported role types of types `String`, `Collection/List/Set<String>`, `Collection/List/Set<role-entity>`, which can all contain comma-separated strings of roles.
- Supports plain Hibernate ORM or ORM with Panache
- No config required
- Supports `@NaturalId` on the same field as `@Username`
- Works _before_ the request, using `JPAConfig`'s support to get `EntityManagerFactory`
- Supports clear and MCF passwords

Under the hood, it generates this sort of `IdentityProvider` implementation:

```java
@Singleton
public class UserEntityIdentityProvider implements JpaIdentityProvider {

    @Override
    public SecurityIdentity authenticate(EntityManager em,
            UsernamePasswordAuthenticationRequest request) {

        // With Natural Id
        Session session = em.unwrap(Session.class);
        SimpleNaturalIdLoadAccess<PlainUserEntity> naturalIdLoadAccess = session.bySimpleNaturalId(PlainUserEntity.class);
        PlainUserEntity user = naturalIdLoadAccess.load(request.getUsername());
        // With normal query
        //        Query query = em.createQuery("FROM PlainUserEntity WHERE name = :name");
        //        query.setParameter("name", request.getUsername());
        //        PlainUserEntity user = getSingleUser(query);
        if (user == null)
            return null;

        // for MCF:
        //               Password storedPassword = getMcfPasword(user.pass);
        // for clear:
        Password storedPassword = getClearPassword(user.pass);

        QuarkusSecurityIdentity.Builder builder = checkPassword(storedPassword, request);

        addRoles(builder, user.role);
        return builder.build();
    }

}
```

So overall it's pretty complete, but I have a few questions before I'm ready to merge (besides the lack of docs):

- I default to MCF (#5667) passwords in single column (which supports bcrypt and many others), with clear text password being supported. I think this is fine for the start, right?
- I wanted to only require a single `@UserDefinition` annotation and default to looking up fields if they're named "user", "username", "pass", "password", "passwd", etc… but then I wondered if that would not be a security risk if a user adds a `@UserDefinition` annotation to his class and we pick up `user` for the username, but it turns out that in his model, this is not a primary key column and we should actually use the `email` column, so this could be a dangerous risk so I didn't do it. It feels lame to have to use 4 annotations, though, so WDYT? I'd love to use convention over configuration here.