### PR TITLE
Gather and expose information about all known scopes before transforming annotations

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ContextRegistrarBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ContextRegistrarBuildItem.java
@@ -1,20 +1,56 @@
 package io.quarkus.arc.deployment;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.jandex.DotName;
+import org.jboss.logging.Logger;
+
 import io.quarkus.arc.processor.ContextRegistrar;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Make it possible to register a custom CDI context.
+ * Make it possible to register one or more custom CDI contexts.
+ * If you are registering a new context, you also pass in the respective annotation value into the constructor either in
+ * {@link DotName} form, or as {@code Class<? extends Annotation>}.
+ *
+ * This information is then leveraged in {@link CustomScopeAnnotationsBuildItem} which allows consumers to browse
+ * all known custom scoped within deployment even early in the build process.
  */
 public final class ContextRegistrarBuildItem extends MultiBuildItem {
 
-    private final ContextRegistrar contextRegistrar;
+    private static final Logger LOGGER = Logger.getLogger(ContextRegistrarBuildItem.class);
 
-    public ContextRegistrarBuildItem(ContextRegistrar contextRegistrar) {
+    private final ContextRegistrar contextRegistrar;
+    private final Collection<DotName> annotationNames;
+
+    public ContextRegistrarBuildItem(ContextRegistrar contextRegistrar, DotName... annotationsNames) {
         this.contextRegistrar = contextRegistrar;
+        if (annotationsNames.length == 0) {
+            // log info level - usually you want to pass in annotation name as well
+            LOGGER.infof("A ContextRegistrarBuildItem was created but no annotation name/class was specified." +
+                    "This information can be later on consumed by other extensions via CustomScopeAnnotationsBuildItem, " +
+                    "please consider adding it.");
+        }
+        Collection<DotName> names = new ArrayList<>(annotationsNames.length);
+        for (DotName name : annotationsNames) {
+            names.add(name);
+        }
+        this.annotationNames = names;
+    }
+
+    public ContextRegistrarBuildItem(ContextRegistrar contextRegistrar, Class<? extends Annotation>... annotationsClasses) {
+        this(contextRegistrar, Arrays.stream(annotationsClasses).map(Class::getName)
+                .map(DotName::createSimple).toArray(DotName[]::new));
     }
 
     public ContextRegistrar getContextRegistrar() {
         return contextRegistrar;
+    }
+
+    public Collection<DotName> getAnnotationNames() {
+        return annotationNames;
     }
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/CustomScopeAnnotationsBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/CustomScopeAnnotationsBuildItem.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.deployment;
+
+import java.util.Collection;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Holds information about all known custom scopes in the deployment and has utility methods allowing to check
+ * whether given class has some scope annotation.
+ */
+public final class CustomScopeAnnotationsBuildItem extends SimpleBuildItem {
+
+    private Collection<DotName> customScopeNames;
+
+    public CustomScopeAnnotationsBuildItem(Collection<DotName> customScopeNames) {
+        this.customScopeNames = customScopeNames;
+    }
+
+    /**
+     * Returns a collection of all known custom scopes represented as {@link DotName}.
+     *
+     * @return collection of known custom scopes (built-in scopes are not included)
+     */
+    public Collection<DotName> getCustomScopeNames() {
+        return customScopeNames;
+    }
+
+    /**
+     * Returns true if the given class has some of the custom scope annotations, false otherwise.
+     * List of known custom scopes can be seen via {@link CustomScopeAnnotationsBuildItem#getCustomScopeNames()}.
+     * In order to check for presence of any scope annotation (including built-in ones),
+     * see {@link CustomScopeAnnotationsBuildItem#isScopeDeclaredOn(ClassInfo)}.
+     *
+     * @param clazz Class to check for annotations
+     * @return true if the clazz contains some of the custom scope annotations, false otherwise
+     */
+    public boolean isCustomScopeDeclaredOn(ClassInfo clazz) {
+        for (DotName scope : customScopeNames) {
+            if (clazz.classAnnotation(scope) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the given class has some scope annotations, false otherwise.
+     * This method check for all scope annotations, including built-in ones as well as custom scopes.
+     * List of known custom scopes can be seen via {@link CustomScopeAnnotationsBuildItem#getCustomScopeNames()}.
+     *
+     * @param clazz Class to check for annotations
+     * @return true if the clazz contains any scope annotation, false otherwise
+     */
+    public boolean isScopeDeclaredOn(ClassInfo clazz) {
+        return BuiltinScope.isDeclaredOn(clazz) || isCustomScopeDeclaredOn(clazz);
+    }
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/StartupBuildSteps.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/StartupBuildSteps.java
@@ -52,7 +52,7 @@ public class StartupBuildSteps {
     private static final Logger LOGGER = Logger.getLogger(StartupBuildSteps.class);
 
     @BuildStep
-    AnnotationsTransformerBuildItem annotationTransformer() {
+    AnnotationsTransformerBuildItem annotationTransformer(CustomScopeAnnotationsBuildItem customScopes) {
         return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
 
             @Override
@@ -62,7 +62,7 @@ public class StartupBuildSteps {
 
             @Override
             public void transform(TransformationContext context) {
-                if (context.isClass() && !BuiltinScope.isDeclaredOn(context.getTarget().asClass())) {
+                if (context.isClass() && !customScopes.isScopeDeclaredOn(context.getTarget().asClass())) {
                     // Class with no built-in scope annotation but with @Scheduled method
                     if (Annotations.contains(context.getTarget().asClass().classAnnotations(), STARTUP_NAME)) {
                         LOGGER.debugf("Found @Startup on a class %s with no scope annotations - adding @ApplicationScoped",

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -99,7 +99,7 @@ class NarayanaJtaProcessor {
             public void register(RegistrationContext registrationContext) {
                 registrationContext.configure(TransactionScoped.class).normal().contextClass(TransactionContext.class).done();
             }
-        }));
+        }, TransactionScoped.class));
     }
 
 }

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -47,6 +47,7 @@ import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.AutoInjectAnnotationBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
+import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanClassNameExclusion;
 import io.quarkus.arc.processor.AnnotationsTransformer;
@@ -377,7 +378,8 @@ public class ResteasyServerCommonProcessor {
     @BuildStep
     void processPathInterfaceImplementors(CombinedIndexBuildItem combinedIndexBuildItem,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
-            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            CustomScopeAnnotationsBuildItem scopes) {
         // NOTE: we cannot process @Path interface implementors within the ResteasyServerCommonProcessor.build() method because of build cycles
         IndexView index = combinedIndexBuildItem.getIndex();
         Set<DotName> pathInterfaces = new HashSet<>();
@@ -401,8 +403,8 @@ public class ResteasyServerCommonProcessor {
                     .setDefaultScope(resteasyConfig.singletonResources ? BuiltinScope.SINGLETON.getName() : null)
                     .setUnremovable();
             for (ClassInfo implementor : pathInterfaceImplementors) {
-                if (BuiltinScope.isDeclaredOn(implementor)) {
-                    // It has a built-in scope - just mark it as unremovable
+                if (scopes.isScopeDeclaredOn(implementor)) {
+                    // It has a scope defined - just mark it as unremovable
                     unremovableBeans
                             .produce(new UnremovableBeanBuildItem(new BeanClassNameExclusion(implementor.name().toString())));
                 } else {

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -31,6 +31,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
@@ -93,7 +94,7 @@ public class SchedulerProcessor {
     }
 
     @BuildStep
-    AnnotationsTransformerBuildItem annotationTransformer() {
+    AnnotationsTransformerBuildItem annotationTransformer(CustomScopeAnnotationsBuildItem scopes) {
         return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
 
             @Override
@@ -103,8 +104,8 @@ public class SchedulerProcessor {
 
             @Override
             public void transform(TransformationContext context) {
-                if (context.isClass() && !BuiltinScope.isDeclaredOn(context.getTarget().asClass())) {
-                    // Class with no built-in scope annotation but with @Scheduled method
+                if (context.isClass() && !scopes.isScopeDeclaredOn(context.getTarget().asClass())) {
+                    // Class with no scope annotation but with @Scheduled method
                     if (context.getTarget().asClass().annotations().containsKey(SCHEDULED_NAME)
                             || context.getTarget().asClass().annotations().containsKey(SCHEDULES_NAME)) {
                         LOGGER.debugf("Found scheduled business methods on a class %s with no annotations - adding @Singleton",

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
@@ -38,7 +39,6 @@ import io.quarkus.arc.processor.AnnotationStore;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
-import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.Capabilities;
@@ -86,7 +86,8 @@ public class SmallRyeReactiveMessagingProcessor {
     }
 
     @BuildStep
-    AnnotationsTransformerBuildItem transformBeanScope(BeanArchiveIndexBuildItem index) {
+    AnnotationsTransformerBuildItem transformBeanScope(BeanArchiveIndexBuildItem index,
+            CustomScopeAnnotationsBuildItem scopes) {
         return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
             @Override
             public boolean appliesTo(AnnotationTarget.Kind kind) {
@@ -98,7 +99,7 @@ public class SmallRyeReactiveMessagingProcessor {
                 if (ctx.isClass()) {
                     ClassInfo clazz = ctx.getTarget().asClass();
                     Map<DotName, List<AnnotationInstance>> annotations = clazz.annotations();
-                    if (BuiltinScope.isDeclaredOn(clazz)
+                    if (scopes.isScopeDeclaredOn(clazz)
                             || annotations.containsKey(ReactiveMessagingDotNames.JAXRS_PATH)
                             || annotations.containsKey(ReactiveMessagingDotNames.REST_CONTROLLER)
                             || annotations.containsKey(ReactiveMessagingDotNames.JAXRS_PROVIDER)) {

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -190,7 +190,7 @@ public class UndertowBuildStep {
             public void register(RegistrationContext registrationContext) {
                 registrationContext.configure(SessionScoped.class).normal().contextClass(HttpSessionContext.class).done();
             }
-        }));
+        }, SessionScoped.class));
         listeners.produce(new ListenerBuildItem(HttpSessionContext.class.getName()));
     }
 


### PR DESCRIPTION
…ing annotations.

Fixes #7076 

Doing this I realized that we already expose [`SCOPES`](https://github.com/quarkusio/quarkus/blob/master/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuildExtension.java#L59) within build extensions. However, this is of type `ScopeInfo` (whereas here we want `DotName`) and is created too late for annotation transformers to use that. So, I've created another `Key` that represents scopes as `Collection<DotName>`. That way we don't break backward compatibility with any usage of `SCOPES`.

However, we still break compatibility with any existing custom scope definitions since `ContextRegistrarBuildItem` has an extra method. While I've fixed that for our own scopes (session and transactional), I highly doubt there are any other user defined custom scopes at this point as this feature was sparsely used even in pure CDI. And if they are, the fix is trivial.

Let me know what you think @mkouba and I can adjust the PR accordingly.