### PR TITLE
Feature/#1483 extensions/kubernetes using JKube+Dekorate

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -826,10 +826,6 @@
                         <artifactId>jaxb-api</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-compress</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.apache.maven</groupId>
                         <artifactId>maven-artifact</artifactId>
                     </exclusion>
@@ -844,10 +840,6 @@
                     <exclusion>
                         <groupId>org.apache.maven.shared</groupId>
                         <artifactId>maven-shared-utils</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcpkix-jdk15on</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.codehaus.plexus</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -139,6 +139,7 @@
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.41</kotlin.version>
         <dekorate.version>0.9.9</dekorate.version>
+        <jkube.version>0.1-SNAPSHOT</jkube.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
@@ -790,6 +791,77 @@
                 <artifactId>knative-annotations</artifactId>
                 <version>${dekorate.version}</version>
                 <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jkube</groupId>
+                <artifactId>jkube-kit-config-resource</artifactId>
+                <version>${jkube.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-compress</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-artifact</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-model-builder</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-settings</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.maven.shared</groupId>
+                        <artifactId>maven-shared-utils</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-classworlds</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-interpolation</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm-util</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>

--- a/extensions/kubernetes/deployment/pom.xml
+++ b/extensions/kubernetes/deployment/pom.xml
@@ -62,6 +62,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-kit-config-resource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AbstractJKubeProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AbstractJKubeProcessor.java
@@ -12,12 +12,15 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.jkube.kit.build.maven.MavenBuildContext;
 import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.build.service.docker.RegistryService;
 import org.eclipse.jkube.kit.build.service.docker.ServiceHub;
 import org.eclipse.jkube.kit.build.service.docker.ServiceHubFactory;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.build.service.docker.access.log.LogOutputSpecFactory;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
+import org.eclipse.jkube.kit.config.image.build.OpenShiftBuildStrategy;
+import org.eclipse.jkube.kit.config.resource.BuildRecreateMode;
 import org.eclipse.jkube.kit.config.service.BuildService;
 import org.eclipse.jkube.kit.config.service.JkubeServiceHub;
 import org.eclipse.microprofile.config.Config;
@@ -33,8 +36,12 @@ class AbstractJKubeProcessor {
         return new BuildService.BuildServiceConfig.Builder()
                 .dockerBuildContext(new org.eclipse.jkube.kit.build.service.docker.BuildService.BuildContext.Builder()
                         .mojoParameters(fakeDockerMojoParameters)
+                        .registryConfig(new RegistryService.RegistryConfig.Builder().build())
                         .build())
                 .dockerMavenBuildContext(fakeDockerMojoParameters)
+                .openshiftBuildStrategy(OpenShiftBuildStrategy.docker)
+                .s2iBuildNameSuffix("")
+                .buildRecreateMode(BuildRecreateMode.all)
                 .buildDirectory(projectDirectory.resolve("target").toString())
                 .build();
     }

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AbstractJKubeProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AbstractJKubeProcessor.java
@@ -1,0 +1,83 @@
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.deployment.FakeMavenMojoEnvironment.PLEXUS_CONTAINER;
+import static io.quarkus.kubernetes.deployment.FakeMavenMojoEnvironment.fakeMavenBuildContext;
+
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.stream.StreamSupport;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.jkube.kit.build.maven.MavenBuildContext;
+import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.build.service.docker.ServiceHub;
+import org.eclipse.jkube.kit.build.service.docker.ServiceHubFactory;
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
+import org.eclipse.jkube.kit.build.service.docker.access.log.LogOutputSpecFactory;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
+import org.eclipse.jkube.kit.config.service.BuildService;
+import org.eclipse.jkube.kit.config.service.JkubeServiceHub;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+class AbstractJKubeProcessor {
+
+    AbstractJKubeProcessor() {
+    }
+
+    private static BuildService.BuildServiceConfig initBuildServiceConfig(Path projectDirectory) {
+        final MavenBuildContext fakeDockerMojoParameters = fakeMavenBuildContext(projectDirectory);
+        return new BuildService.BuildServiceConfig.Builder()
+                .dockerBuildContext(new org.eclipse.jkube.kit.build.service.docker.BuildService.BuildContext.Builder()
+                        .mojoParameters(fakeDockerMojoParameters)
+                        .build())
+                .dockerMavenBuildContext(fakeDockerMojoParameters)
+                .buildDirectory(projectDirectory.resolve("target").toString())
+                .build();
+    }
+
+    private static DockerAccess initDockerAccess(JKubeLogger jKubeLogger)
+            throws MojoExecutionException, MojoFailureException, ComponentLookupException {
+
+        return PLEXUS_CONTAINER.lookup(DockerAccessFactory.class).createDockerAccess(
+                new DockerAccessFactory.DockerAccessContext.Builder()
+                        .log(jKubeLogger)
+                        .skipMachine(false)
+                        .maxConnections(100)
+                        .projectProperties(new Properties())
+                        .build());
+    }
+
+    private static ServiceHub initServiceHub(JKubeLogger jKubeLogger)
+            throws MojoExecutionException, MojoFailureException, ComponentLookupException {
+
+        return PLEXUS_CONTAINER.lookup(ServiceHubFactory.class).createServiceHub(null, null,
+                initDockerAccess(jKubeLogger), jKubeLogger, new LogOutputSpecFactory(true, true, ""));
+    }
+
+    private static ClusterConfiguration initClusterConfiguration() {
+        final Config config = ConfigProvider.getConfig();
+        final Properties props = new Properties();
+        StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .forEach(key -> props.put(key, config.getValue(key, String.class)));
+        return new ClusterConfiguration.Builder().from(System.getProperties()).from(props).build();
+    }
+
+    static ClusterAccess initClusterAccess() {
+        return new ClusterAccess(initClusterConfiguration());
+    }
+
+    static JkubeServiceHub initJKubeServiceHub(JKubeLogger jKubeLogger, Path projectDirectory)
+            throws MojoExecutionException, MojoFailureException, ComponentLookupException {
+
+        return new JkubeServiceHub.Builder()
+                .log(jKubeLogger)
+                .clusterAccess(initClusterAccess())
+                .buildServiceConfig(initBuildServiceConfig(projectDirectory))
+                .dockerServiceHub(initServiceHub(jKubeLogger))
+                .build();
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AbstractJKubeProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AbstractJKubeProcessor.java
@@ -28,6 +28,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 class AbstractJKubeProcessor {
 
+    static final String TARGET_DIR = "target";
+
     AbstractJKubeProcessor() {
     }
 

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java
@@ -1,0 +1,97 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.nio.file.Path;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.plugins.assembly.archive.AssemblyArchiver;
+import org.apache.maven.plugins.assembly.io.AssemblyReader;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.archiver.Archiver;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.eclipse.jkube.kit.build.maven.MavenBuildContext;
+import org.eclipse.jkube.kit.build.maven.assembly.DockerAssemblyManager;
+import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.build.service.docker.ServiceHubFactory;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.property.PropertyConfigHandler;
+
+/**
+ * TODO: REMOVE THIS, PoC purpose only.
+ * JKube should be updated to avoid this tight coupling with Plexus
+ */
+class FakeMavenMojoEnvironment {
+
+    static final PlexusContainer PLEXUS_CONTAINER = fakeMavenMojoEnvironment();
+
+    private FakeMavenMojoEnvironment() {
+    }
+
+    private static PlexusContainer fakeMavenMojoEnvironment() {
+        final PlexusContainer pc;
+        try {
+            pc = new DefaultPlexusContainer(new DefaultContainerConfiguration());
+            for (Class clazz : new Class[] {
+                    PropertyConfigHandler.class, ImageConfigResolver.class, DockerAccessFactory.class
+            }) {
+                pc.addComponentDescriptor(initComponentDescriptor(clazz, pc.getContainerRealm()));
+            }
+            final ComponentDescriptor<DockerAssemblyManager> dam = initComponentDescriptor(DockerAssemblyManager.class,
+                    pc.getContainerRealm());
+            dam.addRequirement(initComponentRequirement(Archiver.class, "trackArchiver"));
+            dam.addRequirement(initComponentRequirement(AssemblyArchiver.class, "assemblyArchiver"));
+            dam.addRequirement(initComponentRequirement(AssemblyReader.class, "assemblyReader"));
+            dam.addRequirement(initComponentRequirement(ArchiverManager.class, "archiverManager"));
+            pc.addComponentDescriptor(dam);
+            final ComponentDescriptor<ServiceHubFactory> shf = initComponentDescriptor(ServiceHubFactory.class,
+                    pc.getContainerRealm());
+            shf.addRequirement(initComponentRequirement(DockerAssemblyManager.class, "dockerAssemblyManager"));
+            pc.addComponentDescriptor(shf);
+        } catch (Exception e) {
+            throw new RuntimeException("Error instantiating JKubeProcessor", e);
+        }
+        return pc;
+    }
+
+    private static ComponentRequirement initComponentRequirement(Class role, String fieldName) {
+        final ComponentRequirement ret = new ComponentRequirement();
+        ret.setRole(role.getCanonicalName());
+        ret.setFieldName(fieldName);
+        return ret;
+    }
+
+    private static <T> ComponentDescriptor<T> initComponentDescriptor(
+            Class<T> clazz, final ClassRealm classRealm, Class<? extends T> defaultImplementation) {
+        final ComponentDescriptor<T> ret = new ComponentDescriptor<>(clazz, classRealm);
+        ret.setRoleClass(clazz);
+        ret.setImplementationClass(defaultImplementation);
+        ret.setRole(clazz.getCanonicalName());
+        ret.setIsolatedRealm(false);
+        return ret;
+    }
+
+    private static <T> ComponentDescriptor<T> initComponentDescriptor(Class<T> clazz, final ClassRealm classRealm) {
+        return initComponentDescriptor(clazz, classRealm, clazz);
+    }
+
+    static MavenBuildContext fakeMavenBuildContext(Path projectDirectory) {
+        final MavenProject mp = new MavenProject();
+        mp.getProperties().put("build_dir", projectDirectory.resolve("target").toString());
+        mp.setFile(projectDirectory.resolve("pom.xml").toFile());
+        mp.setPackaging("jar");
+        mp.setBuild(new Build());
+        mp.getBuild().setOutputDirectory("target/classes");
+        mp.getBuild().setSourceDirectory("src/main/java");
+        mp.getBuild().setDirectory("target");
+        return new MavenBuildContext.Builder()
+                .sourceDirectory("src")
+                .outputDirectory("target")
+                .project(mp)
+                .build();
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java
@@ -36,11 +36,9 @@ class FakeMavenMojoEnvironment {
         final PlexusContainer pc;
         try {
             pc = new DefaultPlexusContainer(new DefaultContainerConfiguration());
-            for (Class clazz : new Class[] {
-                    PropertyConfigHandler.class, ImageConfigResolver.class, DockerAccessFactory.class
-            }) {
-                pc.addComponentDescriptor(initComponentDescriptor(clazz, pc.getContainerRealm()));
-            }
+            pc.addComponentDescriptor(initComponentDescriptor(PropertyConfigHandler.class, pc.getContainerRealm()));
+            pc.addComponentDescriptor(initComponentDescriptor(ImageConfigResolver.class, pc.getContainerRealm()));
+            pc.addComponentDescriptor(initComponentDescriptor(DockerAccessFactory.class, pc.getContainerRealm()));
             final ComponentDescriptor<DockerAssemblyManager> dam = initComponentDescriptor(DockerAssemblyManager.class,
                     pc.getContainerRealm());
             dam.addRequirement(initComponentRequirement(Archiver.class, "trackArchiver"));

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java
@@ -1,5 +1,7 @@
 package io.quarkus.kubernetes.deployment;
 
+import static io.quarkus.kubernetes.deployment.AbstractJKubeProcessor.TARGET_DIR;
+
 import java.nio.file.Path;
 
 import org.apache.maven.model.Build;
@@ -79,16 +81,16 @@ class FakeMavenMojoEnvironment {
 
     static MavenBuildContext fakeMavenBuildContext(Path projectDirectory) {
         final MavenProject mp = new MavenProject();
-        mp.getProperties().put("build_dir", projectDirectory.resolve("target").toString());
+        mp.getProperties().put("build_dir", projectDirectory.resolve(TARGET_DIR).toString());
         mp.setFile(projectDirectory.resolve("pom.xml").toFile());
         mp.setPackaging("jar");
         mp.setBuild(new Build());
         mp.getBuild().setOutputDirectory("target/classes");
         mp.getBuild().setSourceDirectory("src/main/java");
-        mp.getBuild().setDirectory("target");
+        mp.getBuild().setDirectory(TARGET_DIR);
         return new MavenBuildContext.Builder()
                 .sourceDirectory("src")
-                .outputDirectory("target")
+                .outputDirectory(TARGET_DIR)
                 .project(mp)
                 .build();
     }

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/JKubeLogger.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/JKubeLogger.java
@@ -1,0 +1,38 @@
+package io.quarkus.kubernetes.deployment;
+
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.jboss.logging.Logger;
+
+public class JKubeLogger implements KitLogger {
+
+    private final Logger log;
+
+    JKubeLogger(Logger log) {
+        this.log = log;
+    }
+
+    @Override
+    public void debug(String format, Object... params) {
+        log.debugf(format, params);
+    }
+
+    @Override
+    public void info(String format, Object... params) {
+        log.infof(format, params);
+    }
+
+    @Override
+    public void warn(String format, Object... params) {
+        log.warnf(format, params);
+    }
+
+    @Override
+    public void error(String format, Object... params) {
+        log.errorf(format, params);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesApplyProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesApplyProcessor.java
@@ -1,0 +1,131 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
+import org.eclipse.jkube.kit.config.service.ApplyService;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesManifestBuildItem;
+
+public class KubernetesApplyProcessor {
+
+    private static final Logger log = Logger.getLogger(KubernetesApplyProcessor.class);
+
+    static List<Path> getApplicableManifests(String target, Path outputDirectory,
+            List<KubernetesManifestBuildItem> generatedManifests) {
+
+        return generatedManifests
+                .stream()
+                .filter(mf -> mf.getTarget().equals(target))
+                .map(KubernetesManifestBuildItem::getPath)
+                .filter(Objects::nonNull)
+                .map(outputDirectory::resolve)
+                .filter(p -> p.toFile().exists())
+                .filter(p -> p.toFile().isFile())
+                .filter(p -> p.toFile().getName().matches(".+\\.ya?ml$"))
+                .collect(Collectors.toList());
+    }
+
+    private static <T extends KubernetesClient> String getTarget(T kubernetesClient) {
+        return OpenshiftHelper.isOpenShift(kubernetesClient) ? "openshift" : "kubernetes";
+    }
+
+    private static ClusterConfiguration getClusterConfiguration() {
+        final Config config = ConfigProvider.getConfig();
+        final Properties props = new Properties();
+        StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .forEach(key -> props.put(key, config.getValue(key, String.class)));
+        return new ClusterConfiguration.Builder().from(System.getProperties()).from(props).build();
+    }
+
+    private static <T extends KubernetesClient> T initClient(JKubeLogger log) {
+        return new ClusterAccess(getClusterConfiguration()).createDefaultClient(log);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public List<ArtifactResultBuildItem> apply(
+            KubernetesConfig kubernetesConfig,
+            OutputTargetBuildItem outputTargetBuildItem,
+            List<KubernetesManifestBuildItem> generatedManifests,
+            JarBuildItem jarBuildItem) {
+
+        if (kubernetesConfig.skipApply) {
+            log.info("Kubernetes apply phase is skipped");
+            return Collections.emptyList();
+        }
+
+        final JKubeLogger jKubeLogger = new JKubeLogger(log);
+        final KubernetesClient kubernetesClient = initClient(jKubeLogger);
+        final ApplyService applyService = new ApplyService(kubernetesClient, jKubeLogger);
+        final List<Path> generatedManifestPaths = getApplicableManifests(
+                getTarget(kubernetesClient), outputTargetBuildItem.getOutputDirectory(), generatedManifests);
+        generatedManifestPaths.forEach(manifestPath -> {
+            final File manifestFile = manifestPath.toFile();
+            try (FileInputStream fis = new FileInputStream(manifestFile)) {
+                applyService.applyList(Serialization.unmarshal(fis, KubernetesList.class), manifestFile.getName());
+            } catch (Exception ex) {
+                log.errorf(ex, "Error parsing manifest %s", manifestFile.getName());
+            }
+        });
+        return generatedManifestPaths.stream()
+                .map(mf -> new ArtifactResultBuildItem(mf, "yml", Collections.emptyMap()))
+                .collect(Collectors.toList());
+    }
+
+    private static final class JKubeLogger implements KitLogger {
+
+        private final Logger log;
+
+        private JKubeLogger(Logger log) {
+            this.log = log;
+        }
+
+        @Override
+        public void debug(String format, Object... params) {
+            log.debugf(format, params);
+        }
+
+        @Override
+        public void info(String format, Object... params) {
+            log.infof(format, params);
+        }
+
+        @Override
+        public void warn(String format, Object... params) {
+            log.warnf(format, params);
+        }
+
+        @Override
+        public void error(String format, Object... params) {
+            log.errorf(format, params);
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return log.isDebugEnabled();
+        }
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesBuildProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesBuildProcessor.java
@@ -1,0 +1,90 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.eclipse.jkube.kit.build.service.docker.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.service.JkubeServiceHub;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.JarBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesImageBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesProjectBuildItem;
+
+public class KubernetesBuildProcessor extends AbstractJKubeProcessor {
+
+    private static final Logger log = Logger.getLogger(KubernetesBuildProcessor.class);
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public KubernetesImageBuildItem build(
+            KubernetesConfig kubernetesConfig,
+            OutputTargetBuildItem outputTargetBuildItem,
+            Optional<KubernetesProjectBuildItem> kubernetesProjectBI,
+            Optional<JarBuildItem> jarBuildItem) {
+
+        if (!jarBuildItem.isPresent() || !kubernetesProjectBI.isPresent() || kubernetesConfig.skipBuild) {
+            log.info("Kubernetes build phase is skipped");
+            return null;
+        }
+        final JKubeLogger jKubeLogger = new JKubeLogger(log);
+        final Path projectDirectory = outputTargetBuildItem.getOutputDirectory().getParent();
+        final Path dockerFile = projectDirectory.resolve("src/main/docker/Dockerfile.jvm");
+        final String imageName = String.format("%s/%s:%s", kubernetesProjectBI.get().getGroup(),
+                kubernetesProjectBI.get().getName(), kubernetesProjectBI.get().getVersion());
+        copyFiles(projectDirectory, imageName);
+        final BuildConfiguration buildConfig = new BuildConfiguration.Builder()
+                .dockerFile(dockerFile.toFile().getAbsolutePath())
+                .workdir(projectDirectory.toString())
+                .build();
+        try {
+            final JkubeServiceHub jkubeServiceHub = initJKubeServiceHub(jKubeLogger, projectDirectory);
+            final ImageConfiguration imageConfiguration = new ImageConfiguration.Builder()
+                    .name(imageName)
+                    .buildConfig(buildConfig)
+                    .build();
+            imageConfiguration.initAndValidate(original -> imageName, jKubeLogger);
+            jkubeServiceHub.getBuildService().build(imageConfiguration);
+            return new KubernetesImageBuildItem(imageName);
+        } catch (Exception e) {
+            log.error("Error building Docker image", e);
+        }
+        return null;
+    }
+
+    private static void copyFiles(Path projectDir, String imageName) {
+        final String targetDirName = "target";
+        final File buildTargetDir = projectDir.resolve(targetDirName).resolve(imageName.replace(':', '/'))
+                .resolve("build").resolve(targetDirName).toFile();
+        if (buildTargetDir.mkdirs()) {
+            final FileFilter jarFilter = ff -> ff.getName().endsWith(".jar");
+            Stream.of(Objects.requireNonNull(projectDir.resolve(targetDirName).toFile().listFiles(jarFilter)))
+                    .forEach(copyFileRelative(buildTargetDir.toPath()));
+            Stream.of(Objects.requireNonNull(projectDir.resolve(targetDirName).resolve("lib").toFile().listFiles(jarFilter)))
+                    .forEach(copyFileRelative(buildTargetDir.toPath().resolve("lib")));
+        }
+    }
+
+    private static Consumer<? super File> copyFileRelative(Path targetDir) {
+        targetDir.toFile().mkdirs();
+        return srcFile -> {
+            try {
+                Files.copy(srcFile.toPath(),
+                        targetDir.resolve(srcFile.toPath().getParent().relativize(srcFile.toPath())));
+            } catch (IOException e) {
+                log.errorf(e, "Error copying file %s", srcFile.getName());
+            }
+        };
+    }
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public class KubernetesConfig {
+
+    /**
+     * Skip apply resources to cluster
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean skipApply;
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -4,8 +4,14 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME, name = "test")
 public class KubernetesConfig {
+
+    /**
+     * Skip image build
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean skipBuild;
 
     /**
      * Skip apply resources to cluster

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -18,4 +18,10 @@ public class KubernetesConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean skipApply;
+
+    /**
+     * Relative path for Dockerfile
+     */
+    @ConfigItem(defaultValue = "src/main/docker/Dockerfile.jvm")
+    public String dockerFile;
 }

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesPortProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesPortProcessor.java
@@ -1,0 +1,19 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.OptionalInt;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.kubernetes.spi.KubernetesPortBuildItem;
+
+class KubernetesPortProcessor {
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public KubernetesPortBuildItem buildTimePort() {
+        return new KubernetesPortBuildItem(
+                ConfigProvider.getConfig().getValue("quarkus.http.port", OptionalInt.class).orElse(8080),
+                "http");
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -124,6 +125,7 @@ class KubernetesProcessor {
         try {
             final SessionWriter sessionWriter = new SimpleFileWriter(root, false);
             Project project = createProject(applicationInfo, archiveRootBuildItem);
+            project.getBuildInfo().setOutputFile(Paths.get("app.jar"));
             sessionWriter.setProject(project);
             final Session session = Session.getSession();
             session.setWriter(sessionWriter);

--- a/extensions/kubernetes/deployment/src/test/java/io/quarkus/kubernetes/deployment/KubernetesApplyProcessorTest.java
+++ b/extensions/kubernetes/deployment/src/test/java/io/quarkus/kubernetes/deployment/KubernetesApplyProcessorTest.java
@@ -1,0 +1,54 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.deployment.KubernetesApplyProcessor.getApplicableManifests;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.kubernetes.spi.KubernetesManifestBuildItem;
+
+class KubernetesApplyProcessorTest {
+
+    private static Path mockOutputPath() {
+        final Path outputPath = mock(Path.class);
+        doAnswer(i -> {
+            final Path resolvedPath = mock(Path.class, RETURNS_DEEP_STUBS);
+            when(resolvedPath.toFile().exists()).thenReturn(true);
+            when(resolvedPath.toFile().isFile()).thenReturn(true);
+            when(resolvedPath.toFile().getName()).thenReturn(i.getArgument(0));
+            return resolvedPath;
+        }).when(outputPath).resolve(anyString());
+
+        return outputPath;
+    }
+
+    @Test
+    void getApplicableManifestsValidManifestsInPathShouldReturnNonEmptyList() {
+        final Path outputPath = mockOutputPath();
+        final List<KubernetesManifestBuildItem> generatedManifests = Arrays.asList(
+                new KubernetesManifestBuildItem("openshift", null),
+                new KubernetesManifestBuildItem("openshift", "no-extension"),
+                new KubernetesManifestBuildItem("openshift", "invalid.extension"),
+                new KubernetesManifestBuildItem("openshift", "valid.yaml"),
+                new KubernetesManifestBuildItem("openshift", "invalid.yoml"),
+                new KubernetesManifestBuildItem("openshift", "valid.corner.yml"),
+                new KubernetesManifestBuildItem("openshift", "invalid.yml."),
+                new KubernetesManifestBuildItem("kubernetes", "valid.yaml"),
+                new KubernetesManifestBuildItem("kubernetes", "invalid.yoml"),
+                new KubernetesManifestBuildItem("kubernetes", "valid.corner.yml"));
+
+        final List<Path> result = getApplicableManifests("openshift", outputPath, generatedManifests);
+
+        assertFalse(result.isEmpty());
+        assertEquals(2, result.size());
+        assertTrue(result.stream().map(Path::toFile).map(File::getName).anyMatch("valid.yaml"::equals));
+        assertTrue(result.stream().map(Path::toFile).map(File::getName).anyMatch("valid.corner.yml"::equals));
+    }
+}

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesImageBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesImageBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class KubernetesImageBuildItem extends SimpleBuildItem {
+
+    private final String imageName;
+
+    public KubernetesImageBuildItem(String imageName) {
+        this.imageName = imageName;
+    }
+
+    public String getImageName() {
+        return imageName;
+    }
+}

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesManifestBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesManifestBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class KubernetesManifestBuildItem extends MultiBuildItem {
+
+    private final String target;
+    private final String path;
+
+    public KubernetesManifestBuildItem(String target, String path) {
+        this.target = target;
+        this.path = path;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesProjectBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesProjectBuildItem.java
@@ -1,0 +1,42 @@
+package io.quarkus.kubernetes.spi;
+
+import java.nio.file.Path;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class KubernetesProjectBuildItem extends SimpleBuildItem {
+
+    private final Path root;
+    private final String group;
+    private final String name;
+    private final String version;
+    private final Path outputFile;
+
+    public KubernetesProjectBuildItem(Path root, String group, String name, String version, Path outputFile) {
+        this.root = root;
+        this.group = group;
+        this.name = name;
+        this.version = version;
+        this.outputFile = outputFile;
+    }
+
+    public Path getRoot() {
+        return root;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Path getOutputFile() {
+        return outputFile;
+    }
+}


### PR DESCRIPTION
PoC showcasing extensions/kubernetes integration with [JKube-kit](https://github.com/eclipse/jkube) to perform image build and manifest apply to the cluster.

Additional work should be performed in JKube in order to decouple some of the services from Maven and it s context (Very ugly class providing Maven coupled context: https://github.com/manusa/quarkus/blob/518cbb0776428b5108753a574a3085cea8a4e319/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/FakeMavenMojoEnvironment.java).

This code should not be merged under any circumstance, not production ready.

Relates to:
https://github.com/fabric8io/fabric8-maven-plugin/issues/1483