### PR TITLE
Add a quick workaround to get javadoc generation happy

### DIFF
--- a/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/DummyForJavadoc.java
+++ b/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/DummyForJavadoc.java
@@ -1,0 +1,8 @@
+package io.quarkus.elytron.security.common.deployment;
+
+/**
+ * Quick workaround to have at least one public class and generate a Javadoc jar.
+ */
+public class DummyForJavadoc {
+
+}

--- a/extensions/elytron-security-common/runtime/src/main/java/io/quarkus/elytron/security/common/runtime/graal/DummyForJavadoc.java
+++ b/extensions/elytron-security-common/runtime/src/main/java/io/quarkus/elytron/security/common/runtime/graal/DummyForJavadoc.java
@@ -1,0 +1,8 @@
+package io.quarkus.elytron.security.common.runtime.graal;
+
+/**
+ * Quick workaround to have at least one public class and generate a Javadoc jar.
+ */
+public class DummyForJavadoc {
+
+}


### PR DESCRIPTION
This is ugly but, to properly build a Javadoc jar, we need at least one public class.

And we need a javadoc jar to be compliant with Central publishing rules.