### PR TITLE
Adjust the artifact name of the PDF documentation to avoid conflicts

### DIFF
--- a/docs/assembly-pdf.xml
+++ b/docs/assembly-pdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-    <id>quarkus-documentation-pdf</id>
+    <id>pdf</id>
     <formats>
        <format>zip</format>
     </formats>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -282,8 +282,8 @@
                                         <descriptor>assembly-pdf.xml</descriptor>
                                     </descriptors>
                                     <recompressZippedFiles>true</recompressZippedFiles>
-                                    <finalName>quarkus-documentation-pdf-${project.version}</finalName>
-                                    <appendAssemblyId>false</appendAssemblyId>
+                                    <finalName>quarkus-documentation-${project.version}</finalName>
+                                    <appendAssemblyId>true</appendAssemblyId>
                                     <outputDirectory>target/</outputDirectory>
                                     <workDirectory>target/assembly-pdf/work</workDirectory>
                                     <tarLongFileMode>gnu</tarLongFileMode>


### PR DESCRIPTION
The final name is not used when pushing to Central and we need a
classifier to avoid conflicts.
The good thing is that we will be able to point the downloads to Central
instead of serving them ourselves.

I just noticed that when doing the release so better fix it now rather than never.