### PR TITLE
Add JSON-B and Jackson serialization to the Kafka guide

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -354,6 +354,197 @@ If enabled, when you access the `/health/ready` endpoint of your application you
 This behavior can be enabled by setting the `quarkus.kafka.health.enabled` property to `true` in your `application.properties`.
 You also need to point `quarkus.kafka.bootstrap-servers` to your Kafka cluster.
 
+== JSON serialization
+
+Quarkus has built-in capabilities to deal with JSON Kafka messages.
+
+Imagine we have a `Fruit` pojo as follows:
+
+[source,java]
+----
+public class Fruit {
+
+    public String name;
+    public int price;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name, int price) {
+        this.name = name;
+        this.price = price;
+    }
+}
+----
+
+And we want to use it to receive messages from Kafka, make some price transformation, and send messages back to Kafka.
+
+[source,java]
+----
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+* A bean consuming data from the "fruit-in" Kafka topic and applying some price conversion.
+* The result is pushed to the "fruit-out" stream.
+*/
+@ApplicationScoped
+public class FruitProcessor {
+
+    private static final double CONVERSION_RATE = 0.88;
+
+    @Incoming("fruit-in")
+    @Outgoing("fruit-out")
+    @Broadcast
+    public double process(Fruit fruit) {
+        fruit.price = fruit.price * CONVERSION_RATE;
+        return fruit;
+    }
+
+}
+----
+
+To do this, we will need to setup JSON serialization with JSON-B or Jackson.
+
+NOTE: With JSON serialization correctly configured, you can also use `Publisher<Fruit>` and `Emitter<Fruit>`.
+
+=== Serializing via JSON-B
+
+First, you need to include the `quarkus-jsonb` extension (if you already use the `quarkus-resteasy-jsonb` extension, this is not needed).
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-jsonb</artifactId>
+</dependency>
+----
+
+There is an existing `JsonbSerializer` that can be used to serialize all pojos via JSON-B,
+but the corresponding deserializer is generic, so it needs to be subclassed.
+
+So, let's create a `FruitDeserializer` that extends the generic `JsonbDeserializer`.
+
+[source,java]
+----
+package com.acme.fruit.jsonb;
+
+import io.quarkus.kafka.client.serialization.JsonbDeserializer;
+
+public class FruitDeserializer extends JsonbDeserializer<Fruit> {
+    public FruitDeserializer(){
+        // pass the class to the parent.
+        super(Fruit.class);
+    }
+}
+----
+
+NOTE: If you don't want to create a deserializer for each of your pojo, you can use the generic `io.vertx.kafka.client.serialization.JsonObjectDeserializer`
+that will deserialize to a `javax.json.JsonObject`. The corresponding serializer can also be used: `io.vertx.kafka.client.serialization.JsonObjectSerializer`.
+
+Finally, configure your streams to use the JSON-B serializer and deserializer.
+
+[source,properties]
+----
+# Configure the Kafka source (we read from it)
+mp.messaging.incoming.fruit-in.connector=smallrye-kafka
+mp.messaging.incoming.fruit-in.topic=fruit-in
+mp.messaging.incoming.fruit-in.value.deserializer=com.acme.fruit.jsonb.FruitDeserializer
+
+# Configure the Kafka sink (we write to it)
+mp.messaging.outgoing.fruit-out.connector=smallrye-kafka
+mp.messaging.outgoing.fruit-out.topic=fruit-out
+mp.messaging.outgoing.fruit-out.value.serializer=io.quarkus.kafka.client.serialization.JsonbSerializer
+----
+
+Now, your Kafka messages will contain a JSON-B serialized representation of your Fruit pojo.
+
+=== Serializing via Jackson
+
+First, you need to include the `quarkus-jackson` extension (if you already use the `quarkus-jackson-jsonb` extension, this is not needed).
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-jackson</artifactId>
+</dependency>
+----
+
+There is an existing `ObjectMapperSerializer` that can be used to serialize all pojos via Jackson,
+but the corresponding deserializer is generic, so it needs to be subclassed.
+
+So, let's create a `FruitDeserializer` that extends the `ObjectMapperDeserializer`.
+
+[source,java]
+----
+package com.acme.fruit.jackson;
+
+import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
+
+public class FruitDeserializer extends ObjectMapperDeserializer<Fruit> {
+    public FruitDeserializer(){
+        // pass the class to the parent.
+        super(Fruit.class);
+    }
+}
+----
+
+Finally, configure your streams to use the Jackson serializer and deserializer.
+
+[source,properties]
+----
+# Configure the Kafka source (we read from it)
+mp.messaging.incoming.fruit-in.connector=smallrye-kafka
+mp.messaging.incoming.fruit-in.topic=fruit-in
+mp.messaging.incoming.fruit-in.value.deserializer=com.acme.fruit.jackson.FruitDeserializer
+
+# Configure the Kafka sink (we write to it)
+mp.messaging.outgoing.fruit-out.connector=smallrye-kafka
+mp.messaging.outgoing.fruit-out.topic=fruit-out
+mp.messaging.outgoing.fruit-out.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+----
+
+Now, your Kafka messages will contain a Jackson serialized representation of your Fruit pojo.
+
+=== Sending JSON Server-Sent Events (SSE)
+
+If you want RESTEasy to send JSON Server-Sent Events, you need to use the `@SseElementType` annotation to define the content type of the events,
+as the method will be annotated with `@Produces(MediaType.SERVER_SENT_EVENTS)`.
+
+The following example shows how to use SSE from a Kafka topic source.
+
+[source,java]
+----
+import io.smallrye.reactive.messaging.annotations.Channel;
+import org.reactivestreams.Publisher;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.annotations.SseElementType;
+
+@Path("/fruits")
+public class PriceResource {
+
+    @Inject
+    @Channel("fruit-out") Publisher<Fruit> fruits;
+
+    @GET
+    @Path("/stream")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @SseElementType(MediaType.APPLICATION_JSON)
+    public Publisher<Fruit> stream() {
+        return fruits;
+    }
+}
+----
+
 == Going further
 
 This guide has shown how you can interact with Kafka using Quarkus.


### PR DESCRIPTION
Add JSON serialization documentation to the Kafka guide.

When using reactive messaging, I had a hard time figuring out that I need to use `@SseElementType(MediaType.APPLICATION_JSON)` to be able to generates JSON SSE, I didn't add this to the guide because I'm not sure it needs to be put here or inside a more general reactive guide ?