### PR TITLE
Improving the mailer adoc by adding quarkus.mailer.mock=false in the initial set of properties.

### DIFF
--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -60,6 +60,7 @@ quarkus.mailer.port=465
 quarkus.mailer.ssl=true
 quarkus.mailer.username=....
 quarkus.mailer.password=....
+quarkus.mailer.mock=false
 ----
 
 [NOTE]


### PR DESCRIPTION
The sendgrid example in the **current state** will not work for anyone who tried, because the quarkus.mailer.mock=false is not present. If you just try to send the email it will fail and you will have to read the whole testing section to find out that the quarkus.mailer.mock is true by default.

I find this misleading I personally have lost around 40 mins finding and debugging why the email is not send and finding that I am in a mock mode.

I greatly believe that this will help the others using mailer to send email with or without sendgrid.

Maybe it is wise to even add a comment somewhere below the properties similar on how the password vault is explained.