### PR TITLE
Ignore empty lines in jaxb.index file

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -218,8 +218,9 @@ class JaxbProcessor {
             addResource(path);
 
             for (String line : Files.readAllLines(p)) {
-                if (!line.startsWith("#")) {
-                    String clazz = pkg + line.trim();
+                line = line.trim();
+                if (!line.isEmpty() && !line.startsWith("#")) {
+                    String clazz = pkg + line;
                     Class<?> cl = Class.forName(clazz);
 
                     while (cl != Object.class) {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/6070

On a more general note, perhaps we should catch the classloading exception(s) in that method and just log a WARN for any of those entries that fail to load?

This commit for now will handle empty lines without running into CNFE errors.