### PR TITLE
Document new requirements to build on Fedora

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -37,7 +37,7 @@ What does having a working C developer environment mean?
 [source,shell]
 ----
 # dnf (rpm-based)
-sudo dnf install gcc glibc-devel zlib-devel
+sudo dnf install gcc glibc-devel zlib-devel libstdc++-static
 # Debian-based distributions:
 sudo apt-get install build-essential libz-dev zlib1g-dev
 ----


### PR DESCRIPTION

Since the update to GraalVM 19.3, at least on Fedora one also needs to install `libstdc++-static`.

No idea about Debian - I guess someone else will figure that one out :)

