### PR TITLE
Disable automatic association management in Hibernate ORM entities

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
@@ -4,6 +4,7 @@ import java.util.function.BiFunction;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.bytecode.enhance.spi.Enhancer;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
 import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -46,6 +47,15 @@ public final class HibernateEntityEnhancer implements BiFunction<String, ClassVi
             //note that as getLoadingClassLoader is resolved immediately this can't be created until transform time
 
             DefaultEnhancementContext enhancementContext = new DefaultEnhancementContext() {
+
+                @Override
+                public boolean doBiDirectionalAssociationManagement(final UnloadedField field) {
+                    //Don't enable automatic association management as it's often too surprising.
+                    //Also, there's several cases in which its semantics are of unspecified,
+                    //such as what should happen when dealing with ordered collections.
+                    return false;
+                }
+
                 @Override
                 public ClassLoader getLoadingClassLoader() {
                     return Thread.currentThread().getContextClassLoader();

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -448,6 +448,7 @@ public class TestEndpoint {
 
         Dog dog = new Dog("octave", "dalmatian");
         dog.owner = person;
+        person.dogs.add(dog);
         dog.persist();
 
         return person;
@@ -768,6 +769,7 @@ public class TestEndpoint {
 
         Dog dog = new Dog("octave", "dalmatian");
         dog.owner = person;
+        person.dogs.add(dog);
         dogDao.persist(dog);
 
         return person;


### PR DESCRIPTION
During the Hibernate team meeting we reviewed the usage of bytecode enhancement in Quarkus and decided that the "automatic assosciation management" is not quite a good idea to have enabled here.

I suspect nobody actually noticed that it was on, but it would be a good idea to mention this in release notes so for people to be aware of this when upgrading.