### PR TITLE
Set the Hibernate ORM CONNECTION_HANDLING strategy to DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION by default

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -71,6 +71,7 @@ import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.jpa.internal.util.LogHelper;
 import org.hibernate.jpa.internal.util.PersistenceUnitTransactionTypeHelper;
 import org.hibernate.jpa.spi.IdentifierGeneratorStrategyProvider;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.hibernate.service.Service;
@@ -267,6 +268,22 @@ public class FastBootMetadataBuilder {
         }
         //Agroal already does disable auto-commit, so Hibernate ORM should trust that:
         cfg.put(AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, Boolean.TRUE.toString());
+
+        /**
+         * Set CONNECTION_HANDLING to DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION
+         * as it generally performs better, at no drawbacks.
+         * The reason it's not the default in Hibernate ORM is that some containers suspect it to leak connections
+         * when running in this mode, as they trace resource handling across different beans.
+         * 
+         * @see org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode
+         */
+        {
+            final Object explicitSetting = cfg.get(AvailableSettings.CONNECTION_HANDLING);
+            if (explicitSetting == null) {
+                cfg.put(AvailableSettings.CONNECTION_HANDLING,
+                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION);
+            }
+        }
 
         if (readBooleanConfigurationValue(cfg, WRAP_RESULT_SETS)) {
             LOG.warn("Wrapping result sets is not supported. Setting " + WRAP_RESULT_SETS + " to false.");


### PR DESCRIPTION
…TION_AND_RELEASE_AFTER_TRANSACTION by default

This is a better performing default. I had originally planned to propose flipping the default in Hibernate ORM, but there's a need to keep the existing default for compatibility with paranoid containers.