### PR TITLE
ArC - improve performance of Reflections.findX() methods

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -315,12 +315,15 @@ public class ArcContainerImpl implements ArcContainer {
                 LOGGER.warn("An error occurred during delivery of the @Destroyed(ApplicationScoped.class) event", e);
             }
             singletonContext.destroy();
+
             // Clear caches
+            Reflections.clearCaches();
             contexts.clear();
             beans.clear();
             resolved.clear();
             observers.clear();
             running.set(false);
+
             LOGGER.debugf("ArC DI container shut down");
         }
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
@@ -202,20 +202,23 @@ public final class Reflections {
         final Class<?> clazz;
         final String methodName;
         final Class<?>[] parameterTypes;
+        final int hashCode;
 
         public MethodKey(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {
             this.clazz = clazz;
             this.methodName = methodName;
             this.parameterTypes = parameterTypes;
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(parameterTypes);
+            result = prime * result + ((clazz == null) ? 0 : clazz.hashCode());
+            result = prime * result + ((methodName == null) ? 0 : methodName.hashCode());
+            this.hashCode = result;
         }
 
         @Override
         public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + Arrays.hashCode(parameterTypes);
-            result = prime * result + Objects.hash(clazz, methodName);
-            return result;
+            return hashCode;
         }
 
         @Override
@@ -240,15 +243,21 @@ public final class Reflections {
 
         final Class<?> clazz;
         final String fieldName;
+        final int hashCode;
 
         public FieldKey(Class<?> clazz, String fieldName) {
             this.clazz = clazz;
             this.fieldName = fieldName;
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((clazz == null) ? 0 : clazz.hashCode());
+            result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+            this.hashCode = result;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(clazz, fieldName);
+            return hashCode;
         }
 
         @Override
@@ -267,4 +276,5 @@ public final class Reflections {
         }
 
     }
+
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
@@ -11,29 +11,78 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Function;
 
+/**
+ * Neither the class nor its methods are considered a public API and should only be used internally.
+ */
 public final class Reflections {
+
+    // Note that we intentionally do not use weak references for keys/values
+    // The reason is that:
+    // (1) ArC does not support multiple deployments on the classpath
+    // (2) the caches are cleared when the container is shut down
+    private static final ComputingCache<FieldKey, Field> FIELDS_CACHE = new ComputingCache<>(new Function<FieldKey, Field>() {
+        @Override
+        public Field apply(FieldKey key) {
+            return findFieldInternal(key.clazz, key.fieldName);
+        }
+    });
+    private static final ComputingCache<MethodKey, Method> METHODS_CACHE = new ComputingCache<>(
+            new Function<MethodKey, Method>() {
+                @Override
+                public Method apply(MethodKey key) {
+                    return findMethodInternal(key.clazz, key.methodName, key.parameterTypes);
+                }
+            });
+
+    static void clearCaches() {
+        FIELDS_CACHE.clear();
+        METHODS_CACHE.clear();
+    }
 
     private Reflections() {
     }
 
+    /**
+     * 
+     * @param clazz
+     * @param fieldName
+     * @return the field declared in the class hierarchy
+     */
     public static Field findField(Class<?> clazz, String fieldName) {
+        return FIELDS_CACHE.getValue(new FieldKey(clazz, fieldName));
+    }
+
+    private static Field findFieldInternal(Class<?> clazz, String fieldName) {
         try {
             return clazz.getDeclaredField(fieldName);
         } catch (NoSuchFieldException e) {
             if (clazz.getSuperclass() != null) {
-                return findField(clazz.getSuperclass(), fieldName);
+                return findFieldInternal(clazz.getSuperclass(), fieldName);
             }
             throw new IllegalArgumentException(e);
         }
     }
 
+    /**
+     * 
+     * @param clazz
+     * @param methodName
+     * @param parameterTypes
+     * @return the method declared in the class hierarchy
+     */
     public static Method findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
+        return METHODS_CACHE.getValue(new MethodKey(clazz, methodName, parameterTypes));
+    }
+
+    private static Method findMethodInternal(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
         try {
             return clazz.getDeclaredMethod(methodName, parameterTypes);
         } catch (NoSuchMethodException e) {
             if (clazz.getSuperclass() != null) {
-                return findMethod(clazz.getSuperclass(), methodName, parameterTypes);
+                return findMethodInternal(clazz.getSuperclass(), methodName, parameterTypes);
             }
             throw new IllegalArgumentException(e);
         }
@@ -148,4 +197,74 @@ public final class Reflections {
         }
     }
 
+    static final class MethodKey {
+
+        final Class<?> clazz;
+        final String methodName;
+        final Class<?>[] parameterTypes;
+
+        public MethodKey(Class<?> clazz, String methodName, Class<?>[] parameterTypes) {
+            this.clazz = clazz;
+            this.methodName = methodName;
+            this.parameterTypes = parameterTypes;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(parameterTypes);
+            result = prime * result + Objects.hash(clazz, methodName);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            MethodKey other = (MethodKey) obj;
+            return Objects.equals(clazz, other.clazz) && Objects.equals(methodName, other.methodName)
+                    && Arrays.equals(parameterTypes, other.parameterTypes);
+        }
+
+    }
+
+    static final class FieldKey {
+
+        final Class<?> clazz;
+        final String fieldName;
+
+        public FieldKey(Class<?> clazz, String fieldName) {
+            this.clazz = clazz;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(clazz, fieldName);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            FieldKey other = (FieldKey) obj;
+            return Objects.equals(clazz, other.clazz) && Objects.equals(fieldName, other.fieldName);
+        }
+
+    }
 }


### PR DESCRIPTION
- resolves #6959

### Implementation notes
- we do cache all results in static caches
- we intentionally do not use weak references for keys/values - caches are cleared when the when the container is shut down

### Microbenchmarks

I've added a microbenchmark to compare the performance results: https://github.com/mkouba/arc-benchmarks/blob/master/src/main/java/io/quarkus/arc/benchmarks/ReflectionsBenchmark.java. And the results are:
```
1.2.0.Final
Benchmark                         Mode  Cnt       Score       Error  Units
ReflectionsBenchmark.findField   thrpt   25  468775,169 ± 21317,025  ops/s
ReflectionsBenchmark.findMethod  thrpt   25  320135,824 ±  6466,329  ops/s

999-SNAPSHOT
Benchmark                         Mode  Cnt         Score         Error  Units
ReflectionsBenchmark.findField   thrpt   25  62357079,271 ± 2309336,554  ops/s
ReflectionsBenchmark.findMethod  thrpt   25  54075745,129 ± 1846794,145  ops/s
```