### PR TITLE
Add hint support for Hibernate with Panache

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
@@ -123,6 +123,15 @@ public interface PanacheQuery<Entity> {
      */
     public <T extends Entity> PanacheQuery<T> withLock(LockModeType lockModeType);
 
+    /**
+     * Set a query property or hint on the underlying JPA Query.
+     *
+     * @param hintName name of the property or hint.
+     * @param value value for the property or hint.
+     * @return this query, modified
+     */
+    public <T extends Entity> PanacheQuery<T> withHint(String hintName, Object value);
+
     // Results
 
     /**

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -97,6 +97,12 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
         return (PanacheQuery<T>) this;
     }
 
+    @Override
+    public <T extends Entity> PanacheQuery<T> withHint(String hintName, Object value) {
+        jpaQuery.setHint(hintName, value);
+        return (PanacheQuery<T>) this;
+    }
+
     // Results
 
     @Override

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -18,6 +18,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.hibernate.engine.spi.SelfDirtinessTracker;
+import org.hibernate.jpa.QueryHints;
 import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
@@ -89,6 +90,11 @@ public class TestEndpoint {
         Assertions.assertEquals(person, persons.get(0));
 
         persons = Person.find("name = ?1", "stef").withLock(LockModeType.PESSIMISTIC_READ).list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+
+        // next calls to this query will be cached
+        persons = Person.find("name = ?1", "stef").withHint(QueryHints.HINT_CACHEABLE, "true").list();
         Assertions.assertEquals(1, persons.size());
         Assertions.assertEquals(person, persons.get(0));
 


### PR DESCRIPTION
Adds the `PanacheQuery.withHint(String, Object)` methods to allow setting hints with Hibernate with Panache.

Fixes #3482 maybe also #5613 (needs to be decided if we provides enhanced support to Query cache from Panache or not)