### PR TITLE
Feature/create artemis test module

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -302,6 +302,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-artemis</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-artemis-jms</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/integration-tests/artemis-core/pom.xml
+++ b/integration-tests/artemis-core/pom.xml
@@ -29,6 +29,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-artemis-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-artemis</artifactId>
+        </dependency>
 
         <!-- Health check -->
         <dependency>

--- a/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisConsumerTest.java
+++ b/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisConsumerTest.java
@@ -7,6 +7,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.artemis.test.ArtemisTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;

--- a/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
+++ b/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.artemis.test.ArtemisTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;

--- a/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisProducerTest.java
+++ b/integration-tests/artemis-core/src/test/java/io/quarkus/it/artemis/ArtemisProducerTest.java
@@ -7,6 +7,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.artemis.test.ArtemisTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;

--- a/integration-tests/artemis-jms/pom.xml
+++ b/integration-tests/artemis-jms/pom.xml
@@ -29,6 +29,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-artemis</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Health check -->
         <dependency>

--- a/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisConsumerTest.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisConsumerTest.java
@@ -6,6 +6,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.artemis.test.ArtemisTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;

--- a/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisHealthCheckTest.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.artemis.test.ArtemisTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;

--- a/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisProducerTest.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkus/it/artemis/ArtemisProducerTest.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.artemis.test.ArtemisTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;

--- a/test-framework/artemis-test/pom.xml
+++ b/test-framework/artemis-test/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>quarkus-test-artemis</artifactId>
+    <name>Quarkus - Artemis - Test</name>
+    <description>Module that will hold all tests resources that can will be usable by Quarkus developers and users of the framework
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <version>${artemis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-json_1.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.johnzon</groupId>
+                    <artifactId>johnzon-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-framework/artemis-test/src/main/java/io/quarkus/artemis/test/ArtemisTestResource.java
+++ b/test-framework/artemis-test/src/main/java/io/quarkus/artemis/test/ArtemisTestResource.java
@@ -1,0 +1,36 @@
+package io.quarkus.artemis.test;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.commons.io.FileUtils;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class ArtemisTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private EmbeddedActiveMQ embedded;
+
+    @Override
+    public Map<String, String> start() {
+        try {
+            FileUtils.deleteDirectory(Paths.get("./target/artemis").toFile());
+            embedded = new EmbeddedActiveMQ();
+            embedded.start();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not start embedded ActiveMQ server", e);
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        try {
+            embedded.stop();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not stop embedded ActiveMQ server", e);
+        }
+    }
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -14,6 +14,7 @@
     <name>Quarkus - Test Framework</name>
     <packaging>pom</packaging>
     <modules>
+        <module>artemis-test</module>
         <module>common</module>
         <module>h2</module>
         <module>derby</module>


### PR DESCRIPTION
Fixes #3833
The idea of this pr is:
1) create the test module with ArtemisResourceTest
1) expose it to be used by the developers that use Quarkus
1) replace integration tests that used the test class