### PR TITLE
Native executable must be made executable in Dockerfile

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
@@ -17,6 +17,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY ${build_dir}/*-runner /work/application
-RUN chmod 775 /work
+RUN chmod 775 /work /work/application
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
The native executable must be changed to be executable **/work/application** explicit. 
Otherwise, if built with docker (mvn package -Pnative -Dquarkus.native.container-build=true) from a **windows system** (windows cmd) the application can not start inside docker/openshift.

```
container_linux.go:235: starting container process caused "exec: \"./application\": permission denied"
```