### PR TITLE
Generalize registration of jackson modules

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -389,4 +389,9 @@ One thing to note is that the live reload feature is not available when making c
 
 == Packaging the application
 
-As usual, the application can be packaged using `./mvnw clean package` and executed using the `-runner.jar` file. You can also build the native executable using `./mvnw package -Pnative`, or `./gradlew buildNative`.  
+As usual, the application can be packaged using `./mvnw clean package` and executed using the `-runner.jar` file. You can also build the native executable using `./mvnw package -Pnative`, or `./gradlew buildNative`.
+
+== Kotlin and Jackson
+
+If the `com.fasterxml.jackson.module:jackson-module-kotlin` dependency and the `quarkus-jackson` extension (or the `quarkus-resteasy-extension`) have been added to project,
+then Quarkus automatically registers the `KotlinModule` to the `ObjectMapper` bean (see link:rest-json#Jackson[this] guide for more details).

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/ObjectMapperProducer.java
@@ -6,9 +6,6 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import io.quarkus.arc.DefaultBean;
 
@@ -20,7 +17,6 @@ public class ObjectMapperProducer {
     @Produces
     public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers) {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModules(new Jdk8Module(), new JavaTimeModule(), new ParameterNamesModule());
         for (ObjectMapperCustomizer customizer : customizers) {
             customizer.customize(objectMapper);
         }

--- a/extensions/jackson/spi/src/main/java/io/quarkus/jackson/spi/ClassPathJacksonModuleBuildItem.java
+++ b/extensions/jackson/spi/src/main/java/io/quarkus/jackson/spi/ClassPathJacksonModuleBuildItem.java
@@ -1,0 +1,23 @@
+package io.quarkus.jackson.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * BuildItem used to signal that some Jackson module has been detected on the classpath
+ *
+ * The modules are then registered with the ObjectMapper.
+ *
+ * Note: Modules are assumed to have a default constructor
+ */
+public final class ClassPathJacksonModuleBuildItem extends MultiBuildItem {
+
+    private final String moduleClassName;
+
+    public ClassPathJacksonModuleBuildItem(String moduleClassName) {
+        this.moduleClassName = moduleClassName;
+    }
+
+    public String getModuleClassName() {
+        return moduleClassName;
+    }
+}

--- a/extensions/kotlin/deployment/pom.xml
+++ b/extensions/kotlin/deployment/pom.xml
@@ -19,6 +19,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kotlin</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-spi</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
@@ -1,12 +1,30 @@
 package io.quarkus.kotlin.deployment;
 
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 
 public class KotlinProcessor {
+
+    private static final String KOTLIN_JACKSON_MODULE = "com.fasterxml.jackson.module.kotlin.KotlinModule";
 
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.KOTLIN);
+    }
+
+    /*
+     * Register the Kotlin Jackson module if that has been added to the classpath
+     * Producing the BuildItem is entirely safe since if quarkus-jackson is not on the classpath
+     * the BuildItem will just be ignored
+     */
+    @BuildStep
+    void registerKotlinJacksonModule(BuildProducer<ClassPathJacksonModuleBuildItem> classPathJacksonModules) {
+        try {
+            Class.forName(KOTLIN_JACKSON_MODULE, false, Thread.currentThread().getContextClassLoader());
+            classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(KOTLIN_JACKSON_MODULE));
+        } catch (Exception ignored) {
+        }
     }
 }

--- a/extensions/scala/deployment/pom.xml
+++ b/extensions/scala/deployment/pom.xml
@@ -19,6 +19,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scala</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-spi</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/scala/deployment/src/main/java/io/quarkus/scala/deployment/ScalaProcessor.java
+++ b/extensions/scala/deployment/src/main/java/io/quarkus/scala/deployment/ScalaProcessor.java
@@ -1,12 +1,30 @@
 package io.quarkus.scala.deployment;
 
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 
 public class ScalaProcessor {
+
+    private static final String SCALA_JACKSON_MODULE = "com.fasterxml.jackson.module.scala.DefaultScalaModule";
 
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.SCALA);
+    }
+
+    /*
+     * Register the Scala Jackson module if that has been added to the classpath
+     * Producing the BuildItem is entirely safe since if quarkus-jackson is not on the classpath
+     * the BuildItem will just be ignored
+     */
+    @BuildStep
+    void registerScalaJacksonModule(BuildProducer<ClassPathJacksonModuleBuildItem> classPathJacksonModules) {
+        try {
+            Class.forName(SCALA_JACKSON_MODULE, false, Thread.currentThread().getContextClassLoader());
+            classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(SCALA_JACKSON_MODULE));
+        } catch (Exception ignored) {
+        }
     }
 }

--- a/integration-tests/jackson/model/pom.xml
+++ b/integration-tests/jackson/model/pom.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-arc</artifactId>
         </dependency>
 
         <!-- SLF4J -->
@@ -56,14 +56,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <dependency>

--- a/integration-tests/jackson/model/src/main/java/io/quarkus/reproducer/jacksonbuilder/model/InheritedModelWithBuilderBase.java
+++ b/integration-tests/jackson/model/src/main/java/io/quarkus/reproducer/jacksonbuilder/model/InheritedModelWithBuilderBase.java
@@ -2,14 +2,10 @@ package io.quarkus.reproducer.jacksonbuilder.model;
 
 import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import io.quarkus.arc.Arc;
 
 /**
  * Model class with inheritance and builder.
@@ -98,18 +94,7 @@ abstract class InheritedModelWithBuilderBase {
     // -------------------------------------------------------------------------
 
     protected static ObjectMapper getObjectMapper() {
-        if (null == objectMapper) {
-            objectMapper = new ObjectMapper()
-                    .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-                    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                    .configure(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS, false)
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
-                    .registerModule(new ParameterNamesModule())
-                    .registerModule(new Jdk8Module())
-                    .registerModule(new JavaTimeModule());
-        }
-        return objectMapper;
+        return Arc.container().instance(ObjectMapper.class).get();
     }
 
 }

--- a/integration-tests/jackson/model/src/main/java/io/quarkus/reproducer/jacksonbuilder/model/ModelWithBuilder.java
+++ b/integration-tests/jackson/model/src/main/java/io/quarkus/reproducer/jacksonbuilder/model/ModelWithBuilder.java
@@ -2,17 +2,13 @@ package io.quarkus.reproducer.jacksonbuilder.model;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import io.quarkus.arc.Arc;
 
 /**
  * Simple model class.
@@ -136,18 +132,7 @@ public class ModelWithBuilder {
     // -------------------------------------------------------------------------
 
     private static ObjectMapper getObjectMapper() {
-        if (null == objectMapper) {
-            objectMapper = new ObjectMapper()
-                    .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-                    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                    .configure(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS, false)
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
-                    .registerModule(new ParameterNamesModule())
-                    .registerModule(new Jdk8Module())
-                    .registerModule(new JavaTimeModule());
-        }
-        return objectMapper;
+        return Arc.container().instance(ObjectMapper.class).get();
     }
 
 }

--- a/integration-tests/jackson/model/src/main/java/io/quarkus/reproducer/jacksonbuilder/model/RegisteredPojoModel.java
+++ b/integration-tests/jackson/model/src/main/java/io/quarkus/reproducer/jacksonbuilder/model/RegisteredPojoModel.java
@@ -2,14 +2,9 @@ package io.quarkus.reproducer.jacksonbuilder.model;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
@@ -89,18 +84,7 @@ public class RegisteredPojoModel {
     // -------------------------------------------------------------------------
 
     private static ObjectMapper getObjectMapper() {
-        if (null == objectMapper) {
-            objectMapper = new ObjectMapper()
-                    .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-                    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                    .configure(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS, false)
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
-                    .registerModule(new ParameterNamesModule())
-                    .registerModule(new Jdk8Module())
-                    .registerModule(new JavaTimeModule());
-        }
-        return objectMapper;
+        return Arc.container().instance(ObjectMapper.class).get();
     }
 
 }

--- a/integration-tests/jackson/service/pom.xml
+++ b/integration-tests/jackson/service/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/jackson/service/src/main/java/io/quarkus/reproducer/MyObjectMapperCustomizer.java
+++ b/integration-tests/jackson/service/src/main/java/io/quarkus/reproducer/MyObjectMapperCustomizer.java
@@ -1,0 +1,23 @@
+package io.quarkus.reproducer;
+
+import javax.inject.Singleton;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class MyObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS, false)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+    }
+}

--- a/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/ObjectMapperModulesTest.java
+++ b/integration-tests/jackson/service/src/test/java/io/quarkus/reproducer/ObjectMapperModulesTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.reproducer;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ObjectMapperModulesTest {
+
+    private static final Object JDK8_MODULE_TYPE_ID = new Jdk8Module().getTypeId();
+    private static final Object JAVA_TIME_MODULE_TYPE_ID = new JavaTimeModule().getTypeId();
+    private static final Object PARAMETER_NAMES_MODULE_TYPE_ID = new ParameterNamesModule().getTypeId();
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testExpectedModulesAreRegistered() {
+        assertThat(objectMapper.getRegisteredModuleIds())
+                .contains(JDK8_MODULE_TYPE_ID, JAVA_TIME_MODULE_TYPE_ID, PARAMETER_NAMES_MODULE_TYPE_ID);
+    }
+}


### PR DESCRIPTION
This change makes use of the generated `ObjectMapperCustomizer` in order to allow auto-registration of discovered Jackson modules (thus removing the need of hard-coding the modules in the bean producer).

I initially got the idea for this by looking at #5860 but it's more general.