### PR TITLE
[WIP] Support both GraalVM 19.2.1 and 19.3.1 - Duplicate targeting GraalVM 19.3.1-java8

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -74,7 +74,7 @@
         <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
         <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
-        <graal-sdk.version>19.3.0.2</graal-sdk.version>
+        <graal-sdk.version>19.2.1</graal-sdk.version>
         <gizmo.version>1.0.0.Final</gizmo.version>
         <jackson.version>2.10.2</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
@@ -841,7 +841,7 @@
                 <version>${jboss-logmanager.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.graalvm.nativeimage</groupId>
+                        <groupId>com.oracle.substratevm</groupId>
                         <artifactId>svm</artifactId>
                     </exclusion>
                     <exclusion>
@@ -1653,7 +1653,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.graalvm.nativeimage</groupId>
+                <groupId>com.oracle.substratevm</groupId>
                 <artifactId>svm</artifactId>
                 <version>${graal-sdk.version}</version>
                 <scope>provided</scope>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -32,7 +32,7 @@
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>19.3.0.2</graal-sdk.version-for-documentation>
+        <graal-sdk.version-for-documentation>19.2.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
         <axle-client.version>0.0.9</axle-client.version>
         <vertx.version>3.8.4</vertx.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -132,7 +132,7 @@ public class NativeConfig {
     /**
      * The docker image to use to do the image build
      */
-    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.3.0.2-java8")
+    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.2.1")
     public String builderImage;
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -132,7 +132,7 @@ public class NativeConfig {
     /**
      * The docker image to use to do the image build
      */
-    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.2.1")
+    @ConfigItem(defaultValue = "quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8")
     public String builderImage;
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -38,7 +38,7 @@ public class NativeConfig {
     /**
      * If JNI should be enabled
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     public boolean enableJni;
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -266,7 +266,7 @@ public class NativeImageBuildStep {
             if (!nativeConfig.enableIsolates) {
                 command.add("-H:-SpawnIsolates");
             }
-            if (nativeConfig.enableJni) {
+            if (nativeConfig.enableJni || (graalVMVersion.isPresent() && !graalVMVersion.get().contains(" 19.2."))) {
                 command.add("-H:+JNI");
             } else {
                 command.add("-H:-JNI");

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -322,12 +322,13 @@ public class NativeImageBuildStep {
 
     private void checkGraalVMVersion(String version) {
         log.info("Running Quarkus native-image plugin on " + version);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.");
+        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.0");
         final boolean vmVersionIsObsolete = version.contains(" 19.3.0 ")
                 || obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
         if (vmVersionIsObsolete) {
-            throw new IllegalStateException(
-                    "Out of date build of GraalVM detected: " + version + ". Please upgrade to GraalVM 19.3.0.2");
+            throw new IllegalStateException("Unsupported version of GraalVM detected: " + version + "."
+                    + " Quarkus currently offers a stable support of GraalVM 19.2.1 and a preview support of GraalVM 19.3.1."
+                    + " Please upgrade GraalVM to one of these versions.");
         }
     }
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -46,7 +46,7 @@ public class QuarkusNative extends QuarkusTask {
 
     private boolean enableServer = false;
 
-    private boolean enableJni = true;
+    private boolean enableJni = false;
 
     private boolean autoServiceLoaderRegistration = false;
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/NativeImageMojo.java
@@ -100,7 +100,7 @@ public class NativeImageMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private Boolean enableServer;
 
-    @Parameter(defaultValue = "true")
+    @Parameter(defaultValue = "false")
     private Boolean enableJni;
 
     @Parameter(defaultValue = "false")

--- a/devtools/maven/src/main/resources/create-extension-templates/integration-test-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/integration-test-pom.xml
@@ -105,6 +105,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <enableReports>false</enableReports>
                                 </configuration>

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -32,7 +32,7 @@
             <artifactId>quarkus-amazon-lambda-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -33,7 +33,7 @@
             <artifactId>aws-serverless-java-container-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/artemis-core/runtime/pom.xml
+++ b/extensions/artemis-core/runtime/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/azure-functions-http/deployment/pom.xml
+++ b/extensions/azure-functions-http/deployment/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/azure-functions-http/runtime/pom.xml
+++ b/extensions/azure-functions-http/runtime/pom.xml
@@ -24,7 +24,7 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/caffeine/runtime/pom.xml
+++ b/extensions/caffeine/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/elasticsearch-rest-client/runtime/pom.xml
+++ b/extensions/elasticsearch-rest-client/runtime/pom.xml
@@ -43,7 +43,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/elytron-security-common/runtime/pom.xml
+++ b/extensions/elytron-security-common/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/elytron-security-properties-file/runtime/pom.xml
+++ b/extensions/elytron-security-properties-file/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>quarkus-elytron-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/flyway/runtime/pom.xml
+++ b/extensions/flyway/runtime/pom.xml
@@ -30,7 +30,7 @@
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-search-elasticsearch/runtime/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/runtime/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>hibernate-search-mapper-orm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -58,7 +58,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -93,7 +93,7 @@
             <artifactId>protostream-processor</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/infinispan-embedded/runtime/pom.xml
+++ b/extensions/infinispan-embedded/runtime/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -27,7 +27,7 @@
             <artifactId>jaeger-thrift</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -15,7 +15,7 @@
     <description>XML serialization support</description>
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jdbc/jdbc-derby/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-derby/runtime/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>derbyclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -28,7 +28,7 @@
             -->
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graal/Engine.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graal/Engine.java
@@ -3,12 +3,18 @@ package io.quarkus.jdbc.h2.runtime.graal;
 import org.h2.engine.ConnectionInfo;
 import org.h2.engine.Session;
 
+import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 @TargetClass(className = "org.h2.engine.Engine")
 @Substitute
 public final class Engine {
+
+    @Substitute
+    public static org.h2.engine.Engine getInstance() {
+        return SubstrateUtil.cast(new Engine(), org.h2.engine.Engine.class);
+    }
 
     @Substitute
     public Session createSession(ConnectionInfo ci) {

--- a/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -66,7 +66,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-mysql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/runtime/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/jgit/runtime/pom.xml
+++ b/extensions/jgit/runtime/pom.xml
@@ -15,7 +15,7 @@
     <description>Access your Git repositories</description>
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/jsch/runtime/pom.xml
+++ b/extensions/jsch/runtime/pom.xml
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/kafka-streams/runtime/pom.xml
+++ b/extensions/kafka-streams/runtime/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>kafka-streams</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/logging-gelf/runtime/pom.xml
+++ b/extensions/logging-gelf/runtime/pom.xml
@@ -20,7 +20,7 @@
             <artifactId>logstash-gelf</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>smallrye-reactive-converter-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/narayana-stm/deployment/pom.xml
+++ b/extensions/narayana-stm/deployment/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-narayana-stm</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/extensions/narayana-stm/runtime/pom.xml
+++ b/extensions/narayana-stm/runtime/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/neo4j/runtime/pom.xml
+++ b/extensions/neo4j/runtime/pom.xml
@@ -27,7 +27,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/netty/runtime/pom.xml
+++ b/extensions/netty/runtime/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -377,6 +377,18 @@ final class Target_io_netty_channel_ChannelHandlerMask {
     }
 }
 
+@TargetClass(className = "io.netty.util.internal.NativeLibraryLoader")
+final class Target_io_netty_util_internal_NativeLibraryLoader {
+
+    // This method can trick GraalVM into thinking that Classloader#defineClass is getting classed
+    @Substitute
+    static Class<?> tryToLoadClass(final ClassLoader loader, final Class<?> helper)
+            throws ClassNotFoundException {
+        return Class.forName(helper.getName(), false, loader);
+    }
+
+}
+
 class NettySubstitutions {
 
 }

--- a/extensions/quartz/runtime/pom.xml
+++ b/extensions/quartz/runtime/pom.xml
@@ -24,7 +24,7 @@
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/rest-client/runtime/pom.xml
+++ b/extensions/rest-client/runtime/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-common/deployment/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -15,7 +15,7 @@
     <description>REST framework implementing JAX-RS and more</description>
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/resteasy/deployment/pom.xml
+++ b/extensions/resteasy/deployment/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>quarkus-security-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/security/runtime/pom.xml
+++ b/extensions/security/runtime/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-fault-tolerance/deployment/pom.xml
+++ b/extensions/smallrye-fault-tolerance/deployment/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/undertow/runtime/pom.xml
+++ b/extensions/undertow/runtime/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>

--- a/extensions/vertx-core/runtime/pom.xml
+++ b/extensions/vertx-core/runtime/pom.xml
@@ -42,7 +42,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
+            <groupId>com.oracle.substratevm</groupId>
             <artifactId>svm</artifactId>
         </dependency>
 

--- a/integration-tests/amazon-lambda-http-resteasy/pom.xml
+++ b/integration-tests/amazon-lambda-http-resteasy/pom.xml
@@ -101,6 +101,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/amazon-lambda-http/pom.xml
+++ b/integration-tests/amazon-lambda-http/pom.xml
@@ -109,6 +109,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/amazon-lambda/pom.xml
+++ b/integration-tests/amazon-lambda/pom.xml
@@ -98,6 +98,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/elytron-security-jdbc/pom.xml
+++ b/integration-tests/elytron-security-jdbc/pom.xml
@@ -105,6 +105,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <enableReports>false</enableReports>
                                 </configuration>

--- a/integration-tests/flyway/pom.xml
+++ b/integration-tests/flyway/pom.xml
@@ -120,6 +120,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -137,6 +137,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/hibernate-search-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-elasticsearch/pom.xml
@@ -185,6 +185,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -122,6 +122,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/infinispan-cache-jpa/pom.xml
+++ b/integration-tests/infinispan-cache-jpa/pom.xml
@@ -121,6 +121,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/infinispan-embedded/pom.xml
+++ b/integration-tests/infinispan-embedded/pom.xml
@@ -141,7 +141,7 @@
                                     <dumpProxies>false</dumpProxies>
                                     <!-- We have some example stack files we want to use -->
                                     <additionalBuildArgs>
-                                        <additionalBuildArg>-H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/resources-config.json</additionalBuildArg>
+                                        <additionalBuildArg>-H:ResourceConfigurationFiles=resources-config.json</additionalBuildArg>
                                     </additionalBuildArgs>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
                                 </configuration>

--- a/integration-tests/infinispan-embedded/pom.xml
+++ b/integration-tests/infinispan-embedded/pom.xml
@@ -144,6 +144,7 @@
                                         <additionalBuildArg>-H:ResourceConfigurationFiles=resources-config.json</additionalBuildArg>
                                     </additionalBuildArgs>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/jpa-derby/pom.xml
+++ b/integration-tests/jpa-derby/pom.xml
@@ -112,6 +112,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/jpa-h2/pom.xml
+++ b/integration-tests/jpa-h2/pom.xml
@@ -112,6 +112,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -148,6 +148,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -156,6 +156,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -148,6 +148,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -143,6 +143,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/jpa-without-entity/pom.xml
+++ b/integration-tests/jpa-without-entity/pom.xml
@@ -105,6 +105,7 @@
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                     <debugBuildProcess>false</debugBuildProcess>
                                 </configuration>
                             </execution>

--- a/integration-tests/jsch/src/test/java/io/quarkus/it/jsch/JSchTest.java
+++ b/integration-tests/jsch/src/test/java/io/quarkus/it/jsch/JSchTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
@@ -37,6 +38,7 @@ public class JSchTest {
     }
 
     @Test
+    @DisabledOnNativeImage("This test fails with GraalVM 19.2.1 but is successful with GraalVM 19.3.1")
     void shouldConnect() {
         given().queryParam("host", sshd.getHost())
                 .queryParam("port", sshd.getPort())

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/integration-tests/itest/pom.xml
@@ -99,6 +99,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <enableReports>false</enableReports>
                                 </configuration>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -171,6 +171,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>false</enableJni>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/vertx-graphql/pom.xml
+++ b/integration-tests/vertx-graphql/pom.xml
@@ -91,6 +91,7 @@
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                     <enableReports>false</enableReports>
                                 </configuration>

--- a/integration-tests/vertx-http/pom.xml
+++ b/integration-tests/vertx-http/pom.xml
@@ -103,6 +103,7 @@
                                         <additionalBuildArg>-H:EnableURLProtocols=http,https</additionalBuildArg>
                                     </additionalBuildArgs>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableJni>true</enableJni>
                                     <enableAllSecurityServices>true</enableAllSecurityServices>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Duplicate of #6574 with a different GraalVM target: `19.3.1-java8`.

This is a control PR that is not meant to be merged and will be closed as soon as #6574 is merged.