### PR TITLE
Update of mssql-jdbc and mssql-server image, network bridge

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -110,7 +110,7 @@
         <postgresql-jdbc.version>42.2.9</postgresql-jdbc.version>
         <mariadb-jdbc.version>2.5.3</mariadb-jdbc.version>
         <mysql-jdbc.version>8.0.19</mysql-jdbc.version>
-        <mssql-jdbc.version>7.2.1.jre8</mssql-jdbc.version>
+        <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
         <derby-jdbc.version>10.14.2.0</derby-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <rest-assured.version>4.1.2</rest-assured.version>

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -186,9 +186,12 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>microsoft/mssql-server-linux:2017-CU12</name>
+                                    <name>microsoft/mssql-server-linux:2017-CU13</name>
                                     <alias>quarkus-test-mssqldb</alias>
                                     <run>
+                                        <network>
+                                            <mode>bridge</mode>
+                                        </network>
                                         <ports>
                                             <port>1433:1433</port>
                                         </ports>


### PR DESCRIPTION
Update of mssql-jdbc and mssql-server image, network bridge.

Without network bridge for docker I receive `quarkus-integration-test-jpa-mssql: Execution docker-start of goal io.fabric8:docker-maven-plugin:0.31.0:start failed: hostname can't be null`