### PR TITLE
Ensure that type of annotation is a Class when resolving custom stereotypes usage

### DIFF
--- a/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
+++ b/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
@@ -129,7 +129,8 @@ public class SpringDIProcessor {
         for (final DotName name : stereotypeScopes.keySet()) {
             instances.put(name, index.getAnnotations(name)
                     .stream()
-                    .filter(it -> isAnnotation(it.target().asClass().flags()))
+                    .filter(it -> it.target().kind() == AnnotationTarget.Kind.CLASS
+                            && isAnnotation(it.target().asClass().flags()))
                     .collect(Collectors.toSet()));
         }
         additionalStereotypeBuildItemBuildProducer.produce(new AdditionalStereotypeBuildItem(instances));

--- a/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/AppConfiguration.java
+++ b/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/AppConfiguration.java
@@ -33,11 +33,21 @@ public class AppConfiguration {
         return new AnotherRequestBean();
     }
 
+    @Bean
+    @CustomPrototype
+    public CustomPrototypeBean beanWithCustomPrototype() {
+        return new CustomPrototypeBean();
+    }
+
     private static class SingletonBean {
 
     }
 
     private static class AnotherRequestBean {
+
+    }
+
+    public static class CustomPrototypeBean {
 
     }
 }

--- a/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/CustomPrototype.java
+++ b/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/CustomPrototype.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.spring;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Scope("prototype")
+public @interface CustomPrototype {
+}

--- a/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/InjectedSpringBeansResource.java
+++ b/integration-tests/spring-di/src/main/java/io/quarkus/it/spring/InjectedSpringBeansResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.spring;
 
+import static io.quarkus.it.spring.AppConfiguration.CustomPrototypeBean;
+
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
@@ -18,6 +20,8 @@ public class InjectedSpringBeansResource {
     RequestBean requestBean;
     @Inject
     SessionBean sessionBean;
+    @Inject
+    CustomPrototypeBean anotherRequestBean;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)


### PR DESCRIPTION
Fixes  #5910

When resolving **custom** stereotype annotation used by other annotations (probable usage is to cascade creation of stereotypes) the logic need to filter out Spring's bean creation methods used in @Configuration class, because they are ... methods.

This PR contains : 
- a simple proposal fix that matches, to me, the underlying logic
- an integration test validating the behavior

