### PR TITLE
Add hazelcast-client extension

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -377,6 +377,7 @@ jobs:
           - category: Cache
             timeout: 30
             test-modules: >
+              hazelcast-client
               infinispan-cache-jpa
               infinispan-client
               infinispan-embedded

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -119,6 +119,7 @@
         <testng.version>6.14.2</testng.version>
         <assertj.version>3.15.0</assertj.version>
         <json-smart.version>2.3</json-smart.version>
+        <hazelcast.version>4.0</hazelcast.version>
         <infinispan.version>10.1.2.Final</infinispan.version>
         <infinispan.protostream.version>4.3.1.Final</infinispan.protostream.version>
         <caffeine.version>2.8.0</caffeine.version>
@@ -431,6 +432,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-hibernate-validator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hazelcast-client</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -869,6 +875,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-test-h2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-hazelcast</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -2434,6 +2445,11 @@
                 </exclusions>
             </dependency>
 
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${hazelcast.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>

--- a/ci-templates/stages.yml
+++ b/ci-templates/stages.yml
@@ -361,6 +361,7 @@ stages:
             - infinispan-cache-jpa
             - infinispan-client
             - infinispan-embedded
+            - hazelcast-client
             - cache
           name: cache
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -23,6 +23,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String HIBERNATE_ORM_PANACHE = "hibernate-orm-panache";
     public static final String HIBERNATE_VALIDATOR = "hibernate-validator";
     public static final String HIBERNATE_SEARCH_ELASTICSEARCH = "hibernate-search-elasticsearch";
+    public static final String HAZELCAST_CLIENT = "hazelcast-client";
     public static final String INFINISPAN_CLIENT = "infinispan-client";
     public static final String INFINISPAN_EMBEDDED = "infinispan-embedded";
     public static final String JAEGER = "jaeger";

--- a/docs/src/main/asciidoc/hazelcast-client.adoc
+++ b/docs/src/main/asciidoc/hazelcast-client.adoc
@@ -1,0 +1,88 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Hazelcast Client
+
+include::./attributes.adoc[]
+
+https://hazelcast.com/products/imdg/[Hazelcast IMDG] is a distributed in-memory object store and compute engine
+that supports a wide variety of data structures such as Map, Set, List, MultiMap, RingBuffer, HyperLogLog.
+
+Use Hazelcast IMDG to store your data in RAM, spread and replicate it across a cluster of machines,
+and perform data-local computation on it.
+
+Hazelcast is:
+- cloud and Kubernetes friendly
+- often used as a Distributed Cache amongst other use cases
+
+More information about Hazelcast can be found at http://hazelcast.org.
+
+== Configuration
+
+You can add the `hazelcast-client` extension to your Quarkus project by adding the following dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-hazelcast-client</artifactId>
+</dependency>
+----
+
+Extension exposes a single native-mode-compatible Hazelcast Client bean (`HazelcastInstance`)
+which can be directly injected into your beans:
+
+[source,java]
+----
+@Inject
+HazelcastInstance hazelcastClient;
+----
+
+If your use case is more demanding, you can wire `HazelcastInstance` bean yourself - keep in mind
+that you will be able to benefit from GraalVM compatibility anyway.
+
+The Hazelcast client exposes most common configuration options via `application.properties` file
+that can be provided in the `src/main/resources` directory. These are the properties that
+can be configured in this file:
+
+include::{generated-dir}/config/quarkus-hazelcast-client.adoc[opts=optional, leveloffset=+1]
+
+If you require fine-grained configuration options, you can fall back to configuring the client
+using the classic `hazelcast-client.yaml` or `hazelcast-client.xml` config files.
+
+== Testing
+
+To make testing simple, Quarkus provides the `HazelcastServerTestResource` which automatically launches
+an embedded Hazelcast instance with defaults settings and manages its lifecycle:
+
+[source,java]
+----
+@QuarkusTest
+@QuarkusTestResource(HazelcastServerTestResource.class)
+public class HazelcastAwareTest {
+
+    @Test
+    public void test() {
+        // you can safely call embedded Hazelcast instance from here
+    }
+}
+----
+
+Maven dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-test-hazelcast</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+
+== Native Mode Limitations
+- Java serialization is not supported
+- User code deployment is not supported
+

--- a/extensions/hazelcast-client/deployment/pom.xml
+++ b/extensions/hazelcast-client/deployment/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-hazelcast-client-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-hazelcast-client-deployment</artifactId>
+    <name>Quarkus - Hazelcast - Client - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hazelcast-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+</project>

--- a/extensions/hazelcast-client/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientConfiguredBuildItem.java
+++ b/extensions/hazelcast-client/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientConfiguredBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.hazelcast.client.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Marker build item indicating that Hazelcast client is configured
+ */
+final class HazelcastClientConfiguredBuildItem extends SimpleBuildItem {
+}

--- a/extensions/hazelcast-client/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
+++ b/extensions/hazelcast-client/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
@@ -1,0 +1,235 @@
+package io.quarkus.hazelcast.client.deployment;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.impl.ClientExtension;
+import com.hazelcast.client.impl.spi.ClientProxyFactory;
+import com.hazelcast.cluster.MembershipListener;
+import com.hazelcast.collection.ItemListener;
+import com.hazelcast.com.fasterxml.jackson.core.JsonFactory;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.MerkleTreeConfig;
+import com.hazelcast.config.replacer.EncryptionReplacer;
+import com.hazelcast.config.replacer.PropertyReplacer;
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.core.EntryListener;
+import com.hazelcast.internal.config.DomConfigHelper;
+import com.hazelcast.internal.util.ICMPHelper;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.nio.SocketInterceptor;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.nio.ssl.BasicSSLContextFactory;
+import com.hazelcast.partition.MigrationListener;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy;
+import com.hazelcast.topic.MessageListener;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.util.ServiceUtil;
+import io.quarkus.hazelcast.client.runtime.HazelcastClientBytecodeRecorder;
+import io.quarkus.hazelcast.client.runtime.HazelcastClientConfig;
+import io.quarkus.hazelcast.client.runtime.HazelcastClientProducer;
+
+/**
+ * @author Grzegorz Piwowarek
+ */
+class HazelcastClientProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FeatureBuildItem.HAZELCAST_CLIENT);
+    }
+
+    @BuildStep
+    void enableSSL(BuildProducer<ExtensionSslNativeSupportBuildItem> ssl) {
+        ssl.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.HAZELCAST_CLIENT));
+    }
+
+    @BuildStep
+    void registerServiceProviders(BuildProducer<ServiceProviderBuildItem> services) throws IOException {
+        registerServiceProviders(DiscoveryStrategyFactory.class, services);
+        registerServiceProviders(ClientExtension.class, services);
+        registerServiceProviders(JsonFactory.class, services);
+    }
+
+    @BuildStep
+    void setup(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(HazelcastClientProducer.class));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    HazelcastClientConfiguredBuildItem resolveClientProperties(HazelcastClientBytecodeRecorder recorder,
+            HazelcastClientConfig config) {
+        recorder.configureRuntimeProperties(config);
+        return new HazelcastClientConfiguredBuildItem();
+    }
+
+    @BuildStep
+    void registerConfigurationFiles(
+            BuildProducer<NativeImageResourceBuildItem> resources,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> watchedFiles) {
+        resources.produce(new NativeImageResourceBuildItem(
+                "hazelcast-client.yml",
+                "hazelcast-client-default.xml",
+                "hazelcast-client.yaml",
+                "hazelcast-client.xml"));
+
+        watchedFiles.produce(new HotDeploymentWatchedFileBuildItem("hazelcast-client.yml"));
+        watchedFiles.produce(new HotDeploymentWatchedFileBuildItem("hazelcast-client.yaml"));
+        watchedFiles.produce(new HotDeploymentWatchedFileBuildItem("hazelcast-client.xml"));
+    }
+
+    @BuildStep
+    void registerReflectivelyCreatedClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
+                HazelcastClientCachingProvider.class,
+                DomConfigHelper.class,
+                EventJournalConfig.class,
+                MerkleTreeConfig.class));
+    }
+
+    @BuildStep
+    void registerCustomImplementationClasses(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchies,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings) {
+
+        registerTypeHierarchy(reflectiveClassHierarchies, ignoreWarnings,
+                SocketInterceptor.class,
+                MembershipListener.class,
+                MigrationListener.class,
+                EntryListener.class,
+                MessageListener.class,
+                ItemListener.class,
+                MapListener.class,
+                com.hazelcast.client.impl.ClientExtension.class,
+                ClientProxyFactory.class);
+    }
+
+    @BuildStep
+    void registerCustomConfigReplacerClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchies,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings) {
+
+        registerTypeHierarchy(reflectiveClassHierarchies, ignoreWarnings, ConfigReplacer.class);
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
+                EncryptionReplacer.class,
+                PropertyReplacer.class));
+    }
+
+    @BuildStep
+    void registerCustomDiscoveryStrategiesClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchies,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings) {
+
+        registerTypeHierarchy(reflectiveClassHierarchies, ignoreWarnings,
+                DiscoveryStrategy.class,
+                NodeFilter.class);
+
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, MulticastDiscoveryStrategy.class));
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
+                "com.hazelcast.aws.AwsDiscoveryStrategy",
+                "com.hazelcast.aws.AwsDiscoveryStrategyFactory",
+                "com.hazelcast.gcp.GcpDiscoveryStrategy",
+                "com.hazelcast.gcp.GcpDiscoveryStrategyFactory"));
+
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
+                "com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategyFactory",
+                "com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy"));
+    }
+
+    void registerServiceProviders(Class<?> klass, BuildProducer<ServiceProviderBuildItem> services) throws IOException {
+        String service = "META-INF/services/" + klass.getName();
+
+        Set<String> implementations = ServiceUtil
+                .classNamesNamedIn(Thread.currentThread().getContextClassLoader(), service);
+
+        services.produce(new ServiceProviderBuildItem(klass.getName(), new ArrayList<>(implementations)));
+    }
+
+    @BuildStep
+    void registerCustomCredentialFactories(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchies,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings) {
+        registerTypeHierarchy(
+                reflectiveClassHierarchies, ignoreWarnings,
+                com.hazelcast.security.ICredentialsFactory.class);
+
+        reflectiveClasses.produce(
+                new ReflectiveClassBuildItem(false, false, com.hazelcast.config.security.StaticCredentialsFactory.class));
+    }
+
+    @BuildStep
+    void registerSSLUtilities(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchies,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings) {
+
+        registerTypeHierarchy(
+                reflectiveClassHierarchies, ignoreWarnings,
+                com.hazelcast.nio.ssl.SSLContextFactory.class);
+        reflectiveClasses.produce(
+                new ReflectiveClassBuildItem(false, false, BasicSSLContextFactory.class));
+    }
+
+    @BuildStep
+    void registerUserImplementationsOfSerializableUtilities(
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveClassHierarchies,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings) {
+        registerTypeHierarchy(reflectiveClassHierarchies, ignoreWarnings,
+                DataSerializable.class,
+                DataSerializableFactory.class,
+                PortableFactory.class,
+                Serializer.class);
+    }
+
+    @BuildStep
+    void registerICMPHelper(BuildProducer<NativeImageResourceBuildItem> resources,
+            BuildProducer<RuntimeReinitializedClassBuildItem> reinitializedClasses) {
+        resources.produce(new NativeImageResourceBuildItem(
+                "lib/linux-x86/libicmp_helper.so",
+                "lib/linux-x86_64/libicmp_helper.so"));
+        reinitializedClasses.produce(new RuntimeReinitializedClassBuildItem(ICMPHelper.class.getName()));
+    }
+
+    @BuildStep
+    void registerXMLParsingUtilities(BuildProducer<NativeImageResourceBuildItem> resources) {
+        resources.produce(new NativeImageResourceBuildItem("hazelcast-client-config-4.0.xsd"));
+    }
+
+    private static void registerTypeHierarchy(
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyClass,
+            BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignoreWarnings,
+            Class<?>... classNames) {
+
+        for (Class<?> klass : classNames) {
+            DotName simpleName = DotName.createSimple(klass.getName());
+
+            reflectiveHierarchyClass
+                    .produce(new ReflectiveHierarchyBuildItem(Type.create(simpleName, Type.Kind.CLASS)));
+            ignoreWarnings.produce(new ReflectiveHierarchyIgnoreWarningBuildItem(simpleName));
+        }
+    }
+}

--- a/extensions/hazelcast-client/pom.xml
+++ b/extensions/hazelcast-client/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hazelcast-client-parent</artifactId>
+    <name>Quarkus - Hazelcast - Client</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/hazelcast-client/runtime/pom.xml
+++ b/extensions/hazelcast-client/runtime/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-hazelcast-client-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-hazelcast-client</artifactId>
+    <name>Quarkus - Hazelcast - Client - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientBytecodeRecorder.java
+++ b/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientBytecodeRecorder.java
@@ -1,0 +1,13 @@
+package io.quarkus.hazelcast.client.runtime;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class HazelcastClientBytecodeRecorder {
+
+    public void configureRuntimeProperties(HazelcastClientConfig config) {
+        HazelcastClientProducer producer = Arc.container().instance(HazelcastClientProducer.class).get();
+        producer.injectConfig(config);
+    }
+}

--- a/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
+++ b/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
@@ -1,0 +1,50 @@
+package io.quarkus.hazelcast.client.runtime;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "hazelcast-client", phase = ConfigPhase.RUN_TIME)
+public class HazelcastClientConfig {
+
+    /**
+     * Hazelcast Cluster members
+     */
+    @ConfigItem
+    public Optional<List<InetSocketAddress>> clusterMembers;
+
+    /**
+     * Hazelcast client labels
+     */
+    @ConfigItem
+    public Optional<List<String>> labels;
+
+    /**
+     * Hazelcast Cluster group name
+     */
+    @ConfigItem
+    public Optional<String> clusterName;
+
+    /**
+     * Outbound ports
+     */
+    @ConfigItem
+    public Optional<List<Integer>> outboundPorts;
+
+    /**
+     * Outbound port definitions
+     */
+    @ConfigItem
+    public Optional<List<String>> outboundPortDefinitions;
+
+    /**
+     * Connection timeout
+     */
+    @ConfigItem
+    public OptionalInt connectionTimeout;
+}

--- a/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientProducer.java
+++ b/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientProducer.java
@@ -1,0 +1,35 @@
+package io.quarkus.hazelcast.client.runtime;
+
+import static com.hazelcast.client.HazelcastClient.newHazelcastClient;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.core.HazelcastInstance;
+
+import io.quarkus.arc.DefaultBean;
+
+@ApplicationScoped
+public class HazelcastClientProducer {
+    HazelcastClientConfig config;
+
+    @Produces
+    @Singleton
+    @DefaultBean
+    public HazelcastInstance hazelcastClientInstance() {
+        return newHazelcastClient(new HazelcastConfigurationResolver()
+                .resolveClientConfig(config));
+    }
+
+    @PreDestroy
+    public void destroy() {
+        HazelcastClient.shutdownAll();
+    }
+
+    public void injectConfig(HazelcastClientConfig config) {
+        this.config = config;
+    }
+}

--- a/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
+++ b/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
@@ -1,0 +1,59 @@
+package io.quarkus.hazelcast.client.runtime;
+
+import java.net.InetSocketAddress;
+
+import com.hazelcast.client.config.ClientConfig;
+
+class HazelcastConfigurationParser {
+
+    ClientConfig fromApplicationProperties(HazelcastClientConfig config, ClientConfig clientConfig) {
+        setClusterAddress(clientConfig, config);
+        setLabels(clientConfig, config);
+
+        setOutboundPorts(clientConfig, config);
+        setOutboundPortDefinitions(clientConfig, config);
+
+        setConnectionTimeout(clientConfig, config);
+
+        return clientConfig;
+    }
+
+    private void setClusterAddress(ClientConfig clientConfig, HazelcastClientConfig config) {
+        if (config.clusterMembers.isPresent()) {
+            for (InetSocketAddress clusterMember : config.clusterMembers.get()) {
+                clientConfig.getNetworkConfig().addAddress(clusterMember.toString());
+            }
+        }
+    }
+
+    private void setLabels(ClientConfig clientConfig, HazelcastClientConfig config) {
+        if (config.labels.isPresent()) {
+            for (String label : config.labels.get()) {
+                clientConfig.addLabel(label);
+            }
+        }
+    }
+
+    private void setConnectionTimeout(ClientConfig clientConfig, HazelcastClientConfig config) {
+        if (config.connectionTimeout.isPresent()) {
+            int timeout = config.connectionTimeout.getAsInt();
+            clientConfig.getNetworkConfig().setConnectionTimeout(timeout);
+        }
+    }
+
+    private void setOutboundPortDefinitions(ClientConfig clientConfig, HazelcastClientConfig config) {
+        if (config.outboundPortDefinitions.isPresent()) {
+            for (String outboundPortDefinition : config.outboundPortDefinitions.get()) {
+                clientConfig.getNetworkConfig().addOutboundPortDefinition(outboundPortDefinition);
+            }
+        }
+    }
+
+    private void setOutboundPorts(ClientConfig clientConfig, HazelcastClientConfig config) {
+        if (config.outboundPorts.isPresent()) {
+            for (Integer outboundPort : config.outboundPorts.get()) {
+                clientConfig.getNetworkConfig().addOutboundPort(outboundPort);
+            }
+        }
+    }
+}

--- a/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationResolver.java
+++ b/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationResolver.java
@@ -1,0 +1,13 @@
+package io.quarkus.hazelcast.client.runtime;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.FailoverClientConfigSupport;
+
+class HazelcastConfigurationResolver {
+    private final HazelcastConfigurationParser parser = new HazelcastConfigurationParser();
+
+    ClientConfig resolveClientConfig(HazelcastClientConfig properties) {
+        ClientConfig clientConfig = FailoverClientConfigSupport.resolveClientConfig(null);
+        return parser.fromApplicationProperties(properties, clientConfig);
+    }
+}

--- a/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_JCacheDetector.java
+++ b/extensions/hazelcast-client/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_JCacheDetector.java
@@ -1,0 +1,20 @@
+package io.quarkus.hazelcast.client.runtime.graal;
+
+import com.hazelcast.cache.impl.JCacheDetector;
+import com.hazelcast.logging.ILogger;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(JCacheDetector.class)
+public final class Target_JCacheDetector {
+
+    @Substitute
+    public static boolean isJCacheAvailable(ClassLoader classLoader) {
+        return false;
+    }
+
+    @Substitute
+    public static boolean isJCacheAvailable(ClassLoader classLoader, ILogger logger) {
+        return false;
+    }
+}

--- a/extensions/hazelcast-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/hazelcast-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+---
+name: "Hazelcast Client"
+metadata:
+  keywords:
+  - "hazelcast-client"
+  - "hazelcast"
+  - "cache"
+  - "distributed cache"
+  - "caching"
+  guide: "https://quarkus.io/guides/hazelcast-client"
+  categories:
+  - "data"
+  status: "preview"

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -112,6 +112,9 @@
         <module>oidc</module>
         <module>keycloak-authorization</module>
 
+        <!-- Hazelcast -->
+        <module>hazelcast-client</module>
+
         <!-- Infinispan -->
         <module>infinispan-client</module>
         <module>infinispan-embedded</module>

--- a/integration-tests/hazelcast-client/pom.xml
+++ b/integration-tests/hazelcast-client/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-hazelcast-client</artifactId>
+    <name>Quarkus - Integration Tests - Hazelcast Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hazelcast-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-hazelcast</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/CustomNodeFilter.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/CustomNodeFilter.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.hazelcast.client;
+
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.NodeFilter;
+
+class CustomNodeFilter implements NodeFilter {
+
+    @Override
+    public boolean test(DiscoveryNode candidate) {
+        return true;
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/DataSerializableWrapper.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/DataSerializableWrapper.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.hazelcast.client;
+
+import java.io.IOException;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+public class DataSerializableWrapper implements com.hazelcast.nio.serialization.DataSerializable {
+    private String value;
+
+    public DataSerializableWrapper() {
+    }
+
+    public DataSerializableWrapper(String value) {
+        this.value = value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        value = in.readUTF();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(value);
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/IdentifiedDataSerializableWrapper.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/IdentifiedDataSerializableWrapper.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.hazelcast.client;
+
+import java.io.IOException;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public class IdentifiedDataSerializableWrapper implements IdentifiedDataSerializable {
+    private String value;
+
+    public IdentifiedDataSerializableWrapper() {
+    }
+
+    public IdentifiedDataSerializableWrapper(String value) {
+        this.value = value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        value = in.readUTF();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(value);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return 42;
+    }
+
+    @Override
+    public int getClassId() {
+        return 42;
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/IdentifiedDataSerializableWrapperFactory.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/IdentifiedDataSerializableWrapperFactory.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.hazelcast.client;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+class IdentifiedDataSerializableWrapperFactory implements com.hazelcast.nio.serialization.DataSerializableFactory {
+    @Override
+    public IdentifiedDataSerializable create(int typeId) {
+        if (typeId == 42) {
+            return new IdentifiedDataSerializableWrapper();
+        }
+
+        throw new IllegalArgumentException(typeId + " unknown");
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/PortableWrapper.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/PortableWrapper.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.hazelcast.client;
+
+import java.io.IOException;
+
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+
+public class PortableWrapper implements Portable {
+    final static int ID = 5;
+
+    private String value;
+
+    public PortableWrapper() {
+    }
+
+    public PortableWrapper(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return 1;
+    }
+
+    @Override
+    public int getClassId() {
+        return ID;
+    }
+
+    @Override
+    public void writePortable(PortableWriter writer) throws IOException {
+        writer.writeUTF("value", value);
+    }
+
+    @Override
+    public void readPortable(PortableReader reader) throws IOException {
+        value = reader.readUTF("value");
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/PortableWrapperFactory.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/PortableWrapperFactory.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.hazelcast.client;
+
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+
+class PortableWrapperFactory implements PortableFactory {
+    @Override
+    public Portable create(int classId) {
+        if (PortableWrapper.ID == classId) {
+            return new PortableWrapper();
+        } else {
+            return null;
+        }
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/RootResource.java
+++ b/integration-tests/hazelcast-client/src/main/java/io/quarkus/it/hazelcast/client/RootResource.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.hazelcast.client;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+import com.hazelcast.core.HazelcastInstance;
+
+@Path("/hazelcast-client")
+public class RootResource {
+
+    @Inject
+    HazelcastInstance hazelcastInstance;
+
+    @POST
+    @Path("/ds/put")
+    @Produces(MediaType.APPLICATION_JSON)
+    public void ds_put(@QueryParam("key") String key, @QueryParam("value") String value) {
+        DataSerializableWrapper dataSerializableWrapper = new DataSerializableWrapper();
+        dataSerializableWrapper.setValue(value);
+        hazelcastInstance.getMap("ds_map").put(key, dataSerializableWrapper);
+    }
+
+    @GET
+    @Path("/ds/get")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String ds_get(@QueryParam("key") String key) {
+        return hazelcastInstance.<String, DataSerializableWrapper> getMap("ds_map")
+                .getOrDefault(key, new DataSerializableWrapper("default")).getValue();
+    }
+
+    @POST
+    @Path("/ids/put")
+    @Produces(MediaType.APPLICATION_JSON)
+    public void ids_put(@QueryParam("key") String key, @QueryParam("value") String value) {
+        IdentifiedDataSerializableWrapper dataSerializableWrapper = new IdentifiedDataSerializableWrapper();
+        dataSerializableWrapper.setValue(value);
+        hazelcastInstance.getMap("ids_map").put(key, dataSerializableWrapper);
+    }
+
+    @GET
+    @Path("/ids/get")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String ids_get(@QueryParam("key") String key) {
+        return hazelcastInstance.<String, IdentifiedDataSerializableWrapper> getMap("ids_map")
+                .getOrDefault(key, new IdentifiedDataSerializableWrapper("default")).getValue();
+    }
+
+    @POST
+    @Path("/ptable/put")
+    @Produces(MediaType.APPLICATION_JSON)
+    public void ptable_put(@QueryParam("key") String key, @QueryParam("value") String value) {
+        PortableWrapper portable = new PortableWrapper("value1");
+        portable.setValue(value);
+        hazelcastInstance.getMap("ptable_map").put(key, portable);
+    }
+
+    @GET
+    @Path("/ptable/get")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String ptable_put_get(@QueryParam("key") String key) {
+        return hazelcastInstance.<String, PortableWrapper> getMap("ptable_map")
+                .getOrDefault(key, new PortableWrapper("default")).getValue();
+    }
+}

--- a/integration-tests/hazelcast-client/src/main/resources/hazelcast-client.yaml
+++ b/integration-tests/hazelcast-client/src/main/resources/hazelcast-client.yaml
@@ -1,0 +1,46 @@
+hazelcast-client:
+  network:
+    cluster-members:
+      - 127.0.0.1
+    outbound-ports:
+      - 34600
+      - 34700-34710
+    smart-routing: false
+    redo-operation: true
+    connection-timeout: 60000
+    socket-options:
+      tcp-no-delay: false
+      keep-alive: true
+      reuse-address: true
+      linger-seconds: 3
+      buffer-size: 128
+
+  config-replacers:
+    fail-if-value-missing: false
+    replacers:
+      - class-name: com.hazelcast.config.replacer.EncryptionReplacer
+        properties:
+          passwordFile: password
+          passwordUserProperties: false
+          cipherAlgorithm: DES
+          keyLengthBits: 64
+          secretKeyAlgorithm: DES
+          secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
+
+  discovery-strategies:
+    node-filter:
+      class: io.quarkus.it.hazelcast.client.CustomNodeFilter
+
+  serialization:
+    portable-version: 3
+    use-native-byte-order: true
+    byte-order: BIG_ENDIAN
+    enable-compression: false
+    enable-shared-object: true
+    allow-unsafe: false
+    data-serializable-factories:
+      - factory-id: 42
+        class-name: io.quarkus.it.hazelcast.client.IdentifiedDataSerializableWrapperFactory
+    portable-factories:
+      - factory-id: 1
+        class-name: io.quarkus.it.hazelcast.client.PortableWrapperFactory

--- a/integration-tests/hazelcast-client/src/test/java/io/quarkus/it/hazelcast/client/HazelcastClientFunctionalityInGraalITCase.java
+++ b/integration-tests/hazelcast-client/src/test/java/io/quarkus/it/hazelcast/client/HazelcastClientFunctionalityInGraalITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.hazelcast.client;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class HazelcastClientFunctionalityInGraalITCase extends HazelcastClientFunctionalityTest {
+}

--- a/integration-tests/hazelcast-client/src/test/java/io/quarkus/it/hazelcast/client/HazelcastClientFunctionalityTest.java
+++ b/integration-tests/hazelcast-client/src/test/java/io/quarkus/it/hazelcast/client/HazelcastClientFunctionalityTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.it.hazelcast.client;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.hazelcast.HazelcastServerTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@QuarkusTestResource(HazelcastServerTestResource.class)
+public class HazelcastClientFunctionalityTest {
+
+    @Test
+    public void shouldReadFromDistributedMap() {
+        RestAssured
+                .when().get("/hazelcast-client/ds/get?key=nonexisting")
+                .then().body(is("default"));
+    }
+
+    @Test
+    public void shouldWriteDataSerializableToDistributedMap() {
+        RestAssured
+                .when().post("/hazelcast-client/ds/put?key=foo&value=foo_value")
+                .thenReturn();
+
+        RestAssured
+                .when().get("/hazelcast-client/ds/get?key=foo")
+                .then().body(is("foo_value"));
+    }
+
+    @Test
+    public void shouldWriteIdentifiedDataSerializableToDistributedMap() {
+        RestAssured
+                .when().post("/hazelcast-client/ids/put?key=foo&value=foo_value")
+                .thenReturn();
+
+        RestAssured
+                .when().get("/hazelcast-client/ids/get?key=foo")
+                .then().body(is("foo_value"));
+    }
+
+    @Test
+    public void shouldWritePortableToDistributedMap() {
+        RestAssured
+                .when().post("/hazelcast-client/ptable/put?key=foo&value=foo_value")
+                .thenReturn();
+
+        RestAssured
+                .when().get("/hazelcast-client/ptable/get?key=foo")
+                .then().body(is("foo_value"));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -25,6 +25,7 @@
         <module>shared-library</module>
         <module>hibernate-validator</module>
         <module>common-jpa-entities</module>
+        <module>hazelcast-client</module>
         <module>infinispan-client</module>
         <module>infinispan-embedded</module>
         <module>main</module>

--- a/test-framework/hazelcast/pom.xml
+++ b/test-framework/hazelcast/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-test-hazelcast</artifactId>
+    <name>Quarkus - Test Framework - Hazelcast Support</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/hazelcast/src/main/java/io/quarkus/test/hazelcast/HazelcastServerTestResource.java
+++ b/test-framework/hazelcast/src/main/java/io/quarkus/test/hazelcast/HazelcastServerTestResource.java
@@ -1,0 +1,27 @@
+package io.quarkus.test.hazelcast;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class HazelcastServerTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private volatile HazelcastInstance member;
+
+    @Override
+    public Map<String, String> start() {
+        member = Hazelcast.newHazelcastInstance();
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        if (member != null) {
+            member.shutdown();
+        }
+    }
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -18,6 +18,7 @@
         <module>common</module>
         <module>h2</module>
         <module>derby</module>
+        <module>hazelcast</module>
         <module>kubernetes-client</module>
         <module>junit5-internal</module>
         <module>junit5</module>


### PR DESCRIPTION
Hi!

I prepared the initial version of the `hazelcast-client` extension. 

Design-wise, we need to resolve and parse configuration files at runtime in order to maintain environment independence. We could push most of it to build-time gaining a few milliseconds, but we'd need to rebuild the native image for each environment.

Please review and advise.

----
Related: https://github.com/quarkusio/quarkus/pull/6792
