### PR TITLE
Changes for config cogs tweak

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -73,12 +73,10 @@ final public class Constants {
     public static final String MEMORY_SIZE_INFORMATION = String.format(Constants.MORE_INFO_ABOUT_TYPE_FORMAT,
             Constants.MEMORY_SIZE_NOTE_ANCHOR, "MemorySize");
 
-    public static final String CONFIG_PHASE_RUNTIME_ILLUSTRATION = "icon:cogs[title=Overridable at runtime]";
-    public static final String CONFIG_PHASE_BOOTSTRAP_ILLUSTRATION = "icon:cogs[title=Bootstrap - Overridable at runtime]";
-    public static final String CONFIG_PHASE_BUILD_TIME_ILLUSTRATION = "icon:archive[title=Fixed at build time]";
+    public static final String CONFIG_PHASE_BUILD_TIME_ILLUSTRATION = "icon:lock[title=Fixed at build time]";
     public static final String CONFIG_PHASE_LEGEND = String.format(
-            "%n%s Configuration property fixed at build time - %s️ Configuration property overridable at runtime %n",
-            CONFIG_PHASE_BUILD_TIME_ILLUSTRATION, CONFIG_PHASE_RUNTIME_ILLUSTRATION);
+            "%n%s Configuration property fixed at build time - All other configuration properties are overridable at runtime",
+            CONFIG_PHASE_BUILD_TIME_ILLUSTRATION);
 
     public static final String DURATION_FORMAT_NOTE = "\n[NOTE]" +
             "\n[[" + DURATION_NOTE_ANCHOR + "]]\n" +

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigPhase.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigPhase.java
@@ -5,9 +5,9 @@ import java.util.Comparator;
 import io.quarkus.annotation.processor.Constants;
 
 public enum ConfigPhase implements Comparable<ConfigPhase> {
-    RUN_TIME("The configuration is overridable at runtime", Constants.CONFIG_PHASE_RUNTIME_ILLUSTRATION, "RunTime"),
+    RUN_TIME("The configuration is overridable at runtime", "", "RunTime"),
     BOOTSTRAP("The configuration is used to bootstrap runtime Config Sources and is overridable at runtime",
-            Constants.CONFIG_PHASE_BOOTSTRAP_ILLUSTRATION, "Bootstrap"),
+            "", "Bootstrap"),
     BUILD_TIME("The configuration is not overridable at runtime", Constants.CONFIG_PHASE_BUILD_TIME_ILLUSTRATION, "BuildTime"),
     BUILD_AND_RUN_TIME_FIXED("The configuration is not overridable at runtime", Constants.CONFIG_PHASE_BUILD_TIME_ILLUSTRATION,
             "BuildTime");

--- a/docs/src/main/asciidoc/all-config.adoc
+++ b/docs/src/main/asciidoc/all-config.adoc
@@ -10,4 +10,4 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-include::{generated-dir}/config/all-config.adoc[opts=optional]
+include::{generated-dir}/config/quarkus-all-config.adoc[opts=optional]

--- a/docs/src/main/asciidoc/stylesheet/config.css
+++ b/docs/src/main/asciidoc/stylesheet/config.css
@@ -50,7 +50,7 @@ table.configuration-reference.tableblock tbody tr td {
 }
 
 table.configuration-reference.tableblock tbody tr td > .content > .paragraph .icon {
-  margin-left: -25px;
+  margin-left: -19px;
   margin-top: 5px;
   float: left;
 }

--- a/docs/src/main/java/io/quarkus/docs/generation/AllConfigGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AllConfigGenerator.java
@@ -175,7 +175,8 @@ public class AllConfigGenerator {
         }
 
         // write our docs
-        ConfigDocGeneratedOutput allConfigGeneratedOutput = new ConfigDocGeneratedOutput("all-config.adoc", true, allItems,
+        ConfigDocGeneratedOutput allConfigGeneratedOutput = new ConfigDocGeneratedOutput("quarkus-all-config.adoc", true,
+                allItems,
                 false);
         configDocWriter.writeAllExtensionConfigDocumentation(allConfigGeneratedOutput);
     }


### PR DESCRIPTION
Also renamed the generated all-config due to jekyll giving it precedence of the the guide itself

As requested by @maxandersen 