### PR TITLE
revert change to run()

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/QuarkusStreamHandler.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/QuarkusStreamHandler.java
@@ -30,7 +30,13 @@ public class QuarkusStreamHandler implements RequestStreamHandler {
                 Class appClass = Class.forName("io.quarkus.runner.ApplicationImpl");
                 String[] args = {};
                 Application app = (Application) appClass.newInstance();
-                app.run(args);
+                Runtime.getRuntime().addShutdownHook(new Thread() {
+                    @Override
+                    public void run() {
+                        app.stop();
+                    }
+                });
+                app.start(args);
                 errorWriter.println("Quarkus bootstrapped successfully.");
                 started = true;
             } catch (Exception ex) {


### PR DESCRIPTION
Simply changing the `start()` call to `run()` causes the system to block on AWS and it doesn't serve any requests.  This change reverts back to calling `start()` and adds a shutdown hook to call `stop()` so that any external resources are properly cleaned up.