### PR TITLE
Allow vertx-http to customize body of security errors

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationErrorResponseHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationErrorResponseHandler.java
@@ -1,0 +1,10 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.vertx.core.buffer.Buffer;
+
+public interface AuthenticationErrorResponseHandler {
+    Buffer body(AuthenticationFailedException exception);
+
+    Buffer body(AuthenticationRedirectException exception);
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationErrorResponseHandlerProvider.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationErrorResponseHandlerProvider.java
@@ -1,0 +1,35 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import io.netty.buffer.Unpooled;
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.security.AuthenticationFailedException;
+import io.vertx.core.buffer.Buffer;
+
+@ApplicationScoped
+class AuthenticationErrorResponseHandlerProvider {
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    public AuthenticationErrorResponseHandler createHandler() {
+        return new DefaultHandler();
+    }
+
+    static class DefaultHandler implements AuthenticationErrorResponseHandler {
+        private static final Buffer EMPTY_BUFFER = Buffer.buffer(Unpooled.EMPTY_BUFFER);
+
+        @Override
+        public Buffer body(AuthenticationFailedException exception) {
+            return EMPTY_BUFFER;
+        }
+
+        @Override
+        public Buffer body(AuthenticationRedirectException exception) {
+            return EMPTY_BUFFER;
+        }
+    }
+}


### PR DESCRIPTION
As explained in #5751 , `io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder` ends the response as soon as a authentication is detected. This prevents us to customize the response's body elsewhere.

The idea of this pull request is to manage this body with a dedicated bean.