### PR TITLE
Upgrade of Hibernate ORM to 5.4.11.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -81,8 +81,8 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.13</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
+        <hibernate-orm.version>5.4.11.Final</hibernate-orm.version>
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
-        <hibernate-orm.version>5.4.10.Final</hibernate-orm.version>
         <hibernate-search.version>6.0.0.Beta4</hibernate-search.version>
         <narayana.version>5.10.0.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -13,6 +13,7 @@ import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.boot.registry.selector.internal.StrategySelectorImpl;
+import org.hibernate.bytecode.internal.ProxyFactoryFactoryInitiator;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
 import org.hibernate.engine.jdbc.batch.internal.BatchBuilderInitiator;
 import org.hibernate.engine.jdbc.connections.internal.ConnectionProviderInitiator;
@@ -34,6 +35,7 @@ import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitia
 import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractorInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
 
+import io.quarkus.hibernate.orm.runtime.customized.DisabledBytecodeProviderInitiator;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusJtaPlatformInitiator;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedState;
 import io.quarkus.hibernate.orm.runtime.service.CfgXmlAccessServiceInitiatorQuarkus;
@@ -134,6 +136,11 @@ public class PreconfiguredServiceRegistryBuilder {
      */
     private static List<StandardServiceInitiator> buildQuarkusServiceInitiatorList(RecordedState rs) {
         final ArrayList<StandardServiceInitiator> serviceInitiators = new ArrayList<StandardServiceInitiator>();
+
+        //Enforces no bytecode enhancement will happen at runtime:
+        serviceInitiators.add(DisabledBytecodeProviderInitiator.INSTANCE);
+        //Use the default ProxyFactoryFactoryInitiator:
+        serviceInitiators.add(ProxyFactoryFactoryInitiator.INSTANCE);
 
         // Replaces org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceInitiator :
         // not used

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/DisabledBytecodeProviderInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/DisabledBytecodeProviderInitiator.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.bytecode.internal.none.BytecodeProviderImpl;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+public final class DisabledBytecodeProviderInitiator implements StandardServiceInitiator<BytecodeProvider> {
+
+    /**
+     * Singleton access
+     */
+    public static final StandardServiceInitiator<BytecodeProvider> INSTANCE = new DisabledBytecodeProviderInitiator();
+
+    @Override
+    public BytecodeProvider initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+        //This one disables any use of bytecode enhancement at runtime.
+        return new BytecodeProviderImpl();
+    }
+
+    @Override
+    public Class<BytecodeProvider> getServiceInitiated() {
+        return BytecodeProvider.class;
+    }
+
+}


### PR DESCRIPTION

This is a pre-requisite for a sequence of fixes I'll be sending later; they all need the version upgraded first, so it would be simpler to first merge this and then send individual PRs for each fix.