### PR TITLE
Properly show configuration errors in the output

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -16,7 +16,7 @@ public final class ConfigDiagnostic {
     private static final Logger log = Logger.getLogger("io.quarkus.config");
 
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
-    private static List<String> errorsMessages = new CopyOnWriteArrayList<>();
+    private static final List<String> errorsMessages = new CopyOnWriteArrayList<>();
 
     private ConfigDiagnostic() {
     }


### PR DESCRIPTION
Fixes: #6466

With this change, the output of  `./myapp -Dquarkus.profile= -Dquarkus.http.port=foo` is:

```
Exception in thread "main" java.lang.RuntimeException: Failed to start quarkus
        at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:194)
        at io.quarkus.runtime.Application.start(Application.java:87)
        at io.quarkus.runtime.Application.run(Application.java:210)
        at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:41)
Caused by: io.quarkus.runtime.configuration.ConfigurationException: One or more configuration errors has prevented the application from starting. The errors are:
Configuration key "quarkus.profile" is required, but its value is empty/missing: Property quarkus.profile not found
An invalid value was given for configuration key "quarkus.http.port": For input string: "foo"
```