### PR TITLE
Add area/cache auto-labelling

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -75,6 +75,9 @@ labelPRBasedOnFilePath:
         - extensions/artemis-jms/**/*
         - integration-tests/artemis-core/**/*
         - integration-tests/artemis-jms/**/*
+    area/cache:
+        - extensions/cache/**/*
+        - integration-tests/cache/**/*
     area/config:
         - extensions/config-yaml/**/*
         - core/deployment/src/main/java/io/quarkus/deployment/configuration/**/*


### PR DESCRIPTION
I created the `area/cache` label for the `quarkus-cache` extension.

This PR is also needed to enable auto-labelling.