### PR TITLE
only base64 encode binary types

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2318,6 +2318,20 @@
                 <groupId>com.amazonaws.serverless</groupId>
                 <artifactId>aws-serverless-java-container-core</artifactId>
                 <version>${aws-lambda-serverless-java-container.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>javax.ws.rs-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -185,6 +185,12 @@ It should give you something like the following output:
 
 The `OutputValue` attribute is the root URL for your lambda. Copy it to your browser and add `hello` at the end.
 
+[NOTE]
+Responses for binary types will be automatically encoded with base64.  This is different than the behavior using
+`quarkus:dev` which will return the raw bytes.  Amazon's API has additional restrictions requiring the base64 encoding.
+In general, client code will automatically handle this encoding but in certain custom situations, you should be aware
+you may need to manually manage that encoding.
+
 == Examine the POM
 
 If you want to adapt an existing Resteasy, Undertow, or Vert.x Web project to Amazon Lambda, there's a couple

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws.serverless</groupId>
+            <artifactId>aws-serverless-java-container-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
         </dependency>


### PR DESCRIPTION
This restricts the base64 encoding only to known binary types.

The one question i have is the encoding of the byte[] for non-binary types.  There was a cleaner way rather than hardcoding UTF-8 but I can't recall what that was offhand.

fixes  #5196