### PR TITLE
Remove a duplicated space from project creation error message

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -182,7 +182,7 @@ public class CreateProjectMojo extends AbstractMojo {
             projectRoot = new File(outputDirectory, projectArtifactId);
             if (projectRoot.exists()) {
                 throw new MojoExecutionException("Unable to create the project, " +
-                        " the directory " + projectRoot.getAbsolutePath() + " already exists");
+                        "the directory " + projectRoot.getAbsolutePath() + " already exists");
             }
         }
 


### PR DESCRIPTION
No rocket science here but I stumbled upon this one several times while experimenting this morning so I thought I might as well fix it.