### PR TITLE
Remove configuration related code that is no longer used

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -20,7 +20,6 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.eclipse.microprofile.config.spi.Converter;
 import org.objectweb.asm.Opcodes;
 import org.wildfly.common.Assert;
@@ -138,8 +137,6 @@ public final class RunTimeConfigurationGenerator {
             IntFunction.class);
     static final MethodDescriptor CU_CONFIG_BUILDER = MethodDescriptor.ofMethod(ConfigUtils.class, "configBuilder",
             SmallRyeConfigBuilder.class, boolean.class);
-    static final MethodDescriptor CU_ADD_SOURCE_PROVIDER = MethodDescriptor.ofMethod(ConfigUtils.class, "addSourceProvider",
-            void.class, SmallRyeConfigBuilder.class, ConfigSourceProvider.class);
 
     static final MethodDescriptor HM_NEW = MethodDescriptor.ofConstructor(HashMap.class);
     static final MethodDescriptor HM_PUT = MethodDescriptor.ofMethod(HashMap.class, "put", Object.class, Object.class,
@@ -376,10 +373,6 @@ public final class RunTimeConfigurationGenerator {
 
             // create the run time config
             final ResultHandle runTimeBuilder = readConfig.invokeStaticMethod(CU_CONFIG_BUILDER, readConfig.load(true));
-
-            // add in our run time only config source provider
-            readConfig.invokeStaticMethod(CU_ADD_SOURCE_PROVIDER, runTimeBuilder, readConfig.newInstance(
-                    MethodDescriptor.ofConstructor("io.quarkus.runtime.generated.ConfigSourceProviderImpl")));
 
             // create the map for run time specified values config source
             final ResultHandle specifiedRunTimeValues = clinit.newInstance(HM_NEW);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigBuildSteps.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigBuildSteps.java
@@ -3,7 +3,6 @@ package io.quarkus.deployment.steps;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -12,60 +11,18 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.eclipse.microprofile.config.spi.Converter;
 
-import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DeploymentClassLoaderBuildItem;
-import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.deployment.builditem.RunTimeConfigurationSourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
-import io.quarkus.gizmo.ClassCreator;
-import io.quarkus.gizmo.ClassOutput;
-import io.quarkus.gizmo.MethodCreator;
-import io.quarkus.gizmo.MethodDescriptor;
-import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.graal.InetRunTime;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
 class ConfigBuildSteps {
 
-    static final String PROVIDER_CLASS_NAME = "io.quarkus.runtime.generated.ConfigSourceProviderImpl";
-
     static final String SERVICES_PREFIX = "META-INF/services/";
-
-    @BuildStep
-    void generateConfigSources(List<RunTimeConfigurationSourceBuildItem> runTimeSources,
-            final BuildProducer<GeneratedClassBuildItem> generatedClass) {
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
-
-        try (ClassCreator cc = ClassCreator.builder().interfaces(ConfigSourceProvider.class).setFinal(true)
-                .className(PROVIDER_CLASS_NAME)
-                .classOutput(classOutput).build()) {
-            try (MethodCreator mc = cc.getMethodCreator(MethodDescriptor.ofMethod(ConfigSourceProvider.class,
-                    "getConfigSources", Iterable.class, ClassLoader.class))) {
-
-                final ResultHandle array = mc.newArray(ConfigSource.class, mc.load(runTimeSources.size()));
-                for (int i = 0; i < runTimeSources.size(); i++) {
-                    final RunTimeConfigurationSourceBuildItem runTimeSource = runTimeSources.get(i);
-                    final String className = runTimeSource.getClassName();
-                    final OptionalInt priority = runTimeSource.getPriority();
-                    ResultHandle value;
-                    if (priority.isPresent()) {
-                        value = mc.newInstance(MethodDescriptor.ofConstructor(className, int.class),
-                                mc.load(priority.getAsInt()));
-                    } else {
-                        value = mc.newInstance(MethodDescriptor.ofConstructor(className));
-                    }
-                    mc.writeArrayValue(array, i, value);
-                }
-                final ResultHandle list = mc.invokeStaticMethod(
-                        MethodDescriptor.ofMethod(Arrays.class, "asList", List.class, Object[].class), array);
-                mc.returnValue(list);
-            }
-        }
-    }
 
     // XXX replace this with constant-folded service loader impl
     @BuildStep

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -14,7 +14,6 @@ import java.util.function.IntFunction;
 import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 
 import io.smallrye.config.PropertiesConfigSourceProvider;
 import io.smallrye.config.SmallRyeConfigBuilder;
@@ -71,19 +70,6 @@ public final class ConfigUtils {
         builder.addDiscoveredSources();
         builder.addDiscoveredConverters();
         return builder;
-    }
-
-    /**
-     * Add a configuration source provider to the builder.
-     *
-     * @param builder the builder
-     * @param provider the provider to add
-     */
-    public static void addSourceProvider(SmallRyeConfigBuilder builder, ConfigSourceProvider provider) {
-        final Iterable<ConfigSource> sources = provider.getConfigSources(Thread.currentThread().getContextClassLoader());
-        for (ConfigSource source : sources) {
-            builder.withSources(source);
-        }
     }
 
     static final class EnvConfigSource implements ConfigSource {


### PR DESCRIPTION
This stuff see to be left over from the previous iteration of the Configuration support and resulted in the generation of a `io.quarkus.runtime.generated.ConfigSourceProviderImpl` class that always returned an empty array

