### PR TITLE
fix (#6826): Upgrade to dekorate 0.10.9 which further improves handling

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -139,7 +139,7 @@
         <awssdk.version>2.10.3</awssdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.41</kotlin.version>
-        <dekorate.version>0.10.8</dekorate.version>
+        <dekorate.version>0.10.9</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>


### PR DESCRIPTION
of kebabcase in arrays.

There was an issue with how dekorate is handling kebabcase in properties referring to arrays. This resulted in some properties being ignored. This is fixed in `0.10.9`.