### PR TITLE
Move Spring Data JPA classes to panache to avoid dev-mode CL issue

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
@@ -9,6 +9,8 @@ import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 
+//TODO this class is only needed by the Spring Data JPA module and would be placed there it it weren't for a dev-mode classloader issue
+// see https://github.com/quarkusio/quarkus/issues/6214
 public class AdditionalJpaOperations {
 
     @SuppressWarnings("rawtypes")
@@ -19,7 +21,6 @@ public class AdditionalJpaOperations {
         Query jpaQuery = em.createQuery(sort != null ? findQuery + JpaOperations.toOrderBy(sort) : findQuery);
         JpaOperations.bindParameters(jpaQuery, params);
         return new CustomCountPanacheQuery(em, jpaQuery, findQuery, countQuery, params);
-        //        return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
     }
 
     @SuppressWarnings("rawtypes")
@@ -35,6 +36,5 @@ public class AdditionalJpaOperations {
         Query jpaQuery = em.createQuery(sort != null ? findQuery + JpaOperations.toOrderBy(sort) : findQuery);
         JpaOperations.bindParameters(jpaQuery, params);
         return new CustomCountPanacheQuery(em, jpaQuery, findQuery, countQuery, params);
-        //        return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
     }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
@@ -3,6 +3,8 @@ package io.quarkus.hibernate.orm.panache.runtime;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
+//TODO this class is only needed by the Spring Data JPA module and would be placed there it it weren't for a dev-mode classloader issue
+// see https://github.com/quarkusio/quarkus/issues/6214
 public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
 
     private final String customCountQuery;


### PR DESCRIPTION
Fixes #6214

This obviously isn't an ideal fix, but it's a tiny price to pay to get something working that will otherwise perhaps need dev mode classloader work