### PR TITLE
Ensure that the cron job's report is always executed

### DIFF
--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -48,6 +48,7 @@ jobs:
         run: mvn -B  --settings azure-mvn-settings.xml verify -f integration-tests/pom.xml -DskipTests  -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j
 
       - name: Report
+        if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
           STATUS: ${{ job.status }}


### PR DESCRIPTION
It seems like without this the `report` step is not executed if the previous step fails