### PR TITLE
Allows empty Sort.by

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/JpaOperationsSortTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/JpaOperationsSortTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.orm.panache.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
+import io.quarkus.panache.common.Sort;
+
+public class JpaOperationsSortTest {
+
+    @Test
+    public void testSortBy() {
+        Sort sort = Sort.by("foo", "bar");
+        assertEquals(" ORDER BY foo , bar", JpaOperations.toOrderBy(sort));
+    }
+
+    @Test
+    public void testEmptySortByYieldsEmptyString() {
+        Sort emptySort = Sort.by();
+        assertEquals("", JpaOperations.toOrderBy(emptySort));
+    }
+
+}

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -206,6 +206,9 @@ public class JpaOperations {
     }
 
     public static String toOrderBy(Sort sort) {
+        if (sort.getColumns().size() == 0) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder(" ORDER BY ");
         for (int i = 0; i < sort.getColumns().size(); i++) {
             Sort.Column column = sort.getColumns().get(i);


### PR DESCRIPTION
 - When Sort.by without arguments is used, there won't be any
   Sort by clause in the query

Closes #6664