### PR TITLE
Add quarkus-kafka-streams-deployment to bom/deployment

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -168,6 +168,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-kafka-streams-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-reactive-streams-operators-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
I noticed that `quarkus-kafka-streams-deployment` was missing from `bom/deployment`