### PR TITLE
quarkus:create-extension fixes and enhancements

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -94,7 +94,7 @@ public final class CreateUtils {
         try {
             final Path classOrigin = MojoUtils.getClassOrigin(cls);
             if (Files.isDirectory(classOrigin)) {
-                return resolvePluginInfo(classOrigin);
+                return resolvePluginInfo(classOrigin.resolve("META-INF").resolve("maven").resolve("plugin.xml"));
             }
             try (FileSystem fs = ZipUtils.newFileSystem(classOrigin)) {
                 return resolvePluginInfo(fs.getPath("META-INF", "maven", "plugin.xml"));

--- a/devtools/maven/src/main/resources/create-extension-templates/deployment-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/deployment-pom.xml
@@ -18,8 +18,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
-[#if !assumeManaged ]            <version>[=quarkusVersion]</version>
-[/#if]
         </dependency>
         <dependency>
             <groupId>[=groupId]</groupId>

--- a/devtools/maven/src/main/resources/create-extension-templates/parent-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/parent-pom.xml
@@ -11,10 +11,10 @@
     </parent>
 [/#if]
 
-[#if groupId?? && groupId != grandParentGroupId ]    <groupId>[=groupId]</groupId>
+[#if grandParentGroupId?? ][#if groupId != grandParentGroupId ]    <groupId>[=groupId]</groupId>[/#if][#else ]    <groupId>[=groupId]</groupId>
 [/#if]
     <artifactId>[=artifactId]-parent</artifactId>
-[#if groupId?? && groupId != grandParentGroupId && version?? && version != grandParentVersion ]    <version>[=version]</version>
+[#if groupId?? && (!grandParentGroupId?? || groupId != grandParentGroupId) && version?? && (!grandParentVersion?? || version != grandParentVersion) ]    <version>[=version]</version>
 [/#if]
 [#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Parent</name>
 [/#if]

--- a/devtools/maven/src/main/resources/create-extension-templates/runtime-pom.xml
+++ b/devtools/maven/src/main/resources/create-extension-templates/runtime-pom.xml
@@ -13,9 +13,13 @@
     <artifactId>[=artifactId]</artifactId>
 [#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Runtime</name>
 [/#if]
-[#if additionalRuntimeDependencies?size > 0 ]
 
     <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+[#if additionalRuntimeDependencies?size > 0 ]
 [#list additionalRuntimeDependencies as dep]
         <dependency>
             <groupId>[=dep.groupId]</groupId>
@@ -30,8 +34,8 @@
 [/#if]
         </dependency>
 [/#list]
-    </dependencies>
 [/#if]
+    </dependencies>
 
     <build>
         <plugins>

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/BuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/BuildFile.java
@@ -63,7 +63,7 @@ public abstract class BuildFile implements Closeable {
     protected abstract boolean hasDependency(Extension extension) throws IOException;
 
     public boolean addExtensionAsGAV(String query) throws IOException {
-        Dependency parsed = MojoUtils.parse(query.trim().toLowerCase());
+        Dependency parsed = MojoUtils.parse(query.trim());
         boolean alreadyThere = getDependencies().stream()
                 .anyMatch(d -> d.getManagementKey().equalsIgnoreCase(parsed.getManagementKey()));
         if (!alreadyThere) {

--- a/independent-projects/tools/common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/maven/utilities/MojoUtils.java
@@ -76,13 +76,13 @@ public class MojoUtils {
         Dependency res = new Dependency();
         String[] segments = dependency.split(":");
         if (segments.length >= 2) {
-            res.setGroupId(segments[0]);
-            res.setArtifactId(segments[1]);
+            res.setGroupId(segments[0].toLowerCase());
+            res.setArtifactId(segments[1].toLowerCase());
             if (segments.length >= 3 && !segments[2].isEmpty()) {
                 res.setVersion(segments[2]);
             }
             if (segments.length >= 4) {
-                res.setClassifier(segments[3]);
+                res.setClassifier(segments[3].toLowerCase());
             }
             return res;
         } else {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -3,6 +3,7 @@ package io.quarkus.maven;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -10,49 +11,108 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.maven.utilities.MojoUtils;
 
 public class CreateExtensionMojoTest {
 
-    static CreateExtensionMojo createMojo(String testProjectName) throws IllegalArgumentException,
-            IllegalAccessException, IOException, NoSuchFieldException, SecurityException {
-        final Path srcDir = Paths.get("src/test/resources/projects/" + testProjectName);
-        /*
-         * We want to run on the same project multiple times with different args so let's create a copy with a random
-         * suffix
-         */
-        final Path copyDir = getCopyDir(testProjectName);
-        Files.walk(srcDir).forEach(source -> {
-            try {
-                final Path dest = copyDir.resolve(srcDir.relativize(source));
-                Files.copy(source, dest);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
-
+    private static CreateExtensionMojo initMojo(final Path projectDir) throws IOException {
         final CreateExtensionMojo mojo = new CreateExtensionMojo();
-        mojo.basedir = copyDir;
+        mojo.project = new MavenProject();
+        mojo.basedir = projectDir.toFile();
+
+        final File pom = new File(projectDir.toFile(), "pom.xml");
+        if (pom.exists()) {
+            mojo.project.setFile(pom);
+            final Model rawModel = MojoUtils.readPom(pom);
+            // the project would have an interpolated model at runtime, which we can't fully init here
+            // here are just some key parts
+            if (rawModel.getDependencyManagement() != null) {
+                List<Dependency> deps = rawModel.getDependencyManagement().getDependencies();
+                if (deps != null && !deps.isEmpty()) {
+                    Dependency deploymentBom = null;
+                    for (Dependency dep : deps) {
+                        if (dep.getArtifactId().equals("quarkus-bom-deployment") && dep.getGroupId().equals("io.quarkus")) {
+                            deploymentBom = dep;
+                        }
+                    }
+                    if (deploymentBom != null) {
+                        String version = deploymentBom.getVersion();
+                        if (CreateExtensionMojo.QUARKUS_VERSION_POM_EXPR.equals(version)) {
+                            version = rawModel.getProperties().getProperty(version.substring(2, version.length() - 1));
+                            if (version == null) {
+                                throw new IllegalStateException(
+                                        "Failed to resolve " + deploymentBom.getVersion() + " from " + pom);
+                            }
+                        }
+                        Dependency dep = new Dependency();
+                        dep.setGroupId("io.quarkus");
+                        dep.setArtifactId("quarkus-core-deployment");
+                        dep.setType("jar");
+                        dep.setVersion(version);
+                        deps.add(dep);
+                    }
+                }
+            }
+            mojo.project.setModel(rawModel);
+        }
+
+        Build build = mojo.project.getBuild();
+        if (build.getPluginManagement() == null) {
+            build.setPluginManagement(new PluginManagement());
+        }
+
         mojo.encoding = CreateExtensionMojo.DEFAULT_ENCODING;
         mojo.templatesUriBase = CreateExtensionMojo.DEFAULT_TEMPLATES_URI_BASE;
         mojo.quarkusVersion = CreateExtensionMojo.DEFAULT_QUARKUS_VERSION;
         mojo.bomEntryVersion = CreateExtensionMojo.DEFAULT_BOM_ENTRY_VERSION;
         mojo.assumeManaged = true;
         mojo.nameSegmentDelimiter = CreateExtensionMojo.DEFAULT_NAME_SEGMENT_DELIMITER;
+        mojo.platformGroupId = CreateExtensionMojo.PLATFORM_DEFAULT_GROUP_ID;
+        mojo.platformArtifactId = CreateExtensionMojo.PLATFORM_DEFAULT_ARTIFACT_ID;
+        mojo.compilerPluginVersion = CreateExtensionMojo.COMPILER_PLUGIN_DEFAULT_VERSION;
         return mojo;
     }
 
-    private static Path getCopyDir(String testProjectName) {
+    private static Path createProjectFromTemplate(String testProjectName) throws IOException {
+        final Path srcDir = Paths.get("src/test/resources/projects/" + testProjectName);
+        /*
+         * We want to run on the same project multiple times with different args so let's create a copy with a random
+         * suffix
+         */
+        final Path copyDir = newProjectDir(testProjectName);
+        Files.walk(srcDir).forEach(source -> {
+            final Path dest = copyDir.resolve(srcDir.relativize(source));
+            try {
+                Files.copy(source, dest);
+            } catch (IOException e) {
+                if (!Files.isDirectory(dest)) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        return copyDir;
+    }
+
+    private static Path newProjectDir(String testProjectName) throws IOException {
         int count = 0;
         while (count < 100) {
             Path path = Paths.get("target/test-classes/projects/" + testProjectName + "-" + UUID.randomUUID());
             if (!Files.exists(path)) {
+                Files.createDirectories(path);
                 return path;
             }
             count++;
@@ -65,19 +125,19 @@ public class CreateExtensionMojoTest {
     @Test
     void createExtensionUnderExistingPomMinimal() throws MojoExecutionException, MojoFailureException,
             IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
-        final CreateExtensionMojo mojo = createMojo("create-extension-pom");
+        final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "my-project-(minimal-extension)";
         mojo.assumeManaged = false;
         mojo.execute();
 
         assertTreesMatch(Paths.get("src/test/resources/expected/create-extension-pom-minimal"),
-                mojo.basedir);
+                mojo.basedir.toPath());
     }
 
     @Test
     void createExtensionUnderExistingPomWithAdditionalRuntimeDependencies() throws MojoExecutionException, MojoFailureException,
             IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
-        final CreateExtensionMojo mojo = createMojo("create-extension-pom");
+        final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "my-project-(add-to-bom)";
         mojo.assumeManaged = false;
         mojo.runtimeBomPath = Paths.get("boms/runtime/pom.xml");
@@ -86,38 +146,50 @@ public class CreateExtensionMojoTest {
         mojo.execute();
 
         assertTreesMatch(Paths.get("src/test/resources/expected/create-extension-pom-add-to-bom"),
-                mojo.basedir);
+                mojo.basedir.toPath());
     }
 
     @Test
     void createExtensionUnderExistingPomWithItest() throws MojoExecutionException, MojoFailureException,
             IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
-        final CreateExtensionMojo mojo = createMojo("create-extension-pom");
+        final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "my-project-(itest)";
         mojo.assumeManaged = false;
         mojo.itestParentPath = Paths.get("integration-tests/pom.xml");
         mojo.execute();
 
         assertTreesMatch(Paths.get("src/test/resources/expected/create-extension-pom-itest"),
-                mojo.basedir);
+                mojo.basedir.toPath());
     }
 
     @Test
     void createExtensionUnderExistingPomCustomGrandParent() throws MojoExecutionException, MojoFailureException,
             IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException, IOException {
-        final CreateExtensionMojo mojo = createMojo("create-extension-pom");
+        final CreateExtensionMojo mojo = initMojo(createProjectFromTemplate("create-extension-pom"));
         mojo.artifactId = "myproject-(with-grand-parent)";
-        mojo.grandParentArtifactId = "build-bom";
-        mojo.grandParentRelativePath = "../../build-bom/pom.xml";
+        mojo.grandParentArtifactId = "grand-parent";
+        mojo.grandParentRelativePath = "../pom.xml";
         mojo.templatesUriBase = "file:templates";
 
         mojo.runtimeBomPath = Paths.get("boms/runtime/pom.xml");
         mojo.deploymentBomPath = Paths.get("boms/deployment/pom.xml");
         mojo.execute();
-
         assertTreesMatch(
                 Paths.get("src/test/resources/expected/create-extension-pom-with-grand-parent"),
-                mojo.basedir);
+                mojo.basedir.toPath());
+    }
+
+    @Test
+    void createNewExtensionProject() throws Exception {
+        final CreateExtensionMojo mojo = initMojo(newProjectDir("new-ext-project"));
+        mojo.groupId = "org.acme";
+        mojo.artifactId = "my-ext";
+        mojo.version = "1.0-SNAPSHOT";
+        mojo.assumeManaged = null;
+        mojo.execute();
+        assertTreesMatch(
+                Paths.get("src/test/resources/expected/new-extension-project"),
+                mojo.basedir.toPath());
     }
 
     static void assertTreesMatch(Path expected, Path actual) throws IOException {

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/deployment/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
-            <version>${quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/add-to-bom/runtime/pom.xml
@@ -15,6 +15,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.example</groupId>
             <artifactId>example-1</artifactId>
         </dependency>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-add-to-bom/pom.xml
@@ -9,10 +9,34 @@
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
         <rest-assured.version>3.3.0</rest-assured.version>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
 
     <modules>
         <module>integration-tests</module>
         <module>add-to-bom</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom-deployment</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/deployment/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
-            <version>${quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-itest/itest/runtime/pom.xml
@@ -13,6 +13,13 @@
     <artifactId>my-project-itest</artifactId>
     <name>Itest - Runtime</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/minimal-extension/deployment/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
-            <version>${quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-minimal/pom.xml
@@ -9,10 +9,34 @@
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
         <rest-assured.version>3.3.0</rest-assured.version>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
 
     <modules>
         <module>integration-tests</module>
         <module>minimal-extension</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom-deployment</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/pom.xml
@@ -9,10 +9,34 @@
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
         <rest-assured.version>3.3.0</rest-assured.version>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
 
     <modules>
         <module>integration-tests</module>
         <module>with-grand-parent</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom-deployment</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.acme</groupId>
-        <artifactId>build-bom</artifactId>
+        <artifactId>grand-parent</artifactId>
         <version>0.1-SNAPSHOT</version>
-        <relativePath>../../build-bom/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>myproject-with-grand-parent-parent</artifactId>

--- a/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/create-extension-pom-with-grand-parent/with-grand-parent/runtime/pom.xml
@@ -13,6 +13,13 @@
     <artifactId>myproject-with-grand-parent</artifactId>
     <name>With Grand Parent - Runtime</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/pom.xml
@@ -5,40 +5,28 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.acme</groupId>
-        <artifactId>my-project-minimal-extension-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <artifactId>my-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>my-project-minimal-extension</artifactId>
-    <name>Minimal Extension - Runtime</name>
+    <artifactId>my-ext-deployment</artifactId>
+    <name>My Ext - Deployment</name>
 
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>my-ext</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>extension-descriptor</goal>
-                        </goals>
-                        <phase>compile</phase>
-                        <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-                            </deployment>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -54,4 +42,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/main/java/org/acme/my/ext/deployment/MyExtProcessor.java
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/src/main/java/org/acme/my/ext/deployment/MyExtProcessor.java
@@ -1,0 +1,15 @@
+package org.acme.my.ext.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class MyExtProcessor {
+
+    private static final String FEATURE = "my-ext";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/pom.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>org.acme</groupId>
-    <artifactId>grand-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <artifactId>my-ext-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>My Ext - Parent</name>
+
     <packaging>pom</packaging>
     <properties>
-        <quarkus.version>0.19.0</quarkus.version>
-        <rest-assured.version>3.3.0</rest-assured.version>
+        <quarkus.version>999-SNAPSHOT</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
-
     <modules>
-        <module>integration-tests</module>
-        <module>itest</module>
+        <module>deployment</module>
+        <module>runtime</module>
     </modules>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -28,11 +29,11 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
                 </plugin>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/runtime/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.acme</groupId>
-        <artifactId>my-project-minimal-extension-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <artifactId>my-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>my-project-minimal-extension</artifactId>
-    <name>Minimal Extension - Runtime</name>
+    <artifactId>my-ext</artifactId>
+    <name>My Ext - Runtime</name>
 
     <dependencies>
         <dependency>

--- a/integration-tests/maven/src/test/resources/projects/create-extension-pom/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/create-extension-pom/pom.xml
@@ -9,9 +9,33 @@
     <properties>
         <quarkus.version>0.19.0</quarkus.version>
         <rest-assured.version>3.3.0</rest-assured.version>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
 
     <modules>
         <module>integration-tests</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom-deployment</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
This change includes the following improvements:
* make sure the generated extension project can actually be built (by adding if necessary the maven compiler plugin version, quarkus version property, importing quarkus-bom-deployment);
* support creating an extension project in an empty dir with a single command, e.g. mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create-extension -DgroupId=org.acme -DartifactId=my-ext -Dversion=1.0-SNAPSHOT;
* simplifies and aligns certain mojo parameter property names with quarkus:create.

Fixes #3321 