### PR TITLE
ArC - introduce BeanStream

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -379,8 +379,8 @@ NOTE: A bean registration that is a result of an `AdditionalBeanBuildItem` is re
 === Synthetic Beans
 
 Sometimes it is very useful to register a synthetic bean, i.e. a bean that doesn't need to have a corresponding java class.
-In CDI this could be achieved using `AfterBeanDiscovery.addBean()` methods.
-In Quarkus we produce a `BeanRegistrarBuildItem` and leverage the `io.quarkus.arc.processor.BeanConfigurator` API to build a synthetic bean definition.
+In CDI, this could be achieved using `AfterBeanDiscovery.addBean()` methods.
+In Quarkus, we produce a `BeanRegistrarBuildItem` and leverage the `io.quarkus.arc.processor.BeanConfigurator` API to build a synthetic bean definition.
 
 [source,java]
 ----
@@ -397,6 +397,8 @@ BeanRegistrarBuildItem syntheticBean() {
 ----
 
 NOTE: The output of a `BeanConfigurator` is recorded as bytecode. Therefore there are some limitations in how a synthetic bean instance is created. See also `BeanConfigurator.creator()` methods.
+
+TIP: You can easily filter all class-based beans via the convenient `BeanStream` returned from the `RegistrationContext.beans()` method.
 
 If an extension needs to produce other build items during the "bean registration" phase it should use the `BeanRegistrationPhaseBuildItem` instead.
 The reason is that injected objects are only valid during a `@BuildStep` method invocation.
@@ -511,7 +513,7 @@ BeanDeploymentValidatorBuildItem beanDeploymentValidator() {
 }
 ----
 
-NOTE: See also `io.quarkus.arc.processor.BuildExtension.Key` to discover the available metadata.
+TIP: You can easily filter all registered beans via the convenient `BeanStream` returned from the `ValidationContext.beans()` method.
 
 If an extension needs to produce other build items during the "validation" phase it should use the `ValidationPhaseBuildItem` instead.
 The reason is that injected objects are only valid during a `@BuildStep` method invocation.
@@ -574,13 +576,15 @@ The built-in keys located in `io.quarkus.arc.processor.BuildExtension.Key` are:
 * `ANNOTATION_STORE`
 ** Contains an `AnnotationStore` that keeps information about all `AnnotationTarget` annotations after application of annotation transformers
 * `INJECTION_POINTS`
-** `List<InjectionPointInfo>` containing all injection points
+** `Collection<InjectionPointInfo>` containing all injection points
 * `BEANS`
-** `List<BeanInfo>` containing all beans
+** `Collection<BeanInfo>` containing all beans
+* `REMOVED_BEANS`
+** `Collection<BeanInfo>` containing all the removed beans; see <<remove_unused_beans>> for more information
 * `OBSERVERS`
-** `List<ObserverInfo>` containing all observers
+** `Collection<ObserverInfo>` containing all observers
 * `SCOPES`
-** `List<ScopeInfo>` containing all scopes, including custom ones
+** `Collection<ScopeInfo>` containing all scopes, including custom ones
 * `QUALIFIERS`
 ** `Map<DotName, ClassInfo>` containing all qualifiers
 * `INTERCEPTOR_BINDINGS`
@@ -600,7 +604,7 @@ Here is a summary of which extensions can access which metadata:
 * `InjectionPointsTransformer`
 ** Has access to `ANNOTATION_STORE`, `QUALIFIERS`, `INTERCEPTOR_BINDINGS`, `STEREOTYPES`
 * `BeanRegistrar`
-** Has access to all build metadata
+** Has access to `ANNOTATION_STORE`, `QUALIFIERS`, `INTERCEPTOR_BINDINGS`, `STEREOTYPES`, `BEANS`
 * `BeanDeploymentValidator`
 ** Has access to all build metadata
 

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -127,12 +127,10 @@ public class SchedulerProcessor {
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
 
         // We need to collect all business methods annotated with @Scheduled first
-        for (BeanInfo bean : validationPhase.getContext().get(BuildExtension.Key.BEANS)) {
-            if (bean.isClassBean()) {
-                collectScheduledMethods(config, beanArchives.getIndex(), annotationStore, bean,
-                        bean.getTarget().get().asClass(),
-                        scheduledBusinessMethods, validationPhase.getContext());
-            }
+        for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
+            collectScheduledMethods(config, beanArchives.getIndex(), annotationStore, bean,
+                    bean.getTarget().get().asClass(),
+                    scheduledBusinessMethods, validationPhase.getContext());
         }
     }
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -34,7 +34,6 @@ import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanInfo;
-import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.QuarkusConfig;
@@ -192,10 +191,8 @@ public class SmallRyeFaultToleranceProcessor {
     void validateFaultToleranceAnnotations(
             ValidationPhaseBuildItem validationPhase, SmallryeFaultToleranceRecorder recorder) {
         List<String> beanNames = new ArrayList<>();
-        for (BeanInfo bean : validationPhase.getContext().get(BuildExtension.Key.BEANS)) {
-            if (bean.isClassBean()) {
-                beanNames.add(bean.getBeanClass().toString());
-            }
+        for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
+            beanNames.add(bean.getBeanClass().toString());
         }
         recorder.validate(beanNames);
     }

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -338,39 +338,37 @@ public class SmallRyeMetricsProcessor {
             ValidationPhaseBuildItem validationPhase,
             BeanArchiveIndexBuildItem beanArchiveIndex) {
         IndexView index = beanArchiveIndex.getIndex();
-        for (io.quarkus.arc.processor.BeanInfo bean : validationPhase.getContext().get(BuildExtension.Key.BEANS)) {
-            if (bean.isProducerField() || bean.isProducerMethod()) {
-                MetricType metricType = getMetricType(bean.getImplClazz());
-                if (metricType != null) {
-                    AnnotationTarget target = bean.getTarget().get();
-                    AnnotationInstance metricAnnotation = null;
-                    String memberName = null;
-                    if (bean.isProducerField()) {
-                        FieldInfo field = target.asField();
-                        metricAnnotation = field.annotation(METRIC);
-                        memberName = field.name();
-                    }
-                    if (bean.isProducerMethod()) {
-                        MethodInfo method = target.asMethod();
-                        metricAnnotation = method.annotation(METRIC);
-                        memberName = method.name();
-                    }
-                    if (metricAnnotation != null) {
-                        String nameValue = metricAnnotation.valueWithDefault(index, "name").asString();
-                        boolean absolute = metricAnnotation.valueWithDefault(index, "absolute").asBoolean();
-                        String metricSimpleName = !nameValue.isEmpty() ? nameValue : memberName;
-                        String declaringClassName = bean.getDeclaringBean().getImplClazz().name().toString();
-                        String metricsFinalName = absolute ? metricSimpleName
-                                : MetricRegistry.name(declaringClassName, metricSimpleName);
-                        recorder.registerMetricFromProducer(
-                                bean.getIdentifier(),
-                                metricType,
-                                metricsFinalName,
-                                metricAnnotation.valueWithDefault(index, "tags").asStringArray(),
-                                metricAnnotation.valueWithDefault(index, "description").asString(),
-                                metricAnnotation.valueWithDefault(index, "displayName").asString(),
-                                metricAnnotation.valueWithDefault(index, "unit").asString());
-                    }
+        for (io.quarkus.arc.processor.BeanInfo bean : validationPhase.getContext().beans().producers()) {
+            MetricType metricType = getMetricType(bean.getImplClazz());
+            if (metricType != null) {
+                AnnotationTarget target = bean.getTarget().get();
+                AnnotationInstance metricAnnotation = null;
+                String memberName = null;
+                if (bean.isProducerField()) {
+                    FieldInfo field = target.asField();
+                    metricAnnotation = field.annotation(METRIC);
+                    memberName = field.name();
+                }
+                if (bean.isProducerMethod()) {
+                    MethodInfo method = target.asMethod();
+                    metricAnnotation = method.annotation(METRIC);
+                    memberName = method.name();
+                }
+                if (metricAnnotation != null) {
+                    String nameValue = metricAnnotation.valueWithDefault(index, "name").asString();
+                    boolean absolute = metricAnnotation.valueWithDefault(index, "absolute").asBoolean();
+                    String metricSimpleName = !nameValue.isEmpty() ? nameValue : memberName;
+                    String declaringClassName = bean.getDeclaringBean().getImplClazz().name().toString();
+                    String metricsFinalName = absolute ? metricSimpleName
+                            : MetricRegistry.name(declaringClassName, metricSimpleName);
+                    recorder.registerMetricFromProducer(
+                            bean.getIdentifier(),
+                            metricType,
+                            metricsFinalName,
+                            metricAnnotation.valueWithDefault(index, "tags").asStringArray(),
+                            metricAnnotation.valueWithDefault(index, "description").asString(),
+                            metricAnnotation.valueWithDefault(index, "displayName").asString(),
+                            metricAnnotation.valueWithDefault(index, "unit").asString());
                 }
             }
         }

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -118,27 +118,25 @@ public class SmallRyeReactiveMessagingProcessor {
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
 
         // We need to collect all business methods annotated with @Incoming/@Outgoing first
-        for (BeanInfo bean : validationPhase.getContext().get(BuildExtension.Key.BEANS)) {
-            if (bean.isClassBean()) {
-                // TODO: add support for inherited business methods
-                for (MethodInfo method : bean.getTarget().get().asClass().methods()) {
-                    AnnotationInstance incoming = annotationStore.getAnnotation(method,
-                            io.quarkus.smallrye.reactivemessaging.deployment.DotNames.INCOMING);
-                    AnnotationInstance outgoing = annotationStore.getAnnotation(method,
-                            io.quarkus.smallrye.reactivemessaging.deployment.DotNames.OUTGOING);
-                    if (incoming != null || outgoing != null) {
-                        if (incoming != null && incoming.value().asString().isEmpty()) {
-                            validationPhase.getContext().addDeploymentProblem(
-                                    new DeploymentException("Empty @Incoming annotation on method " + method));
-                        }
-                        if (outgoing != null && outgoing.value().asString().isEmpty()) {
-                            validationPhase.getContext().addDeploymentProblem(
-                                    new DeploymentException("Empty @Outgoing annotation on method " + method));
-                        }
-                        // TODO: validate method params and return type?
-                        mediatorMethods.produce(new MediatorBuildItem(bean, method));
-                        LOGGER.debugf("Found mediator business method %s declared on %s", method, bean);
+        for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
+            // TODO: add support for inherited business methods
+            for (MethodInfo method : bean.getTarget().get().asClass().methods()) {
+                AnnotationInstance incoming = annotationStore.getAnnotation(method,
+                        io.quarkus.smallrye.reactivemessaging.deployment.DotNames.INCOMING);
+                AnnotationInstance outgoing = annotationStore.getAnnotation(method,
+                        io.quarkus.smallrye.reactivemessaging.deployment.DotNames.OUTGOING);
+                if (incoming != null || outgoing != null) {
+                    if (incoming != null && incoming.value().asString().isEmpty()) {
+                        validationPhase.getContext().addDeploymentProblem(
+                                new DeploymentException("Empty @Incoming annotation on method " + method));
                     }
+                    if (outgoing != null && outgoing.value().asString().isEmpty()) {
+                        validationPhase.getContext().addDeploymentProblem(
+                                new DeploymentException("Empty @Outgoing annotation on method " + method));
+                    }
+                    // TODO: validate method params and return type?
+                    mediatorMethods.produce(new MediatorBuildItem(bean, method));
+                    LOGGER.debugf("Found mediator business method %s declared on %s", method, bean);
                 }
             }
         }

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -104,7 +104,7 @@ class VertxWebProcessor {
 
         // Collect all business methods annotated with @Route and @RouteFilter
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
-        for (BeanInfo bean : validationPhase.getContext().get(BuildExtension.Key.BEANS)) {
+        for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
             if (bean.isClassBean()) {
                 // NOTE: inherited business methods are not taken into account
                 ClassInfo beanClass = bean.getTarget().get().asClass();

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -108,23 +108,20 @@ class VertxProcessor {
 
         // We need to collect all business methods annotated with @MessageConsumer first
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
-        for (BeanInfo bean : validationPhase.getContext().get(BuildExtension.Key.BEANS)) {
-            if (bean.isClassBean()) {
-                // TODO: inherited business methods?
-                for (MethodInfo method : bean.getTarget().get().asClass().methods()) {
-                    AnnotationInstance consumeEvent = annotationStore.getAnnotation(method, CONSUME_EVENT);
-                    if (consumeEvent != null) {
-                        // Validate method params and return type
-                        List<Type> params = method.parameters();
-                        if (params.size() != 1) {
-                            throw new IllegalStateException(String.format(
-                                    "Event consumer business method must accept exactly one parameter: %s [method: %s, bean:%s",
-                                    params, method, bean));
-                        }
-                        messageConsumerBusinessMethods
-                                .produce(new EventConsumerBusinessMethodItem(bean, method, consumeEvent));
-                        LOGGER.debugf("Found event consumer business method %s declared on %s", method, bean);
+        for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
+            for (MethodInfo method : bean.getTarget().get().asClass().methods()) {
+                AnnotationInstance consumeEvent = annotationStore.getAnnotation(method, CONSUME_EVENT);
+                if (consumeEvent != null) {
+                    // Validate method params and return type
+                    List<Type> params = method.parameters();
+                    if (params.size() != 1) {
+                        throw new IllegalStateException(String.format(
+                                "Event consumer business method must accept exactly one parameter: %s [method: %s, bean:%s",
+                                params, method, bean));
                     }
+                    messageConsumerBusinessMethods
+                            .produce(new EventConsumerBusinessMethodItem(bean, method, consumeEvent));
+                    LOGGER.debugf("Found event consumer business method %s declared on %s", method, bean);
                 }
             }
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -59,7 +59,9 @@ public final class BeanConfigurator<T> {
 
     private final Map<String, Object> params;
 
-    private boolean isDefaultBean;
+    private boolean defaultBean;
+
+    private boolean removable;
 
     /**
      *
@@ -77,6 +79,7 @@ public final class BeanConfigurator<T> {
         this.scope = BuiltinScope.DEPENDENT.getInfo();
         this.params = new HashMap<>();
         this.name = null;
+        this.removable = true;
     }
 
     public BeanConfigurator<T> param(String name, Class<?> value) {
@@ -152,7 +155,12 @@ public final class BeanConfigurator<T> {
     }
 
     public BeanConfigurator<T> defaultBean() {
-        this.isDefaultBean = true;
+        this.defaultBean = true;
+        return this;
+    }
+
+    public BeanConfigurator<T> unremovable() {
+        this.removable = false;
         return this;
     }
 
@@ -216,7 +224,7 @@ public final class BeanConfigurator<T> {
                     .beanDeployment(beanDeployment).scope(scope).types(types)
                     .qualifiers(qualifiers)
                     .alternativePriority(alternativePriority).name(name).creator(creatorConsumer).destroyer(destroyerConsumer)
-                    .params(params).defaultBean(isDefaultBean).build());
+                    .params(params).defaultBean(defaultBean).removable(removable).build());
         }
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeploymentValidator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeploymentValidator.java
@@ -19,7 +19,7 @@ public interface BeanDeploymentValidator extends BuildExtension {
      * @see Key#OBSERVERS
      * @see DeploymentException
      */
-    default void validate(ValidationContext validationContext) {
+    default void validate(ValidationContext context) {
     }
 
     /**
@@ -37,6 +37,18 @@ public interface BeanDeploymentValidator extends BuildExtension {
         void addDeploymentProblem(Throwable t);
 
         List<Throwable> getDeploymentProblems();
+
+        /**
+         * 
+         * @return a new stream of beans that form the deployment
+         */
+        BeanStream beans();
+
+        /**
+         * 
+         * @return a new stream of beans that are considered {@code unused} and were removed from the deployment
+         */
+        BeanStream removedBeans();
 
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanRegistrar.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanRegistrar.java
@@ -12,9 +12,9 @@ public interface BeanRegistrar extends BuildExtension {
 
     /**
      *
-     * @param registrationContext
+     * @param context
      */
-    void register(RegistrationContext registrationContext);
+    void register(RegistrationContext context);
 
     interface RegistrationContext extends BuildContext {
 
@@ -33,6 +33,14 @@ public interface BeanRegistrar extends BuildExtension {
         default <T> BeanConfigurator<T> configure(Class<?> beanClass) {
             return configure(DotName.createSimple(beanClass.getName()));
         }
+
+        /**
+         * The returned stream contains all non-synthetic beans (beans derived from classes) and beans
+         * registered by other {@link BeanRegistrar}s before the stream is created.
+         * 
+         * @return a new stream of beans
+         */
+        BeanStream beans();
 
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanStream.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanStream.java
@@ -1,0 +1,283 @@
+package io.quarkus.arc.processor;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+
+/**
+ * Convenient {@link Stream} wrapper that can be used to filter a set of beans.
+ * <p>
+ * This object is stateful and cannot be reused. After a terminal opration is performed, the underlying stream is considered
+ * consumed, and can no longer be used.
+ * <p>
+ * This construct is not threadsafe.
+ */
+public final class BeanStream implements Iterable<BeanInfo> {
+
+    private Stream<BeanInfo> stream;
+
+    public BeanStream(Collection<BeanInfo> beans) {
+        this.stream = Objects.requireNonNull(beans, "Beans collection is null").stream();
+    }
+
+    /**
+     * 
+     * @param scopeName
+     * @return the new stream of beans
+     * @see BeanInfo#getScope()
+     */
+    public BeanStream withScope(Class<? extends Annotation> scope) {
+        return withScope(DotName.createSimple(scope.getName()));
+    }
+
+    /**
+     * 
+     * @param scopeName
+     * @return the new stream of beans
+     * @see BeanInfo#getScope()
+     */
+    public BeanStream withScope(DotName scopeName) {
+        stream = stream.filter(bean -> bean.getScope().getDotName().equals(scopeName));
+        return this;
+    }
+
+    /**
+     * 
+     * @param beanType
+     * @return the new stream of beans
+     * @see BeanInfo#getTypes()
+     */
+    public BeanStream withBeanType(Class<?> beanType) {
+        return withBeanType(DotName.createSimple(beanType.getName()));
+    }
+
+    /**
+     * 
+     * @param beanType
+     * @return the new stream of beans
+     * @see BeanInfo#getTypes()
+     */
+    public BeanStream withBeanType(DotName beanTypeName) {
+        stream = stream.filter(bean -> bean.getTypes().stream().anyMatch(t -> t.name().equals(beanTypeName)));
+        return this;
+    }
+
+    /**
+     * 
+     * @param beanType
+     * @return the new stream of beans
+     * @see BeanInfo#getTypes()
+     */
+    public BeanStream withBeanType(Type beanType) {
+        stream = stream.filter(bean -> bean.getTypes().stream().anyMatch(t -> t.equals(beanType)));
+        return this;
+    }
+
+    /**
+     * 
+     * @param beanClass
+     * @return the new stream of beans
+     * @see BeanInfo#getBeanClass()
+     */
+    public BeanStream withBeanClass(Class<?> beanClass) {
+        return withBeanClass(DotName.createSimple(beanClass.getName()));
+    }
+
+    /**
+     * 
+     * @param beanClass
+     * @return the new stream of beans
+     * @see BeanInfo#getBeanClass()
+     */
+    public BeanStream withBeanClass(DotName beanClass) {
+        stream = stream.filter(bean -> bean.getBeanClass().equals(beanClass));
+        return this;
+    }
+
+    /**
+     * 
+     * @param qualifier
+     * @return the new stream of beans
+     * @see BeanInfo#getQualifiers()
+     */
+    @SafeVarargs
+    public final BeanStream withQualifier(Class<? extends Annotation>... qualifiers) {
+        if (qualifiers.length == 1) {
+            return withQualifier(DotName.createSimple(qualifiers[0].getName()));
+        } else {
+            return withQualifier(Arrays.stream(qualifiers).map(q -> DotName.createSimple(q.getName())).toArray(DotName[]::new));
+        }
+    }
+
+    /**
+     * 
+     * @param qualifierNames
+     * @return the new stream of beans
+     * @see BeanInfo#getQualifiers()
+     */
+    public BeanStream withQualifier(DotName... qualifierNames) {
+        if (qualifierNames.length == 1) {
+            stream = stream.filter(bean -> bean.getQualifiers().stream().anyMatch(q -> q.name().equals(qualifierNames[0])));
+        } else {
+            stream = stream.filter(bean -> bean.getQualifiers().stream().anyMatch(q -> {
+                for (DotName qualifierName : qualifierNames) {
+                    if (q.name().equals(qualifierName)) {
+                        return true;
+                    }
+                }
+                return false;
+            }));
+        }
+        return this;
+    }
+
+    /**
+     * 
+     * @param name
+     * @return the new stream of beans
+     * @see BeanInfo#getName()
+     */
+    public BeanStream withName(String name) {
+        stream = stream.filter(bean -> name.equals(bean.getName()));
+        return this;
+    }
+
+    /**
+     * 
+     * @param id
+     * @return an {@link Optional} with the matching bean, or an empty {@link Optional} if no such bean is found
+     * @see BeanInfo#getIdentifier()
+     */
+    public Optional<BeanInfo> findByIdentifier(String id) {
+        return stream.filter(bean -> id.equals(bean.getIdentifier())).findFirst();
+    }
+
+    /**
+     * 
+     * @return the new stream of producer beans
+     */
+    public BeanStream producers() {
+        stream = stream.filter(bean -> bean.isProducerField() || bean.isProducerMethod());
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of producer method beans
+     */
+    public BeanStream producerMethods() {
+        stream = stream.filter(BeanInfo::isProducerMethod);
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of producer field beans
+     */
+    public BeanStream producerFields() {
+        stream = stream.filter(BeanInfo::isProducerField);
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of class beans
+     */
+    public BeanStream classBeans() {
+        stream = stream.filter(BeanInfo::isClassBean);
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of synthetic beans
+     */
+    public BeanStream syntheticBeans() {
+        stream = stream.filter(BeanInfo::isSynthetic);
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of named beans
+     * @see BeanInfo#getName()
+     */
+    public BeanStream namedBeans() {
+        stream = stream.filter(bean -> bean.getName() != null);
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of default beans
+     * @see BeanInfo#isDefaultBean()
+     */
+    public BeanStream defaultBeans() {
+        stream = stream.filter(BeanInfo::isDefaultBean);
+        return this;
+    }
+
+    /**
+     * 
+     * @return the new stream of default beans
+     * @see BeanInfo#isAlternative()
+     */
+    public BeanStream alternativeBeans() {
+        stream = stream.filter(BeanInfo::isAlternative);
+        return this;
+    }
+
+    /**
+     * Terminal operation.
+     * 
+     * @return the list of beans
+     */
+    public List<BeanInfo> collect() {
+        return stream.collect(Collectors.toList());
+    }
+
+    /**
+     * 
+     * @return the underlying stream instance
+     */
+    public Stream<BeanInfo> stream() {
+        return stream;
+    }
+
+    /**
+     * Terminal operation.
+     * 
+     * @return true if the stream contains no elements
+     */
+    public boolean isEmpty() {
+        return stream.count() == 0;
+    }
+
+    /**
+     * Terminal operation.
+     * 
+     * @return the iterator
+     */
+    @Override
+    public Iterator<BeanInfo> iterator() {
+        return stream.iterator();
+    }
+
+    /**
+     * Terminal operation.
+     * 
+     * @return an {@link Optional} with the first matching bean, or an empty {@link Optional} if no bean is matching
+     */
+    public Optional<BeanInfo> firstResult() {
+        return stream.findFirst();
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuildExtension.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuildExtension.java
@@ -1,6 +1,6 @@
 package io.quarkus.arc.processor;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -51,11 +51,12 @@ public interface BuildExtension {
         // Built-in keys
         static String BUILT_IN_PREFIX = BuildExtension.class.getPackage().getName() + ".";
         static Key<IndexView> INDEX = new SimpleKey<>(BUILT_IN_PREFIX + "index");
-        static Key<List<InjectionPointInfo>> INJECTION_POINTS = new SimpleKey<>(BUILT_IN_PREFIX + "injectionPoints");
-        static Key<List<BeanInfo>> BEANS = new SimpleKey<>(BUILT_IN_PREFIX + "beans");
-        static Key<List<ObserverInfo>> OBSERVERS = new SimpleKey<>(BUILT_IN_PREFIX + "observers");
+        static Key<Collection<InjectionPointInfo>> INJECTION_POINTS = new SimpleKey<>(BUILT_IN_PREFIX + "injectionPoints");
+        static Key<Collection<BeanInfo>> BEANS = new SimpleKey<>(BUILT_IN_PREFIX + "beans");
+        static Key<Collection<BeanInfo>> REMOVED_BEANS = new SimpleKey<>(BUILT_IN_PREFIX + "removedBeans");
+        static Key<Collection<ObserverInfo>> OBSERVERS = new SimpleKey<>(BUILT_IN_PREFIX + "observers");
         static Key<AnnotationStore> ANNOTATION_STORE = new SimpleKey<>(BUILT_IN_PREFIX + "annotationStore");
-        static Key<List<ScopeInfo>> SCOPES = new SimpleKey<>(BUILT_IN_PREFIX + "scopes");
+        static Key<Collection<ScopeInfo>> SCOPES = new SimpleKey<>(BUILT_IN_PREFIX + "scopes");
         static Key<Map<DotName, ClassInfo>> QUALIFIERS = new SimpleKey<>(BUILT_IN_PREFIX + "qualifiers");
         static Key<Map<DotName, ClassInfo>> INTERCEPTOR_BINDINGS = new SimpleKey<>(BUILT_IN_PREFIX + "interceptorBindings");
         static Key<Map<DotName, ClassInfo>> STEREOTYPES = new SimpleKey<>(BUILT_IN_PREFIX + "stereotypes");

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/validator/BeanDeploymentValidatorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/build/extension/validator/BeanDeploymentValidatorTest.java
@@ -1,20 +1,27 @@
 package io.quarkus.arc.test.build.extension.validator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.BeanCreator;
 import io.quarkus.arc.processor.BeanDeploymentValidator;
+import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.processor.ObserverInfo;
 import io.quarkus.arc.test.ArcTestContainer;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
@@ -25,8 +32,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class BeanDeploymentValidatorTest {
 
     @RegisterExtension
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class)
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Alpha.class, UselessBean.class)
             .beanRegistrars(new TestRegistrar())
+            .removeUnusedBeans(true)
             .beanDeploymentValidators(new TestValidator()).build();
 
     @Test
@@ -47,17 +55,24 @@ public class BeanDeploymentValidatorTest {
     static class TestValidator implements BeanDeploymentValidator {
 
         @Override
-        public void validate(ValidationContext validationContext) {
-            assertTrue(validationContext.get(Key.BEANS)
-                    .stream()
-                    .anyMatch(b -> b.isClassBean() && b.getBeanClass()
-                            .toString()
-                            .equals(Alpha.class.getName())));
-            assertTrue(validationContext.get(Key.BEANS)
-                    .stream()
-                    .anyMatch(b -> b.isSynthetic() && b.getTypes()
-                            .contains(EmptyStringListCreator.listStringType())));
-            assertTrue(validationContext.get(Key.OBSERVERS)
+        public void validate(ValidationContext context) {
+            assertFalse(context.removedBeans().withBeanClass(UselessBean.class).isEmpty());
+
+            assertFalse(context.beans().classBeans().withBeanClass(Alpha.class).isEmpty());
+            assertFalse(context.beans().syntheticBeans().withBeanType(EmptyStringListCreator.listStringType())
+                    .isEmpty());
+            List<BeanInfo> namedAlpha = context.beans().withName("alpha").collect();
+            assertEquals(1, namedAlpha.size());
+            assertEquals(Alpha.class.getName(), namedAlpha.get(0).getBeanClass().toString());
+
+            Collection<ObserverInfo> observers = context.get(Key.OBSERVERS);
+
+            List<BeanInfo> namedClassWithObservers = context.beans().classBeans().namedBeans().stream()
+                    .filter(b -> observers.stream().anyMatch(o -> o.getDeclaringBean().equals(b))).collect(Collectors.toList());
+            assertEquals(1, namedClassWithObservers.size());
+            assertEquals(Alpha.class.getName(), namedClassWithObservers.get(0).getBeanClass().toString());
+
+            assertTrue(observers
                     .stream()
                     .anyMatch(o -> o.getObservedType()
                             .equals(Type.create(DotName.createSimple(Object.class.getName()), Kind.CLASS))));
@@ -66,11 +81,12 @@ public class BeanDeploymentValidatorTest {
 
     }
 
+    @Named
     @ApplicationScoped
     static class Alpha {
 
         @Inject
-        private List<String> strings;
+        List<String> strings;
 
         void observeAppContextInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
         }
@@ -93,6 +109,11 @@ public class BeanDeploymentValidatorTest {
         public List<String> create(CreationalContext<List<String>> creationalContext, Map<String, Object> params) {
             return Collections.emptyList();
         }
+
+    }
+
+    @ApplicationScoped
+    static class UselessBean {
 
     }
 


### PR DESCRIPTION
- convenient Stream wrapper that can be used to filter beans
- allow for inspecting removed beans in BeanDeploymentValidator
- also make it possible to mark a synthetic bean as unremovable
- resolves #5653