### PR TITLE
Read from the process before waiting for exit

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -134,15 +134,15 @@ public class NativeImageBuildStep {
             nativeImage = Collections.singletonList(getNativeImageExecutable(graal, java, env).getAbsolutePath());
         }
 
-        Optional<String> graalVMVersion = Optional.empty();
+        final Optional<String> graalVMVersion;
 
         try {
             List<String> versionCommand = new ArrayList<>(nativeImage);
             versionCommand.add("--version");
 
             Process versionProcess = new ProcessBuilder(versionCommand.toArray(new String[0]))
+                    .redirectErrorStream(true)
                     .start();
-            versionProcess.waitFor();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(versionProcess.getInputStream()))) {
                 graalVMVersion = reader.lines().filter((l) -> l.startsWith("GraalVM Version")).findFirst();
             }


### PR DESCRIPTION
If you do not read from the Process InputStream is it
possible that the process will block if the process buffer
is too small to contain the full output.

There is no need to call waitFor as reading the InputStream
will have the same effect.