### PR TITLE
Fix HTTPS issue on native for OAuth2

### DIFF
--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
@@ -39,6 +39,8 @@ public class OAuth2Recorder {
 
         if (config.caCertFile.isPresent()) {
             validatorBuilder.useSslContext(createSSLContext(config));
+        } else {
+            validatorBuilder.useSslContext(SSLContext.getDefault());
         }
 
         OAuth2IntrospectValidator validator = validatorBuilder.build();


### PR DESCRIPTION
Fixes #5731

~~I don't like the way I fix it but I cannot find a better way.~~

The issue was that the Elytron `OAuth2IntrospectValidator` needs a SSLContext inside it's constructor in case of HTTPS introspect URL.

As all security related build steps are STATIC_INIT, the constructor is called at static initilization time during the native process, and GraalVM refuses to have an SSLContext in it's image heap so it crash.

~~I try to switch the security related build items to RUNTIME_INIT but cannot success, maybe it's possible but there is a lot of different build items procudes and consumes by some other extensions so it's risky to change that.~~

~~I try to provide a substitution but as the `OAuth2IntrospectValidator` use a private builder with private fields I cannot substitute the constructor (maybe I will also need to substitute the builder ...).~~

~~So the best implementation I can find is to copy/paste the `OAuth2IntrospectValidator` and make the SSLContext related stuff lazy.~~

**UPDATE:** All security related build steps has been moved to RUNTIME_INIT so an easy fix can be done.

Tested OK in both JVM and native builds.