### PR TITLE
Prevent generation of init group methods for build time config

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -461,7 +461,10 @@ public final class RunTimeConfigurationGenerator {
                 FieldDescriptor rootFieldDescriptor = root.getDescriptor();
 
                 // Get or generate group init method
-                MethodDescriptor initGroup = generateInitGroup(root);
+                MethodDescriptor initGroup = null;
+                if (root.getConfigPhase() != ConfigPhase.BUILD_TIME) {
+                    initGroup = generateInitGroup(root);
+                }
 
                 final MethodDescriptor ctor = accessorFinder
                         .getConstructorFor(MethodDescriptor.ofConstructor(configurationClass));


### PR DESCRIPTION
Not only are the init group methods unnecessary for build time
config since they are never called, but calling `generateInitGroup`
for build time config can also result in the generation of code
that refers to enums that are build time only if those enums
are part of the build time configuration (an issue I first came
across when working on #5496)