### PR TITLE
Increase timeout in native image stages that frequently fails in CI

### DIFF
--- a/ci-templates/stages.yml
+++ b/ci-templates/stages.yml
@@ -239,7 +239,7 @@ stages:
         parameters:
           poolSettings: ${{parameters.poolSettings}}
           expectUseVMs: ${{parameters.expectUseVMs}}
-          timeoutInMinutes: 25
+          timeoutInMinutes: 30
           modules:
             - artemis-core
             - artemis-jms


### PR DESCRIPTION
See #6314 for example such a failure