### PR TITLE
[WIP] Support both GraalVM 19.2.1 and 19.3.0.2 - 19.3.0.2 SDK & 19.2.1 GraalVM image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -132,7 +132,7 @@ public class NativeConfig {
     /**
      * The docker image to use to do the image build
      */
-    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.3.0.2-java8")
+    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.2.1")
     public String builderImage;
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -322,12 +322,12 @@ public class NativeImageBuildStep {
 
     private void checkGraalVMVersion(String version) {
         log.info("Running Quarkus native-image plugin on " + version);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.");
+        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.0");
         final boolean vmVersionIsObsolete = version.contains(" 19.3.0 ")
                 || obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
         if (vmVersionIsObsolete) {
-            throw new IllegalStateException(
-                    "Out of date build of GraalVM detected: " + version + ". Please upgrade to GraalVM 19.3.0.2");
+            throw new IllegalStateException("Unsupported version of GraalVM detected: " + version
+                    + ". Quarkus currently offers a stable support of GraalVM 19.2.1 and an experimental support of GraalVM 19.3.0.2");
         }
     }
 


### PR DESCRIPTION
Fixes #6483

svm version (SDK): 19.3.0.2
GraalVM image version : 19.2.1

I'm submitting this to get an early CI result. I only ran a small part of the full Quarkus native build, so CI might fail (and it will probably be related to substitutions) in multiple modules.

I'll continue testing this PR locally while CI builds it (and hopefully succeeds!).