### PR TITLE
CreateProjectMojo - validate className

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -26,6 +26,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.lang.model.SourceVersion;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -191,6 +193,10 @@ public class CreateProjectMojo extends AbstractMojo {
             sanitizeExtensions();
             final SourceType sourceType = CreateProject.determineSourceType(extensions);
             sanitizeOptions(sourceType);
+
+            if (className != null && !isClassNameValid(className)) {
+                throw new MojoExecutionException("Unable to create the project, " + className + " is not valid FQCN.");
+            }
 
             final Map<String, Object> context = new HashMap<>();
             context.put("path", path);
@@ -381,6 +387,10 @@ public class CreateProjectMojo extends AbstractMojo {
                 path = "/" + path;
             }
         }
+    }
+
+    private boolean isClassNameValid(String className) {
+        return SourceVersion.isName(className) && !SourceVersion.isKeyword(className);
     }
 
     private void sanitizeExtensions() {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -134,6 +134,23 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
     }
 
     @Test
+    public void testProjectGenerationWithInvalidPackage() throws Exception {
+        testDir = initEmptyProject("projects/project-generation-invalid-package");
+        assertThat(testDir).isDirectory();
+        invoker = initInvoker(testDir);
+
+        Properties properties = new Properties();
+        properties.put("projectGroupId", "org.acme");
+        properties.put("projectArtifactId", "acme");
+        properties.put("className", "org.acme.invalid-package-name.MyResource");
+
+        InvocationResult result = setup(properties);
+
+        assertThat(result.getExitCode()).isNotZero();
+        assertThat(new File(testDir, "src/main/java/org/acme")).doesNotExist();
+    }
+
+    @Test
     public void testProjectGenerationFromMinimalPomWithResource() throws Exception {
         testDir = initProject("projects/simple-pom-it", "projects/project-generation-from-empty-pom-with-resource");
         assertThat(testDir).isDirectory();


### PR DESCRIPTION
Currently, Quarkus plugin generates project when `className` is invalid
for example -DclassName="cz.rsvoboda.quarkus.getting-started.GreetingResource"

This PR introduces the validation of the `className` attribute, a test is included.

Example of the output:
```bash
mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create \
    -DplatformArtifactId=quarkus-bom \
    -DprojectGroupId=cz.rsvoboda.quarkus \
    -DprojectArtifactId=getting-started \
    -DclassName="cz.rsvoboda.quarkus.getting-started.GreetingResource" \
    -Dpath="/hello"
...
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create
  (default-cli) on project standalone-pom: Unable to create the project,
  cz.rsvoboda.quarkus.getting-started.GreetingResource is not valid FQCN. -> [Help 1]
...
```