### PR TITLE
Make sure TCCL is correct for outer test class

### DIFF
--- a/integration-tests/jsonb/src/test/java/io/quarkus/it/jsonb/JsonInStaticBlockTestCase.java
+++ b/integration-tests/jsonb/src/test/java/io/quarkus/it/jsonb/JsonInStaticBlockTestCase.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.jsonb;
+
+import javax.json.bind.spi.JsonbProvider;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class JsonInStaticBlockTestCase {
+    static {
+        JsonbProvider.provider().create();
+    }
+
+    @Test
+    void get() {
+
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -252,7 +252,14 @@ public class QuarkusTestExtension
         if (isNativeTest(extensionContext)) {
             return invocation.proceed();
         }
-        T result = invocation.proceed();
+        T result;
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(extensionContext.getRequiredTestClass().getClassLoader());
+            result = invocation.proceed();
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
         ExtensionState state = ensureStarted(extensionContext);
         initTestState(extensionContext, state);
         return result;


### PR DESCRIPTION
We still need to create an instance of the original test,
make sure the TCCL is correct to avoid problems