### PR TITLE
Upgrade Jackson to 2.10.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -76,7 +76,7 @@
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
         <graal-sdk.version>19.3.0</graal-sdk.version>
         <gizmo.version>1.0.0.Final</gizmo.version>
-        <jackson.version>2.9.10.20191020</jackson.version>
+        <jackson.version>2.10.1</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.13</commons-codec.version>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -35,6 +35,10 @@
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>

--- a/tcks/microprofile-opentracing/base/pom.xml
+++ b/tcks/microprofile-opentracing/base/pom.xml
@@ -93,7 +93,15 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jackson-provider</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -31,6 +31,10 @@
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>


### PR DESCRIPTION
This is a draft PR as we need to discuss it (and I want CI to check it).

The current situation is uncomfortable:
- Vert.x is still based on 2.9 (but we don't really know it 2.10 would break it);
- RESTEasy 4.4.2 uses 2.10-specific Jackson stuff and we need to upgrade to it to fix a few issues.

Thus, I'm wondering if we should take the risk to upgrade to Jackson 2.10.

/cc @geoand @cescoffier 