### PR TITLE
Move to RUNTIME_INIT all security related build items

### DIFF
--- a/extensions/elytron-security-jdbc/deployment/src/main/java/io/quarkus/elytron/security/jdbc/deployment/ElytronSecurityJdbcProcessor.java
+++ b/extensions/elytron-security-jdbc/deployment/src/main/java/io/quarkus/elytron/security/jdbc/deployment/ElytronSecurityJdbcProcessor.java
@@ -46,7 +46,7 @@ class ElytronSecurityJdbcProcessor {
      * @throws Exception - on any failure
      */
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void configureJdbcRealmAuthConfig(JdbcRecorder recorder,
             BuildProducer<SecurityRealmBuildItem> securityRealm,
             BeanContainerBuildItem beanContainerBuildItem, //we need this to make sure ArC is initialized

--- a/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
+++ b/extensions/elytron-security-oauth2/deployment/src/main/java/io/quarkus/elytron/security/oauth2/deployment/OAuth2DeploymentProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.elytron.security.oauth2.deployment;
 
-import java.util.function.Supplier;
-
 import javax.enterprise.context.ApplicationScoped;
 
 import org.wildfly.security.auth.server.SecurityRealm;
@@ -60,7 +58,7 @@ class OAuth2DeploymentProcessor {
      * @throws Exception - on any failure
      */
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     AdditionalBeanBuildItem configureOauth2RealmAuthConfig(OAuth2Recorder recorder,
             BuildProducer<SecurityRealmBuildItem> securityRealm) throws Exception {
         if (oauth2.enabled) {
@@ -84,7 +82,7 @@ class OAuth2DeploymentProcessor {
     RuntimeBeanBuildItem augmentor(OAuth2Recorder recorder) {
         return RuntimeBeanBuildItem.builder(SecurityIdentityAugmentor.class)
                 .setScope(ApplicationScoped.class)
-                .setSupplier((Supplier) recorder.augmentor(oauth2))
+                .setRuntimeValue(recorder.augmentor(oauth2))
                 .setRemovable(false)
                 .build();
     }

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2Recorder.java
@@ -13,7 +13,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -85,13 +84,8 @@ public class OAuth2Recorder {
         }
     }
 
-    public Supplier<OAuth2Augmentor> augmentor(OAuth2Config config) {
-        return new Supplier<OAuth2Augmentor>() {
-            @Override
-            public OAuth2Augmentor get() {
-                return new OAuth2Augmentor(config.roleClaim);
-            }
-        };
+    public RuntimeValue<OAuth2Augmentor> augmentor(OAuth2Config config) {
+        return new RuntimeValue<>(new OAuth2Augmentor(config.roleClaim));
     }
 
 }

--- a/extensions/elytron-security/deployment/src/main/java/io/quarkus/elytron/security/deployment/ElytronDeploymentProcessor.java
+++ b/extensions/elytron-security/deployment/src/main/java/io/quarkus/elytron/security/deployment/ElytronDeploymentProcessor.java
@@ -75,7 +75,7 @@ class ElytronDeploymentProcessor {
      * @throws Exception
      */
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     SecurityDomainBuildItem build(ElytronRecorder recorder, List<SecurityRealmBuildItem> realms)
             throws Exception {
         if (realms.size() > 0) {
@@ -105,7 +105,7 @@ class ElytronDeploymentProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void identityManager(ElytronRecorder recorder, SecurityDomainBuildItem securityDomain, BeanContainerBuildItem bc) {
         if (securityDomain != null) {
             recorder.setDomainForIdentityProvider(bc.getValue(), securityDomain.getSecurityDomain());


### PR DESCRIPTION
Security configuration should be overritable at runtime as it vastly depends on the environement you run inside.

This PR will move the configuration of Oauth2, JDBC and properties file from STATIC to RUNTIME so that native images can override them at runtime like JVM mode does.