### PR TITLE
Initialize com.microsoft.sqlserver.jdbc.KerbAuthentication at run time

### DIFF
--- a/extensions/jdbc/jdbc-mssql/deployment/src/main/java/io/quarkus/jdbc/mssql/deployment/MsSQLProcessor.java
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/main/java/io/quarkus/jdbc/mssql/deployment/MsSQLProcessor.java
@@ -5,6 +5,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.NativeImageEnableAllCharsetsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 public class MsSQLProcessor {
 
@@ -20,4 +21,8 @@ public class MsSQLProcessor {
         nativeEnableAllCharsets.produce(new NativeImageEnableAllCharsetsBuildItem());
     }
 
+    @BuildStep
+    public RuntimeInitializedClassBuildItem runtimeInitializedClass() {
+        return new RuntimeInitializedClassBuildItem("com.microsoft.sqlserver.jdbc.KerbAuthentication");
+    }
 }

--- a/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
+++ b/extensions/kogito/deployment/src/main/java/io/quarkus/kogito/deployment/KogitoAssetsProcessor.java
@@ -137,7 +137,7 @@ public class KogitoAssetsProcessor {
     }
 
     @BuildStep
-    public RuntimeInitializedClassBuildItem init() {
+    public RuntimeInitializedClassBuildItem runtimeInitializedClass() {
         return new RuntimeInitializedClassBuildItem(ClassFieldAccessorFactory.class.getName());
     }
 


### PR DESCRIPTION
Fixes #6020 

This PR fixes a specific error from the #6020 stack trace which was still happening on `master`:
```
Error: No instances of java.io.FilePermission are allowed in the image heap as this class should be initialized at image runtime. Object has been initialized without the native-image initialization instrumentation and the stack trace can't be tracked.
Trace: 	object java.util.concurrent.ConcurrentHashMap$Node
	object java.util.concurrent.ConcurrentHashMap$Node[]
	object java.util.concurrent.ConcurrentHashMap
	object java.io.FilePermissionCollection
	object java.util.concurrent.ConcurrentHashMap$Node
	object java.util.concurrent.ConcurrentHashMap$Node[]
	object java.util.concurrent.ConcurrentHashMap
	object java.security.Permissions
	object java.security.ProtectionDomain
	object java.security.ProtectionDomain[]
	object java.security.AccessControlContext
	object com.microsoft.sqlserver.jdbc.JaasConfiguration
	field javax.security.auth.login.Configuration.configuration
```