### PR TITLE
Handle association manually as automatic association management was disabled

### DIFF
--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -222,6 +222,9 @@ public class LibraryResource {
         book.title = title;
         book.author = author;
         book.persist();
+
+        author.books.add(book);
+        author.persist();
     }
 
     @DELETE


### PR DESCRIPTION
Update the Hibernate Search Elasticsearch quickstart.

See https://github.com/quarkusio/quarkus/pull/6569