### PR TITLE
MP Config support for injection of all primitive types

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -157,19 +157,7 @@ public class ConfigBuildStep {
             return false;
         }
         if (type.kind() == Kind.PRIMITIVE) {
-            switch (type.asPrimitiveType().primitive()) {
-                case BOOLEAN:
-                case DOUBLE:
-                case FLOAT:
-                case LONG:
-                case INT:
-                case SHORT:
-                case BYTE:
-                case CHAR:
-                    return true;
-                default:
-                    return false;
-            }
+            return true;
         }
         return DotNames.STRING.equals(type.name()) ||
                 DotNames.OPTIONAL.equals(type.name()) ||

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -163,15 +163,26 @@ public class ConfigBuildStep {
                 case FLOAT:
                 case LONG:
                 case INT:
+                case SHORT:
+                case BYTE:
+                case CHAR:
                     return true;
                 default:
                     return false;
             }
         }
-        return DotNames.STRING.equals(type.name()) || DotNames.OPTIONAL.equals(type.name()) || SET_NAME.equals(type.name())
-                || LIST_NAME.equals(type.name()) || DotNames.LONG.equals(type.name()) || DotNames.FLOAT.equals(type.name())
-                || DotNames.INTEGER.equals(type.name()) || DotNames.BOOLEAN.equals(type.name())
-                || DotNames.DOUBLE.equals(type.name());
+        return DotNames.STRING.equals(type.name()) ||
+                DotNames.OPTIONAL.equals(type.name()) ||
+                SET_NAME.equals(type.name()) ||
+                LIST_NAME.equals(type.name()) ||
+                DotNames.LONG.equals(type.name()) ||
+                DotNames.FLOAT.equals(type.name()) ||
+                DotNames.INTEGER.equals(type.name()) ||
+                DotNames.BOOLEAN.equals(type.name()) ||
+                DotNames.DOUBLE.equals(type.name()) ||
+                DotNames.SHORT.equals(type.name()) ||
+                DotNames.BYTE.equals(type.name()) ||
+                DotNames.CHARACTER.equals(type.name());
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/QualifierConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/QualifierConfigurator.java
@@ -69,6 +69,8 @@ public final class QualifierConfigurator<C extends Consumer<AnnotationInstance>>
             return AnnotationValue.createShortValue(name, (short) val);
         } else if (val instanceof Boolean) {
             return AnnotationValue.createBooleanValue(name, (boolean) val);
+        } else if (val instanceof Character) {
+            return AnnotationValue.createCharacterValue(name, (char) val);
         } else if (val instanceof Enum) {
             return AnnotationValue.createEnumValue(name, DotName.createSimple(val.getClass().getName()), val.toString());
         } else if (val instanceof Class) {


### PR DESCRIPTION
MP Config 1.4 will support injection for Short, Byte and Char. This is preparation work to support these native types in Quarkus. This also requires 
updates to MP Config API (not released yet) and SmallRye Config, but it shouldn't impact the current version.