### PR TITLE
JWTAuthContextInfo - setSignerKey was deprecated

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TokenRealmUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TokenRealmUnitTest.java
@@ -29,9 +29,7 @@ public class TokenRealmUnitTest {
         KeyPair keyPair = generateKeyPair();
         PublicKey pk1 = keyPair.getPublic();
         PrivateKey pk1Priv = keyPair.getPrivate();
-        JWTAuthContextInfo contextInfo = new JWTAuthContextInfo();
-        contextInfo.setSignerKey((RSAPublicKey) pk1);
-        contextInfo.setIssuedBy("https://server.example.com");
+        JWTAuthContextInfo contextInfo = new JWTAuthContextInfo((RSAPublicKey) pk1, "https://server.example.com");
         MpJwtValidator jwtValidator = new MpJwtValidator(contextInfo);
         QuarkusIdentityProviderManagerImpl authenticator = QuarkusIdentityProviderManagerImpl.builder()
                 .addProvider(new AnonymousIdentityProvider())


### PR DESCRIPTION
JWTAuthContextInfo - setSignerKey was deprecated

https://github.com/smallrye/smallrye-jwt/commit/15ecc62b4e926c051ddb6378ec07ef0e996aa2b1