### PR TITLE
Check to see if injection point is same as current thread local value

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointProvider.java
@@ -26,8 +26,12 @@ public class InjectionPointProvider implements InjectableReferenceProvider<Injec
     static InjectionPoint set(InjectionPoint injectionPoint) {
         if (injectionPoint != null) {
             InjectionPoint prev = InjectionPointProvider.CURRENT.get();
-            InjectionPointProvider.CURRENT.set(injectionPoint);
-            return prev;
+            if (injectionPoint.equals(prev)) {
+                return injectionPoint;
+            } else {
+                InjectionPointProvider.CURRENT.set(injectionPoint);
+                return prev;
+            }
         } else {
             CURRENT.remove();
             return null;


### PR DESCRIPTION
While running a benchmark [1] for changes in https://github.com/quarkusio/quarkus/pull/7003 28.9% of cpu time was spent in `io/quarkus/arc/impl/InjectionPointProvider.set()`.  By checking whether the same injectionPoint passed to InjectionPointProvider.set() was already stored in the ThreadLocal, cpu time for this method call dropped to 13.25%. 

@mkouba How likely is the scenario that the injectionPoint passed to `io/quarkus/arc/impl/InjectionPointProvider.set()` will be the same? Or is it just a consequence of this particular benchmark? I am not certain that in a real-world scanerio whether this change will make as big a difference for this method call


1 - https://github.com/mkouba/arc-benchmarks/blob/master/src/main/java/io/quarkus/arc/benchmarks/SubclassInstantiationBenchmark.java