### PR TITLE
Make tests more stable by using LinkedHashSet for deterministic iterations

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/CompilerFlags.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/CompilerFlags.java
@@ -2,7 +2,7 @@ package io.quarkus.dev;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -27,7 +27,7 @@ public class CompilerFlags {
             String sourceJavaVersion,
             String targetJavaVersion) {
 
-        this.defaultFlags = defaultFlags == null ? new HashSet<>() : new HashSet<>(defaultFlags);
+        this.defaultFlags = defaultFlags == null ? new LinkedHashSet<>() : new LinkedHashSet<>(defaultFlags);
         this.userFlags = userFlags == null ? new ArrayList<>() : new ArrayList<>(userFlags);
         this.sourceJavaVersion = sourceJavaVersion;
         this.targetJavaVersion = targetJavaVersion;
@@ -38,7 +38,7 @@ public class CompilerFlags {
 
         // The set of effective default flags is the set of default flags except the ones also
         // set by the user.  This ensures that we do not needlessly pass the default flags twice.
-        Set<String> effectiveDefaultFlags = new HashSet<>(this.defaultFlags);
+        Set<String> effectiveDefaultFlags = new LinkedHashSet<>(this.defaultFlags);
         effectiveDefaultFlags.removeAll(userFlags);
 
         flagList.addAll(effectiveDefaultFlags);

--- a/core/devmode/src/test/java/io/quarkus/dev/CompilerFlagsTest.java
+++ b/core/devmode/src/test/java/io/quarkus/dev/CompilerFlagsTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -85,7 +85,7 @@ public class CompilerFlagsTest {
     }
 
     private Set<String> setOf(String... strings) {
-        return new HashSet<>(Arrays.asList(strings));
+        return new LinkedHashSet<>(Arrays.asList(strings));
     }
 
 }


### PR DESCRIPTION
The tests `io.quarkus.dev.CompilerFlagsTest#redundancyReduction` and `io.quarkus.dev.CompilerFlagsTest#defaulting` compare a `HashSet `with a `List`,  but `HashSet` does not guarantee any specific order of entries. Thus, tests can fail due to a different iteration order.
This PR uses a `LinkedHashSet` to guarantee the iteration order.