### PR TITLE
MongoDB with Panache multi-update

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -198,8 +198,8 @@ Person.deleteAll();
 // delete by id
 boolean deleted = Person.deleteById(personId);
 
-// update all living persons
-Person.update("name = 'Moral' where status = ?1", Status.Alive);
+// set the name of all living persons to 'Mortal'
+Person.update("name = 'Mortal' where status = ?1", Status.Alive);
 
 ----
 
@@ -385,8 +385,8 @@ personRepository.deleteAll();
 // delete by id
 boolean deleted = personRepository.deleteById(personId);
 
-// update all living persons
-personRepository.update("name = 'Moral' where status = ?1", Status.Alive);
+// set the name of all living persons to 'Mortal'
+personRepository.update("name = 'Mortal' where status = ?1", Status.Alive);
 
 ----
 
@@ -515,7 +515,7 @@ link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_Us
 [source,java]
 ----
 Order.find("select distinct o from Order o left join fetch o.lineItems");
-Order.update("update from Person set name = 'Moral' where status = ?", Status.Alive);
+Order.update("update from Person set name = 'Mortal' where status = ?", Status.Alive);
 ----
 
 === Query parameters

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -225,6 +225,9 @@ Person.deleteAll();
 
 // delete by id
 boolean deleted = Person.deleteById(personId);
+
+// set the name of all living persons to 'Mortal'
+long updated = Person.update("name", "Mortal").where("status", Status.Alive);
 ----
 
 All `list` methods have equivalent `stream` versions.
@@ -388,6 +391,9 @@ personRepository.deleteAll();
 
 // delete by id
 boolean deleted = personRepository.deleteById(personId);
+
+// set the name of all living persons to 'Mortal'
+long updated = personRepository.update("name", "Mortal").where("status", Status.Alive);
 ----
 
 All `list` methods have equivalent `stream` versions.
@@ -495,7 +501,7 @@ MongoDB with Panache will then map it to a MongoDB native query.
 
 If your query does not start with `{`, we will consider it a PanacheQL query:
 
-- `<singlePropertyName>` (and single parameter) which will expand to `{'singleColumnName': '?'}`
+- `<singlePropertyName>` (and single parameter) which will expand to `{'singleColumnName': '?1'}`
 - `<query>` will expand to `{<query>}` where we will map the PanacheQL query to MongoDB native query form. We support the following operators that will be mapped to the corresponding MongoDB operators: 'and', 'or' ( mixing 'and' and 'or' is not currently supported), '=', '>', '>=', '<', '<=', '!=', 'is null', 'is not null', and 'like' that is mapped to the MongoDB `$regex` operator.
 
 Here are some query examples:
@@ -510,6 +516,17 @@ link:https://docs.mongodb.com/manual/reference/bson-types/#document-bson-type-da
 The MongoDB POJO codec doesn't support `ZonedDateTime` and `OffsetDateTime` so you should convert them prior usage.
 
 MongoDB with Panache also supports extended MongoDB queries by providing a `Document` query, this is supported by the find/list/stream/count/delete methods.
+
+MongoDB with Panache offers operations to update multiple documents based on an update document and a query :
+`Person.update("foo = ?1, bar = ?2", fooName, barName).where("name = ?1", name)`.
+
+For these operations, you can express the update document the same way you express your queries, here are some examples:
+
+- `<singlePropertyName>` (and single parameter) which will expand to the update document `{'$set' : {'singleColumnName': '?1'}}`
+- `firstname = ?1, status = ?2` will be mapped to the update document `{'$set' : {'firstname': ?1, 'status': ?2}}`
+- `firstname = :firstname, status = :status` will be mapped to the update document `{'$set' : {'firstname': :firstname, 'status': :status}}`
+- `{'firstname' : ?1, 'status' : ?2}` will be mapped to the update document `{'$set' : {'firstname': ?1, 'status': ?2}}`
+- `{'firstname' : firstname, 'status' : :status}` ` will be mapped to the update document `{'$set' : {'firstname': :firstname, 'status': :status}}`
 
 === Query parameters
 
@@ -809,6 +826,9 @@ deleteCount = ReactivePerson.deleteAll();
 
 // delete by id
 Uni<Boolean> deleted = ReactivePerson.deleteById(personId);
+
+// set the name of all living persons to 'Mortal'
+Uni<Long> updated = ReactivePerson.update("name", "Mortal").where("status", Status.Alive);
 ----
 
 TIP: If you use MongoDB with Panache in conjunction with RESTEasy, you can directly return a reactive type inside your JAX-RS resource endpoint as long as you include the `quarkus-resteasy-mutiny` extension.

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -731,7 +731,7 @@ public abstract class PanacheEntityBase {
     }
 
     /**
-     * Update all entities of this type matching the given query, with mandatory indexed parameters.
+     * Update all entities of this type matching the given query, with optional indexed parameters.
      *
      * @param query a {@link io.quarkus.hibernate.orm.panache query string}
      * @param params optional sequence of indexed parameters

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
@@ -794,7 +794,7 @@ public abstract class PanacheMongoEntityBase {
     /**
      * Insert all given entities.
      *
-     * @param entities the entities to update
+     * @param entities the entities to insert
      * @see #persist()
      * @see #persist(Stream)
      * @see #persist(Iterable)
@@ -873,6 +873,55 @@ public abstract class PanacheMongoEntityBase {
      */
     public static void persistOrUpdate(Object firstEntity, Object... entities) {
         MongoOperations.persistOrUpdate(firstEntity, entities);
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with optional indexed parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params optional sequence of indexed parameters
+     * @return a new {@link PanacheUpdate} instance for the given update document
+     * @see #update(String, Map)
+     * @see #update(String, Parameters)
+     */
+    @GenerateBridge
+    public static PanacheUpdate update(String update, Object... params) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Map} of named parameters
+     * @return a new {@link PanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Parameters)
+     *
+     */
+    @GenerateBridge
+    public static PanacheUpdate update(String update, Map<String, Object> params) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Parameters} of named parameters
+     * @return a new {@link PanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Map)
+     */
+    @GenerateBridge
+    public static PanacheUpdate update(String update, Parameters params) {
+        throw MongoOperations.implementationInjectionMissing();
     }
 
     /**

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
@@ -881,6 +881,55 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
     }
 
     /**
+     * Update all entities of this type by the given update document, with optional indexed parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which documents the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params optional sequence of indexed parameters
+     * @return a new {@link PanacheUpdate} instance for the given update document
+     * @see #update(String, Map)
+     * @see #update(String, Parameters)
+     */
+    @GenerateBridge
+    public default PanacheUpdate update(String update, Object... params) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which documents the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Map} of named parameters
+     * @return a new {@link PanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Parameters)
+     *
+     */
+    @GenerateBridge
+    public default PanacheUpdate update(String update, Map<String, Object> params) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Parameters} of named parameters
+     * @return a new {@link PanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Map)
+     */
+    @GenerateBridge
+    public default PanacheUpdate update(String update, Parameters params) {
+        throw MongoOperations.implementationInjectionMissing();
+    }
+
+    /**
      * Allow to access the underlying Mongo Collection
      */
     @GenerateBridge

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheUpdate.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheUpdate.java
@@ -1,0 +1,47 @@
+package io.quarkus.mongodb.panache;
+
+import java.util.Map;
+
+import io.quarkus.panache.common.Parameters;
+
+/**
+ * Interface representing an update query.
+ *
+ * Use one of its methods to perform the update query.
+ */
+public interface PanacheUpdate {
+
+    /**
+     * Execute the update query with the update document.
+     *
+     * @param query a {@link io.quarkus.mongodb.panache query string}
+     * @param params params optional sequence of indexed parameters
+     * @return the number of entities updated.
+     */
+    public long where(String query, Object... params);
+
+    /**
+     * Execute the update query with the update document.
+     *
+     * @param query a {@link io.quarkus.mongodb.panache query string}
+     * @param params {@link Map} of named parameters
+     * @return the number of entities updated.
+     */
+    public long where(String query, Map<String, Object> params);
+
+    /**
+     * Execute the update query with the update document.
+     *
+     * @param query a {@link io.quarkus.mongodb.panache query string}
+     * @param params {@link Parameters} of named parameters
+     * @return the number of entities updated.
+     */
+    public long where(String query, Parameters params);
+
+    /**
+     * Execute an update on all documents with the update document.
+     *
+     * @return the number of entities updated.
+     */
+    public long all();
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoEntityBase.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import org.bson.Document;
 
+import io.quarkus.mongodb.panache.PanacheUpdate;
 import io.quarkus.mongodb.panache.reactive.runtime.ReactiveMongoOperations;
 import io.quarkus.mongodb.panache.runtime.MongoOperations;
 import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
@@ -884,6 +885,55 @@ public abstract class ReactivePanacheMongoEntityBase {
      */
     public static Uni<Void> persistOrUpdate(Object firstEntity, Object... entities) {
         return ReactiveMongoOperations.persistOrUpdate(firstEntity, entities);
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with optional indexed parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params optional sequence of indexed parameters
+     * @return a new {@link ReactivePanacheUpdate} instance for the given update document
+     * @see #update(String, Map)
+     * @see #update(String, Parameters)
+     */
+    @GenerateBridge
+    public static ReactivePanacheUpdate update(String update, Object... params) {
+        throw ReactiveMongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Map} of named parameters
+     * @return a new {@link ReactivePanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Parameters)
+     *
+     */
+    @GenerateBridge
+    public static ReactivePanacheUpdate update(String update, Map<String, Object> params) {
+        throw ReactiveMongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Parameters} of named parameters
+     * @return a new {@link ReactivePanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Map)
+     */
+    @GenerateBridge
+    public static ReactivePanacheUpdate update(String update, Parameters params) {
+        throw ReactiveMongoOperations.implementationInjectionMissing();
     }
 
     /**

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoRepositoryBase.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import org.bson.Document;
 
+import io.quarkus.mongodb.panache.PanacheUpdate;
 import io.quarkus.mongodb.panache.reactive.runtime.ReactiveMongoOperations;
 import io.quarkus.mongodb.panache.runtime.MongoOperations;
 import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
@@ -883,6 +884,55 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
     public default Uni<Void> persistOrUpdate(Entity firstEntity,
             @SuppressWarnings("unchecked") Entity... entities) {
         return ReactiveMongoOperations.persistOrUpdate(firstEntity, entities);
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with optional indexed parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params optional sequence of indexed parameters
+     * @return a new {@link ReactivePanacheUpdate} instance for the given update document
+     * @see #update(String, Map)
+     * @see #update(String, Parameters)
+     */
+    @GenerateBridge
+    public default ReactivePanacheUpdate update(String update, Object... params) {
+        throw ReactiveMongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Map} of named parameters
+     * @return a new {@link ReactivePanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Parameters)
+     *
+     */
+    @GenerateBridge
+    public default ReactivePanacheUpdate update(String update, Map<String, Object> params) {
+        throw ReactiveMongoOperations.implementationInjectionMissing();
+    }
+
+    /**
+     * Update all entities of this type by the given update document, with named parameters.
+     * The returned {@link PanacheUpdate} object will allow to restrict on which document the update should be applied.
+     *
+     * @param update the update document, if it didn't contain <code>$set</code> we add it.
+     *        It can also be expressed as a {@link io.quarkus.mongodb.panache query string}.
+     * @param params {@link Parameters} of named parameters
+     * @return a new {@link ReactivePanacheUpdate} instance for the given update document
+     * @see #update(String, Object...)
+     * @see #update(String, Map)
+     */
+    @GenerateBridge
+    public default ReactivePanacheUpdate update(String update, Parameters params) {
+        throw ReactiveMongoOperations.implementationInjectionMissing();
     }
 
     /**

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheUpdate.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheUpdate.java
@@ -1,0 +1,47 @@
+package io.quarkus.mongodb.panache.reactive;
+
+import java.util.Map;
+
+import io.quarkus.panache.common.Parameters;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Interface representing an update query.
+ *
+ * Use one of its methods to perform the update query.
+ */
+public interface ReactivePanacheUpdate {
+    /**
+     * Execute the update query with the update document.
+     *
+     * @param query a {@link io.quarkus.mongodb.panache query string}
+     * @param params params optional sequence of indexed parameters
+     * @return the number of entities updated.
+     */
+    public Uni<Long> where(String query, Object... params);
+
+    /**
+     * Execute the update query with the update document.
+     *
+     * @param query a {@link io.quarkus.mongodb.panache query string}
+     * @param params {@link Map} of named parameters
+     * @return the number of entities updated.
+     */
+    public Uni<Long> where(String query, Map<String, Object> params);
+
+    /**
+     * Execute the update query with the update document.
+     *
+     * @param query a {@link io.quarkus.mongodb.panache query string}
+     * @param params {@link Parameters} of named parameters
+     * @return the number of entities updated.
+     */
+    public Uni<Long> where(String query, Parameters params);
+
+    /**
+     * Execute an update on all documents with the update document.
+     *
+     * @return the number of entities updated.
+     */
+    public Uni<Long> all();
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheUpdateImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheUpdateImpl.java
@@ -1,0 +1,46 @@
+package io.quarkus.mongodb.panache.reactive.runtime;
+
+import java.util.Map;
+
+import org.bson.Document;
+
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheUpdate;
+import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
+import io.quarkus.panache.common.Parameters;
+import io.smallrye.mutiny.Uni;
+
+public class ReactivePanacheUpdateImpl implements ReactivePanacheUpdate {
+    private Class<?> entityClass;
+    private Document update;
+    private ReactiveMongoCollection<?> collection;
+
+    public ReactivePanacheUpdateImpl(Class<?> entityClass, Document update, ReactiveMongoCollection<?> collection) {
+        this.entityClass = entityClass;
+        this.update = update;
+        this.collection = collection;
+    }
+
+    @Override
+    public Uni<Long> where(String query, Object... params) {
+        String bindQuery = ReactiveMongoOperations.bindFilter(entityClass, query, params);
+        Document docQuery = Document.parse(bindQuery);
+        return collection.updateMany(docQuery, update).map(result -> result.getModifiedCount());
+    }
+
+    @Override
+    public Uni<Long> where(String query, Map<String, Object> params) {
+        String bindQuery = ReactiveMongoOperations.bindFilter(entityClass, query, params);
+        Document docQuery = Document.parse(bindQuery);
+        return collection.updateMany(docQuery, update).map(result -> result.getModifiedCount());
+    }
+
+    @Override
+    public Uni<Long> where(String query, Parameters params) {
+        return where(query, params.map());
+    }
+
+    @Override
+    public Uni<Long> all() {
+        return collection.updateMany(new Document(), update).map(result -> result.getModifiedCount());
+    }
+}

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheUpdateImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheUpdateImpl.java
@@ -1,0 +1,46 @@
+package io.quarkus.mongodb.panache.runtime;
+
+import java.util.Map;
+
+import org.bson.Document;
+
+import com.mongodb.client.MongoCollection;
+
+import io.quarkus.mongodb.panache.PanacheUpdate;
+import io.quarkus.panache.common.Parameters;
+
+public class PanacheUpdateImpl implements PanacheUpdate {
+    private Class<?> entityClass;
+    private Document update;
+    private MongoCollection collection;
+
+    public PanacheUpdateImpl(Class<?> entityClass, Document update, MongoCollection collection) {
+        this.entityClass = entityClass;
+        this.update = update;
+        this.collection = collection;
+    }
+
+    @Override
+    public long where(String query, Object... params) {
+        String bindQuery = MongoOperations.bindFilter(entityClass, query, params);
+        Document docQuery = Document.parse(bindQuery);
+        return collection.updateMany(docQuery, update).getModifiedCount();
+    }
+
+    @Override
+    public long where(String query, Map<String, Object> params) {
+        String bindQuery = MongoOperations.bindFilter(entityClass, query, params);
+        Document docQuery = Document.parse(bindQuery);
+        return collection.updateMany(docQuery, update).getModifiedCount();
+    }
+
+    @Override
+    public long where(String query, Parameters params) {
+        return where(query, params.map());
+    }
+
+    @Override
+    public long all() {
+        return collection.updateMany(new Document(), update).getModifiedCount();
+    }
+}

--- a/extensions/panache/mongodb-panache/runtime/src/test/java/io/quarkus/mongodb/panache/runtime/MongoOperationsTest.java
+++ b/extensions/panache/mongodb-panache/runtime/src/test/java/io/quarkus/mongodb/panache/runtime/MongoOperationsTest.java
@@ -37,29 +37,29 @@ class MongoOperationsTest {
     }
 
     @Test
-    public void testBindShorthandQuery() {
-        String query = MongoOperations.bindQuery(Object.class, "field", new Object[] { "a value" });
+    public void testBindShorthandFilter() {
+        String query = MongoOperations.bindFilter(Object.class, "field", new Object[] { "a value" });
         assertEquals("{'field':'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field", new Object[] { true });
+        query = MongoOperations.bindFilter(Object.class, "field", new Object[] { true });
         assertEquals("{'field':true}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field", new Object[] { LocalDate.of(2019, 3, 4) });
+        query = MongoOperations.bindFilter(Object.class, "field", new Object[] { LocalDate.of(2019, 3, 4) });
         assertEquals("{'field':ISODate('2019-03-04')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
+        query = MongoOperations.bindFilter(Object.class, "field", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field",
+        query = MongoOperations.bindFilter(Object.class, "field",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field",
+        query = MongoOperations.bindFilter(Object.class, "field",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         //test field replacement
-        query = MongoOperations.bindQuery(DemoObj.class, "property", new Object[] { "a value" });
+        query = MongoOperations.bindFilter(DemoObj.class, "property", new Object[] { "a value" });
         assertEquals("{'value':'a value'}", query);
     }
 
@@ -68,176 +68,209 @@ class MongoOperationsTest {
     }
 
     @Test
-    public void testBindNativeQueryByIndex() {
-        String query = MongoOperations.bindQuery(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
+    public void testBindNativeFilterByIndex() {
+        String query = MongoOperations.bindFilter(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
         assertEquals("{'field': 'a value'}", query);
 
-        query = MongoOperations.bindQuery(DemoObj.class, "{'field.sub': ?1}", new Object[] { "a value" });
+        query = MongoOperations.bindFilter(DemoObj.class, "{'field.sub': ?1}", new Object[] { "a value" });
         assertEquals("{'field.sub': 'a value'}", query);
 
         //test that there are no field replacement for native queries
-        query = MongoOperations.bindQuery(DemoObj.class, "{'property': ?1}", new Object[] { "a value" });
+        query = MongoOperations.bindFilter(DemoObj.class, "{'property': ?1}", new Object[] { "a value" });
         assertEquals("{'property': 'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { LocalDate.of(2019, 3, 4) });
         assertEquals("{'field': ISODate('2019-03-04')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
         assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
         assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': ?1}",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
         assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': ?1, 'isOk': ?2}", new Object[] { "a value", true });
+        query = MongoOperations.bindFilter(Object.class, "{'field': ?1, 'isOk': ?2}", new Object[] { "a value", true });
         assertEquals("{'field': 'a value', 'isOk': true}", query);
     }
 
     @Test
-    public void testBindNativeQueryByName() {
-        String query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
+    public void testBindNativeFilterByName() {
+        String query = MongoOperations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field': 'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field.sub': :field}",
+        query = MongoOperations.bindFilter(Object.class, "{'field.sub': :field}",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field.sub': 'a value'}", query);
 
         //test that there are no field replacement for native queries
-        query = MongoOperations.bindQuery(DemoObj.class, "{'property': :field}",
+        query = MongoOperations.bindFilter(DemoObj.class, "{'property': :field}",
                 Parameters.with("field", "a value").map());
         assertEquals("{'property': 'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDate.of(2019, 3, 4)).map());
         assertEquals("{'field': ISODate('2019-03-04')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)).map());
         assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)).map());
         assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': :field}",
                 Parameters.with("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))).map());
         assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field': :field, 'isOk': :isOk}",
+        query = MongoOperations.bindFilter(Object.class, "{'field': :field, 'isOk': :isOk}",
                 Parameters.with("field", "a value").and("isOk", true).map());
         assertEquals("{'field': 'a value', 'isOk': true}", query);
     }
 
     @Test
-    public void testBindEnhancedQueryByIndex() {
-        String query = MongoOperations.bindQuery(Object.class, "field = ?1", new Object[] { "a value" });
+    public void testBindEnhancedFilterByIndex() {
+        String query = MongoOperations.bindFilter(Object.class, "field = ?1", new Object[] { "a value" });
         assertEquals("{'field':'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "{'field.sub': :field}",
+        query = MongoOperations.bindFilter(Object.class, "{'field.sub': :field}",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field.sub': 'a value'}", query);
 
         //test field replacement
-        query = MongoOperations.bindQuery(DemoObj.class, "property = ?1", new Object[] { "a value" });
+        query = MongoOperations.bindFilter(DemoObj.class, "property = ?1", new Object[] { "a value" });
         assertEquals("{'value':'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = ?1", new Object[] { LocalDate.of(2019, 3, 4) });
+        query = MongoOperations.bindFilter(Object.class, "field = ?1", new Object[] { LocalDate.of(2019, 3, 4) });
         assertEquals("{'field':ISODate('2019-03-04')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = ?1", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
+        query = MongoOperations.bindFilter(Object.class, "field = ?1", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = ?1",
+        query = MongoOperations.bindFilter(Object.class, "field = ?1",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = ?1",
+        query = MongoOperations.bindFilter(Object.class, "field = ?1",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = ?1 and isOk = ?2", new Object[] { "a value", true });
+        query = MongoOperations.bindFilter(Object.class, "field = ?1 and isOk = ?2", new Object[] { "a value", true });
         assertEquals("{'field':'a value','isOk':true}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = ?1 or isOk = ?2", new Object[] { "a value", true });
+        query = MongoOperations.bindFilter(Object.class, "field = ?1 or isOk = ?2", new Object[] { "a value", true });
         assertEquals("{'$or':[{'field':'a value'},{'isOk':true}]}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "count >= ?1 and count < ?2", new Object[] { 5, 10 });
+        query = MongoOperations.bindFilter(Object.class, "count >= ?1 and count < ?2", new Object[] { 5, 10 });
         assertEquals("{'count':{'$gte':5},'count':{'$lt':10}}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field != ?1", new Object[] { "a value" });
+        query = MongoOperations.bindFilter(Object.class, "field != ?1", new Object[] { "a value" });
         assertEquals("{'field':{'$ne':'a value'}}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field like ?1", new Object[] { "a value" });
+        query = MongoOperations.bindFilter(Object.class, "field like ?1", new Object[] { "a value" });
         assertEquals("{'field':{'$regex':'a value'}}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field is not null", new Object[] {});
+        query = MongoOperations.bindFilter(Object.class, "field is not null", new Object[] {});
         assertEquals("{'field':{'$exists':true}}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field is null", new Object[] {});
+        query = MongoOperations.bindFilter(Object.class, "field is null", new Object[] {});
         assertEquals("{'field':{'$exists':false}}", query);
 
         // test with hardcoded value
-        query = MongoOperations.bindQuery(Object.class, "field = 'some hardcoded value'", new Object[] {});
+        query = MongoOperations.bindFilter(Object.class, "field = 'some hardcoded value'", new Object[] {});
         assertEquals("{'field':'some hardcoded value'}", query);
     }
 
     @Test
-    public void testBindEnhancedQueryByName() {
-        String query = MongoOperations.bindQuery(Object.class, "field = :field",
+    public void testBindEnhancedFilterByName() {
+        String query = MongoOperations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field':'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field.sub = :field",
+        query = MongoOperations.bindFilter(Object.class, "field.sub = :field",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field.sub':'a value'}", query);
 
         //test field replacement
-        query = MongoOperations.bindQuery(DemoObj.class, "property = :field",
+        query = MongoOperations.bindFilter(DemoObj.class, "property = :field",
                 Parameters.with("field", "a value").map());
         assertEquals("{'value':'a value'}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = :field",
+        query = MongoOperations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", LocalDate.of(2019, 3, 4)).map());
         assertEquals("{'field':ISODate('2019-03-04')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = :field",
+        query = MongoOperations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)).map());
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = :field",
+        query = MongoOperations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)).map());
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = :field",
+        query = MongoOperations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))).map());
         assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = :field and isOk = :isOk",
+        query = MongoOperations.bindFilter(Object.class, "field = :field and isOk = :isOk",
                 Parameters.with("field", "a value").and("isOk", true).map());
         assertEquals("{'field':'a value','isOk':true}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field = :field or isOk = :isOk",
+        query = MongoOperations.bindFilter(Object.class, "field = :field or isOk = :isOk",
                 Parameters.with("field", "a value").and("isOk", true).map());
         assertEquals("{'$or':[{'field':'a value'},{'isOk':true}]}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "count > :lower and count <= :upper",
+        query = MongoOperations.bindFilter(Object.class, "count > :lower and count <= :upper",
                 Parameters.with("lower", 5).and("upper", 10).map());
         assertEquals("{'count':{'$gt':5},'count':{'$lte':10}}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field != :field",
+        query = MongoOperations.bindFilter(Object.class, "field != :field",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field':{'$ne':'a value'}}", query);
 
-        query = MongoOperations.bindQuery(Object.class, "field like :field",
+        query = MongoOperations.bindFilter(Object.class, "field like :field",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field':{'$regex':'a value'}}", query);
     }
 
+    @Test
+    public void testBindUpdate() {
+        // native update by index without $set
+        String update = MongoOperations.bindUpdate(DemoObj.class, "{'field': ?1}", new Object[] { "a value" });
+        assertEquals("{'$set':{'field': 'a value'}}", update);
+
+        // native update by name without $set
+        update = MongoOperations.bindUpdate(Object.class, "{'field': :field}",
+                Parameters.with("field", "a value").map());
+        assertEquals("{'$set':{'field': 'a value'}}", update);
+
+        // native update by index with $set
+        update = MongoOperations.bindUpdate(DemoObj.class, "{'$set':{'field': ?1}}", new Object[] { "a value" });
+        assertEquals("{'$set':{'field': 'a value'}}", update);
+
+        // native update by name with $set
+        update = MongoOperations.bindUpdate(Object.class, "{'$set':{'field': :field}}",
+                Parameters.with("field", "a value").map());
+        assertEquals("{'$set':{'field': 'a value'}}", update);
+
+        // shortand update
+        update = MongoOperations.bindUpdate(Object.class, "field", new Object[] { "a value" });
+        assertEquals("{'$set':{'field':'a value'}}", update);
+
+        // enhanced update by index
+        update = MongoOperations.bindUpdate(Object.class, "field = ?1", new Object[] { "a value" });
+        assertEquals("{'$set':{'field':'a value'}}", update);
+
+        // enhanced update by name
+        update = MongoOperations.bindUpdate(Object.class, "field = :field",
+                Parameters.with("field", "a value").map());
+        assertEquals("{'$set':{'field':'a value'}}", update);
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonEntityResource.java
@@ -76,4 +76,11 @@ public class PersonEntityResource {
     public void deleteAll() {
         PersonEntity.deleteAll();
     }
+
+    @POST
+    @Path("/rename")
+    public Response rename(@QueryParam("previousName") String previousName, @QueryParam("newName") String newName) {
+        PersonEntity.update("lastname", newName).where("lastname", previousName);
+        return Response.ok().build();
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/PersonRepositoryResource.java
@@ -81,4 +81,11 @@ public class PersonRepositoryResource {
     public void deleteAll() {
         personRepository.deleteAll();
     }
+
+    @POST
+    @Path("/rename")
+    public Response rename(@QueryParam("previousName") String previousName, @QueryParam("newName") String newName) {
+        personRepository.update("lastname", newName).where("lastname", previousName);
+        return Response.ok().build();
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonEntityResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonEntityResource.java
@@ -77,4 +77,11 @@ public class ReactivePersonEntityResource {
     public Uni<Void> deleteAll() {
         return ReactivePersonEntity.deleteAll().map(l -> null);
     }
+
+    @POST
+    @Path("/rename")
+    public Uni<Response> rename(@QueryParam("previousName") String previousName, @QueryParam("newName") String newName) {
+        return ReactivePersonEntity.update("lastname", newName).where("lastname", previousName)
+                .map(count -> Response.ok().build());
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/reactive/person/ReactivePersonRepositoryResource.java
@@ -84,4 +84,11 @@ public class ReactivePersonRepositoryResource {
     public Uni<Void> deleteAll() {
         return reactivePersonRepository.deleteAll().map(l -> null);
     }
+
+    @POST
+    @Path("/rename")
+    public Uni<Response> rename(@QueryParam("previousName") String previousName, @QueryParam("newName") String newName) {
+        return reactivePersonRepository.update("lastname", newName).where("lastname", previousName)
+                .map(count -> Response.ok().build());
+    }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestResource.java
@@ -103,10 +103,24 @@ public class TestResource {
         TestImperativeEntity.update(list);
         TestImperativeEntity.update(list.stream());
         TestImperativeEntity.persistOrUpdate(list);
-        Assertions.assertEquals(5, TestImperativeEntity.count("category = ?1", "newCategory"));
+        long updated = TestImperativeEntity.update("category", "newCategory2").where("category", "newCategory");
+        Assertions.assertEquals(5, updated);
+        updated = TestImperativeEntity.update("category = ?1", "newCategory").where("category = ?1", "newCategory2");
+        Assertions.assertEquals(5, updated);
+        updated = TestImperativeEntity.update("{'category' : ?1}", "newCategory2").where("{'category' : ?1}", "newCategory");
+        Assertions.assertEquals(5, updated);
+        updated = TestImperativeEntity.update("category = :category", Parameters.with("category", "newCategory"))
+                .where("category = :category", Parameters.with("category", "newCategory2"));
+        Assertions.assertEquals(5, updated);
+        updated = TestImperativeEntity.update("{'category' : :category}", Parameters.with("category", "newCategory2"))
+                .where("{'category' : :category}", Parameters.with("category", "newCategory"));
+        Assertions.assertEquals(5, updated);
+        Assertions.assertEquals(5, TestImperativeEntity.count("category = ?1", "newCategory2"));
+        updated = TestImperativeEntity.update("newField", "newValue").all();
+        Assertions.assertEquals(10, updated);
 
         // delete
-        TestImperativeEntity.delete("category = ?1", "newCategory");
+        TestImperativeEntity.delete("category = ?1", "newCategory2");
         TestImperativeEntity.delete("{'category' : ?1}", "category1");
         Assertions.assertEquals(0, TestImperativeEntity.count());
         TestImperativeEntity.persist(entities.stream());
@@ -198,10 +212,26 @@ public class TestResource {
         }
         testImperativeRepository.update(list);
         testImperativeRepository.update(list.stream());
-        Assertions.assertEquals(5, testImperativeRepository.count("category = ?1", "newCategory"));
+        testImperativeRepository.persistOrUpdate(list);
+        long updated = testImperativeRepository.update("category", "newCategory2").where("category", "newCategory");
+        Assertions.assertEquals(5, updated);
+        updated = testImperativeRepository.update("category = ?1", "newCategory").where("category = ?1", "newCategory2");
+        Assertions.assertEquals(5, updated);
+        updated = testImperativeRepository.update("{'category' : ?1}", "newCategory2").where("{'category' : ?1}",
+                "newCategory");
+        Assertions.assertEquals(5, updated);
+        updated = testImperativeRepository.update("category = :category", Parameters.with("category", "newCategory"))
+                .where("category = :category", Parameters.with("category", "newCategory2"));
+        Assertions.assertEquals(5, updated);
+        updated = testImperativeRepository.update("{'category' : :category}", Parameters.with("category", "newCategory2"))
+                .where("{'category' : :category}", Parameters.with("category", "newCategory"));
+        Assertions.assertEquals(5, updated);
+        Assertions.assertEquals(5, testImperativeRepository.count("category = ?1", "newCategory2"));
+        updated = testImperativeRepository.update("newField", "newValue").all();
+        Assertions.assertEquals(10, updated);
 
         // delete
-        testImperativeRepository.delete("category = ?1", "newCategory");
+        testImperativeRepository.delete("category = ?1", "newCategory2");
         testImperativeRepository.delete("{'category' : ?1}", "category1");
         Assertions.assertEquals(0, testImperativeRepository.count());
         testImperativeRepository.persist(entities.stream());
@@ -368,10 +398,28 @@ public class TestResource {
         }
         TestReactiveEntity.update(list).await().indefinitely();
         TestReactiveEntity.update(list.stream()).await().indefinitely();
-        Assertions.assertEquals(5, TestReactiveEntity.count("category = ?1", "newCategory").await().indefinitely());
+        TestReactiveEntity.persistOrUpdate(list).await().indefinitely();
+        long updated = TestReactiveEntity.update("category", "newCategory2").where("category", "newCategory").await()
+                .indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = TestReactiveEntity.update("category = ?1", "newCategory").where("category = ?1", "newCategory2").await()
+                .indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = TestReactiveEntity.update("{'category' : ?1}", "newCategory2").where("{'category' : ?1}", "newCategory")
+                .await().indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = TestReactiveEntity.update("category = :category", Parameters.with("category", "newCategory"))
+                .where("category = :category", Parameters.with("category", "newCategory2")).await().indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = TestReactiveEntity.update("{'category' : :category}", Parameters.with("category", "newCategory2"))
+                .where("{'category' : :category}", Parameters.with("category", "newCategory")).await().indefinitely();
+        Assertions.assertEquals(5, updated);
+        Assertions.assertEquals(5, TestReactiveEntity.count("category = ?1", "newCategory2").await().indefinitely());
+        updated = TestReactiveEntity.update("newField", "newValue").all().await().indefinitely();
+        Assertions.assertEquals(10, updated);
 
         // delete
-        TestReactiveEntity.delete("category = ?1", "newCategory").await().indefinitely();
+        TestReactiveEntity.delete("category = ?1", "newCategory2").await().indefinitely();
         TestReactiveEntity.delete("{'category' : ?1}", "category1").await().indefinitely();
         Assertions.assertEquals(0, TestReactiveEntity.count().await().indefinitely());
         TestReactiveEntity.persist(entities.stream()).await().indefinitely();
@@ -469,10 +517,28 @@ public class TestResource {
         }
         testReactiveRepository.update(list).await().indefinitely();
         testReactiveRepository.update(list.stream()).await().indefinitely();
-        Assertions.assertEquals(5, testReactiveRepository.count("category = ?1", "newCategory").await().indefinitely());
+        testReactiveRepository.persistOrUpdate(list).await().indefinitely();
+        long updated = testReactiveRepository.update("category", "newCategory2").where("category", "newCategory").await()
+                .indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = testReactiveRepository.update("category = ?1", "newCategory").where("category = ?1", "newCategory2").await()
+                .indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = testReactiveRepository.update("{'category' : ?1}", "newCategory2").where("{'category' : ?1}", "newCategory")
+                .await().indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = testReactiveRepository.update("category = :category", Parameters.with("category", "newCategory"))
+                .where("category = :category", Parameters.with("category", "newCategory2")).await().indefinitely();
+        Assertions.assertEquals(5, updated);
+        updated = testReactiveRepository.update("{'category' : :category}", Parameters.with("category", "newCategory2"))
+                .where("{'category' : :category}", Parameters.with("category", "newCategory")).await().indefinitely();
+        Assertions.assertEquals(5, updated);
+        Assertions.assertEquals(5, testReactiveRepository.count("category = ?1", "newCategory2").await().indefinitely());
+        updated = testReactiveRepository.update("newField", "newValue").all().await().indefinitely();
+        Assertions.assertEquals(10, updated);
 
         // delete
-        testReactiveRepository.delete("category = ?1", "newCategory").await().indefinitely();
+        testReactiveRepository.delete("category = ?1", "newCategory2").await().indefinitely();
         testReactiveRepository.delete("{'category' : ?1}", "category1").await().indefinitely();
         Assertions.assertEquals(0, testReactiveRepository.count().await().indefinitely());
         testReactiveRepository.persist(entities.stream()).await().indefinitely();

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -262,6 +262,16 @@ class MongodbPanacheResourceTest {
         //expected the firstname field to be null as we project on lastname only
         Assertions.assertNull(list.get(0).firstname);
 
+        //rename the Doe
+        RestAssured
+                .given()
+                .queryParam("previousName", "Doe").queryParam("newName", "Dupont")
+                .header("Content-Type", "application/json")
+                .when().post(endpoint + "/rename")
+                .then().statusCode(200);
+        list = get(endpoint + "/search/Dupont").as(LIST_OF_PERSON_TYPE_REF);
+        Assertions.assertEquals(2, list.size());
+
         //count
         Long count = get(endpoint + "/count").as(Long.class);
         Assertions.assertEquals(4, count);

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
@@ -284,6 +284,16 @@ class ReactiveMongodbPanacheResourceTest {
         //expected the firstname field to be null as we project on lastname only
         Assertions.assertNull(list.get(0).firstname);
 
+        //rename the Doe
+        RestAssured
+                .given()
+                .queryParam("previousName", "Doe").queryParam("newName", "Dupont")
+                .header("Content-Type", "application/json")
+                .when().post(endpoint + "/rename")
+                .then().statusCode(200);
+        list = get(endpoint + "/search/Dupont").as(LIST_OF_PERSON_TYPE_REF);
+        Assertions.assertEquals(2, list.size());
+
         //count
         Long count = get(endpoint + "/count").as(Long.class);
         assertEquals(4, count);


### PR DESCRIPTION
Fixes 5924

@FroMage @viniciusfcf this is the implementation of Panache multi-update for MongoDB.

I took a slightly different aproach as for MongoDB, an udpate is not a single query but two: a filter (the query part) and an update document. So the method signature is not the same as with Hibernate (but parameters and PanacheQL works for both parts).

I just regret that we didn't call these methods `updateAll` in the first time as it seems more logical for me (and reading the JavaDoc ...), but it's too late to change this for Hibernate with Panache so better keep them this way also in MongoDB with Panache.