### PR TITLE
Add FormAuth smoke test to Elytron package and Vert.x http package

### DIFF
--- a/extensions/elytron-security-properties-file/deployment/src/test/java/io/quarkus/security/test/FormAuthTestCase.java
+++ b/extensions/elytron-security-properties-file/deployment/src/test/java/io/quarkus/security/test/FormAuthTestCase.java
@@ -1,0 +1,54 @@
+package io.quarkus.security.test;
+
+import static io.restassured.RestAssured.given;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.authentication.FormAuthConfig;
+
+/**
+ * Tests of FORM authentication mechanism
+ * <p>
+ * See @io.quarkus.vertx.http.security.FormAuthTestCase for functional coverage.
+ */
+public class FormAuthTestCase {
+    static Class[] testClasses = {
+            TestSecureServlet.class, TestApplication.class, RolesEndpointClassLevel.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("application-form-auth.properties", "application.properties")
+                    .addAsResource("test-users.properties")
+                    .addAsResource("test-roles.properties"));
+
+    @Test()
+    public void testSecureAccessSuccess() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        given().auth()
+                .form("stuart", "test",
+                        new FormAuthConfig("j_security_check", "j_username", "j_password")
+                                .withLoggingEnabled())
+                .when().get("/secure-test").then().statusCode(200);
+
+        given().auth()
+                .form("jdoe", "p4ssw0rd",
+                        new FormAuthConfig("j_security_check", "j_username", "j_password")
+                                .withLoggingEnabled())
+                .when().get("/secure-test").then().statusCode(403);
+
+        given().auth()
+                .form("scott", "jb0ss",
+                        new FormAuthConfig("j_security_check", "j_username", "j_password")
+                                .withLoggingEnabled())
+                .when().get("/jaxrs-secured/rolesClass").then().statusCode(200);
+    }
+
+}

--- a/extensions/elytron-security-properties-file/deployment/src/test/resources/application-form-auth.properties
+++ b/extensions/elytron-security-properties-file/deployment/src/test/resources/application-form-auth.properties
@@ -1,0 +1,23 @@
+# Logging
+quarkus.log.level=DEBUG
+quarkus.log.console.enable=true
+quarkus.log.console.level=DEBUG
+quarkus.log.file.enable=true
+quarkus.log.file.path=/tmp/trace.log
+quarkus.log.file.level=TRACE
+quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
+quarkus.log.category."io.quarkus.arc".level=TRACE
+quarkus.log.category."io.undertow.request.security".level=TRACE
+
+# Identities
+quarkus.security.users.file.enabled=true
+quarkus.security.users.file.users=test-users.properties
+quarkus.security.users.file.roles=test-roles.properties
+quarkus.security.users.file.plain-text=true
+
+# Auth method
+quarkus.http.auth.form.enabled=true
+quarkus.http.auth.basic=false
+quarkus.http.auth.form.login-page=/
+quarkus.http.auth.form.error-page=/
+quarkus.http.auth.form.landing-page=/

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthCookiesTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthCookiesTestCase.java
@@ -1,0 +1,91 @@
+package io.quarkus.vertx.http.security;
+
+import static org.hamcrest.Matchers.*;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+
+public class FormAuthCookiesTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.form.enabled=true\n" +
+            "quarkus.http.auth.form.login-page=login\n" +
+            "quarkus.http.auth.form.error-page=error\n" +
+            "quarkus.http.auth.form.landing-page=landing\n" +
+            "quarkus.http.auth.policy.r1.roles-allowed=admin\n" +
+            "quarkus.http.auth.permission.roles1.paths=/admin%E2%9D%A4\n" +
+            "quarkus.http.auth.permission.roles1.policy=r1\n" +
+            "quarkus.http.auth.form.timeout=PT6S\n" +
+            "quarkus.http.auth.form.new-cookie-interval=PT2S\n" +
+            "quarkus.http.auth.form.cookie-name=laitnederc-sukrauq\n" +
+            "quarkus.http.auth.session.encryption-key=CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT-CHANGEIT\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<JavaArchive>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestTrustedIdentityProvider.class, PathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin");
+    }
+
+    @Test
+    public void testFormBasedAuthSuccess() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        CookieFilter cookies = new CookieFilter();
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/admin❤")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/admin%E2%9D%A4"));
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "admin")
+                .formParam("j_password", "admin")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/admin%E2%9D%A4"))
+                .cookie("laitnederc-sukrauq", notNullValue());
+
+        RestAssured
+                .given()
+                .filter(cookies)
+                .redirects().follow(false)
+                .when()
+                .get("/admin❤")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(equalTo("admin:/admin%E2%9D%A4"));
+
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -61,7 +61,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
             key = httpConfiguration.encryptionKey;
         }
         FormAuthConfig form = buildTimeConfig.auth.form;
-        loginManager = new PersistentLoginManager(key, "quarkus-credential", form.timeout.toMillis(),
+        loginManager = new PersistentLoginManager(key, form.cookieName, form.timeout.toMillis(),
                 form.newCookieInterval.toMillis());
         loginPage = form.loginPage.startsWith("/") ? form.loginPage : "/" + form.loginPage;
         errorPage = form.errorPage.startsWith("/") ? form.errorPage : "/" + form.errorPage;


### PR DESCRIPTION
The class FormAuthCookiesTestCase will receive additional work, mostly cookie value rotation, time out etc.

Fixes #5689