### PR TITLE
Fix Scheduling Quartz Tasks with MSSQL JDBC Store

### DIFF
--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -100,7 +100,7 @@ public class QuartzProcessor {
             return HSQLDBDelegate.class.getName();
         }
 
-        if (resolvedDriver.contains("com.microsoft.sqlserver.jdbc.SQLServerResource")) {
+        if (resolvedDriver.contains("com.microsoft.sqlserver.jdbc.SQLServerDriver")) {
             return MSSQLDelegate.class.getName();
         }
 


### PR DESCRIPTION
The current implementation does not recognize mssql driver and thus does not load the correct delegate class.