### PR TITLE
Exclude jackson-module-scala

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2167,6 +2167,10 @@
                         <artifactId>jackson-core</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.12</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.scala-lang</groupId>
                         <artifactId>scala-reflect</artifactId>
                     </exclusion>


### PR DESCRIPTION
This breaks jackson if it is included and scala is not present