### PR TITLE
Vault Extension Serialization Error in Native Mode at Runtime Fixes #5636

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/VaultAppRoleAuthAuthMetadata.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/VaultAppRoleAuthAuthMetadata.java
@@ -1,4 +1,4 @@
 package io.quarkus.vault.runtime.client.dto;
 
-public class VaultAppRoleAuthAuthMetadata {
+public class VaultAppRoleAuthAuthMetadata implements VaultModel {
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/VaultAppRoleAuthBody.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/VaultAppRoleAuthBody.java
@@ -2,7 +2,7 @@ package io.quarkus.vault.runtime.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class VaultAppRoleAuthBody {
+public class VaultAppRoleAuthBody implements VaultModel {
 
     @JsonProperty("role_id")
     public String roleId;


### PR DESCRIPTION
2 classes `VaultAppRoleAuthBody` and `VaultAppRoleAuthAuthMetadata` were missing `implements VaultModel` which is the marker when generating the `ReflectiveClassBuildItem` in `VaultProcessor`