### PR TITLE
Gradle test app model

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.SourceSet;
 
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
+import io.quarkus.runtime.LaunchMode;
 
 public class QuarkusPluginExtension {
 
@@ -97,8 +98,12 @@ public class QuarkusPluginExtension {
                 project.getVersion().toString());
     }
 
-    public AppModelResolver resolveAppModel() {
-        return new AppModelGradleResolver(project);
+    public AppModelResolver getAppModelResolver() {
+        return getAppModelResolver(LaunchMode.NORMAL);
+    }
+
+    public AppModelResolver getAppModelResolver(LaunchMode mode) {
+        return new AppModelGradleResolver(project, mode);
     }
 
     /**

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -54,7 +54,7 @@ public class QuarkusBuild extends QuarkusTask {
         getLogger().lifecycle("building quarkus runner");
 
         final AppArtifact appArtifact = extension().getAppArtifact();
-        final AppModelResolver modelResolver = extension().resolveAppModel();
+        final AppModelResolver modelResolver = extension().getAppModelResolver();
         try {
             // this needs to be done otherwise the app artifact doesn't get a proper path
             modelResolver.resolveModel(appArtifact);

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -238,7 +238,7 @@ public class QuarkusDev extends QuarkusTask {
             StringBuilder classPathManifest = new StringBuilder();
 
             final AppModel appModel;
-            final AppModelResolver modelResolver = extension().resolveAppModel();
+            final AppModelResolver modelResolver = extension().getAppModelResolver();
             try {
                 final AppArtifact appArtifact = extension.getAppArtifact();
                 appArtifact.setPath(extension.outputDirectory().toPath());

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateConfig.java
@@ -39,7 +39,7 @@ public class QuarkusGenerateConfig extends QuarkusTask {
         getLogger().lifecycle("generating example config");
 
         final AppArtifact appArtifact = extension().getAppArtifact();
-        final AppModelResolver modelResolver = extension().resolveAppModel();
+        final AppModelResolver modelResolver = extension().getAppModelResolver();
         if (extension().resourcesDir().isEmpty()) {
             throw new GradleException("No resources directory, cannot create application.properties");
         }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -344,7 +344,7 @@ public class QuarkusNative extends QuarkusTask {
         getLogger().lifecycle("building native image");
 
         final AppArtifact appArtifact = extension().getAppArtifact();
-        final AppModelResolver modelResolver = extension().resolveAppModel();
+        final AppModelResolver modelResolver = extension().getAppModelResolver();
         try {
             modelResolver.resolveModel(appArtifact);
         } catch (AppModelResolverException e) {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -42,7 +42,7 @@ public abstract class QuarkusPlatformTask extends QuarkusTask {
         }
 
         return QuarkusJsonPlatformDescriptorResolver.newInstance()
-                .setArtifactResolver(extension().resolveAppModel())
+                .setArtifactResolver(extension().getAppModelResolver())
                 .setMessageWriter(msgWriter)
                 .resolveFromBom(
                         getRequiredProperty(props, "quarkusPlatformGroupId"),

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.testing.Test;
 import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.gradle.QuarkusPluginExtension;
+import io.quarkus.runtime.LaunchMode;
 
 public class QuarkusTestConfig extends QuarkusTask {
 
@@ -22,7 +23,8 @@ public class QuarkusTestConfig extends QuarkusTask {
     public void setupTest() {
         final QuarkusPluginExtension quarkusExt = extension();
         try {
-            final AppModel deploymentDeps = quarkusExt.resolveAppModel().resolveModel(quarkusExt.getAppArtifact());
+            final AppModel deploymentDeps = quarkusExt.getAppModelResolver(LaunchMode.TEST)
+                    .resolveModel(quarkusExt.getAppArtifact());
             final String nativeRunner = getProject().getBuildDir().toPath().resolve(quarkusExt.finalName() + "-runner")
                     .toAbsolutePath()
                     .toString();

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
@@ -1,13 +1,10 @@
 package io.quarkus.gradle.tasks;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.testing.Test;
 
@@ -30,19 +27,15 @@ public class QuarkusTestConfig extends QuarkusTask {
                     .toAbsolutePath()
                     .toString();
 
-            SourceSetContainer sourceSets = getProject().getConvention().getPlugin(JavaPluginConvention.class)
-                    .getSourceSets();
-            SourceSet testSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME);
-            File classesDir = testSourceSet.getOutput().getClassesDirs().getFiles().iterator().next();
-            classesDir.mkdirs();
-            try (ObjectOutputStream out = new ObjectOutputStream(
-                    new FileOutputStream(new File(classesDir, BootstrapConstants.SERIALIZED_APP_MODEL)))) {
+            final Path serializedModel = Files.createTempFile("quarkus-", "-gradle-test");
+            try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(serializedModel))) {
                 out.writeObject(deploymentDeps);
             }
 
             for (Test test : getProject().getTasks().withType(Test.class)) {
                 final Map<String, Object> props = test.getSystemProperties();
                 props.put("native.image.path", nativeRunner);
+                props.put(BootstrapConstants.SERIALIZED_APP_MODEL, serializedModel.toString());
             }
         } catch (Exception e) {
             throw new IllegalStateException("Failed to resolve deployment classpath", e);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -6,12 +6,12 @@ package io.quarkus.bootstrap;
  */
 public interface BootstrapConstants {
 
-    String SERIALIZED_APP_MODEL = "serialized-app-model.data";
+    String SERIALIZED_APP_MODEL = "quarkus-internal.serialized-app-model.path";
     String DESCRIPTOR_FILE_NAME = "quarkus-extension.properties";
-    
+
     @Deprecated
     String EXTENSION_PROPS_JSON_FILE_NAME = "quarkus-extension.json";
-    
+
     String QUARKUS_EXTENSION_FILE_NAME = "quarkus-extension.yaml";
 
     String META_INF = "META-INF";


### PR DESCRIPTION
This PR fixes a couple of issues in our Gradle plugin.

1. To pass the resolved application dependencies to Quarkus test extension we serialize the AppModel resolve in QuarkusTestConfig to the test classes directory. The issue is that the file may get removed before the tests are executed as "stale content". This issue is currently fixed by saving the serialized AppModel in a temporary directory outside of the project directory tree.

2. When AppModel is resolved by the Gradle AppModel resolver only the application compile configuration is taken into account. When running tests however, the test dependencies are missing from the model. This is fixed by making the Gradle AppModel resolver aware of the launch mode the AppModel is intended to be used for.