### PR TITLE
Disable native tests execution for elytron-security-ldap

### DIFF
--- a/ci-templates/stages.yml
+++ b/ci-templates/stages.yml
@@ -259,6 +259,7 @@ stages:
             - elytron-security-oauth2
             - elytron-security
             - elytron-security-jdbc
+            - elytron-security-ldap
             - elytron-undertow
           name: security_1
           keycloak: true

--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -11,9 +11,11 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.JniBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
 import io.quarkus.elytron.security.ldap.LdapRecorder;
+import io.quarkus.elytron.security.ldap.QuarkusDirContextFactory;
 import io.quarkus.elytron.security.ldap.config.LdapSecurityRealmConfig;
 import io.quarkus.runtime.RuntimeValue;
 
@@ -64,4 +66,8 @@ class ElytronSecurityLdapProcessor {
         return new JniBuildItem();
     }
 
+    @BuildStep
+    ReflectiveClassBuildItem enableReflection() {
+        return new ReflectiveClassBuildItem(true, true, QuarkusDirContextFactory.INITIAL_CONTEXT_FACTORY);
+    }
 }

--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
 import io.quarkus.elytron.security.ldap.LdapRecorder;
@@ -56,6 +57,11 @@ class ElytronSecurityLdapProcessor {
             return new ElytronPasswordMarkerBuildItem();
         }
         return null;
+    }
+
+    @BuildStep
+    JniBuildItem enableJni() {
+        return new JniBuildItem();
     }
 
 }

--- a/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/DelegatingLdapContext.java
+++ b/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/DelegatingLdapContext.java
@@ -1,0 +1,497 @@
+package io.quarkus.elytron.security.ldap;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Hashtable;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.ReferralException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.ExtendedRequest;
+import javax.naming.ldap.ExtendedResponse;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+import javax.net.SocketFactory;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.realm.ldap.ThreadLocalSSLSocketFactory;
+import org.wildfly.security.manager.action.SetContextClassLoaderAction;
+
+class DelegatingLdapContext implements LdapContext {
+
+    private final DirContext delegating;
+    private final CloseHandler closeHandler;
+    private final SocketFactory socketFactory;
+
+    interface CloseHandler {
+        void handle(DirContext context) throws NamingException;
+    }
+
+    DelegatingLdapContext(DirContext delegating, CloseHandler closeHandler, SocketFactory socketFactory)
+            throws NamingException {
+        this.delegating = delegating;
+        this.closeHandler = closeHandler;
+        this.socketFactory = socketFactory;
+    }
+
+    // for needs of newInstance()
+    private DelegatingLdapContext(DirContext delegating, SocketFactory socketFactory) throws NamingException {
+        this.delegating = delegating;
+        this.closeHandler = null; // close handler should not be applied to copy
+        this.socketFactory = socketFactory;
+    }
+
+    public LdapContext newInitialLdapContext(Hashtable<?, ?> environment, Control[] connCtls) throws NamingException {
+        ClassLoader previous = setSocketFactory();
+        try {
+            return new InitialLdapContext(environment, null);
+        } finally {
+            unsetSocketFactory(previous);
+        }
+    }
+
+    @Override
+    public void close() throws NamingException {
+        if (closeHandler == null) {
+            delegating.close();
+        } else {
+            closeHandler.handle(delegating);
+        }
+    }
+
+    // for needs of search()
+    private NamingEnumeration<SearchResult> wrap(NamingEnumeration<SearchResult> delegating) {
+        return new NamingEnumeration<SearchResult>() {
+
+            @Override
+            public boolean hasMoreElements() {
+                ClassLoader previous = setSocketFactory();
+                try {
+                    return delegating.hasMoreElements();
+                } finally {
+                    unsetSocketFactory(previous);
+                }
+            }
+
+            @Override
+            public SearchResult nextElement() {
+                ClassLoader previous = setSocketFactory();
+                try {
+                    return delegating.nextElement();
+                } finally {
+                    unsetSocketFactory(previous);
+                }
+            }
+
+            @Override
+            public SearchResult next() throws NamingException {
+                ClassLoader previous = setSocketFactory();
+                try {
+                    return delegating.next();
+                } finally {
+                    unsetSocketFactory(previous);
+                }
+            }
+
+            @Override
+            public boolean hasMore() throws NamingException {
+                ClassLoader previous = setSocketFactory();
+                try {
+                    return delegating.hasMore();
+                } finally {
+                    unsetSocketFactory(previous);
+                }
+            }
+
+            @Override
+            public void close() throws NamingException {
+                delegating.close();
+            }
+        };
+    }
+
+    public DelegatingLdapContext wrapReferralContextObtaining(ReferralException e) throws NamingException {
+        ClassLoader previous = setSocketFactory();
+        try {
+            return new DelegatingLdapContext((DirContext) e.getReferralContext(), socketFactory);
+        } finally {
+            unsetSocketFactory(previous);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "->" + delegating.toString();
+    }
+
+    // LdapContext specific
+
+    @Override
+    public ExtendedResponse extendedOperation(ExtendedRequest request) throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        return ((LdapContext) delegating).extendedOperation(request);
+    }
+
+    @Override
+    public LdapContext newInstance(Control[] requestControls) throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        LdapContext newContext = ((LdapContext) delegating).newInstance(requestControls);
+        return new DelegatingLdapContext(newContext, socketFactory);
+    }
+
+    @Override
+    public void reconnect(Control[] controls) throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        ClassLoader previous = setSocketFactory();
+        try {
+            ((LdapContext) delegating).reconnect(controls);
+        } finally {
+            unsetSocketFactory(previous);
+        }
+    }
+
+    @Override
+    public Control[] getConnectControls() throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        return ((LdapContext) delegating).getConnectControls();
+    }
+
+    @Override
+    public void setRequestControls(Control[] requestControls) throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        ((LdapContext) delegating).setRequestControls(requestControls);
+    }
+
+    @Override
+    public Control[] getRequestControls() throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        return ((LdapContext) delegating).getRequestControls();
+    }
+
+    @Override
+    public Control[] getResponseControls() throws NamingException {
+        if (!(delegating instanceof LdapContext))
+            throw Assert.unsupported();
+        return ((LdapContext) delegating).getResponseControls();
+    }
+
+    // DirContext methods delegates only
+
+    @Override
+    public void bind(String name, Object obj, Attributes attrs) throws NamingException {
+        delegating.bind(name, obj, attrs);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name) throws NamingException {
+        return delegating.getAttributes(name);
+    }
+
+    @Override
+    public Attributes getAttributes(String name) throws NamingException {
+        return delegating.getAttributes(name);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name, String[] attrIds) throws NamingException {
+        return delegating.getAttributes(name, attrIds);
+    }
+
+    @Override
+    public Attributes getAttributes(String name, String[] attrIds) throws NamingException {
+        return delegating.getAttributes(name, attrIds);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, int mod_op, Attributes attrs) throws NamingException {
+        delegating.modifyAttributes(name, mod_op, attrs);
+    }
+
+    @Override
+    public void modifyAttributes(String name, int mod_op, Attributes attrs) throws NamingException {
+        delegating.modifyAttributes(name, mod_op, attrs);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, ModificationItem[] mods) throws NamingException {
+        delegating.modifyAttributes(name, mods);
+    }
+
+    @Override
+    public void modifyAttributes(String name, ModificationItem[] mods) throws NamingException {
+        delegating.modifyAttributes(name, mods);
+    }
+
+    @Override
+    public void bind(Name name, Object obj, Attributes attrs) throws NamingException {
+        delegating.bind(name, obj, attrs);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj, Attributes attrs) throws NamingException {
+        delegating.rebind(name, obj, attrs);
+    }
+
+    @Override
+    public void rebind(String name, Object obj, Attributes attrs) throws NamingException {
+        delegating.rebind(name, obj, attrs);
+    }
+
+    @Override
+    public DirContext createSubcontext(Name name, Attributes attrs) throws NamingException {
+        return delegating.createSubcontext(name, attrs);
+    }
+
+    @Override
+    public DirContext createSubcontext(String name, Attributes attrs) throws NamingException {
+        return delegating.createSubcontext(name, attrs);
+    }
+
+    @Override
+    public DirContext getSchema(Name name) throws NamingException {
+        return delegating.getSchema(name);
+    }
+
+    @Override
+    public DirContext getSchema(String name) throws NamingException {
+        return delegating.getSchema(name);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(Name name) throws NamingException {
+        return delegating.getSchemaClassDefinition(name);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(String name) throws NamingException {
+        return delegating.getSchemaClassDefinition(name);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes, String[] attributesToReturn)
+            throws NamingException {
+        return wrap(delegating.search(name, matchingAttributes, attributesToReturn));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes, String[] attributesToReturn)
+            throws NamingException {
+        return wrap(delegating.search(name, matchingAttributes, attributesToReturn));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes) throws NamingException {
+        return wrap(delegating.search(name, matchingAttributes));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes) throws NamingException {
+        return wrap(delegating.search(name, matchingAttributes));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filter, SearchControls cons) throws NamingException {
+        return wrap(delegating.search(name, filter, cons));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons) throws NamingException {
+        return wrap(delegating.search(name, filter, cons));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filterExpr, Object[] filterArgs, SearchControls cons)
+            throws NamingException {
+        return wrap(delegating.search(name, filterExpr, filterArgs, cons));
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filterExpr, Object[] filterArgs, SearchControls cons)
+            throws NamingException {
+        return wrap(delegating.search(name, filterExpr, filterArgs, cons));
+    }
+
+    @Override
+    public Object lookup(Name name) throws NamingException {
+        return delegating.lookup(name);
+    }
+
+    @Override
+    public Object lookup(String name) throws NamingException {
+        return delegating.lookup(name);
+    }
+
+    @Override
+    public void bind(Name name, Object obj) throws NamingException {
+        delegating.bind(name, obj);
+    }
+
+    @Override
+    public void bind(String name, Object obj) throws NamingException {
+        delegating.bind(name, obj);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj) throws NamingException {
+        delegating.rebind(name, obj);
+    }
+
+    @Override
+    public void rebind(String name, Object obj) throws NamingException {
+        delegating.rebind(name, obj);
+    }
+
+    @Override
+    public void unbind(Name name) throws NamingException {
+        delegating.unbind(name);
+    }
+
+    @Override
+    public void unbind(String name) throws NamingException {
+        delegating.unbind(name);
+    }
+
+    @Override
+    public void rename(Name oldName, Name newName) throws NamingException {
+        delegating.rename(oldName, newName);
+    }
+
+    @Override
+    public void rename(String oldName, String newName) throws NamingException {
+        delegating.rename(oldName, newName);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+        return delegating.list(name);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+        return delegating.list(name);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+        return delegating.listBindings(name);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+        return delegating.listBindings(name);
+    }
+
+    @Override
+    public void destroySubcontext(Name name) throws NamingException {
+        delegating.destroySubcontext(name);
+    }
+
+    @Override
+    public void destroySubcontext(String name) throws NamingException {
+        delegating.destroySubcontext(name);
+    }
+
+    @Override
+    public Context createSubcontext(Name name) throws NamingException {
+        return delegating.createSubcontext(name);
+    }
+
+    @Override
+    public Context createSubcontext(String name) throws NamingException {
+        return delegating.createSubcontext(name);
+    }
+
+    @Override
+    public Object lookupLink(Name name) throws NamingException {
+        return delegating.lookupLink(name);
+    }
+
+    @Override
+    public Object lookupLink(String name) throws NamingException {
+        return delegating.lookupLink(name);
+    }
+
+    @Override
+    public NameParser getNameParser(Name name) throws NamingException {
+        return delegating.getNameParser(name);
+    }
+
+    @Override
+    public NameParser getNameParser(String name) throws NamingException {
+        return delegating.getNameParser(name);
+    }
+
+    @Override
+    public Name composeName(Name name, Name prefix) throws NamingException {
+        return delegating.composeName(name, prefix);
+    }
+
+    @Override
+    public String composeName(String name, String prefix) throws NamingException {
+        return delegating.composeName(name, prefix);
+    }
+
+    @Override
+    public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+        return delegating.addToEnvironment(propName, propVal);
+    }
+
+    @Override
+    public Object removeFromEnvironment(String propName) throws NamingException {
+        return delegating.removeFromEnvironment(propName);
+    }
+
+    @Override
+    public Hashtable<?, ?> getEnvironment() throws NamingException {
+        return delegating.getEnvironment();
+    }
+
+    @Override
+    public String getNameInNamespace() throws NamingException {
+        return delegating.getNameInNamespace();
+    }
+
+    private ClassLoader setSocketFactory() {
+        if (socketFactory != null) {
+            ThreadLocalSSLSocketFactory.set(socketFactory);
+            return setClassLoaderTo(getSocketFactoryClassLoader());
+        }
+        return null;
+    }
+
+    private void unsetSocketFactory(ClassLoader previous) {
+        if (socketFactory != null) {
+            ThreadLocalSSLSocketFactory.unset();
+            setClassLoaderTo(previous);
+        }
+    }
+
+    private ClassLoader getSocketFactoryClassLoader() {
+        return ThreadLocalSSLSocketFactory.class.getClassLoader();
+    }
+
+    private ClassLoader setClassLoaderTo(final ClassLoader targetClassLoader) {
+        return doPrivileged(new SetContextClassLoaderAction(targetClassLoader));
+    }
+
+    private static <T> T doPrivileged(final PrivilegedAction<T> action) {
+        return System.getSecurityManager() != null ? AccessController.doPrivileged(action) : action.run();
+    }
+}

--- a/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/LdapRecorder.java
+++ b/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/LdapRecorder.java
@@ -13,7 +13,6 @@ import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.auth.realm.ldap.AttributeMapping;
 import org.wildfly.security.auth.realm.ldap.DirContextFactory;
 import org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder;
-import org.wildfly.security.auth.realm.ldap.SimpleDirContextFactoryBuilder;
 import org.wildfly.security.auth.server.SecurityRealm;
 
 import io.quarkus.elytron.security.ldap.config.AttributeMappingConfig;
@@ -58,12 +57,10 @@ public class LdapRecorder {
     }
 
     private ExceptionSupplier<DirContext, NamingException> createDirContextSupplier(DirContextConfig dirContext) {
-        DirContextFactory dirContextFactory = SimpleDirContextFactoryBuilder.builder()
-                .setProviderUrl(dirContext.url)
-                .setSecurityPrincipal(dirContext.principal)
-                .setSecurityCredential(dirContext.password)
-                .build();
-
+        DirContextFactory dirContextFactory = new QuarkusDirContextFactory(
+                dirContext.url,
+                dirContext.principal,
+                dirContext.password);
         return () -> dirContextFactory.obtainDirContext(DirContextFactory.ReferralMode.IGNORE);
     }
 

--- a/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/QuarkusDirContextFactory.java
+++ b/extensions/elytron-security-ldap/runtime/src/main/java/io/quarkus/elytron/security/ldap/QuarkusDirContextFactory.java
@@ -1,0 +1,151 @@
+package io.quarkus.elytron.security.ldap;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Hashtable;
+
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+
+import org.wildfly.security.auth.realm.ldap.DirContextFactory;
+import org.wildfly.security.manager.action.SetContextClassLoaderAction;
+
+public class QuarkusDirContextFactory implements DirContextFactory {
+    //    private static final ElytronMessages log = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security");
+
+    private static final String CONNECT_TIMEOUT = "com.sun.jndi.ldap.connect.timeout";
+    private static final String READ_TIMEOUT = "com.sun.jndi.ldap.read.timeout";
+    private static final String SOCKET_FACTORY = "java.naming.ldap.factory.socket";
+    public static final String INITIAL_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    private static final String SECURITY_AUTHENTICATION = "simple";
+
+    private static final String DEFAULT_CONNECT_TIMEOUT = "5000"; // ms
+    private static final String DEFAULT_READ_TIMEOUT = "60000"; // ms
+    private static final String LDAPS_SCHEME = "ldaps";
+
+    private final String providerUrl;
+    private final String securityPrincipal;
+    private final String securityCredential;
+    private final ClassLoader targetClassLoader;
+
+    public QuarkusDirContextFactory(String providerUrl, String securityPrincipal, String securityCredential) {
+        this.providerUrl = providerUrl;
+        this.securityPrincipal = securityPrincipal;
+        this.securityCredential = securityCredential;
+        this.targetClassLoader = getClass().getClassLoader();
+    }
+
+    @Override
+    public DirContext obtainDirContext(ReferralMode mode) throws NamingException {
+        char[] charPassword = null;
+        if (securityCredential != null) { // password from String
+            charPassword = securityCredential.toCharArray();
+        }
+        return createDirContext(securityPrincipal, charPassword, mode);
+    }
+
+    @Override
+    public DirContext obtainDirContext(CallbackHandler handler, ReferralMode mode) throws NamingException {
+        NameCallback nameCallback = new NameCallback("Principal Name");
+        PasswordCallback passwordCallback = new PasswordCallback("Password", false);
+
+        try {
+            handler.handle(new Callback[] { nameCallback, passwordCallback });
+        } catch (Exception e) {
+            throw new RuntimeException("Could not obtain credential", e);
+            //            throw log.couldNotObtainCredentialWithCause(e);
+        }
+
+        String securityPrincipal = nameCallback.getName();
+
+        if (securityPrincipal == null) {
+            throw new RuntimeException("Could not obtain principal");
+            //            throw log.couldNotObtainPrincipal();
+        }
+
+        char[] securityCredential = passwordCallback.getPassword();
+
+        if (securityCredential == null) {
+            throw new RuntimeException("Could not obtain credential");
+            //            throw log.couldNotObtainCredential();
+        }
+
+        return createDirContext(securityPrincipal, securityCredential, mode);
+    }
+
+    private DirContext createDirContext(String securityPrincipal, char[] securityCredential, ReferralMode mode)
+            throws NamingException {
+        final ClassLoader oldClassLoader = setClassLoaderTo(targetClassLoader);
+        try {
+            Hashtable<String, Object> env = new Hashtable<>();
+
+            env.put(InitialDirContext.INITIAL_CONTEXT_FACTORY, INITIAL_CONTEXT_FACTORY);
+            env.put(InitialDirContext.PROVIDER_URL, providerUrl);
+            env.put(InitialDirContext.SECURITY_AUTHENTICATION, SECURITY_AUTHENTICATION);
+            if (securityPrincipal != null) {
+                env.put(InitialDirContext.SECURITY_PRINCIPAL, securityPrincipal);
+            }
+            if (securityCredential != null) {
+                env.put(InitialDirContext.SECURITY_CREDENTIALS, securityCredential);
+            }
+            env.put(InitialDirContext.REFERRAL, mode == null ? ReferralMode.IGNORE.getValue() : mode.getValue());
+            env.put(CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT);
+            env.put(READ_TIMEOUT, DEFAULT_READ_TIMEOUT);
+
+            //            if (log.isDebugEnabled()) {
+            //                log.debugf("Creating [" + InitialDirContext.class + "] with environment:");
+            //                env.forEach((key, value) -> log.debugf("    Property [%s] with value [%s]", key,
+            //                        key != InitialDirContext.SECURITY_CREDENTIALS ? Arrays2.objectToString(value) : "******"));
+            //            }
+
+            InitialLdapContext initialContext;
+
+            try {
+                initialContext = new InitialLdapContext(env, null);
+            } catch (NamingException ne) {
+                //                log.debugf(ne, "Could not create [%s]. Failed to connect to LDAP server.", InitialLdapContext.class);
+                throw ne;
+            }
+
+            //            log.debugf("[%s] successfully created. Connection established to LDAP server.", initialContext);
+
+            return new DelegatingLdapContext(initialContext, this::returnContext, null);
+        } finally {
+            setClassLoaderTo(oldClassLoader);
+        }
+    }
+
+    @Override
+    public void returnContext(DirContext context) {
+
+        if (context == null) {
+            return;
+        }
+
+        if (context instanceof InitialDirContext) {
+            final ClassLoader oldClassLoader = setClassLoaderTo(targetClassLoader);
+            try {
+                context.close();
+                //                log.debugf("Context [%s] was closed. Connection closed or just returned to the pool.", context);
+            } catch (NamingException ignored) {
+            } finally {
+                setClassLoaderTo(oldClassLoader);
+            }
+        }
+    }
+
+    private ClassLoader setClassLoaderTo(final ClassLoader targetClassLoader) {
+        return doPrivileged(new SetContextClassLoaderAction(targetClassLoader));
+    }
+
+    private static <T> T doPrivileged(final PrivilegedAction<T> action) {
+        return System.getSecurityManager() != null ? AccessController.doPrivileged(action) : action.run();
+    }
+
+}

--- a/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapTest.java
+++ b/integration-tests/elytron-security-ldap/src/test/java/io/quarkus/elytron/security/ldap/it/ElytronSecurityLdapTest.java
@@ -4,10 +4,12 @@ import static org.hamcrest.Matchers.containsString;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @QuarkusTest
+@DisabledOnNativeImage("Native test throws 'Fatal error: Failed to leave the current IsolateThread context and to detach the current thread. (code 12)'")
 class ElytronSecurityLdapTest {
 
     @Test


### PR DESCRIPTION
This PR enables native compilation but fails native execution failing with:

`Fatal error: Failed to leave the current IsolateThread context and to detach the current thread. (code 12)` 

Fixes #6606