### PR TITLE
Qute: Support iterating by number

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -231,7 +231,7 @@ A section helper that defines the logic of a section can "execute" any of the bl
 
 ===== Loop Section
 
-The loop section makes it possible to iterate over an instance of `Iterable`, `Map` 's entry set and `Stream`.
+The loop section makes it possible to iterate over an instance of `Iterable`, `Map` 's entry set, `Stream` and an Integer.
 It has two flavors.
 The first one is using the `each` name alias.
 
@@ -261,6 +261,22 @@ It's also possible to access the iteration metadata inside the loop:
 {/each}
 ----
 <1> `count` represents one-based index. Metadata also include zero-based `index`, `hasNext`, `odd`, `even`.
+
+The `for` statement also works with integers, starting from 1. In the example below, considering that `total = 3`:
+
+[source]
+----
+{#for i in total}
+  {i}:
+{/for}
+----
+
+The output will be:
+
+[source]
+----
+1:2:3:
+----
 
 ===== If Section
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -43,6 +44,8 @@ public class LoopSectionHelper implements SectionHelper {
                 iterator = ((Map<?, ?>) it).entrySet().iterator();
             } else if (it instanceof Stream) {
                 iterator = ((Stream<?>) it).sequential().iterator();
+            } else if (it instanceof Integer) {
+                iterator = IntStream.rangeClosed(1, (Integer) it).iterator();
             } else {
                 throw new IllegalStateException("Cannot iterate over: " + it);
             }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
@@ -102,4 +102,14 @@ public class LoopSectionTest {
                 engine.parse(template).render(data));
     }
 
+    @Test
+    public void testIntegerStream() {
+        Engine engine = Engine.builder()
+                .addSectionHelper(new LoopSectionHelper.Factory()).addDefaultValueResolvers()
+                .build();
+
+        assertEquals("1:2:3:",
+                engine.parse("{#for i in total}{i}:{/for}").data("total", 3).render());
+    }
+
 }


### PR DESCRIPTION
I reused the `for` instruction to iterate by number. Support for descending order is not yet implemented. Let me see how that works for you @lordofthejars 

Fixes #6963