### PR TITLE
Add Netty substitution that addresses Camel Quarkus issue

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -377,6 +377,18 @@ final class Target_io_netty_channel_ChannelHandlerMask {
     }
 }
 
+@TargetClass(className = "io.netty.util.internal.NativeLibraryLoader")
+final class Target_io_netty_util_internal_NativeLibraryLoader {
+
+    // This method can trick GraalVM into thinking that Classloader#defineClass is getting classed
+    @Substitute
+    static Class<?> tryToLoadClass(final ClassLoader loader, final Class<?> helper)
+            throws ClassNotFoundException {
+        return Class.forName(helper.getName(), false, loader);
+    }
+
+}
+
 class NettySubstitutions {
 
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -380,7 +380,7 @@ final class Target_io_netty_channel_ChannelHandlerMask {
 @TargetClass(className = "io.netty.util.internal.NativeLibraryLoader")
 final class Target_io_netty_util_internal_NativeLibraryLoader {
 
-    // This method can trick GraalVM into thinking that Classloader#defineClass is getting classed
+    // This method can trick GraalVM into thinking that Classloader#defineClass is getting called
     @Substitute
     static Class<?> tryToLoadClass(final ClassLoader loader, final Class<?> helper)
             throws ClassNotFoundException {


### PR DESCRIPTION
Addresses the issue in Camel Quarkus with GraalVM 19.3.1 (it only appears in that version) where the native image generation fails with:

```
[camel-quarkus-integration-test-http-1.1.0-SNAPSHOT-runner:31640]     analysis: 480,218.87 ms
Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing com.oracle.svm.reflect.ClassLoader_defineClass_c6c343b4d6dc22ca64eb2d8503b13ac9c340dcb3.invoke(java.lang.Object, java.lang.Object[])
Parsing context:
        parsing java.lang.reflect.Method.invoke(Method.java:498)
        parsing org.apache.camel.support.ObjectHelper.invokeMethod(ObjectHelper.java:182)
        parsing org.apache.camel.main.BaseMainSupport.loadConfigurations(BaseMainSupport.java:467)
        parsing org.apache.camel.main.BaseMainSupport.postProcessCamelContext(BaseMainSupport.java:522)
        parsing org.apache.camel.quarkus.core.CamelMain.postProcessCamelContext(CamelMain.java:59)
        parsing org.apache.camel.quarkus.core.CamelMain.doStart(CamelMain.java:49)
        parsing org.apache.camel.support.service.ServiceSupport.start(ServiceSupport.java:117)
        parsing org.apache.camel.quarkus.core.CamelMainRecorder.start(CamelMainRecorder.java:92)
        parsing io.quarkus.deployment.steps.Main$start76.deploy_0(Main$start76.zig:78)
        parsing io.quarkus.deployment.steps.Main$start76.deploy(Main$start76.zig:97)
        parsing io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:261)
        parsing io.quarkus.runtime.Application.start(Application.java:87)
        parsing io.quarkus.runtime.Application.run(Application.java:210)
        parsing io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:41)
        parsing com.oracle.svm.core.JavaMainWrapper.runCore(JavaMainWrapper.java:151)
        parsing com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:186)
        parsing com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(generated:0)

        at com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:138)
        at com.oracle.graal.pointsto.flow.MethodTypeFlow.doParse(MethodTypeFlow.java:327)
        at com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureParsed(MethodTypeFlow.java:300)
        at com.oracle.graal.pointsto.flow.MethodTypeFlow.addContext(MethodTypeFlow.java:107)
        at com.oracle.graal.pointsto.DefaultAnalysisPolicy$DefaultVirtualInvokeTypeFlow.onObservedUpdate(DefaultAnalysisPolicy.java:191)
        at com.oracle.graal.pointsto.flow.TypeFlow.notifyObservers(TypeFlow.java:343)
        at com.oracle.graal.pointsto.flow.TypeFlow.update(TypeFlow.java:385)
        at com.oracle.graal.pointsto.BigBang$2.run(BigBang.java:511)
        at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$execute$0(CompletionExecutor.java:171)
        at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method java.lang.ClassLoader.defineClass(String, byte[], int, int) is reachable: The declaring class of this element has been substituted, but this element is not present in the substitution class
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
        at com.oracle.svm.hosted.substitute.AnnotationSubstitutionProcessor.lookup(AnnotationSubstitutionProcessor.java:183)
        at com.oracle.graal.pointsto.infrastructure.SubstitutionProcessor$ChainedSubstitutionProcessor.lookup(SubstitutionProcessor.java:128)
        at com.oracle.graal.pointsto.infrastructure.SubstitutionProcessor$ChainedSubstitutionProcessor.lookup(SubstitutionProcessor.java:128)
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.lookupAllowUnresolved(AnalysisUniverse.java:397)
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.lookup(AnalysisUniverse.java:377)
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.lookup(AnalysisUniverse.java:75)
        at com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess.lookupJavaMethod(UniverseMetaAccess.java:93)
        at com.oracle.graal.pointsto.meta.AnalysisMetaAccess.lookupJavaMethod(AnalysisMetaAccess.java:66)
        at com.oracle.graal.pointsto.meta.AnalysisMetaAccess.lookupJavaMethod(AnalysisMetaAccess.java:39)
        at com.oracle.svm.reflect.hosted.ReflectionSubstitutionType$ReflectiveInvokeMethod.buildGraph(ReflectionSubstitutionType.java:511)
        at com.oracle.graal.pointsto.meta.AnalysisMethod.buildGraph(AnalysisMethod.java:319)
        at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:185)
        at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:340)
        at com.oracle.graal.pointsto.flow.MethodTypeFlow.doParse(MethodTypeFlow.java:310)
```

Both the root cause tracking and the substitution were provided by @dmlloyd (hence the author of the commit)