### PR TITLE
Don't fire the startup event until the vert.x producer has been initialized

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/StartupEvent.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/StartupEvent.java
@@ -16,8 +16,6 @@ package io.quarkus.runtime;
  *
  * The annotated method can access other injected beans.
  *
- *
- * TODO: make a real API.
  */
 public class StartupEvent {
 }

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.IOThreadDetectorBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -64,7 +65,8 @@ class VertxCoreProcessor {
     @BuildStep
     @Record(value = ExecutionTime.RUNTIME_INIT)
     CoreVertxBuildItem build(VertxCoreRecorder recorder, BeanContainerBuildItem beanContainer,
-            LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown, VertxConfiguration config) {
+            LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown, VertxConfiguration config,
+            BuildProducer<ServiceStartBuildItem> serviceStartBuildItem) {
 
         Supplier<Vertx> vertx = recorder.configureVertx(beanContainer.getValue(), config,
                 launchMode.getLaunchMode(), shutdown);

--- a/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VertxInjectionTest.java
+++ b/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VertxInjectionTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.vertx.core.deployment;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Vertx;
+
+public class VertxInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyBean.class));
+
+    @Test
+    public void test() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        Assertions.assertTrue(bean.isOk());
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        @Inject
+        Vertx vertx;
+
+        boolean ok;
+
+        public boolean isOk() {
+            return ok;
+        }
+
+        public void init(@Observes StartupEvent ev) {
+            Assertions.assertNotNull(vertx);
+            ok = true;
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/VertxInjectionTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/VertxInjectionTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.vertx;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Vertx;
+
+public class VertxInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyBean.class));
+
+    @Test
+    public void test() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        Assertions.assertTrue(bean.isOk());
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        @Inject
+        Vertx vertx;
+
+        @Inject
+        io.vertx.axle.core.Vertx axle;
+
+        @Inject
+        io.vertx.reactivex.core.Vertx rx;
+
+        boolean ok;
+
+        public boolean isOk() {
+            return ok;
+        }
+
+        public void init(@Observes StartupEvent ev) {
+            Assertions.assertNotNull(vertx);
+            Assertions.assertNotNull(axle);
+            Assertions.assertNotNull(rx);
+            ok = true;
+        }
+    }
+}


### PR DESCRIPTION
Add tests to the fix proposed in https://github.com/quarkusio/quarkus/pull/6630.