### PR TITLE
Disable the DNS resolver when creating the options

### DIFF
--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.core.runtime.VertxLogDelegateFactory;
 import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.vertx.core.Vertx;
+import io.vertx.core.spi.resolver.ResolverProvider;
 
 class VertxCoreProcessor {
 
@@ -33,7 +34,7 @@ class VertxCoreProcessor {
                 .addRuntimeInitializedClass("io.vertx.core.http.impl.VertxHttp2ClientUpgradeCodec")
                 .addRuntimeInitializedClass("io.vertx.core.eventbus.impl.clustered.ClusteredEventBus")
 
-                .addNativeImageSystemProperty("vertx.disableDnsResolver", "true")
+                .addNativeImageSystemProperty(ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME, "true")
                 .addNativeImageSystemProperty("vertx.logger-delegate-factory-class-name",
                         VertxLogDelegateFactory.class.getName())
                 .build();

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -38,6 +38,7 @@ import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
+import io.vertx.core.spi.resolver.ResolverProvider;
 
 @Recorder
 public class VertxCoreRecorder {
@@ -113,10 +114,6 @@ public class VertxCoreRecorder {
 
         VertxOptions options = convertToVertxOptions(conf, true);
 
-        if (!conf.useAsyncDNS) {
-            System.setProperty("vertx.disableDnsResolver", "true");
-        }
-
         if (options.getEventBusOptions().isClustered()) {
             CompletableFuture<Vertx> latch = new CompletableFuture<>();
             Vertx.clusteredVertx(options, ar -> {
@@ -133,6 +130,10 @@ public class VertxCoreRecorder {
     }
 
     private static VertxOptions convertToVertxOptions(VertxConfiguration conf, boolean allowClustering) {
+        if (!conf.useAsyncDNS) {
+            System.setProperty(ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME, "true");
+        }
+
         VertxOptions options = new VertxOptions();
 
         if (allowClustering) {


### PR DESCRIPTION
So that it's properly disabled even if only the web Vert.x instance is
created.

Related to https://github.com/quarkusio/quarkus/issues/6678

/cc @cescoffier 