### PR TITLE
Mention possibility to disable JSON for non prod

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -91,7 +91,6 @@ application POM as the following snippet illustrates.
 .Modifications to POM file to add the JSON logging extension
 [source,xml]
 ----
-<build>
   <dependencies>
     <!-- ... your other dependencies are here ... -->
     <dependency>
@@ -99,12 +98,20 @@ application POM as the following snippet illustrates.
       <artifactId>quarkus-logging-json</artifactId>
     </dependency>
   </dependencies>
-</build>
 ----
 
 The presence of this extension will, by default, replace the output format configuration from the console configuration.
 This means that the format string and the color settings (if any) will be ignored.  The other console configuration items
 (including those controlling asynchronous logging and the log level) will continue to be applied.
+
+For some, it will make sense to use logging that is humanly readable (unstructured) in dev mode and JSON logging (structured) in production mode. This can be achieved using different profiles, as shown in the following configuration. 
+
+.Disable JSON logging in application.properties for dev and test mode
+[source, properties]
+----
+%dev.quarkus.log.console.json=false
+%test.quarkus.log.console.json=false
+----
 
 ===== Configuration
 


### PR DESCRIPTION
* Mention possibility to disable JSON for non prod

Remove <build> surrounding extension - it's not valid. 

Add small example of how to use human readable logging for dev/test and structured JSON for production.