### PR TITLE
Allow specifying quarkus.native.builder-image via gradle plugin parameter native-builder-image

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusNative.java
@@ -62,6 +62,8 @@ public class QuarkusNative extends QuarkusTask {
 
     private String dockerBuild;
 
+    private String nativeBuilderImage;
+
     private boolean enableVMInspection = false;
 
     private boolean enableFallbackImages = false;
@@ -282,6 +284,17 @@ public class QuarkusNative extends QuarkusTask {
         this.dockerBuild = dockerBuild;
     }
 
+    @Option(description = "Docker image", option = "native-builder-image")
+    public void setNativeBuilderImage(String nativeBuilderImage) {
+        this.nativeBuilderImage = nativeBuilderImage;
+    }
+
+    @Optional
+    @Input
+    public String getNativeBuilderImage() {
+        return nativeBuilderImage;
+    }
+
     @Input
     public boolean isEnableVMInspection() {
         return enableVMInspection;
@@ -417,6 +430,9 @@ public class QuarkusNative extends QuarkusTask {
         }
         if (containerRuntimeOptions != null && !containerRuntimeOptions.trim().isEmpty()) {
             configs.put("quarkus.native.container-runtime-options", containerRuntimeOptions);
+        }
+        if (nativeBuilderImage != null && !nativeBuilderImage.trim().isEmpty()) {
+            configs.put("quarkus.native.builder-image", nativeBuilderImage);
         }
         configs.put("quarkus.native.dump-proxies", Boolean.toString(dumpProxies));
         configs.put("quarkus.native.enable-all-security-services", Boolean.toString(enableAllSecurityServices));


### PR DESCRIPTION
Currently it is not possible to specify this in the gradle file. Especially for multi-module builds, it is nice to be able to set this via gradle in the main module.