### PR TITLE
Substitute BootLoader.loadClassOrNull(name) to fix a NPE with JDK 11

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/BootLoaderSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/BootLoaderSubstitutions.java
@@ -7,17 +7,30 @@ import java.util.Enumeration;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.hub.ClassForNameSupport;
 import com.oracle.svm.core.jdk.JDK11OrLater;
 
-/*
- * The `hasClassPath()` method substitution from this class is required to work around a NPE when `BootLoader.hasClassPath()`
- * is called. This was fixed in a GraalVM commit (https://github.com/oracle/graal/commit/68027de) which will be backported to
- * 19.3.1. We copied the entire GraalVM commit content into Quarkus for the sake of consistency.
- * See https://github.com/oracle/graal/issues/1966 for more details about the NPE.
- */
 @TargetClass(className = "jdk.internal.loader.BootLoader", onlyWith = JDK11OrLater.class)
 final class Target_jdk_internal_loader_BootLoader {
 
+    /*
+     * The following substitution is required to work around a NPE that happened when `BootLoader.loadClassOrNull(name)` was
+     * called during the Quarkus native integration tests execution. It will be directly fixed in a future GraalVM release
+     * which is undetermined for now. This substitution should be removed as soon as Quarkus depends on a GraalVM version that
+     * includes the fix.
+     */
+    @Substitute
+    private static Class<?> loadClassOrNull(String name) {
+        return ClassForNameSupport.forNameOrNull(name, false);
+    }
+
+    /*
+     * The following substitution is required to work around a NPE that happened when `BootLoader.hasClassPath()` was called
+     * during the Quarkus native integration tests execution. It was fixed in a GraalVM commit which should be backported to
+     * 19.3.1 (https://github.com/oracle/graal/commit/68027de). This substitution should be removed as soon as Quarkus depends
+     * on a GraalVM version that includes that commit.
+     * See https://github.com/oracle/graal/issues/1966 for more details about the NPE.
+     */
     @Substitute
     private static boolean hasClassPath() {
         return true;


### PR DESCRIPTION
Fixes #6127

I'm submitting this as a draft to see if CI is happy with is (even if there's no reason it wouldn't). In the meantine, I'm just starting a full JDK 11 Quarkus native build locally to make sure the exception is gone for good and see if there's anything left to fix apart from the `ConcurrentModificationException`.