### PR TITLE
docs: fix project artifact id for jackson

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -60,7 +60,7 @@ Quarkus also supports https://github.com/FasterXML/jackson[Jackson] so, if you p
 ----
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
-    -DprojectArtifactId=rest-json \
+    -DprojectArtifactId=rest-json-quickstart \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
     -Dextensions="resteasy-jackson"


### PR DESCRIPTION
According to the following command `cd rest-json-quickstart`,  project artifact id should be `rest-json-quickstart` rather than `rest-json`.