### PR TITLE
Fix JaCoCo report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
                                             <structure name="JaCoCo for Quarkus">
                                                 <classfiles>
                                                     <fileset dir="${basedir}">
-                                                        <include name="**ResultHandle doLoad(Method${project.version}.jar"/>
+                                                        <include name="**/*${project.version}.jar"/>
                                                         <exclude name="**/target/lib/*.jar"/>
                                                         <exclude name="independent-projects/**/*.jar"/>
                                                         <exclude name="integration-tests/**/*.jar"/>


### PR DESCRIPTION
Fix JaCoCo report, empty report was generated

This issue was introduced via big change for license header removal https://github.com/quarkusio/quarkus/commit/c9cba824e8812fa3f15474b8382ac5d90f7238aa