### PR TITLE
Add Support to Multiple Vault KV Paths

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -8,6 +8,7 @@ import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -82,10 +83,35 @@ public class VaultRuntimeConfig {
     public Duration secretConfigCachePeriod;
 
     /**
-     * Vault path in kv store, where all properties will be available as MP config.
+     * List of comma separated vault paths in kv store,
+     * where all properties will be available as MP config properties as-is, with no prefix.
+     * For instance, if vault contains property {@code foo}, it will be made available to the
+     * quarkus application as
+     * {@code @ConfigProperty(name = "foo") String foo;}
+     * <p>
+     * If 2 paths contain the same property, the last path will win. For instance if
+     * {@code secret/base-config} contains {@code foo='bar'} and
+     * {@code secret/myapp/config} contains {@code foo='myappbar'}, then
+     * {@code @ConfigProperty(name = "foo") String foo;} will have for value {@code "bar"}
+     * with application properties
+     * {@code quarkus.vault.secret-config-kv-path=base-config,myapp/config}
      */
     @ConfigItem
-    public Optional<String> secretConfigKvPath;
+    public Optional<List<String>> secretConfigKvPath;
+
+    /**
+     * List of comma separated vault paths in kv store,
+     * where all properties will be available as prefixed MP config properties.
+     * For instance if the application properties contains
+     * {@code quarkus.vault.secret-config-kv-path-prefix.myprefix=config}, all properties located
+     * in vault path {@code secret/config} contains {@code foo='bar'}, then {@code myprefix.foo}
+     * will be available in the MP config.
+     * <p>
+     * If the same property is available in 2 different paths for the same prefix, the last one
+     * will win.
+     */
+    @ConfigItem(name = "secret-config-kv-path")
+    public Map<String, List<String>> secretConfigKvPrefixPath;
 
     /**
      * Used to hide confidential infos, for logging in particular.

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultMultiPathConfigITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultMultiPathConfigITCase.java
@@ -1,0 +1,42 @@
+package io.quarkus.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS)
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultMultiPathConfigITCase {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault-multi-path.properties", "application.properties"));
+
+    @Test
+    public void defaultPath() {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        assertEquals("red", config.getValue("color", String.class));
+        assertEquals("XL", config.getValue("size", String.class));
+        assertEquals("3", config.getValue("weight", String.class));
+    }
+
+    @Test
+    public void prefixPath() {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        assertEquals("green", config.getValue("singer.color", String.class));
+        assertEquals("paul", config.getValue("singer.firstname", String.class));
+        assertEquals("simon", config.getValue("singer.lastname", String.class));
+        assertEquals("78", config.getValue("singer.age", String.class));
+    }
+}

--- a/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
@@ -1,0 +1,7 @@
+quarkus.vault.url=https://localhost:8200
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password=sinclair
+quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
+quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
+
+quarkus.vault.tls.skip-verify=true

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -204,6 +204,12 @@ public class VaultTestExtension {
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
 
+        // multi config
+        execVault(format("vault kv put %s/multi/default1 color=blue size=XL", SECRET_PATH_V1));
+        execVault(format("vault kv put %s/multi/default2 color=red weight=3", SECRET_PATH_V1));
+        execVault(format("vault kv put %s/multi/singer1 firstname=paul lastname=shaffer", SECRET_PATH_V1));
+        execVault(format("vault kv put %s/multi/singer2 lastname=simon age=78 color=green", SECRET_PATH_V1));
+
         // static secrets kv v2
         execVault(format("vault secrets enable -path=%s -version=2 kv", SECRET_PATH_V2));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));

--- a/test-framework/vault/src/main/resources/vault.policy
+++ b/test-framework/vault/src/main/resources/vault.policy
@@ -8,6 +8,11 @@ path "secret/config" {
   capabilities = ["read"]
 }
 
+# vault config source kv engine v1 with multi paths
+path "secret/multi/*" {
+  capabilities = ["read"]
+}
+
 # kv engine v2
 path "secret-v2/data/foo" {
   capabilities = ["read"]


### PR DESCRIPTION
Fixes #5638.

This provides the ability to express 
 - multiple paths for property `quarkus.vault.secret-config-kv-path` and
 - provide an optional property prefix

Consider for instance those vault paths containing secrets:
```
multi/default1:
  color=blue
  size=XL

multi/default2:
  color=red
  weight=3

multi/singer1:
  firstname=paul
  lastname=shaffer

multi/singer2:
  color=green
  lastname=simon
  age=78
```

And the following `application.properties`:
```
quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
```

Then the quarkus application would see the following properties:
```
color=red
size=XL
weight=3

singer.color=green
singer.firstname=paul
singer.lastname=simon
singer.age=78
```

If multiple paths contain the same key for a particular prefix, the last path will win (going from the most general, to the most specific). This rule applies also on the _no prefix_ property, but not in between different prefix zones.

In the example above the following overrides apply:
 - `color=red` from `multi/default2` overrides `color=blue` from `multi/default1`
 - `singer.lastname=simon` from `multi/singer2` overrides `singer.lastname=shaffer` from `multi/singer1`
 - `singer.color=green` from `multi/singer2` does **not** override `color=red` from `multi/default2`, because they are in different prefix zones

cc @sberyozkin @valones @gsmet 