### PR TITLE
Swallow exceptions thrown from Bean.destroy()

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/PostResource.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/PostResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.test;
 
+import javax.annotation.PreDestroy;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
@@ -10,4 +11,10 @@ public class PostResource {
     public String modify(String data) {
         return "Hello: " + data;
     }
+
+    @PreDestroy
+    void destroy() {
+        throw new IllegalStateException("Something bad happened but dev mode should work fine");
+    }
+
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceHandleImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceHandleImpl.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.spi.CreationalContext;
+import org.jboss.logging.Logger;
 
 /**
  *
@@ -17,6 +18,8 @@ import javax.enterprise.context.spi.CreationalContext;
  * @param <T>
  */
 class InstanceHandleImpl<T> implements InstanceHandle<T> {
+
+    private static final Logger LOGGER = Logger.getLogger(InstanceHandleImpl.class.getName());
 
     @SuppressWarnings("unchecked")
     public static final <T> InstanceHandle<T> unavailable() {
@@ -83,7 +86,16 @@ class InstanceHandleImpl<T> implements InstanceHandle<T> {
         if (parentCreationalContext != null) {
             parentCreationalContext.release();
         } else {
-            bean.destroy(instance, creationalContext);
+            try {
+                bean.destroy(instance, creationalContext);
+            } catch (Throwable t) {
+                String msg = "Error occured while destroying instance of bean [%s]";
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.errorf(t, msg, bean.getClass().getName());
+                } else {
+                    LOGGER.errorf(msg + ": %s", bean.getClass().getName(), t);
+                }
+            }
         }
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/destroy/BeanPreDestroyErrorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/destroy/BeanPreDestroyErrorTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.bean.destroy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.math.BigDecimal;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class BeanPreDestroyErrorTest {
+
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(DestroyBean.class, DestroyProducerBean.class);
+
+    @Test
+    public void testErrorSwallowed() {
+        // Test that an exception is not rethrown
+        InstanceHandle<DestroyBean> beanInstance = Arc.container().instance(DestroyBean.class);
+        assertEquals(42, beanInstance.get().ping());
+        beanInstance.destroy();
+
+        InstanceHandle<BigDecimal> bigInstance = Arc.container().instance(BigDecimal.class);
+        assertEquals(BigDecimal.ONE, bigInstance.get());
+        bigInstance.destroy();
+    }
+
+    @Singleton
+    static class DestroyBean {
+
+        int ping() {
+            return 42;
+        }
+
+        @PreDestroy
+        void destroy() {
+            throw new IllegalStateException();
+        }
+
+    }
+
+    @Dependent
+    static class DestroyProducerBean {
+
+        @Produces
+        BigDecimal produce() {
+            return BigDecimal.ONE;
+        }
+
+        void dispose(@Disposes BigDecimal val) {
+            throw new IllegalStateException();
+        }
+
+    }
+}


### PR DESCRIPTION
- otherwise an error prevents proper container shutdown
- resolves #6529
- also fix EventImpl - use the correct event type