### PR TITLE
Fix resource registration in native-image for 19.3 of Graal

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
@@ -54,7 +54,7 @@ public class NativeImageAutoFeatureStep {
     static final String RUNTIME_REFLECTION = RuntimeReflection.class.getName();
     static final String BEFORE_ANALYSIS_ACCESS = Feature.BeforeAnalysisAccess.class.getName();
     static final String DYNAMIC_PROXY_REGISTRY = "com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry";
-    static final String LOCALIZATION_SUPPORT = "com.oracle.svm.core.jdk.LocalizationSupport";
+    static final String LOCALIZATION_FEATURE = "com.oracle.svm.core.jdk.LocalizationFeature";
 
     @BuildStep
     void generateFeature(BuildProducer<GeneratedNativeImageClassBuildItem> nativeImageClass,
@@ -170,7 +170,7 @@ public class NativeImageAutoFeatureStep {
         }
 
         if (!resourceBundles.isEmpty()) {
-            ResultHandle locClass = overallCatch.loadClass(LOCALIZATION_SUPPORT);
+            ResultHandle locClass = overallCatch.loadClass(LOCALIZATION_FEATURE);
 
             ResultHandle params = overallCatch.marshalAsArray(Class.class, overallCatch.loadClass(String.class));
             ResultHandle registerMethod = overallCatch.invokeVirtualMethod(


### PR DESCRIPTION
Building a native-image of some random Quarkus application, with latest Quarkus master and Graal `19.3.0` shows this following exception:
```
java.lang.NoSuchMethodException: com.oracle.svm.core.jdk.LocalizationSupport.addBundleToCache(java.lang.String)
	at java.lang.Class.getDeclaredMethod(Class.java:2130)
	at io.quarkus.runner.AutoFeature.beforeAnalysis(AutoFeature.zig:920)
	at com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$7(NativeImageGenerator.java:669)
	at com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:63)
	at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:669)
	at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:530)
	at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$0(NativeImageGenerator.java:445)
	at java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1386)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```
The build doesn't fail, but clearly this means the resources aren't registered.

The commit here fixes the issue by changing our references of `com.oracle.svm.core.jdk.LocalizationSupport` to `com.oracle.svm.core.jdk.LocalizationFeature` to match the Graal `19.3.0` renaming of this class.

This commit is only relevant to the master branch.