### PR TITLE
Introduce basic-test-suite profile

### DIFF
--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -141,5 +141,16 @@
                 <gradle.task>assemble</gradle.task>
             </properties>
         </profile>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <properties>
+                <gradle.task>assemble</gradle.task>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -61,4 +61,17 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/kubernetes/invoker/pom.xml
+++ b/integration-tests/kubernetes/invoker/pom.xml
@@ -86,4 +86,28 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <skipInvocation>true</skipInvocation>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -17,4 +17,5 @@
     <module>invoker</module>
     <module>standard</module>
   </modules>
+
 </project>

--- a/integration-tests/kubernetes/standard/pom.xml
+++ b/integration-tests/kubernetes/standard/pom.xml
@@ -105,4 +105,18 @@
         </testResources>
     </build>
     
+    <profiles>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+    
 </project>

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -199,5 +199,16 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/scala/pom.xml
+++ b/integration-tests/scala/pom.xml
@@ -61,4 +61,18 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>basic-test-suite</id>
+            <activation>
+                <property>
+                    <name>basicTests</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
- to skip some parts of the test suite during the full build
- integration tests: maven tooling, kotlin, scala, kubernetes, gradle


NOTE: `mvn clean install -DbasicTests` takes `26:43 min` on my machine, compared to `46:32 min` for `mvn clean install`.