### PR TITLE
Provided ManagedExecutor and ThreadContext beans should be default so that users can override them easily

### DIFF
--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/CustomProducersTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/CustomProducersTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.context.test;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that user can override default beans for {@code ManagedExecutor} and {@code ThreadContext}.
+ * Default beans are singletons (no proxy) whereas the newly defined beans here are application scoped.
+ * Therefore it is enough to check that the injected values are proxied.
+ */
+public class CustomProducersTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProducerBean.class));
+
+    @Inject
+    ManagedExecutor me;
+
+    @Inject
+    ThreadContext tc;
+
+    @Test
+    public void testDefaultBeansCanBeOverriden() {
+        Assertions.assertNotNull(me);
+        Assertions.assertNotNull(tc);
+        Assertions.assertTrue(me instanceof ClientProxy);
+        Assertions.assertTrue(tc instanceof ClientProxy);
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/ProducerBean.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/ProducerBean.java
@@ -1,0 +1,33 @@
+package io.quarkus.context.test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+
+@ApplicationScoped
+public class ProducerBean {
+
+    @Produces
+    @ApplicationScoped
+    public ThreadContext getAllThreadContext() {
+        return ThreadContext.builder().propagated(ThreadContext.ALL_REMAINING).cleared().unchanged().build();
+    }
+
+    @ApplicationScoped
+    @Produces
+    public ManagedExecutor getAllManagedExecutor() {
+        return ManagedExecutor.builder().build();
+    }
+
+    @Produces
+    public String doIt() {
+        return "foo";
+    }
+
+    public void disposeExecutor(@Disposes ManagedExecutor me) {
+        me.shutdown();
+    }
+}

--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationProvider.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationProvider.java
@@ -11,6 +11,7 @@ import javax.inject.Singleton;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 
+import io.quarkus.arc.DefaultBean;
 import io.smallrye.context.SmallRyeManagedExecutor;
 import io.smallrye.context.SmallRyeThreadContext;
 
@@ -36,6 +37,7 @@ public class SmallRyeContextPropagationProvider {
 
     @Produces
     @Singleton
+    @DefaultBean
     public ThreadContext getAllThreadContext() {
         return ThreadContext.builder().propagated(ThreadContext.ALL_REMAINING).cleared().unchanged().build();
     }
@@ -43,6 +45,7 @@ public class SmallRyeContextPropagationProvider {
     @Typed(ManagedExecutor.class)
     @Produces
     @Singleton
+    @DefaultBean
     public ManagedExecutor getAllManagedExecutor() {
         return managedExecutor;
     }


### PR DESCRIPTION
… that users can override them easily.

Fixes #6148 