### PR TITLE
Make JSON logging default to enabled

### DIFF
--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonConfig.java
@@ -16,7 +16,7 @@ public class JsonConfig {
     /**
      * Determine whether to enable the JSON console formatting extension, which disables "normal" console formatting.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigItem(name = ConfigItem.PARENT, defaultValue = "true")
     boolean enable;
     /**
      * Enable "pretty printing" of the JSON record. Note that some JSON parsers will fail to read pretty printed output.


### PR DESCRIPTION
The docs say that this is enabled by default, and IMHO this
makes sense.