### PR TITLE
Support for the fixed redirect URI

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -11,6 +11,8 @@ import java.util.function.Function;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.jboss.logging.Logger;
+
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdTokenCredential;
@@ -19,6 +21,7 @@ import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.AuthenticationRedirectException;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpHeaders;
@@ -31,9 +34,11 @@ import io.vertx.ext.web.impl.CookieImpl;
 @ApplicationScoped
 public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMechanism {
 
+    private static final Logger LOG = Logger.getLogger(CodeAuthenticationMechanism.class);
+
     private static final String STATE_COOKIE_NAME = "q_auth";
     private static final String SESSION_COOKIE_NAME = "q_session";
-    private static final String SESSION_COOKIE_DELIM = "___";
+    private static final String COOKIE_DELIM = "___";
 
     private static QuarkusSecurityIdentity augmentIdentity(SecurityIdentity securityIdentity,
             String accessToken,
@@ -62,7 +67,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
         // if session already established, try to re-authenticate
         if (sessionCookie != null) {
-            String[] tokens = sessionCookie.getValue().split(SESSION_COOKIE_DELIM);
+            String[] tokens = sessionCookie.getValue().split(COOKIE_DELIM);
             return authenticate(identityProviderManager, new IdTokenCredential(tokens[0]))
                     .thenCompose(new Function<SecurityIdentity, CompletionStage<SecurityIdentity>>() {
                         @Override
@@ -78,9 +83,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     @Override
     public CompletionStage<ChallengeData> getChallenge(RoutingContext context) {
-        removeSessionCookie(context);
+        removeCookie(context, SESSION_COOKIE_NAME);
         ChallengeData challenge;
-
         JsonObject params = new JsonObject();
 
         List<Object> scopes = new ArrayList<>();
@@ -89,8 +93,12 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         config.authentication.scopes.ifPresent(scopes::addAll);
 
         params.put("scopes", new JsonArray(scopes));
-        params.put("redirect_uri", buildRedirectUri(context));
-        params.put("state", generateState(context));
+
+        URI absoluteUri = URI.create(context.request().absoluteURI());
+        String dynamicPath = getDynamicPath(context, absoluteUri);
+        params.put("redirect_uri", buildCodeRedirectUri(context, absoluteUri, dynamicPath));
+
+        params.put("state", generateState(context, dynamicPath));
 
         challenge = new ChallengeData(HttpResponseStatus.FOUND.code(), HttpHeaders.LOCATION, auth.authorizeURL(params));
 
@@ -105,9 +113,53 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (code == null) {
             return CompletableFuture.completedFuture(null);
         }
+
         CompletableFuture<SecurityIdentity> cf = new CompletableFuture<>();
+
+        URI absoluteUri = URI.create(context.request().absoluteURI());
+
+        Cookie stateCookie = context.getCookie(STATE_COOKIE_NAME);
+        if (stateCookie != null) {
+            List<String> values = context.queryParam("state");
+            // IDP must return a 'state' query parameter and the value of the state cookie must start with this parameter's value
+            if (values.size() != 1 || !stateCookie.getValue().startsWith(values.get(0))) {
+                cf.completeExceptionally(new AuthenticationFailedException());
+                return cf;
+            } else if (context.queryParam("pathChecked").isEmpty()) {
+                // This is an original redirect from IDP, check if the request path needs to be updated
+                String[] pair = stateCookie.getValue().split(COOKIE_DELIM);
+                if (pair.length == 2) {
+                    // The extra path that needs to be added to the current request path
+                    String extraPath = pair[1];
+                    // Adding a query marker that the state cookie has already been used to restore the path
+                    // as deleting it now would increase the risk of CSRF
+                    String extraQuery = "?pathChecked=true";
+
+                    // The query parameters returned from IDP need to be included
+                    if (absoluteUri.getRawQuery() != null) {
+                        extraQuery += ("&" + absoluteUri.getRawQuery());
+                    }
+
+                    String localRedirectUri = buildLocalRedirectUri(context, absoluteUri, extraPath + extraQuery);
+                    LOG.debug("Local redirectUri: " + localRedirectUri);
+
+                    cf.completeExceptionally(new AuthenticationRedirectException(localRedirectUri));
+                    return cf;
+                }
+                // The redirect path matches the original request path, the state cookie is no longer needed
+                removeCookie(context, STATE_COOKIE_NAME);
+            } else {
+                // Local redirect restoring the original request path, the state cookie is no longer needed
+                removeCookie(context, STATE_COOKIE_NAME);
+            }
+        } else {
+            // State cookie must be available to minimize the risk of CSRF
+            cf.completeExceptionally(new AuthenticationFailedException());
+            return cf;
+        }
+
         params.put("code", code);
-        params.put("redirect_uri", buildRedirectUri(context));
+        params.put("redirect_uri", buildCodeRedirectUri(context, absoluteUri, getDynamicPath(context, absoluteUri)));
 
         auth.authenticate(params, userAsyncResult -> {
             if (userAsyncResult.failed()) {
@@ -129,46 +181,74 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         return cf;
     }
 
-    private void processSuccessfulAuthentication(RoutingContext context, CompletableFuture<SecurityIdentity> cf,
+    private void processSuccessfulAuthentication(RoutingContext context,
+            CompletableFuture<SecurityIdentity> cf,
             AccessToken result, SecurityIdentity securityIdentity) {
-        removeSessionCookie(context);
+        removeCookie(context, SESSION_COOKIE_NAME);
         CookieImpl cookie = new CookieImpl(SESSION_COOKIE_NAME, new StringBuilder(result.opaqueIdToken())
-                .append(SESSION_COOKIE_DELIM)
+                .append(COOKIE_DELIM)
                 .append(result.opaqueAccessToken())
-                .append(SESSION_COOKIE_DELIM)
+                .append(COOKIE_DELIM)
                 .append(result.opaqueRefreshToken()).toString());
 
         cookie.setMaxAge(result.idToken().getInteger("exp"));
         cookie.setSecure(context.request().isSSL());
         cookie.setHttpOnly(true);
-
         context.response().addCookie(cookie);
+
         cf.complete(augmentIdentity(securityIdentity, result.opaqueAccessToken(),
                 result.opaqueRefreshToken()));
     }
 
-    private String generateState(RoutingContext context) {
-        CookieImpl cookie = new CookieImpl(STATE_COOKIE_NAME, UUID.randomUUID().toString());
+    private String getDynamicPath(RoutingContext context, URI absoluteUri) {
+        if (config.authentication.redirectPath.isPresent()) {
+            String redirectPath = config.authentication.redirectPath.get();
+            String requestPath = absoluteUri.getRawPath();
+            if (requestPath.startsWith(redirectPath) && requestPath.length() > redirectPath.length()) {
+                return requestPath.substring(redirectPath.length());
+            }
+        }
+        return null;
+    }
+
+    private String generateState(RoutingContext context, String dynamicPath) {
+        String uuid = UUID.randomUUID().toString();
+        String cookieValue = uuid;
+        if (dynamicPath != null) {
+            cookieValue += (COOKIE_DELIM + dynamicPath);
+        }
+
+        CookieImpl cookie = new CookieImpl(STATE_COOKIE_NAME, cookieValue);
 
         cookie.setHttpOnly(true);
         cookie.setSecure(context.request().isSSL());
-        cookie.setMaxAge(-1);
+        // max-age is 30 minutes
+        cookie.setMaxAge(60 * 30);
 
         context.response().addCookie(cookie);
-
-        return cookie.getValue();
+        return uuid;
     }
 
-    private String buildRedirectUri(RoutingContext context) {
-        URI absoluteUri = URI.create(context.request().absoluteURI());
+    private String buildCodeRedirectUri(RoutingContext context, URI absoluteUri, String dynamicPath) {
         StringBuilder builder = new StringBuilder(context.request().scheme()).append("://")
-                .append(absoluteUri.getAuthority())
-                .append(absoluteUri.getPath());
+                .append(absoluteUri.getAuthority());
 
-        return builder.toString();
+        String path = dynamicPath != null
+                ? config.authentication.redirectPath.get()
+                : absoluteUri.getRawPath();
+
+        return builder.append(path).toString();
     }
 
-    private void removeSessionCookie(RoutingContext context) {
-        context.response().removeCookie(SESSION_COOKIE_NAME, true);
+    private String buildLocalRedirectUri(RoutingContext context, URI absoluteUri, String extraPath) {
+        return new StringBuilder(context.request().scheme()).append("://")
+                .append(absoluteUri.getAuthority())
+                .append(absoluteUri.getRawPath())
+                .append(extraPath)
+                .toString();
+    }
+
+    private Cookie removeCookie(RoutingContext context, String cookieName) {
+        return context.response().removeCookie(cookieName, true);
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
@@ -138,12 +138,23 @@ public class OidcConfig {
         }
     }
 
+    /**
+     * Defines the authorization request properties when authenticating
+     * users using the Authorization Code Grant Type.
+     */
     @ConfigGroup
     public static class Authentication {
+        /**
+         * Relative path for calculating a "redirect_uri" parameter.
+         * It set it will be appended to the request URI's host and port, otherwise the complete request URI will be used.
+         * It has to start from the forward slash, for example: "/service"
+         *
+         */
+        @ConfigItem
+        public Optional<String> redirectPath;
 
         /**
-         * Defines a fixed list of scopes which should be added to authorization requests when authenticating users using the
-         * Authorization Code Grant Type.
+         * List of scopes
          *
          */
         @ConfigItem

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationRedirectException.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationRedirectException.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.http.runtime.security;
+
+/**
+ * Exception indicating that a redirect is required for the authentication flow to complete.
+ * For example, it can be used during an OIDC authorization code flow to redirect a user to
+ * the original request URI.
+ */
+public class AuthenticationRedirectException extends RuntimeException {
+
+    int code;
+    String redirectUri;
+
+    public AuthenticationRedirectException(String redirectUri) {
+        this(302, redirectUri);
+    }
+
+    public AuthenticationRedirectException(int code, String redirectUri) {
+        this.code = code;
+        this.redirectUri = redirectUri;
+    }
+
+    public int getCode() {
+        return 302;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -15,6 +15,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
@@ -47,6 +48,11 @@ public class HttpSecurityRecorder {
                                         event.response().end();
                                     }
                                 });
+                            } else if (throwable instanceof AuthenticationRedirectException) {
+                                AuthenticationRedirectException redirectEx = (AuthenticationRedirectException) throwable;
+                                event.response().setStatusCode(redirectEx.getCode());
+                                event.response().headers().set(HttpHeaders.LOCATION, redirectEx.getRedirectUri());
+                                event.response().end();
                             } else {
                                 event.fail(throwable);
                             }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.authentication.scopes=profile,email,phone
+quarkus.oidc.authentication.redirect-path=/web-app
 quarkus.http.cors=true
 quarkus.oidc.application-type=web-app
 quarkus.http.auth.permission.roles1.paths=/index.html

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -208,7 +208,6 @@ public class CodeFlowTest {
     }
 
     @Test
-    //@Disabled
     public void testAccessTokenInjection() throws IOException, InterruptedException {
         try (final WebClient webClient = new WebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/index.html");
@@ -247,6 +246,24 @@ public class CodeFlowTest {
             assertEquals("Welcome to Test App", page.getTitleText());
 
             page = webClient.getPage("http://localhost:8081/web-app/refresh");
+
+            assertEquals("RT injected", page.getBody().asText());
+        }
+    }
+
+    @Test
+    public void testAccessAndRefreshTokenInjectionWithoutIndexHtml() throws IOException, InterruptedException {
+        try (final WebClient webClient = new WebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/refresh");
+
+            assertEquals("Log in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
 
             assertEquals("RT injected", page.getBody().asText());
         }


### PR DESCRIPTION
Fixes #5733 . 
This PR introduces a (relative) `redirect-path` property, which, if set, will be used to calculate a static `redirect_uri` parameter. The remaining (dynamic part) of the current request URI will be stored in a `q_auth` state cookie (queries parameters can also be saved but it can be done in a follow up PR).

Right now the problem is that a `RoutingContext.reroute` method does not seem to work.
Note a 'state' parameter (as well as a state cookie) are not added unless a dynamic path is available because there is nothing else at the moment that is being saved.
