### PR TITLE
Use the bean index to scan subresources, check parameters and look for @Context

### DIFF
--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -232,7 +232,7 @@ public class ResteasyServerCommonProcessor {
             }
         }
 
-        Set<DotName> subresources = findSubresources(index, scannedResources);
+        Set<DotName> subresources = findSubresources(beanArchiveIndexBuildItem.getIndex(), scannedResources);
         if (!subresources.isEmpty()) {
             for (DotName locator : subresources) {
                 reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, locator.toString()));
@@ -247,9 +247,9 @@ public class ResteasyServerCommonProcessor {
         // see https://issues.jboss.org/browse/RESTEASY-2183
         generateDefaultConstructors(transformers, withoutDefaultCtor, additionalJaxRsResourceDefiningAnnotations);
 
-        checkParameterNames(index, additionalJaxRsResourceMethodParamAnnotations);
+        checkParameterNames(beanArchiveIndexBuildItem.getIndex(), additionalJaxRsResourceMethodParamAnnotations);
 
-        registerContextProxyDefinitions(index, proxyDefinition);
+        registerContextProxyDefinitions(beanArchiveIndexBuildItem.getIndex(), proxyDefinition);
 
         registerReflectionForSerialization(reflectiveClass, reflectiveHierarchy, combinedIndexBuildItem,
                 beanArchiveIndexBuildItem, additionalJaxRsResourceMethodAnnotations);


### PR DESCRIPTION
In the case of generated resource beans such as in Kogito, this was
causing failures.

It should fix the quickstart issue we have right now.

/cc @mswiderski 