### PR TITLE
 Remove the higher MAVEN_OPTS defined for Windows

### DIFF
--- a/ci-templates/stages.yml
+++ b/ci-templates/stages.yml
@@ -113,7 +113,7 @@ stages:
           # Always use hosted pool for windows
           vmImage: 'vs2017-win2016'
           MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
-          MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3072m'
+          MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
         steps:
           - task: CacheBeta@0 #we know the very first job will have restored or created this, so this will never write built artifacts to the cache
             inputs:


### PR DESCRIPTION
This was before Stuart's fixes so let's see how it goes without it.