### PR TITLE
BOM - exclude jakarta.ejb-api in the jakarta.interceptor-api dependency

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1254,6 +1254,14 @@
                 <groupId>jakarta.interceptor</groupId>
                 <artifactId>jakarta.interceptor-api</artifactId>
                 <version>${jakarta.interceptor-api.version}</version>
+                <exclusions>
+                    <!-- There is a bug in 1.2.5 -->
+                    <!-- The dependency is removed in master: https://github.com/eclipse-ee4j/interceptor-api/commit/017aeb56849bbb448319aaf36df45a07ec54f451 -->
+                    <exclusion>
+                        <groupId>jakarta.ejb</groupId>
+                        <artifactId>jakarta.ejb-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.xml.bind</groupId>

--- a/extensions/infinispan-embedded/runtime/pom.xml
+++ b/extensions/infinispan-embedded/runtime/pom.xml
@@ -53,6 +53,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
         </dependency>


### PR DESCRIPTION
- there is a bug in v1.2.5, should be fixed in the next version