### PR TITLE
Let the delegate handlers decide to autoflush

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -117,6 +117,7 @@ public class LoggingSetupRecorder {
             }
         }
 
+        InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
         InitialConfigurator.DELAYED_HANDLER.setHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
     }
 
@@ -125,6 +126,7 @@ public class LoggingSetupRecorder {
             final ConsoleHandler handler = new ConsoleHandler(new PatternFormatter(
                     "%d{HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n"));
             handler.setLevel(Level.INFO);
+            InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
             InitialConfigurator.DELAYED_HANDLER.setHandlers(new Handler[] { handler });
         }
     }


### PR DESCRIPTION
Fixes the problem where Vert.x threads can block even if async logging is enabled.
