### PR TITLE
Don't close the EntityManager twice

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/entitymanager/TransactionScopedEntityManager.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/entitymanager/TransactionScopedEntityManager.java
@@ -61,7 +61,6 @@ public class TransactionScopedEntityManager implements EntityManager {
                 @Override
                 public void beforeCompletion() {
                     newEm.flush();
-                    newEm.close();
                 }
 
                 @Override


### PR DESCRIPTION

The EntityManager is being closed twice: both during the `beforeCompletion` and during  `afterCompletion` of the transaction sync.

It's not a problem as we're being leanient about this, but even so closing the EM is not particularly cheap and this should be avoided.

N.B. this would be a problem if we eventually decided to enable Hibernate ORM's strict JPA compliance, as in that case it would throw an exception.