### PR TITLE
graalvmHome should be optional in gradle buildNative

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -180,6 +180,7 @@ public class QuarkusNative extends QuarkusTask {
         this.enableIsolates = enableIsolates;
     }
 
+    @Optional
     @Input
     public String getGraalvmHome() {
         return graalvmHome;


### PR DESCRIPTION
This was accidentally removed from the latest refactoring :)