### PR TITLE
Use network bridge for docker to avoid hostname can't be null fail

### DIFF
--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -179,6 +179,9 @@
                                     <name>mariadb:10.4</name>
                                     <alias>quarkus-test-mariadb</alias>
                                     <run>
+                                        <network>
+                                            <mode>bridge</mode>
+                                        </network>
                                         <ports>
                                             <port>3308:3306</port>
                                         </ports>

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -189,6 +189,9 @@
                                     <name>microsoft/mssql-server-linux:2017-CU12</name>
                                     <alias>quarkus-test-mssqldb</alias>
                                     <run>
+                                        <network>
+                                            <mode>bridge</mode>
+                                        </network>
                                         <ports>
                                             <port>1433:1433</port>
                                         </ports>

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -189,6 +189,9 @@
                                     <name>mariadb:10.4</name>
                                     <alias>quarkus-test-mariadb</alias>
                                     <run>
+                                        <network>
+                                            <mode>bridge</mode>
+                                        </network>
                                         <ports>
                                             <port>3308:3306</port>
                                         </ports>


### PR DESCRIPTION
Use network bridge for docker to avoid `hostname can't be null` fail

checked via `./mvnw -fn clean verify -Ddocker -Dtest-mariadb -Dtest-mssql -Dtest-mysql -Dtest-postgresql -Dtest-gelf -Dtest-neo4j -Dtest-keycloak -pl integration-tests/jpa-mariadb,integration-tests/jpa-mssql,integration-tests/reactive-mysql-client` command