### PR TITLE
TestResource to provide a Mongodb Database for the tests

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -764,6 +764,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-mongodb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-test-derby</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/test-framework/mongodb/pom.xml
+++ b/test-framework/mongodb/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-test-mongodb</artifactId>
+    <name>Quarkus - Test framework - MongoDB Database Support</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/mongodb/pom.xml
+++ b/test-framework/mongodb/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>quarkus-test-mongodb</artifactId>
-    <name>Quarkus - Test framework - MongoDB Database Support</name>
+    <name>Quarkus - Test Framework - MongoDB Database Support</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoDatabaseTestResource.java
+++ b/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoDatabaseTestResource.java
@@ -1,0 +1,89 @@
+package io.quarkus.test.mongodb;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jboss.logging.Logger;
+
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongoCmdOptionsBuilder;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.runtime.Network;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+/**
+ * Resource to provide a mongo database instance during the execution of the Tests.
+ * 
+ * @see QuarkusTestResource
+ */
+public class MongoDatabaseTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final Logger LOGGER = Logger.getLogger(MongoDatabaseTestResource.class);
+
+    private static final String CONFIGURED_CONNECTION_STRING = "mongodb.connection_string";
+
+    private static final String QUARKUS_CONNECTION_STRING_PROPERTY = "quarkus.mongodb.connection-string";
+    private static final String QUARKUS_PROFILE_PREFIX = "%test";
+
+    private static final int DEFAULT_PORT = 27018;
+
+    private static MongodExecutable MONGO;
+
+    @Override
+    public Map<String, String> start() {
+        String uri = getConfiguredConnectionString();
+        // This switch allow testing against a running mongo database.
+        if (uri == null) {
+            Version.Main version = Version.Main.V4_0;
+            int port = DEFAULT_PORT;
+            try {
+                LOGGER.infof("Starting Mongo %s on port %s", version, port);
+                IMongodConfig config = new MongodConfigBuilder()
+                        .version(version)
+                        .cmdOptions(new MongoCmdOptionsBuilder().useNoJournal(false).build())
+                        .net(new Net(port, Network.localhostIsIPv6()))
+                        .build();
+                MONGO = MongodStarter.getDefaultInstance().prepare(config);
+                MONGO.start();
+                uri = "mongodb://localhost:" + port;
+            } catch (IOException e) {
+                LOGGER.error("Unable to start MongoDB", e);
+            }
+            return Collections.singletonMap(QUARKUS_PROFILE_PREFIX + "." + QUARKUS_CONNECTION_STRING_PROPERTY, uri);
+        } else {
+            LOGGER.infof("Using existing Mongo %s", uri);
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (MONGO != null) {
+            try {
+                MONGO.stop();
+            } catch (Exception e) {
+                LOGGER.error("Unable to stop MongoDB", e);
+            }
+        }
+    }
+
+    protected static String getConfiguredConnectionString() {
+        return getProperty(CONFIGURED_CONNECTION_STRING);
+    }
+
+    protected static String getProperty(String name) {
+        return Optional.ofNullable(name)
+                .map(System::getProperty)
+                .map(String::trim)
+                .filter(String::isEmpty)
+                .orElse(null);
+    }
+
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -17,6 +17,7 @@
         <module>artemis-test</module>
         <module>common</module>
         <module>h2</module>
+        <module>mongodb</module>
         <module>derby</module>
         <module>kubernetes-client</module>
         <module>junit5-internal</module>


### PR DESCRIPTION
When required through QuarkusResourceTest, it provides a Mongodb embed Database for testing purposes like mongodb-client and mongodb-panache applications.

Following the guidelines of the current [MongoTestBase.java](https://github.com/quarkusio/quarkus/blob/master/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/MongoTestBase.java), this resource provides a MongoDB embed database if none is configured by a System property.

As a result of including this resource, it could be added in the tests of both extensions to replace the start and stop methods in MongoTestBase for all the tests.

A demo using this feature can be found at [quarkus-mongodb-test](https://github.com/juazugas/quarkus-mongodb-test).