### PR TITLE
Qute - escape expressions in HTML by default

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -182,6 +182,24 @@ This could be useful to access data for which the key is overriden:
 
 ====
 
+===== Character Escapes
+
+For HTML and XML templates the `'`, `"`, `<`, `>`, `&` characters are escaped by default.
+If you need to render the unescaped value:
+
+1. Use the `raw` or `safe` properties implemented as extension methods of the `java.lang.Object`,
+2. Wrap the `String` value in a `io.quarkus.qute.RawString`.
+
+[source,html]
+----
+<html>
+<h1>{title}</h1> <1>
+{paragraph.raw} <2>
+</html>
+----
+<1> `title` that resolves to `Expressions & Escapes` will be rendered as `Expressions &amp;amp; Escapes`
+<2> `paragraph` that resolves to `<p>My text!</p>` will be rendered as `<p>My text!</p>`
+
 ==== Sections
 
 A section:

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/EscapingTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/EscapingTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.qute.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.RawString;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateData;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EscapingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(Item.class)
+                    .addAsResource(new StringAsset("{text} {other} {text.raw} {text.safe} {item.foo}"),
+                            "templates/foo.html")
+                    .addAsResource(new StringAsset("{item} {item.raw}"),
+                            "templates/item.html")
+                    .addAsResource(new StringAsset("{text} {other} {text.raw} {text.safe} {item.foo}"),
+                            "templates/bar.txt"));
+
+    @Inject
+    Template foo;
+
+    @Inject
+    Template bar;
+
+    @Inject
+    Template item;
+
+    @Test
+    public void testEscaper() {
+        assertEquals("&lt;div&gt; &amp;&quot;&#39; <div> <div> <span>",
+                foo.data("text", "<div>").data("other", "&\"'").data("item", new Item()).render());
+        // No escaping for txt templates
+        assertEquals("<div> &\"' <div> <div> <span>",
+                bar.data("text", "<div>").data("other", "&\"'").data("item", new Item()).render());
+        // Item.toString() is escaped too
+        assertEquals("&lt;h1&gt;Item&lt;/h1&gt; <h1>Item</h1>",
+                item.data("item", new Item()).render());
+    }
+
+    @TemplateData
+    public static class Item {
+
+        public RawString getFoo() {
+            return new RawString("<span>");
+        }
+
+        @Override
+        public String toString() {
+            return "<h1>Item</h1>";
+        }
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/VariantTemplateTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/VariantTemplateTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qute.TemplateInstance;
-import io.quarkus.qute.api.Variant;
+import io.quarkus.qute.Variant;
 import io.quarkus.qute.api.VariantTemplate;
 import io.quarkus.test.QuarkusUnitTest;
 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/api/VariantTemplate.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/api/VariantTemplate.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute.api;
 
 import io.quarkus.qute.Template;
+import io.quarkus.qute.Variant;
 
 /**
  * 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
@@ -2,6 +2,7 @@ package io.quarkus.qute.runtime;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -16,6 +17,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.Variant;
 import io.quarkus.qute.api.ResourcePath;
 
 @Singleton
@@ -102,6 +104,11 @@ public class TemplateProducer {
         @Override
         public String getGeneratedId() {
             return template.get().getGeneratedId();
+        }
+
+        @Override
+        public Optional<Variant> getVariant() {
+            return template.get().getVariant();
         }
 
     }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/VariantTemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/VariantTemplateProducer.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
@@ -27,8 +28,8 @@ import io.quarkus.qute.Expression;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.TemplateInstanceBase;
+import io.quarkus.qute.Variant;
 import io.quarkus.qute.api.ResourcePath;
-import io.quarkus.qute.api.Variant;
 import io.quarkus.qute.api.VariantTemplate;
 
 @Singleton
@@ -114,6 +115,11 @@ public class VariantTemplateProducer {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public Optional<Variant> getVariant() {
+            throw new UnsupportedOperationException();
+        }
+
     }
 
     class VariantTemplateInstanceImpl extends TemplateInstanceBase {
@@ -166,15 +172,15 @@ public class VariantTemplateProducer {
     }
 
     static String parseMediaType(String suffix) {
-        // TODO support more media types...
-        if (suffix.equalsIgnoreCase(".html")) {
-            return "text/html";
+        // TODO we need a proper way to parse the media type
+        if (suffix.equalsIgnoreCase(".html") || suffix.equalsIgnoreCase(".htm")) {
+            return Variant.TEXT_HTML;
         } else if (suffix.equalsIgnoreCase(".xml")) {
-            return "text/xml";
+            return Variant.TEXT_XML;
         } else if (suffix.equalsIgnoreCase(".txt")) {
-            return "text/plain";
+            return Variant.TEXT_PLAIN;
         } else if (suffix.equalsIgnoreCase(".json")) {
-            return "application/json";
+            return Variant.APPLICATION_JSON;
         }
         LOGGER.warn("Unknown media type for suffix: " + suffix);
         return "application/octet-stream";

--- a/extensions/resteasy-qute/runtime/src/main/java/io/quarkus/resteasy/qute/runtime/TemplateResponseFilter.java
+++ b/extensions/resteasy-qute/runtime/src/main/java/io/quarkus/resteasy/qute/runtime/TemplateResponseFilter.java
@@ -17,7 +17,7 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.resteasy.core.interception.jaxrs.SuspendableContainerResponseContext;
 
 import io.quarkus.qute.TemplateInstance;
-import io.quarkus.qute.api.Variant;
+import io.quarkus.qute.Variant;
 import io.quarkus.qute.api.VariantTemplate;
 
 @Provider

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
@@ -13,7 +13,11 @@ public interface Engine {
         return new EngineBuilder();
     }
 
-    public Template parse(String content);
+    default Template parse(String content) {
+        return parse(content, null);
+    }
+
+    public Template parse(String content, Variant variant);
 
     public SectionHelperFactory<?> getSectionHelperFactory(String name);
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -25,7 +24,7 @@ public final class EngineBuilder {
     private final Map<String, SectionHelperFactory<?>> sectionHelperFactories;
     private final List<ValueResolver> valueResolvers;
     private final List<NamespaceResolver> namespaceResolvers;
-    private final List<Function<String, Optional<Reader>>> locators;
+    private final List<TemplateLocator> locators;
     private final List<ResultMapper> resultMappers;
     private Function<String, SectionHelperFactory<?>> sectionHelperFunc;
 
@@ -105,7 +104,7 @@ public final class EngineBuilder {
      * @return self
      * @see Engine#getTemplate(String)
      */
-    public EngineBuilder addLocator(Function<String, Optional<Reader>> locator) {
+    public EngineBuilder addLocator(TemplateLocator locator) {
         this.locators.add(locator);
         return this;
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Escaper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Escaper.java
@@ -1,0 +1,85 @@
+package io.quarkus.qute;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Escapes a characted sequence using a map of replacements.
+ */
+public final class Escaper {
+
+    private final Map<Character, String> replacements;
+
+    /**
+     *
+     * @param replacements
+     */
+    private Escaper(Map<Character, String> replacements) {
+        this.replacements = replacements.isEmpty() ? Collections.emptyMap()
+                : new HashMap<>(replacements);
+    }
+
+    /**
+     *
+     * @param value
+     * @return an escaped value
+     */
+    public String escape(CharSequence value) {
+        Objects.requireNonNull(value);
+        if (value.length() == 0) {
+            return value.toString();
+        }
+        for (int i = 0; i < value.length(); i++) {
+            String replacement = replacements.get(value.charAt(i));
+            if (replacement != null) {
+                // In most cases we will not need to escape the value at all
+                return doEscape(value, i, new StringBuilder(value.subSequence(0, i)).append(replacement));
+            }
+        }
+        return value.toString();
+    }
+
+    private String doEscape(CharSequence value, int index, StringBuilder builder) {
+        int length = value.length();
+        while (++index < length) {
+            char c = value.charAt(index);
+            String replacement = replacements.get(c);
+            if (replacement != null) {
+                builder.append(replacement);
+            } else {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private final Map<Character, String> replacements;
+
+        private Builder() {
+            this.replacements = new HashMap<>();
+        }
+
+        public Builder add(char c, String replacement) {
+            replacements.put(c, replacement);
+            return this;
+        }
+
+        public Escaper build() {
+            return new Escaper(replacements);
+        }
+
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/RawString.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/RawString.java
@@ -1,0 +1,23 @@
+package io.quarkus.qute;
+
+/**
+ * Raw string is never escaped.
+ */
+public final class RawString {
+
+    private final String value;
+
+    public RawString(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResultMapper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResultMapper.java
@@ -1,5 +1,7 @@
 package io.quarkus.qute;
 
+import io.quarkus.qute.TemplateNode.Origin;
+
 /**
  * The first result mapper that applies to the result object is used to map the result to the string value. The mapper with
  * higher priority wins.
@@ -9,10 +11,11 @@ public interface ResultMapper extends WithPriority {
 
     /**
      * 
+     * @param origin
      * @param result
      * @return {@code true} if this mapper applies to the given result
      */
-    default boolean appliesTo(Object result) {
+    default boolean appliesTo(Origin origin, Object result) {
         return true;
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SingleResultNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SingleResultNode.java
@@ -25,7 +25,7 @@ public class SingleResultNode implements ResultNode {
             String result = null;
             if (mappers != null) {
                 for (ResultMapper mapper : mappers) {
-                    if (mapper.appliesTo(value)) {
+                    if (mapper.appliesTo(expression.origin, value)) {
                         result = mapper.map(value, expression);
                         break;
                     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Template.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Template.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -43,7 +44,7 @@ public interface Template {
 
     /**
      * 
-     * @return an immutable set of expressions
+     * @return an immutable set of expressions used in the template
      */
     Set<Expression> getExpressions();
 
@@ -53,5 +54,11 @@ public interface Template {
      * @return the generated id
      */
     String getGeneratedId();
+
+    /**
+     * 
+     * @return the template variant
+     */
+    Optional<Variant> getVariant();
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -14,12 +15,14 @@ class TemplateImpl implements Template {
 
     private final String generatedId;
     private final EngineImpl engine;
+    private final Optional<Variant> variant;
     final SectionNode root;
 
-    TemplateImpl(EngineImpl engine, SectionNode root, String generatedId) {
+    TemplateImpl(EngineImpl engine, SectionNode root, String generatedId, Optional<Variant> variant) {
         this.engine = engine;
         this.root = root;
         this.generatedId = generatedId;
+        this.variant = variant;
     }
 
     @Override
@@ -35,6 +38,11 @@ class TemplateImpl implements Template {
     @Override
     public String getGeneratedId() {
         return generatedId;
+    }
+
+    @Override
+    public Optional<Variant> getVariant() {
+        return variant;
     }
 
     private class TemplateInstanceImpl extends TemplateInstanceBase {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateLocator.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateLocator.java
@@ -1,0 +1,37 @@
+package io.quarkus.qute;
+
+import java.io.Reader;
+import java.util.Optional;
+
+/**
+ * Locates template sources.
+ * 
+ * @see Engine#getTemplate(String)
+ */
+public interface TemplateLocator extends WithPriority {
+
+    /**
+     * 
+     * @param id
+     * @return the template location for the given id
+     */
+    Optional<TemplateLocation> locate(String id);
+
+    interface TemplateLocation {
+
+        /**
+         * A {@link Reader} instance produced by a locator is immediately closed right after the template content is parsed.
+         * 
+         * @return
+         */
+        Reader read();
+
+        /**
+         * 
+         * @return the template variant
+         */
+        Optional<Variant> getVariant();
+
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -24,13 +25,22 @@ public interface TemplateNode {
         return Collections.emptySet();
     }
 
+    /**
+     * 
+     * @return the origin of the node
+     */
     Origin getOrigin();
 
-    interface Origin {
+    /**
+     * Represents an origin of a template node.
+     */
+    public interface Origin {
 
         int getLine();
 
         String getTemplateId();
+
+        Optional<Variant> getVariant();
 
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -14,6 +14,21 @@ public final class ValueResolvers {
 
     static final String THIS = "this";
 
+    public static ValueResolver rawResolver() {
+        return new ValueResolver() {
+
+            public boolean appliesTo(EvalContext context) {
+                return context.getBase() != null
+                        && (context.getName().equals("raw") || context.getName().equals("safe"));
+            }
+
+            @Override
+            public CompletionStage<Object> resolve(EvalContext context) {
+                return CompletableFuture.completedFuture(new RawString(context.getBase().toString()));
+            }
+        };
+    }
+
     public static ValueResolver collectionResolver() {
         return new ValueResolver() {
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Variant.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Variant.java
@@ -1,4 +1,4 @@
-package io.quarkus.qute.api;
+package io.quarkus.qute;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -6,7 +6,12 @@ import java.util.Objects;
 /**
  * Media type, locale and encoding.
  */
-public class Variant {
+public final class Variant {
+
+    public final static String TEXT_HTML = "text/html";
+    public final static String TEXT_PLAIN = "text/plain";
+    public final static String TEXT_XML = "text/xml";
+    public final static String APPLICATION_JSON = "application/json";
 
     public final Locale locale;
     public final String mediaType;

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/EscaperTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/EscaperTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.qute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.qute.TemplateNode.Origin;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 
+ */
+public class EscaperTest {
+
+    @Test
+    public void testEscaping() throws IOException {
+        Escaper escaper = Escaper.builder().add('a', "aaa").build();
+        assertEquals("aaa", escaper.escape("a"));
+        assertEquals("b", escaper.escape("b"));
+
+        Escaper html = Escaper.builder().add('"', "&quot;").add('\'', "&#39;")
+                .add('&', "&amp;").add('<', "&lt;").add('>', "&gt;").build();
+        assertEquals("&lt;strong&gt;Čolek&lt;/strong&gt;", html.escape("<strong>Čolek</strong>"));
+        assertEquals("&lt;a&gt;&amp;link&quot;&#39;&lt;/a&gt;", html.escape("<a>&link\"'</a>"));
+    }
+
+    @Test
+    public void testRawStringRevolver() {
+
+        Escaper escaper = Escaper.builder().add('a', "A").build();
+        Engine engine = Engine.builder().addValueResolver(ValueResolvers.mapResolver())
+                .addValueResolver(ValueResolvers.rawResolver()).addResultMapper(new ResultMapper() {
+
+                    @Override
+                    public boolean appliesTo(Origin origin, Object result) {
+                        return result instanceof String;
+                    }
+
+                    @Override
+                    public String map(Object result, Expression expression) {
+                        return escaper.escape(result.toString());
+                    }
+                }).build();
+
+        assertEquals("HAM HaM", engine.parse("{foo} {foo.raw}").data("foo", "HaM").render());
+
+    }
+
+}

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
@@ -3,6 +3,7 @@ package io.quarkus.qute;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.quarkus.qute.Results.Result;
+import io.quarkus.qute.TemplateNode.Origin;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -146,7 +147,7 @@ public class SimpleTest {
                                 return 10;
                             }
 
-                            public boolean appliesTo(Object val) {
+                            public boolean appliesTo(Origin origin, Object val) {
                                 return val.equals(Result.NOT_FOUND);
                             }
 
@@ -160,7 +161,7 @@ public class SimpleTest {
                                 return 1;
                             }
 
-                            public boolean appliesTo(Object val) {
+                            public boolean appliesTo(Origin origin, Object val) {
                                 return val.equals(Result.NOT_FOUND);
                             }
 
@@ -174,7 +175,7 @@ public class SimpleTest {
                                 return 1;
                             }
 
-                            public boolean appliesTo(Object val) {
+                            public boolean appliesTo(Origin origin, Object val) {
                                 return val instanceof Collection;
                             }
 


### PR DESCRIPTION
- resolves #6155
- API changes:
 - introduce TemplateLocator
 - add Template#getVariant()

What this PR does?

1. For HTML templates `'`,`"`,`<`, `>` and `&` are escaped by default
2. It's possilble to use `raw` and `safe` extension methods for String to "unescape" the value; ie. `{foo.myString.raw}`
3. `RawString` is never escaped
4. `Template` now has an optional `Variant`