### PR TITLE
Remove the nimbus test dependency

### DIFF
--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -52,12 +52,6 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-            <version>6.7</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR removes a Nimbus test dependency. Our own JWT generation API is in the works, but for now this utility code needs an update