### PR TITLE
doc: remove unused import of PathVariable

### DIFF
--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -62,7 +62,6 @@ package org.acme.spring.web;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @RestController
 @RequestMapping("/greeting")


### PR DESCRIPTION
PathVariable annotation is not used in the code snippet, so I removed it for clarification.