### PR TITLE
Document property indirection for passwords coming from Vault - Fixes #3279

### DIFF
--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -62,6 +62,24 @@ quarkus.mailer.username=....
 quarkus.mailer.password=....
 ----
 
+[NOTE]
+====
+It is recommended to encrypt any sensitive data, such as the `quarkus.mailer.password`.
+One approach is to save the value into a secure store like HashiCorp Vault, and refer to it from the configuration.
+Assuming for instance that Vault contains key `mail-password` at path `myapps/myapp/myconfig`, then the mailer
+extension can be simply configured as:
+```
+...
+# path within the kv secret engine where is located the application sensitive configuration
+quarkus.vault.secret-config-kv-path=myapps/myapp/myconfig
+
+...
+quarkus.mailer.password=${mail-password}
+```
+Please note that the password value is evaluated only once, at startup time. If `mail-password` was changed in Vault,
+the only way to get the new value would be to restart the application.
+====
+
 [TIP]
 For more information about the Mailer extension configuration please refer to the <<configuration-reference, Configuration Reference>>.
 

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -426,6 +426,21 @@ quarkus.datasource.credentials-provider = mydatabase
 quarkus.hibernate-orm.database.generation=drop-and-create
 ----
 
+[NOTE]
+====
+Another way to specify the datasource password is with property indirection. Assuming that vault path
+`myapps/vault-quickstart/config` contains key `my-db-password`, all is required on the datasource configuration is:
+```
+quarkus.datasource.username = sarah
+quarkus.datasource.password = ${my-db-password}
+```
+The only drawback is that the password will never be fetched again from vault after the initial property loading.
+This means that if the db password was changed while running, the application would have to be restarted after
+vault has been updated with the new password.
+This contrasts with the credentials provider approach, which fetches the password from vault everytime a connection
+creation is attempted.
+====
+
 Restart the application after rebuilding it, and test it with the new endpoint:
 
 [source,shell]

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -56,6 +56,8 @@ public class VaultITCase {
 
     private static final Logger log = Logger.getLogger(VaultITCase.class);
 
+    public static final String MY_PASSWORD = "my-password";
+
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
@@ -69,6 +71,9 @@ public class VaultITCase {
 
     @ConfigProperty(name = PASSWORD_PROPERTY_NAME)
     String someSecret;
+
+    @ConfigProperty(name = MY_PASSWORD)
+    String someSecretThroughIndirection;
 
     @Test
     public void credentialsProvider() {
@@ -86,6 +91,15 @@ public class VaultITCase {
 
         Config config = ConfigProviderResolver.instance().getConfig();
         String value = config.getValue(PASSWORD_PROPERTY_NAME, String.class);
+        assertEquals(DB_PASSWORD, value);
+    }
+
+    @Test
+    public void configPropertyIndirection() {
+        assertEquals(DB_PASSWORD, someSecretThroughIndirection);
+
+        Config config = ConfigProviderResolver.instance().getConfig();
+        String value = config.getValue(MY_PASSWORD, String.class);
         assertEquals(DB_PASSWORD, value);
     }
 

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -3,6 +3,8 @@ quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=config
 
+my-password=${password}
+
 quarkus.vault.credentials-provider.static.kv-path=config
 quarkus.vault.credentials-provider.dynamic.database-credentials-role=mydbrole
 


### PR DESCRIPTION
This provides documentation (and a test) on the ability to store a password in vault, and refer to it anywhere in the configuration using property indirection.

This was made possible thanks to https://github.com/quarkusio/quarkus/issues/3937.

This solves for instance https://github.com/quarkusio/quarkus/issues/3279, assuming Vault is an option in the user's environment.

cc @sberyozkin 