### PR TITLE
Upgrade to Hibernate Search 6.0.0 beta3

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -83,12 +83,12 @@
         <classmate.version>1.3.4</classmate.version>
         <hibernate-validator.version>6.1.0.Final</hibernate-validator.version>
         <hibernate-orm.version>5.4.10.Final</hibernate-orm.version>
-        <hibernate-search.version>6.0.0.Beta2</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Beta3</hibernate-search.version>
         <narayana.version>5.10.0.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.7</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.4.0</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.5.0</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.15</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -16,8 +16,8 @@
 
     <properties>
         <!-- Maven plugin versions -->
-        <elasticsearch-maven-plugin.version>6.14</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.4.0</elasticsearch-server.version>
+        <elasticsearch-maven-plugin.version>6.15</elasticsearch-maven-plugin.version>
+        <elasticsearch-server.version>7.5.0</elasticsearch-server.version>
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->

--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -594,7 +594,7 @@ Let's use Docker to start one of each:
 
 [source, shell]
 ----
-docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.5.0
 ----
 
 [source, shell]

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
@@ -25,42 +25,17 @@ import org.hibernate.search.backend.elasticsearch.document.model.esnative.impl.R
 import org.hibernate.search.backend.elasticsearch.document.model.esnative.impl.RoutingType;
 import org.hibernate.search.backend.elasticsearch.index.settings.esnative.impl.Analysis;
 import org.hibernate.search.backend.elasticsearch.index.settings.esnative.impl.IndexSettings;
-import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.declaration.MarkerBinding;
-import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.declaration.PropertyBinding;
-import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.declaration.RoutingKeyBinding;
-import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.declaration.TypeBinding;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ScaledNumberField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMapping;
 import org.jboss.jandex.DotName;
 
 class HibernateSearchClasses {
 
     static final DotName INDEXED = DotName.createSimple(Indexed.class.getName());
 
-    static final List<DotName> FIELD_ANNOTATIONS = Arrays.asList(
-            DotName.createSimple(DocumentId.class.getName()),
-            DotName.createSimple(GenericField.class.getName()),
-            DotName.createSimple(FullTextField.class.getName()),
-            DotName.createSimple(KeywordField.class.getName()),
-            DotName.createSimple(ScaledNumberField.class.getName()),
-            DotName.createSimple(IndexedEmbedded.class.getName()),
-            DotName.createSimple(AssociationInverseSide.class.getName()),
-            DotName.createSimple(IndexingDependency.class.getName()));
-
-    static final List<DotName> BINDING_DECLARATION_ANNOTATIONS_ON_PROPERTIES = Arrays.asList(
-            DotName.createSimple(PropertyBinding.class.getName()),
-            DotName.createSimple(MarkerBinding.class.getName()));
-
-    static final List<DotName> BINDING_DECLARATION_ANNOTATIONS_ON_TYPES = Arrays.asList(
-            DotName.createSimple(TypeBinding.class.getName()),
-            DotName.createSimple(RoutingKeyBinding.class.getName()));
+    static final DotName PROPERTY_MAPPING_META_ANNOTATION = DotName.createSimple(
+            org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping.class.getName());
+    static final DotName TYPE_MAPPING_META_ANNOTATION = DotName.createSimple(TypeMapping.class.getName());
 
     static final List<DotName> SCHEMA_MAPPING_CLASSES = Arrays.asList(
             DotName.createSimple(AbstractTypeMapping.class.getName()),

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -38,6 +38,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.configuration.ConfigurationError;
+import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.search.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfig;
@@ -50,6 +51,11 @@ class HibernateSearchElasticsearchProcessor {
     private static final String HIBERNATE_SEARCH_ELASTICSEARCH = "Hibernate Search Elasticsearch";
 
     HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig;
+
+    @BuildStep
+    void setupLogFilters(BuildProducer<LogCleanupFilterBuildItem> filters) {
+        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.search.engine.Version", "HSEARCH000034"));
+    }
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -136,6 +136,10 @@ class HibernateSearchElasticsearchProcessor {
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
         Set<DotName> reflectiveClassCollector = new HashSet<>();
 
+        // TODO remove this when upgrading to Beta4 (when https://hibernate.atlassian.net/browse/HSEARCH-3795 is solved)
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(false, false, org.hibernate.search.engine.logging.impl.Log_$logger.class));
+
         if (buildTimeConfig.defaultBackend.analysis.configurer.isPresent()) {
             reflectiveClass.produce(
                     new ReflectiveClassBuildItem(true, false, buildTimeConfig.defaultBackend.analysis.configurer.get()));

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -1,10 +1,9 @@
 package io.quarkus.hibernate.search.elasticsearch;
 
-import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.BINDING_DECLARATION_ANNOTATIONS_ON_PROPERTIES;
-import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.BINDING_DECLARATION_ANNOTATIONS_ON_TYPES;
-import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.FIELD_ANNOTATIONS;
 import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.INDEXED;
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.PROPERTY_MAPPING_META_ANNOTATION;
 import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.SCHEMA_MAPPING_CLASSES;
+import static io.quarkus.hibernate.search.elasticsearch.HibernateSearchClasses.TYPE_MAPPING_META_ANNOTATION;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -130,7 +129,6 @@ class HibernateSearchElasticsearchProcessor {
     private void registerReflection(IndexView index, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
         Set<DotName> reflectiveClassCollector = new HashSet<>();
-        Set<DotName> reflectiveTypeCollector = new HashSet<>();
 
         if (buildTimeConfig.defaultBackend.analysis.configurer.isPresent()) {
             reflectiveClass.produce(
@@ -142,53 +140,38 @@ class HibernateSearchElasticsearchProcessor {
                     new ReflectiveClassBuildItem(true, false, buildTimeConfig.backgroundFailureHandler.get()));
         }
 
-        for (DotName fieldAnnotation : FIELD_ANNOTATIONS) {
-            for (AnnotationInstance fieldAnnotationInstance : index.getAnnotations(fieldAnnotation)) {
-                AnnotationTarget annotationTarget = fieldAnnotationInstance.target();
-                if (annotationTarget.kind() == Kind.FIELD) {
-                    FieldInfo fieldInfo = annotationTarget.asField();
-                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, fieldInfo.declaringClass());
-                    addReflectiveType(index, reflectiveTypeCollector, fieldInfo.type());
-                } else if (annotationTarget.kind() == Kind.METHOD) {
-                    MethodInfo methodInfo = annotationTarget.asMethod();
-                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, methodInfo.declaringClass());
-                    addReflectiveType(index, reflectiveTypeCollector, methodInfo.returnType());
-                }
-            }
-        }
-
         Set<Type> reflectiveHierarchyCollector = new HashSet<>();
 
-        for (DotName bindingDeclarationOnProperties : BINDING_DECLARATION_ANNOTATIONS_ON_PROPERTIES) {
-            for (AnnotationInstance propertyBridgeMappingInstance : index.getAnnotations(bindingDeclarationOnProperties)) {
-                for (AnnotationInstance propertyBridgeInstance : index.getAnnotations(propertyBridgeMappingInstance.name())) {
-                    AnnotationTarget annotationTarget = propertyBridgeInstance.target();
-                    if (annotationTarget.kind() == Kind.FIELD) {
-                        FieldInfo fieldInfo = annotationTarget.asField();
-                        addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector,
-                                fieldInfo.declaringClass());
-                        reflectiveHierarchyCollector.add(fieldInfo.type());
-                    } else if (annotationTarget.kind() == Kind.METHOD) {
-                        MethodInfo methodInfo = annotationTarget.asMethod();
-                        addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector,
-                                methodInfo.declaringClass());
-                        reflectiveHierarchyCollector.add(methodInfo.returnType());
-                    }
+        for (AnnotationInstance propertyMappingMetaAnnotationInstance : index
+                .getAnnotations(PROPERTY_MAPPING_META_ANNOTATION)) {
+            for (AnnotationInstance propertyMappingAnnotationInstance : index
+                    .getAnnotations(propertyMappingMetaAnnotationInstance.name())) {
+                AnnotationTarget annotationTarget = propertyMappingAnnotationInstance.target();
+                if (annotationTarget.kind() == Kind.FIELD) {
+                    FieldInfo fieldInfo = annotationTarget.asField();
+                    addReflectiveClass(index, reflectiveClassCollector, reflectiveHierarchyCollector,
+                            fieldInfo.declaringClass());
+                    addReflectiveType(index, reflectiveClassCollector, reflectiveHierarchyCollector,
+                            fieldInfo.type());
+                } else if (annotationTarget.kind() == Kind.METHOD) {
+                    MethodInfo methodInfo = annotationTarget.asMethod();
+                    addReflectiveClass(index, reflectiveClassCollector, reflectiveHierarchyCollector,
+                            methodInfo.declaringClass());
+                    addReflectiveType(index, reflectiveClassCollector, reflectiveHierarchyCollector,
+                            methodInfo.returnType());
                 }
             }
         }
 
-        for (DotName bindingDeclarationOnTypes : BINDING_DECLARATION_ANNOTATIONS_ON_TYPES) {
-            for (AnnotationInstance typeBridgeMappingInstance : index.getAnnotations(bindingDeclarationOnTypes)) {
-                for (AnnotationInstance typeBridgeInstance : index.getAnnotations(typeBridgeMappingInstance.name())) {
-                    addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector,
-                            typeBridgeInstance.target().asClass());
-                }
+        for (AnnotationInstance typeBridgeMappingInstance : index.getAnnotations(TYPE_MAPPING_META_ANNOTATION)) {
+            for (AnnotationInstance typeBridgeInstance : index.getAnnotations(typeBridgeMappingInstance.name())) {
+                addReflectiveClass(index, reflectiveClassCollector, reflectiveHierarchyCollector,
+                        typeBridgeInstance.target().asClass());
             }
         }
 
         String[] reflectiveClasses = Stream
-                .of(reflectiveClassCollector.stream(), reflectiveTypeCollector.stream(), SCHEMA_MAPPING_CLASSES.stream())
+                .of(reflectiveClassCollector.stream(), SCHEMA_MAPPING_CLASSES.stream())
                 .flatMap(Function.identity()).map(c -> c.toString()).toArray(String[]::new);
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, reflectiveClasses));
 
@@ -198,7 +181,7 @@ class HibernateSearchElasticsearchProcessor {
     }
 
     private static void addReflectiveClass(IndexView index, Set<DotName> reflectiveClassCollector,
-            Set<DotName> reflectiveTypeCollector, ClassInfo classInfo) {
+            Set<Type> reflectiveTypeCollector, ClassInfo classInfo) {
         if (skipClass(classInfo.name(), reflectiveClassCollector)) {
             return;
         }
@@ -219,29 +202,27 @@ class HibernateSearchElasticsearchProcessor {
             } else if (superClassType instanceof ParameterizedType) {
                 ParameterizedType parameterizedType = superClassType.asParameterizedType();
                 for (Type typeArgument : parameterizedType.arguments()) {
-                    addReflectiveType(index, reflectiveTypeCollector, typeArgument);
+                    addReflectiveType(index, reflectiveClassCollector, reflectiveTypeCollector, typeArgument);
                 }
                 superClassType = parameterizedType.owner();
             }
         }
     }
 
-    private static void addReflectiveType(IndexView index, Set<DotName> reflectiveTypeCollector, Type type) {
+    private static void addReflectiveType(IndexView index, Set<DotName> reflectiveClassCollector,
+            Set<Type> reflectiveTypeCollector, Type type) {
         if (type instanceof VoidType || type instanceof PrimitiveType || type instanceof UnresolvedTypeVariable) {
             return;
         } else if (type instanceof ClassType) {
-            if (skipClass(type.name(), reflectiveTypeCollector)) {
-                return;
-            }
-
-            reflectiveTypeCollector.add(type.name());
+            ClassInfo classInfo = index.getClassByName(type.name());
+            addReflectiveClass(index, reflectiveClassCollector, reflectiveTypeCollector, classInfo);
         } else if (type instanceof ArrayType) {
-            addReflectiveType(index, reflectiveTypeCollector, type.asArrayType().component());
+            addReflectiveType(index, reflectiveClassCollector, reflectiveTypeCollector, type.asArrayType().component());
         } else if (type instanceof ParameterizedType) {
             ParameterizedType parameterizedType = type.asParameterizedType();
-            addReflectiveType(index, reflectiveTypeCollector, parameterizedType.owner());
+            addReflectiveType(index, reflectiveClassCollector, reflectiveTypeCollector, parameterizedType.owner());
             for (Type typeArgument : parameterizedType.arguments()) {
-                addReflectiveType(index, reflectiveTypeCollector, typeArgument);
+                addReflectiveType(index, reflectiveClassCollector, reflectiveTypeCollector, typeArgument);
             }
         }
     }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -124,6 +124,8 @@ public class HibernateSearchElasticsearchRecorder {
                 ElasticsearchBackendRuntimeConfig elasticsearchBackendConfig) {
             addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.HOSTS,
                     elasticsearchBackendConfig.hosts);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.PROTOCOL,
+                    elasticsearchBackendConfig.protocol.getHibernateSearchString());
             addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.USERNAME,
                     elasticsearchBackendConfig.username);
             addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.PASSWORD,
@@ -140,8 +142,6 @@ public class HibernateSearchElasticsearchRecorder {
             if (elasticsearchBackendConfig.discovery.enabled) {
                 addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DISCOVERY_REFRESH_INTERVAL,
                         elasticsearchBackendConfig.discovery.refreshInterval.getSeconds());
-                addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DISCOVERY_SCHEME,
-                        elasticsearchBackendConfig.discovery.defaultScheme);
             }
 
             addBackendDefaultIndexConfig(propertyCollector, backendName, ElasticsearchIndexSettings.LIFECYCLE_STRATEGY,

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.search.elasticsearch.runtime;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -9,6 +10,8 @@ import org.hibernate.search.backend.elasticsearch.index.IndexLifecycleStrategyNa
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.common.impl.StringHelper;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
@@ -62,8 +65,15 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         /**
          * The list of hosts of the Elasticsearch servers.
          */
-        @ConfigItem(defaultValue = "http://localhost:9200")
+        @ConfigItem(defaultValue = "localhost:9200")
         List<String> hosts;
+
+        /**
+         * The protocol to use when contacting Elasticsearch servers.
+         * Set to "https" to enable SSL/TLS.
+         */
+        @ConfigItem(defaultValue = "http")
+        ElasticsearchClientProtocol protocol;
 
         /**
          * The username used for authentication.
@@ -115,6 +125,40 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         Map<String, ElasticsearchIndexConfig> indexes;
     }
 
+    public enum ElasticsearchClientProtocol {
+        /**
+         * Use clear-text HTTP, with SSL/TLS disabled.
+         */
+        HTTP("http"),
+        /**
+         * Use HTTPS, with SSL/TLS enabled.
+         */
+        HTTPS("https");
+
+        public static ElasticsearchClientProtocol of(String value) {
+            return StringHelper.parseDiscreteValues(
+                    values(),
+                    ElasticsearchClientProtocol::getHibernateSearchString,
+                    (invalidValue, validValues) -> new SearchException(
+                            String.format(
+                                    Locale.ROOT,
+                                    "Invalid protocol: '%1$s'. Valid protocols are: %2$s.",
+                                    invalidValue,
+                                    validValues)),
+                    value);
+        }
+
+        private final String hibernateSearchString;
+
+        ElasticsearchClientProtocol(String hibernateSearchString) {
+            this.hibernateSearchString = hibernateSearchString;
+        }
+
+        public String getHibernateSearchString() {
+            return hibernateSearchString;
+        }
+    }
+
     @ConfigGroup
     public static class ElasticsearchIndexConfig {
         /**
@@ -139,11 +183,6 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         @ConfigItem(defaultValue = "10S")
         Duration refreshInterval;
 
-        /**
-         * The scheme that should be used for the new nodes discovered.
-         */
-        @ConfigItem(defaultValue = "http")
-        String defaultScheme;
     }
 
     @ConfigGroup

--- a/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/search/HibernateSearchTestResource.java
@@ -60,6 +60,43 @@ public class HibernateSearchTestResource {
     }
 
     @PUT
+    @Path("/purge")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testPurge() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        searchSession.workspace().purge();
+
+        return "OK";
+    }
+
+    @PUT
+    @Path("/flush")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testFlush() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        searchSession.workspace().flush();
+
+        return "OK";
+    }
+
+    @GET
+    @Path("/search-empty")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testSearchEmpty() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        List<Person> person = searchSession.search(Person.class)
+                .predicate(f -> f.matchAll())
+                .fetchHits(20);
+
+        assertEquals(0, person.size());
+
+        return "OK";
+    }
+
+    @PUT
     @Path("/mass-indexer")
     @Produces(MediaType.TEXT_PLAIN)
     public String testMassIndexer() throws InterruptedException {

--- a/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/HibernateSearchTest.java
+++ b/integration-tests/hibernate-search-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/HibernateSearchTest.java
@@ -19,7 +19,22 @@ public class HibernateSearchTest {
                 .statusCode(200)
                 .body(is("OK"));
 
+        RestAssured.when().put("/test/hibernate-search/purge").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().put("/test/hibernate-search/flush").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().get("/test/hibernate-search/search-empty").then()
+                .statusCode(200);
+
         RestAssured.when().put("/test/hibernate-search/mass-indexer").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().get("/test/hibernate-search/search").then()
                 .statusCode(200)
                 .body(is("OK"));
     }


### PR DESCRIPTION
https://in.relation.to/2019/12/16/hibernate-search-6-0-0-Beta3/

@gsmet I will need your advice, especially on the reflection stuff. I'm not sure I fully grasped what was going on there, so I may have removed important code.

To summarize, starting with Beta3 all Hibernate Search mapping annotations are meta-annotated, so we do not need to list them all. Custom annotations must also be meta-annotated with the same meta-annotation, so they are no longer a specific use case.

However, it seems we were behaving differently for built-in annotations and custom bridge annotations (the code wasn't exactly the same). I did as well as I could, but that may not be enough...