### PR TITLE
fix typo in quarkus-amazon-lambda extension's maven archetype resources

### DIFF
--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/java/TestLambda.java
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/java/TestLambda.java
@@ -14,6 +14,6 @@ public class TestLambda implements RequestHandler<InputObject, OutputObject> {
 
     @Override
     public OutputObject handleRequest(InputObject input, Context context) {
-        return service.proces(input).setRequestId(context.getAwsRequestId());
+        return service.process(input).setRequestId(context.getAwsRequestId());
     }
 }


### PR DESCRIPTION

Method name is `process`, not `proces`.
 
https://github.com/quarkusio/quarkus/blob/master/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/java/ProcessingService.java#L10

