### PR TITLE
doc: use public inner class for reflection

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -128,7 +128,7 @@ Let's now create the `Result` class as an inner class:
 
 [source, java]
 ----
-private class Result {
+public class Result {
         
     Result(String message) {
         this.success = true;


### PR DESCRIPTION
Hi, I was learning the quarkus guide [`Validation with Hibernate Validator`](https://quarkus.io/guides/validation) and found that when `Result` is added as private inner class, it ends up with the following exception.
As [I make it public](https://github.com/kdnakt/quarkus-sandbox/commit/885882eacb3bdcb0dde562550337c5923c7bc458#diff-cf29726706d51adcfc762ee31f167994), the code worked fine without exception, so I modified the document.

https://github.com/kdnakt/quarkus-sandbox/commit/a8de4f63e4aa474765f3be2a776357a8a69ea26a#diff-cf29726706d51adcfc762ee31f167994
```
2020-01-15 03:12:30,757 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (executor-thread-1) HTTP Request to /books/manual-validation failed, error id: 2e1548f4-1e42-4112-a463-12c17e50e165-1: org.jboss.resteasy.spi.UnhandledException: javax.ws.rs.ProcessingException: RESTEASY008205: JSON Binding serialization error javax.json.bind.JsonbException: Unable to serialize property 'message' from com.kdnakt.quarkus.validation.BookResource.Result
        at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:381)
        at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:209)
        at org.jboss.resteasy.core.SynchronousDispatcher.writeResponse(SynchronousDispatcher.java:587)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:508)
        at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:252)
        at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:153)
        at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:363)
        at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:156)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:238)
        at io.quarkus.resteasy.runtime.standalone.RequestDispatcher.service(RequestDispatcher.java:73)
        at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:120)
        at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.access$000(VertxRequestHandler.java:36)
        at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$1.run(VertxRequestHandler.java:85)
        at io.quarkus.runtime.CleanableExecutor$CleaningRunnable.run(CleanableExecutor.java:224)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
        at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2011)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1535)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1395)
        at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
        at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
        at java.base/java.lang.Thread.run(Thread.java:834)
        at org.jboss.threads.JBossThread.run(JBossThread.java:479)
Caused by: javax.ws.rs.ProcessingException: RESTEASY008205: JSON Binding serialization error javax.json.bind.JsonbException: Unable to serialize property 'message' from com.kdnakt.quarkus.validation.BookResource.Result
        at org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider.writeTo(JsonBindingProvider.java:141)
        at org.jboss.resteasy.core.interception.jaxrs.AbstractWriterInterceptorContext.writeTo(AbstractWriterInterceptorContext.java:193)
        at org.jboss.resteasy.core.interception.jaxrs.ServerWriterInterceptorContext.writeTo(ServerWriterInterceptorContext.java:64)
        at org.jboss.resteasy.core.interception.jaxrs.AbstractWriterInterceptorContext.proceed(AbstractWriterInterceptorContext.java:155)
        at org.jboss.resteasy.core.ServerResponseWriter.lambda$writeNomapResponse$2(ServerResponseWriter.java:156)
        at org.jboss.resteasy.core.interception.jaxrs.ContainerResponseContextImpl.filter(ContainerResponseContextImpl.java:404)
        at org.jboss.resteasy.core.ServerResponseWriter.executeFilters(ServerResponseWriter.java:232)
        at org.jboss.resteasy.core.ServerResponseWriter.writeNomapResponse(ServerResponseWriter.java:97)
        at org.jboss.resteasy.core.ServerResponseWriter.writeNomapResponse(ServerResponseWriter.java:70)
        at org.jboss.resteasy.core.SynchronousDispatcher.writeResponse(SynchronousDispatcher.java:578)
        ... 21 more
Caused by: javax.json.bind.JsonbException: Unable to serialize property 'message' from com.kdnakt.quarkus.validation.BookResource.Result
        at org.eclipse.yasson.internal.serializer.ObjectSerializer.serializeInternal(ObjectSerializer.java:67)
        at org.eclipse.yasson.internal.serializer.AbstractContainerSerializer.serialize(AbstractContainerSerializer.java:64)
        at org.eclipse.yasson.internal.Marshaller.serializeRoot(Marshaller.java:148)
        at org.eclipse.yasson.internal.Marshaller.marshall(Marshaller.java:76)
        at org.eclipse.yasson.internal.Marshaller.marshall(Marshaller.java:102)
        at org.eclipse.yasson.internal.JsonBinding.toJson(JsonBinding.java:118)
        at org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider.writeTo(JsonBindingProvider.java:137)
        ... 30 more
Caused by: javax.json.bind.JsonbException: Error getting value on: com.kdnakt.quarkus.validation.BookResource$Result@61f648b1
        at org.eclipse.yasson.internal.model.GetValueCommand.getValue(GetValueCommand.java:36)
        at org.eclipse.yasson.internal.model.ReflectionPropagation.getValue(ReflectionPropagation.java:73)
        at org.eclipse.yasson.internal.model.PropertyModel.getValue(PropertyModel.java:284)
        at org.eclipse.yasson.internal.serializer.ObjectSerializer.marshallProperty(ObjectSerializer.java:87)
        at org.eclipse.yasson.internal.serializer.ObjectSerializer.serializeInternal(ObjectSerializer.java:65)
        ... 36 more
Caused by: java.lang.IllegalAccessException: class org.eclipse.yasson.internal.model.GetFromGetter cannot access a member of class com.kdnakt.quarkus.validation.BookResource$Result with modifiers "public"
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
        at java.base/java.lang.reflect.Method.invoke(Method.java:558)
        at org.eclipse.yasson.internal.model.GetFromGetter.internalGetValue(GetFromGetter.java:28)
        at org.eclipse.yasson.internal.model.GetValueCommand.getValue(GetValueCommand.java:34)
        ... 40 more

```