### PR TITLE
docs: fix link to native-and-ssl in mailer.adoc

### DIFF
--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -310,7 +310,7 @@ By default both the mailer and Gmail default to `XOAUTH2` which requires registe
 == Using SSL with native executables
 
 Note that if you enable SSL for the mailer and you want to build a native executable, you will need to enable the SSL support.
-Please refer to the native-and-ssl[Using SSL With Native Executables] guide for more information.
+Please refer to the link:native-and-ssl[Using SSL With Native Executables] guide for more information.
 
 == Using the underlying Vert.x Mail Client
 


### PR DESCRIPTION
https://quarkus.io/guides/mailer

Currently it looks like this:

<img width="622" alt="スクリーンショット 2020-01-08 0 30 52" src="https://user-images.githubusercontent.com/5971361/71906845-3e72c180-31ae-11ea-8b15-f335c16c1e20.png">
