### PR TITLE
Make Neo4j transport encryption configurable

### DIFF
--- a/extensions/neo4j/runtime/pom.xml
+++ b/extensions/neo4j/runtime/pom.xml
@@ -26,14 +26,16 @@
             <artifactId>quarkus-smallrye-health</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jConfiguration.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jConfiguration.java
@@ -1,6 +1,11 @@
 package io.quarkus.neo4j.runtime;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Optional;
+
+import org.neo4j.driver.Config;
 
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -29,6 +34,19 @@ public class Neo4jConfiguration {
     public Authentication authentication;
 
     /**
+     * If the driver should use encrypted traffic.
+     */
+    @ConfigItem
+    public boolean encrypted;
+
+    /**
+     * Configure trust settings for encrypted traffic.
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public TrustSettings trustSettings;
+
+    /**
      * Connection pool.
      */
     @ConfigItem
@@ -54,7 +72,67 @@ public class Neo4jConfiguration {
          * Set this to true to disable authentication.
          */
         @ConfigItem
-        public boolean disabled = false;
+        public boolean disabled;
+    }
+
+    @ConfigGroup
+    static class TrustSettings {
+
+        public enum Strategy {
+
+            TRUST_ALL_CERTIFICATES,
+
+            TRUST_CUSTOM_CA_SIGNED_CERTIFICATES,
+
+            TRUST_SYSTEM_CA_SIGNED_CERTIFICATES
+        }
+
+        /**
+         * Configures which trust strategy to apply when using encrypted traffic.
+         */
+        @ConfigItem(defaultValue = "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES")
+        public Strategy strategy;
+
+        /**
+         * The file of the certificate to use.
+         */
+        @ConfigItem
+        public Optional<Path> certFile = Optional.empty();
+
+        /**
+         * If hostname verification is used.
+         */
+        @ConfigItem
+        public boolean hostnameVerificationEnabled;
+
+        Config.TrustStrategy toInternalRepresentation() {
+
+            Config.TrustStrategy internalRepresentation;
+            Strategy nonNullStrategy = strategy == null ? Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES : strategy;
+            switch (nonNullStrategy) {
+                case TRUST_ALL_CERTIFICATES:
+                    internalRepresentation = Config.TrustStrategy.trustAllCertificates();
+                    break;
+                case TRUST_SYSTEM_CA_SIGNED_CERTIFICATES:
+                    internalRepresentation = Config.TrustStrategy.trustSystemCertificates();
+                    break;
+                case TRUST_CUSTOM_CA_SIGNED_CERTIFICATES:
+
+                    File certFile = this.certFile.map(Path::toFile).filter(File::isFile)
+                            .orElseThrow(() -> new RuntimeException("Configured trust strategy requires a certificate file."));
+                    internalRepresentation = Config.TrustStrategy.trustCustomCertificateSignedBy(certFile);
+                    break;
+                default:
+                    throw new RuntimeException("Unknown trust strategy: " + this.strategy.name());
+            }
+
+            if (hostnameVerificationEnabled) {
+                internalRepresentation.withHostnameVerification();
+            } else {
+                internalRepresentation.withoutHostnameVerification();
+            }
+            return internalRepresentation;
+        }
     }
 
     @ConfigGroup

--- a/extensions/neo4j/runtime/src/test/java/io/quarkus/neo4j/runtime/Neo4jConfigurationTest.java
+++ b/extensions/neo4j/runtime/src/test/java/io/quarkus/neo4j/runtime/Neo4jConfigurationTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.neo4j.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Config;
+
+import io.quarkus.neo4j.runtime.Neo4jConfiguration.TrustSettings;
+
+class Neo4jConfigurationTest {
+
+    @Nested
+    class TrustSettingsTest {
+
+        @Test
+        void defaultsShouldWork() {
+
+            TrustSettings trustSettings = new TrustSettings();
+
+            Config.TrustStrategy internalRepresentation = trustSettings.toInternalRepresentation();
+            assertFalse(internalRepresentation.isHostnameVerificationEnabled());
+            assertEquals(Config.TrustStrategy.Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES,
+                    internalRepresentation.strategy());
+        }
+
+        @Test
+        void trustAllSettingShouldWork() {
+
+            TrustSettings trustSettings = new TrustSettings();
+            trustSettings.strategy = TrustSettings.Strategy.TRUST_ALL_CERTIFICATES;
+
+            Config.TrustStrategy internalRepresentation = trustSettings.toInternalRepresentation();
+            assertEquals(Config.TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES, internalRepresentation.strategy());
+        }
+
+        @Test
+        void hostnameVerificationSettingShouldWork() {
+
+            TrustSettings trustSettings = new TrustSettings();
+            trustSettings.hostnameVerificationEnabled = true;
+
+            Config.TrustStrategy internalRepresentation = trustSettings.toInternalRepresentation();
+            assertTrue(internalRepresentation.isHostnameVerificationEnabled());
+        }
+
+        @Test
+        void customCaShouldRequireCertFile() {
+
+            TrustSettings trustSettings = new TrustSettings();
+            trustSettings.strategy = TrustSettings.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES;
+
+            String msg = assertThrows(RuntimeException.class, () -> trustSettings.toInternalRepresentation())
+                    .getMessage();
+            assertEquals("Configured trust strategy requires a certificate file.", msg);
+        }
+
+        @Test
+        void customCaShouldRequireExistingCertFile() {
+
+            TrustSettings trustSettings = new TrustSettings();
+            trustSettings.strategy = TrustSettings.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES;
+            trustSettings.certFile = Optional.of(Paths.get("na"));
+
+            String msg = assertThrows(RuntimeException.class, () -> trustSettings.toInternalRepresentation())
+                    .getMessage();
+            assertEquals("Configured trust strategy requires a certificate file.", msg);
+        }
+
+        @Test
+        void trustCustomCaSettingShouldWork() throws IOException {
+
+            TrustSettings trustSettings = new TrustSettings();
+            trustSettings.strategy = TrustSettings.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES;
+            trustSettings.certFile = Optional.of(Files.createTempFile("quarkus-neo4j-test", ".cert"));
+
+            Config.TrustStrategy internalRepresentation = trustSettings.toInternalRepresentation();
+            assertEquals(Config.TrustStrategy.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES,
+                    internalRepresentation.strategy());
+        }
+    }
+}


### PR DESCRIPTION
This makes the encryption-option of the driver configurable (at least when not in native image mode). I chose the name `Config` for the class to align the naming with the integrations with other platforms. In case you can tell me how to have another class name map to `config` in the properties, than I would rather name `DriverSettings` (analogue to https://github.com/neo4j/neo4j-java-driver-spring-boot-starter/blob/master/neo4j-java-driver-spring-boot-autoconfigure/src/main/java/org/neo4j/driver/springframework/boot/autoconfigure/Neo4jDriverProperties.java#L287).