### PR TITLE
Remove Elasticsearch port bindings in the logging-gelf docker-compose

### DIFF
--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
@@ -3,9 +3,6 @@ version: '3.2'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.2
-    ports:
-      - "9200:9200"
-      - "9300:9300"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
@@ -3,9 +3,6 @@ version: '3.2'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.2
-    ports:
-      - "9200:9200"
-      - "9300:9300"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -3,8 +3,6 @@ version: '3.2'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.2
-    ports:
-      - "9200:9200"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     networks:


### PR DESCRIPTION
@gsmet I remove the port binding for Elasticsearch for the docker-compose shiped inside the logging-gelf integration tests as they are not needed (it can be handy if you need raw access to elasticsearch). Maybe it will be easier now to integrate the test inside the CI ;)