### PR TITLE
doc: add spring security guide

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -68,7 +68,8 @@ The following properties can be used to configure form based auth:
 
 include::{generated-dir}/config/quarkus-vertx-http-config-group-form-auth-config.adoc[opts=optional, leveloffset=+1]
 
-## Authorization in REST endpoints and CDI beans using annotations
+[#standard-security-annotations]
+== Authorization in REST endpoints and CDI beans using annotations
 
 Quarkus comes with built-in security to allow for Role-Based Access Control (link:https://en.wikipedia.org/wiki/Role-based_access_control[RBAC])
 based on the common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints and CDI beans.

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -603,3 +603,4 @@ Quarkus support has more Spring compatibility features. See the following guides
 
 * link:spring-di[Quarkus - Extension for Spring DI]
 * link:spring-web[Quarkus - Extension for Spring Web]
+* link:spring-security[Quarkus - Extension for Spring Security]

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -313,3 +313,4 @@ Quarkus supports additional Spring compatibility features. See the following gui
 
 * link:spring-web[Quarkus - Extension for Spring Web]
 * link:spring-data-jpa[Quarkus - Extension for Spring Data JPA]
+* link:spring-security[Quarkus - Extension for Spring Security]

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -1,0 +1,262 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Quarkus Extension for Spring Security API
+
+include::./attributes.adoc[]
+
+While users are encouraged to use <<security.adoc#standard-security-annotations,Java standard annotations for security authorizations>>, Quarkus provides a compatibility layer for Spring Security in the form of the `spring-security` extension.
+
+This guide explains how a Quarkus application can leverage the well known Spring Security annotations to define authorizations on RESTful services using roles.
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* less than 15 minutes
+* an IDE
+* JDK 1.8+ installed with `JAVA_HOME` configured appropriately
+* Apache Maven 3.5.3+
+* Some familiarity with the Spring Web extension
+
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `spring-security-quickstart` {quickstarts-tree-url}/spring-security-quickstart[directory].
+
+== Creating the Maven project
+
+First, we need a new project. Create a new project with the following command:
+
+[source,shell,subs=attributes+]
+----
+mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=spring-security-quickstart \
+    -DclassName="org.acme.spring.security.GreetingController" \
+    -Dpath="/greeting" \
+    -Dextensions="spring-web, spring-security, quarkus-elytron-security-properties-file"
+cd spring-security-quickstart
+----
+
+This command generates a Maven project with a REST endpoint and imports the `spring-web`, `spring-security` and `security-properties-file` extensions.
+
+For more information about `security-properties-file` you can check the guide of link:security-properties[quarkus-elytron-security-properties-file] extension.
+
+== GreetingController
+
+The Quarkus Maven plugin automatically generated a controller with the Spring Web annotations to define our REST endpoint (instead of the JAX-RS ones used by default).
+The `src/main/java/org/acme/spring/web/GreetingController.java` file looks as follows:
+
+[source,java]
+----
+package org.acme.spring.security;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RestController
+@RequestMapping("/greeting")
+public class GreetingController {
+
+    @GetMapping
+    public String hello() {
+        return "hello";
+    }
+}
+----
+
+== GreetingControllerTest
+
+Note that a test for the controller has been created as well:
+
+[source, java]
+----
+package org.acme.spring.security;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class GreetingControllerTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/greeting")
+          .then()
+             .statusCode(200)
+             .body(is("hello"));
+    }
+
+}
+----
+
+== Package and run the application
+
+Run the application with: `./mvn quarkus:dev`.
+Open your browser to http://localhost:8080/greeting.
+
+The result should be: `{"message": "hello"}`.
+
+== Modify the controller to secure the `hello` method
+
+In order to restrict access to the `hello` method to users with certain roles, the `@Secured` annotation will be utilized.
+The updated controller will be:
+
+[source,java]
+----
+package org.acme.spring.security;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RestController
+@RequestMapping("/greeting")
+public class GreetingController {
+
+    @Secured("admin")
+    @GetMapping
+    public String hello() {
+        return "hello";
+    }
+}
+----
+
+The easiest way to setup users and roles for our example is to use the `security-properties-file` extension. This extension essentially allows users and roles to be defined in the main Quarkus configuration file - `application.properties`.
+For more information about this extension check link:security-properties.adoc[the associated guide].
+An example configuration would be the following:
+
+[source,properties]
+----
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.scott=jb0ss
+quarkus.security.users.embedded.roles.scott=admin,user
+quarkus.security.users.embedded.users.stuart=test
+quarkus.security.users.embedded.roles.stuart=user
+----
+
+Note that the test also needs to be updated. It could look like:
+
+== GreetingControllerTest
+
+[source, java]
+----
+package org.acme.spring.security;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class GreetingControllerTest {
+
+    @Test
+    public void testHelloEndpointForbidden() {
+        given().auth().preemptive().basic("stuart", "test")
+                .when().get("/greeting")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    public void testHelloEndpoint() {
+        given().auth().preemptive().basic("scott", "jb0ss")
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
+    }
+
+}
+----
+
+== Test the changes
+
+- Access allowed
+
+Open your browser again to http://localhost:8080/greeting and introduce `scott` and `jb0ss` in the dialog displayed.
+
+The word `hello` should be displayed.
+
+- Access forbidden
+
+Open your browser again to http://localhost:8080/greeting and let empty the dialog displayed.
+
+The result should be:
+----
+Access to localhost was denied
+You don't have authorization to view this page.
+HTTP ERROR 403
+----
+
+== Run the application as a native executable
+
+You can of course create a native image using the instructions of the link:building-native-image[Building a native executable guide].
+
+
+== Supported Spring Security functionalities
+
+Quarkus currently only supports a small subset of the functionalities that Spring Security provides and more features will be added in the future. More specifically, Quarkus supports the security related features of role-based authorization semantics
+(think of `@Secured` instead of `@RolesAllowed`).
+
+=== Annotations
+
+The table below summarizes the supported annotations:
+
+.Supported Spring Security annotations
+|===
+|Name|Comments
+
+|@Secured
+|
+
+|===
+
+
+== Important Technical Note
+
+Please note that the Spring support in Quarkus does not start a Spring Application Context nor are any Spring infrastructure classes run.
+Spring classes and annotations are only used for reading metadata and / or are used as user code method return types or parameter types.
+What that means for end users, is that adding arbitrary Spring libraries will not have any effect. Moreover Spring infrastructure
+classes (like `org.springframework.beans.factory.config.BeanPostProcessor` for example) will not be executed.
+
+== Conversion Table
+
+The following table shows how Spring Security annotations can be converted to JAX-RS annotations.
+
+|===
+|Spring |JAX-RS |Comments
+
+|@Secured("admin")
+|@RolesAllowed("admin")
+|
+
+|===
+
+== More Spring guides
+
+Quarkus support has more Spring compatibility features. See the following guides for more details:
+
+* link:spring-di[Quarkus - Extension for Spring DI]
+* link:spring-web[Quarkus - Extension for Spring Web]
+* link:spring-data-jpa[Quarkus - Extension for Spring Data JPA]
+
+

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -325,5 +325,5 @@ Quarkus support has more Spring compatibility features. See the following guides
 
 * link:spring-di[Quarkus - Extension for Spring DI]
 * link:spring-data-jpa[Quarkus - Extension for Spring Data JPA]
-
+* link:spring-security[Quarkus - Extension for Spring Security]
 


### PR DESCRIPTION
Here the initial guide of `spring-security` extension. The quickstart has been also added: 
https://github.com/quarkusio/quarkus-quickstarts/pull/390
@geoand Can you review and add once finished add the `@PreAuthorize` infos :-)