### PR TITLE
ArC - optimize CreationalContext

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.processor;
 
 import io.quarkus.arc.AlternativePriority;
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.impl.ComputingCache;
 import java.util.Optional;
 import javax.annotation.PostConstruct;
@@ -55,6 +56,7 @@ public final class DotNames {
     public static final DotName POST_CONSTRUCT = create(PostConstruct.class);
     public static final DotName PRE_DESTROY = create(PreDestroy.class);
     public static final DotName INSTANCE = create(Instance.class);
+    public static final DotName INJECTABLE_INSTANCE = create(InjectableInstance.class);
     public static final DotName PROVIDER = create(Provider.class);
     public static final DotName INJECTION_POINT = create(InjectionPoint.class);
     public static final DotName INTERCEPTOR = create(Interceptor.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -186,6 +186,10 @@ final class MethodDescriptors {
             SubclassMethodMetadata.class,
             List.class, Method.class, Set.class);
 
+    static final MethodDescriptor CREATIONAL_CTX_HAS_DEPENDENT_INSTANCES = MethodDescriptor.ofMethod(
+            CreationalContextImpl.class,
+            "hasDependentInstances", boolean.class);
+
     private MethodDescriptors() {
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -336,7 +336,7 @@ public class ObserverGenerator extends AbstractGenerator {
                                 annotationLiterals, observer));
             } else {
                 if (injectionPoint.getResolvedBean().getAllInjectionPoints().stream()
-                        .anyMatch(ip -> BuiltinBean.INJECTION_POINT.getRawTypeDotName().equals(ip.getRequiredType().name()))) {
+                        .anyMatch(ip -> BuiltinBean.INJECTION_POINT.hasRawTypeDotName(ip.getRequiredType().name()))) {
                     // IMPL NOTE: Injection point resolves to a dependent bean that injects InjectionPoint metadata and so we need to wrap the injectable
                     // reference provider
                     ResultHandle requiredQualifiersHandle = BeanGenerator.collectQualifiers(classOutput, observerCreator,

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
@@ -1,0 +1,27 @@
+package io.quarkus.arc;
+
+import java.lang.annotation.Annotation;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.util.TypeLiteral;
+
+/**
+ * Enhanced version of {@link Instance}.
+ * 
+ * @param <T>
+ */
+public interface InjectableInstance<T> extends Instance<T> {
+
+    InstanceHandle<T> getHandle();
+
+    Iterable<InstanceHandle<T>> handles();
+
+    @Override
+    InjectableInstance<T> select(Annotation... qualifiers);
+
+    @Override
+    <U extends T> InjectableInstance<U> select(Class<U> subtype, Annotation... qualifiers);
+
+    @Override
+    <U extends T> InjectableInstance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -77,7 +77,7 @@ public class BeanManagerImpl implements BeanManager {
             InjectableBean<?> bean = (InjectableBean<?>) resolve(beans);
             InjectionPoint prev = InjectionPointProvider.set(ij);
             try {
-                return ArcContainerImpl.instance().beanInstanceHandle(bean, (CreationalContextImpl) ctx, false).get();
+                return ArcContainerImpl.beanInstanceHandle(bean, (CreationalContextImpl) ctx, false, null).get();
             } finally {
                 InjectionPointProvider.set(prev);
             }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
@@ -40,6 +40,10 @@ public class CreationalContextImpl<T> implements CreationalContext<T> {
         dependentInstances.add(instanceHandle);
     }
 
+    public boolean hasDependentInstances() {
+        return !dependentInstances.isEmpty();
+    }
+
     void destroyDependentInstance(Object dependentInstance) {
         synchronized (dependentInstances) {
             for (Iterator<InstanceHandle<?>> iterator = dependentInstances.iterator(); iterator.hasNext();) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceHandleImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceHandleImpl.java
@@ -4,6 +4,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InstanceHandle;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.spi.CreationalContext;
 
@@ -20,29 +21,27 @@ class InstanceHandleImpl<T> implements InstanceHandle<T> {
         return (InstanceHandle<T>) UNAVAILABLE;
     }
 
-    static final InstanceHandleImpl<Object> UNAVAILABLE = new InstanceHandleImpl<Object>(null, null, null, null);
+    static final InstanceHandleImpl<Object> UNAVAILABLE = new InstanceHandleImpl<Object>(null, null, null, null, null);
 
     private final InjectableBean<T> bean;
-
     private final T instance;
-
     private final CreationalContext<T> creationalContext;
-
     private final CreationalContext<?> parentCreationalContext;
-
     private final AtomicBoolean destroyed;
+    private final Consumer<T> destroyLogic;
 
     InstanceHandleImpl(InjectableBean<T> bean, T instance, CreationalContext<T> creationalContext) {
-        this(bean, instance, creationalContext, null);
+        this(bean, instance, creationalContext, null, null);
     }
 
     InstanceHandleImpl(InjectableBean<T> bean, T instance, CreationalContext<T> creationalContext,
-            CreationalContext<?> parentCreationalContext) {
+            CreationalContext<?> parentCreationalContext, Consumer<T> destroyLogic) {
         this.bean = bean;
         this.instance = instance;
         this.creationalContext = creationalContext;
         this.parentCreationalContext = parentCreationalContext;
         this.destroyed = new AtomicBoolean(false);
+        this.destroyLogic = destroyLogic;
     }
 
     @Override
@@ -61,10 +60,14 @@ class InstanceHandleImpl<T> implements InstanceHandle<T> {
     @Override
     public void destroy() {
         if (instance != null && destroyed.compareAndSet(false, true)) {
-            if (bean.getScope().equals(Dependent.class)) {
-                destroyInternal();
+            if (destroyLogic != null) {
+                destroyLogic.accept(instance);
             } else {
-                Arc.container().getActiveContext(bean.getScope()).destroy(bean);
+                if (bean.getScope().equals(Dependent.class)) {
+                    destroyInternal();
+                } else {
+                    Arc.container().getActiveContext(bean.getScope()).destroy(bean);
+                }
             }
         }
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/dependent/DependentCreationalContextTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/dependent/DependentCreationalContextTest.java
@@ -1,0 +1,91 @@
+package io.quarkus.arc.test.contexts.dependent;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.impl.InstanceImpl;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class DependentCreationalContextTest {
+
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(NoPreDestroy.class, HasDestroy.class, HasDependency.class,
+            ProducerNoDisposer.class, ProducerWithDisposer.class, String.class, Boolean.class);
+
+    @Test
+    public void testCreationalContextOptimization() {
+        InstanceImpl<Object> instance = (InstanceImpl<Object>) Arc.container().beanManager().createInstance();
+        assertBeanType(instance, NoPreDestroy.class, false);
+        assertBeanType(instance, HasDestroy.class, true);
+        assertBeanType(instance, HasDependency.class, true);
+        // ProducerNoDisposer
+        assertBeanType(instance, boolean.class, false);
+        // ProducerWithDisposer
+        assertBeanType(instance, String.class, true);
+    }
+
+    <T> void assertBeanType(InstanceImpl<Object> instance, Class<T> beanType, boolean shouldBeStored) {
+        T bean = instance.select(beanType).get();
+        assertNotNull(bean);
+        if (shouldBeStored) {
+            assertTrue(instance.hasDependentInstances());
+        } else {
+            assertFalse(instance.hasDependentInstances());
+        }
+        instance.destroy(bean);
+    }
+
+    @Dependent
+    static class NoPreDestroy {
+
+    }
+
+    @Dependent
+    static class HasDestroy {
+
+        @PreDestroy
+        void destroy() {
+        }
+
+    }
+
+    @Dependent
+    static class HasDependency {
+
+        @Inject
+        HasDestroy dep;
+
+    }
+
+    @Dependent
+    static class ProducerNoDisposer {
+
+        @Produces
+        Boolean ping() {
+            return true;
+        }
+
+    }
+
+    @Dependent
+    static class ProducerWithDisposer {
+
+        @Produces
+        String ping() {
+            return "ok";
+        }
+
+        void dispose(@Disposes String ping) {
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/InjectableInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/InjectableInstanceTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.arc.test.instance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.impl.InstanceImpl;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InjectableInstanceTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Alpha.class, Washcloth.class);
+
+    @Test
+    public void testDestroy() {
+        assertFalse(Washcloth.DESTROYED.get());
+
+        Arc.container().instance(Alpha.class).get().doSomething();
+        assertTrue(Washcloth.DESTROYED.get());
+    }
+
+    @Singleton
+    static class Alpha {
+
+        @Inject
+        InjectableInstance<Washcloth> instance;
+
+        void doSomething() {
+            try (InstanceHandle<Washcloth> handle = instance.getHandle()) {
+                InjectableBean<Washcloth> bean = handle.getBean();
+                assertNotNull(bean);
+                assertEquals(Dependent.class, bean.getScope());
+                handle.get().wash();
+
+                // Washcloth has @PreDestroy - the dependent instance should be there
+                assertTrue(((InstanceImpl<?>) instance).hasDependentInstances());
+            }
+
+            // InstanceHandle.destroy() should remove the instance from the CC of the Instance
+            assertFalse(((InstanceImpl<?>) instance).hasDependentInstances());
+        }
+
+    }
+
+    @Dependent
+    static class Washcloth {
+
+        static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+
+        void wash() {
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+
+    }
+
+}


### PR DESCRIPTION
- do not always store all dependent instances in CC
- also introduce io.quarkus.arc.InjectableInstance
- resolves #5281