### PR TITLE
Log a warning if Arc finds observer for @Initialized(ApplicationScope…

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ObserverValidationProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ObserverValidationProcessor.java
@@ -1,0 +1,59 @@
+package io.quarkus.arc.deployment;
+
+import java.util.Collection;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.processor.Annotations;
+import io.quarkus.arc.processor.BeanDeploymentValidator;
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.arc.processor.ObserverInfo;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+
+/**
+ * Validates observer methods from application classes.
+ * If an observer listening for {@code @Initialized(ApplicationScoped.class)} is found, it logs a warning.
+ */
+public class ObserverValidationProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(ObserverValidationProcessor.class.getName());
+
+    @BuildStep
+    public void validateApplicationObserver(ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            BuildProducer<BeanDeploymentValidatorBuildItem> validators) {
+        // an index of all root archive classes (usually src/main/classes)
+        IndexView applicationClassesIndex = applicationArchivesBuildItem.getRootArchive().getIndex();
+
+        validators.produce(new BeanDeploymentValidatorBuildItem(new BeanDeploymentValidator() {
+
+            @Override
+            public void validate(ValidationContext context) {
+                Collection<ObserverInfo> allObservers = context.get(Key.OBSERVERS);
+                // do the validation for each observer that can be found within application classes
+                for (ObserverInfo observer : allObservers) {
+                    DotName declaringBeanDotName = observer.getDeclaringBean().getBeanClass();
+                    AnnotationInstance instance = Annotations.getParameterAnnotation(observer.getObserverMethod(),
+                            DotNames.INITIALIZED);
+                    if (applicationClassesIndex.getClassByName(declaringBeanDotName) != null && instance != null &&
+                            instance.value().asClass().name().equals(BuiltinScope.APPLICATION.getName())) {
+                        // found an observer for @Initialized(ApplicationScoped.class)
+                        // log a warning and recommend to use StartupEvent instead
+                        final String observerWarning = "The method %s#%s is an observer for " +
+                                "@Initialized(ApplicationScoped.class). Observer notification for this event may " +
+                                "vary between JVM and native modes! We strongly recommend to observe StartupEvent " +
+                                "instead as that one is consistently delivered in both modes once the container is " +
+                                "running.";
+                        LOGGER.warnf(observerWarning, observer.getDeclaringBean().getImplClazz(),
+                                observer.getObserverMethod().name());
+                    }
+                }
+            }
+        }));
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
@@ -62,4 +62,23 @@ public final class Annotations {
         return annotations;
     }
 
+    /**
+     * Iterates over all annotations on a method and its parameters, filters out all non-parameter annotations
+     * and returns a first encountered {@link AnnotationInstance} with Annotation specified as {@link DotName}.
+     * Returns {@code null} if no such annotation exists.
+     *
+     * @param method MethodInfo to be searched for annotations
+     * @param annotation Annotation we are looking for, represented as DotName
+     * @return First encountered {@link AnnotationInstance} fitting the requirements, {@code null} if none is found
+     */
+    public static AnnotationInstance getParameterAnnotation(MethodInfo method, DotName annotation) {
+        for (AnnotationInstance annotationInstance : method.annotations()) {
+            if (annotationInstance.target().kind().equals(Kind.METHOD_PARAMETER) &&
+                    annotationInstance.name().equals(annotation)) {
+                return annotationInstance;
+            }
+        }
+        return null;
+    }
+
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Priority;
+import javax.enterprise.context.Initialized;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -81,6 +82,7 @@ public final class DotNames {
     public static final DotName NAMED = create(Named.class);
     public static final DotName ACTIVATE_REQUEST_CONTEXT = create(ActivateRequestContext.class);
     public static final DotName TRANSACTION_PHASE = create(TransactionPhase.class);
+    public static final DotName INITIALIZED = create(Initialized.class);
 
     public static final DotName BOOLEAN = create(Boolean.class);
     public static final DotName BYTE = create(Byte.class);


### PR DESCRIPTION
Fixes #5946 

This will give you following warning in the console on build:
`WARN: The method io.my.app.ContextObserver#observeContextInit is an observer for @Initialized(ApplicationScoped.class). Observer notification for this event may vary between JVM and native modes! We strongly recommend to observe StartupEvent instead as that one is consistently delivered in both modes once the container is running.`

@mkouba I am open to better WARN message suggestions; just couldn't come up with anything short yet explanatory enough. We could also just link to the docs we have, but I kinda don't like doing links from code to website...