### PR TITLE
Make config-yaml a full extension

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -14,6 +14,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String ARTEMIS_CORE = "artemis-core";
     public static final String ARTEMIS_JMS = "artemis-jms";
     public static final String CDI = "cdi";
+    public static final String CONFIG_YAML = "config-yaml";
     public static final String DYNAMODB = "dynamodb";
     public static final String ELASTICSEARCH_REST_CLIENT = "elasticsearch-rest-client";
     public static final String FLYWAY = "flyway";

--- a/extensions/config-yaml/deployment/pom.xml
+++ b/extensions/config-yaml/deployment/pom.xml
@@ -8,43 +8,25 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml-parent</artifactId>
         <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
     </parent>
 
-    <artifactId>quarkus-config-yaml</artifactId>
-    <name>Quarkus - Configuration - YAML - Runtime</name>
+    <artifactId>quarkus-config-yaml-deployment</artifactId>
+    <name>Quarkus - Configuration - YAML - Deployment</name>
 
     <dependencies>
         <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config-source-yaml</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.config</groupId>
-            <artifactId>microprofile-config-api</artifactId>
-        </dependency>
-        <!-- Test deps -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
+            <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
+++ b/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
@@ -1,0 +1,12 @@
+package io.quarkus.config.yaml.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+public final class ConfigYamlProcessor {
+
+    @BuildStep
+    public FeatureBuildItem feature() {
+        return new FeatureBuildItem(FeatureBuildItem.CONFIG_YAML);
+    }
+}

--- a/extensions/config-yaml/pom.xml
+++ b/extensions/config-yaml/pom.xml
@@ -15,6 +15,7 @@
    <packaging>pom</packaging>
    <modules>
        <module>runtime</module>
+       <module>deployment</module>
    </modules>
 
 </project>

--- a/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/ApplicationYamlProvider.java
+++ b/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/ApplicationYamlProvider.java
@@ -25,6 +25,7 @@ public final class ApplicationYamlProvider implements ConfigSourceProvider {
 
     static final String APPLICATION_YAML = "application.yaml";
 
+    @Override
     public Iterable<ConfigSource> getConfigSources(final ClassLoader forClassLoader) {
         List<ConfigSource> sources = Collections.emptyList();
         // mirror the in-JAR application.properties

--- a/extensions/config-yaml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/config-yaml/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "YAML Configuration"
+metadata:
+  keywords:
+  - "config"
+  - "configuration"
+  - "yaml"
+  categories:
+  - "core"
+  status: "stable"
+  guide: "https://quarkus.io/guides/config#yaml"


### PR DESCRIPTION
With the existing set up, it wasn't possible to install it via `add-extension` (I noticed that while reviewing the documentation).

I also added a `FeatureBuildItem` as having it changes the behavior of Quarkus and we need to be aware it's there.

/cc @dmlloyd 