### PR TITLE
awaitility and okhttp version update

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -96,3 +96,5 @@ update_configs:
           dependency_name: "org.testcontainers:junit-jupiter"
       - match:
           dependency_name: "org.mockito:mockito-core"
+      - match:
+          dependency_name: "org.awaitility:awaitility"

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -143,7 +143,7 @@
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
-        <awaitility.version>4.0.1</awaitility.version>
+        <awaitility.version>4.0.2</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
         <jboss-logmanager.version>1.0.4</jboss-logmanager.version>
         <jgit.version>5.5.1.201910021850-r</jgit.version>
@@ -153,7 +153,7 @@
         <mongo-client.version>3.10.2</mongo-client.version>
         <mongo-reactivestreams-client.version>1.11.0</mongo-reactivestreams-client.version>
         <artemis.version>2.11.0</artemis.version>
-        <okhttp.version>3.12.6</okhttp.version>
+        <okhttp.version>3.14.6</okhttp.version>
         <sentry.version>1.7.28</sentry.version>
         <!-- Used for integration tests, to make sure webjars work-->
         <bootstrap.version>3.1.0</bootstrap.version>


### PR DESCRIPTION
awaitility and okhttp version update

awaitility added to dependabot

okhttp 4 series has enforcer issues, dependency convergence errors are reported so that's why okhttp 3.14.6 was picked and no dependabot rule added