### PR TITLE
Remove unused "libDir" param

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -94,12 +94,6 @@ public class BuildMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.directory}")
     private File buildDir;
 
-    /**
-     * The directory for library jars
-     */
-    @Parameter(defaultValue = "${project.build.directory}/lib")
-    private File libDir;
-
     @Parameter(defaultValue = "${project.build.finalName}")
     private String finalName;
 


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/5683

The `BuildMojo` no longer uses the `libDir` param. The Mojos now all seem to use the (configured) build directory as the root for any sub-directories it wants to resolve, like `classes`, `lib` etc...

The commit here removes this unused param. 

Note that although this was unusued internally, it was still advertized as a valid parameter configurable for the `quarkus-maven-plugin`. So I'm marking this as a backward incompatible change.

Also adding a backport tag to see if we want this included in `1.0.0` to reduce the chances of this param being used by users.

