### PR TITLE
[WIP] Support both GraalVM 19.2.1 and 19.3.0.2 - 19.2.1 SDK edition

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -829,7 +829,7 @@
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager-embedded</artifactId>
                 <version>${jboss-logmanager.version}</version>
-                <exclusions>
+                <exclusions> 
                     <exclusion>
                         <groupId>com.oracle.substratevm</groupId>
                         <artifactId>svm</artifactId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -74,7 +74,7 @@
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
         <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
-        <graal-sdk.version>19.3.0.2</graal-sdk.version>
+        <graal-sdk.version>19.2.1</graal-sdk.version>
         <gizmo.version>1.0.0.Final</gizmo.version>
         <jackson.version>2.10.2</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
@@ -831,7 +831,7 @@
                 <version>${jboss-logmanager.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.graalvm.nativeimage</groupId>
+                        <groupId>com.oracle.substratevm</groupId>
                         <artifactId>svm</artifactId>
                     </exclusion>
                     <exclusion>
@@ -1632,7 +1632,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.graalvm.nativeimage</groupId>
+                <groupId>com.oracle.substratevm</groupId>
                 <artifactId>svm</artifactId>
                 <version>${graal-sdk.version}</version>
                 <scope>provided</scope>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -32,7 +32,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>19.3.0</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>19.2.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>0.0.9</axle-client.version>
         <vertx.version>3.8.4</vertx.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -132,7 +132,7 @@ public class NativeConfig {
     /**
      * The docker image to use to do the image build
      */
-    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.3.0.2-java8")
+    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.2.1")
     public String builderImage;
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -73,7 +73,7 @@ public class NativeImageBuildStep {
         Path outputDir = nativeImageSourceJarBuildItem.getPath().getParent();
 
         final String runnerJarName = runnerJar.getFileName().toString();
-
+        System.out.println("CI, please, could you build my PR?");
         HashMap<String, String> env = new HashMap<>(System.getenv());
         List<String> nativeImage;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -322,12 +322,12 @@ public class NativeImageBuildStep {
 
     private void checkGraalVMVersion(String version) {
         log.info("Running Quarkus native-image plugin on " + version);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.");
+        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.0");
         final boolean vmVersionIsObsolete = version.contains(" 19.3.0 ")
                 || obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
         if (vmVersionIsObsolete) {
-            throw new IllegalStateException(
-                    "Out of date build of GraalVM detected: " + version + ". Please upgrade to GraalVM 19.3.0.2");
+            throw new IllegalStateException("Unsupported version of GraalVM detected: " + version
+                    + ". Quarkus currently offers a stable support of GraalVM 19.2.1 and an experimental support of GraalVM 19.3.0.2");
         }
     }
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -32,7 +32,7 @@
             <artifactId>quarkus-amazon-lambda-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -33,7 +33,7 @@
             <artifactId>aws-serverless-java-container-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/artemis-core/runtime/pom.xml
+++ b/extensions/artemis-core/runtime/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/azure-functions-http/deployment/pom.xml
+++ b/extensions/azure-functions-http/deployment/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/azure-functions-http/runtime/pom.xml
+++ b/extensions/azure-functions-http/runtime/pom.xml
@@ -24,7 +24,7 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/caffeine/runtime/pom.xml
+++ b/extensions/caffeine/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/elasticsearch-rest-client/runtime/pom.xml
+++ b/extensions/elasticsearch-rest-client/runtime/pom.xml
@@ -43,7 +43,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/elytron-security-common/runtime/pom.xml
+++ b/extensions/elytron-security-common/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>quarkus-elytron-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/flyway/runtime/pom.xml
+++ b/extensions/flyway/runtime/pom.xml
@@ -30,7 +30,7 @@
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-search-elasticsearch/runtime/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/runtime/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>hibernate-search-mapper-orm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -58,7 +58,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -93,7 +93,7 @@
             <artifactId>protostream-processor</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/infinispan-embedded/runtime/pom.xml
+++ b/extensions/infinispan-embedded/runtime/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>jaeger-thrift</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -15,7 +15,7 @@
     <description>XML serialization support</description>
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jdbc/jdbc-derby/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-derby/runtime/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>derbyclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -28,7 +28,7 @@
             -->
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -66,7 +66,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-mysql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/runtime/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jgit/runtime/pom.xml
+++ b/extensions/jgit/runtime/pom.xml
@@ -15,7 +15,7 @@
     <description>Access your Git repositories</description>
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jsch/runtime/pom.xml
+++ b/extensions/jsch/runtime/pom.xml
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/kafka-streams/runtime/pom.xml
+++ b/extensions/kafka-streams/runtime/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>kafka-streams</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/logging-gelf/runtime/pom.xml
+++ b/extensions/logging-gelf/runtime/pom.xml
@@ -20,7 +20,7 @@
             <artifactId>logstash-gelf</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>smallrye-reactive-converter-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/neo4j/runtime/pom.xml
+++ b/extensions/neo4j/runtime/pom.xml
@@ -27,7 +27,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/quartz/runtime/pom.xml
+++ b/extensions/quartz/runtime/pom.xml
@@ -24,7 +24,7 @@
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/rest-client/runtime/pom.xml
+++ b/extensions/rest-client/runtime/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-common/deployment/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -15,7 +15,7 @@
     <description>REST framework implementing JAX-RS and more</description>
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/resteasy/deployment/pom.xml
+++ b/extensions/resteasy/deployment/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>quarkus-security-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-fault-tolerance/deployment/pom.xml
+++ b/extensions/smallrye-fault-tolerance/deployment/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/vertx-core/runtime/pom.xml
+++ b/extensions/vertx-core/runtime/pom.xml
@@ -42,7 +42,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 


### PR DESCRIPTION
Same as #6487, but this time we're using the 19.2.1 SDK instead of the 19.3.0.2 SDK.