### PR TITLE
Undertow: unused servlet initParams code, adds tests

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -12,10 +12,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -329,16 +327,11 @@ public class UndertowBuildStep {
         if (webMetaData.getServlets() != null) {
             for (ServletMetaData servlet : webMetaData.getServlets()) {
                 reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, servlet.getServletClass()));
-                Map<String, String> params = new HashMap<>();
-                for (Map.Entry<String, String> i : params.entrySet()) {
-                    params.put(i.getKey(), i.getValue());
-                }
                 RuntimeValue<ServletInfo> sref = recorder.registerServlet(deployment, servlet.getServletName(),
                         context.classProxy(servlet.getServletClass()),
                         servlet.isAsyncSupported(),
                         servlet.getLoadOnStartupInt(),
                         bc.getValue(),
-                        params,
                         null);
                 if (servlet.getInitParam() != null) {
                     for (ParamValueMetaData init : servlet.getInitParam()) {
@@ -402,16 +395,12 @@ public class UndertowBuildStep {
         if (webMetaData.getFilters() != null) {
             for (FilterMetaData filter : webMetaData.getFilters()) {
                 reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, filter.getFilterClass()));
-                Map<String, String> params = new HashMap<>();
-                for (Map.Entry<String, String> i : params.entrySet()) {
-                    params.put(i.getKey(), i.getValue());
-                }
                 RuntimeValue<FilterInfo> sref = recorder.registerFilter(deployment,
                         filter.getFilterName(),
                         context.classProxy(filter.getFilterClass()),
                         filter.isAsyncSupported(),
                         bc.getValue(),
-                        params, null);
+                        null);
                 if (filter.getInitParam() != null) {
                     for (ParamValueMetaData init : filter.getInitParam()) {
                         recorder.addFilterInitParam(sref, init.getParamName(), init.getParamValue());
@@ -487,7 +476,7 @@ public class UndertowBuildStep {
                 reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, servlet.getServletClass()));
             }
             recorder.registerServlet(deployment, servlet.getName(), context.classProxy(servletClass),
-                    servlet.isAsyncSupported(), servlet.getLoadOnStartup(), bc.getValue(), servlet.getInitParams(),
+                    servlet.isAsyncSupported(), servlet.getLoadOnStartup(), bc.getValue(),
                     servlet.getInstanceFactory());
 
             for (String m : servlet.getMappings()) {
@@ -499,7 +488,7 @@ public class UndertowBuildStep {
             String filterClass = filter.getFilterClass();
             reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, filterClass));
             recorder.registerFilter(deployment, filter.getName(), context.classProxy(filterClass), filter.isAsyncSupported(),
-                    bc.getValue(), filter.getInitParams(), filter.getInstanceFactory());
+                    bc.getValue(), filter.getInstanceFactory());
             for (FilterBuildItem.FilterMappingInfo m : filter.getMappings()) {
                 if (m.getMappingType() == FilterBuildItem.FilterMappingInfo.MappingType.URL) {
                     recorder.addFilterURLMapping(deployment, filter.getName(), m.getMapping(), m.getDispatcher());

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedFilterInitParam.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedFilterInitParam.java
@@ -1,0 +1,28 @@
+package io.quarkus.undertow.test;
+
+import static io.quarkus.undertow.test.AnnotatedServletInitParam.SERVLET_ENDPOINT;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.http.HttpFilter;
+
+@WebFilter(urlPatterns = SERVLET_ENDPOINT, description = "Haha Filter", initParams = {
+        @WebInitParam(name = "AnnotatedInitFilterParamName", value = "AnnotatedInitFilterParamValue", description = "Described filter init param")
+})
+public class AnnotatedFilterInitParam extends HttpFilter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        response.getWriter().println("invoked-before-chain");
+        response.getWriter().println(getInitParameter("AnnotatedInitFilterParamName"));
+        chain.doFilter(request, response);
+        response.getWriter().println("invoked-after-chain");
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServletInitParam.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServletInitParam.java
@@ -1,0 +1,23 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = AnnotatedServletInitParam.SERVLET_ENDPOINT, initParams = {
+        @WebInitParam(name = "AnnotatedInitParamName", value = "AnnotatedInitParamValue", description = "This is my init param")
+}, description = "Hahahah", loadOnStartup = 1)
+public class AnnotatedServletInitParam extends HttpServlet {
+
+    public static final String SERVLET_ENDPOINT = "/annotatedInitParamServlet";
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().println(getInitParameter("AnnotatedInitParamName"));
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServletInitParamsTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedServletInitParamsTestCase.java
@@ -1,0 +1,27 @@
+package io.quarkus.undertow.test;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AnnotatedServletInitParamsTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AnnotatedServletInitParam.class, AnnotatedFilterInitParam.class));
+
+    @Test
+    public void testAnnotatedInitParamsServlet() {
+        RestAssured.when().get(AnnotatedServletInitParam.SERVLET_ENDPOINT).then()
+                .statusCode(200)
+                .body(CoreMatchers.is("invoked-before-chain\n" +
+                        "AnnotatedInitFilterParamValue\n" +
+                        "AnnotatedInitParamValue\n" +
+                        "invoked-after-chain\n"));
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ServletWebXmlInitParamsTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ServletWebXmlInitParamsTestCase.java
@@ -1,0 +1,90 @@
+package io.quarkus.undertow.test;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ServletWebXmlInitParamsTestCase {
+
+    static final String WEB_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "\n" +
+            "<web-app version=\"3.0\"\n" +
+            "         xmlns=\"http://java.sun.com/xml/ns/javaee\"\n" +
+            "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+            "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+            +
+            "         metadata-complete=\"false\">\n" +
+            "<servlet>\n" +
+            "    <servlet-name>mapped</servlet-name>\n" +
+            "    <servlet-class>" + WebXmlInitParamsServlet.class.getName() + "</servlet-class>\n" +
+            "    <init-param>\n" +
+            "      <param-name>ThisIsParameterName1</param-name>\n" +
+            "      <param-value>ThisIsParameterValue1</param-value>\n" +
+            "    </init-param>\n" +
+            "    <init-param>\n" +
+            "      <param-name>ThisIsParameterName2</param-name>\n" +
+            "      <param-value>ThisIsParameterValue2</param-value>\n" +
+            "    </init-param>\n" +
+            "  </servlet>\n" +
+            "\n" +
+            "  <servlet-mapping>\n" +
+            "    <servlet-name>mapped</servlet-name>\n" +
+            "    <url-pattern>/mapped</url-pattern>\n" +
+            "  </servlet-mapping>\n" +
+            "\n" +
+            "<filter>\n" +
+            "  <filter-name>MyTestFilter</filter-name>\n" +
+            "  <filter-class>" + WebXmlInitParamsFilter.class.getName() + "</filter-class>\n" +
+            "  <init-param>\n" +
+            "    <param-name>MyFilterParamName1</param-name>\n" +
+            "    <param-value>MyFilterParamValue1</param-value>\n" +
+            "  </init-param>\n" +
+            "  <init-param>\n" +
+            "    <param-name>MyFilterParamName2</param-name>\n" +
+            "    <param-value>MyFilterParamValue2</param-value>\n" +
+            "  </init-param>\n" +
+            "</filter>\n" +
+            "<filter-mapping>\n" +
+            "  <filter-name>MyTestFilter</filter-name>\n" +
+            "  <url-pattern>/mapped</url-pattern>\n" +
+            "</filter-mapping>\n" +
+            "\n" +
+            "  <context-param>\n" +
+            "    <param-name>MyContextParamName1</param-name>\n" +
+            "    <param-value>MyContextParamValue1</param-value>\n" +
+            "  </context-param>\n" +
+            "\n" +
+            "  <context-param>\n" +
+            "    <param-name>MyContextParamName2</param-name>\n" +
+            "    <param-value>MyContextParamValue2</param-value>\n" +
+            "  </context-param>\n" +
+            "\n" +
+            "</web-app>";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(WebXmlInitParamsServlet.class, WebXmlInitParamsFilter.class)
+                    .addAsManifestResource(new StringAsset(WEB_XML), "web.xml"));
+
+    @Test
+    public void testWebXmlServlet() {
+        RestAssured.when().get("/mapped").then()
+                .statusCode(200)
+                .body(is("invoked-before-chain\n" +
+                        "MyFilterParamValue1\n" +
+                        "MyFilterParamValue2\n" +
+                        "ThisIsParameterValue1\n" +
+                        "ThisIsParameterValue2\n" +
+                        "MyContextParamValue1\n" +
+                        "MyContextParamValue2\n" +
+                        "invoked-after-chain\n"));
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/WebXmlInitParamsFilter.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/WebXmlInitParamsFilter.java
@@ -1,0 +1,28 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+public class WebXmlInitParamsFilter implements Filter {
+    private FilterConfig filterConfig;
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+        this.filterConfig = filterConfig;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp,
+            FilterChain chain) throws IOException, ServletException {
+        resp.getWriter().println("invoked-before-chain");
+        resp.getWriter().println(filterConfig.getInitParameter("MyFilterParamName1"));
+        resp.getWriter().println(filterConfig.getInitParameter("MyFilterParamName2"));
+        chain.doFilter(req, resp);
+        resp.getWriter().println("invoked-after-chain");
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/WebXmlInitParamsServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/WebXmlInitParamsServlet.java
@@ -1,0 +1,19 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class WebXmlInitParamsServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().println(getServletConfig().getInitParameter("ThisIsParameterName1"));
+        resp.getWriter().println(getServletConfig().getInitParameter("ThisIsParameterName2"));
+        resp.getWriter().println(getServletContext().getInitParameter("MyContextParamName1"));
+        resp.getWriter().println(getServletContext().getInitParameter("MyContextParamName2"));
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -8,7 +8,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -221,16 +220,13 @@ public class UndertowDeploymentRecorder {
             Class<?> servletClass,
             boolean asyncSupported,
             int loadOnStartup,
-            BeanContainer beanContainer, Map<String, String> initParams,
+            BeanContainer beanContainer,
             InstanceFactory<? extends Servlet> instanceFactory) throws Exception {
 
         InstanceFactory<? extends Servlet> factory = instanceFactory != null ? instanceFactory
                 : new QuarkusInstanceFactory(beanContainer.instanceFactory(servletClass));
         ServletInfo servletInfo = new ServletInfo(name, (Class<? extends Servlet>) servletClass,
                 factory);
-        for (Map.Entry<String, String> e : initParams.entrySet()) {
-            servletInfo.addInitParam(e.getKey(), e.getValue());
-        }
         deploymentInfo.getValue().addServlet(servletInfo);
         servletInfo.setAsyncSupported(asyncSupported);
         if (loadOnStartup > 0) {
@@ -277,16 +273,11 @@ public class UndertowDeploymentRecorder {
             String name, Class<?> filterClass,
             boolean asyncSupported,
             BeanContainer beanContainer,
-            Map<String, String> initParams,
             InstanceFactory<? extends Filter> instanceFactory) throws Exception {
 
         InstanceFactory<? extends Filter> factory = instanceFactory != null ? instanceFactory
                 : new QuarkusInstanceFactory(beanContainer.instanceFactory(filterClass));
         FilterInfo filterInfo = new FilterInfo(name, (Class<? extends Filter>) filterClass, factory);
-
-        for (Map.Entry<String, String> e : initParams.entrySet()) {
-            filterInfo.addInitParam(e.getKey(), e.getValue());
-        }
         info.getValue().addFilter(filterInfo);
         filterInfo.setAsyncSupported(asyncSupported);
         return new RuntimeValue<>(filterInfo);


### PR DESCRIPTION
Two occurrences of

```
- Map<String, String> params = new HashMap<>();
- for (Map.Entry<String, String> i : params.entrySet()) {
-     params.put(i.getKey(), i.getValue());
- }
```

are removed from UndertowBuildStep.

New tests covering init params and descriptions for Servlet and Filter were added, both for xml and annotation.

ping @stuartwdouglas