### PR TITLE
Extending smoke tests for SR context propagation integration.

### DIFF
--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
@@ -12,7 +12,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class ContextUnitTest {
+/**
+ * Tests simple context propagation of basic contexts (Arc, RestEasy, server, transaction) via either
+ * {@link org.eclipse.microprofile.context.ManagedExecutor} (ME) or
+ * {@link org.eclipse.microprofile.context.ThreadContext} (TC).
+ */
+public class SimpleContextPropagationTest {
     private static Class[] testClasses = {
             ContextEndpoint.class, RequestBean.class, ContextEntity.class, TestResources.class, CompletionExceptionMapper.class,
             TransactionalBean.class
@@ -25,37 +30,55 @@ public class ContextUnitTest {
                     .addAsResource("application.properties"));
 
     @Test()
-    public void testRESTEasyContextPropagation() {
+    public void testRESTEasyMEContextPropagation() {
         RestAssured.when().get("/context/resteasy").then()
                 .statusCode(Response.Status.OK.getStatusCode());
     }
 
     @Test()
-    public void testServletContextPropagation() {
+    public void testRESTEasyTCContextPropagation() {
+        RestAssured.when().get("/context/resteasy-tc").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test()
+    public void testServletMEContextPropagation() {
         RestAssured.when().get("/context/servlet").then()
                 .statusCode(Response.Status.OK.getStatusCode());
     }
 
     @Test()
-    public void testThreadContextPropagation() {
-        RestAssured.when().get("/context/thread-context").then()
+    public void testServletTCContextPropagation() {
+        RestAssured.when().get("/context/servlet-tc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
     }
 
     @Test()
-    public void testArcContextPropagation() {
+    public void testArcMEContextPropagation() {
         RestAssured.when().get("/context/arc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
     }
 
     @Test()
-    public void testArcContextPropagationDisabled() {
+    public void testArcTCContextPropagation() {
+        RestAssured.when().get("/context/arc-tc").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test()
+    public void testArcMEContextPropagationDisabled() {
         RestAssured.when().get("/context/noarc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
     }
 
     @Test()
-    public void testTransactionContextPropagation() {
+    public void testArcTCContextPropagationDisabled() {
+        RestAssured.when().get("/context/noarc-tc").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test()
+    public void testTransactionMEContextPropagation() {
         RestAssured.when().get("/context/transaction").then()
                 .statusCode(Response.Status.OK.getStatusCode());
         RestAssured.when().get("/context/transaction2").then()
@@ -63,6 +86,12 @@ public class ContextUnitTest {
         RestAssured.when().get("/context/transaction3").then()
                 .statusCode(Response.Status.CONFLICT.getStatusCode());
         RestAssured.when().get("/context/transaction4").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionTCContextPropagation() {
+        RestAssured.when().get("/context/transaction-tc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
     }
 

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/customContext/CustomContext.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/customContext/CustomContext.java
@@ -1,0 +1,22 @@
+package io.quarkus.context.test.customContext;
+
+/**
+ * Custom context for test purposes.
+ * Store some value (String) in a thread local variable.
+ */
+public class CustomContext {
+
+    public static final String NAME = "MyContext";
+    private static ThreadLocal<String> context = ThreadLocal.withInitial(() -> "");
+
+    private CustomContext() {
+    }
+
+    public static String get() {
+        return context.get();
+    }
+
+    public static void set(String label) {
+        context.set(label);
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/customContext/CustomContextProvider.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/customContext/CustomContextProvider.java
@@ -1,0 +1,46 @@
+package io.quarkus.context.test.customContext;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.microprofile.context.spi.ThreadContextController;
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+
+/**
+ * Simple context provider for {@link CustomContext}
+ */
+public class CustomContextProvider implements ThreadContextProvider {
+
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return snapshot("");
+    }
+
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return snapshot(CustomContext.get());
+    }
+
+    public String getThreadContextType() {
+        return CustomContext.NAME;
+    }
+
+    private ThreadContextSnapshot snapshot(String label) {
+        return () -> {
+            String labelToRestore = CustomContext.get();
+            AtomicBoolean restored = new AtomicBoolean();
+
+            // Construct an instance that restores the previous context that was on the thread
+            // prior to applying the specified 'label' as the new context.
+            ThreadContextController contextRestorer = () -> {
+                if (restored.compareAndSet(false, true)) {
+                    CustomContext.set(labelToRestore);
+                } else {
+                    throw new IllegalStateException();
+                }
+            };
+
+            CustomContext.set(label);
+            return contextRestorer;
+        };
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/customContext/CustomContextTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/customContext/CustomContextTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.context.test.customContext;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that custom context can be declared and is propagated.
+ * Note that default TC (and ME) propagate ALL contexts.
+ */
+public class CustomContextTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(CustomContextTest.class, CustomContext.class, CustomContextProvider.class)
+                    .addAsServiceProvider(ThreadContextProvider.class, CustomContextProvider.class));
+
+    @Inject
+    ThreadContext tc;
+
+    @Test
+    public void testCustomContextPropagation() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        // set something to custom context
+        CustomContext.set("foo");
+
+        CompletableFuture<String> ret = tc.withContextCapture(CompletableFuture.completedFuture("void"));
+        CompletableFuture<Void> cfs = ret.thenApplyAsync(text -> {
+            Assertions.assertEquals("foo", CustomContext.get());
+            return null;
+        }, executor);
+        cfs.get();
+    }
+}


### PR DESCRIPTION
This PR revisits/extends smoke tests that SR context propagation currently has.

@FroMage please sanity check this and if you have ideas for any other part of the spec that should be smoke tested within Quarkus, let me know and I can add it.