### PR TITLE
Add OIDC token grace period, better support for namespace-qualified claim paths and redirects

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -18,6 +18,7 @@ import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
 import io.vertx.ext.auth.oauth2.providers.KeycloakAuth;
+import io.vertx.ext.jwt.JWTOptions;
 
 @Recorder
 public class OidcRecorder {
@@ -77,6 +78,12 @@ public class OidcRecorder {
         }
         if (oidcConfig.getToken().issuer.isPresent()) {
             options.setValidateIssuer(false);
+        }
+
+        if (oidcConfig.getToken().getExpirationGrace().isPresent()) {
+            JWTOptions jwtOptions = new JWTOptions();
+            jwtOptions.setLeeway(oidcConfig.getToken().getExpirationGrace().get());
+            options.setJWTOptions(jwtOptions);
         }
 
         final long connectionDelayInSecs = oidcConfig.getConnectionDelay().isPresent()

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -135,6 +135,16 @@ public class OidcUtilsTest {
     }
 
     @Test
+    public void testTokenWithCustomNamespacedRoles() throws Exception {
+        OidcTenantConfig.Roles rolesCfg = OidcTenantConfig.Roles
+                .fromClaimPath("application_card/embedded/\"https://custom/roles\"");
+        List<String> roles = OidcUtils.findRoles(null, rolesCfg, read(getClass().getResourceAsStream("/tokenCustomPath.json")));
+        assertEquals(2, roles.size());
+        assertTrue(roles.contains("r3"));
+        assertTrue(roles.contains("r4"));
+    }
+
+    @Test
     public void testTokenWithScope() throws Exception {
         OidcTenantConfig.Roles rolesCfg = OidcTenantConfig.Roles.fromClaimPath("scope");
         List<String> roles = OidcUtils.findRoles(null, rolesCfg, read(getClass().getResourceAsStream("/tokenScope.json")));

--- a/extensions/oidc/runtime/src/test/resources/tokenCustomPath.json
+++ b/extensions/oidc/runtime/src/test/resources/tokenCustomPath.json
@@ -13,7 +13,11 @@
             "roles": [
                 "r1",
                 "r2"
-            ]
+            ],
+            "https://custom/roles": [
+                "r3",
+                "r4"
+             ]
        }
   }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.keycloak;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.oidc.TenantResolver;
+import io.vertx.core.http.Cookie;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantResolver implements TenantResolver {
+
+    @Override
+    public String resolve(RoutingContext context) {
+        List<String> tenantidList = context.queryParam("tenantid");
+        if (tenantidList.isEmpty()) {
+            Cookie cookie = context.getCookie("tenantid");
+            return cookie != null ? cookie.getValue() : null;
+        }
+        context.response().addCookie(Cookie.cookie("tenantid", tenantidList.get(0)));
+        return tenantidList.get(0);
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -42,6 +42,12 @@ public class ProtectedResource {
     }
 
     @GET
+    @Path("callback")
+    public String getNameCallback() {
+        return "callback:" + getName();
+    }
+
+    @GET
     @Path("access")
     public String getAccessToken() {
         if (!accessTokenCredential.getToken().equals(accessToken.getRawToken())) {

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -1,9 +1,23 @@
 # Configuration file
+
+# Default tenant configuration
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.authentication.scopes=profile,email,phone
 quarkus.oidc.authentication.redirect-path=/web-app
+quarkus.oidc.authentication.extra-params.max-age=60
 quarkus.http.cors=true
 quarkus.oidc.application-type=web-app
+
+# Tenant which does not need to restore a request path after redirect
+quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-1.client-id=quarkus-app
+quarkus.oidc.tenant-1.credentials.secret=secret
+quarkus.oidc.tenant-1.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-1.authentication.redirect-path=/web-app/callback
+quarkus.oidc.tenant-1.authentication.restore-path-after-redirect=false
+
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated
+
+#quarkus.log.category."org.apache.http".level=TRACE


### PR DESCRIPTION
Fixes #6853.
(`redirect-path` support on the master is very limited: not possible to redirect to any other path but the one which the current request path starts from)
Fixes #6842.
(namespace qualified claim paths)
Fixes #6836.
(Token expiration grace period)

Also adds an ability to set the extra authentication request parameters as asked by @emmanuelBayle 