### PR TITLE
Fix org.apache.kafka.common.utils.Crc32C substitution with JDK 11

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -2,7 +2,6 @@ package io.quarkus.kafka.client.deployment;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.zip.Checksum;
 
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.consumer.RoundRobinAssignor;
@@ -34,17 +33,11 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.deployment.Capabilities;
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
-import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.kafka.client.serialization.JsonbDeserializer;
 import io.quarkus.kafka.client.serialization.JsonbSerializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
@@ -75,7 +68,6 @@ public class KafkaProcessor {
             StringDeserializer.class,
             FloatDeserializer.class,
     };
-    static final String TARGET_JAVA_9_CHECKSUM_FACTORY = "io.quarkus.kafka.client.generated.Target_Java9ChecksumFactory";
 
     @BuildStep
     public void build(CombinedIndexBuildItem indexBuildItem, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -114,30 +106,5 @@ public class KafkaProcessor {
 
         // enable JNI
         jni.produce(new JniBuildItem());
-    }
-
-    /**
-     * Generate a class which replaces the usage of {@code MethodHandle} in {@code Java9ChecksumFactory} with a plain
-     * constructor invocation when run under GraalVM. This is necessary because the native image generator does not
-     * support method handles.
-     *
-     * @return the generated class
-     */
-    @BuildStep
-    public void replaceJava9Code(BuildProducer<GeneratedClassBuildItem> producer) {
-        // make our own class output to ensure that our step is run.
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(producer, false);
-        try (ClassCreator cc = ClassCreator.builder().className(TARGET_JAVA_9_CHECKSUM_FACTORY)
-                .classOutput(classOutput).setFinal(true).superClass(Object.class).build()) {
-
-            cc.addAnnotation("com/oracle/svm/core/annotate/TargetClass").addValue("className",
-                    "org.apache.kafka.common.utils.Crc32C$Java9ChecksumFactory");
-            cc.addAnnotation("com/oracle/svm/core/annotate/Substitute");
-
-            try (MethodCreator mc = cc.getMethodCreator("create", Checksum.class)) {
-                mc.addAnnotation("com/oracle/svm/core/annotate/Substitute");
-                mc.returnValue(mc.newInstance(MethodDescriptor.ofConstructor("java.util.zip.CRC32C")));
-            }
-        }
     }
 }

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/Crc32CSubstitutions.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/Crc32CSubstitutions.java
@@ -1,0 +1,35 @@
+package io.quarkus.kafka.client.runtime.graal;
+
+import java.lang.invoke.MethodHandle;
+import java.util.zip.Checksum;
+
+import org.apache.kafka.common.utils.Crc32C;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK11OrLater;
+
+/**
+ * The following substitution replaces the usage of {@code MethodHandle} in {@code Java9ChecksumFactory} with a plain
+ * constructor invocation when run under GraalVM. This is necessary because the native image generator does not support method
+ * handles.
+ */
+@TargetClass(value = Crc32C.class, innerClass = "Java9ChecksumFactory", onlyWith = JDK11OrLater.class)
+final class Target_org_apache_kafka_common_utils_Crc32C_Java9ChecksumFactory {
+
+    @Alias
+    @RecomputeFieldValue(kind = Kind.Reset)
+    private static MethodHandle CONSTRUCTOR;
+
+    @Substitute
+    public Checksum create() {
+        try {
+            return (Checksum) Class.forName("java.util.zip.CRC32C").getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6009.

I couldn't get the `KafkaProcessor` substitution to work with JDK 11, so I simply replaced it with a non-generated version.

Please note that these changes fixed the NPE locally, but I wasn't able to get successful tests results because the native image is not starting fast enough (an exception saying `Failed to start native image, process has exited` is thrown at some point). That's a problem I only have with JDK 11 native tests and with many integration tests modules. The native image generation, which was failing before this PR, ended successfully though.