### PR TITLE
Format profile - activeByDefault removal, keeping just no-format property

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -369,7 +369,6 @@
         <profile>
             <id>format</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>!no-format</name>
                 </property>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -339,7 +339,6 @@
         <profile>
             <id>format</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>!no-format</name>
                 </property>


### PR DESCRIPTION
Format profile - `activeByDefault` removal, keeping just `no-format` property.

`activeByDefault` behavior already achieved by default via `!no-format` activation property.
