### PR TITLE
Removed unused properties according to issue 4630

### DIFF
--- a/extensions/elytron-security-properties-file/deployment/src/test/resources/application-custom-auth.properties
+++ b/extensions/elytron-security-properties-file/deployment/src/test/resources/application-custom-auth.properties
@@ -1,7 +1,6 @@
 quarkus.security.users.file.enabled=true
 quarkus.security.users.file.users=test-users.properties
 quarkus.security.users.file.roles=test-roles.properties
-quarkus.security.users.file.auth-mechanism=CUSTOM
 quarkus.security.users.file.plain-text=true
 
 #quarkus.log.min-level=DEBUG

--- a/extensions/smallrye-jwt/deployment/src/test/resources/application.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/application.properties
@@ -1,5 +1,4 @@
 mp.jwt.verify.publickey.location=/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com
-
-quarkus.smallrye-jwt.auth-mechanism=MP-JWT
 quarkus.smallrye-jwt.enabled=true
+

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationDefaultGroups.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationDefaultGroups.properties
@@ -1,5 +1,4 @@
 mp.jwt.verify.publickey.location=/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com
 smallrye.jwt.claims.groups=User
-quarkus.smallrye-jwt.auth-mechanism=MP-JWT
 quarkus.smallrye-jwt.enabled=true

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtCookie.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtCookie.properties
@@ -4,5 +4,4 @@ smallrye.jwt.claims.groups=User
 smallrye.jwt.token.header=Cookie
 smallrye.jwt.token.cookie=cookie_a
 smallrye.jwt.sign.key-location=/privateKey.pem
-quarkus.smallrye-jwt.auth-mechanism=MP-JWT
 quarkus.smallrye-jwt.enabled=true

--- a/extensions/smallrye-jwt/deployment/src/test/resources/smallryeJwtDisabled.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/smallryeJwtDisabled.properties
@@ -1,5 +1,3 @@
 mp.jwt.verify.publickey.location=/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com
-
-quarkus.smallrye-jwt.auth-mechanism=MP-JWT
 quarkus.smallrye-jwt.enabled=false

--- a/extensions/spring-security/deployment/src/test/resources/application.properties
+++ b/extensions/spring-security/deployment/src/test/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.security.users.file.enabled=true
 quarkus.security.users.file.users=test-users.properties
 quarkus.security.users.file.roles=test-roles.properties
-#quarkus.security.users.file.auth-mechanism=BASIC
 quarkus.security.users.file.plain-text=true

--- a/integration-tests/spring-web/src/main/resources/application.properties
+++ b/integration-tests/spring-web/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 quarkus.security.users.file.enabled=true
 quarkus.security.users.file.users=test-users.properties
 quarkus.security.users.file.roles=test-roles.properties
-quarkus.security.users.file.auth-mechanism=BASIC
 quarkus.security.users.file.plain-text=true


### PR DESCRIPTION
Removes unused properties ```quarkus.smallrye-jwt.auth-mechanism``` and ```quarkus.security.users.embedded.auth-mechanism```.
Tests continue to pass for extensions/elytron-security-properties-file/deployment, extensions/smallrye-jwt/deployment, extensions/spring-security/deployment, integration-tests/spring-web.