### PR TITLE
Set dependabot directory config to root

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,8 @@
+# Documentation in https://dependabot.com/docs/config-file/
 version: 1
 update_configs:
   - package_manager: "java:maven"
-    directory: "/bom/runtime"
+    directory: "/"
     update_schedule: "daily"
     allowed_updates:
       - match:


### PR DESCRIPTION
This allows dependabot to also update dependency references that are not included in the BOM