### PR TITLE
Force loading of JDBC drivers in runtime classloader

### DIFF
--- a/extensions/smallrye-opentracing/deployment/pom.xml
+++ b/extensions/smallrye-opentracing/deployment/pom.xml
@@ -75,6 +75,26 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Fruit.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Fruit.java
@@ -1,0 +1,51 @@
+package io.quarkus.smallrye.opentracing.deployment;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQuery;
+import javax.persistence.QueryHint;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "known_fruits")
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@Cacheable
+public class Fruit {
+
+    @Id
+    @SequenceGenerator(name = "fruitsSequence", sequenceName = "known_fruits_id_seq", allocationSize = 1, initialValue = 10)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fruitsSequence")
+    private Integer id;
+
+    @Column(length = 40, unique = true)
+    private String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/TracingTest.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/TracingTest.java
@@ -8,8 +8,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -30,6 +30,9 @@ public class TracingTest {
                     .addClass(TestResource.class)
                     .addClass(Service.class)
                     .addClass(RestService.class)
+                    .addClass(Fruit.class)
+                    .addAsResource("application.properties")
+                    .addAsResource("import.sql")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 
     static MockTracer mockTracer = new MockTracer();
@@ -37,7 +40,7 @@ public class TracingTest {
         GlobalTracer.register(mockTracer);
     }
 
-    @AfterEach
+    @BeforeEach
     public void after() {
         mockTracer.reset();
     }

--- a/extensions/smallrye-opentracing/deployment/src/test/resources/application.properties
+++ b/extensions/smallrye-opentracing/deployment/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
+quarkus.datasource.url=jdbc:tracing:h2:mem:test
+quarkus.datasource.max-size=8
+quarkus.datasource.min-size=2
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+

--- a/extensions/smallrye-opentracing/deployment/src/test/resources/import.sql
+++ b/extensions/smallrye-opentracing/deployment/src/test/resources/import.sql
@@ -1,0 +1,3 @@
+INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
+INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
+INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/7079

The issue noted there is due to the way the `java.sql.DriverManager` deals with access to `java.sql.Driver` instances. Callers of various APIs on the `DriverManager` are allowed access to `Driver` based on classloader checks.

In that linked issue, it so happens that the Postgres driver gets loaded (early) in the augmentation classloader whereas the Tracing driver (the one which needs that underlying Postgres driver) gets loaded (a bit late) in the runtime classloader. As a result, the call from the Tracing driver, at runtime, is not allowed access to the Postgres driver.

The reason why this works in Java 11 is because in Java 11 the `java.sql.DriverManager` loads the drivers lazily[1] unlike in Java 8 where the `DriverManager` loads them eagerly[2]. Given the reliance on TCCL, in `DriverManager` for loading the drivers, this leads to potentially non-deterministic situation where the driver may or may not be loaded in the correct classloader.

To remedy this, the commit in this PR, forces loading of (any available) `Driver`s in the runtime classloader just before the datasource is being produced. This ensures that these drivers are then accessible in the rest of the runtime.

The commit also includes a testcase which reproduces the failure and verifies the fix.

[1] https://hg.openjdk.java.net/jdk/jdk/file/3b89be93a7e7/src/java.sql/share/classes/java/sql/DriverManager.java#l570
[2]  https://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/4db0e91b95c8/src/share/classes/java/sql/DriverManager.java#l100