### PR TITLE
Disable the unnecessary JVM debug launch of integration tests

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -302,7 +302,9 @@ public class CreateProjectMojoIT extends MojoTestBase {
         // As the directory is not empty (log) navigate to the artifactID directory
         testDir = new File(testDir, "acme");
         running = new RunningInvoker(testDir, false);
-        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap());
+        final Properties mvnRunProps = new Properties();
+        mvnRunProps.setProperty("debug", "false");
+        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap(), mvnRunProps);
 
         String resp = getHttpResponse();
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -297,7 +298,9 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         testDir = initProject("projects/classic", "projects/project-classic-run-config-change");
         assertThat(testDir).isDirectory();
         running = new RunningInvoker(testDir, false);
-        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap());
+        final Properties mvnRunProps = new Properties();
+        mvnRunProps.setProperty("debug", "false");
+        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap(), mvnRunProps);
 
         String resp = getHttpResponse();
 
@@ -328,7 +331,9 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         testDir = initProject("projects/classic-noconfig", "projects/project-classic-run-noconfig-add-config");
         assertThat(testDir).isDirectory();
         running = new RunningInvoker(testDir, false);
-        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap());
+        final Properties mvnRunProps = new Properties();
+        mvnRunProps.setProperty("debug", "false");
+        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap(), mvnRunProps);
 
         String resp = getHttpResponse();
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,7 +93,9 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         agentDir = initProject("projects/classic", "projects/project-classic-run-config-change-local");
         assertThat(testDir).isDirectory();
         running = new RunningInvoker(testDir, false);
-        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap());
+        final Properties mvnRunProps = new Properties();
+        mvnRunProps.setProperty("debug", "false");
+        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap(), mvnRunProps);
 
         String resp = getHttpResponse();
         runningAgent = new RunningInvoker(agentDir, false);

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.AfterEach;
@@ -34,8 +35,16 @@ public class RunAndCheckMojoTestBase extends MojoTestBase {
         final List<String> args = new ArrayList<>(2 + options.length);
         args.add("compile");
         args.add("quarkus:dev");
+        boolean hasDebugOptions = false;
         for (String option : options) {
             args.add(option);
+            if (option.trim().startsWith("-Ddebug=") || option.trim().startsWith("-Dsuspend=")) {
+                hasDebugOptions = true;
+            }
+        }
+        if (!hasDebugOptions) {
+            // if no explicit debug options have been specified, let's just disable debugging
+            args.add("-Ddebug=false");
         }
         running.execute(args, Collections.emptyMap());
     }
@@ -55,7 +64,9 @@ public class RunAndCheckMojoTestBase extends MojoTestBase {
     protected void runAndExpectError() throws FileNotFoundException, MavenInvocationException {
         assertThat(testDir).isDirectory();
         running = new RunningInvoker(testDir, false);
-        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap());
+        final Properties mvnRunProps = new Properties();
+        mvnRunProps.setProperty("debug", "false");
+        running.execute(Arrays.asList("compile", "quarkus:dev"), Collections.emptyMap(), mvnRunProps);
 
         getHttpErrorResponse();
     }


### PR DESCRIPTION
`quarkus:dev` by default launches the JVM in debug mode. As a result, our integration tests which launch this mojo end up launching the JVM unnecessarily in debug mode with port opening on `5005`. This can be avoided (especially for CI runs).

The commit here disables this by default `debug` launch of these tests, with a change in the `test-framework`. Unless the test intentionally passes a debug attribute (either the `-Ddebug` or `-Dsuspend`), the test framework will disable the JVM debug launch. This should avoid the unnecessary opening and closing of the debug port as well as, in theory, probably speed it up a bit (although I don't know how noticeable that's going to be). 