### PR TITLE
Enable SSL native support for quarkus-jsch

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -32,6 +32,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String JDBC_MSSQL = "jdbc-mssql";
     public static final String JDBC_MYSQL = "jdbc-mysql";
     public static final String JGIT = "jgit";
+    public static final String JSCH = "jsch";
     public static final String KAFKA_STREAMS = "kafka-streams";
     public static final String KEYCLOAK_AUTHORIZATION = "keycloak-authorization";
     public static final String KOGITO = "kogito";

--- a/extensions/jsch/deployment/src/main/java/io/quarkus/jsch/deployment/JSchProcessor.java
+++ b/extensions/jsch/deployment/src/main/java/io/quarkus/jsch/deployment/JSchProcessor.java
@@ -2,6 +2,8 @@ package io.quarkus.jsch.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.EnableAllSecurityServicesBuildItem;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.jsch.runtime.PortWatcherRunTime;
@@ -11,6 +13,11 @@ class JSchProcessor {
     @BuildStep
     EnableAllSecurityServicesBuildItem enableAllSecurityServices() {
         return new EnableAllSecurityServicesBuildItem();
+    }
+
+    @BuildStep
+    ExtensionSslNativeSupportBuildItem sslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.JSCH);
     }
 
     @BuildStep


### PR DESCRIPTION
As discussed on Zulip, this build item must be added since the extension requires SSL.

cc @gsmet, @geoand 