### PR TITLE
Adjust the count down latch in the verticle IT

### DIFF
--- a/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/VerticleDeployer.java
+++ b/integration-tests/vertx/src/main/java/io/quarkus/it/vertx/verticles/VerticleDeployer.java
@@ -18,7 +18,7 @@ public class VerticleDeployer {
     Vertx vertx;
 
     public void init(@Observes StartupEvent ev) {
-        CountDownLatch latch = new CountDownLatch(4);
+        CountDownLatch latch = new CountDownLatch(5);
         vertx.deployVerticle(BareVerticle::new, new DeploymentOptions().setConfig(new JsonObject()
                 .put("id", "bare")))
                 .thenAccept(x -> latch.countDown());


### PR DESCRIPTION
Fixes small problem in VerticleDeployer IT by fixing the number of `countDown` and the initialization number of latch.