### PR TITLE
ArC- reduce overhead of metadata initialization in subclass constructors

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
@@ -30,6 +30,7 @@ import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
@@ -228,7 +229,20 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
                     valueMethod.writeArrayValue(retValue, i, valueMethod.load(charArray[i]));
                 }
                 break;
-            // TODO: handle other less common types of array components
+            case FLOAT:
+                float[] floatArray = value.asFloatArray();
+                retValue = valueMethod.newArray(componentType(method), valueMethod.load(floatArray.length));
+                for (int i = 0; i < floatArray.length; i++) {
+                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(floatArray[i]));
+                }
+                break;
+            case DOUBLE:
+                double[] doubleArray = value.asDoubleArray();
+                retValue = valueMethod.newArray(componentType(method), valueMethod.load(doubleArray.length));
+                for (int i = 0; i < doubleArray.length; i++) {
+                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(doubleArray[i]));
+                }
+                break;
             default:
                 // Return empty array for empty arrays and unsupported types
                 // For an empty array the component kind is UNKNOWN
@@ -241,14 +255,30 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
                                 annotationClass);
                     }
                 }
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(0));
+                DotName componentName = componentTypeName(method);
+                // Use empty array constants for common component kinds
+                if (DotNames.CLASS.equals(componentName)) {
+                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY);
+                } else if (DotNames.STRING.equals(componentName)) {
+                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_STRING_ARRAY);
+                } else if (PrimitiveType.LONG.name().equals(componentName)) {
+                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_LONG_ARRAY);
+                } else if (PrimitiveType.INT.name().equals(componentName)) {
+                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_INT_ARRAY);
+                } else {
+                    retValue = valueMethod.newArray(componentName.toString(), valueMethod.load(0));
+                }
         }
         return retValue;
     }
 
     static String componentType(MethodInfo method) {
+        return componentTypeName(method).toString();
+    }
+
+    static DotName componentTypeName(MethodInfo method) {
         ArrayType arrayType = method.returnType().asArrayType();
-        return arrayType.component().name().toString();
+        return arrayType.component().name();
     }
 
     static String generatedSharedName(DotName annotationName) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import io.quarkus.arc.impl.AnnotationLiterals;
 import io.quarkus.arc.impl.Qualifiers;
 import io.quarkus.gizmo.FieldDescriptor;
 import java.util.Set;
@@ -12,6 +13,22 @@ final class FieldDescriptors {
     static final FieldDescriptor QUALIFIERS_IP_QUALIFIERS = FieldDescriptor.of(Qualifiers.class, "IP_DEFAULT_QUALIFIERS",
             Set.class);
 
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_CLASS_ARRAY",
+            Class[].class);
+
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_STRING_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_STRING_ARRAY",
+            String[].class);
+
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_LONG_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_LONG_ARRAY",
+            long[].class);
+    
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_INT_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_INT_ARRAY",
+            int[].class);
+    
     private FieldDescriptors() {
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
@@ -24,11 +24,11 @@ final class FieldDescriptors {
     static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_LONG_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
             "EMPTY_LONG_ARRAY",
             long[].class);
-    
+
     static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_INT_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
             "EMPTY_INT_ARRAY",
             int[].class);
-    
+
     private FieldDescriptors() {
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -168,6 +168,12 @@ final class MethodDescriptors {
     static final MethodDescriptor COLLECTIONS_UNMODIFIABLE_SET = MethodDescriptor.ofMethod(Collections.class, "unmodifiableSet",
             Set.class, Set.class);
 
+    static final MethodDescriptor COLLECTIONS_SINGLETON = MethodDescriptor.ofMethod(Collections.class, "singleton",
+            Set.class, Object.class);
+
+    static final MethodDescriptor COLLECTIONS_SINGLETON_LIST = MethodDescriptor.ofMethod(Collections.class, "singletonList",
+            List.class, Object.class);
+
     static final MethodDescriptor COLLECTIONS_EMPTY_MAP = MethodDescriptor.ofMethod(Collections.class, "emptyMap",
             Map.class);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -195,9 +195,16 @@ public class SubclassGenerator extends AbstractGenerator {
         // Init intercepted methods and interceptor chains
         // private final Map<String,SubclassMethodMetadata> metadata
         // metadata = new HashMap<>()
+        int metadataMapCapacity = bean.getInterceptedMethods().size();
+        if (metadataMapCapacity < 3) {
+            metadataMapCapacity++;
+        } else {
+            metadataMapCapacity = (int) ((float) metadataMapCapacity / 0.75F + 1.0F);
+        }
         FieldCreator metadataField = subclass.getFieldCreator(FIELD_NAME_METADATA, Map.class.getName())
                 .setModifiers(ACC_PRIVATE | ACC_FINAL);
-        ResultHandle metadataHandle = constructor.newInstance(MethodDescriptor.ofConstructor(HashMap.class));
+        ResultHandle metadataHandle = constructor.newInstance(MethodDescriptor.ofConstructor(HashMap.class, int.class),
+                constructor.load(metadataMapCapacity));
         constructor.writeInstanceField(metadataField.getFieldDescriptor(), constructor.getThis(),
                 metadataHandle);
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractInvocationContext.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ abstract class AbstractInvocationContext implements ArcInvocationContext, Suppli
 
     @Override
     public Set<Annotation> getInterceptorBindings() {
-        return interceptorBindings;
+        return Collections.unmodifiableSet(interceptorBindings);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AnnotationLiterals.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AnnotationLiterals.java
@@ -1,0 +1,13 @@
+package io.quarkus.arc.impl;
+
+public final class AnnotationLiterals {
+
+    public static final Class<?>[] EMPTY_CLASS_ARRAY = new Class[0];
+    public static final String[] EMPTY_STRING_ARRAY = new String[0];
+    public static final int[] EMPTY_INT_ARRAY = new int[0];
+    public static final long[] EMPTY_LONG_ARRAY = new long[0];
+
+    private AnnotationLiterals() {
+    }
+
+}


### PR DESCRIPTION
- use shared literal instances for interceptor bindings
- use shared interceptor chains