### PR TITLE
Introduce QuteContext synthetic bean

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanRegistrationPhaseBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanRegistrationPhaseBuildItem.java
@@ -12,6 +12,8 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 
 /**
+ * Bean registration phase can be used to register synthetic beans.
+ * <p>
  * An extension that needs to produce other build items during the "bean registration" phase should use this build item. The
  * build step should produce a {@link BeanConfiguratorBuildItem} or at least inject a {@link BuildProducer} for this build item,
  * otherwise it could be ignored or processed at the wrong time, e.g. after

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ContextRegistrationPhaseBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ContextRegistrationPhaseBuildItem.java
@@ -11,6 +11,8 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 
 /**
+ * Context registration phase can be used to register custom CDI contexts.
+ * <p>
  * An extension that needs to produce other build items during the "context registration" phase should use this build item. The
  * build step should produce a {@link ContextConfiguratorBuildItem} or at least inject a {@link BuildProducer} for this build
  * item, otherwise it could be ignored or processed at the wrong time, e.g. after

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ValidationPhaseBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ValidationPhaseBuildItem.java
@@ -10,6 +10,8 @@ import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 
 /**
+ * Validation phase can be used to validate the deployment.
+ * <p>
  * An extension that needs to produce other build items during the "validation" phase should use this build item. The
  * build step should produce a {@link ValidationErrorBuildItem} or at least inject a {@link BuildProducer} for this build
  * item, otherwise it could be ignored or processed at the wrong time, e.g. after

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkus.qute.deployment;
 
-import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import static java.util.stream.Collectors.toMap;
 
 import java.io.File;
@@ -44,10 +44,11 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
-import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
-import io.quarkus.arc.processor.BeanDeploymentValidator.ValidationContext;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.DotNames;
@@ -87,6 +88,7 @@ import io.quarkus.qute.runtime.BuiltinTemplateExtensions;
 import io.quarkus.qute.runtime.EngineProducer;
 import io.quarkus.qute.runtime.QuteConfig;
 import io.quarkus.qute.runtime.QuteRecorder;
+import io.quarkus.qute.runtime.QuteRecorder.QuteContext;
 import io.quarkus.qute.runtime.TemplateProducer;
 import io.quarkus.qute.runtime.VariantTemplateProducer;
 import io.quarkus.qute.rxjava.RxjavaPublisherFactory;
@@ -344,8 +346,9 @@ public class QuteProcessor {
             BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
             List<TemplateExtensionMethodBuildItem> templateExtensionMethods,
             List<TypeCheckExcludeBuildItem> excludes,
-            ValidationPhaseBuildItem validationPhase,
-            BuildProducer<ValidationErrorBuildItem> validationError,
+            BeanRegistrationPhaseBuildItem registrationPhase,
+            // This producer is needed to ensure the correct ordering, ie. this build step must be executed before the ArC validation step
+            BuildProducer<BeanConfiguratorBuildItem> configurators,
             BuildProducer<ImplicitValueResolverBuildItem> requiredClasses) {
 
         IndexView index = beanArchiveIndex.getIndex();
@@ -358,10 +361,11 @@ public class QuteProcessor {
         Set<Expression> injectExpressions = collectInjectExpressions(analysis);
 
         if (!injectExpressions.isEmpty()) {
-            ValidationContext context = validationPhase.getContext();
-
-            Map<String, BeanInfo> namedBeans = context.get(BuildExtension.Key.BEANS).stream()
-                    .filter(b -> b.getName() != null).collect(toMap(BeanInfo::getName, Function.identity()));
+            // IMPLEMENTATION NOTE: 
+            // We do not support injection of synthetic beans with names 
+            // Dependency on the ValidationPhaseBuildItem would result in a cycle in the build chain
+            Map<String, BeanInfo> namedBeans = registrationPhase.getContext().beans().withName()
+                    .collect(toMap(BeanInfo::getName, Function.identity()));
 
             Set<Expression> expressions = collectInjectExpressions(analysis);
             for (Expression expression : expressions) {
@@ -633,12 +637,10 @@ public class QuteProcessor {
     }
 
     @BuildStep
-    @Record(RUNTIME_INIT)
-    void initialize(QuteRecorder recorder, QuteConfig config,
+    @Record(value = STATIC_INIT)
+    void initialize(QuteConfig config, BuildProducer<SyntheticBeanBuildItem> syntheticBeans, QuteRecorder recorder,
             List<GeneratedValueResolverBuildItem> generatedValueResolvers, List<TemplatePathBuildItem> templatePaths,
-            Optional<TemplateVariantsBuildItem> templateVariants,
-            BeanContainerBuildItem beanContainer,
-            List<ServiceStartBuildItem> startedServices) {
+            Optional<TemplateVariantsBuildItem> templateVariants) {
 
         List<String> templates = new ArrayList<>();
         List<String> tags = new ArrayList<>();
@@ -651,19 +653,19 @@ public class QuteProcessor {
                 templates.add(templatePath.getPath());
             }
         }
-
-        recorder.initEngine(config, beanContainer.getValue(), generatedValueResolvers.stream()
-                .map(GeneratedValueResolverBuildItem::getClassName).collect(Collectors.toList()),
-                templates,
-                tags);
-
         Map<String, List<String>> variants;
         if (templateVariants.isPresent()) {
             variants = templateVariants.get().getVariants();
         } else {
             variants = Collections.emptyMap();
         }
-        recorder.initVariants(beanContainer.getValue(), variants);
+
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(QuteContext.class)
+                .supplier(recorder.createContext(config, generatedValueResolvers.stream()
+                        .map(GeneratedValueResolverBuildItem::getClassName).collect(Collectors.toList()), templates,
+                        tags, variants))
+                .done());
+        ;
     }
 
     private Type resolveType(AnnotationTarget member, Match match, IndexView index) {

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRecorder.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRecorder.java
@@ -2,22 +2,61 @@ package io.quarkus.qute.runtime;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
-import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class QuteRecorder {
 
-    public void initEngine(QuteConfig config, BeanContainer container, List<String> resolverClasses,
-            List<String> templatePaths, List<String> tags) {
-        EngineProducer producer = container.instance(EngineProducer.class);
-        producer.init(config, resolverClasses, templatePaths, tags);
+    public Supplier<Object> createContext(QuteConfig config, List<String> resolverClasses,
+            List<String> templatePaths, List<String> tags, Map<String, List<String>> variants) {
+        return new Supplier<Object>() {
+
+            @Override
+            public Object get() {
+                return new QuteContext() {
+
+                    @Override
+                    public List<String> getTemplatePaths() {
+                        return templatePaths;
+                    }
+
+                    @Override
+                    public List<String> getTags() {
+                        return tags;
+                    }
+
+                    @Override
+                    public List<String> getResolverClasses() {
+                        return resolverClasses;
+                    }
+
+                    @Override
+                    public QuteConfig getConfig() {
+                        return config;
+                    }
+
+                    @Override
+                    public Map<String, List<String>> getVariants() {
+                        return variants;
+                    }
+                };
+            }
+        };
     }
 
-    public void initVariants(BeanContainer container, Map<String, List<String>> variants) {
-        VariantTemplateProducer producer = container.instance(VariantTemplateProducer.class);
-        producer.init(variants);
+    public interface QuteContext {
+
+        QuteConfig getConfig();
+
+        List<String> getResolverClasses();
+
+        List<String> getTemplatePaths();
+
+        List<String> getTags();
+
+        Map<String, List<String>> getVariants();
     }
 
 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/VariantTemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/VariantTemplateProducer.java
@@ -21,6 +21,7 @@ import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.interceptor.Interceptor;
 
 import org.jboss.logging.Logger;
 import org.reactivestreams.Publisher;
@@ -33,7 +34,10 @@ import io.quarkus.qute.TemplateInstanceBase;
 import io.quarkus.qute.Variant;
 import io.quarkus.qute.api.ResourcePath;
 import io.quarkus.qute.api.VariantTemplate;
+import io.quarkus.qute.runtime.QuteRecorder.QuteContext;
+import io.quarkus.runtime.Startup;
 
+@Startup(Interceptor.Priority.PLATFORM_BEFORE)
 @Singleton
 public class VariantTemplateProducer {
 
@@ -44,19 +48,14 @@ public class VariantTemplateProducer {
 
     private Map<String, TemplateVariants> templateVariants;
 
-    void init(Map<String, List<String>> variants) {
-        if (templateVariants != null) {
-            LOGGER.warn("Qute VariantTemplateProducer already initialized!");
-            return;
-        }
-        LOGGER.debugf("Initializing VariantTemplateProducer: %s", templateVariants);
-
+    VariantTemplateProducer(QuteContext context) {
         Map<String, TemplateVariants> templateVariants = new HashMap<>();
-        for (Entry<String, List<String>> entry : variants.entrySet()) {
+        for (Entry<String, List<String>> entry : context.getVariants().entrySet()) {
             TemplateVariants var = new TemplateVariants(initVariants(entry.getKey(), entry.getValue()), entry.getKey());
             templateVariants.put(entry.getKey(), var);
         }
         this.templateVariants = Collections.unmodifiableMap(templateVariants);
+        LOGGER.debugf("Initializing Qute variant templates: %s", templateVariants);
     }
 
     @Typed(VariantTemplate.class)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanStream.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanStream.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jboss.jandex.DotName;
@@ -162,6 +163,16 @@ public final class BeanStream implements Iterable<BeanInfo> {
 
     /**
      * 
+     * @return the new stream of beans
+     * @see BeanInfo#getName()
+     */
+    public BeanStream withName() {
+        stream = stream.filter(bean -> bean.getName() != null);
+        return this;
+    }
+
+    /**
+     * 
      * @param id
      * @return an {@link Optional} with the matching bean, or an empty {@link Optional} if no such bean is found
      * @see BeanInfo#getIdentifier()
@@ -288,6 +299,18 @@ public final class BeanStream implements Iterable<BeanInfo> {
      */
     public Optional<BeanInfo> firstResult() {
         return stream.findFirst();
+    }
+
+    /**
+     * Terminal operation.
+     * 
+     * @param <R>
+     * @param <A>
+     * @param collector
+     * @return the collected result
+     */
+    public <R, A> R collect(Collector<BeanInfo, A, R> collector) {
+        return stream.collect(collector);
     }
 
 }


### PR DESCRIPTION
- this should replace the need for volatile fields declared on the bean class

TLDR> we use final fields, constructor injection and a synthetic bean whose instance is supplied by a recorder.

~The only downside of this approach I'm aware of is that you need to add `@Observes StartupEvent` to init the bean eagerly. We could probably introduce a new annotation like `@Startup`.~