### PR TITLE
Remove the unused property minLevel from CategoryConfig

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryConfig.java
@@ -7,12 +7,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class CategoryConfig {
 
     /**
-     * The minimum level that this category can be set to
-     */
-    @ConfigItem(defaultValue = "inherit")
-    String minLevel;
-
-    /**
      * The log level level for this category
      */
     @ConfigItem(defaultValue = "inherit")


### PR DESCRIPTION
This change was already part of PR https://github.com/quarkusio/quarkus/pull/5861 but is a separate one as proposed by @dmlloyd .