### PR TITLE
Fix a missing closing tag in Qute documentation

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -413,6 +413,7 @@ These sections can be used to include another template and possibly override som
     <div>
       My body.
     </div>
+  {/body}
 {/include}
 ----
 <1> `include` section is used to specify the extended template.


### PR DESCRIPTION
Fixes #6774

Add a closing ‘body’ tag that was missing in the ascii doc related to Qute template.