### PR TITLE
ArC - activate request context for any observer notification

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -251,6 +251,18 @@ class MyBeanStarter {
 
 NOTE: Quarkus users are encouraged to always prefer the `@Observes StartupEvent` to `@Initialized(ApplicationScoped.class)` as explained in the link:lifecycle[Application Initialization and Termination] guide. 
 
+=== Request Context Lifecycle 
+
+The request context is also active:
+
+* during notification of a synchronous observer method.
+
+The request context is destroyed:
+
+* after the observer notification completes for an event, if it was not already active when the notification started.
+
+NOTE: An event with qualifier `@Initialized(RequestScoped.class)` is fired when the request context is initialized for an observer notification. Moreover, the events with qualifiers `@BeforeDestroyed(RequestScoped.class)` and `@Destroyed(RequestScoped.class)` are fired when the request context is destroyed. 
+
 === Qualified Injected Fields
 
 In CDI, if you declare a field injection point you need to use `@Inject` and optionally a set of qualifiers:

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/builtin/beans/BuiltInBeansAreResolvableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/builtin/beans/BuiltInBeansAreResolvableTest.java
@@ -49,6 +49,7 @@ public class BuiltInBeansAreResolvableTest {
         assertFalse(instance.select(BeanManager.class, new DummyQualifier.Literal()).isResolvable());
     }
 
+    @SuppressWarnings({ "serial", "unchecked", "rawtypes" })
     @Test
     public void testEventBean() {
         // use dynamic resolution to test it
@@ -57,33 +58,34 @@ public class BuiltInBeansAreResolvableTest {
         Instance<Event> rawNoQualifier = instance.select(Event.class);
         assertTrue(rawNoQualifier.isResolvable());
         DummyBean.resetCounters();
-        rawNoQualifier.get().fire(new Object());
-        assertEquals(0, DummyBean.noQualifiers);
+        rawNoQualifier.get().fire(new Payload());
+        assertEquals(1, DummyBean.noQualifiers);
         assertEquals(0, DummyBean.qualifierTimesTriggered);
-        assertEquals(1, DummyBean.objectTimesTriggered);
+        assertEquals(1, DummyBean.timesTriggered);
 
         // event with type and no qualifier
-        Instance<Event<String>> typedEventNoQualifier = instance.select(new TypeLiteral<Event<String>>() {
+        Instance<Event<Payload>> typedEventNoQualifier = instance.select(new TypeLiteral<Event<Payload>>() {
         });
         assertTrue(typedEventNoQualifier.isResolvable());
         DummyBean.resetCounters();
-        typedEventNoQualifier.get().fire("foo");
+        typedEventNoQualifier.get().fire(new Payload());
         assertEquals(1, DummyBean.noQualifiers);
         assertEquals(0, DummyBean.qualifierTimesTriggered);
-        assertEquals(1, DummyBean.objectTimesTriggered);
+        assertEquals(1, DummyBean.timesTriggered);
 
         // event with type and qualifier
-        Instance<Event<String>> typedEventWithQualifier = instance.select(new TypeLiteral<Event<String>>() {
+        Instance<Event<Payload>> typedEventWithQualifier = instance.select(new TypeLiteral<Event<Payload>>() {
         }, new DummyQualifier.Literal());
         assertTrue(typedEventWithQualifier.isResolvable());
         DummyBean.resetCounters();
-        typedEventWithQualifier.get().fire("foo");
+        typedEventWithQualifier.get().fire(new Payload());
         assertEquals(1, DummyBean.noQualifiers);
         assertEquals(1, DummyBean.qualifierTimesTriggered);
-        assertEquals(1, DummyBean.objectTimesTriggered);
+        assertEquals(1, DummyBean.timesTriggered);
 
     }
 
+    @SuppressWarnings({ "serial", "unchecked" })
     @Test
     public void testInstanceBean() {
         BeanManager bm = Arc.container().beanManager();
@@ -202,29 +204,32 @@ public class BuiltInBeansAreResolvableTest {
 
         public static int noQualifiers = 0;
         public static int qualifierTimesTriggered = 0;
-        public static int objectTimesTriggered = 0;
+        public static int timesTriggered = 0;
 
-        public void observeEvent(@Observes String payload) {
+        public void observeEvent(@Observes Payload payload) {
             noQualifiers++;
         }
 
-        public void observeQualifiedEvent(@Observes @DummyQualifier String payload) {
+        public void observeQualifiedEvent(@Observes @DummyQualifier Payload payload) {
             qualifierTimesTriggered++;
         }
 
-        public void observeBasicEvent(@Observes @Any Object objPayload) {
-            objectTimesTriggered++;
+        public void observeBasicEvent(@Observes @Any Payload payload) {
+            timesTriggered++;
         }
 
         public static void resetCounters() {
             noQualifiers = 0;
             qualifierTimesTriggered = 0;
-            objectTimesTriggered = 0;
+            timesTriggered = 0;
         }
 
         public void ping() {
         }
 
         ;
+    }
+
+    static class Payload {
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/request/RequestInObserverNotificationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/request/RequestInObserverNotificationTest.java
@@ -1,0 +1,91 @@
+package io.quarkus.arc.test.observers.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RequestInObserverNotificationTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(RequestFoo.class, MyObserver.class);
+
+    @Test
+    public void testObserverNotification() {
+        ArcContainer container = Arc.container();
+        AtomicReference<String> msg = new AtomicReference<String>();
+        RequestFoo.DESTROYED.set(false);
+
+        // Request context should be activated automatically
+        container.beanManager().getEvent().select(AtomicReference.class).fire(msg);
+        String fooId1 = msg.get();
+        assertNotNull(fooId1);
+        assertTrue(RequestFoo.DESTROYED.get());
+
+        RequestFoo.DESTROYED.set(false);
+        msg.set(null);
+
+        ManagedContext requestContext = container.requestContext();
+        assertFalse(requestContext.isActive());
+        try {
+            requestContext.activate();
+            String fooId2 = container.instance(RequestFoo.class).get().getId();
+            assertNotEquals(fooId1, fooId2);
+            container.beanManager().getEvent().select(AtomicReference.class).fire(msg);
+            assertEquals(fooId2, msg.get());
+        } finally {
+            requestContext.terminate();
+        }
+        assertTrue(RequestFoo.DESTROYED.get());
+    }
+
+    @Singleton
+    static class MyObserver {
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        void observeString(@Observes AtomicReference value, RequestFoo foo) {
+            // does not trigger ContextNotActiveException
+            value.set(foo.getId());
+        }
+
+    }
+
+    @RequestScoped
+    static class RequestFoo {
+
+        static final AtomicBoolean DESTROYED = new AtomicBoolean();
+
+        private String id;
+
+        @PostConstruct
+        void init() {
+            id = UUID.randomUUID().toString();
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+    }
+
+}


### PR DESCRIPTION
- resolves #6221

@manovotn I've modified the `BuiltInBeansAreResolvableTest` because the observer was notified for `@Initialized(RequestScoped.class)`

FYI @FroMage @stuartwdouglas @jaikiran...