### PR TITLE
Hibernate ORM should not resolve placeholders in configuration properties

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -24,7 +24,6 @@ import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.hql.internal.QueryTranslatorFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.internal.EntityManagerMessageLogger;
-import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
@@ -96,7 +95,6 @@ public class PreconfiguredServiceRegistryBuilder {
 
         final Map settingsCopy = new HashMap();
         settingsCopy.putAll(configurationValues);
-        ConfigurationHelper.resolvePlaceHolders(settingsCopy);
 
         destroyedRegistry.resetAndReactivate(bootstrapServiceRegistry, initiators, providedServices, settingsCopy);
         return destroyedRegistry;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
@@ -29,7 +29,6 @@ import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.hql.internal.QueryTranslatorFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.integrator.spi.IntegratorService;
-import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
@@ -343,7 +342,6 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
         final Map settingsCopy = new HashMap();
         settingsCopy.putAll(settings);
         settingsCopy.put(org.hibernate.boot.cfgxml.spi.CfgXmlAccessService.LOADED_CONFIG_KEY, aggregatedCfgXml);
-        ConfigurationHelper.resolvePlaceHolders(settingsCopy);
 
         return new StandardServiceRegistryImpl(autoCloseRegistry, bootstrapServiceRegistry, initiators,
                 providedServices, settingsCopy);


### PR DESCRIPTION
…ties

This feature is mimicking the configuration parsing of upstream Hibernate ORM, but I feel it's redundant in Quarkus as we already have a layer for such replacements (right?).

So let's shave a little more from bootime :)

Also, reasons:

- I prefer to remove such things now than later (easier to add back if we change our minds)
- Consistency with the Quarkus configuration