### PR TITLE
exclude resteasy-cdi from quarkus rest client

### DIFF
--- a/extensions/rest-client/runtime/pom.xml
+++ b/extensions/rest-client/runtime/pom.xml
@@ -37,6 +37,10 @@
                         jboss-interceptors-api_1.2_spec
                     </artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-cdi</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
As discussed with @mkouba @asoldano and @manovotn, the dependency is not needed.