### PR TITLE
Try another fix to the Java 11 cron ci job

### DIFF
--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -66,6 +66,7 @@ jobs:
           # we need to install Java 8 because kscript doesn't yet work with Java 11: https://github.com/holgerbrandl/kscript/issues/239
           if [[ ${JAVA_VERSION} = 11 ]]; then
             echo "y" | sdk install java 8.0.232-open
+            export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
           fi
 
           sdk install kscript 2.9.0


### PR DESCRIPTION
`kscript` was still failing even when Java 8 was installed via `sdkman` for the Java 11.
Hopefully this change will force Java 8