### PR TITLE
Show command line in 'gradle quarkusDev' in one line

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -1,5 +1,7 @@
 package io.quarkus.gradle.tasks;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -80,8 +82,9 @@ public class QuarkusDev extends QuarkusTask {
     @InputDirectory
     @Optional
     public File getBuildDir() {
-        if (buildDir == null)
+        if (buildDir == null) {
             buildDir = getProject().getBuildDir();
+        }
         return buildDir;
     }
 
@@ -92,10 +95,11 @@ public class QuarkusDev extends QuarkusTask {
     @Optional
     @InputDirectory
     public File getSourceDir() {
-        if (sourceDir == null)
+        if (sourceDir == null) {
             return extension().sourceDir();
-        else
+        } else {
             return new File(sourceDir);
+        }
     }
 
     @Option(description = "Set source directory", option = "source-dir")
@@ -106,10 +110,11 @@ public class QuarkusDev extends QuarkusTask {
     @Optional
     @InputDirectory
     public File getWorkingDir() {
-        if (workingDir == null)
+        if (workingDir == null) {
             return extension().workingDir();
-        else
+        } else {
             return new File(workingDir);
+        }
     }
 
     @Option(description = "Set working directory", option = "working-dir")
@@ -259,8 +264,9 @@ public class QuarkusDev extends QuarkusTask {
             StringBuilder resources = new StringBuilder();
             String res = null;
             for (File file : extension.resourcesDir()) {
-                if (resources.length() > 0)
+                if (resources.length() > 0) {
                     resources.append(File.pathSeparator);
+                }
                 resources.append(file.getAbsolutePath());
                 res = file.getAbsolutePath();
             }
@@ -341,15 +347,11 @@ public class QuarkusDev extends QuarkusTask {
 
             args.add("-jar");
             args.add(tempFile.getAbsolutePath());
-            ProcessBuilder pb = new ProcessBuilder(args.toArray(new String[0]));
-            pb.redirectErrorStream(true);
-            pb.redirectInput(ProcessBuilder.Redirect.INHERIT);
-            pb.directory(getWorkingDir());
-            System.out.println("Starting process: ");
-            pb.command().forEach(System.out::println);
-            System.out.println("Args: ");
-            args.forEach(System.out::println);
-
+            ProcessBuilder pb = new ProcessBuilder(args)
+                    .redirectErrorStream(true)
+                    .redirectInput(ProcessBuilder.Redirect.INHERIT)
+                    .directory(getWorkingDir());
+            System.out.printf("Launching JVM with command line: %s%n", pb.command().stream().collect(joining(" ")));
             Process p = pb.start();
             Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
                 @Override

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -362,7 +362,7 @@ public class QuarkusDev extends QuarkusTask {
             try {
                 ExecutorService es = Executors.newSingleThreadExecutor();
                 es.submit(() -> copyOutputToConsole(p.getInputStream()));
-
+                es.shutdown();
                 p.waitFor();
             } catch (Exception e) {
                 p.destroy();


### PR DESCRIPTION
Original output:
```gradle
➜  my-gradle3 gradle quarkusDev
Listening for transport dt_socket at address: 5005

> Task :quarkusDev
Starting process: 
/home/ggastald/.sdkman/candidates/java/8.0.232-open/jre/bin/java
-Xdebug
-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n
-XX:TieredStopAtLevel=1
-Xverify:none
-Djava.util.logging.manager=org.jboss.logmanager.LogManager
-jar
/tmp/my-gradle3/build/my-gradle3-1.0-SNAPSHOT-dev.jar
Args: 
/home/ggastald/.sdkman/candidates/java/8.0.232-open/jre/bin/java
-Xdebug
-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n
-XX:TieredStopAtLevel=1
-Xverify:none
-Djava.util.logging.manager=org.jboss.logmanager.LogManager
-jar
/tmp/my-gradle3/build/my-gradle3-1.0-SNAPSHOT-dev.jar
<=========----> 75% EXECUTING [9s]
> :quarkusDev

```


With this PR: 

```gradle                                                                                                                                                                            ➜  my-gradle3 gradle quarkusDev 
Listening for transport dt_socket at address: 5005

> Task :quarkusDev
Launching JVM with command line: /home/ggastald/.sdkman/candidates/java/8.0.232-open/jre/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n -XX:TieredStopAtLevel=1 -Xverify:none -Djava.util.logging.manager=org.jboss.logmanager.LogManager -jar /tmp/my-gradle3/build/my-gradle3-1.0-SNAPSHOT-dev.jar

2019-12-10 10:04:55,696 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT started in 1.158s. Listening on: http://0.0.0.0:8080
2019-12-10 10:04:55,751 INFO  [io.quarkus] (main) Profile dev activated. Live Coding activated.
2019-12-10 10:04:55,751 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
<==<=========----> 75% EXECUTING [17s]
> :quarkusDev
```