### PR TITLE
Update Dockerfile config for minimal-quarkus-quickstart-native

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i.adoc
@@ -90,8 +90,8 @@ The following command will create a chained build that is triggered whenever the
 oc new-build --name=minimal-quarkus-quickstart-native \
     --docker-image=registry.access.redhat.com/ubi7-dev-preview/ubi-minimal \
     --source-image=quarkus-quickstart-native \
-    --source-image-path='/home/quarkus/quarkus-quickstart-1.0-SNAPSHOT-runner:.' \
-    --dockerfile=$'FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest\nCOPY *-runner /application\nCMD /application\nEXPOSE 8080' \
+    --source-image-path='/home/quarkus/application:.' \
+    --dockerfile=$'FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest\nCOPY application /application\nCMD /application\nEXPOSE 8080'
 ----
 
 To create a service from the minimal build run the following command:


### PR DESCRIPTION
quarkus-quickstart-native build now results in the compiled app as /home/quarkus/application and now the Dockerfile for the minimal-quarkus-quickstart-native is updated accordingly