### PR TITLE
Enlist repository parameterized types for reflection

### DIFF
--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug6324AbstractRepository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug6324AbstractRepository.java
@@ -1,0 +1,6 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+
+public abstract class Bug6324AbstractRepository<T> implements PanacheMongoRepository<T> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug6324ConcreteRepository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug6324ConcreteRepository.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Bug6324ConcreteRepository extends Bug6324AbstractRepository<NeedReflection> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug6324Repository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/Bug6324Repository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+
+@ApplicationScoped
+public class Bug6324Repository implements PanacheMongoRepository<NeedReflection> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
@@ -41,4 +41,13 @@ public class BugResource {
     public Response testNeedReflection() {
         return Response.ok(bug6324Repository.listAll()).build();
     }
+
+    @Inject
+    Bug6324ConcreteRepository bug6324ConcreteRepository;
+
+    @GET
+    @Path("6324/abstract")
+    public Response testNeedReflectionAndAbstract() {
+        return Response.ok(bug6324ConcreteRepository.listAll()).build();
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
@@ -6,6 +6,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/bugs")
 @Produces(MediaType.TEXT_PLAIN)
@@ -30,5 +31,14 @@ public class BugResource {
     public String testBug5885() {
         bug5885EntityRepository.findById(1L);
         return "OK";
+    }
+
+    @Inject
+    Bug6324Repository bug6324Repository;
+
+    @GET
+    @Path("6324")
+    public Response testNeedReflection() {
+        return Response.ok(bug6324Repository.listAll()).build();
     }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/NeedReflection.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/NeedReflection.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+public class NeedReflection {
+    public String comment;
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -338,4 +338,9 @@ class MongodbPanacheResourceTest {
     public void testBug5885() {
         get("/bugs/5885").then().body(is("OK"));
     }
+
+    @Test
+    public void testNeedReflection() {
+        get("/bugs/6324").then().statusCode(200);
+    }
 }

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -342,5 +342,7 @@ class MongodbPanacheResourceTest {
     @Test
     public void testNeedReflection() {
         get("/bugs/6324").then().statusCode(200);
+
+        get("/bugs/6324/abstract").then().statusCode(200);
     }
 }


### PR DESCRIPTION
Fixes #6324 

Enlist for relfection types parameters from interfaces and super classes.
This fixes the issue with the repository implementation where the repository type parameter (it should be the MongoDB persisted class) is not registered for reflection so it can fails if not direct usage is made that GraalVM can be aware of.

I didn't climb up the hierarchy of interfaces and super classes so it's still possible to have relfection issue for complex type hierarchies. I don't now if it worth it to implement it.