### PR TITLE
Vert.x is resumed when using non-default paths

### DIFF
--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -223,7 +223,7 @@ public class ResteasyStandaloneBuildStep {
             // We need to register a special handler for non-default deployment path (specified as application path or resteasyConfig.path)
             Handler<RoutingContext> handler = recorder.vertxRequestHandler(vertx.getVertx(), beanContainer.getValue());
             // Exact match for resources matched to the root path
-            routes.produce(new RouteBuildItem(standalone.deploymentRootPath, handler));
+            routes.produce(new RouteBuildItem(standalone.deploymentRootPath, handler, false));
             String matchPath = standalone.deploymentRootPath;
             if (matchPath.endsWith("/")) {
                 matchPath += "*";
@@ -231,7 +231,7 @@ public class ResteasyStandaloneBuildStep {
                 matchPath += "/*";
             }
             // Match paths that begin with the deployment path
-            routes.produce(new RouteBuildItem(matchPath, handler));
+            routes.produce(new RouteBuildItem(matchPath, handler, false));
         }
 
         boolean isVirtual = requireVirtual.isPresent();

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -173,7 +173,7 @@ public class UndertowBuildStep {
         if (servletContextPathBuildItem.getServletContextPath().equals("/")) {
             undertowProducer.accept(new DefaultRouteBuildItem(ut));
         } else {
-            routeProducer.produce(new RouteBuildItem(servletContextPathBuildItem.getServletContextPath() + "/*", ut));
+            routeProducer.produce(new RouteBuildItem(servletContextPathBuildItem.getServletContextPath() + "/*", ut, false));
         }
         return new ServiceStartBuildItem("undertow");
     }

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestIdentityController.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestIdentityController.java
@@ -1,0 +1,37 @@
+package io.quarkus.undertow.test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TestIdentityController {
+
+    public static final Map<String, TestIdentity> idenitities = new ConcurrentHashMap<>();
+
+    public static Builder resetRoles() {
+        idenitities.clear();
+        return new Builder();
+    }
+
+    public static class Builder {
+        public Builder add(String username, String password, String... roles) {
+            idenitities.put(username, new TestIdentity(username, password, roles));
+            return this;
+        }
+    }
+
+    public static final class TestIdentity {
+
+        public final String username;
+        public final String password;
+        public final Set<String> roles;
+
+        private TestIdentity(String username, String password, String... roles) {
+            this.username = username;
+            this.password = password;
+            this.roles = new HashSet<>(Arrays.asList(roles));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -15,19 +15,34 @@ public final class RouteBuildItem extends MultiBuildItem {
     private final Function<Router, Route> routeFunction;
     private final Handler<RoutingContext> handler;
     private final HandlerType type;
+    private final boolean resume;
 
-    public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler, HandlerType type) {
+    public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler, HandlerType type,
+            boolean resume) {
         this.routeFunction = routeFunction;
         this.handler = handler;
         this.type = type;
+        this.resume = resume;
+    }
+
+    public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler, HandlerType type) {
+        this(routeFunction, handler, type, true);
     }
 
     public RouteBuildItem(Function<Router, Route> routeFunction, Handler<RoutingContext> handler) {
         this(routeFunction, handler, HandlerType.NORMAL);
     }
 
+    public RouteBuildItem(String route, Handler<RoutingContext> handler, HandlerType type, boolean resume) {
+        this(new BasicRoute(route), handler, type, resume);
+    }
+
     public RouteBuildItem(String route, Handler<RoutingContext> handler, HandlerType type) {
         this(new BasicRoute(route), handler, type);
+    }
+
+    public RouteBuildItem(String route, Handler<RoutingContext> handler, boolean resume) {
+        this(new BasicRoute(route), handler, HandlerType.NORMAL, resume);
     }
 
     public RouteBuildItem(String route, Handler<RoutingContext> handler) {
@@ -46,4 +61,7 @@ public final class RouteBuildItem extends MultiBuildItem {
         return routeFunction;
     }
 
+    public boolean isResume() {
+        return resume;
+    }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -91,7 +91,7 @@ class VertxHttpProcessor {
         RuntimeValue<Router> router = recorder.initializeRouter(vertx.getVertx(), launchModeBuildItem.getLaunchMode(),
                 shutdown);
         for (RouteBuildItem route : routes) {
-            recorder.addRoute(router, route.getRouteFunction(), route.getHandler(), route.getType());
+            recorder.addRoute(router, route.getRouteFunction(), route.getHandler(), route.getType(), route.isResume());
         }
 
         return new VertxWebRouterBuildItem(router);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -468,16 +468,20 @@ public class VertxHttpRecorder {
     }
 
     public void addRoute(RuntimeValue<Router> router, Function<Router, Route> route, Handler<RoutingContext> handler,
-            HandlerType blocking) {
+            HandlerType blocking, boolean resume) {
 
         Route vr = route.apply(router.getValue());
 
+        Handler<RoutingContext> requestHandler = handler;
+        if (resume) {
+            requestHandler = new ResumeHandler(handler);
+        }
         if (blocking == HandlerType.BLOCKING) {
-            vr.blockingHandler(new ResumeHandler(handler));
+            vr.blockingHandler(requestHandler);
         } else if (blocking == HandlerType.FAILURE) {
-            vr.failureHandler(new ResumeHandler(handler));
+            vr.failureHandler(requestHandler);
         } else {
-            vr.handler(new ResumeHandler(handler));
+            vr.handler(requestHandler);
         }
     }
 

--- a/integration-tests/elytron-undertow/src/main/resources/application.properties
+++ b/integration-tests/elytron-undertow/src/main/resources/application.properties
@@ -6,4 +6,4 @@ quarkus.security.users.embedded.roles.mary=managers
 quarkus.security.users.embedded.users.poul=poul
 quarkus.security.users.embedded.roles.poul=interns
 quarkus.security.users.embedded.plain-text=true
-
+quarkus.servlet.context-path=/foo

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthTest.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/BaseAuthTest.java
@@ -3,6 +3,7 @@ package io.quarkus.it.undertow.elytron;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -12,6 +13,7 @@ import io.restassured.http.ContentType;
 class BaseAuthTest {
 
     @Test
+    @RepeatedTest(100)
     void testPost() {
         // This is a regression test in that we had a problem where the Vert.x request was not paused
         // before the authentication filters ran and the post message was thrown away by Vert.x because
@@ -21,7 +23,7 @@ class BaseAuthTest {
                 .body("Bill")
                 .contentType(ContentType.TEXT)
                 .when()
-                .post("/")
+                .post("/foo/")
                 .then()
                 .statusCode(200)
                 .body(is("hello Bill"));
@@ -32,7 +34,7 @@ class BaseAuthTest {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/")
+                .get("/foo/")
                 .then()
                 .statusCode(200)
                 .body(is("hello"));

--- a/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/WebXmlPermissionsTestCase.java
+++ b/integration-tests/elytron-undertow/src/test/java/io/quarkus/it/undertow/elytron/WebXmlPermissionsTestCase.java
@@ -21,7 +21,7 @@ class WebXmlPermissionsTestCase {
                 .body("Bill")
                 .contentType(ContentType.TEXT)
                 .when()
-                .post("/")
+                .post("/foo/")
                 .then()
                 .statusCode(200)
                 .body(is("hello Bill"));
@@ -31,7 +31,7 @@ class WebXmlPermissionsTestCase {
     void testOpenApiNoPermissions() {
         given()
                 .when()
-                .get("/openapi")
+                .get("/foo/openapi")
                 .then()
                 .statusCode(401);
     }
@@ -41,7 +41,7 @@ class WebXmlPermissionsTestCase {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/openapi")
+                .get("/foo/openapi")
                 .then()
                 .statusCode(403);
     }
@@ -52,7 +52,7 @@ class WebXmlPermissionsTestCase {
                 .auth()
                 .basic("mary", "mary")
                 .when()
-                .get("/openapi")
+                .get("/foo/openapi")
                 .then()
                 .statusCode(200);
     }
@@ -62,7 +62,7 @@ class WebXmlPermissionsTestCase {
         given()
                 .header("Authorization", "Basic am9objpqb2hu")
                 .when()
-                .get("/secure/a")
+                .get("/foo/secure/a")
                 .then()
                 .statusCode(403);
     }
@@ -71,7 +71,7 @@ class WebXmlPermissionsTestCase {
     void testSecuredServletWithNoAuth() {
         given()
                 .when()
-                .get("/secure/a")
+                .get("/foo/secure/a")
                 .then()
                 .statusCode(401);
     }
@@ -82,7 +82,7 @@ class WebXmlPermissionsTestCase {
                 .auth()
                 .basic("mary", "mary")
                 .when()
-                .get("/secure/a")
+                .get("/foo/secure/a")
                 .then()
                 .statusCode(200);
     }


### PR DESCRIPTION
If the servlet context path is set then Undertow would be
registered using a RouteBuildItem instead of a DefaultRouteBuildItem.

This behaves differently in terms of resuming in the request,
so if both the context path was set and security was in use
the request body could disappear sometimes.