### PR TITLE
Vert.x Verticles support

### DIFF
--- a/extensions/vertx-core/deployment/pom.xml
+++ b/extensions/vertx-core/deployment/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VerticleWithClassNameDeploymentTest.java
+++ b/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VerticleWithClassNameDeploymentTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.vertx.core.deployment;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * It should be possible to deploy a verticle from a class name and deployment options.
+ */
+public class VerticleWithClassNameDeploymentTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanDeployingAVerticleFromClass.class, MyVerticle.class));
+
+    @Test
+    public void testDeploymentOfVerticleUsingClassName() {
+        String resp1 = RestAssured.get("http://localhost:8080").asString();
+        String resp2 = RestAssured.get("http://localhost:8080").asString();
+        Assertions.assertTrue(resp1.startsWith("OK"));
+        Assertions.assertTrue(resp2.startsWith("OK"));
+        Assertions.assertNotEquals(resp1, resp2);
+    }
+
+    public static class BeanDeployingAVerticleFromClass {
+        @Inject
+        Vertx vertx;
+
+        public void init(@Observes StartupEvent ev) throws InterruptedException {
+            CountDownLatch latch = new CountDownLatch(1);
+            vertx.deployVerticle(MyVerticle.class.getName(),
+                    new DeploymentOptions().setInstances(2),
+                    ar -> latch.countDown());
+            latch.await();
+        }
+    }
+
+    public static class MyVerticle extends AbstractVerticle {
+
+        @Override
+        public void start(Future<Void> done) {
+            vertx.createHttpServer()
+                    .requestHandler(req -> req.response().end("OK-" + Thread.currentThread().getName()))
+                    .listen(8080, ar -> done.handle(ar.mapEmpty()));
+        }
+
+    }
+
+}

--- a/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VerticleWithInstanceDeploymentTest.java
+++ b/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VerticleWithInstanceDeploymentTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.vertx.core.deployment;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * It should be possible to deploy a verticle from a class name and deployment options.
+ */
+public class VerticleWithInstanceDeploymentTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanDeployingAVerticleFromInstance.class, MyVerticle.class));
+
+    @Test
+    public void testDeploymentOfVerticleInstance() {
+        String resp1 = RestAssured.get("http://localhost:8080").asString();
+        String resp2 = RestAssured.get("http://localhost:8080").asString();
+        Assertions.assertTrue(resp1.startsWith("OK"));
+        Assertions.assertTrue(resp2.startsWith("OK"));
+        Assertions.assertNotEquals(resp1, resp2);
+    }
+
+    public static class BeanDeployingAVerticleFromInstance {
+        @Inject
+        Vertx vertx;
+
+        public void init(@Observes StartupEvent ev) throws InterruptedException {
+            CountDownLatch latch = new CountDownLatch(2);
+            vertx.deployVerticle(new MyVerticle(),
+                    ar -> latch.countDown());
+            vertx.deployVerticle(new MyVerticle(),
+                    ar -> latch.countDown());
+            latch.await();
+        }
+    }
+
+    public static class MyVerticle extends AbstractVerticle {
+
+        @Override
+        public void start(Future<Void> done) {
+            vertx.createHttpServer()
+                    .requestHandler(req -> req.response().end("OK-" + Thread.currentThread().getName()))
+                    .listen(8080, ar -> done.handle(ar.mapEmpty()));
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.kubernetes.spi.KubernetesPortBuildItem;
 import io.quarkus.netty.runtime.virtual.VirtualServerChannel;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.core.deployment.EventLoopCountBuildItem;
 import io.quarkus.vertx.core.deployment.InternalWebVertxBuildItem;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
@@ -113,7 +114,9 @@ class VertxHttpProcessor {
             HttpBuildTimeConfig httpBuildTimeConfig, HttpConfiguration httpConfiguration,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass, List<WebsocketSubProtocolsBuildItem> websocketSubProtocols,
             List<RequireBodyHandlerBuildItem> requireBodyHandlerBuildItems,
-            BodyHandlerBuildItem bodyHandlerBuildItem)
+            BodyHandlerBuildItem bodyHandlerBuildItem,
+            CoreVertxBuildItem core // Injected to be sure that Vert.x has been produced before calling this method.
+    )
             throws BuildException, IOException {
         Optional<DefaultRouteBuildItem> defaultRoute;
         if (defaultRoutes == null || defaultRoutes.isEmpty()) {

--- a/extensions/vertx/deployment/pom.xml
+++ b/extensions/vertx/deployment/pom.xml
@@ -53,6 +53,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -10,6 +10,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
@@ -34,6 +36,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
@@ -46,6 +49,7 @@ import io.quarkus.vertx.ConsumeEvent;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.runtime.VertxProducer;
 import io.quarkus.vertx.runtime.VertxRecorder;
+import io.vertx.reactivex.core.AbstractVerticle;
 
 class VertxProcessor {
 
@@ -151,6 +155,15 @@ class VertxProcessor {
                 }
             }
         });
+    }
+
+    @BuildStep
+    void registerRxVerticleClasses(CombinedIndexBuildItem indexBuildItem,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        for (ClassInfo ci : indexBuildItem.getIndex()
+                .getAllKnownSubclasses(DotName.createSimple(AbstractVerticle.class.getName()))) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ci.toString()));
+        }
     }
 
 }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/devmode/MyVerticle.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/devmode/MyVerticle.java
@@ -1,0 +1,19 @@
+package io.quarkus.vertx.devmode;
+
+import java.util.UUID;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+
+public class MyVerticle extends AbstractVerticle {
+
+    private final String id = UUID.randomUUID().toString();
+
+    @Override
+    public void start(Future<Void> done) {
+        vertx.eventBus().consumer("address")
+                .handler(m -> m.reply("ok-" + id))
+                .completionHandler(ar -> done.handle(ar.mapEmpty()));
+    }
+
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/devmode/VerticleClassnameHotReloadTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/devmode/VerticleClassnameHotReloadTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.vertx.devmode;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+
+public class VerticleClassnameHotReloadTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyVerticle.class, BeanDeployingAVerticleFromInstance.class));
+
+    @Test
+    public void testDeploymentOfVerticleClass() {
+        String resp = RestAssured.get("/").asString();
+        Assertions.assertTrue(resp.startsWith("ok"));
+        test.modifySourceFile(MyVerticle.class, data -> data.replace("ok", "hello"));
+        resp = RestAssured.get("/").asString();
+        Assertions.assertTrue(resp.startsWith("hello"));
+        String resp2 = RestAssured.get("/").asString();
+        Assertions.assertEquals(resp, resp2);
+    }
+
+    @ApplicationScoped
+    public static class BeanDeployingAVerticleFromInstance {
+        @Inject
+        Vertx vertx;
+
+        public void init(@Observes Router router) throws InterruptedException {
+            CountDownLatch latch = new CountDownLatch(1);
+            vertx.deployVerticle(MyVerticle.class.getName(),
+                    ar -> latch.countDown());
+            router.get("/").handler(rc -> vertx.eventBus().<String> request("address", "",
+                    ar -> rc.response().end(ar.result().body())));
+            latch.await();
+        }
+    }
+
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/devmode/VerticleInstanceHotReloadTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/devmode/VerticleInstanceHotReloadTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.vertx.devmode;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+
+public class VerticleInstanceHotReloadTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyVerticle.class, BeanDeployingAVerticleFromInstance.class));
+
+    @Test
+    public void testDeploymentOfVerticleInstance() {
+        String resp = RestAssured.get("/").asString();
+        Assertions.assertTrue(resp.startsWith("ok"));
+        test.modifySourceFile(MyVerticle.class, data -> data.replace("ok", "hello"));
+        resp = RestAssured.get("/").asString();
+        Assertions.assertTrue(resp.startsWith("hello"));
+        String resp2 = RestAssured.get("/").asString();
+        Assertions.assertEquals(resp, resp2);
+
+    }
+
+    @ApplicationScoped
+    public static class BeanDeployingAVerticleFromInstance {
+        @Inject
+        Vertx vertx;
+
+        public void init(@Observes Router router) throws InterruptedException {
+            CountDownLatch latch = new CountDownLatch(1);
+            vertx.deployVerticle(new MyVerticle(),
+                    ar -> latch.countDown());
+            router.get("/").handler(rc -> vertx.eventBus().<String> request("address", "",
+                    ar -> rc.response().end(ar.result().body())));
+            latch.await();
+        }
+    }
+
+}

--- a/integration-tests/vertx/pom.xml
+++ b/integration-tests/vertx/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/BareVerticle.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/BareVerticle.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.vertx.verticles;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+
+public class BareVerticle extends AbstractVerticle {
+
+    @Override
+    public void start(Future<Void> done) {
+        String address = config().getString("id");
+        vertx.eventBus().consumer(address)
+                .handler(message -> message.reply("OK-" + address))
+                .completionHandler(done);
+    }
+}

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/RxVerticle.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/RxVerticle.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.vertx.verticles;
+
+import io.reactivex.Completable;
+import io.vertx.reactivex.core.AbstractVerticle;
+
+public class RxVerticle extends AbstractVerticle {
+
+    @Override
+    public Completable rxStart() {
+        String address = config().getString("id");
+        return vertx.eventBus().consumer(address)
+                .handler(message -> message.reply("OK-" + address))
+                .rxCompletionHandler();
+    }
+
+}

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/VerticleDeployer.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/VerticleDeployer.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.vertx.verticles;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.axle.core.Vertx;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+public class VerticleDeployer {
+
+    @Inject
+    Vertx vertx;
+
+    public void init(@Observes StartupEvent ev) {
+        CountDownLatch latch = new CountDownLatch(4);
+        vertx.deployVerticle(BareVerticle::new, new DeploymentOptions().setConfig(new JsonObject()
+                .put("id", "bare")))
+                .thenAccept(x -> latch.countDown());
+
+        vertx.deployVerticle(BareVerticle.class.getName(), new DeploymentOptions().setConfig(new JsonObject()
+                .put("id", "bare-classname")))
+                .thenAccept(x -> latch.countDown());
+
+        vertx.deployVerticle(RxVerticle::new, new DeploymentOptions().setConfig(new JsonObject()
+                .put("id", "rx")))
+                .thenAccept(x -> latch.countDown());
+
+        vertx.deployVerticle(RxVerticle.class.getName(), new DeploymentOptions().setConfig(new JsonObject()
+                .put("id", "rx-classname")))
+                .thenAccept(x -> latch.countDown());
+        latch.countDown();
+    }
+
+}

--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/VerticleEndpoint.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/VerticleEndpoint.java
@@ -1,0 +1,49 @@
+package io.quarkus.it.vertx.verticles;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.vertx.axle.core.Vertx;
+import io.vertx.axle.core.eventbus.Message;
+
+@Path("/verticles")
+@Produces(MediaType.TEXT_PLAIN)
+public class VerticleEndpoint {
+
+    @Inject
+    Vertx vertx;
+
+    @GET
+    @Path("/bare")
+    public CompletionStage<String> bare() {
+        return vertx.eventBus().<String> request("bare", "")
+                .thenApply(Message::body);
+    }
+
+    @GET
+    @Path("/bare-classname")
+    public CompletionStage<String> bareWithClassName() {
+        return vertx.eventBus().<String> request("bare-classname", "")
+                .thenApply(Message::body);
+    }
+
+    @GET
+    @Path("/rx")
+    public CompletionStage<String> rx() {
+        return vertx.eventBus().<String> request("rx", "")
+                .thenApply(Message::body);
+    }
+
+    @GET
+    @Path("/rx-classname")
+    public CompletionStage<String> rxWithClassName() {
+        return vertx.eventBus().<String> request("rx-classname", "")
+                .thenApply(Message::body);
+    }
+
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleIT.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.vertx;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class VerticleIT extends VerticleTest {
+
+}

--- a/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleTest.java
+++ b/integration-tests/vertx/src/test/java/io/quarkus/it/vertx/VerticleTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.vertx;
+
+import static io.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class VerticleTest {
+
+    @Test
+    public void testBareVerticle() {
+        String s = get("/vertx-test/verticles/bare").asString();
+        assertThat(s).isEqualTo("OK-bare");
+    }
+
+    @Test
+    public void testBareWithClassNameVerticle() {
+        String s = get("/vertx-test/verticles/bare-classname").asString();
+        assertThat(s).isEqualTo("OK-bare-classname");
+    }
+
+    @Test
+    public void testRxVerticle() {
+        String s = get("/vertx-test/verticles/rx").asString();
+        assertThat(s).isEqualTo("OK-rx");
+    }
+
+    @Test
+    public void testRxWithClassNameVerticle() {
+        String s = get("/vertx-test/verticles/rx-classname").asString();
+        assertThat(s).isEqualTo("OK-rx-classname");
+    }
+}


### PR DESCRIPTION
* Verticle classes should be registered for reflection (when `deployVerticle` is used with class name)
* Router restarted before Vert.x which led to NPE
* Add IT and live reload tests