### PR TITLE
Reactive routes - detect unordered conflicting routes

### DIFF
--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteMatcher.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteMatcher.java
@@ -1,0 +1,74 @@
+package io.quarkus.vertx.web.runtime;
+
+import io.vertx.core.http.HttpMethod;
+
+public class RouteMatcher {
+
+    private String path;
+    private String regex;
+    private String[] produces;
+    private String[] consumes;
+    private HttpMethod[] methods;
+    private int order;
+
+    public RouteMatcher() {
+    }
+
+    public RouteMatcher(String path, String regex, String[] produces, String[] consumes, HttpMethod[] methods, int order) {
+        this.path = path;
+        this.regex = regex;
+        this.produces = produces;
+        this.consumes = consumes;
+        this.methods = methods;
+        this.order = order;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public String[] getProduces() {
+        return produces;
+    }
+
+    public void setProduces(String[] produces) {
+        this.produces = produces;
+    }
+
+    public String[] getConsumes() {
+        return consumes;
+    }
+
+    public void setConsumes(String[] consumes) {
+        this.consumes = consumes;
+    }
+
+    public HttpMethod[] getMethods() {
+        return methods;
+    }
+
+    public void setMethods(HttpMethod[] methods) {
+        this.methods = methods;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+}

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -5,7 +5,6 @@ import java.util.function.Function;
 
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.RouterProducer;
-import io.quarkus.vertx.web.Route;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
@@ -30,34 +29,34 @@ public class VertxWebRecorder {
         }
     }
 
-    public Function<Router, io.vertx.ext.web.Route> createRouteFunction(Route routeAnnotation,
+    public Function<Router, io.vertx.ext.web.Route> createRouteFunction(RouteMatcher matcher,
             Handler<RoutingContext> bodyHandler) {
         return new Function<Router, io.vertx.ext.web.Route>() {
             @Override
             public io.vertx.ext.web.Route apply(Router router) {
                 io.vertx.ext.web.Route route;
-                if (!routeAnnotation.regex().isEmpty()) {
-                    route = router.routeWithRegex(routeAnnotation.regex());
-                } else if (!routeAnnotation.path().isEmpty()) {
-                    route = router.route(ensureStartWithSlash(routeAnnotation.path()));
+                if (matcher.getRegex() != null && !matcher.getRegex().isEmpty()) {
+                    route = router.routeWithRegex(matcher.getRegex());
+                } else if (matcher.getPath() != null && !matcher.getPath().isEmpty()) {
+                    route = router.route(matcher.getPath());
                 } else {
                     route = router.route();
                 }
-                if (routeAnnotation.methods().length > 0) {
-                    for (HttpMethod method : routeAnnotation.methods()) {
+                if (matcher.getMethods().length > 0) {
+                    for (HttpMethod method : matcher.getMethods()) {
                         route.method(method);
                     }
                 }
-                if (routeAnnotation.order() > 0) {
-                    route.order(routeAnnotation.order());
+                if (matcher.getOrder() > 0) {
+                    route.order(matcher.getOrder());
                 }
-                if (routeAnnotation.produces().length > 0) {
-                    for (String produces : routeAnnotation.produces()) {
+                if (matcher.getProduces().length > 0) {
+                    for (String produces : matcher.getProduces()) {
                         route.produces(produces);
                     }
                 }
-                if (routeAnnotation.consumes().length > 0) {
-                    for (String consumes : routeAnnotation.consumes()) {
+                if (matcher.getConsumes().length > 0) {
+                    for (String consumes : matcher.getConsumes()) {
                         route.consumes(consumes);
                     }
                 }
@@ -67,14 +66,6 @@ public class VertxWebRecorder {
                 return route;
             }
         };
-    }
-
-    private String ensureStartWithSlash(String path) {
-        if (path.startsWith("/")) {
-            return path;
-        } else {
-            return "/" + path;
-        }
     }
 
 }


### PR DESCRIPTION
- resolves #6165

The warning looks like:
```
[WARNING] Route org.acme.quarkus.sample.MyDeclarativeRoutes#hello() can match the same request and has the same order [0] as:
	- org.acme.quarkus.sample.MyDeclarativeRoutes#greetings()
[WARNING] You can use @Route#order() to ensure the routes are not executed in random order
```