### PR TITLE
Update Vert.x version to 3.8.4

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -100,9 +100,7 @@
         <wildfly-elytron.version>2.0.0.Alpha4</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.0.Final</jboss-threads.version>
-        <vertx.version>3.8.3</vertx.version>
-        <!-- patch release of vert.x web -->
-        <vertx-web.version>3.8.3-01</vertx-web.version>
+        <vertx.version>3.8.4</vertx.version>
         <httpclient.version>4.5.10</httpclient.version>
         <httpcore.version>4.4.12</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>
@@ -1951,12 +1949,12 @@
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-web</artifactId>
-                <version>${vertx-web.version}</version>
+                <version>${vertx.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-web-common</artifactId>
-                <version>${vertx-web.version}</version>
+                <version>${vertx.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,7 +35,7 @@
         <graal-sdk.version-for-documentation>19.2.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>0.0.9</axle-client.version>
-        <vertx.version>3.8.3</vertx.version>
+        <vertx.version>3.8.4</vertx.version>
         <artemis.version>2.10.1</artemis.version>
 
         <!-- Dev tools -->


### PR DESCRIPTION
Also remove the patched Vert.x web version, it's now included in the 3.8.4.