### PR TITLE
Put trace context into MDC

### DIFF
--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerConfig.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerConfig.java
@@ -111,4 +111,10 @@ public class JaegerConfig {
     @ConfigItem
     public Optional<String> senderFactory;
 
+    /**
+     * Whether the trace context should be logged.
+     */
+    @ConfigItem(defaultValue = "true")
+    public Boolean logTraceContext;
+
 }

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
@@ -60,6 +60,8 @@ public class JaegerDeploymentRecorder {
         initTracerProperty("JAEGER_TAGS", jaeger.tags, tags -> tags.toString());
         initTracerProperty("JAEGER_PROPAGATION", jaeger.propagation, format -> format.toString());
         initTracerProperty("JAEGER_SENDER_FACTORY", jaeger.senderFactory, sender -> sender);
+        initTracerProperty(QuarkusJaegerTracer.LOG_TRACE_CONTEXT, Optional.of(jaeger.logTraceContext),
+                logTraceContext -> logTraceContext.toString());
     }
 
     private <T> void initTracerProperty(String property, Optional<T> value, Function<T, String> accessor) {

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/MDCScope.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/MDCScope.java
@@ -1,0 +1,48 @@
+package io.quarkus.jaeger.runtime;
+
+import org.jboss.logging.MDC;
+
+import io.jaegertracing.internal.JaegerSpanContext;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+
+/**
+ * Scope that sets span context into MDC.
+ */
+public class MDCScope implements Scope {
+
+    /**
+     * MDC keys
+     */
+    private static final String TRACE_ID = "traceId";
+    private static final String SPAN_ID = "spanId";
+    private static final String SAMPLED = "sampled";
+
+    private final Scope wrapped;
+
+    public MDCScope(Scope scope) {
+        this.wrapped = scope;
+        if (scope.span().context() instanceof JaegerSpanContext) {
+            putContext((JaegerSpanContext) scope.span().context());
+        }
+    }
+
+    @Override
+    public void close() {
+        wrapped.close();
+        MDC.remove(TRACE_ID);
+        MDC.remove(SPAN_ID);
+        MDC.remove(SAMPLED);
+    }
+
+    @Override
+    public Span span() {
+        return wrapped.span();
+    }
+
+    protected void putContext(JaegerSpanContext spanContext) {
+        MDC.put(TRACE_ID, spanContext.getTraceId());
+        MDC.put(SPAN_ID, String.format("%16x", spanContext.getSpanId()));
+        MDC.put(SAMPLED, Boolean.toString(spanContext.isSampled()));
+    }
+}

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/MDCScopeManager.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/MDCScopeManager.java
@@ -1,0 +1,24 @@
+package io.quarkus.jaeger.runtime;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+
+public class MDCScopeManager implements ScopeManager {
+
+    private final ScopeManager wrapped;
+
+    public MDCScopeManager(ScopeManager scopeManager) {
+        this.wrapped = scopeManager;
+    }
+
+    @Override
+    public Scope activate(Span span, boolean finishSpanOnClose) {
+        return new MDCScope(wrapped.activate(span, finishSpanOnClose));
+    }
+
+    @Override
+    public Scope active() {
+        return wrapped.active();
+    }
+}


### PR DESCRIPTION
Resolves https://groups.google.com/forum/#!msg/quarkus-dev/dej_Ref-YAQ/yH_hZysTBQAJ

* This change adds trace context (traceId, spanId, sampled) into MDC. 
* The feature is automatically enabled and can be configured via `quarkus.jaeger.log-trace-context=true`

Follow up feature can be to add baggage/distributed context into MDC. As we don't want to log all baggage content we might provide a white list configuration to identify which keys should be logged.


Example log output with `%X` pattern
```
11:33:14 INFO  {sampled=true, spanId=6f81a2edfb7c7699, traceId=6f81a2edfb7c7699} [or.ac.qu.GreetingResource] (executor-thread-63) hello
```

Signed-off-by: Pavol Loffay <ploffay@redhat.com>