### PR TITLE
[Doc] Add link to GraalVM requirements in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If you have not done so on this machine, you need to:
  
 * Install Git and configure your GitHub access
 * Install Java SDK (OpenJDK recommended)
-* Install [GraalVM](http://www.graalvm.org/downloads/) (community edition is enough)
+* Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:
     * Linux
         * Make sure headers are available on your system (you'll hit 'Basic header file missing (<zlib.h>)' error if they aren't).


### PR DESCRIPTION
- Add GraalVM version to use
- Update link for GraalVM sdk releases as previous link points to `19.3.0` version only

