### PR TITLE
#5950 Pulling up user creation in Dockerfile for layer caching

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
@@ -17,15 +17,18 @@
 FROM fabric8/java-alpine-openjdk8-jre:1.6.5
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV AB_ENABLED=jmx_exporter
-COPY ${build_dir}/lib/* /deployments/lib/
-COPY ${build_dir}/*-runner.jar /deployments/app.jar
-EXPOSE 8080
 
-# run with user 1001 and be prepared for be running in OpenShift too
+# Be prepared for running in OpenShift too
 RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
   && chown -R 1001:root /deployments
+
+COPY ${build_dir}/lib/* /deployments/lib/
+COPY ${build_dir}/*-runner.jar /deployments/app.jar
+EXPOSE 8080
+
+# run with user 1001
 USER 1001
 
 ENTRYPOINT [ "/deployments/run-java.sh" ]


### PR DESCRIPTION
In case of rebuilding an image, the create user command would run again before, as it came after the more volatile commands for adding dependencies and runner.

Fixes: #5950 