### PR TITLE
Use filesystem specific name separator while trying to resolve a resource in RuntimeClassLoader 

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/RuntimeClassLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/RuntimeClassLoader.java
@@ -462,7 +462,16 @@ public class RuntimeClassLoader extends ClassLoader implements ClassOutput, Tran
         Path resourcePath = null;
 
         for (Path i : applicationClassDirectories) {
-            resourcePath = i.resolve(name);
+            // Resource names are always separated by the "/" character.
+            // Here we are trying to resolve those resources using a filesystem
+            // Path, so we replace the "/" character with the filesystem
+            // specific separator before resolving
+            String path = name;
+            final String pathSeparator = i.getFileSystem().getSeparator();
+            if (!pathSeparator.equals("/")) {
+                path = name.replace("/", pathSeparator);
+            }
+            resourcePath = i.resolve(path);
             if (Files.exists(resourcePath)) {
                 break;
             }


### PR DESCRIPTION
Potential fix for https://github.com/quarkusio/quarkus/issues/5821

I haven't done any actual testing of Windows and even on *nix, I've run minimal tests (`core/deployment` passed fine). Given that @mkouba had already narrowed it down to this method, I decided to just try out this change and see how CI responds.
