### PR TITLE
Exclude osgi.annotation.versioning dependency

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -275,6 +275,7 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <exclude>org.osgi:org.osgi.annotation.versioning</exclude>
                                         </excludes>
                                         <includes>
                                             <!-- this is for REST Assured -->

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -34,6 +34,10 @@
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation.versioning</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/extensions/smallrye-metrics/spi/pom.xml
+++ b/extensions/smallrye-metrics/spi/pom.xml
@@ -22,6 +22,12 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
             <version>${microprofile-metrics-api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation.versioning</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>quarkus-test-common</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation.versioning</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/independent-projects/qute/rxjava/pom.xml
+++ b/independent-projects/qute/rxjava/pom.xml
@@ -27,6 +27,12 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-streams-operators-1.0</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation.versioning</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tcks/microprofile-jwt/pom.xml
+++ b/tcks/microprofile-jwt/pom.xml
@@ -63,6 +63,10 @@
                     <groupId>org.jboss.shrinkwrap.resolver</groupId>
                     <artifactId>shrinkwrap-resolver-depchain</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation.versioning</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -75,6 +79,10 @@
                 <exclusion>
                     <groupId>org.jboss.shrinkwrap.resolver</groupId>
                     <artifactId>shrinkwrap-resolver-depchain</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.annotation.versioning</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Exclude the org.osgi:osgi.annotation.versioning from dependency graph
