### PR TITLE
Fix duplicate dependencies issue in OpenTracing guide

### DIFF
--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -46,7 +46,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=opentracing-quickstart \
     -DclassName="org.acme.opentracing.TracedResource" \
     -Dpath="/hello" \
-    -Dextensions="opentracing"
+    -Dextensions="quarkus-smallrye-opentracing"
 cd opentracing-quickstart
 ----
 


### PR DESCRIPTION
Fixing duplicate extensions:

- quarkus-smallrye-opentracing
- camel-quarkus-opentracing