### PR TITLE
Fix file system path for overriding application.properties when using dev-mode with Gradle

### DIFF
--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -396,7 +396,7 @@ _will also_ be taken into account.
 
 NOTE: Environment variables names are following the conversion rules of link:https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#default-configsources[Eclipse MicroProfile]
 
-NOTE: The `config/application.properties` features is available in development mode as well. To make use of it, `config/application.properties` needs to be placed inside the build tool's output directory (`target` for Maven and `build` for Gradle).
+NOTE: The `config/application.properties` features is available in development mode as well. To make use of it, `config/application.properties` needs to be placed inside the build tool's output directory (`target` for Maven and `build/classes/java/main` for Gradle).
 Keep in mind however that any cleaning operation from the build tool like `mvn clean` or `gradle clean` will remove the `config` directory as well.
 
 === Configuration Profiles


### PR DESCRIPTION
* resolves #6227 (documentation issue only)