### PR TITLE
Fix GraalVM SDK version in documentation

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -32,7 +32,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>19.3.0</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>19.3.0.2</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>0.0.9</axle-client.version>
         <vertx.version>3.8.4</vertx.version>


### PR DESCRIPTION
This should be the same version as [the one from the BOM](https://github.com/quarkusio/quarkus/blob/master/bom/runtime/pom.xml#L77) since we [removed](https://github.com/quarkusio/quarkus/pull/6364/commits/2ab449625a62034f0b1c86203d124d8480ff7715) a `19.3.0` substitution that was incompatible with `19.3.0.2`.