### PR TITLE
Remove useless version from the reactive * client poms

### DIFF
--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-mysql-client</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
No rocket science but that's 2 less warnings in Eclipse.