### PR TITLE
Fix "Class-Path" parsing issues in -dev.jar generated by Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -54,7 +54,6 @@ import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
-import io.quarkus.bootstrap.util.PropertyUtils;
 import io.quarkus.dev.DevModeContext;
 import io.quarkus.dev.DevModeMain;
 import io.quarkus.gradle.QuarkusPluginExtension;
@@ -319,6 +318,8 @@ public class QuarkusDev extends QuarkusTask {
             context.setFrameworkClassesDir(wiringClassesDirectory.getAbsoluteFile());
             context.setCacheDir(new File(getBuildDir(), "transformer-cache").getAbsoluteFile());
 
+            // this is the jar file we will use to launch the dev mode main class
+            context.setDevModeRunnerJarFile(tempFile);
             try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(tempFile))) {
                 out.putNextEntry(new ZipEntry("META-INF/"));
                 Manifest manifest = new Manifest();
@@ -407,19 +408,9 @@ public class QuarkusDev extends QuarkusTask {
         if (filesIncludedInClasspath.add(file)) {
             getProject().getLogger().info("Adding dependency {}", file);
 
-            URI uri = file.toPath().toAbsolutePath().toUri();
-            String path = uri.getRawPath();
-            if (PropertyUtils.isWindows()) {
-                if (path.length() > 2 && Character.isLetter(path.charAt(0)) && path.charAt(1) == ':') {
-                    path = "/" + path;
-                }
-            }
-            classPathManifest.append(path);
+            final URI uri = file.toPath().toAbsolutePath().toUri();
             context.getClassPath().add(toUrl(uri));
-            if (file.isDirectory()) {
-                classPathManifest.append("/");
-            }
-            classPathManifest.append(" ");
+            classPathManifest.append(uri).append(" ");
         }
     }
 


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/4527 and https://github.com/quarkusio/quarkus/pull/5808 fixed issues related to the `Class-Path` attribute in the manifest file of the `-dev.jar` that we generate. However, those fixes addressed the issue only in the Maven plugin/Mojo and missed out their Gradle counterpart. This PR brings in those same fixes into the Gradle plugin.