### PR TITLE
Ensure Hibernate ORM runtime starts after Flyway has completed its actions

### DIFF
--- a/extensions/flyway/deployment/pom.xml
+++ b/extensions/flyway/deployment/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-flyway</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/HibernateOrmIntegrationRuntimeConfiguredBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/integration/HibernateOrmIntegrationRuntimeConfiguredBuildItem.java
@@ -2,6 +2,13 @@ package io.quarkus.hibernate.orm.deployment.integration;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * Build item which can be used by extensions to order the Hibernate ORM runtime startup.
+ * Such {@link io.quarkus.builder.BuildStep build steps} producing this build item will
+ * have their actions executed before Hibernate ORM runtime startup is triggered. This is
+ * typically useful for extensions which want do certain actions (like setting up the DB
+ * schema) that are necessary to happen before the Hibernate ORM runtime starts.
+ */
 public final class HibernateOrmIntegrationRuntimeConfiguredBuildItem extends MultiBuildItem {
 
     private final String name;


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/5942

Right now, there's no deterministic ordering between Hibernate ORM runtime startup and Flyway runtime startup. As a result, there's a possibility that Hibernate ORM runtime starts even before Flyway gets a chance to run its DB related migrations. This can cause issues like https://github.com/quarkusio/quarkus/issues/5942.

The commit here fixes that issue by having the Flyway runtime build step produce a `HibernateOrmIntegrationRuntimeConfiguredBuildItem` which Hibernate ORM already honours for ordering its runtime startup.

@Sanne, I updated the javadoc of `HibernateOrmIntegrationRuntimeConfiguredBuildItem` to make a mention of what its purpose is. I guessed this semantic based on its usage in `HibernateORMProcessor#startPersistenceUnits` and  `HibernateSearchElasticsearchProcessor`. I hope this updated javadoc accurately describes its intended semantics.