### PR TITLE
Hibernate Validator dev mode tests added

### DIFF
--- a/extensions/hibernate-validator/deployment/pom.xml
+++ b/extensions/hibernate-validator/deployment/pom.xml
@@ -41,6 +41,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/ClassLevelConstraint.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/ClassLevelConstraint.java
@@ -1,0 +1,23 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { ClassLevelValidator.class })
+@Documented
+public @interface ClassLevelConstraint {
+
+    String message() default "My class constraint message";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/ClassLevelValidator.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/ClassLevelValidator.java
@@ -1,0 +1,11 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ClassLevelValidator implements ConstraintValidator<ClassLevelConstraint, TestBean> {
+    @Override
+    public boolean isValid(TestBean bean, ConstraintValidatorContext context) {
+        return false;
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/DependentTestBean.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/DependentTestBean.java
@@ -1,0 +1,10 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class DependentTestBean {
+    public String testMethod(/* <placeholder> */ String message) {
+        return message;
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/DevModeConstraintValidationTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/DevModeConstraintValidationTest.java
@@ -1,0 +1,130 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class DevModeConstraintValidationTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestBean.class,
+                    DevModeTestResource.class, ClassLevelConstraint.class, ClassLevelValidator.class, DependentTestBean.class));
+
+    @Test
+    public void testClassConstraintHotReplacement() {
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("ok"));
+
+        TEST.modifySourceFile("TestBean.java",
+                s -> s.replace("// <placeholder1>", "@io.quarkus.hibernate.validator.test.devmode.ClassLevelConstraint"));
+
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("My class constraint message"));
+    }
+
+    @Test
+    public void testPropertyConstraintHotReplacement() {
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("ok"));
+
+        TEST.modifySourceFile("TestBean.java", s -> s.replace("// <placeholder2>",
+                "@javax.validation.constraints.NotNull(message=\"My property message\")"));
+
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("My property message"));
+    }
+
+    @Test
+    public void testMethodConstraintHotReplacement() {
+
+        RestAssured.given()
+                .when()
+                .get("/test/mymessage")
+                .then()
+                .body(containsString("mymessage"));
+
+        TEST.modifySourceFile("DependentTestBean.java", s -> s.replace("/* <placeholder> */",
+                "@javax.validation.constraints.Size(max=1, message=\"My method message\")"));
+
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .get("/test/mymessage")
+                .then()
+                .body(containsString("My method message"));
+    }
+
+    @Test
+    public void testNewBeanHotReplacement() {
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("ok"));
+
+        TEST.addSourceFile(NewTestBean.class);
+        TEST.modifySourceFile("DevModeTestResource.java", s -> s.replace("@Valid TestBean",
+                "@Valid NewTestBean"));
+
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("My new bean message"));
+    }
+
+    @Test
+    public void testNewConstraintHotReplacement() {
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("ok"));
+
+        TEST.addSourceFile(NewConstraint.class);
+        TEST.addSourceFile(NewValidator.class);
+        TEST.modifySourceFile("TestBean.java", s -> s.replace("// <placeholder2>",
+                "@NewConstraint"));
+
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .body("{}")
+                .post("/test/validate")
+                .then()
+                .body(containsString("My new constraint message"));
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/DevModeTestResource.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/DevModeTestResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/test")
+public class DevModeTestResource {
+
+    @Inject
+    DependentTestBean bean;
+
+    @POST
+    @Path("/validate")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String validateBean(@Valid TestBean testBean) {
+        return "ok";
+    }
+
+    @GET
+    @Path("/{message}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String validateCDIBean(@PathParam("message") String message) {
+        return bean.testMethod(message);
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/NewConstraint.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/NewConstraint.java
@@ -1,0 +1,23 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { NewValidator.class })
+@Documented
+public @interface NewConstraint {
+
+    String message() default "My new constraint message";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/NewTestBean.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/NewTestBean.java
@@ -1,0 +1,8 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import javax.validation.constraints.NotNull;
+
+public class NewTestBean {
+    @NotNull(message = "My new bean message")
+    public String name;
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/NewValidator.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/NewValidator.java
@@ -1,0 +1,11 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NewValidator implements ConstraintValidator<NewConstraint, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return false;
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/TestBean.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/devmode/TestBean.java
@@ -1,0 +1,16 @@
+package io.quarkus.hibernate.validator.test.devmode;
+
+// <placeholder1>
+public class TestBean {
+
+    public String name;
+
+    // <placeholder2>
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Hibernate Validator dev mode tests added:
- adding a constraint on a property of an existing bean
- adding a class constraint on an existing bean
- adding a method constraint on a CDI bean
- adding an entirely new constrained bean
