### PR TITLE
Configure all Test tasks properly (#3552)

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/TaskDependenciesFunctionalTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/TaskDependenciesFunctionalTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TaskDependenciesFunctionalTest {
+    @TempDir
+    Path projectDir;
+
+    /**
+     * Ensure that all Test tasks depend on the task
+     * QuarkusTestConfig
+     * This should include Test tasks created after the
+     * plugin is applied (such as acceptTest in this test).
+     */
+    @Test
+    public void shouldMakeTestTasksDependOnQuarkusTestConfig() throws IOException {
+        createBuildFile();
+
+        BuildResult build = GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withArguments("-m", "acceptTest")
+                .withPluginClasspath()
+                .build();
+
+        assertThat(build.getOutput()).contains(":quarkusTestConfig SKIPPED");
+    }
+
+    private void createBuildFile() throws IOException {
+        Path buildFile = projectDir.resolve("build.gradle");
+
+        try (InputStream is = getClass().getResourceAsStream("/TaskDependenciesFunctionalTest.gradle");
+                BufferedInputStream bis = new BufferedInputStream(is)) {
+            Files.copy(bis, buildFile);
+        }
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/TaskDependenciesFunctionalTest.gradle
+++ b/devtools/gradle/src/functionalTest/resources/TaskDependenciesFunctionalTest.gradle
@@ -1,0 +1,7 @@
+plugins {
+  id 'java'
+  id 'io.quarkus'
+}
+
+task acceptTest(type: Test) {
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle;
 
 import java.util.Collections;
+import java.util.function.Consumer;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -104,12 +105,15 @@ public class QuarkusPlugin implements Plugin<Project> {
                     Task testNative = tasks.create(TEST_NATIVE_TASK_NAME, QuarkusTestNative.class);
                     testNative.dependsOn(buildNative);
                     testNative.setShouldRunAfter(Collections.singletonList(tasks.findByName(JavaPlugin.TEST_TASK_NAME)));
-                    tasks.withType(Test.class).forEach(t -> {
+
+                    Consumer<Test> configureTestTask = t -> {
                         // Quarkus test configuration task which should be executed before any Quarkus test
                         t.dependsOn(quarkusTestConfig);
                         // also make each task use the JUnit platform since it's the only supported test environment
                         t.useJUnitPlatform();
-                    });
+                    };
+                    tasks.withType(Test.class).forEach(configureTestTask);
+                    tasks.withType(Test.class).whenTaskAdded(t -> configureTestTask.accept(t));
                 });
     }
 


### PR DESCRIPTION
Also configure Test tasks that are created (in the build file, or in other plugins) after the quarkus plugin is applied.