### PR TITLE
Maven create extension test fixes

### DIFF
--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -57,6 +57,13 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                     <escapeString>\</escapeString>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-descriptor-json-plugin</artifactId>
                 <version>${project.version}</version>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/CreateExtensionMojoTest.java
@@ -188,7 +188,7 @@ public class CreateExtensionMojoTest {
         mojo.assumeManaged = null;
         mojo.execute();
         assertTreesMatch(
-                Paths.get("src/test/resources/expected/new-extension-project"),
+                Paths.get("target/test-classes/expected/new-extension-project"),
                 mojo.basedir.toPath());
     }
 

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/deployment/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.acme</groupId>
             <artifactId>my-ext</artifactId>
-            <version>${project.version}</version>
+            <version>\${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/pom.xml
@@ -11,8 +11,8 @@
 
     <packaging>pom</packaging>
     <properties>
-        <quarkus.version>999-SNAPSHOT</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <quarkus.version>${project.version}</quarkus.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
     <modules>
         <module>deployment</module>
@@ -35,7 +35,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${compiler-plugin.version}</version>
+                    <version>\${compiler-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources/expected/new-extension-project/my-ext/runtime/pom.xml
@@ -33,7 +33,7 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            <deployment>\${project.groupId}:\${project.artifactId}-deployment:\${project.version}
                             </deployment>
                         </configuration>
                     </execution>


### PR DESCRIPTION
* compare the project files after the resource filtering;
* escape properties that are not supposed to be replaced during resource filtering