### PR TITLE
Filter WARN message from Netty when it can't parse the /etc/hosts file

### DIFF
--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -13,6 +13,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.netty.deployment.EventLoopSupplierBuildItem;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.core.runtime.VertxCoreProducer;
@@ -78,5 +79,10 @@ class VertxCoreProcessor {
             LaunchModeBuildItem launchModeBuildItem) {
         RuntimeValue<Vertx> vertx = recorder.initializeWeb(config, context, launchModeBuildItem.getLaunchMode());
         return new InternalWebVertxBuildItem(vertx);
+    }
+
+    @BuildStep
+    LogCleanupFilterBuildItem filterNettyHostsFileParsingWarn() {
+        return new LogCleanupFilterBuildItem("io.netty.resolver.HostsFileParser", "Failed to load and parse hosts file");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/5647

Netty logs a `WARN` message (along with the exception stacktrace) when it can't parse the hosts file. The commit here filters out that message using the `LogCleanupFilterBuildItem`.

No automated tests added, but manual testing showed that this change helped prevent that `WARN` message showing up in the logs.