### PR TITLE
Dockerfile.native - run with non-root user 1001

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
@@ -17,6 +17,14 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 WORKDIR /work/
 COPY ${build_dir}/*-runner /work/application
-RUN chmod 775 /work /work/application
+
+# set up permissions for user `1001`
+RUN chmod 775 /work /work/application \
+  && chown -R 1001 /work \
+  && chmod -R "g+rwX" /work \
+  && chown -R 1001:root /work
+
 EXPOSE 8080
+USER 1001
+
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
The native docker-image should run with non-root user 1001.