### PR TITLE
Fix AnalysisConfigurer example in Hibernate Search documentation

### DIFF
--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -431,13 +431,13 @@ To fulfill our requirements, let's create the following implementation:
 ----
 package org.acme.hibernate.search.elasticsearch.config;
 
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.analysis.model.dsl.ElasticsearchAnalysisDefinitionContainerContext;
 
 public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 
     @Override
-    public void configure(ElasticsearchAnalysisDefinitionContainerContext context) {
+    public void configure(ElasticsearchAnalysisConfigurationContext context) {
         context.analyzer("name").custom() // <1>
                 .tokenizer("standard")
                 .tokenFilters("asciifolding", "lowercase");


### PR DESCRIPTION
Fix configure parameter Classs. Changing ElasticsearchAnalysisDefinitionContainerContext to ElasticsearchAnalysisConfigurationContext