### PR TITLE
Mark the scheduler extension as stable - Fixes #5765

### DIFF
--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -10,13 +10,6 @@ include::./attributes.adoc[]
 Modern applications often need to run specific tasks periodically.
 In this guide, you learn how to schedule periodic tasks.
 
-[NOTE]
-====
-This extension is considered `preview`.
-API or configuration properties might change as the extension matures.
-Feedback is welcome on our https://groups.google.com/d/forum/quarkus-dev[mailing list] or as issues in our https://github.com/quarkusio/quarkus/issues[GitHub issue tracker].
-====
-
 == Prerequisites
 
 To complete this guide, you need:

--- a/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/scheduler/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   guide: "https://quarkus.io/guides/scheduler"
   categories:
   - "miscellaneous"
-  status: "preview"
+  status: "stable"


### PR DESCRIPTION
- Remove the "preview" note from the guide
- Update the quarkus-extension.yaml file

Fixes: #5765 