### PR TITLE
fix: add spring-security extension metadata

### DIFF
--- a/extensions/spring-security/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/spring-security/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "Quarkus Extension for Spring Security API"
+metadata:
+  keywords:
+  - "spring-security"
+  - "spring"
+  - "security"
+  guide: "https://quarkus.io/guides/spring-security"
+  categories:
+  - "compatibility"
+  status: "preview"


### PR DESCRIPTION
I think I missed that when adding the spring-security extension.
WDYT @geoand @michalszynkiewicz @gsmet ?
Related to #5225