### PR TITLE
Revert "Work around an issue in vertx where getting remote/client SocketAddress of the request leads to a NPE"

### DIFF
--- a/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/LazyHostSupplier.java
+++ b/extensions/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/LazyHostSupplier.java
@@ -2,13 +2,10 @@ package io.quarkus.resteasy.runtime.standalone;
 
 import java.util.Objects;
 
-import org.jboss.logging.Logger;
-
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
 
 final class LazyHostSupplier {
-    private static final Logger logger = Logger.getLogger(LazyHostSupplier.class.getName());
 
     private final HttpServerRequest request;
     private String remoteHost = null;
@@ -23,17 +20,7 @@ final class LazyHostSupplier {
         if (initialized) {
             return this.remoteHost;
         } else {
-            SocketAddress socketAddress = null;
-            try {
-                socketAddress = request.remoteAddress();
-            } catch (NullPointerException npe) {
-                // ideally there shouldn't be an exception for this call.
-                // This is just to workaround a current issue in vertx
-                // https://github.com/quarkusio/quarkus/issues/5247
-                // https://github.com/eclipse-vertx/vert.x/issues/3181
-                // TODO: remove this workaround once vertx issue is resolved
-                logger.debug("Ignoring exception that occurred when obtaining remote address of request " + request, npe);
-            }
+            SocketAddress socketAddress = request.remoteAddress();
             // client address may not be available with VirtualHttp;
             this.remoteHost = socketAddress != null ? socketAddress.host() : null;
             initialized = true;


### PR DESCRIPTION
Reverts quarkusio/quarkus#5250

The issue has been fixed in Vertx 3.8.5, the workaround is not required anymore as par @cescoffier here https://github.com/quarkusio/quarkus/pull/5250#discussion_r371130706

/cc @cescoffier 