### PR TITLE
Revert removal of a Netty GraalVM tweak

### DIFF
--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -42,7 +42,7 @@ jobs:
         run: mvn -B install -DskipTests -DskipITs -Dno-format
 
       - name: Run integration tests in native
-        run: mvn -B  --settings azure-mvn-settings.xml verify -f integration-tests/pom.xml -DskipTests  -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j
+        run: mvn -B  --settings azure-mvn-settings.xml verify -f integration-tests/pom.xml -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j
 
       - name: Report
         if: always()

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -183,7 +183,6 @@ class NettyProcessor {
                 "io.quarkus.netty.runtime.graal.Holder_io_netty_util_concurrent_ScheduledFutureTask");
     }
 
-    // TODO: Remove this when netty.version is 4.1.43.Final or greater.
     @BuildStep
     public List<UnsafeAccessedFieldBuildItem> unsafeAccessedFields() {
         return Arrays.asList(

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.netty.deployment;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -21,6 +23,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.netty.BossEventLoopGroup;
 import io.quarkus.netty.MainEventLoopGroup;
 import io.quarkus.netty.runtime.NettyRecorder;
@@ -178,5 +181,13 @@ class NettyProcessor {
     public RuntimeReinitializedClassBuildItem reinitScheduledFutureTask() {
         return new RuntimeReinitializedClassBuildItem(
                 "io.quarkus.netty.runtime.graal.Holder_io_netty_util_concurrent_ScheduledFutureTask");
+    }
+
+    // TODO: Remove this when netty.version is 4.1.43.Final or greater.
+    @BuildStep
+    public List<UnsafeAccessedFieldBuildItem> unsafeAccessedFields() {
+        return Arrays.asList(
+                new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "selectedKeys"),
+                new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "publicSelectedKeys"));
     }
 }


### PR DESCRIPTION
Apparently, this has not been fixed in Netty.

Also, really enables the tests for native JDK 11 on GH actions. /cc @geoand 

Fixes #7035

/cc @Sanne @gwenneg 