### PR TITLE
Use Vert.x BodyHandler

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -24,7 +24,7 @@
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
         <jaeger.version>0.34.0</jaeger.version>
-        <quarkus-http.version>3.0.0.Final</quarkus-http.version>
+        <quarkus-http.version>3.0.1.Final</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.3</microprofile-config-api.version>
         <microprofile-context-propagation.version>1.0.1</microprofile-context-propagation.version>

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerConfig.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerConfig.java
@@ -41,13 +41,13 @@ public class KeycloakPolicyEnforcerConfig {
          * Specifies how policies are enforced.
          */
         @ConfigItem(defaultValue = "ENFORCING")
-        String enforcementMode;
+        public String enforcementMode;
 
         /**
          * Specifies the paths to protect.
          */
         @ConfigItem
-        Map<String, PathConfig> paths;
+        public Map<String, PathConfig> paths;
 
         /**
          * Defines how the policy enforcer should track associations between paths in your application and resources defined in
@@ -56,7 +56,7 @@ public class KeycloakPolicyEnforcerConfig {
          * protected resources
          */
         @ConfigItem
-        PathCacheConfig pathCache;
+        public PathCacheConfig pathCache;
 
         /**
          * Specifies how the adapter should fetch the server for resources associated with paths in your application. If true,
@@ -65,14 +65,14 @@ public class KeycloakPolicyEnforcerConfig {
          * enforcer is going to fetch resources on-demand accordingly with the path being requested
          */
         @ConfigItem(defaultValue = "true")
-        boolean lazyLoadPaths;
+        public boolean lazyLoadPaths;
 
         /**
          * Defines a set of one or more claims that must be resolved and pushed to the Keycloak server in order to make these
          * claims available to policies
          */
         @ConfigItem
-        ClaimInformationPointConfig claimInformationPoint;
+        public ClaimInformationPointConfig claimInformationPoint;
 
         /**
          * Specifies how scopes should be mapped to HTTP methods. If set to true, the policy enforcer will use the HTTP method
@@ -80,7 +80,7 @@ public class KeycloakPolicyEnforcerConfig {
          * the current request to check whether or not access should be granted
          */
         @ConfigItem
-        boolean httpMethodAsScope;
+        public boolean httpMethodAsScope;
 
         @ConfigGroup
         public static class PathConfig {
@@ -89,13 +89,13 @@ public class KeycloakPolicyEnforcerConfig {
              * The name of a resource on the server that is to be associated with a given path
              */
             @ConfigItem
-            Optional<String> name;
+            public Optional<String> name;
 
             /**
              * A URI relative to the application’s context path that should be protected by the policy enforcer
              */
             @ConfigItem
-            Optional<String> path;
+            public Optional<String> path;
 
             /**
              * The HTTP methods (for example, GET, POST, PATCH) to protect and how they are associated with the scopes for a
@@ -103,14 +103,14 @@ public class KeycloakPolicyEnforcerConfig {
              * resource in the server
              */
             @ConfigItem
-            Map<String, MethodConfig> methods;
+            public Map<String, MethodConfig> methods;
 
             /**
              * Specifies how policies are enforced
              */
             @DefaultConverter
             @ConfigItem(defaultValue = "ENFORCING")
-            PolicyEnforcerConfig.EnforcementMode enforcementMode;
+            public PolicyEnforcerConfig.EnforcementMode enforcementMode;
 
             /**
              * Defines a set of one or more claims that must be resolved and pushed to the Keycloak server in order to make
@@ -118,7 +118,7 @@ public class KeycloakPolicyEnforcerConfig {
              * claims available to policies
              */
             @ConfigItem
-            ClaimInformationPointConfig claimInformationPoint;
+            public ClaimInformationPointConfig claimInformationPoint;
         }
 
         @ConfigGroup
@@ -128,20 +128,20 @@ public class KeycloakPolicyEnforcerConfig {
              * The name of the HTTP method
              */
             @ConfigItem
-            String method;
+            public String method;
 
             /**
              * An array of strings with the scopes associated with the method
              */
             @ConfigItem
-            List<String> scopes;
+            public List<String> scopes;
 
             /**
              * A string referencing the enforcement mode for the scopes associated with a method
              */
             @DefaultConverter
             @ConfigItem(defaultValue = "ALL")
-            PolicyEnforcerConfig.ScopeEnforcementMode scopesEnforcementMode;
+            public PolicyEnforcerConfig.ScopeEnforcementMode scopesEnforcementMode;
         }
 
         @ConfigGroup
@@ -151,13 +151,13 @@ public class KeycloakPolicyEnforcerConfig {
              * Defines the time in milliseconds when the entry should be expired
              */
             @ConfigItem(defaultValue = "1000")
-            int maxEntries = 1000;
+            public int maxEntries = 1000;
 
             /**
              * Defines the limit of entries that should be kept in the cache
              */
             @ConfigItem(defaultValue = "30000")
-            long lifespan = 30000;
+            public long lifespan = 30000;
         }
 
         @ConfigGroup
@@ -167,13 +167,13 @@ public class KeycloakPolicyEnforcerConfig {
              *
              */
             @ConfigItem(name = ConfigItem.PARENT)
-            Map<String, Map<String, Map<String, String>>> complexConfig;
+            public Map<String, Map<String, Map<String, String>>> complexConfig;
 
             /**
              *
              */
             @ConfigItem(name = ConfigItem.PARENT)
-            Map<String, Map<String, String>> simpleConfig;
+            public Map<String, Map<String, String>> simpleConfig;
         }
     }
 }

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.runtime.standalone;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -7,7 +8,6 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.core.SecurityContext;
 
-import io.quarkus.vertx.http.runtime.VertxInputStream;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.core.SynchronousDispatcher;
@@ -20,6 +20,7 @@ import io.quarkus.arc.ManagedContext;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.quarkus.vertx.http.runtime.VertxInputStream;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -64,9 +65,8 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
         // otherwise request handlers may not get set up before request ends
         InputStream is;
         try {
-            if (request.get("quarkus.request.inputstream") != null) {
-                is = request.get("quarkus.request.inputstream");
-                is.mark(0);
+            if (request.getBody() != null) {
+                is = new ByteArrayInputStream(request.getBody().getBytes());
             } else {
                 is = new VertxInputStream(request.request());
             }

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxRequestHandler.java
@@ -7,6 +7,7 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.core.SecurityContext;
 
+import io.quarkus.vertx.http.runtime.VertxInputStream;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.core.SynchronousDispatcher;
@@ -61,9 +62,14 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext request) {
         // have to create input stream here.  Cannot execute in another thread
         // otherwise request handlers may not get set up before request ends
-        VertxInputStream is;
+        InputStream is;
         try {
-            is = new VertxInputStream(request.request());
+            if (request.get("quarkus.request.inputstream") != null) {
+                is = request.get("quarkus.request.inputstream");
+                is.mark(0);
+            } else {
+                is = new VertxInputStream(request.request());
+            }
         } catch (IOException e) {
             request.fail(e);
             return;

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -353,7 +353,8 @@ public class UndertowDeploymentRecorder {
         return new Handler<RoutingContext>() {
             @Override
             public void handle(RoutingContext event) {
-                VertxHttpExchange exchange = new VertxHttpExchange(event.request(), allocator, executorService, event);
+                VertxHttpExchange exchange = new VertxHttpExchange(event.request(), allocator, executorService, event,
+                        event.getBody());
                 Optional<MemorySize> maxBodySize = httpConfiguration.limits.maxBodySize;
                 if (maxBodySize.isPresent()) {
                     exchange.setMaxEntitySize(maxBodySize.get().asLongValue());

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/BodyHandlerBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/BodyHandlerBuildItem.java
@@ -1,13 +1,9 @@
-package io.quarkus.vertx.web.deployment;
+package io.quarkus.vertx.http.deployment;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
-/**
- * use {@link io.quarkus.vertx.http.deployment.BodyHandlerBuildItem} instead
- */
-@Deprecated
 public final class BodyHandlerBuildItem extends SimpleBuildItem {
     private final Handler<RoutingContext> handler;
 

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireBodyHandlerBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RequireBodyHandlerBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.vertx.http.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * This is a marker that indicates that the body handler should be installed
+ * on all routes, as an extension requires the request to be fully buffered.
+ */
+public final class RequireBodyHandlerBuildItem extends MultiBuildItem {
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -81,7 +81,7 @@ public class VertxInputStream extends InputStream {
         if (finished) {
             return -1;
         }
-        
+
         return exchange.readBytesAvailable();
     }
 
@@ -201,13 +201,13 @@ public class VertxInputStream extends InputStream {
             if (input1 != null) {
                 return input1.getByteBuf().readableBytes();
             }
-            
+
             String length = request.getHeader(HttpHeaders.CONTENT_LENGTH);
-            
+
             if (length == null) {
                 return 0;
             }
-            
+
             return Integer.parseInt(length);
         }
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -1,4 +1,4 @@
-package io.quarkus.resteasy.runtime.standalone;
+package io.quarkus.vertx.http.runtime;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +10,7 @@ import io.netty.buffer.ByteBuf;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 
 public class VertxInputStream extends InputStream {
@@ -80,6 +81,7 @@ public class VertxInputStream extends InputStream {
         if (finished) {
             return -1;
         }
+        
         return exchange.readBytesAvailable();
     }
 
@@ -199,7 +201,14 @@ public class VertxInputStream extends InputStream {
             if (input1 != null) {
                 return input1.getByteBuf().readableBytes();
             }
-            return 0;
+            
+            String length = request.getHeader(HttpHeaders.CONTENT_LENGTH);
+            
+            if (length == null) {
+                return 0;
+            }
+            
+            return Integer.parseInt(length);
         }
     }
 

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -48,9 +48,9 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
+import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.RouteBase;
 import io.quarkus.vertx.web.RouteFilter;
@@ -149,9 +149,8 @@ class VertxWebProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
-    BodyHandlerBuildItem bodyHandler(VertxWebRecorder recorder, HttpConfiguration httpConfiguration) {
-        return new BodyHandlerBuildItem(recorder.createBodyHandler(httpConfiguration));
+    BodyHandlerBuildItem bodyHandler(io.quarkus.vertx.http.deployment.BodyHandlerBuildItem realOne) {
+        return new BodyHandlerBuildItem(realOne.getHandler());
     }
 
     @BuildStep
@@ -163,9 +162,10 @@ class VertxWebProcessor {
             BuildProducer<GeneratedClassBuildItem> generatedClass,
             AnnotationProxyBuildItem annotationProxy,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
-            BodyHandlerBuildItem bodyHandler,
+            io.quarkus.vertx.http.deployment.BodyHandlerBuildItem bodyHandler,
             BuildProducer<RouteBuildItem> routeProducer,
-            BuildProducer<FilterBuildItem> filterProducer) throws IOException {
+            BuildProducer<FilterBuildItem> filterProducer,
+            List<RequireBodyHandlerBuildItem> bodyHandlerRequired) throws IOException {
 
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
 

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -1,20 +1,15 @@
 package io.quarkus.vertx.web.runtime;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Optional;
 import java.util.function.Function;
 
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.runtime.configuration.MemorySize;
-import io.quarkus.vertx.http.runtime.BodyConfig;
-import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.RouterProducer;
 import io.quarkus.vertx.web.Route;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BodyHandler;
 
 @Recorder
 public class VertxWebRecorder {
@@ -66,29 +61,10 @@ public class VertxWebRecorder {
                         route.consumes(consumes);
                     }
                 }
-                route.handler(bodyHandler);
+                if (bodyHandler != null) {
+                    route.handler(bodyHandler);
+                }
                 return route;
-            }
-        };
-    }
-
-    public Handler<RoutingContext> createBodyHandler(HttpConfiguration httpConfiguration) {
-        BodyHandler bodyHandler = BodyHandler.create();
-        Optional<MemorySize> maxBodySize = httpConfiguration.limits.maxBodySize;
-        if (maxBodySize.isPresent()) {
-            bodyHandler.setBodyLimit(maxBodySize.get().asLongValue());
-        }
-        final BodyConfig bodyConfig = httpConfiguration.body;
-        bodyHandler.setHandleFileUploads(bodyConfig.handleFileUploads);
-        bodyHandler.setUploadsDirectory(bodyConfig.uploadsDirectory);
-        bodyHandler.setDeleteUploadedFilesOnEnd(bodyConfig.deleteUploadedFilesOnEnd);
-        bodyHandler.setMergeFormAttributes(bodyConfig.mergeFormAttributes);
-        bodyHandler.setPreallocateBodyBuffer(bodyConfig.preallocateBodyBuffer);
-        return new Handler<RoutingContext>() {
-            @Override
-            public void handle(RoutingContext event) {
-                event.request().resume();
-                bodyHandler.handle(event);
             }
         };
     }

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -1,20 +1,26 @@
 package io.quarkus.it.keycloak;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 import javax.security.auth.AuthPermission;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import org.keycloak.representations.idm.authorization.Permission;
 
 import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.core.http.HttpServerRequest;
 
 @Path("/api/permission")
 public class ProtectedResource {
@@ -45,6 +51,17 @@ public class ProtectedResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<Permission> httpResponseClaimProtected() {
+        return identity.getAttribute("permissions");
+    }
+
+    @Path("/body-claim")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Permission> bodyClaim(Map<String, Object> body, @Context HttpServerRequest request) {
+        if (body == null && !body.containsKey("from-body")) {
+            return Collections.emptyList();
+        }
         return identity.getAttribute("permissions");
     }
 }

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -32,3 +32,8 @@ quarkus.keycloak.policy-enforcer.paths.3.claim-information-point.http.headers.Au
 # Disables policy enforcement for a path
 quarkus.keycloak.policy-enforcer.paths.4.path=/api/public
 quarkus.keycloak.policy-enforcer.paths.4.enforcement-mode=DISABLED
+
+# Defines a claim which value is based on the response from an external service
+quarkus.keycloak.policy-enforcer.paths.5.path=/api/permission/body-claim
+quarkus.keycloak.policy-enforcer.paths.5.claim-information-point.claims.from-body={request.body['/from-body']}
+


### PR DESCRIPTION
Fixes #5959

This change allows the body handler to be used for Undertow
and RESTEasy standalone. When the request is fully buffered
it can be consumed multiple times, which allows keycloak
to also process it.