### PR TITLE
Update KC authorization test to return the data only if 'from-body' key exists

### DIFF
--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -59,7 +59,7 @@ public class ProtectedResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public List<Permission> bodyClaim(Map<String, Object> body, @Context HttpServerRequest request) {
-        if (body == null && !body.containsKey("from-body")) {
+        if (body == null || !body.containsKey("from-body")) {
             return Collections.emptyList();
         }
         return identity.getAttribute("permissions");


### PR DESCRIPTION
Fixes #6037