### PR TITLE
update directory for kotlin guide maven archetype

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -41,7 +41,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DclassName="org.acme.rest.GreetingResource" \
     -Dpath="/greeting" \
     -Dextensions="kotlin,resteasy-jsonb"
-cd kotlin-quickstart
+cd rest-kotlin-quickstart
 ----
 
 When adding `kotlin` to the extensions list, the Maven plugin will generate a project that is properly


### PR DESCRIPTION
Updating the directory to make the one generated by the archetype.

Also worth noting that I could not get the CDI inject example working, even when adding `<option>all-open:annotation=javax.enterprise.context.ApplicationScoped</option>`. I was getting errors about `GreetingService` being marked as final, which I thought that maven switch would fix. I chose to give up on it.