### PR TITLE
Allow JAXB to be a runtime dependency of Hibernate ORM

### DIFF
--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -33,7 +33,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
@@ -71,22 +70,6 @@
             <artifactId>hibernate-envers</artifactId>
             <scope>test</scope>
          </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.xml.bind</groupId>
-            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -50,7 +50,7 @@
                     <artifactId>javassist</artifactId>
                 </exclusion>
 
-                <!-- XML parsers only needed to parse configurations during the deployment phase -->
+                <!-- These XML parsers are banned in the project as we use the new package -->
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
@@ -66,6 +66,21 @@
                     <artifactId>javax.activation-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- We need XML mapping support to support Hibernate Envers -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>


### PR DESCRIPTION
Fixes #6020

Ok so I was trying to figure out why we'd need XML parsing now, as we didn't need it originally.

The reason is to support Envers: it generates XML resources during the metadata build process, which we then have to parse; I've been looking into avoiding this as in theory all metadata is built during augmentation, but it's making the scope of the changes a bit too large for my liking.

Si I'd say for now it's better to just allow JAXB to be promoted as a runtime dependency, we'll have to get back at how stuff is booted anyway.