### PR TITLE
enable hot reload on application.yaml

### DIFF
--- a/extensions/config-yaml/deployment/pom.xml
+++ b/extensions/config-yaml/deployment/pom.xml
@@ -23,6 +23,22 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
+        <!-- Test deps -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
+++ b/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
@@ -1,12 +1,19 @@
 package io.quarkus.config.yaml.deployment;
 
+import io.quarkus.config.yaml.runtime.ApplicationYamlProvider;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 
 public final class ConfigYamlProcessor {
 
     @BuildStep
     public FeatureBuildItem feature() {
         return new FeatureBuildItem(FeatureBuildItem.CONFIG_YAML);
+    }
+
+    @BuildStep
+    HotDeploymentWatchedFileBuildItem watchYamlConfig() {
+        return new HotDeploymentWatchedFileBuildItem(ApplicationYamlProvider.APPLICATION_YAML);
     }
 }

--- a/extensions/config-yaml/deployment/src/test/java/io/quarkus/config/yaml/deployment/ApplicationYamlHotDeploymentTest.java
+++ b/extensions/config-yaml/deployment/src/test/java/io/quarkus/config/yaml/deployment/ApplicationYamlHotDeploymentTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.config.yaml.deployment;
+
+import static io.quarkus.config.yaml.runtime.ApplicationYamlProvider.APPLICATION_YAML;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class ApplicationYamlHotDeploymentTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(APPLICATION_YAML)
+                    .addClass(FooResource.class));
+
+    @Test
+    public void testConfigReload() {
+        RestAssured.when().get("/foo").then()
+                .statusCode(200)
+                .body(is("AAAA"));
+
+        test.modifyResourceFile(APPLICATION_YAML, s -> s.replace("AAAA", "BBBB"));
+
+        RestAssured.when().get("/foo").then()
+                .statusCode(200)
+                .body(is("BBBB"));
+    }
+}

--- a/extensions/config-yaml/deployment/src/test/java/io/quarkus/config/yaml/deployment/FooResource.java
+++ b/extensions/config-yaml/deployment/src/test/java/io/quarkus/config/yaml/deployment/FooResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.config.yaml.deployment;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/")
+public class FooResource {
+
+    @ConfigProperty(name = "foo.bar")
+    String fooBar;
+
+    @Path("foo")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return fooBar;
+    }
+}

--- a/extensions/config-yaml/deployment/src/test/resources/application.yaml
+++ b/extensions/config-yaml/deployment/src/test/resources/application.yaml
@@ -1,0 +1,2 @@
+foo:
+  bar: AAAA

--- a/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/ApplicationYamlProvider.java
+++ b/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/ApplicationYamlProvider.java
@@ -23,7 +23,7 @@ import io.smallrye.config.source.yaml.YamlConfigSource;
  */
 public final class ApplicationYamlProvider implements ConfigSourceProvider {
 
-    static final String APPLICATION_YAML = "application.yaml";
+    public static final String APPLICATION_YAML = "application.yaml";
 
     @Override
     public Iterable<ConfigSource> getConfigSources(final ClassLoader forClassLoader) {


### PR DESCRIPTION
Hi Quarkus Team and happy new year ! 🎉 

I've been playing with the latest release 1.1.0.Final and I find the new YAML configuration support awesome. Unfortunately I have realised that the hot deployment upon change on `application.yaml` is not supported (unlike with the regular `application.properties` file) :( From what I can tell, the feature was included in the [first draft PR](https://github.com/quarkusio/quarkus/pull/4525/files#diff-870ef4539cfeec6ab40ffb88ab640e26R22), but not the [final one](https://github.com/quarkusio/quarkus/pull/5973/files)

This PR fixes the issue. I am not sure if there is any easy way to add an automated test for this ? I have created a [small reproducer](https://github.com/devauxbr/quarkus-config-yaml-live-reload) to easily test this manually

Any feedback appreciated! :) 

Cheers
