### PR TITLE
Use mongodb-driver-sync instead of mongo-java-driver

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1472,7 +1472,18 @@
 
             <dependency>
                 <groupId>org.mongodb</groupId>
-                <artifactId>mongo-java-driver</artifactId>
+                <artifactId>mongodb-driver-sync</artifactId>
+                <version>${mongo-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-async</artifactId>
+                <version>${mongo-client.version}</version>
+            </dependency>
+            <!-- mongodb-driver-legacy is not needed for Quarkus but we add the dependency for backward compatibility -->
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-legacy</artifactId>
                 <version>${mongo-client.version}</version>
             </dependency>
             <dependency>

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -331,7 +331,7 @@ More information in the codec documentation: https://mongodb.github.io/mongo-jav
 ----
 package org.acme.rest.json.codec;
 
-import com.mongodb.MongoClient;
+import com.mongodb.MongoClientSettings;
 import org.acme.rest.json.Fruit;
 import org.bson.*;
 import org.bson.codecs.Codec;
@@ -346,7 +346,7 @@ public class FruitCodec implements CollectibleCodec<Fruit> {
     private final Codec<Document> documentCodec;
 
     public FruitCodec() {
-        this.documentCodec = MongoClient.getDefaultCodecRegistry().get(Document.class);
+        this.documentCodec = MongoClientSettings.getDefaultCodecRegistry().get(Document.class);
     }
 
     @Override
@@ -478,6 +478,21 @@ to validate the connection to the cluster.
 So when you access the `/health/ready` endpoint of your application you will have information about the connection validation status.
 
 This behavior can be disabled by setting the `quarkus.mongodb.health.enabled` property to `false` in your `application.properties`.
+
+== The legacy client
+
+We don't include the legacy MongoDB client by default. It contains the now retired MongoDB Java API (DB, DBCollection,... )
+and the `com.mongodb.MongoClient` that is now superseded by `com.mongodb.client.MongoClient`.
+
+If you want to use the legacy API, you need to add the following dependency to your `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.mongodb</groupId>
+    <artifactId>mongodb-driver-legacy</artifactId>
+</dependency>
+----
 
 == Building a native executable
 

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>quarkus-mongodb-client</artifactId>
     <name>Quarkus - MongoDB Client - Runtime</name>
     <description>An imperative and reactive client for MongoDB</description>
+
     <dependencies>
 
         <dependency>
@@ -29,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
+            <artifactId>mongodb-driver-sync</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -79,7 +79,7 @@ public class MongoClientRecorder {
     }
 
     void initialize(MongoClientConfig config, List<String> codecProviders) {
-        CodecRegistry defaultCodecRegistry = com.mongodb.MongoClient.getDefaultCodecRegistry();
+        CodecRegistry defaultCodecRegistry = MongoClientSettings.getDefaultCodecRegistry();
 
         MongoClientSettings.Builder settings = MongoClientSettings.builder();
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
@@ -114,25 +114,6 @@ final class InternalStreamConnectionSubtitution {
     }
 }
 
-@TargetClass(MongoClientOptions.class)
-final class MongoClientOptionsSubstitution {
-
-    @Alias
-    private SocketFactory socketFactory;
-
-    @Alias
-    private static SocketFactory DEFAULT_SOCKET_FACTORY;
-
-    @Substitute
-    public SocketFactory getSocketFactory() {
-        if (this.socketFactory != null) {
-            return this.socketFactory;
-        } else {
-            return DEFAULT_SOCKET_FACTORY;
-        }
-    }
-}
-
 @TargetClass(UnixSocketChannelStream.class)
 @Delete
 final class UnixSocketChannelStreamSubstitution {

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/BookCodec.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/BookCodec.java
@@ -9,14 +9,14 @@ import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
-import com.mongodb.MongoClient;
+import com.mongodb.MongoClientSettings;
 
 public class BookCodec implements CollectibleCodec<Book> {
 
     private final Codec<Document> documentCodec;
 
     public BookCodec() {
-        this.documentCodec = MongoClient.getDefaultCodecRegistry().get(Document.class);
+        this.documentCodec = MongoClientSettings.getDefaultCodecRegistry().get(Document.class);
     }
 
     @Override


### PR DESCRIPTION
Today Quarkus uses two MongoDB libraries:

- mongo-java-driver: this is an uberjar of mongodb-driver-sync, mongodb-driver-async, mongodb-driver-core and bson
- mongodb-driver-reactivestreams: it have dependencies to mongodb-driver-async, mongodb-driver-core and bson

So a lot of mongodb classes are duplicated, we also include some legacy classes that are replaced and should not be used anymore.

This PR replace the usage of mongo-java-driver by  mongodb-driver-sync.

It breaks some compatibilities because `com.mongodb.MongoClient` is no more accessible as it is replaced by `com.mongodb.client.MongoClient`. As the Quarkus code only provides bean instance of `com.mongodb.client.MongoClient` it should be safe to do it.

Only some code related to codec didn't works anymore as the default codec registry should be obtain from `MongoClientSettings` inside of from the old `MongoClient`.

A dependency management has been added to `mongodb-client-legacy` that includes the classes from mongo-java-driver that are not present in other libraries. User can add this dependency to have access to the old classes.

We should have a note about this small breaking change inside the release note (or we can add some WARNING in the guide) explaining the changes needed to be done on Codec code and the possibility to add the legacy driver if needed (not recommended).