### PR TITLE
Add warning for @SseElementType(MediaType.APPLICATION_JSON)

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -22,11 +22,11 @@ import javax.ws.rs.ext.Providers;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.AnnotationValue.Kind;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.annotations.SseElementType;
 import org.jboss.resteasy.core.MediaTypeMap;
 import org.jboss.resteasy.plugins.interceptors.AcceptEncodingGZIPFilter;
 import org.jboss.resteasy.plugins.interceptors.GZIPDecodingInterceptor;
@@ -55,8 +55,6 @@ import io.quarkus.runtime.configuration.MemorySize;
 
 public class ResteasyCommonProcessor {
     private static final Logger LOGGER = Logger.getLogger(ResteasyCommonProcessor.class.getName());
-
-    private static final DotName SSE_ELEMENT_TYPE = DotName.createSimple(SseElementType.class.getName());
 
     private static final ProviderDiscoverer[] PROVIDER_DISCOVERERS = {
             new ProviderDiscoverer(ResteasyDotNames.GET, false, true),
@@ -152,7 +150,8 @@ public class ResteasyCommonProcessor {
         if (!capabilities.isCapabilityPresent(Capabilities.RESTEASY_JSON_EXTENSION)) {
 
             boolean needJsonSupport = restJsonSupportNeeded(indexBuildItem, ResteasyDotNames.CONSUMES)
-                    || restJsonSupportNeeded(indexBuildItem, ResteasyDotNames.PRODUCES);
+                    || restJsonSupportNeeded(indexBuildItem, ResteasyDotNames.PRODUCES)
+                    || restJsonSupportNeeded(indexBuildItem, ResteasyDotNames.RESTEASY_SSE_ELEMENT_TYPE);
             if (needJsonSupport) {
                 LOGGER.warn(
                         "Quarkus detected the need of REST JSON support but you have not provided the necessary JSON " +
@@ -195,7 +194,12 @@ public class ResteasyCommonProcessor {
                 continue;
             }
 
-            final List<String> mediaTypes = Arrays.asList(annotationValue.asStringArray());
+            List<String> mediaTypes = Collections.emptyList();
+            if (annotationValue.kind() == Kind.ARRAY) {
+                mediaTypes = Arrays.asList(annotationValue.asStringArray());
+            } else if (annotationValue.kind() == Kind.STRING) {
+                mediaTypes = Collections.singletonList(annotationValue.asString());
+            }
             return mediaTypes.contains(MediaType.APPLICATION_JSON)
                     || mediaTypes.contains(MediaType.APPLICATION_JSON_PATCH_JSON);
         }
@@ -344,7 +348,8 @@ public class ResteasyCommonProcessor {
         if (matches(MediaType.SERVER_SENT_EVENTS_TYPE, mediaType)) {
             final Set<String> additionalProvidersToRegister = new HashSet<>();
             // first check for @SseElementType
-            final AnnotationInstance sseElementTypeAnnInst = targetMethod.annotation(SSE_ELEMENT_TYPE);
+            final AnnotationInstance sseElementTypeAnnInst = targetMethod
+                    .annotation(ResteasyDotNames.RESTEASY_SSE_ELEMENT_TYPE);
             String elementType = null;
             if (sseElementTypeAnnInst != null) {
                 elementType = sseElementTypeAnnInst.value().asString();

--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
@@ -44,6 +44,8 @@ public final class ResteasyDotNames {
             .createSimple(org.jboss.resteasy.annotations.jaxrs.HeaderParam.class.getName());
     public static final DotName RESTEASY_MATRIX_PARAM = DotName
             .createSimple(org.jboss.resteasy.annotations.jaxrs.MatrixParam.class.getName());
+    public static final DotName RESTEASY_SSE_ELEMENT_TYPE = DotName
+            .createSimple(org.jboss.resteasy.annotations.SseElementType.class.getName());
 
     public static final IgnoreForReflectionPredicate IGNORE_FOR_REFLECTION_PREDICATE = new IgnoreForReflectionPredicate();
 


### PR DESCRIPTION
When `@SseElementType(MediaType.APPLICATION_JSON)` is used but `quarkus-resteasy-jsonb` is not defined as a dependency, the following warning will be logged.

`2020-02-03 18:23:10,649 WARN  [io.qua.res.com.dep.ResteasyCommonProcessor] (build-19) Quarkus detected the need of REST JSON support but you have not provided the necessary JSON extension for this. You can visit https://quarkus.io/guides/rest-json for more information on how to set one.`



Fixes #6738 
