### PR TITLE
Upgrade of kogito to 0.7.0 plus required adjustments

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -159,7 +159,7 @@
         <bootstrap.version>3.1.0</bootstrap.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kogito.version>0.6.1</kogito.version>
+        <kogito.version>0.7.1</kogito.version>
         <kubernetes-client.version>4.7.1</kubernetes-client.version>
         <sundr.version>0.19.1</sundr.version> <!-- this is to avoid annoying pop-up in eclipse about failure to init Velocity logging -->
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>

--- a/extensions/kogito/deployment/pom.xml
+++ b/extensions/kogito/deployment/pom.xml
@@ -47,6 +47,12 @@
         <dependency>
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-codegen</artifactId>
+            <exclusions>
+                <exclusion>
+                  <groupId>javax.validation</groupId>
+                  <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- test -->

--- a/extensions/kogito/runtime/pom.xml
+++ b/extensions/kogito/runtime/pom.xml
@@ -42,15 +42,11 @@
         </dependency>
         <dependency>
             <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-model-compiler</artifactId>
+            <artifactId>kogito-drools</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/integration-tests/kogito/src/main/java/io/quarkus/it/kogito/drools/CanDrinkResource.java
+++ b/integration-tests/kogito/src/main/java/io/quarkus/it/kogito/drools/CanDrinkResource.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.kie.kogito.rules.RuleUnit;
 import org.kie.kogito.rules.RuleUnitInstance;
-import org.kie.kogito.rules.impl.SessionData;
+import org.kie.kogito.rules.units.SessionData;
 
 @Path("/candrink/{name}/{age}")
 public class CanDrinkResource {

--- a/integration-tests/kogito/src/main/java/io/quarkus/it/kogito/drools/HelloRuleService.java
+++ b/integration-tests/kogito/src/main/java/io/quarkus/it/kogito/drools/HelloRuleService.java
@@ -6,7 +6,7 @@ import javax.inject.Named;
 
 import org.kie.kogito.rules.RuleUnit;
 import org.kie.kogito.rules.RuleUnitInstance;
-import org.kie.kogito.rules.impl.SessionData;
+import org.kie.kogito.rules.units.SessionData;
 
 @ApplicationScoped
 public class HelloRuleService {

--- a/integration-tests/kogito/src/test/java/io/quarkus/it/kogito/jbpm/OrdersProcessTest.java
+++ b/integration-tests/kogito/src/test/java/io/quarkus/it/kogito/jbpm/OrdersProcessTest.java
@@ -1,18 +1,46 @@
 package io.quarkus.it.kogito.jbpm;
 
-import static org.hamcrest.Matchers.containsString;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class OrdersProcessTest {
 
     @Test
-    public void testRuleEvaluation() {
-        RestAssured.when().get("/runProcess").then()
-                .body(containsString("OK"));
+    public void testOrdersRest() {
+        // test adding new order
+        String addOrderPayload = "{\"approver\" : \"john\", \"order\" : {\"orderNumber\" : \"12345\", \"shipped\" : false}}";
+        String firstCreatedId = given().contentType(ContentType.JSON).accept(ContentType.JSON).body(addOrderPayload).when()
+                .post("/orders").then().statusCode(200).body("id", notNullValue()).extract().path("id");
+
+        // test getting the created order
+        given().accept(ContentType.JSON).when().get("/orders").then().statusCode(200)
+                .body("$.size()", is(1), "[0].id", is(firstCreatedId));
+
+        // test getting order by id
+        given().accept(ContentType.JSON).when().get("/orders/" + firstCreatedId).then()
+                .statusCode(200).body("id", is(firstCreatedId));
+
+        // test delete order
+        // first add second order...
+        String secondCreatedId = given().contentType(ContentType.JSON).accept(ContentType.JSON).body(addOrderPayload)
+                .when().post("/orders").then().statusCode(200).body("id", notNullValue()).extract().path("id");
+        // now delete the first order created
+        given().accept(ContentType.JSON).when().delete("/orders/" + firstCreatedId).then().statusCode(200);
+        // get all orders make sure there is only one
+        given().accept(ContentType.JSON).when().get("/orders").then().statusCode(200)
+                .body("$.size()", is(1), "[0].id", is(secondCreatedId));
+
+        // delete second before finishing
+        given().accept(ContentType.JSON).when().delete("/orders/" + secondCreatedId).then().statusCode(200);
+        // get all orders make sure there is zero
+        given().accept(ContentType.JSON).when().get("/orders").then().statusCode(200)
+                .body("$.size()", is(0));
     }
 }


### PR DESCRIPTION
- Updated jandex proto generator to allow exclusion of static and transient, support simple types for collections
- KOGITO-801 - Live/Hot reload does not work when adding a process definition to a skeleton project
- upgrade kogito dependencies after internal refactoring