### PR TITLE
Set current/explicit Keycloak version in docs examples

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -97,6 +97,7 @@
                         <surefire-version>${version.surefire.plugin}</surefire-version>
                         <graalvm-version>${graal-sdk.version-for-documentation}</graalvm-version>
                         <restassured-version>${rest-assured.version}</restassured-version>
+                        <keycloak-docker-image>${keycloak.docker.image}</keycloak-docker-image>
                         <!-- Project website home page -->
                         <quarkus-home-url>${quarkus-home-url}</quarkus-home-url>
                         <!-- Root URL of the GitHub organization -->

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -173,9 +173,9 @@ NOTE: By default, applications using the `quarkus-oidc` extension are marked as 
 
 To start a Keycloak Server you can use Docker and just run the following command:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 {keycloak-docker-image}
 ----
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -83,9 +83,9 @@ all paths are being protected by a policy that ensures that only `authenticated`
 
 To start a Keycloak Server you can use Docker and just run the following command:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:7.0.0
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 {keycloak-docker-image}
 ----
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -167,9 +167,9 @@ If you plan to consume this application from another application running on a di
 
 To start a Keycloak Server you can use Docker and just run the following command:
 
-[source,bash]
+[source,bash,subs=attributes+]
 ----
-docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:7.0.0
+docker run --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8180:8080 {keycloak-docker-image}
 ----
 
 You should be able to access your Keycloak Server at http://localhost:8180/auth[localhost:8180/auth].


### PR DESCRIPTION
Set current/explicit Keycloak version in docs examples

Similar fix happened in QS - https://github.com/quarkusio/quarkus-quickstarts/pull/387
I was playing with Keycloak 8 and hit issues in native mode.
