### PR TITLE
Upgrade to Hibernate ORM 5.4.10.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -82,7 +82,7 @@
         <commons-codec.version>1.13</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-validator.version>6.1.0.Final</hibernate-validator.version>
-        <hibernate-orm.version>5.4.9.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.10.Final</hibernate-orm.version>
         <hibernate-search.version>6.0.0.Beta2</hibernate-search.version>
         <narayana.version>5.10.0.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>


### PR DESCRIPTION
Upgrade to Hibernate ORM 5.4.10.Final

Doesn't map directly to any of the reported issues on Quarkus, but it does fix some important issues.