### PR TITLE
Forbid native image generation from GraalVM 19.3.0.2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -322,9 +322,8 @@ public class NativeImageBuildStep {
 
     private void checkGraalVMVersion(String version) {
         log.info("Running Quarkus native-image plugin on " + version);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.0");
-        final boolean vmVersionIsObsolete = version.contains(" 19.3.0 ")
-                || obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
+        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.0", "19.3.0");
+        final boolean vmVersionIsObsolete = obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
         if (vmVersionIsObsolete) {
             throw new IllegalStateException("Unsupported version of GraalVM detected: " + version + "."
                     + " Quarkus currently offers a stable support of GraalVM 19.2.1 and a preview support of GraalVM 19.3.1."


### PR DESCRIPTION
This was forgotten in #6574.