### PR TITLE
Ensure that the Kotlin compiler adds method param names to bytecode

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl
@@ -42,6 +42,7 @@ java {
 
 compileKotlin {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
+    kotlinOptions.javaParameters = true
 }
 
 compileTestKotlin {

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -106,6 +106,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <javaParameters>true</javaParameters>
                     <!-- Soon to be replaced by plugin that will pre-configure all necessary annotations -->
                     <compilerPlugins>
                         <plugin>all-open</plugin>

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinCompilationProvider.java
@@ -37,6 +37,7 @@ public class KotlinCompilationProvider implements CompilationProvider {
     @Override
     public void compile(Set<File> filesToCompile, Context context) {
         K2JVMCompilerArguments compilerArguments = new K2JVMCompilerArguments();
+        compilerArguments.setJavaParameters(true);
         if (context.getCompilePluginArtifacts() != null && !context.getCompilePluginArtifacts().isEmpty()) {
             compilerArguments.setPluginClasspaths(context.getCompilePluginArtifacts().toArray(new String[0]));
         }


### PR DESCRIPTION
We already do this for Java, so let's make it consistent for Kotlin too

Fixes: #6041