### PR TITLE
Relax datePattern to pass on Windows with cmder

### DIFF
--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/MojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/MojoTestBase.java
@@ -259,9 +259,9 @@ public class MojoTestBase {
         assertThat(logs.isEmpty()).isFalse();
         String infoLogLevel = "INFO";
         assertThat(logs.contains(infoLogLevel)).isTrue();
-        Predicate<String> datePattern = Pattern.compile("\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2},\\d{3}\\s").asPredicate();
+        Predicate<String> datePattern = Pattern.compile("\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2},\\d{3}").asPredicate();
         assertThat(datePattern.test(logs)).isTrue();
-        assertThat(logs.contains("features: [cdi, resteasy, servlet, undertow-websockets]")).isTrue();
+        assertThat(logs.contains("cdi, resteasy, servlet, undertow-websockets")).isTrue();
         assertThat(logs.contains("JBoss Threads version")).isFalse();
     }
 


### PR DESCRIPTION
Relax `datePattern` to pass on Windows with cmder

When running Quarkus TS on Windows and cmder (https://cmder.net/, de-facto-standard for power users) there are failures in https://github.com/quarkusio/quarkus/tree/master/integration-tests/maven module

```
DevMojoIT.testThatClassAppCanRun:48->MojoTestBase.assertThatOutputWorksCorrectly:263
JarRunnerIT.testThatJarRunnerConsoleOutputWorksCorrectly:59->MojoTestBase.assertThatOutputWorksCorrectly:263
```

When running from cmd following content of output.log is generated:
```
2020-01-15 22:06:01,691 INFO [io.quarkus] (main) acme 1.0-SNAPSHOT (running on Quarkus 999-SNAPSHOT) started in 2.742s. Listening on: http://0.0.0.0:8080
2020-01-15 22:06:01,699 INFO [io.quarkus] (main) Profile prod activated. 
2020-01-15 22:06:01,700 INFO [io.quarkus] (main) Installed features: [cdi, resteasy, servlet, undertow-websockets]
```
When running from cmd following content of output.log is generated (color mode gets enabled):
```
�[38;5;145m2020-01-15 22:00:48,183�[39m�[38;5;188m �[39m�[38;5;107mINFO �[39m�[38;5;188m [�[39m�[38;5;69mio.quarkus�[39m�[38;5;188m] (�[39m�[38;5;71mmain�[39m�[38;5;188m) �[39m�[38;5;151m�[39m�[38;5;188macme�[39m �[38;5;188m1.0-SNAPSHOT�[39m (running on Quarkus �[38;5;188m999-SNAPSHOT�[39m) started in �[38;5;188m4.758�[39ms. �[38;5;188mListening on: http://0.0.0.0:8080�[39m�[39m�[38;5;203m�[39m�[38;5;227m
�[39m�[38;5;145m2020-01-15 22:00:48,203�[39m�[38;5;188m �[39m�[38;5;107mINFO �[39m�[38;5;188m [�[39m�[38;5;69mio.quarkus�[39m�[38;5;188m] (�[39m�[38;5;71mmain�[39m�[38;5;188m) �[39m�[38;5;151m�[39mProfile �[38;5;188mprod�[39m activated. �[38;5;188m�[39m�[39m�[38;5;203m�[39m�[38;5;227m
�[39m�[38;5;145m2020-01-15 22:00:48,204�[39m�[38;5;188m �[39m�[38;5;107mINFO �[39m�[38;5;188m [�[39m�[38;5;69mio.quarkus�[39m�[38;5;188m] (�[39m�[38;5;71mmain�[39m�[38;5;188m) �[39m�[38;5;151m�[39mInstalled features: [�[38;5;188mcdi, resteasy, servlet, undertow-websockets�[39m]�[39m�[38;5;203m�[39m�[38;5;227m
�[39m
```
