### PR TITLE
QuarkusDev should be serializing the AppModel in the same manner as QuarkusTestConfig

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
@@ -1,0 +1,19 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.quarkus.bootstrap.model.AppModel;
+
+public class QuarkusGradleUtils {
+
+    public static Path serializeAppModel(final AppModel appModel) throws IOException {
+        final Path serializedModel = Files.createTempFile("quarkus-", "-gradle-test");
+        try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(serializedModel))) {
+            out.writeObject(appModel);
+        }
+        return serializedModel;
+    }
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
@@ -1,7 +1,5 @@
 package io.quarkus.gradle.tasks;
 
-import java.io.ObjectOutputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -29,10 +27,7 @@ public class QuarkusTestConfig extends QuarkusTask {
                     .toAbsolutePath()
                     .toString();
 
-            final Path serializedModel = Files.createTempFile("quarkus-", "-gradle-test");
-            try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(serializedModel))) {
-                out.writeObject(deploymentDeps);
-            }
+            final Path serializedModel = QuarkusGradleUtils.serializeAppModel(deploymentDeps);
 
             for (Test test : getProject().getTasks().withType(Test.class)) {
                 final Map<String, Object> props = test.getSystemProperties();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -221,7 +221,7 @@ public class BootstrapAppModelFactory {
                 final Path p = Paths.get(serializedModel);
                 if (Files.exists(p)) {
                     try (InputStream existing = Files.newInputStream(Paths.get(serializedModel))) {
-                        AppModel appModel = (AppModel) new ObjectInputStream(existing).readObject();
+                        final AppModel appModel = (AppModel) new ObjectInputStream(existing).readObject();
                         return new CurationResult(appModel);
                     } catch (IOException | ClassNotFoundException e) {
                         log.error("Failed to load serialized app mode", e);


### PR DESCRIPTION
i.e. in a temp file and passing its path using quarkus-internal.serialized-app-model.path

It's tricky to write a test specifically for this issue since all the required deps are going to be built and added to the local maven repo and eventually QuarkusBootstrap will pick them up.