### PR TITLE
Use getHandler helper method in logging tests

### DIFF
--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AdditionalHandlersTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AdditionalHandlersTest.java
@@ -1,21 +1,17 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.extest.runtime.logging.AdditionalLogHandlerValueFactory.TestHandler;
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AdditionalHandlersTest {
@@ -28,17 +24,7 @@ public class AdditionalHandlersTest {
 
     @Test
     public void additionalHandlersConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof TestHandler))
-                .findFirst().orElse(null);
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(TestHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.FINE);
 
         TestHandler testHandler = (TestHandler) handler;

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncConsoleHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncConsoleHandlerTest.java
@@ -1,22 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.handlers.AsyncHandler;
 import org.jboss.logmanager.handlers.ConsoleHandler;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AsyncConsoleHandlerTest {
@@ -30,17 +27,7 @@ public class AsyncConsoleHandlerTest {
 
     @Test
     public void asyncConsoleHandlerConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof AsyncHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(AsyncHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
 
         AsyncHandler asyncHandler = (AsyncHandler) handler;

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncFileHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncFileHandlerTest.java
@@ -1,22 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.handlers.AsyncHandler;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.FileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AsyncFileHandlerTest {
@@ -30,17 +27,7 @@ public class AsyncFileHandlerTest {
 
     @Test
     public void asyncFileHandlerConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof AsyncHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(AsyncHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.INFO);
 
         AsyncHandler asyncHandler = (AsyncHandler) handler;

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/AsyncSyslogHandlerTest.java
@@ -1,22 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.handlers.AsyncHandler;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AsyncSyslogHandlerTest {
@@ -30,17 +27,7 @@ public class AsyncSyslogHandlerTest {
 
     @Test
     public void asyncSyslogHandlerConfigurationTest() throws NullPointerException {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof AsyncHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(AsyncHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
 
         AsyncHandler asyncHandler = (AsyncHandler) handler;

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/ConsoleHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/ConsoleHandlerTest.java
@@ -1,23 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class ConsoleHandlerTest {
@@ -30,14 +26,7 @@ public class ConsoleHandlerTest {
 
     @Test
     public void consoleOutputTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (h instanceof ConsoleHandler))
-                .findFirst().get();
+        Handler handler = getHandler(ConsoleHandler.class);
         assertThat(handler).isNotNull();
         assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
 

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/FileHandlerTest.java
@@ -1,23 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.FileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class FileHandlerTest {
@@ -30,15 +26,7 @@ public class FileHandlerTest {
 
     @Test
     public void fileOutputTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (h instanceof FileHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(FileHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.INFO);
 
         Formatter formatter = handler.getFormatter();

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/LoggingTestsHelper.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/LoggingTestsHelper.java
@@ -1,0 +1,30 @@
+package io.quarkus.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.handlers.DelayedHandler;
+
+import io.quarkus.runtime.logging.InitialConfigurator;
+
+public class LoggingTestsHelper {
+
+    public static Handler getHandler(Class clazz) {
+        LogManager logManager = LogManager.getLogManager();
+        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
+
+        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
+        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
+
+        Handler handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (clazz.isInstance(h)))
+                .findFirst().get();
+        assertThat(handler).isNotNull();
+        return handler;
+    }
+}

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicRotatingLoggingTest.java
@@ -1,23 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.PeriodicRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class PeriodicRotatingLoggingTest {
@@ -31,16 +27,7 @@ public class PeriodicRotatingLoggingTest {
 
     @Test
     public void periodicRotatingConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof PeriodicRotatingFileHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(PeriodicRotatingFileHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.INFO);
 
         Formatter formatter = handler.getFormatter();

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingTest.java
@@ -1,23 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class PeriodicSizeRotatingLoggingTest {
@@ -31,16 +27,7 @@ public class PeriodicSizeRotatingLoggingTest {
 
     @Test
     public void periodicSizeRotatingConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof PeriodicSizeRotatingFileHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(PeriodicSizeRotatingFileHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.INFO);
 
         Formatter formatter = handler.getFormatter();

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/SizeRotatingLoggingTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/SizeRotatingLoggingTest.java
@@ -1,23 +1,19 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class SizeRotatingLoggingTest {
@@ -31,16 +27,7 @@ public class SizeRotatingLoggingTest {
 
     @Test
     public void sizeRotatingConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof SizeRotatingFileHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(SizeRotatingFileHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.INFO);
 
         Formatter formatter = handler.getFormatter();

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/SyslogHandlerTest.java
@@ -1,25 +1,21 @@
 package io.quarkus.logging;
 
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.wildfly.common.net.HostName.getQualifiedHostName;
 import static org.wildfly.common.os.Process.getProcessName;
 
-import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class SyslogHandlerTest {
@@ -32,15 +28,7 @@ public class SyslogHandlerTest {
 
     @Test
     public void syslogOutputTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (h instanceof SyslogHandler))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
+        Handler handler = getHandler(SyslogHandler.class);
         assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
 
         Formatter formatter = handler.getFormatter();

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterCustomConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterCustomConfigTest.java
@@ -1,23 +1,15 @@
 package io.quarkus.logging.json;
 
+import static io.quarkus.logging.json.JsonFormatterDefaultConfigTest.getJsonFormatter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.logging.Formatter;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.JsonFormatter;
 import org.jboss.logmanager.formatters.StructuredFormatter;
-import org.jboss.logmanager.handlers.ConsoleHandler;
-import org.jboss.logmanager.handlers.DelayedHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class JsonFormatterCustomConfigTest {
@@ -28,22 +20,7 @@ public class JsonFormatterCustomConfigTest {
 
     @Test
     public void jsonFormatterCustomConfigurationTest() {
-        LogManager logManager = LogManager.getLogManager();
-        assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
-
-        DelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
-        assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
-        assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
-
-        Handler handler = Arrays.stream(delayedHandler.getHandlers())
-                .filter(h -> (h instanceof ConsoleHandler))
-                .findFirst().orElse(null);
-        assertThat(handler).isNotNull();
-        assertThat(handler.getLevel()).isEqualTo(Level.WARNING);
-
-        Formatter formatter = handler.getFormatter();
-        assertThat(formatter).isInstanceOf(JsonFormatter.class);
-        JsonFormatter jsonFormatter = (JsonFormatter) formatter;
+        JsonFormatter jsonFormatter = getJsonFormatter();
         assertThat(jsonFormatter.isPrettyPrint()).isTrue();
         assertThat(jsonFormatter.getDateTimeFormatter().toString())
                 .isEqualTo("Value(DayOfMonth)' 'Text(MonthOfYear,SHORT)' 'Value(Year,4,19,EXCEEDS_PAD)");

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterDefaultConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterDefaultConfigTest.java
@@ -29,6 +29,17 @@ public class JsonFormatterDefaultConfigTest {
 
     @Test
     public void jsonFormatterDefaultConfigurationTest() {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        assertThat(jsonFormatter.isPrettyPrint()).isFalse();
+        assertThat(jsonFormatter.getDateTimeFormatter().toString())
+                .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault()).toString());
+        assertThat(jsonFormatter.getDateTimeFormatter().getZone()).isEqualTo(ZoneId.systemDefault());
+        assertThat(jsonFormatter.getExceptionOutputType()).isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED);
+        assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n");
+        assertThat(jsonFormatter.isPrintDetails()).isFalse();
+    }
+
+    public static JsonFormatter getJsonFormatter() {
         LogManager logManager = LogManager.getLogManager();
         assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
 
@@ -44,13 +55,6 @@ public class JsonFormatterDefaultConfigTest {
 
         Formatter formatter = handler.getFormatter();
         assertThat(formatter).isInstanceOf(JsonFormatter.class);
-        JsonFormatter jsonFormatter = (JsonFormatter) formatter;
-        assertThat(jsonFormatter.isPrettyPrint()).isFalse();
-        assertThat(jsonFormatter.getDateTimeFormatter().toString())
-                .isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault()).toString());
-        assertThat(jsonFormatter.getDateTimeFormatter().getZone()).isEqualTo(ZoneId.systemDefault());
-        assertThat(jsonFormatter.getExceptionOutputType()).isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED);
-        assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n");
-        assertThat(jsonFormatter.isPrintDetails()).isFalse();
+        return (JsonFormatter) formatter;
     }
 }


### PR DESCRIPTION
Refactoring logging as asked in https://github.com/quarkusio/quarkus/pull/5961#pullrequestreview-328016948

Using getHandler helper method in logging tests and getJsonFormatter in logging-json extension

