### PR TITLE
Fix incorrect Maven dependencies in Kafka Reactive Messaging tutorial

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -413,13 +413,13 @@ NOTE: With JSON serialization correctly configured, you can also use `Publisher<
 
 === Serializing via JSON-B
 
-First, you need to include the `quarkus-jsonb` extension (if you already use the `quarkus-resteasy-jsonb` extension, this is not needed).
+First, you need to include the `quarkus-resteasy-jsonb` extension (if you already use the `quarkus-resteasy-jsonb` extension, this is not needed).
 
 [source, xml]
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-jsonb</artifactId>
+    <artifactId>quarkus-resteasy-jsonb</artifactId>
 </dependency>
 ----
 
@@ -464,13 +464,13 @@ Now, your Kafka messages will contain a JSON-B serialized representation of your
 
 === Serializing via Jackson
 
-First, you need to include the `quarkus-jackson` extension (if you already use the `quarkus-jackson-jsonb` extension, this is not needed).
+First, you need to include the `quarkus-resteasy-jackson` extension (if you already use the `quarkus-jackson-jsonb` extension, this is not needed).
 
 [source, xml]
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-jackson</artifactId>
+    <artifactId>quarkus-resteasy-jackson</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
See issue: https://github.com/quarkusio/quarkus/issues/6849
--- The JAX-RS resource doessnt work with Publisher<Fruit> as return value because the maven dependencies of the json bindings were wrong.