### PR TITLE
Use @Override instead of @DisabledOnNativeImage with new method in IT test

### DIFF
--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceIT.java
@@ -32,6 +32,7 @@ public class VertxProducerResourceIT extends VertxProducerResourceTest {
     }
 
     @Test
+    @Override
     public void testRouteRegistrationMTLS() {
         RequestSpecification spec = new RequestSpecBuilder()
                 .setBaseUri(String.format("%s://%s", url.getProtocol(), url.getHost()))

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceTest.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/VertxProducerResourceTest.java
@@ -10,7 +10,6 @@ import java.net.URL;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.http.TestHTTPResource;
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
@@ -37,7 +36,6 @@ public class VertxProducerResourceTest {
         get("/my-path").then().body(containsString("OK"));
     }
 
-    @DisabledOnNativeImage
     @Test
     public void testRouteRegistrationMTLS() {
         RequestSpecification spec = new RequestSpecBuilder()


### PR DESCRIPTION
Use @Override instead of @DisabledOnNativeImage with new method in IT test

VertxProducerResourceIT.testRouteRegistrationMTLS

Details about need for explicit port definition in native mode is in original commit https://github.com/quarkusio/quarkus/commit/c2afb43e8be9be446532db76f32e4121ec48baf9