### PR TITLE
Bump Jandex to 2.1.2.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <aesh.version>1.11</aesh.version>
-        <jandex.version>2.1.1.Final</jandex.version>
+        <jandex.version>2.1.2.Final</jandex.version>
         <resteasy.version>4.4.1.Final</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>
         <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>


### PR DESCRIPTION
This version contains support for Dynamic Constants (JEP 309) which is essential for JDK 11 support