### PR TITLE
add configuration option to include full MDC in logging-gelf extension

### DIFF
--- a/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfConfig.java
+++ b/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfConfig.java
@@ -93,4 +93,9 @@ public class GelfConfig {
     @ConfigDocSection
     public Map<String, AdditionalFieldConfig> additionalField;
 
+    /**
+     * Whether to include all fields from the MDC.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean includeFullMdc;
 }

--- a/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfLogHandlerRecorder.java
+++ b/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfLogHandlerRecorder.java
@@ -25,6 +25,7 @@ public class GelfLogHandlerRecorder {
         handler.setExtractStackTrace(extractStackTrace);
         handler.setFilterStackTrace(config.filterStackTrace);
         handler.setTimestampPattern(config.timestampPattern);
+        handler.setIncludeFullMdc(config.includeFullMdc);
         handler.setHost(config.host);
         handler.setPort(config.port);
         handler.setLevel(config.level);


### PR DESCRIPTION
Hi Quarkus Team

I've been playing with the latest release 1.1.0.Final and the new `logging-gelf` extension is a great addition. I used to rely on the full featured [logback-logstash-encoder](https://github.com/logstash/logstash-logback-encoder) with [Payara](https://blog.payara.fish/log-directly-to-logstash-from-payara-server) on my application before I migrated it to quarkus, and in the process I had to roll back my logging strategy to the old logging way, i.e. writing to a log file with a special format and grok this file with filebeat and logstash... 

With Payara, adding a new field in JSON log entries used to be just adding a new [MDC](http://logback.qos.ch/manual/mdc.html) field in Java code and have automagically propagated to ELK for each request logs in the current thread. Now it means also changing the log file format and changing the grok pattern which is quite cumbersome. This was one of the only few downside of switching to quarkus... And now it's over ! :)

Well... Almost over, as with this new `logging-gelf` extension we lack the ability to propagate all fields from the MDC. I've been digging in the extension code and I figured that the feature exists in the underlying [`logstash-gelf`](https://logging.paluch.biz/examples/jbossas7.html) extension. So this PR adds the ability to enable this feature via a new configuration property. I have created a [small showcase project](https://github.com/devauxbr/quarkus-gelf-include-full-mdc) to easily test this with a local logstash instance.

Any feedback appreciated! :)

Cheers
