### PR TITLE
Add librocksdbjni-linux64.so to the build when only containerRuntime is set

### DIFF
--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -107,7 +107,7 @@ class KafkaStreamsProcessor {
 
     private void addSupportForRocksDbLib(BuildProducer<NativeImageResourceBuildItem> nativeLibs, NativeConfig nativeConfig) {
         // for RocksDB, either add linux64 native lib when targeting containers
-        if (nativeConfig.containerBuild) {
+        if (nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild) {
             nativeLibs.produce(new NativeImageResourceBuildItem("librocksdbjni-linux64.so"));
         }
         // otherwise the native lib of the platform this build runs on


### PR DESCRIPTION
When the native image is build via mvn clean package -Pnative -Dnative-image.container-runtime=docker the librocksdbjni-linux64.so was not added to the build. Therefore I added the check if the containerRuntime is present.