### PR TITLE
Fix type issue with report script in cron CI job

### DIFF
--- a/.github/NativeBuildReport.kts
+++ b/.github/NativeBuildReport.kts
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 val token = args[0]; 
 val status = args[1];
-val issueNumber = args[2];
+val issueNumber = args[2].toInt();
 
 val REPO = "quarkusio/quarkus"
 


### PR DESCRIPTION
Fixes the following error seen in CI:

```
 [kscript] [ERROR] compilation of '.github/NativeBuildReport.kts' failed
.github/NativeBuildReport.kts:30:33: error: type mismatch: inferred type is String but Int was expected
val issue = repository.getIssue(issueNumber)
```