### PR TITLE
Execute tests for neo4j by default

### DIFF
--- a/integration-tests/neo4j/README.md
+++ b/integration-tests/neo4j/README.md
@@ -2,21 +2,20 @@
 
 ## Running the tests
 
-By default, the tests of this module are disabled.
-
 To run the tests in a standard JVM with Neo4j started as a Docker container, you can run the following command:
 
 ```
-mvn clean install -Dtest-neo4j -Ddocker
+mvn clean install
 ```
 
 To also test as a native image, add `-Dnative`:
 
 ```
-mvn clean install -Dtest-neo4j -Ddocker -Dnative
+mvn clean install -Dnative
 ```
 
 Alternatively you can connect to your own Neo4j instance or cluster.
+Disable Neo4j started as a Docker container with `-Dno-docker`.
 Reconfigure the connection URL with `-Dneo4j.uri=bolt+routing://yourcluster:7687`;
 you'll probably want to change the authentication password too: `-Dneo4j.password=NotS0Secret`.
 

--- a/integration-tests/neo4j/pom.xml
+++ b/integration-tests/neo4j/pom.xml
@@ -87,13 +87,13 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>false</skip>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>false</skip>
                 </configuration>
             </plugin>
             <plugin>
@@ -112,31 +112,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>test-neo4j</id>
-            <activation>
-                <property>
-                    <name>test-neo4j</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>false</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>false</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>native-image</id>
             <activation>
@@ -189,7 +164,7 @@
             <id>docker-neo4j</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>!no-docker</name>
                 </property>
             </activation>
             <properties>


### PR DESCRIPTION
Execute tests for neo4j by default

Currently neo4j tests are not executed, including CI runs