### PR TITLE
Document git config for contributing to Quarkus from Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Be sure to test your pull request in:
 If you have not done so on this machine, you need to:
  
 * Install Git and configure your GitHub access
+    * Windows
+        * Use `git config core.autocrlf true`, as default system line endings are expected by formatter-maven-plugin
 * Install Java SDK (OpenJDK recommended)
 * Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:


### PR DESCRIPTION
I mentioned this during https://github.com/quarkusio/quarkus/pull/6343#issuecomment-569077715

As Quarkus build re-formats all files, the configuration of the formatter-maven-plugin for line endings (https://code.revelc.net/formatter-maven-plugin/format-mojo.html#lineEnding - by default AUTO) needs to be aligned with git configuration for line endoings (core.autocrlf), otherwise it generates noise on all files after running a mvn command.

An alternative is to specify -Dlineendings=LF on every mvn command, but it's not very practical.

