### PR TITLE
Fix an artemis-commons dependency convergence issue

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -14,6 +14,8 @@ update_configs:
       - match:
           dependency_name: "org.apache.activemq:artemis-server"
       - match:
+          dependency_name: "org.apache.activemq:artemis-commons"
+      - match:
           dependency_name: "org.flywaydb:flyway-core"
       - match:
           dependency_name: "org.freemarker:freemarker"

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1324,6 +1324,11 @@
                 <version>${artemis.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-commons</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpclient.version}</version>


### PR DESCRIPTION
We don't have it in Quarkus but we have it in Camel Quarkus. Artemis
dependencies are not consistent.