### PR TITLE
fix project name in the link to legumes.html

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -339,7 +339,8 @@ public class LegumeResource {
 ----
 
 Now let's add a simple web page to display our list of legumes.
-In the `src/main/resources/META-INF/resources` directory, add a `legumes.html` file with the content from this https://raw.githubusercontent.com/quarkusio/quarkus-quickstarts/master/rest-json/src/main/resources/META-INF/resources/legumes.html[legumes.html] file in it.
+In the `src/main/resources/META-INF/resources` directory, add a `legumes.html` file with the content from this
+{quickstarts-blob-url}/rest-json-quickstart/src/main/resources/META-INF/resources/legumes.html[legumes.html] file in it.
 
 Open a browser to http://localhost:8080/legumes.html and you will see our list of legumes.
 


### PR DESCRIPTION
Rest-json quickstart project is now renamed to `rest-json-quickstart`, so I fixed the project name in the link so that we can get correct url as https://github.com/quarkusio/quarkus-quickstarts/blob/master/rest-json-quickstart/src/main/resources/META-INF/resources/legumes.html

Also, I fixed the url part according to the link to fruits.html in the same file.

