### PR TITLE
Improve the Neo4j guide

### DIFF
--- a/docs/src/main/asciidoc/neo4j.adoc
+++ b/docs/src/main/asciidoc/neo4j.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
 = Quarkus - Neo4j
-:neo4j_version: 3.5.13
+:neo4j_version: 4.0.0
 
 include::./attributes.adoc[]
 :extension-status: preview
@@ -35,12 +35,6 @@ while Neo4j itself is available in a GPL3-licensed open-source "community editio
 with online backup and high availability extensions licensed under a closed-source commercial license.
 
 include::./status-include.adoc[]
-
-[WARNING]
-====
-It is based on an alpha version of the Neo4j driver.
-Hence the reason for it to be _preview_
-====
 
 == Programming model
 
@@ -279,10 +273,10 @@ It uses transaction functions of the driver:
 public CompletionStage<Response> create(Fruit fruit) {
     AsyncSession session = driver.asyncSession();
     return session
-        .writeTransactionAsync(tx ->
-            tx.runAsync("CREATE (f:Fruit {name: $name}) RETURN f", Values.parameters("name", fruit.name))
+        .writeTransactionAsync(tx -> tx
+            .runAsync("CREATE (f:Fruit {name: $name}) RETURN f", Values.parameters("name", fruit.name))
+            .thenCompose(fn -> fn.singleAsync())
         )
-        .thenCompose(fn -> fn.singleAsync())
         .thenApply(record -> Fruit.from(record.get("f").asNode()))
         .thenCompose(persistedFruit -> session.closeAsync().thenApply(signal -> persistedFruit))
         .thenApply(persistedFruit -> Response
@@ -321,10 +315,10 @@ We also add some exception handling, in case the resource is called with an inva
 public CompletionStage<Response> getSingle(@PathParam("id") Long id) {
     AsyncSession session = driver.asyncSession();
     return session
-        .readTransactionAsync(tx ->
-            tx.runAsync("MATCH (f:Fruit) WHERE id(f) = $id RETURN f", Values.parameters("id", id))
+        .readTransactionAsync(tx -> tx
+            .runAsync("MATCH (f:Fruit) WHERE id(f) = $id RETURN f", Values.parameters("id", id))
+            .thenCompose(fn -> fn.singleAsync())
     )
-    .thenCompose(fn -> fn.singleAsync())
     .handle((record, exception) -> {
         if(exception != null) {
             Throwable source = exception;
@@ -368,10 +362,10 @@ public CompletionStage<Response> delete(@PathParam("id") Long id) {
 
     AsyncSession session = driver.asyncSession();
     return session
-        .writeTransactionAsync(tx ->
-            tx.runAsync("MATCH (f:Fruit) WHERE id(f) = $id DELETE f", Values.parameters("id", id))
+        .writeTransactionAsync(tx -> tx
+            .runAsync("MATCH (f:Fruit) WHERE id(f) = $id DELETE f", Values.parameters("id", id))
+            .thenCompose(fn -> fn.consumeAsync()) // <1>
         )
-        .thenCompose(fn -> fn.consumeAsync()) // <1>
         .thenCompose(response -> session.closeAsync())
         .thenApply(signal -> Response.noContent().build());
 }


### PR DESCRIPTION
The Neo4j driver has been updated to 4.0.0 final and Neo4j 4.0 can be
used from Docker, the preview flag can now be removed.

The final driver revealed some errors in the existing guide:

The reading of the transactional result of a transactional function
needs to happen inside the same transaction.
Therefor the guide needs a fix so that the composition of the future
extracting the node happens in the transaction, not outside.

A corresponding PR to the Guides itself will be created in a couple of seconds.

Thanks @gunnarmorling for bringing this to my attention, much appreciated. 