### PR TITLE
Move the WildFly Elytron version to 1.11.2.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -97,7 +97,7 @@
         <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
         <wildfly-common.version>1.5.3.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
-        <wildfly-elytron.version>2.0.0.Alpha6</wildfly-elytron.version>
+        <wildfly-elytron.version>1.11.2.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.0.1.Final</jboss-threads.version>
         <vertx.version>3.8.5</vertx.version>


### PR DESCRIPTION
I have been cleaning up our master branches in preparation for creating a .Final release of WildFly Elytron for Quarkus, however after reviewing the end results of the branches there are no changes required by Quarkus in the master branch that are not also in our existing 1.x release streams so for now I think it makes more sense to continue to use the releases we are already producing off 1.x.

If at any point changes are required which can only be applied to the master branch of Elytron there is no problem at all creating .Final releases from that branch but that doesn't seem required today.
