### PR TITLE
Fix GraalVM json resource handling and add infinispan-embedded to native CI

### DIFF
--- a/ci-templates/stages.yml
+++ b/ci-templates/stages.yml
@@ -306,10 +306,11 @@ stages:
         parameters:
           poolSettings: ${{parameters.poolSettings}}
           expectUseVMs: ${{parameters.expectUseVMs}}
-          timeoutInMinutes: 25
+          timeoutInMinutes: 30
           modules:
             - infinispan-cache-jpa
             - infinispan-client
+            - infinispan-embedded
             - cache
           name: cache
 


### PR DESCRIPTION
I found the resource problem from doing a trial run of all integration tests in Github actions. The error I was seeing was:

```
2020-01-23T02:17:33.4083174Z [INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building native image source jar: /home/runner/work/quarkus/quarkus/integration-tests/infinispan-embedded/target/quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-runner.jar
2020-01-23T02:17:33.5359172Z [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from /home/runner/work/quarkus/quarkus/integration-tests/infinispan-embedded/target/quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-native-image-source-jar/quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-runner.jar
2020-01-23T02:17:35.0264138Z [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM Version 19.3.1 CE
2020-01-23T02:17:35.6057784Z [INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] docker run -v /home/runner/work/quarkus/quarkus/integration-tests/infinispan-embedded/target/quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-native-image-source-jar:/project:z --user 1001:115 --rm quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8 -J-DCoordinatorEnvironmentBean.transactionStatusManagerEnable=false -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=1 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -H:ResourceConfigurationFiles=resources-config.json --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime -jar quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http -H:+JNI --no-server -H:-UseServiceLoaderFeature -H:+StackTrace quarkus-integration-test-infinispan-embedded-999-SNAPSHOT-runner
2020-01-23T02:17:35.9995464Z Error: Invalid Path entry resources-config.json
2020-01-23T02:17:35.9996141Z Caused by: java.nio.file.NoSuchFileException: /project/resources-config.json
```

I have also verified that the problem does **not** exist in `1.2.0.Final`

Note: The native CI I am talking about should now start running every night and report problems to (#6717 and #6723)