### PR TITLE
Add JDBC drivers to dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -13,3 +13,14 @@ update_configs:
           dependency_name: "org.eclipse.jgit:org.eclipse.jgit"
       - match:
           dependency_name: "io.fabric8:kubernetes-client-bom"
+      # JDBC Drivers
+      - match:
+          dependency_name: "org.postgresql:postgresql"
+      - match:
+          dependency_name: "org.mariadb.jdbc:mariadb-java-client"
+      - match:
+          dependency_name: "mysql:mysql-connector-java"
+      - match:
+          dependency_name: "org.apache.derby:derbyclient"
+      - match:
+          dependency_name: "com.microsoft.sqlserver:mssql-jdbc"


### PR DESCRIPTION
I haven't added H2 because there is a comment next to the BOM that says 
> keep 1.4.197 as newer versions have severe regressions