### PR TITLE
Fix build hang on systems with low disk space

### DIFF
--- a/integration-tests/artemis-jms/src/test/resources/broker.xml
+++ b/integration-tests/artemis-jms/src/test/resources/broker.xml
@@ -12,6 +12,7 @@
             <acceptor name="activemq">tcp://localhost:61616</acceptor>
         </acceptors>
 
+        <max-disk-usage>-1</max-disk-usage>
         <security-enabled>false</security-enabled>
 
         <queues>


### PR DESCRIPTION
By default artemis will stop receiving messages if the disk is 80% full, which means that I can't do a full build without it hanging.