### PR TITLE
Bump formatter-maven-plugin and impsort-maven-plugin

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -98,3 +98,8 @@ update_configs:
           dependency_name: "org.mockito:mockito-core"
       - match:
           dependency_name: "org.awaitility:awaitility"
+      # Maven plugins
+      - match:
+          dependency_name: "net.revelc.code.formatter:formatter-maven-plugin"
+      - match:
+          dependency_name: "net.revelc.code:impsort-maven-plugin"

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -305,7 +305,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.11.0</version>
                     <configuration>
                         <configFile>${maven.multiModuleProjectDirectory}/ide-config/eclipse-format.xml</configFile>
                         <skip>${format.skip}</skip>
@@ -314,7 +314,7 @@
                 <plugin>
                     <groupId>net.revelc.code</groupId>
                     <artifactId>impsort-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.3.2</version>
                     <configuration>
                         <groups>java.,javax.,org.,com.</groups>
                         <staticGroups>*</staticGroups>

--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/AuthenticationPluginLoader_Substitutions.java
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/AuthenticationPluginLoader_Substitutions.java
@@ -35,7 +35,7 @@ public final class AuthenticationPluginLoader_Substitutions {
                 return new ClearPasswordPlugin();
             case DIALOG:
                 throw new UnsupportedOperationException("Authentication strategy 'dialog' is not supported in GraalVM");
-                //return new SendPamAuthPacket();
+            //return new SendPamAuthPacket();
             case GSSAPI_CLIENT:
                 return new SendGssApiAuthPacket();
             case MYSQL_ED25519_PASSWORD:

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -123,7 +123,8 @@ public class SpringDataJPAProcessor {
                 compositeIndex, (n) -> {
                     // the implementation of fragments don't need to be beans themselves
                     additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(n));
-                }, (className -> {
+                },
+                (className -> {
                     // the generated classes that implement interfaces for holding custom query results need
                     // to be registered for reflection here since this is the only point where the generated class is known
                     reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, className));

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -251,7 +251,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.11.0</version>
                     <configuration>
                         <configFile>${maven.multiModuleProjectDirectory}/ide-config/eclipse-format.xml</configFile>
                         <skip>${format.skip}</skip>
@@ -260,7 +260,7 @@
                 <plugin>
                     <groupId>net.revelc.code</groupId>
                     <artifactId>impsort-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.3.2</version>
                     <configuration>
                         <removeUnused>true</removeUnused>
                     </configuration>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -201,7 +201,7 @@
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.11.0</version>
                     <configuration>
                         <configFile>${maven.multiModuleProjectDirectory}/ide-config/eclipse-format.xml</configFile>
                         <skip>${format.skip}</skip>
@@ -210,7 +210,7 @@
                 <plugin>
                     <groupId>net.revelc.code</groupId>
                     <artifactId>impsort-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.3.2</version>
                     <configuration>
                         <removeUnused>true</removeUnused>
                     </configuration>


### PR DESCRIPTION
Also add them to dependabot.

This formatter-maven-plugin version should fix the annoying issue of hitting the online repositories everyday while looking for the latest Eclipse JDT version