### PR TITLE
Chunk of code polish commits

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -1609,7 +1609,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
      * class responsible for splitting the bytecode into smaller methods, to make sure that even large objects and large
      * numbers of invocations do not put us over the method limit.
      */
-    class SplitMethodContext implements Closeable, MethodContext {
+    static class SplitMethodContext implements Closeable, MethodContext {
         final ResultHandle deferredParameterArray;
         final MethodCreator mainMethod;
         final ClassCreator classCreator;
@@ -1662,7 +1662,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
         }
     }
 
-    final class FixedMethodContext implements MethodContext {
+    static final class FixedMethodContext implements MethodContext {
         final SplitMethodContext parent;
         final MethodCreator currentMethod;
         final Map<Integer, ResultHandle> currentMethodCache;

--- a/core/devmode/src/main/java/io/quarkus/dev/JavaCompilationProvider.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/JavaCompilationProvider.java
@@ -83,7 +83,7 @@ public class JavaCompilationProvider implements CompilationProvider {
         return sourceFilePath;
     }
 
-    class RuntimeUpdatesClassVisitor extends ClassVisitor {
+    static class RuntimeUpdatesClassVisitor extends ClassVisitor {
         private Set<String> sourcePaths;
         private String classesPath;
         private String sourceFile;

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/DotEnvTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/DotEnvTestCase.java
@@ -15,7 +15,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,7 +30,6 @@ public class DotEnvTestCase {
 
     static ClassLoader classLoader;
     static ConfigProviderResolver cpr;
-    Config config;
 
     @BeforeAll
     public static void initConfig() {
@@ -67,7 +65,6 @@ public class DotEnvTestCase {
         final SmallRyeConfig config = builder.build();
         Files.delete(dotEnv);
         cpr.registerConfig(config, classLoader);
-        this.config = config;
         return config;
     }
 

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/RepeatedConstraintsTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/RepeatedConstraintsTest.java
@@ -99,7 +99,7 @@ public class RepeatedConstraintsTest {
     }
 
     @ApplicationScoped
-    public class MyConstraintValidator implements ConstraintValidator<MyConstraint, String> {
+    public static class MyConstraintValidator implements ConstraintValidator<MyConstraint, String> {
 
         @Override
         public boolean isValid(String value, ConstraintValidatorContext context) {

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -106,7 +106,6 @@ public class PanacheResourceProcessor {
     @BuildStep
     void unremovableProducers(BuildProducer<UnremovableBeanBuildItem> unremovable,
             BeanArchiveIndexBuildItem beanArchiveIndex) {
-        Type type = Type.create(MONGOCLIENT_INTERFACE, Type.Kind.CLASS);
         unremovable.produce(
                 new UnremovableBeanBuildItem(
                         new UnremovableBeanBuildItem.BeanClassNameExclusion(

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
@@ -129,7 +129,7 @@ public class AnnotationStore {
         return found;
     }
 
-    class TransformationContextImpl extends AnnotationsTransformationContext<Collection<AnnotationInstance>>
+    static class TransformationContextImpl extends AnnotationsTransformationContext<Collection<AnnotationInstance>>
             implements TransformationContext {
 
         public TransformationContextImpl(BuildContext buildContext, AnnotationTarget target,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointModifier.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointModifier.java
@@ -40,7 +40,7 @@ public class InjectionPointModifier {
         return transformationContext.getQualifiers();
     }
 
-    class TransformationContextImpl extends AnnotationsTransformationContext<Set<AnnotationInstance>>
+    static class TransformationContextImpl extends AnnotationsTransformationContext<Set<AnnotationInstance>>
             implements InjectionPointsTransformer.TransformationContext {
 
         public TransformationContextImpl(BuildContext buildContext, AnnotationTarget target,

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -177,7 +177,7 @@ class RequestContext implements ManagedContext {
                 ArcContainerImpl.instance());
     }
 
-    class RequestContextState implements ContextState {
+    static class RequestContextState implements ContextState {
 
         private final ConcurrentMap<Contextual<?>, ContextInstanceHandle<?>> value;
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/SecDispatcherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/SecDispatcherImpl.java
@@ -97,7 +97,7 @@ public class SecDispatcherImpl implements SecDispatcher {
                 if( dispatcher == null )
                     throw new SecDispatcherException( "no dispatcher for hint "+type );
 
-                String pass = attr == null ? bare : strip( bare );
+                String pass = strip( bare );
 
                 return dispatcher.decrypt( pass, attr, conf );
             }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -103,7 +103,7 @@ class EvaluatorImpl implements Evaluator {
         }
     }
 
-    class EvalContextImpl implements EvalContext {
+    static class EvalContextImpl implements EvalContext {
 
         final boolean tryParent;
         final Object base;

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -224,7 +224,7 @@ public class GradleBuildFile extends BuildFile {
         return getModel().getBuildContent();
     }
 
-    private class Model {
+    private static class Model {
         private String settingsContent;
         private String buildContent;
         private Properties propertiesContent;

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/UsersResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/UsersResource.java
@@ -21,7 +21,7 @@ public class UsersResource {
         return new User(keycloakSecurityContext);
     }
 
-    public class User {
+    public static class User {
 
         private final String userName;
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/ApplicationNameAndVersionTestUtil.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/ApplicationNameAndVersionTestUtil.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 final class ApplicationNameAndVersionTestUtil {
 
@@ -24,7 +25,8 @@ final class ApplicationNameAndVersionTestUtil {
             if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
                 failApplicationPropertiesSetCorrectly();
             }
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            try (BufferedReader br = new BufferedReader(
+                    new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
                 String output = br.readLine();
                 assertThat(output).isEqualTo("acme/1.0-SNAPSHOT");
             }

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/UsersResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/UsersResource.java
@@ -36,7 +36,7 @@ public class UsersResource {
         return new User(((JsonWebToken) identity).getClaim("preferred_username"));
     }
 
-    public class User {
+    public static class User {
 
         private final String userName;
 

--- a/integration-tests/vault-app/src/main/java/io/quarkus/it/vault/VaultTestService.java
+++ b/integration-tests/vault-app/src/main/java/io/quarkus/it/vault/VaultTestService.java
@@ -66,7 +66,6 @@ public class VaultTestService {
         }
 
         String coucou = "coucou";
-        ClearData data = new ClearData(coucou);
         SigningInput input = new SigningInput(coucou);
         String keyName = "my-encryption-key";
         String ciphertext = transit.encrypt(keyName, coucou);

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <jacoco.version>0.8.5</jacoco.version>
     </properties>
 
     <modules>

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/InjectionEnricher.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/InjectionEnricher.java
@@ -175,7 +175,7 @@ public class InjectionEnricher implements TestEnricher {
         }
     }
 
-    public class CreationContextHolder implements Closeable {
+    public static class CreationContextHolder implements Closeable {
 
         final Closeable closeable;
         final Object creationalContext;


### PR DESCRIPTION
Chunk of code polish commits, grouped to save CI capacity a bit.

- Removal of unused local store
- Ensure UTF_8 encoding is used
- Removal of jacoco.version from root pom.xml, property is present in build parent
- DotEnvTestCase - global variable config is not needed
- Redundant check removal
- Make inner classes static to avoid parent class linkage overhead 