### PR TITLE
Upgrade mongodb clients to the latest versions

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -150,8 +150,9 @@
         <flyway.version>6.2.1</flyway.version>
         <yasson.version>1.0.6</yasson.version>
         <neo4j-java-driver.version>4.0.0</neo4j-java-driver.version>
-        <mongo-client.version>3.10.2</mongo-client.version>
-        <mongo-reactivestreams-client.version>1.11.0</mongo-reactivestreams-client.version>
+        <mongo-client.version>3.12.0</mongo-client.version>
+        <mongo-reactivestreams-client.version>1.13.0</mongo-reactivestreams-client.version>
+        <mongo-crypt.version>1.0.0</mongo-crypt.version>
         <artemis.version>2.11.0</artemis.version>
         <okhttp.version>3.14.6</okhttp.version>
         <sentry.version>1.7.28</sentry.version>
@@ -1523,6 +1524,11 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongodb-driver-reactivestreams</artifactId>
                 <version>${mongo-reactivestreams-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-crypt</artifactId>
+                <version>${mongo-crypt.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.minidev</groupId>

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -515,6 +515,8 @@ You can then point your browser to `http://localhost:8080/fruits.html` and use y
 [WARNING]
 ====
 Currently, Quarkus doesn't support the `mongodb+srv` protocol in native mode.
+
+link:https://docs.mongodb.com/manual/core/security-client-side-encryption/[Client-Side Field Level Encryption] is also not supported in native mode.
 ====
 
 == Conclusion

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-reactivestreams</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-crypt</artifactId>
+        </dependency>
 
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>


### PR DESCRIPTION
Upgrades mongo-java-driver to 3.12
Upgrades mongodb-driver-reactivestreams to 1.13
Add the new mongodb-crypt library for field encryption inside the client

Fixes #6418