### PR TITLE
MongoDB with Panache : avoid to project on the class field

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
@@ -50,7 +50,7 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
         Set<String> fieldNames = new HashSet<>();
         // gather field names from getters
         for (Method method : type.getMethods()) {
-            if (method.getName().startsWith("get")) {
+            if (method.getName().startsWith("get") && !method.getName().equals("getClass")) {
                 String fieldName = MongoPropertyUtil.decapitalize(method.getName().substring(3));
                 fieldNames.add(fieldName);
             }


### PR DESCRIPTION
Class is always added to the projection fields as all Java classes have a getClass method.
We should avoid this, it is not realy a bug as MongoDB will ignore unknow fields but it's useless.