### PR TITLE
Fix FaultTolerance perf issue related to the creation of FaultToleranceOperation

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -1,14 +1,11 @@
 package io.quarkus.smallrye.faulttolerance.deployment;
 
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.Set;
 
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.eclipse.microprofile.config.Config;
@@ -25,15 +22,19 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
+import io.quarkus.arc.processor.AnnotationStore;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanInfo;
+import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -60,14 +61,15 @@ import io.smallrye.faulttolerance.propagation.ContextPropagationExecutorFactory;
 
 public class SmallRyeFaultToleranceProcessor {
 
-    @Inject
-    BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
-
-    @Inject
-    BuildProducer<NativeImageSystemPropertyBuildItem> nativeImageSystemProperty;
-
-    @Inject
-    CombinedIndexBuildItem combinedIndexBuildItem;
+    private static final Set<DotName> FT_ANNOTATIONS = new HashSet<>();
+    static {
+        FT_ANNOTATIONS.add(DotName.createSimple(Asynchronous.class.getName()));
+        FT_ANNOTATIONS.add(DotName.createSimple(Bulkhead.class.getName()));
+        FT_ANNOTATIONS.add(DotName.createSimple(CircuitBreaker.class.getName()));
+        FT_ANNOTATIONS.add(DotName.createSimple(Fallback.class.getName()));
+        FT_ANNOTATIONS.add(DotName.createSimple(Retry.class.getName()));
+        FT_ANNOTATIONS.add(DotName.createSimple(Timeout.class.getName()));
+    }
 
     @BuildStep
     public void build(BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer,
@@ -75,20 +77,15 @@ public class SmallRyeFaultToleranceProcessor {
             BuildProducer<ServiceProviderBuildItem> serviceProvider,
             BuildProducer<BeanDefiningAnnotationBuildItem> additionalBda,
             Capabilities capabilities,
-            BuildProducer<SystemPropertyBuildItem> systemProperty) {
+            BuildProducer<SystemPropertyBuildItem> systemProperty,
+            CombinedIndexBuildItem combinedIndexBuildItem,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<NativeImageSystemPropertyBuildItem> nativeImageSystemProperty) {
 
         feature.produce(new FeatureBuildItem(FeatureBuildItem.SMALLRYE_FAULT_TOLERANCE));
 
         serviceProvider.produce(new ServiceProviderBuildItem(ExecutorFactory.class.getName(),
                 ContextPropagationExecutorFactory.class.getName()));
-
-        Set<DotName> ftAnnotations = new HashSet<>();
-        ftAnnotations.add(DotName.createSimple(Asynchronous.class.getName()));
-        ftAnnotations.add(DotName.createSimple(Bulkhead.class.getName()));
-        ftAnnotations.add(DotName.createSimple(CircuitBreaker.class.getName()));
-        ftAnnotations.add(DotName.createSimple(Fallback.class.getName()));
-        ftAnnotations.add(DotName.createSimple(Retry.class.getName()));
-        ftAnnotations.add(DotName.createSimple(Timeout.class.getName()));
 
         IndexView index = combinedIndexBuildItem.getIndex();
 
@@ -111,7 +108,7 @@ public class SmallRyeFaultToleranceProcessor {
             additionalBean.produce(fallbackHandlersBeans.build());
         }
 
-        for (DotName annotation : ftAnnotations) {
+        for (DotName annotation : FT_ANNOTATIONS) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, annotation.toString()));
             // also make them bean defining annotations
             additionalBda.produce(new BeanDefiningAnnotationBuildItem(annotation));
@@ -126,7 +123,7 @@ public class SmallRyeFaultToleranceProcessor {
 
             @Override
             public void transform(TransformationContext context) {
-                if (ftAnnotations.contains(context.getTarget().asClass().name())) {
+                if (FT_ANNOTATIONS.contains(context.getTarget().asClass().name())) {
                     context.transform().add(FaultToleranceBinding.class).done();
                 }
             }
@@ -136,7 +133,7 @@ public class SmallRyeFaultToleranceProcessor {
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder();
         // Also register MP FT annotations so that they are recognized as interceptor bindings
         // Note that MP FT API jar is nor indexed, nor contains beans.xml so it is not part of the app index
-        for (DotName ftAnnotation : ftAnnotations) {
+        for (DotName ftAnnotation : FT_ANNOTATIONS) {
             builder.addBeanClass(ftAnnotation.toString());
         }
         builder.addBeanClasses(FaultToleranceInterceptor.class,
@@ -187,13 +184,43 @@ public class SmallRyeFaultToleranceProcessor {
     @BuildStep
     // needs to be RUNTIME_INIT because we need to read MP Config
     @Record(ExecutionTime.RUNTIME_INIT)
-    void validateFaultToleranceAnnotations(
-            ValidationPhaseBuildItem validationPhase, SmallryeFaultToleranceRecorder recorder) {
-        List<String> beanNames = new ArrayList<>();
-        for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
-            beanNames.add(bean.getBeanClass().toString());
+    void validateFaultToleranceAnnotations(SmallryeFaultToleranceRecorder recorder,
+            ValidationPhaseBuildItem validationPhase,
+            BeanArchiveIndexBuildItem beanArchiveIndexBuildItem) {
+        AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
+        Set<String> beanNames = new HashSet<>();
+        IndexView index = beanArchiveIndexBuildItem.getIndex();
+
+        for (BeanInfo info : validationPhase.getContext().beans()) {
+            if (hasFTAnnotations(index, annotationStore, info.getImplClazz())) {
+                beanNames.add(info.getBeanClass().toString());
+            }
         }
-        recorder.validate(beanNames);
+
+        recorder.createFaultToleranceOperation(beanNames);
+    }
+
+    private boolean hasFTAnnotations(IndexView index, AnnotationStore annotationStore, ClassInfo info) {
+        // first check annotations on type
+        if (annotationStore.hasAnyAnnotation(info, FT_ANNOTATIONS)) {
+            return true;
+        }
+
+        // then check on the methods
+        for (MethodInfo method : info.methods()) {
+            if (annotationStore.hasAnyAnnotation(method, FT_ANNOTATIONS)) {
+                return true;
+            }
+        }
+
+        // then check on the parent
+        DotName parentClassName = info.superName();
+        ClassInfo parentClassInfo = index.getClassByName(parentClassName);
+        if (parentClassName.equals(DotNames.OBJECT) || parentClassInfo == null) {
+            return false; //no more parents
+        }
+
+        return hasFTAnnotations(index, annotationStore, parentClassInfo);
     }
 
     @BuildStep

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFaultToleranceOperationProvider.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFaultToleranceOperationProvider.java
@@ -1,22 +1,80 @@
 package io.quarkus.smallrye.faulttolerance.runtime;
 
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import javax.annotation.Priority;
-import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Alternative;
+import javax.inject.Singleton;
+
+import org.jboss.logging.Logger;
 
 import io.smallrye.faulttolerance.FaultToleranceOperationProvider;
 import io.smallrye.faulttolerance.config.FaultToleranceOperation;
 
-@Dependent
+@Singleton
 @Alternative
 @Priority(1)
 public class QuarkusFaultToleranceOperationProvider implements FaultToleranceOperationProvider {
+    private static final Logger LOG = Logger.getLogger(QuarkusFaultToleranceOperationProvider.class);
+
+    private final Map<CacheKey, FaultToleranceOperation> operationCache = new ConcurrentHashMap<>();
+    private final Function<CacheKey, FaultToleranceOperation> cacheFunction = new Function<CacheKey, FaultToleranceOperation>() {
+        @Override
+        public FaultToleranceOperation apply(CacheKey key) {
+            return createAtRuntime(key);
+        }
+    };
+
+    /**
+     * Called by SmallryeFaultToleranceRecorder to init the operation cache.
+     */
+    void init(Map<CacheKey, FaultToleranceOperation> operationCache) {
+        this.operationCache.putAll(operationCache);
+    }
 
     @Override
     public FaultToleranceOperation get(Class<?> beanClass, Method method) {
-        return FaultToleranceOperation.of(beanClass, method);
+        CacheKey key = new CacheKey(beanClass, method);
+        FaultToleranceOperation existing = operationCache.get(key);
+        return existing != null ? existing : operationCache.computeIfAbsent(key, cacheFunction);
     }
 
+    private FaultToleranceOperation createAtRuntime(CacheKey key) {
+        LOG.debugf("FaultToleranceOperation not found in the cache for %s creating it at runtime", key);
+        return FaultToleranceOperation.of(key.beanClass, key.method);
+    }
+
+    static class CacheKey {
+        private Class<?> beanClass;
+        private Method method;
+        private int hashCode;
+
+        public CacheKey(Class<?> beanClass, Method method) {
+            this.beanClass = beanClass;
+            this.method = method;
+            this.hashCode = Objects.hash(beanClass, method);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(beanClass, cacheKey.beanClass) &&
+                    Objects.equals(method, cacheKey.method);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.hashCode;
+        }
+    }
 }

--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/VertxWebProcessor.java
@@ -119,43 +119,41 @@ class VertxWebProcessor {
         // Collect all business methods annotated with @Route and @RouteFilter
         AnnotationStore annotationStore = validationPhase.getContext().get(BuildExtension.Key.ANNOTATION_STORE);
         for (BeanInfo bean : validationPhase.getContext().beans().classBeans()) {
-            if (bean.isClassBean()) {
-                // NOTE: inherited business methods are not taken into account
-                ClassInfo beanClass = bean.getTarget().get().asClass();
-                AnnotationInstance routeBaseAnnotation = beanClass.classAnnotation(ROUTE_BASE);
-                for (MethodInfo method : beanClass.methods()) {
-                    List<AnnotationInstance> routes = new LinkedList<>();
-                    AnnotationInstance routeAnnotation = annotationStore.getAnnotation(method, ROUTE);
-                    if (routeAnnotation != null) {
+            // NOTE: inherited business methods are not taken into account
+            ClassInfo beanClass = bean.getTarget().get().asClass();
+            AnnotationInstance routeBaseAnnotation = beanClass.classAnnotation(ROUTE_BASE);
+            for (MethodInfo method : beanClass.methods()) {
+                List<AnnotationInstance> routes = new LinkedList<>();
+                AnnotationInstance routeAnnotation = annotationStore.getAnnotation(method, ROUTE);
+                if (routeAnnotation != null) {
+                    validateRouteMethod(bean, method, ROUTE_PARAM_TYPES);
+                    routes.add(routeAnnotation);
+                }
+                if (routes.isEmpty()) {
+                    AnnotationInstance routesAnnotation = annotationStore.getAnnotation(method, ROUTES);
+                    if (routesAnnotation != null) {
                         validateRouteMethod(bean, method, ROUTE_PARAM_TYPES);
-                        routes.add(routeAnnotation);
+                        Collections.addAll(routes, routesAnnotation.value().asNestedArray());
                     }
-                    if (routes.isEmpty()) {
-                        AnnotationInstance routesAnnotation = annotationStore.getAnnotation(method, ROUTES);
-                        if (routesAnnotation != null) {
-                            validateRouteMethod(bean, method, ROUTE_PARAM_TYPES);
-                            Collections.addAll(routes, routesAnnotation.value().asNestedArray());
-                        }
-                    }
+                }
+                if (!routes.isEmpty()) {
+                    LOGGER.debugf("Found route handler business method %s declared on %s", method, bean);
+                    routeHandlerBusinessMethods
+                            .produce(new AnnotatedRouteHandlerBuildItem(bean, method, routes, routeBaseAnnotation));
+                }
+                //
+                AnnotationInstance filterAnnotation = annotationStore.getAnnotation(method, ROUTE_FILTER);
+                if (filterAnnotation != null) {
                     if (!routes.isEmpty()) {
-                        LOGGER.debugf("Found route handler business method %s declared on %s", method, bean);
-                        routeHandlerBusinessMethods
-                                .produce(new AnnotatedRouteHandlerBuildItem(bean, method, routes, routeBaseAnnotation));
-                    }
-                    // 
-                    AnnotationInstance filterAnnotation = annotationStore.getAnnotation(method, ROUTE_FILTER);
-                    if (filterAnnotation != null) {
-                        if (!routes.isEmpty()) {
-                            errors.produce(new ValidationErrorBuildItem(new IllegalStateException(
-                                    String.format(
-                                            "@Route and @RouteFilter cannot be declared on business method %s declared on %s",
-                                            method, bean))));
-                        } else {
-                            validateRouteMethod(bean, method, ROUTE_FILTER_TYPES);
-                            routeFilterBusinessMethods
-                                    .produce(new AnnotatedRouteFilterBuildItem(bean, method, filterAnnotation));
-                            LOGGER.debugf("Found route filter business method %s declared on %s", method, bean);
-                        }
+                        errors.produce(new ValidationErrorBuildItem(new IllegalStateException(
+                                String.format(
+                                        "@Route and @RouteFilter cannot be declared on business method %s declared on %s",
+                                        method, bean))));
+                    } else {
+                        validateRouteMethod(bean, method, ROUTE_FILTER_TYPES);
+                        routeFilterBusinessMethods
+                                .produce(new AnnotatedRouteFilterBuildItem(bean, method, filterAnnotation));
+                        LOGGER.debugf("Found route filter business method %s declared on %s", method, bean);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #6761

Still a draft PR as I want some feedback on the implementation before polishing it (if needed).

As discuss on the mailing list and on the issue, there is some performance issue as currently the `FaultToleranceOperation` is re-created on each request.

The first commit address this issue by using a cache that is filled at `RUNTIME_INIT` by the recorder. It works except for FT annotations on interfaces (like the one on RestClient interfaces). So there is a fallback that create it on the fly. If we only keep this change we need to store inside the cache the `FaultToleranceOperation` created on the fly to fix the issue correctly.

I made a second change when I discover that the recorder load all bean classes to analyse them for FT annotations. I restrict the list of bean classes to analyse using Jandex indexes and it improve a lot the performance of scanning the classpath for FT annotations. On the main integration test, the time to `validate` the annotations drop from 200ms to 7ms => improvement of 20x at runtime !

If we keep the second commit, we will also create `FaultToleranceOperation` for RestClient interfaces correctly at `RUNTIME_INIT` by the recorder as Jandex indexe interfaces.

@Ladicek @mkouba @michalszynkiewicz WDYT ?