### PR TITLE
Allow multiple headers with same name

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/CookieTest.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/CookieTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.test;
+
+import java.util.HashMap;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class CookieTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SetCookieResource.class));
+
+    @Test
+    public void testSetMultipleCookieAsString() {
+        HashMap<String, Object> cookies = new HashMap<>();
+
+        cookies.put("c1", "c1");
+        cookies.put("c2", "c2");
+        cookies.put("c3", "c3");
+
+        RestAssured.when().get("/set-cookies").then().cookies(cookies);
+    }
+}

--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/SetCookieResource.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/SetCookieResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.jboss.resteasy.spi.HttpResponse;
+
+@Path("/set-cookies")
+public class SetCookieResource {
+
+    @GET
+    public void setCookies(@Context HttpResponse response) {
+        response.getOutputHeaders().add(HttpHeaders.SET_COOKIE, "c1=c1");
+        response.getOutputHeaders().add(HttpHeaders.SET_COOKIE, "c2=c2");
+        response.getOutputHeaders().add(HttpHeaders.SET_COOKIE, "c3=c3");
+    }
+}

--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
@@ -121,7 +121,7 @@ public class VertxHttpResponse implements HttpResponse {
                 if (delegate != null) {
                     response.headers().add(key, delegate.toString(value));
                 } else {
-                    response.headers().set(key, value.toString());
+                    response.headers().add(key, value.toString());
                 }
             }
         }


### PR DESCRIPTION
Manually adding multiple JAX-RS Set-Cookie headers
would result in only a single one being sent to the client.