### PR TITLE
ArC and Qute apply the Maven impsort plugin unconditionally

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -263,6 +263,7 @@
                     <version>1.2.0</version>
                     <configuration>
                         <removeUnused>true</removeUnused>
+                        <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
             </plugins>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -213,6 +213,7 @@
                     <version>1.2.0</version>
                     <configuration>
                         <removeUnused>true</removeUnused>
+                        <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION

The core Quarkus modules honour the `format.skip` build property, which is useful when needing to quickly deploy snapshots locally during prototypes. Could also be useful by CI I guess.

This plugin does slow down the build of these modules considerably, so not having this option on the other projects has been nagging me.