### PR TITLE
Prevent throwing NPE when recorded objects contain null collections

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -1067,7 +1067,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
                         handledProperties.add(i.getName());
 
                         Collection propertyValue = (Collection) i.read(param);
-                        if (!propertyValue.isEmpty()) {
+                        if (propertyValue != null && !propertyValue.isEmpty()) {
 
                             List<DeferredParameter> params = new ArrayList<>();
                             for (Object c : propertyValue) {
@@ -1106,7 +1106,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
 
                         handledProperties.add(i.getName());
                         Map<Object, Object> propertyValue = (Map<Object, Object>) i.read(param);
-                        if (!propertyValue.isEmpty()) {
+                        if (propertyValue != null && !propertyValue.isEmpty()) {
                             Map<DeferredParameter, DeferredParameter> def = new LinkedHashMap<>();
                             for (Map.Entry<Object, Object> entry : propertyValue.entrySet()) {
                                 DeferredParameter key = loadObjectInstance(entry.getKey(), existing,


### PR DESCRIPTION
If a recorded object contains a `null` collection, currently we end up with a NPE. I think we should allow null values.