### PR TITLE
Fix Kubernetes manifest port handling

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -76,11 +75,9 @@ class VertxHttpProcessor {
     }
 
     @BuildStep(onlyIf = IsNormal.class)
-    @Record(value = ExecutionTime.RUNTIME_INIT, optional = true)
-    public KubernetesPortBuildItem kubernetes(HttpConfiguration config, VertxHttpRecorder recorder) {
-        int port = ConfigProvider.getConfig().getValue("quarkus.http.port", OptionalInt.class).orElse(8080);
-        recorder.warnIfPortChanged(config, port);
-        return new KubernetesPortBuildItem(config.port, "http");
+    public KubernetesPortBuildItem kubernetes() {
+        int port = ConfigProvider.getConfig().getOptionalValue("quarkus.http.port", Integer.class).orElse(8080);
+        return new KubernetesPortBuildItem(port, "http");
     }
 
     @BuildStep

--- a/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/src/main/resources/application.properties
+++ b/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 # Configuration file
+quarkus.http.port=9090
 kubernetes.name=test-it
 kubernetes.labels[0].key=foo
 kubernetes.labels[0].value=bar

--- a/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/verify.groovy
+++ b/integration-tests/kubernetes/src/it/kubernetes-with-application-properties/verify.groovy
@@ -29,3 +29,9 @@ assert env.value == "SOMEVALUE"
 
 //Check the image
 assert deployment.spec.template.spec.containers[0].image == "quay.io/grp/kubernetes-with-application-properties:0.1-SNAPSHOT"
+assert deployment.spec.template.spec.containers[0].ports[0].containerPort == 9090
+
+//Check the Service
+Service service = list.items.find{r -> r.kind == "Service"}
+assert service != null
+assert service.spec.ports[0].port == 9090

--- a/integration-tests/kubernetes/src/it/kubernetes/verify.groovy
+++ b/integration-tests/kubernetes/src/it/kubernetes/verify.groovy
@@ -1,6 +1,7 @@
 import io.dekorate.utils.Serialization
 import io.dekorate.deps.kubernetes.api.model.KubernetesList
 import io.dekorate.deps.kubernetes.api.model.apps.Deployment;
+import io.dekorate.deps.kubernetes.api.model.Service;
 
 //Check that file exits
 String base = basedir
@@ -11,7 +12,20 @@ assert kubernetesYml.exists()
 KubernetesList list = Serialization.unmarshal(kubernetesYml.text, KubernetesList.class)
 assert list != null
 Deployment deployment = list.items.find{r -> r.kind == "Deployment"}
+Service service = list.items.find{r -> r.kind == "Service"}
 
-//Check that ti contains a Deployment named after the project
+//Check that it contains a Deployment named after the project
 assert deployment != null
 assert deployment.metadata.name == "kubernetes"
+
+//Check the port of the Deployment
+assert deployment.spec.template.spec.containers[0].ports[0].containerPort == 8080
+
+//Check that it contains a Service named after the project
+assert service != null
+assert service.metadata.name == "kubernetes"
+
+//Check the port of the Service
+assert service.spec.ports[0].port == 8080
+
+


### PR DESCRIPTION
This is needed because of the config changes that went in 1.1.
One thing that needed to be removed because of those changes was
the warning we used to produce about potential mismatch between
the port in the Kubernetes manifests and the port set at runtime

Fixes: #6408