### PR TITLE
Make hot deployment work reliably for newly added resources in QuarkusDevModeTest

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NotFoundExceptionMapperTestCase.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/NotFoundExceptionMapperTestCase.java
@@ -7,7 +7,6 @@ import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -54,9 +53,8 @@ public class NotFoundExceptionMapperTestCase {
                 .contentType(ContentType.JSON);
     }
 
-    @Disabled("https://github.com/quarkusio/quarkus/issues/5424")
     @Test
-    public void shouldDisplayNewAddedFileIn404ErrorPage() throws InterruptedException {
+    public void shouldDisplayNewAddedFileIn404ErrorPage() {
         String CONTENT = "html content";
         test.addResourceFile(META_INF_RESOURCES + "index2.html", CONTENT);
 
@@ -74,9 +72,8 @@ public class NotFoundExceptionMapperTestCase {
                 .body(containsString("index2.html")); // check that index2.html is displayed
     }
 
-    @Disabled("https://github.com/quarkusio/quarkus/issues/5424")
     @Test
-    public void shouldNotDisplayDeletedFileIn404ErrorPage() throws InterruptedException {
+    public void shouldNotDisplayDeletedFileIn404ErrorPage() {
         String TEST_CONTENT = "test html content";
         test.addResourceFile(META_INF_RESOURCES + "test.html", TEST_CONTENT);
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -310,6 +310,8 @@ public class QuarkusDevModeTest
         Path path = copySourceFilesForClass(projectSourceRoot, deploymentSourcePath, testLocation,
                 testLocation.resolve(sourceFile.getName().replace(".", "/") + ".class"));
         sleepForFileChanges(path);
+        // since this is a new file addition, even wait for the parent dir's last modified timestamp to change
+        sleepForFileChanges(path.getParent());
     }
 
     void modifyFile(String name, Function<String, String> mutator, Path path) {
@@ -384,11 +386,15 @@ public class QuarkusDevModeTest
      * the deployment resources directory
      */
     public void addResourceFile(String path, byte[] data) {
+        final Path resourceFilePath = deploymentResourcePath.resolve(path);
         try {
-            Files.write(deploymentResourcePath.resolve(path), data);
+            Files.write(resourceFilePath, data);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        sleepForFileChanges(resourceFilePath);
+        // since this is a new file addition, even wait for the parent dir's last modified timestamp to change
+        sleepForFileChanges(resourceFilePath.getParent());
     }
 
     /**
@@ -396,11 +402,14 @@ public class QuarkusDevModeTest
      * the deployment resources directory
      */
     public void deleteResourceFile(String path) {
+        final Path resourceFilePath = deploymentResourcePath.resolve(path);
         try {
-            Files.delete(deploymentResourcePath.resolve(path));
+            Files.delete(resourceFilePath);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        // wait for last modified time of the parent to get updated
+        sleepForFileChanges(resourceFilePath.getParent());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/5424

The `QuarkusDevModeTest` is currently equipped to deal with _modifying_  existing files to trigger hot deployment reliably. It does so by dealing with last modification timestamps on files through https://github.com/quarkusio/quarkus/blob/master/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java#L341 where it internally waits for the file timestamps to change, before letting the test execution to proceed. This `sleepForFileChanges` is currently getting called from within the `QuarkusDevModeTest` whenever a "modification" API (on that class) is being called. However, this `sleepForFileChanges` is missing when new resources get added to the application. As a result, the test framework doesn't wait for enough amount of time before letting the test proceed. This ultimately causes Quarkus hot deployment process to get triggered (through the test case), with the "old" file timestamp on the directories containing this newly added resource. As a result, the directory where this new resource was added isn't considered as a hot deployment change.

The commit here fixes this issue by calling the `sleepForFileChanges` in the test framework whenever a new resource gets added.

I have also re-enabled the 2 `@Disabled` test methods in `NotFoundExceptionMapperTestCase` since they should now pass consistently. I had used `@RepeatedTest(5)` on these 2 test methods to locally reproduce this issue and then verify the fix. I could reproduce that issue locally without this fix and now with this fix the tests consistently pass.