### PR TITLE
Throwing ForbiddenException if OidcUtils.findRoles throws an exception

### DIFF
--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPasswordIdentityProvider.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPasswordIdentityProvider.java
@@ -62,7 +62,7 @@ public class ElytronPasswordIdentityProvider implements IdentityProvider<Usernam
                     throw new RuntimeException(e);
                 } catch (SecurityException e) {
                     log.debug("Authentication failed", e);
-                    throw new AuthenticationFailedException();
+                    throw new AuthenticationFailedException(e);
                 }
             }
         });

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTokenIdentityProvider.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTokenIdentityProvider.java
@@ -61,7 +61,7 @@ public class ElytronTokenIdentityProvider implements IdentityProvider<TokenAuthe
                     throw new RuntimeException(e);
                 } catch (SecurityException e) {
                     log.debug("Authentication failed", e);
-                    throw new AuthenticationFailedException();
+                    throw new AuthenticationFailedException(e);
                 }
             }
         });

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTrustedIdentityProvider.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronTrustedIdentityProvider.java
@@ -70,7 +70,7 @@ public class ElytronTrustedIdentityProvider implements IdentityProvider<TrustedA
                     throw new RuntimeException(e);
                 } catch (SecurityException e) {
                     log.debug("Authentication failed", e);
-                    throw new AuthenticationFailedException();
+                    throw new AuthenticationFailedException(e);
                 }
             }
         });

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -10,6 +10,7 @@ import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 
 import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -64,7 +65,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 try {
                     jwtPrincipal = new OidcJwtCallerPrincipal(JwtClaims.parse(token.accessToken().encode()));
                 } catch (InvalidJwtException e) {
-                    result.completeExceptionally(e);
+                    result.completeExceptionally(new AuthenticationFailedException(e));
                     return;
                 }
                 builder.setPrincipal(jwtPrincipal);
@@ -74,7 +75,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                         builder.addRole(role);
                     }
                 } catch (Exception e) {
-                    result.completeExceptionally(e);
+                    result.completeExceptionally(new ForbiddenException(e));
                     return;
                 }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -11,11 +11,12 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public final class OidcUtils {
+
     private OidcUtils() {
 
     }
 
-    public static List<String> findRoles(String clientId, OidcConfig.Roles rolesConfig, JsonObject json) throws Exception {
+    public static List<String> findRoles(String clientId, OidcConfig.Roles rolesConfig, JsonObject json) {
         // If the user configured a specific path - check and enforce a claim at this path exists
         if (rolesConfig.getRoleClaimPath().isPresent()) {
             return findClaimWithRoles(rolesConfig, rolesConfig.getRoleClaimPath().get(), json, true);
@@ -57,8 +58,7 @@ public final class OidcUtils {
         Object claimValue = json.getValue(pathArray[step]);
         if (claimValue == null) {
             if (mustExist) {
-                throw new OIDCException(
-                        "No claim exists at the path " + claimPath + " at the path segment " + pathArray[step]);
+                throw new OIDCException("No claim exists at the path " + claimPath + " at the path segment " + pathArray[step]);
             }
         } else if (step + 1 < pathArray.length) {
             if (claimValue instanceof JsonObject) {

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/MpJwtValidator.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/MpJwtValidator.java
@@ -71,7 +71,7 @@ public class MpJwtValidator implements IdentityProvider<TokenAuthenticationReque
         } catch (ParseException | MalformedClaimException e) {
             log.debug("Authentication failed", e);
             CompletableFuture<SecurityIdentity> cf = new CompletableFuture<SecurityIdentity>();
-            cf.completeExceptionally(new AuthenticationFailedException());
+            cf.completeExceptionally(new AuthenticationFailedException(e));
             return cf;
         }
     }


### PR DESCRIPTION
Fixes #5750
Fixes #5826

This PR simply completes the future with `ForbiddenException`, instead of propagating `OIDCException`. Note `OidcUtils.findRoles` does not itself throw `ForbiddenException` because it is not guaranteed to be called during the authentication, but it logs a warning now.
`OidcUtilsTest` has a test confirming `OidcUtils.findRoles` throws an exception with the invalid path