### PR TITLE
Do not build with GraalVM 19.3.1 JDK 8 in the periodic build

### DIFF
--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Pull docker image
         run: docker pull quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }}
 
-      - name: Pull docker image
-        run: docker pull quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }}
-
       - name: Set up Java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        java: [ 8, 11 ]
+        java: [ 11 ]
     name: build-and-testing
     steps:
 


### PR DESCRIPTION
It's now the default build of the main CI so we can reduce the matrix.