### PR TITLE
Fix minor formatting issue in Qute documentation

### DIFF
--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -79,10 +79,10 @@ public class HelloResource {
 If your application is running, you can request the endpoint:
 
 [source, shell]
-```
+----
 $ curl -w "\n" http://localhost:8080/hello?name=Martin
 Hello Martin!
-```
+----
 
 == Parameter Declarations and Template Extension Methods
 


### PR DESCRIPTION
@mkouba I noticed a warning while rendering the documentation. You might already have fixed it in your version if you're working on the doc so feel free to dismiss if it conflicts with your work.