### PR TITLE
Resolve swallowed exceptions on Hibernate ORM loading of Integrator services

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
@@ -67,12 +67,19 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
     private final LoadedConfig aggregatedCfgXml;
 
     public RecordableBootstrap(BootstrapServiceRegistry bootstrapServiceRegistry) {
-        this(bootstrapServiceRegistry, LoadedConfig.baseline());
+        this(bootstrapServiceRegistry, initialProperties(), LoadedConfig.baseline());
     }
 
-    public RecordableBootstrap(BootstrapServiceRegistry bootstrapServiceRegistry, LoadedConfig loadedConfigBaseline) {
-        this.settings = new HashMap();
-        this.settings.putAll(QuarkusEnvironment.getInitialProperties());
+    private static Map initialProperties() {
+        HashMap map = new HashMap();
+        map.putAll(QuarkusEnvironment.getInitialProperties());
+        return map;
+    }
+
+    private RecordableBootstrap(BootstrapServiceRegistry bootstrapServiceRegistry, Map properties,
+            LoadedConfig loadedConfigBaseline) {
+        super(bootstrapServiceRegistry, properties, loadedConfigBaseline);
+        this.settings = properties;
         this.bootstrapServiceRegistry = bootstrapServiceRegistry;
         this.configLoader = new ConfigLoader(bootstrapServiceRegistry);
         this.aggregatedCfgXml = loadedConfigBaseline;


### PR DESCRIPTION
…ervices

Without the patch, a default super() constructor was being invoked which was overriding the bootstrap registry's classloader service with the default from ORM instead of the Quarkus classloader service we're supposed to use.

That default constructor was also capturing Environment variables, something we don't want to do.

Both problems had no other consequence than cosmetics and bloat, so this is hard to test for.

Fixes #7081 