### PR TITLE
Add RX Java 2 to the list of dependency maintained by Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -68,6 +68,9 @@ update_configs:
       # Tika
       - match:
           dependency_name: "org.apache.tika:tika-parsers"
+      # RX Java 2
+      - match:
+          dependency_name: "io.reactivex.rxjava2:rxjava"
       # Test dependencies
       - match:
           dependency_name: "io.rest-assured:rest-assured"


### PR DESCRIPTION
Note that RX Java 3 is using a different groupId and so is not handled by this PR. There is no plan right now to switch to RX Java 3.