### PR TITLE
doc: fix compilation error

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -78,6 +78,7 @@ package org.acme.jwt;
 import java.security.Principal;
 
 import javax.annotation.security.PermitAll;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -105,7 +105,7 @@ public class TokenSecuredResource {
     public String hello(@Context SecurityContext ctx) { // <4>
         Principal caller =  ctx.getUserPrincipal(); <5>
         String name = caller == null ? "anonymous" : caller.getName();
-        boolean hasJWT = jwt.getClaims() != null;
+        boolean hasJWT = jwt.getClaimNames() != null;
         String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT);
         return helloReply; // <6>
     }


### PR DESCRIPTION
When I tried the guide `USING JWT RBAC` (https://quarkus.io/guides/security-jwt), I found a compilation error.

I fixed it according to the quickstart project.
https://github.com/quarkusio/quarkus-quickstarts/blob/master/security-jwt-quickstart/src/main/java/org/acme/jwt/TokenSecuredResource.java#L46