### PR TITLE
Limit memory usage in tests

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
@@ -18,7 +18,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.toolchain.ToolchainManager;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -49,28 +48,11 @@ public class RemoteDevMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.sourceDirectory}")
     private File sourceDir;
 
-    @Parameter(defaultValue = "${jvm.args}")
-    private String jvmArgs;
-
     @Parameter(defaultValue = "${session}")
     private MavenSession session;
 
-    @Parameter(defaultValue = "TRUE")
-    private boolean deleteDevJar;
-
     @Component
     private MavenVersionEnforcer mavenVersionEnforcer;
-
-    @Component
-    private ToolchainManager toolchainManager;
-
-    public ToolchainManager getToolchainManager() {
-        return toolchainManager;
-    }
-
-    public MavenSession getSession() {
-        return session;
-    }
 
     @Override
     public void execute() throws MojoFailureException, MojoExecutionException {

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
@@ -46,6 +46,12 @@ public class RunAndCheckMojoTestBase extends MojoTestBase {
             // if no explicit debug options have been specified, let's just disable debugging
             args.add("-Ddebug=false");
         }
+
+        //we need to limit the memory consumption, as we can have a lot of these processes
+        //running at once, if they add default to 75% of total mem we can easily run out
+        //of physical memory as they will consume way more than what they need instead of
+        //just running GC
+        args.add("-Djvm.args=-Xmx128m");
         running.execute(args, Collections.emptyMap());
     }
 

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/verifier/RunningInvoker.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/verifier/RunningInvoker.java
@@ -118,6 +118,12 @@ public class RunningInvoker extends MavenProcessInvoker {
 
         if (System.getProperty("mavenOpts") != null) {
             request.setMavenOpts(System.getProperty("mavenOpts"));
+        } else {
+            //we need to limit the memory consumption, as we can have a lot of these processes
+            //running at once, if they add default to 75% of total mem we can easily run out
+            //of physical memory as they will consume way more than what they need instead of
+            //just running GC
+            request.setMavenOpts("-Xmx128m");
         }
 
         request.setShellEnvironmentInherited(true);


### PR DESCRIPTION
Tests can have lots of processes running at once,
if they all default to 75% of physical memory
we can run out, as processes can continue to allocate
instead of running GC