### PR TITLE
Use ApplicationScoped for Artemis ServerLocator and ConnectionFactory

### DIFF
--- a/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreConfiguredBuildItem.java
+++ b/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreConfiguredBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.artemis.core.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker build item indicating that Artemis Core is configured
+ */
+public final class ArtemisCoreConfiguredBuildItem extends SimpleBuildItem {
+}

--- a/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
+++ b/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
@@ -103,12 +103,13 @@ public class ArtemisCoreProcessor {
 
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    void configure(ArtemisCoreRecorder recorder, ArtemisRuntimeConfig runtimeConfig,
+    ArtemisCoreConfiguredBuildItem configure(ArtemisCoreRecorder recorder, ArtemisRuntimeConfig runtimeConfig,
             BeanContainerBuildItem beanContainer, Optional<ArtemisJmsBuildItem> artemisJms) {
 
         if (artemisJms.isPresent()) {
-            return;
+            return null;
         }
         recorder.setConfig(runtimeConfig, beanContainer.getValue());
+        return new ArtemisCoreConfiguredBuildItem();
     }
 }

--- a/extensions/artemis-core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisCoreProducer.java
+++ b/extensions/artemis-core/runtime/src/main/java/io/quarkus/artemis/core/runtime/ArtemisCoreProducer.java
@@ -6,13 +6,17 @@ import javax.enterprise.inject.Produces;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 
+import io.quarkus.arc.DefaultBean;
+
 @ApplicationScoped
 public class ArtemisCoreProducer {
 
     private ArtemisRuntimeConfig config;
 
     @Produces
-    public ServerLocator produceServerLocator() throws Exception {
+    @ApplicationScoped
+    @DefaultBean
+    public ServerLocator serverLocator() throws Exception {
         return ActiveMQClient.createServerLocator(config.url);
     }
 

--- a/extensions/artemis-jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsConfiguredBuildItem.java
+++ b/extensions/artemis-jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsConfiguredBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.artemis.jms.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker build item indicating that Artemis JMS is configured
+ */
+public final class ArtemisJmsConfiguredBuildItem extends SimpleBuildItem {
+}

--- a/extensions/artemis-jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
+++ b/extensions/artemis-jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
@@ -34,9 +34,10 @@ public class ArtemisJmsProcessor {
 
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    void configure(ArtemisJmsRecorder recorder, ArtemisRuntimeConfig runtimeConfig,
+    ArtemisJmsConfiguredBuildItem configure(ArtemisJmsRecorder recorder, ArtemisRuntimeConfig runtimeConfig,
             BeanContainerBuildItem beanContainer) {
 
         recorder.setConfig(runtimeConfig, beanContainer.getValue());
+        return new ArtemisJmsConfiguredBuildItem();
     }
 }

--- a/extensions/artemis-jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsProducer.java
+++ b/extensions/artemis-jms/runtime/src/main/java/io/quarkus/artemis/jms/runtime/ArtemisJmsProducer.java
@@ -6,6 +6,7 @@ import javax.jms.ConnectionFactory;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 
+import io.quarkus.arc.DefaultBean;
 import io.quarkus.artemis.core.runtime.ArtemisRuntimeConfig;
 
 @ApplicationScoped
@@ -14,7 +15,9 @@ public class ArtemisJmsProducer {
     private ArtemisRuntimeConfig config;
 
     @Produces
-    public ConnectionFactory producesConnectionFactory() {
+    @ApplicationScoped
+    @DefaultBean
+    public ConnectionFactory connectionFactory() {
         return new ActiveMQJMSConnectionFactory(config.url,
                 config.username.orElse(null), config.password.orElse(null));
     }

--- a/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
+++ b/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
@@ -199,7 +199,7 @@ public class SpringDIProcessor {
      *
      * @param target The annotated element declaring the @Scope
      * @return A CDI built in (or session) scope that mostly matches
-     *         the spring one. Websocket scope is currently mapped to @Dependant
+     *         the spring one. Websocket scope is currently mapped to @Dependent
      *         and spring custom scopes are not currently handled.
      */
     private DotName getScope(final AnnotationTarget target) {
@@ -270,7 +270,7 @@ public class SpringDIProcessor {
 
     /**
      * Map spring annotations from an annotated class to equivalent CDI annotations
-     * 
+     *
      * @param target The annotated class
      * @param stereotypeScopes A map on spring stereotype classes to all the scopes
      *        they, or any of their stereotypes (etc) declare
@@ -547,7 +547,7 @@ public class SpringDIProcessor {
     /**
      * Get a single scope from the available options or throw a {@link DefinitionException} explaining
      * where the annotations conflict.
-     * 
+     *
      * @param clazz The class annotated with the scopes
      * @param scopes The scopes from the class and its stereotypes
      * @param scopeStereotypes The stereotype annotations that declared the conflicting scopes
@@ -574,7 +574,7 @@ public class SpringDIProcessor {
 
     /**
      * Get the name of a bean or throw a {@link DefinitionException} if it has more than one name
-     * 
+     *
      * @param clazz The class annotated with the names
      * @param names The names
      * @return The bane name


### PR DESCRIPTION
If no scope is used on a Produces method, it defaults to Dependent, which is probably not the best for the ConnectionFactory and ServerLocator.