### PR TITLE
Initialize ClassFieldAccessorFactory at run time

### DIFF
--- a/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
+++ b/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
@@ -20,6 +20,7 @@ import org.drools.compiler.commons.jci.compilers.JavaCompiler;
 import org.drools.compiler.commons.jci.compilers.JavaCompilerSettings;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
+import org.drools.core.base.ClassFieldAccessorFactory;
 import org.drools.modelcompiler.builder.GeneratedFile;
 import org.drools.modelcompiler.builder.JavaParserCompiler;
 import org.jboss.jandex.ClassInfo;
@@ -53,6 +54,7 @@ import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.runtime.LaunchMode;
 
@@ -132,6 +134,11 @@ public class KogitoAssetsProcessor {
         result.add(
                 new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.feel.runtime.events.FEELEvent")));
         return result;
+    }
+
+    @BuildStep
+    public RuntimeInitializedClassBuildItem init() {
+        return new RuntimeInitializedClassBuildItem(ClassFieldAccessorFactory.class.getName());
     }
 
     @BuildStep(loadsApplicationClasses = true)


### PR DESCRIPTION
Fixes #6017.

Or at least, it fixes the exception mentioned in the issue. The native tests are not starting probably because my computer takes too long to build the image, hence the draft PR. I want to see if the JDK 8 CI is happy with this while I keep trying to run the JDK 11 native tests locally.