### PR TITLE
Extensions/jdbc/mariadb: fix new Options class path registered for reflection

### DIFF
--- a/extensions/jdbc/jdbc-mariadb/deployment/src/main/java/io/quarkus/jdbc/mariadb/deployment/MariaDBJDBCReflections.java
+++ b/extensions/jdbc/jdbc-mariadb/deployment/src/main/java/io/quarkus/jdbc/mariadb/deployment/MariaDBJDBCReflections.java
@@ -16,7 +16,7 @@ public final class MariaDBJDBCReflections {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
 
         //MariaDB's connection process requires reflective read to all fields of Options:
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, "org.mariadb.jdbc.internal.util.Options"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, "org.mariadb.jdbc.util.Options"));
     }
 
     @BuildStep


### PR DESCRIPTION
org.mariadb.jdbc.internal.util.Options changed to org.mariadb.jdbc.util.Options in mariadb-java-client version 2.5.2

Fix #6501 