### PR TITLE
Fix elytron properties perf issues

### DIFF
--- a/extensions/elytron-security-jdbc/runtime/src/main/java/io/quarkus/elytron/security/jdbc/JdbcRecorder.java
+++ b/extensions/elytron-security-jdbc/runtime/src/main/java/io/quarkus/elytron/security/jdbc/JdbcRecorder.java
@@ -19,6 +19,8 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class JdbcRecorder {
 
+    private static final Provider[] PROVIDERS = new Provider[] { new WildFlyElytronProvider() };
+
     /**
      * Create a runtime value for a {@linkplain JdbcSecurityRealm}
      *
@@ -29,7 +31,7 @@ public class JdbcRecorder {
         Supplier<Provider[]> providers = new Supplier<Provider[]>() {
             @Override
             public Provider[] get() {
-                return new Provider[] { new WildFlyElytronProvider() };
+                return PROVIDERS;
             }
         };
         JdbcSecurityRealmBuilder builder = JdbcSecurityRealm.builder().setProviders(providers);

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPropertiesFileRecorder.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPropertiesFileRecorder.java
@@ -44,6 +44,8 @@ import io.quarkus.runtime.annotations.Recorder;
 public class ElytronPropertiesFileRecorder {
     static final Logger log = Logger.getLogger(ElytronPropertiesFileRecorder.class);
 
+    private static final Provider[] PROVIDERS = new Provider[] { new WildFlyElytronProvider() };
+
     /**
      * Load the user.properties and roles.properties files into the {@linkplain SecurityRealm}
      *
@@ -172,7 +174,7 @@ public class ElytronPropertiesFileRecorder {
                 .setProviders(new Supplier<Provider[]>() {
                     @Override
                     public Provider[] get() {
-                        return new Provider[] { new WildFlyElytronProvider() };
+                        return PROVIDERS;
                     }
                 })
                 .setPlainText(config.plainText)
@@ -193,7 +195,7 @@ public class ElytronPropertiesFileRecorder {
         Supplier<Provider[]> providers = new Supplier<Provider[]>() {
             @Override
             public Provider[] get() {
-                return new Provider[] { new WildFlyElytronProvider() };
+                return PROVIDERS;
             }
         };
         SecurityRealm realm = new SimpleMapBackedSecurityRealm(NameRewriter.IDENTITY_REWRITER, providers);


### PR DESCRIPTION
During some performance testing, I discover, thanks to profiler CPU flamegraph, that the Elytron Properties implementation uses a lot of CPU cycles to create the `WilldFlyElytronProvider`.

It apears that the security provider supplier is called on each request calls, and triggers the creation of a new `WilldFlyElytronProvider`.

Creating a unique `WilldFlyElytronProvider` and returing it from the supplier instead of creating it each time fix the issue.