### PR TITLE
Add support for Vert.x Mutiny

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -125,7 +125,9 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <test-containers.version>1.12.4</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <axle-client.version>0.0.10</axle-client.version>
+        <mutiny.version>0.3.1</mutiny.version>
+        <axle-client.version>0.0.12</axle-client.version>
+        <mutiny-client.version>0.0.12</mutiny-client.version>
         <kafka-clients.version>2.3.1</kafka-clients.version>
         <kafka2.version>2.3.1</kafka2.version>
         <debezium.version>1.0.0.Final</debezium.version>
@@ -953,6 +955,16 @@
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-pool</artifactId>
                 <version>${agroal.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>mutiny</artifactId>
+                <version>${mutiny.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-mutiny</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.reactivex.rxjava2</groupId>
@@ -2109,8 +2121,43 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-generator</artifactId>
+                <version>${mutiny-client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-core</artifactId>
+                <version>${mutiny-client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-axle-web-client</artifactId>
                 <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+                <version>${mutiny-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
@@ -2129,8 +2176,18 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-sql-client</artifactId>
+                <version>${mutiny-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-axle-mysql-client</artifactId>
                 <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-mysql-client</artifactId>
+                <version>${mutiny-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
@@ -2139,8 +2196,18 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-pg-client</artifactId>
+                <version>${mutiny-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-axle-mail-client</artifactId>
                 <version>${axle-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-mutiny-vertx-mail-client</artifactId>
+                <version>${mutiny-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -34,7 +34,8 @@
            what we work with by self downloading it: -->
         <graal-sdk.version-for-documentation>19.3.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
-        <axle-client.version>0.0.9</axle-client.version>
+        <axle-client.version>0.0.12</axle-client.version>
+        <mutiny-client.version>0.0.12</mutiny-client.version>
         <vertx.version>3.8.5</vertx.version>
 
         <!-- Dev tools -->

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -44,6 +44,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String MAILER = "mailer";
     public static final String MONGODB_CLIENT = "mongodb-client";
     public static final String MONGODB_PANACHE = "mongodb-panache";
+    public static final String MUTINY = "mutiny";
     public static final String NARAYANA_JTA = "narayana-jta";
     public static final String NARAYANA_STM = "narayana-stm";
     public static final String REACTIVE_PG_CLIENT = "reactive-pg-client";

--- a/docs/src/main/asciidoc/reactive-messaging.adoc
+++ b/docs/src/main/asciidoc/reactive-messaging.adoc
@@ -90,6 +90,36 @@ void consumeBlocking(String message) {
 ----
 ====
 
+Asynchronous processing is also possible by returning either an `io.smallrye.mutiny.Uni` or a `java.util.concurrent.CompletionStage`:
+
+[source,java]
+----
+package org.acme.vertx;
+
+import io.quarkus.vertx.ConsumeEvent;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class GreetingService {
+
+    @ConsumeEvent
+    public CompletionStage<String> consume(String name) {
+        // return a CompletionStage completed when the processing is finished.
+        // You can also fail the CompletionStage explicitly
+    }
+
+    @ConsumeEvent
+    public Uni<String> process(String name) {
+        // return an Uni completed when the processing is finished.
+        // You can also fail the Uni explicitly
+    }
+}
+----
+
 === Configuring the address
 
 The `@ConsumeEvent` annotation can be configured to set the address:
@@ -116,15 +146,24 @@ public String consume(String name) {
 }
 ----
 
-You can also return a `CompletionStage<T>` to handle asynchronous reply:
+You can also return a `Uni<T>` or a `CompletionStage<T>` to handle asynchronous reply:
 
 [source, java]
 ----
 @ConsumeEvent("greeting")
-public CompletionStage<String> consume2(String name) {
-    return CompletableFuture.supplyAsync(name::toUpperCase, executor);
+public Uni<String> consume2(String name) {
+    return Uni.createFrom().item(() -> name.toUpperCase()).emitOn(executor);
 }
 ----
+
+[NOTE]
+====
+You can inject an `executor` if you use the Context Propagation extension:
+[source, code]
+----
+@Inject Executor executor;
+----
+====
 
 === Implementing fire and forget interactions
 
@@ -311,4 +350,3 @@ You can also compile it as a native executable with:
 ----
 ./mvnw clean package -Pnative
 ----
-

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -10,10 +10,12 @@ include::./attributes.adoc[]
 Eclipse https://vertx.io[Vert.x] is a toolkit for building reactive applications.
 It is designed to be lightweight and embeddable.
 Vert.x defines a reactive execution model and provides a large ecosystem.
-Quarkus integrates Vert.x to implement different reactive features, such as asynchronous message passing, and non-blocking HTTP client.
-Basically, Quarkus uses Vert.x as its reactive engine.
+
+Quarkus is based on Vert.x, and almost all network-related features rely on Vert.x.
 While lots of reactive features from Quarkus don't _show_ Vert.x, it's used underneath.
-But you can also access the managed Vert.x instance and benefit from the Vert.x ecosystem.
+Quarkus also integrates smoothly with the Vert.x event bus (to enable asynchronous messaging passing between application components) and some reactive clients.
+You can also use various Vert.x APIs in your Quarkus application, such as deploying _verticles_, instantiating clients...
+
 
 == Installing
 
@@ -57,9 +59,9 @@ Once the extension has been added, you can access the _managed_ Vert.x instance 
 ----
 
 If you are familiar with Vert.x, you know that Vert.x provides different API models.
-For instance _bare_ Vert.x uses callbacks, the RX Java 2 version uses `Single`, `Maybe`, `Completable`, `Observable` and `Flowable`.
+For instance _bare_ Vert.x uses callbacks, the Mutiny variants uses `Uni` and `Multi`, the RX Java 2 version uses `Single`, `Maybe`, `Completable`, `Observable` and `Flowable`...
 
-Quarkus provides 3 Vert.x APIs:
+Quarkus provides 4 Vert.x APIs:
 
 [options="header"]
 |===
@@ -68,22 +70,25 @@ Quarkus provides 3 Vert.x APIs:
 
 | _bare_ | `@Inject io.vertx.core.Vertx vertx` | _bare_ Vert.x instance, the API uses callbacks.
 
-| RX Java 2 | `@Inject io.vertx.reactivex.core.Vertx vertx` | RX Java 2 Vert.x, the API uses RX Java 2 types.
+| https://smallrye.io/smallrye-mutiny/[Mutiny] | `@Inject io.vertx.mutiny.core.Vertx vertx` | The Mutiny API for Vert.x.
 
-| _Axle_ | `@Inject io.vertx.axle.core.Vertx vertx` | Axle Vert.x, the API uses `CompletionStage` and `Reactive Streams`.
+| RX Java 2 | `@Inject io.vertx.reactivex.core.Vertx vertx` | RX Java 2 Vert.x, the API uses RX Java 2 types (deprecated).
+
+| _Axle_ | `@Inject io.vertx.axle.core.Vertx vertx` | Axle Vert.x, the API uses `CompletionStage` and `Reactive Streams` (deprecated).
 
 |===
 
-TIP: You may inject any of the 3 flavors of `Vertx` as well as the `EventBus` in your Quarkus application beans: `bare`, `Axle`, `RxJava2`.
+TIP: You may inject any of the 4 flavors of `Vertx` as well as the `EventBus` in your Quarkus application beans: `bare`, `Mutiny`, `Axle`, `RxJava2`.
 They are just shims and rely on a single _managed_ Vert.x instance.
 
 You will pick one or the other depending on your use cases.
 
 - `bare`: for advanced usage or if you have existing Vert.x code you want to reuse in your Quarkus application
-- `Axle`: works well with Quarkus and MicroProfile APIs (`CompletionStage` for single results and `Publisher` for streams)
-- `Rx Java 2`: when you need support for a wide range of data transformation operators on your streams
+- `mutiny`: Mutiny is an event-driven reactive programming API. It uses 2 types: `Uni` and `Multi`. This is the recommended API.
+- `Axle`: works well with Quarkus and MicroProfile APIs (`CompletionStage` for single results and `Publisher` for streams) - deprecated, it is recommended to switch to Mutiny
+- `Rx Java 2`: when you need support for a wide range of data transformation operators on your streams - deprecated, it is recommended to switch to Mutiny
 
-The following snippets illustrate the difference between these 3 APIs:
+The following snippets illustrate the difference between these 4 APIs:
 
 [source, java]
 ----
@@ -95,6 +100,14 @@ vertx.fileSystem().readFile("lorem-ipsum.txt", ar -> {
         System.out.println("Cannot read the file: " + ar.cause().getMessage());
     }
 });
+
+// Mutiny Vert.x:
+vertx.fileSystem().readFile("lorem-ipsum.txt")
+    .onItem().apply(buffer -> buffer.toString("UTF-8"))
+    .subscribe(
+            content -> System.out.println("Content: " + content),
+            err -> System.out.println("Cannot read the file: " + err.getMessage())
+    );
 
 // Rx Java 2 Vert.x
 vertx.fileSystem().rxReadFile("lorem-ipsum.txt")
@@ -355,6 +368,12 @@ Depending on the API model you want to use you need to add the right dependency 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web-client</artifactId>
+</dependency>
+
+<!-- Mutiny API -->
+<dependency>
+  <groupId>io.smallrye.reactive</groupId>
+  <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
 </dependency>
 
 <!-- Axle API -->

--- a/extensions/mutiny/deployment/pom.xml
+++ b/extensions/mutiny/deployment/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-mutiny-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-mutiny-deployment</artifactId>
+    <name>Quarkus - Mutiny - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -1,0 +1,12 @@
+package io.quarkus.mutiny.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+public class MutinyProcessor {
+
+    @BuildStep
+    public FeatureBuildItem registerFeature() {
+        return new FeatureBuildItem(FeatureBuildItem.MUTINY);
+    }
+}

--- a/extensions/mutiny/deployment/src/test/java/io/quarkus/mutiny/deployment/test/MutinyTest.java
+++ b/extensions/mutiny/deployment/src/test/java/io/quarkus/mutiny/deployment/test/MutinyTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.mutiny.deployment.test;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class MutinyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BeanUsingMutiny.class));
+
+    @Inject
+    BeanUsingMutiny bean;
+
+    @Test
+    public void testUni() {
+        String s = bean.greeting().await().indefinitely();
+        Assertions.assertEquals(s, "hello");
+    }
+
+    @Test
+    public void testMulti() {
+        List<String> list = bean.stream().collectItems().asList().await().indefinitely();
+        Assertions.assertEquals(list.get(0), "hello");
+        Assertions.assertEquals(list.get(1), "world");
+    }
+
+    @ApplicationScoped
+    public static class BeanUsingMutiny {
+
+        public Uni<String> greeting() {
+            return Uni.createFrom().item(() -> "hello")
+                    .emitOn(Infrastructure.getDefaultExecutor());
+        }
+
+        public Multi<String> stream() {
+            return Multi.createFrom().items("hello", "world")
+                    .emitOn(Infrastructure.getDefaultExecutor());
+        }
+
+    }
+}

--- a/extensions/mutiny/pom.xml
+++ b/extensions/mutiny/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>quarkus-mutiny-parent</artifactId>
+    <name>Quarkus - Mutiny</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/mutiny/runtime/pom.xml
+++ b/extensions/mutiny/runtime/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-mutiny-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-mutiny</artifactId>
+    <name>Quarkus - Mutiny - Runtime</name>
+    <description>Mutiny is a Reactive Programming library</description>
+    <dependencies>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -55,6 +55,7 @@
         <module>swagger-ui</module>
 
         <!-- Reactive -->
+        <module>mutiny</module>
         <module>vertx</module>
         <module>vertx-web</module>
         <module>netty</module>

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.vertx.deployment.VertxConstants.COMPLETION_STAGE;
 import static io.quarkus.vertx.deployment.VertxConstants.CONSUME_EVENT;
 import static io.quarkus.vertx.deployment.VertxConstants.LOCAL_EVENT_BUS_CODEC;
 import static io.quarkus.vertx.deployment.VertxConstants.MESSAGE;
+import static io.quarkus.vertx.deployment.VertxConstants.MUTINY_MESSAGE;
 import static io.quarkus.vertx.deployment.VertxConstants.RX_MESSAGE;
 
 import java.util.Arrays;
@@ -121,6 +122,7 @@ public class EventBusCodecProcessor {
 
             // Buffers classes
             Buffer.class.getName(),
+            io.vertx.mutiny.core.buffer.Buffer.class.getName(),
             io.vertx.axle.core.buffer.Buffer.class.getName(),
             io.vertx.reactivex.core.buffer.Buffer.class.getName());
 
@@ -130,7 +132,8 @@ public class EventBusCodecProcessor {
             return returnType;
         } else if (returnType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
             ParameterizedType returnedParamType = returnType.asParameterizedType();
-            if (!returnedParamType.arguments().isEmpty() && (returnedParamType.name().equals(COMPLETION_STAGE))) {
+            if (!returnedParamType.arguments().isEmpty()
+                    && (returnedParamType.name().equals(COMPLETION_STAGE))) {
                 return returnedParamType.arguments().get(0);
             } else {
                 return returnedParamType;
@@ -181,6 +184,7 @@ public class EventBusCodecProcessor {
     private static boolean isMessageClass(ParameterizedType type) {
         return type.name().equals(MESSAGE)
                 || type.name().equals(RX_MESSAGE)
-                || type.name().equals(AXLE_MESSAGE);
+                || type.name().equals(AXLE_MESSAGE)
+                || type.name().equals(MUTINY_MESSAGE);
     }
 }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
@@ -7,6 +7,7 @@ import static io.quarkus.vertx.deployment.VertxConstants.LOCAL_EVENT_BUS_CODEC;
 import static io.quarkus.vertx.deployment.VertxConstants.MESSAGE;
 import static io.quarkus.vertx.deployment.VertxConstants.MUTINY_MESSAGE;
 import static io.quarkus.vertx.deployment.VertxConstants.RX_MESSAGE;
+import static io.quarkus.vertx.deployment.VertxConstants.UNI;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -133,7 +134,7 @@ public class EventBusCodecProcessor {
         } else if (returnType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
             ParameterizedType returnedParamType = returnType.asParameterizedType();
             if (!returnedParamType.arguments().isEmpty()
-                    && (returnedParamType.name().equals(COMPLETION_STAGE))) {
+                    && (returnedParamType.name().equals(COMPLETION_STAGE) || returnedParamType.name().equals(UNI))) {
                 return returnedParamType.arguments().get(0);
             } else {
                 return returnedParamType;

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusConsumer.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusConsumer.java
@@ -158,7 +158,8 @@ class EventBusConsumer {
      */
     private static void logDeprecation(BytecodeCreator invoke, MethodInfo method, String deprecatedClass) {
         String msg = String
-                .format("The `%s.%s` method is using the deprecated `%s` class. It is recommended to switch to `%s`",
+                .format("The `%s.%s` method is using the deprecated `%s` class. This class will be removed in a "
+                        + "future version. It is recommended to switch to `%s`",
                         method.declaringClass().name(), method.name(), deprecatedClass,
                         io.vertx.mutiny.core.eventbus.Message.class.getName());
         ResultHandle loggerName = invoke.load(EventBusConsumer.class.getName());

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxConstants.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxConstants.java
@@ -6,6 +6,7 @@ import org.jboss.jandex.DotName;
 
 import io.quarkus.vertx.ConsumeEvent;
 import io.quarkus.vertx.LocalEventBusCodec;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.eventbus.Message;
 
 public class VertxConstants {
@@ -15,7 +16,10 @@ public class VertxConstants {
             .createSimple(io.vertx.reactivex.core.eventbus.Message.class.getName());
     static final DotName AXLE_MESSAGE = DotName
             .createSimple(io.vertx.axle.core.eventbus.Message.class.getName());
+    static final DotName MUTINY_MESSAGE = DotName
+            .createSimple(io.vertx.mutiny.core.eventbus.Message.class.getName());
     static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
+    static final DotName UNI = DotName.createSimple(Uni.class.getName());
     static final DotName LOCAL_EVENT_BUS_CODEC = DotName.createSimple(LocalEventBusCodec.class.getName());
     static final DotName CONSUME_EVENT = DotName.createSimple(ConsumeEvent.class.getName());
 }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/AxleCodecRegistrationTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/AxleCodecRegistrationTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.core.eventbus.Message;
+import io.vertx.axle.core.Vertx;
+import io.vertx.axle.core.eventbus.Message;
 
-public class CodecRegistrationTest {
+public class AxleCodecRegistrationTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -37,23 +37,23 @@ public class CodecRegistrationTest {
     @Test
     public void testReceptionOfString() {
         String address = "address-1";
-        vertx.eventBus().sendAndForget(address, "a");
-        vertx.eventBus().sendAndForget(address, "b");
-        vertx.eventBus().sendAndForget(address, "c");
+        vertx.eventBus().send(address, "a");
+        vertx.eventBus().send(address, "b");
+        vertx.eventBus().send(address, "c");
         await().until(() -> bean.getAddress1().size() == 3);
     }
 
     @Test
     public void testReceptionOfStringAndSendingNothing() {
         String address = "address-2";
-        vertx.eventBus().sendAndForget(address, "a");
-        vertx.eventBus().sendAndForget(address, "b");
-        vertx.eventBus().sendAndForget(address, "c");
+        vertx.eventBus().send(address, "a");
+        vertx.eventBus().send(address, "b");
+        vertx.eventBus().send(address, "c");
         await().until(() -> bean.getAddress2().size() == 3);
 
         List<Message<?>> messages = new CopyOnWriteArrayList<>();
-        vertx.eventBus().request(address, "d").onItem().invoke(messages::add).subscribeAsCompletionStage();
-        vertx.eventBus().request(address, "e").onItem().invoke(messages::add).subscribeAsCompletionStage();
+        vertx.eventBus().request(address, "d").thenAccept(messages::add);
+        vertx.eventBus().request(address, "e").thenAccept(messages::add);
         await().until(() -> messages.size() == 2);
         assertThat(messages.get(0).body()).isNull();
         assertThat(messages.get(1).body()).isNull();
@@ -63,8 +63,8 @@ public class CodecRegistrationTest {
     public void testWithPrimitiveTypes() {
         String address = "address-3";
         List<Message<Long>> messages = new CopyOnWriteArrayList<>();
-        vertx.eventBus().<Long> request(address, 1).onItem().invoke(messages::add).subscribeAsCompletionStage();
-        vertx.eventBus().<Long> request(address, 2).onItem().invoke(messages::add).subscribeAsCompletionStage();
+        vertx.eventBus().<Long> request(address, 1).thenAccept(messages::add);
+        vertx.eventBus().<Long> request(address, 2).thenAccept(messages::add);
         await().until(() -> messages.size() == 2);
         assertThat(messages.get(0).body()).isBetween(1L, 4L);
         assertThat(messages.get(1).body()).isBetween(1L, 4L);
@@ -74,8 +74,8 @@ public class CodecRegistrationTest {
     public void testWithPrimitiveTypesAndCompletionStage() {
         String address = "address-4";
         List<Message<Long>> messages = new CopyOnWriteArrayList<>();
-        vertx.eventBus().<Long> request(address, 1).onItem().invoke(messages::add).subscribeAsCompletionStage();
-        vertx.eventBus().<Long> request(address, 2).onItem().invoke(messages::add).subscribeAsCompletionStage();
+        vertx.eventBus().<Long> request(address, 1).thenAccept(messages::add);
+        vertx.eventBus().<Long> request(address, 2).thenAccept(messages::add);
         await().until(() -> messages.size() == 2);
         assertThat(messages.get(0).body()).isBetween(1L, 4L);
         assertThat(messages.get(1).body()).isBetween(1L, 4L);
@@ -84,9 +84,9 @@ public class CodecRegistrationTest {
     @Test
     public void testCodecRegistrationBasedOnParameterType() {
         String address = "address-5";
-        vertx.eventBus().sendAndForget(address, new CustomType1("foo"));
-        vertx.eventBus().sendAndForget(address, new CustomType1("bar"));
-        vertx.eventBus().sendAndForget(address, new CustomType1("baz"));
+        vertx.eventBus().send(address, new CustomType1("foo"));
+        vertx.eventBus().send(address, new CustomType1("bar"));
+        vertx.eventBus().send(address, new CustomType1("baz"));
 
         await().until(() -> bean.getSink().size() == 3);
 
@@ -96,9 +96,9 @@ public class CodecRegistrationTest {
 
         bean.getSink().clear();
         address = "address-6";
-        vertx.eventBus().sendAndForget(address, new CustomType1("foo-x"));
-        vertx.eventBus().sendAndForget(address, new CustomType1("bar-x"));
-        vertx.eventBus().sendAndForget(address, new CustomType1("baz-x"));
+        vertx.eventBus().send(address, new CustomType1("foo-x"));
+        vertx.eventBus().send(address, new CustomType1("bar-x"));
+        vertx.eventBus().send(address, new CustomType1("baz-x"));
 
         await().until(() -> bean.getSink().size() == 3);
         set = bean.getSink().stream().map(x -> (CustomType1) x).map(CustomType1::getName)
@@ -110,12 +110,9 @@ public class CodecRegistrationTest {
     public void testCodecRegistrationBasedOnReturnType() {
         String address = "address-7";
         List<CustomType3> list = new CopyOnWriteArrayList<>();
-        vertx.eventBus().<CustomType3> request(address, "foo").onItem().invoke(m -> list.add(m.body()))
-                .subscribeAsCompletionStage();
-        vertx.eventBus().<CustomType3> request(address, "bar").onItem().invoke(m -> list.add(m.body()))
-                .subscribeAsCompletionStage();
-        vertx.eventBus().<CustomType3> request(address, "baz").onItem().invoke(m -> list.add(m.body()))
-                .subscribeAsCompletionStage();
+        vertx.eventBus().<CustomType3> request(address, "foo").thenApply(Message::body).thenAccept(list::add);
+        vertx.eventBus().<CustomType3> request(address, "bar").thenApply(Message::body).thenAccept(list::add);
+        vertx.eventBus().<CustomType3> request(address, "baz").thenApply(Message::body).thenAccept(list::add);
 
         await().until(() -> list.size() == 3);
 
@@ -128,12 +125,9 @@ public class CodecRegistrationTest {
     public void testCodecRegistrationBasedOnReturnTypeWithCompletionStage() {
         String address = "address-8";
         List<CustomType4> list = new CopyOnWriteArrayList<>();
-        vertx.eventBus().<CustomType4> request(address, "foo").onItem().invoke(m -> list.add(m.body()))
-                .subscribeAsCompletionStage();
-        vertx.eventBus().<CustomType4> request(address, "bar").onItem().invoke(m -> list.add(m.body()))
-                .subscribeAsCompletionStage();
-        vertx.eventBus().<CustomType4> request(address, "baz").onItem().invoke(m -> list.add(m.body()))
-                .subscribeAsCompletionStage();
+        vertx.eventBus().<CustomType4> request(address, "foo").thenApply(Message::body).thenAccept(list::add);
+        vertx.eventBus().<CustomType4> request(address, "bar").thenApply(Message::body).thenAccept(list::add);
+        vertx.eventBus().<CustomType4> request(address, "baz").thenApply(Message::body).thenAccept(list::add);
 
         await().until(() -> list.size() == 3);
 
@@ -169,7 +163,7 @@ public class CodecRegistrationTest {
 
         @ConsumeEvent("address-3")
         long listenAddress3(int i) {
-            return i + 1;
+            return (long) (i + 1);
         }
 
         @ConsumeEvent("address-4")

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/AxleCodecTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/AxleCodecTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.axle.core.Vertx;
+import io.vertx.axle.core.eventbus.Message;
+
+public class AxleCodecTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap
+                    .create(JavaArchive.class).addClasses(MyBean.class, MyNonLocalBean.class,
+                            MyPetCodec.class, Person.class, Pet.class));
+
+    @Inject
+    MyBean bean;
+
+    /**
+     * Bean setting the consumption to be non-local.
+     * So, the user must configure the codec explicitly.
+     */
+    @Inject
+    MyNonLocalBean nonLocalBean;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    public void testWithGenericCodec() {
+        Greeting hello = vertx.eventBus().<Greeting> request("person", new Person("bob", "morane"))
+                .thenApply(Message::body)
+                .toCompletableFuture().join();
+        assertThat(hello.getMessage()).isEqualTo("Hello bob morane");
+    }
+
+    @Test
+    public void testWithUserCodec() {
+        Greeting hello = vertx.eventBus().<Greeting> request("pet", new Pet("neo", "rabbit"))
+                .thenApply(Message::body)
+                .toCompletableFuture().join();
+        assertThat(hello.getMessage()).isEqualTo("Hello NEO");
+    }
+
+    @Test
+    public void testWithUserCodecNonLocal() {
+        Greeting hello = vertx.eventBus().<Greeting> request("nl-pet", new Pet("neo", "rabbit"))
+                .thenApply(Message::body)
+                .toCompletableFuture().join();
+        assertThat(hello.getMessage()).isEqualTo("Non Local Hello NEO");
+    }
+
+    static class Greeting {
+        private final String message;
+
+        Greeting(String message) {
+            this.message = message;
+        }
+
+        String getMessage() {
+            return message;
+        }
+    }
+
+    static class MyBean {
+        @ConsumeEvent("person")
+        public CompletionStage<Greeting> hello(Person p) {
+            return CompletableFuture.completedFuture(new Greeting("Hello " + p.getFirstName() + " " + p.getLastName()));
+        }
+
+        @ConsumeEvent(value = "pet", codec = MyPetCodec.class)
+        public CompletionStage<Greeting> hello(Pet p) {
+            return CompletableFuture.completedFuture(new Greeting("Hello " + p.getName()));
+        }
+    }
+
+    static class MyNonLocalBean {
+        @ConsumeEvent(value = "nl-pet", codec = MyPetCodec.class, local = false)
+        public CompletionStage<Greeting> hello(Pet p) {
+            return CompletableFuture.completedFuture(new Greeting("Non Local Hello " + p.getName()));
+        }
+    }
+
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerFailureTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerFailureTest.java
@@ -3,7 +3,9 @@ package io.quarkus.vertx.deployment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyException;
@@ -35,12 +38,15 @@ public class MessageConsumerFailureTest {
 
     @Test
     public void testFailure() throws InterruptedException {
-        verifyFailure("foo", "java.lang.IllegalStateException: Foo is dead");
-        verifyFailure("foo-message", "java.lang.NullPointerException");
-        verifyFailure("foo-completion-stage", "java.lang.NullPointerException: Something is null");
+        verifyFailure("foo", "java.lang.IllegalStateException: Foo is dead", false);
+        verifyFailure("foo-message", "java.lang.NullPointerException", false);
+        verifyFailure("foo-completion-stage", "java.lang.NullPointerException: Something is null", false);
+        verifyFailure("foo-completion-stage-failure", "boom", true);
+        verifyFailure("foo-uni", "java.lang.NullPointerException: Something is null", false);
+        verifyFailure("foo-uni-failure", "boom", true);
     }
 
-    void verifyFailure(String address, String expectedMessage) throws InterruptedException {
+    void verifyFailure(String address, String expectedMessage, boolean explicit) throws InterruptedException {
         BlockingQueue<Object> synchronizer = new LinkedBlockingQueue<>();
         eventBus.request(address, "hello", ar -> {
             try {
@@ -56,7 +62,11 @@ public class MessageConsumerFailureTest {
         Object ret = synchronizer.poll(2, TimeUnit.SECONDS);
         assertTrue(ret instanceof ReplyException);
         ReplyException replyException = (ReplyException) ret;
-        assertEquals(ConsumeEvent.FAILURE_CODE, replyException.failureCode());
+        if (!explicit) {
+            assertEquals(ConsumeEvent.FAILURE_CODE, replyException.failureCode());
+        } else {
+            assertEquals(ConsumeEvent.EXPLICIT_FAILURE_CODE, replyException.failureCode());
+        }
         assertEquals(expectedMessage, replyException.getMessage());
     }
 
@@ -75,6 +85,23 @@ public class MessageConsumerFailureTest {
         @ConsumeEvent("foo-completion-stage")
         CompletionStage<String> failCompletionStage(String message) {
             throw new NullPointerException("Something is null");
+        }
+
+        @ConsumeEvent("foo-completion-stage-failure")
+        CompletionStage<String> failedCompletionStage(String message) {
+            CompletableFuture<String> future = new CompletableFuture<>();
+            future.completeExceptionally(new IOException("boom"));
+            return future;
+        }
+
+        @ConsumeEvent(value = "foo-uni")
+        Uni<String> failUni(String message) {
+            throw new NullPointerException("Something is null");
+        }
+
+        @ConsumeEvent(value = "foo-uni-failure")
+        Uni<String> failedUni(String message) {
+            return Uni.createFrom().failure(new IOException("boom"));
         }
 
     }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerMethodTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerMethodTest.java
@@ -152,6 +152,16 @@ public class MessageConsumerMethodTest {
         assertTrue(SimpleBean.MESSAGES.contains("HELLO"));
     }
 
+    @Test
+    public void testPublishMutiny() throws InterruptedException {
+        SimpleBean.MESSAGES.clear();
+        EventBus eventBus = Arc.container().instance(EventBus.class).get();
+        SimpleBean.latch = new CountDownLatch(1);
+        eventBus.publish("pub-mutiny", "Hello");
+        SimpleBean.latch.await(2, TimeUnit.SECONDS);
+        assertTrue(SimpleBean.MESSAGES.contains("HELLO"));
+    }
+
     static class SimpleBean {
 
         static volatile CountDownLatch latch;
@@ -202,6 +212,12 @@ public class MessageConsumerMethodTest {
 
         @ConsumeEvent("pub-rx")
         void consume(io.vertx.reactivex.core.eventbus.Message<String> message) {
+            MESSAGES.add(message.body().toUpperCase());
+            latch.countDown();
+        }
+
+        @ConsumeEvent("pub-mutiny")
+        void consume(io.vertx.mutiny.core.eventbus.Message<String> message) {
             MESSAGES.add(message.body().toUpperCase());
             latch.countDown();
         }

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/VertxProducerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/VertxProducerTest.java
@@ -32,7 +32,7 @@ public class VertxProducerTest {
     BeanUsingBareVertx beanUsingVertx;
 
     @Inject
-    BeanUsingBareVertx beanUsingMutiny;
+    BeanUsingMutinyVertx beanUsingMutiny;
 
     @Inject
     BeanUsingAxleVertx beanUsingAxle;
@@ -45,6 +45,7 @@ public class VertxProducerTest {
         beanUsingVertx.verify();
         beanUsingAxle.verify();
         beanUsingRx.verify();
+        beanUsingMutiny.verify();
     }
 
     @ApplicationScoped

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/VertxProducerTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/VertxProducerTest.java
@@ -25,10 +25,14 @@ public class VertxProducerTest {
                     .addAsResource(new File("src/test/resources/lorem.txt"), "files/lorem.txt")
                     .addClasses(BeanUsingBareVertx.class)
                     .addClasses(BeanUsingAxleVertx.class)
-                    .addClasses(BeanUsingRXVertx.class));
+                    .addClasses(BeanUsingRXVertx.class)
+                    .addClasses(BeanUsingMutinyVertx.class));
 
     @Inject
     BeanUsingBareVertx beanUsingVertx;
+
+    @Inject
+    BeanUsingBareVertx beanUsingMutiny;
 
     @Inject
     BeanUsingAxleVertx beanUsingAxle;
@@ -88,6 +92,22 @@ public class VertxProducerTest {
             CountDownLatch latch = new CountDownLatch(1);
             vertx.fileSystem().rxReadFile("src/test/resources/lorem.txt")
                     .subscribe(buffer -> latch.countDown());
+            latch.await(5, TimeUnit.SECONDS);
+        }
+
+    }
+
+    @ApplicationScoped
+    static class BeanUsingMutinyVertx {
+
+        @Inject
+        io.vertx.mutiny.core.Vertx vertx;
+
+        public void verify() throws Exception {
+            CountDownLatch latch = new CountDownLatch(1);
+            CompletionStage<io.vertx.mutiny.core.buffer.Buffer> stage = vertx.fileSystem().readFile("files/lorem.txt")
+                    .subscribeAsCompletionStage();
+            stage.thenAccept(buffer -> latch.countDown());
             latch.await(5, TimeUnit.SECONDS);
         }
 

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -55,6 +55,14 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-rx-java2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/ConsumeEvent.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/ConsumeEvent.java
@@ -54,6 +54,14 @@ public @interface ConsumeEvent {
     int FAILURE_CODE = 0x1FF9;
 
     /**
+     * Failure code used when a message consumer explicitly fails an asynchronous processing.
+     *
+     * This status is used when the method annotated with {@link ConsumeEvent} returns a failed
+     * {@link java.util.concurrent.CompletionStage} or {@link io.smallrye.mutiny.Uni}.
+     */
+    int EXPLICIT_FAILURE_CODE = 0x1FFF;
+
+    /**
      * The address the consumer will be registered to. By default, the fully qualified name of the declaring bean class is
      * assumed.
      *

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxProducer.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxProducer.java
@@ -1,33 +1,37 @@
 package io.quarkus.vertx.runtime;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.jboss.logging.Logger;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 
 /**
- * Expose the Vert.x event bus and produces Axle and Rx Vert.x instances.
+ * Expose the Vert.x event bus and produces Mutiny, Axle (Deprecated) and Rx Vert.x (Deprecated) instances.
  * <p>
  * The original Vert.x instance is coming from the core artifact.
+ *
+ * IMPORTANT: The Axle and RxJava 2 API are now deprecated. It is recommended to switch to the Mutiny API.
  */
 @ApplicationScoped
 public class VertxProducer {
 
+    private static final Logger LOGGER = Logger.getLogger(VertxProducer.class);
+
     @Inject
     Vertx vertx;
 
+    @Deprecated
     private io.vertx.axle.core.Vertx axleVertx;
+
+    @Deprecated
     private io.vertx.reactivex.core.Vertx rxVertx;
 
-    @PostConstruct
-    public void initialize() {
-        this.axleVertx = io.vertx.axle.core.Vertx.newInstance(vertx);
-        this.rxVertx = io.vertx.reactivex.core.Vertx.newInstance(vertx);
-    }
+    private io.vertx.mutiny.core.Vertx mutinyVertx;
 
     @Singleton
     @Produces
@@ -37,25 +41,58 @@ public class VertxProducer {
 
     @Singleton
     @Produces
-    public io.vertx.axle.core.Vertx axle() {
+    public synchronized io.vertx.mutiny.core.Vertx mutiny() {
+        if (mutinyVertx == null) {
+            mutinyVertx = io.vertx.mutiny.core.Vertx.newInstance(vertx);
+        }
+        return mutinyVertx;
+    }
+
+    @Singleton
+    @Produces
+    @Deprecated
+    public synchronized io.vertx.axle.core.Vertx axle() {
+        if (axleVertx == null) {
+            LOGGER.warn(
+                    "`io.vertx.axle.core.Vertx` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.Vertx`");
+            axleVertx = io.vertx.axle.core.Vertx.newInstance(vertx);
+        }
         return axleVertx;
     }
 
     @Singleton
     @Produces
+    @Deprecated
     public io.vertx.reactivex.core.Vertx rx() {
+        if (rxVertx == null) {
+            LOGGER.warn(
+                    "`io.vertx.reactivex.core.Vertx` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.eventbus.Vertx`");
+            rxVertx = io.vertx.reactivex.core.Vertx.newInstance(vertx);
+        }
         return rxVertx;
     }
 
     @Singleton
     @Produces
-    public io.vertx.axle.core.eventbus.EventBus axleEventbus() {
-        return axleVertx.eventBus();
+    @Deprecated
+    public io.vertx.axle.core.eventbus.EventBus axleEventBus() {
+        LOGGER.warn(
+                "`io.vertx.axle.core.eventbus.EventBus` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.eventbus.EventBus`");
+        return axle().eventBus();
     }
 
     @Singleton
     @Produces
-    public synchronized io.vertx.reactivex.core.eventbus.EventBus rxRventbus() {
-        return rxVertx.eventBus();
+    @Deprecated
+    public synchronized io.vertx.reactivex.core.eventbus.EventBus rxEventBus() {
+        LOGGER.warn(
+                "`io.vertx.reactivex.core.eventbus.EventBus` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.eventbus.EventBus`");
+        return rx().eventBus();
+    }
+
+    @Singleton
+    @Produces
+    public synchronized io.vertx.mutiny.core.eventbus.EventBus mutinyEventBus() {
+        return mutiny().eventBus();
     }
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxProducer.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxProducer.java
@@ -54,7 +54,8 @@ public class VertxProducer {
     public synchronized io.vertx.axle.core.Vertx axle() {
         if (axleVertx == null) {
             LOGGER.warn(
-                    "`io.vertx.axle.core.Vertx` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.Vertx`");
+                    "`io.vertx.axle.core.Vertx` is deprecated and will be removed in a future version - it is "
+                            + "recommended to switch to `io.vertx.mutiny.core.Vertx`");
             axleVertx = io.vertx.axle.core.Vertx.newInstance(vertx);
         }
         return axleVertx;
@@ -66,7 +67,8 @@ public class VertxProducer {
     public io.vertx.reactivex.core.Vertx rx() {
         if (rxVertx == null) {
             LOGGER.warn(
-                    "`io.vertx.reactivex.core.Vertx` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.eventbus.Vertx`");
+                    "`io.vertx.reactivex.core.Vertx` is deprecated  and will be removed in a future version - it is "
+                            + "recommended to switch to `io.vertx.mutiny.core.eventbus.Vertx`");
             rxVertx = io.vertx.reactivex.core.Vertx.newInstance(vertx);
         }
         return rxVertx;
@@ -77,7 +79,8 @@ public class VertxProducer {
     @Deprecated
     public io.vertx.axle.core.eventbus.EventBus axleEventBus() {
         LOGGER.warn(
-                "`io.vertx.axle.core.eventbus.EventBus` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.eventbus.EventBus`");
+                "`io.vertx.axle.core.eventbus.EventBus` is deprecated and will be removed in a future version - it is "
+                        + "recommended to switch to `io.vertx.mutiny.core.eventbus.EventBus`");
         return axle().eventBus();
     }
 
@@ -86,7 +89,8 @@ public class VertxProducer {
     @Deprecated
     public synchronized io.vertx.reactivex.core.eventbus.EventBus rxEventBus() {
         LOGGER.warn(
-                "`io.vertx.reactivex.core.eventbus.EventBus` is deprecated - it is recommended to switch to `io.vertx.mutiny.core.eventbus.EventBus`");
+                "`io.vertx.reactivex.core.eventbus.EventBus` is deprecated and will be removed in a future version - it "
+                        + "is recommended to switch to `io.vertx.mutiny.core.eventbus.EventBus`");
         return rx().eventBus();
     }
 

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -15,20 +15,19 @@ public class VertxProducerTest {
     private VertxProducer producer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         producer = new VertxProducer();
         recorder = new VertxRecorder();
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         recorder.destroy();
     }
 
     @Test
     public void shouldNotFailWithoutConfig() {
         producer.vertx = VertxCoreRecorder.initialize(null);
-        producer.initialize();
         verifyProducer();
     }
 
@@ -37,10 +36,15 @@ public class VertxProducerTest {
 
         assertThat(producer.axle()).isNotNull();
         assertFalse(producer.axle().isClustered());
-        assertThat(producer.axleEventbus()).isNotNull();
+        assertThat(producer.axleEventBus()).isNotNull();
 
         assertThat(producer.rx()).isNotNull();
         assertFalse(producer.rx().isClustered());
-        assertThat(producer.rxRventbus()).isNotNull();
+        assertThat(producer.rxEventBus()).isNotNull();
+
+        assertThat(producer.mutiny()).isNotNull();
+        assertFalse(producer.mutiny().isClustered());
+        assertThat(producer.mutinyEventBus()).isNotNull();
+
     }
 }


### PR DESCRIPTION
This pull request is the first PR related to the #7097 epic. 

It:

* Creates a Mutiny extension (kept simple for now, would but required for the context propagation part that will come in another PR)
* Exposes the Vert.x Mutiny API
* Add support for `Uni` with `@ConsumeEvent`
* Update the impacted documentation

Note that this PR also changes a few things:

* A deprecation message is printed when the RX or Axle Vert.x and event bus instances are injected
* A deprecation message is printed if a `@ConsumeEvent` method  using an RX or Axle Message is used
* Add explicit async failure support to `@ConsumeEvent` 

This PR is the first of the epic. Once merged, I can work on several other PRs in parallel. 
