### PR TITLE
Qute - more meaningful exception for missing parameter declaration class

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -185,13 +185,19 @@ public class QuteProcessor {
             BuildProducer<ImplicitValueResolverBuildItem> requiredClasses) {
 
         IndexView index = beanArchiveIndex.getIndex();
+        Function<String, String> templateIdToPathFun = new Function<String, String>() {
+            @Override
+            public String apply(String id) {
+                return findTemplatePath(templatesAnalysis, id);
+            }
+        };
 
         for (TemplateAnalysis analysis : templatesAnalysis.getAnalysis()) {
             for (Expression expression : analysis.expressions) {
                 if (expression.typeCheckInfo == null) {
                     continue;
                 }
-                TypeCheckInfo typeCheckInfo = new TypeCheckInfo(expression.typeCheckInfo, index);
+                TypeCheckInfo typeCheckInfo = TypeCheckInfo.create(expression, index, templateIdToPathFun);
                 if (typeCheckInfo.parts.isEmpty()) {
                     continue;
                 }
@@ -285,6 +291,12 @@ public class QuteProcessor {
             BuildProducer<ImplicitValueResolverBuildItem> requiredClasses) {
 
         IndexView index = beanArchiveIndex.getIndex();
+        Function<String, String> templateIdToPathFun = new Function<String, String>() {
+            @Override
+            public String apply(String id) {
+                return findTemplatePath(analysis, id);
+            }
+        };
         Set<Expression> injectExpressions = collectInjectExpressions(analysis);
 
         if (!injectExpressions.isEmpty()) {
@@ -302,7 +314,7 @@ public class QuteProcessor {
                     if (expression.parts.size() == 1) {
                         continue;
                     }
-                    TypeCheckInfo typeCheckInfo = new TypeCheckInfo(expression.typeCheckInfo, index);
+                    TypeCheckInfo typeCheckInfo = TypeCheckInfo.create(expression, index, templateIdToPathFun);
                     if (typeCheckInfo.parts.isEmpty()) {
                         continue;
                     }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/ParamDeclarationWrongClassTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/ParamDeclarationWrongClassTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.qute.deployment;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ParamDeclarationWrongClassTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(Foo.class)
+                    .addAsResource(new StringAsset("{@org.acme.Foo foo}"
+                            + "{foo.name}"), "templates/foo.html"))
+            .setExpectedException(TemplateException.class);
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+}


### PR DESCRIPTION
- resolves #6366

The exception looks like:
```
io.q.q.d.TemplateException: Class [org.acme.Foo] used in the parameter declaration in template [foo.html] on line 1 was not found in the application index. Make sure it is spelled correctly.
```