### PR TITLE
Add tooling guides tip about JDK 11 native image generation from Docker

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -277,9 +277,15 @@ The easiest way to supply custom configuration is via the command line. For exam
 ./gradlew buildNative --docker-build=true
 ----
 
-The produced executable will be a 64 bit Linux executable, so depending on your operating system
-it may no longer be runnable.
+The produced executable will be a 64 bit Linux executable, so depending on your operating system it may no longer be runnable.
 However, it's not an issue as we are going to copy it to a Docker container.
+Note that in this case the build itself runs in a Docker container too, so you don't need to have GraalVM installed locally.
+
+[TIP]
+====
+By default, the native image will be generated using the `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version}-java8` Docker image which is only compatible with JDK 8.
+If you want to build a native image compatible with JDK 11, you will have to use the `-Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version}-java11` build argument.
+====
 
 Another way of customizing the native build image build process is to configure the task inside the Gradle build script. If for example it is required to set the `enableHttpUrlHandler`, it can be done like so:
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -369,6 +369,12 @@ The produced executable will be a 64 bit Linux executable, so depending on your 
 However, it's not an issue as we are going to copy it to a Docker container.
 Note that in this case the build itself runs in a Docker container too, so you don't need to have GraalVM installed locally.
 
+[TIP]
+====
+By default, the native image will be generated using the `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version}-java8` Docker image which is only compatible with JDK 8.
+If you want to build a native image compatible with JDK 11, you will have to use the `-Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version}-java11` build argument.
+====
+
 You can follow the link:building-native-image[Build a native executable guide] as well as link:deploying-to-kubernetes[Deploying Application to Kubernetes and OpenShift] for more information.
 
 [[build-tool-maven]]


### PR DESCRIPTION
Partially addresses #7014.

I'm not sure it's ok to mention the full `ubi-quarkus-native-image` URL like that in the doc, but this is only a temporary tip since the JDK 8 support will be dropped in Quarkus in the near future hopefully.

@gsmet WDYT?