### PR TITLE
Better support for reactive-messaging builds on Java11

### DIFF
--- a/independent-projects/bootstrap/core/pom.xml
+++ b/independent-projects/bootstrap/core/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>asm</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
         </dependency>


### PR DESCRIPTION
Related to #4767

The `quarkus-bootstrap-core` project depends transitively on an older
version of `commons-lang3`, which doesn't work with Java 11 when using
the `smallrye-reactive-messaging` extension. This change causes the
`quarkus-bootstrap-core` project to use the version of `commons-lang3`
that is already managed by the parent project (i.e. version 3.9)