### PR TITLE
Transfer JAX-B annotations from fields to accessor

### DIFF
--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/EntityField.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/EntityField.java
@@ -1,5 +1,8 @@
 package io.quarkus.panache.common.deployment;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import io.quarkus.deployment.bean.JavaBeanUtil;
 
 public class EntityField {
@@ -7,6 +10,7 @@ public class EntityField {
     public final String name;
     public final String descriptor;
     public String signature;
+    public final Set<EntityFieldAnnotation> annotations = new HashSet<>(2);
 
     public EntityField(String name, String descriptor) {
         this.name = name;
@@ -19,6 +23,16 @@ public class EntityField {
 
     public String getSetterName() {
         return JavaBeanUtil.getSetterName(name);
+    }
+
+    public static class EntityFieldAnnotation {
+        public final String descriptor;
+        public String name;
+        public Object value;
+
+        public EntityFieldAnnotation(String desc) {
+            this.descriptor = desc;
+        }
     }
 
 }

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/EntityField.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/EntityField.java
@@ -1,7 +1,15 @@
 package io.quarkus.panache.common.deployment;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 import io.quarkus.deployment.bean.JavaBeanUtil;
 
@@ -27,11 +35,31 @@ public class EntityField {
 
     public static class EntityFieldAnnotation {
         public final String descriptor;
-        public String name;
-        public Object value;
+        public final Map<String, Object> attributes = new HashMap<>(2);
+        public final List<EntityFieldAnnotation> nestedAnnotations = new ArrayList<>(2);
 
         public EntityFieldAnnotation(String desc) {
             this.descriptor = desc;
+        }
+
+        public void writeToVisitor(MethodVisitor mv) {
+            AnnotationVisitor av = mv.visitAnnotation(descriptor, true);
+            for (Entry<String, Object> e : attributes.entrySet()) {
+                av.visit(e.getKey(), e.getValue());
+            }
+            if (!nestedAnnotations.isEmpty()) {
+                // Always visit nested annotations as an array because this covers JAX-B annotations
+                AnnotationVisitor nestedVisitor = av.visitArray("value");
+                for (EntityFieldAnnotation nestedAnno : nestedAnnotations) {
+                    AnnotationVisitor arrayAnnoVisitor = nestedVisitor.visitAnnotation(null, nestedAnno.descriptor);
+                    for (Entry<String, Object> e : nestedAnno.attributes.entrySet()) {
+                        arrayAnnoVisitor.visit(e.getKey(), e.getValue());
+                    }
+                    arrayAnnoVisitor.visitEnd();
+                }
+                nestedVisitor.visitEnd();
+            }
+            av.visitEnd();
         }
     }
 

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityEnhancer.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityEnhancer.java
@@ -21,6 +21,7 @@ import org.objectweb.asm.Type;
 
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.common.deployment.EntityField.EntityFieldAnnotation;
 
 public abstract class PanacheEntityEnhancer<MetamodelType extends MetamodelInfo<?>>
         implements BiFunction<String, ClassVisitor, ClassVisitor> {
@@ -33,6 +34,7 @@ public abstract class PanacheEntityEnhancer<MetamodelType extends MetamodelInfo<
     public final static String PARAMETERS_BINARY_NAME = PARAMETERS_NAME.replace('.', '/');
     public final static String PARAMETERS_SIGNATURE = "L" + PARAMETERS_BINARY_NAME + ";";
 
+    private static final String JAXB_ANNOTATION_PREFIX = "Ljavax/xml/bind/annotation/";
     private static final String JAXB_TRANSIENT_BINARY_NAME = "javax/xml/bind/annotation/XmlTransient";
     private static final String JAXB_TRANSIENT_SIGNATURE = "L" + JAXB_TRANSIENT_BINARY_NAME + ";";
 
@@ -80,15 +82,26 @@ public abstract class PanacheEntityEnhancer<MetamodelType extends MetamodelInfo<
                 @Override
                 public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
                     descriptors.add(descriptor);
-                    return super.visitAnnotation(descriptor, visible);
+                    if (!descriptor.startsWith(JAXB_ANNOTATION_PREFIX)) {
+                        return super.visitAnnotation(descriptor, visible);
+                    }
+                    // Save off JAX-B annotations on the field so they can be applied to the generated getter later
+                    EntityFieldAnnotation efAnno = new EntityFieldAnnotation(descriptor);
+                    ef.annotations.add(efAnno);
+                    return new AnnotationVisitor(Opcodes.ASM7) {
+                        @Override
+                        public void visit(String name, Object value) {
+                            efAnno.name = name;
+                            efAnno.value = value;
+                        }
+                    };
                 }
 
                 @Override
                 public void visitEnd() {
                     // add the @JaxbTransient property to the field so that Jackson prefers the generated getter
                     // jsonb will already use the getter so we're good
-                    if (!descriptors.contains(JAXB_TRANSIENT_SIGNATURE))
-                        super.visitAnnotation(JAXB_TRANSIENT_SIGNATURE, true);
+                    super.visitAnnotation(JAXB_TRANSIENT_SIGNATURE, true);
                     super.visitEnd();
                 }
             };
@@ -185,6 +198,13 @@ public abstract class PanacheEntityEnhancer<MetamodelType extends MetamodelInfo<
                     int returnCode = JandexUtil.getReturnInstruction(field.descriptor);
                     mv.visitInsn(returnCode);
                     mv.visitMaxs(0, 0);
+                    // Apply JAX-B annotations that are being transferred from the field
+                    for (EntityFieldAnnotation anno : field.annotations) {
+                        AnnotationVisitor av = mv.visitAnnotation(anno.descriptor, true);
+                        if (anno.name != null)
+                            av.visit(anno.name, anno.value);
+                        av.visitEnd();
+                    }
                     mv.visitEnd();
                 }
 

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheMovingAnnotationVisitor.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheMovingAnnotationVisitor.java
@@ -1,0 +1,37 @@
+package io.quarkus.panache.common.deployment;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.panache.common.deployment.EntityField.EntityFieldAnnotation;
+
+/**
+ * An AnnotationVisitor that intercepts and records annotations so that they can
+ * be applied to a different element later
+ */
+public class PanacheMovingAnnotationVisitor extends AnnotationVisitor {
+
+    private final EntityFieldAnnotation fieldAnno;
+
+    public PanacheMovingAnnotationVisitor(EntityFieldAnnotation fieldAnno) {
+        super(Opcodes.ASM7);
+        this.fieldAnno = fieldAnno;
+    }
+
+    @Override
+    public void visit(String name, Object value) {
+        fieldAnno.attributes.put(name, value);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(String name, String descriptor) {
+        EntityFieldAnnotation nestedAnno = new EntityFieldAnnotation(descriptor);
+        fieldAnno.nestedAnnotations.add(nestedAnno);
+        return new PanacheMovingAnnotationVisitor(nestedAnno);
+    }
+
+    @Override
+    public AnnotationVisitor visitArray(String name) {
+        return this;
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/JAXBEntity.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/JAXBEntity.java
@@ -4,6 +4,8 @@ import javax.persistence.Entity;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
@@ -22,6 +24,12 @@ public class JAXBEntity extends PanacheEntity {
 
     @XmlAttribute
     public String defaultAnnotatedProp;
+
+    @XmlElements({
+            @XmlElement(name = "array1"),
+            @XmlElement(name = "array2")
+    })
+    public String arrayAnnotatedProp;
 
     public String unAnnotatedProp;
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/JAXBEntity.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/JAXBEntity.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+@XmlRootElement(name = "JAXBEntity")
+@XmlAccessorType(XmlAccessType.NONE)
+public class JAXBEntity extends PanacheEntity {
+
+    @XmlAttribute(name = "Named")
+    public String namedAnnotatedProp;
+
+    @XmlTransient
+    public String transientProp;
+
+    @XmlAttribute
+    public String defaultAnnotatedProp;
+
+    public String unAnnotatedProp;
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1,5 +1,10 @@
 package io.quarkus.it.panache;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -16,6 +21,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.hibernate.jpa.QueryHints;
@@ -997,5 +1004,46 @@ public class TestEndpoint {
     public String testBug5885() {
         bug5885EntityRepository.findById(1L);
         return "OK";
+    }
+
+    @GET
+    @Path("testJaxbAnnotationTransfer")
+    public String testJaxbAnnotationTransfer() throws Exception {
+        // Test for fix to this bug: https://github.com/quarkusio/quarkus/issues/6021
+
+        // Ensure that any JAX-B annotations are properly moved to generated getters
+        Method m = JAXBEntity.class.getMethod("getNamedAnnotatedProp");
+        XmlAttribute anno = m.getAnnotation(XmlAttribute.class);
+        assertNotNull(anno);
+        assertEquals("Named", anno.name());
+        assertNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getDefaultAnnotatedProp");
+        anno = m.getAnnotation(XmlAttribute.class);
+        assertNotNull(anno);
+        assertEquals("##default", anno.name());
+        assertNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getUnAnnotatedProp");
+        assertNull(m.getAnnotation(XmlAttribute.class));
+        assertNull(m.getAnnotation(XmlTransient.class));
+
+        m = JAXBEntity.class.getMethod("getTransientProp");
+        assertNull(m.getAnnotation(XmlAttribute.class));
+        assertNotNull(m.getAnnotation(XmlTransient.class));
+
+        // Ensure that all original fields were labeled @XmlTransient and had their original JAX-B annotations removed
+        ensureFieldSanitized("namedAnnotatedProp");
+        ensureFieldSanitized("transientProp");
+        ensureFieldSanitized("defaultAnnotatedProp");
+        ensureFieldSanitized("unAnnotatedProp");
+
+        return "OK";
+    }
+
+    private void ensureFieldSanitized(String fieldName) throws Exception {
+        Field f = JAXBEntity.class.getField(fieldName);
+        assertNull(f.getAnnotation(XmlAttribute.class));
+        assertNotNull(f.getAnnotation(XmlTransient.class));
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -22,6 +22,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.engine.spi.SelfDirtinessTracker;
@@ -1032,11 +1033,21 @@ public class TestEndpoint {
         assertNull(m.getAnnotation(XmlAttribute.class));
         assertNotNull(m.getAnnotation(XmlTransient.class));
 
+        m = JAXBEntity.class.getMethod("getArrayAnnotatedProp");
+        assertNull(m.getAnnotation(XmlTransient.class));
+        XmlElements elementsAnno = m.getAnnotation(XmlElements.class);
+        assertNotNull(elementsAnno);
+        assertNotNull(elementsAnno.value());
+        assertEquals(2, elementsAnno.value().length);
+        assertEquals("array1", elementsAnno.value()[0].name());
+        assertEquals("array2", elementsAnno.value()[1].name());
+
         // Ensure that all original fields were labeled @XmlTransient and had their original JAX-B annotations removed
         ensureFieldSanitized("namedAnnotatedProp");
         ensureFieldSanitized("transientProp");
         ensureFieldSanitized("defaultAnnotatedProp");
         ensureFieldSanitized("unAnnotatedProp");
+        ensureFieldSanitized("arrayAnnotatedProp");
 
         return "OK";
     }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -59,6 +59,14 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/5885").then().body(is("OK"));
     }
 
+    @Test
+    public void testJaxbAnnotationTransfer() {
+        RestAssured.when()
+                .get("/test/testJaxbAnnotationTransfer")
+                .then()
+                .body(is("OK"));
+    }
+
     /**
      * This test is disabled in native mode as there is no interaction with the quarkus integration test endpoint.
      */


### PR DESCRIPTION
For Panache entity enhancement we add @XmlTransient to the original fields
to force Jackson to use the generated accessor methods. However, this can
cause conflicts if the field was originally annotated with JAX-B annotations
that are mutually exclusive with @XmlTransient.

Signed-off-by: Andrew Guibert <andy.guibert@gmail.com>

Fixes https://github.com/quarkusio/quarkus/issues/6021