### PR TITLE
Include sun.security.util.Resources bundle in native image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ResourceBundleStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ResourceBundleStep.java
@@ -1,0 +1,17 @@
+package io.quarkus.deployment.steps;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
+
+public class ResourceBundleStep {
+
+    @BuildStep
+    public NativeImageResourceBundleBuildItem nativeImageResourceBundle() {
+        /*
+         * The following resource bundle sometimes needs to be included into the native image with JDK 11.
+         * This might no longer be required if GraalVM auto-includes it in a future release.
+         * See https://github.com/oracle/graal/issues/2005 for more details about it.
+         */
+        return new NativeImageResourceBundleBuildItem("sun.security.util.Resources");
+    }
+}


### PR DESCRIPTION
Fixes #6236 

This was successfully tested locally with GraalVM 19.3.0 and JDK 11. Let's see if CI is happy as well (it wasn't tested with JDK 8 locally).