### PR TITLE
Fix MongoDB date format issue

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -323,7 +323,9 @@ Here are some query examples:
 - `lastname like ?1` will be mapped to `{'lastname': {'$regex': ?1}}`. Be careful that this will be link:https://docs.mongodb.com/manual/reference/operator/query/regex/#op._S_regex[MongoDB regex] support and not SQL like pattern.
 - `lastname is not null` will be mapped to `{'lastname':{'$exists': true}}`
 
-We also handle some basic date type transformations: all fields of type `Date`, `LocalDate` or `LocalDateTime` will be mapped to the link:https://docs.mongodb.com/manual/reference/bson-types/#document-bson-type-date[BSON Date] using the `ISODate` type (UTC datetime).
+We also handle some basic date type transformations: all fields of type `Date`, `LocalDate`, `LocalDateTime` or `Instant` will be mapped to the
+link:https://docs.mongodb.com/manual/reference/bson-types/#document-bson-type-date[BSON Date] using the `ISODate` type (UTC datetime).
+The MongoDB POJO codec doesn't support `ZonedDateTime` and `OffsetDateTime` so you should convert them prior usage.
 
 MongoDB with Panache also supports extended MongoDB queries by providing a `Document` query, this is supported by the find/list/stream/count/delete methods.
 

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/CommonQueryBinder.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/CommonQueryBinder.java
@@ -7,10 +7,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.TimeZone;
 
 final class CommonQueryBinder {
 
-    static final String ISO_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+    private static final String ISO_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    // the default DateTimeFormatter.ISO_LOCAL_DATE_TIME format with too many nano fraction (up to 9) for MongoDB (only 3)
+    private static final DateTimeFormatter ISO_DATE_FORMATTER = DateTimeFormatter.ofPattern(ISO_DATE_PATTERN);
 
     private CommonQueryBinder() {
     }
@@ -25,6 +28,7 @@ final class CommonQueryBinder {
         }
         if (value instanceof Date) {
             SimpleDateFormat dateFormat = new SimpleDateFormat(ISO_DATE_PATTERN);
+            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
             Date dateValue = (Date) value;
             return "ISODate('" + dateFormat.format(dateValue) + "')";
         }
@@ -34,11 +38,11 @@ final class CommonQueryBinder {
         }
         if (value instanceof LocalDateTime) {
             LocalDateTime dateValue = (LocalDateTime) value;
-            return "ISODate('" + DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(dateValue) + "')";
+            return "ISODate('" + ISO_DATE_FORMATTER.format(dateValue.atZone(ZoneOffset.UTC)) + "')";
         }
         if (value instanceof Instant) {
             Instant dateValue = (Instant) value;
-            return "ISODate('" + DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(dateValue.atZone(ZoneOffset.UTC)) + "')";
+            return "ISODate('" + ISO_DATE_FORMATTER.format(dateValue.atZone(ZoneOffset.UTC)) + "')";
         }
         return "'" + value.toString().replace("\\", "\\\\").replace("'", "\\'") + "'";
     }

--- a/extensions/panache/mongodb-panache/runtime/src/test/java/io/quarkus/mongodb/panache/runtime/MongoOperationsTest.java
+++ b/extensions/panache/mongodb-panache/runtime/src/test/java/io/quarkus/mongodb/panache/runtime/MongoOperationsTest.java
@@ -48,15 +48,15 @@ class MongoOperationsTest {
         assertEquals("{'field':ISODate('2019-03-04')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         //test field replacement
         query = MongoOperations.bindQuery(DemoObj.class, "property", new Object[] { "a value" });
@@ -64,7 +64,7 @@ class MongoOperationsTest {
     }
 
     private Object toDate(LocalDateTime of) {
-        return Date.from(of.atZone(ZoneId.systemDefault()).toInstant());
+        return Date.from(of.atZone(ZoneId.of("UTC")).toInstant());
     }
 
     @Test
@@ -85,15 +85,15 @@ class MongoOperationsTest {
 
         query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
-        assertEquals("{'field': ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
-        assertEquals("{'field': ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "{'field': ?1}",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
-        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000')}", query);
+        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "{'field': ?1, 'isOk': ?2}", new Object[] { "a value", true });
         assertEquals("{'field': 'a value', 'isOk': true}", query);
@@ -120,15 +120,15 @@ class MongoOperationsTest {
 
         query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)).map());
-        assertEquals("{'field': ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)).map());
-        assertEquals("{'field': ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "{'field': :field}",
                 Parameters.with("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))).map());
-        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000')}", query);
+        assertEquals("{'field': ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "{'field': :field, 'isOk': :isOk}",
                 Parameters.with("field", "a value").and("isOk", true).map());
@@ -152,15 +152,15 @@ class MongoOperationsTest {
         assertEquals("{'field':ISODate('2019-03-04')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = ?1", new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1) });
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = ?1",
                 new Object[] { LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC) });
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = ?1",
                 new Object[] { toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1)) });
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = ?1 and isOk = ?2", new Object[] { "a value", true });
         assertEquals("{'field':'a value','isOk':true}", query);
@@ -209,15 +209,15 @@ class MongoOperationsTest {
 
         query = MongoOperations.bindQuery(Object.class, "field = :field",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1)).map());
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = :field",
                 Parameters.with("field", LocalDateTime.of(2019, 3, 4, 1, 1, 1).toInstant(ZoneOffset.UTC)).map());
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = :field",
                 Parameters.with("field", toDate(LocalDateTime.of(2019, 3, 4, 1, 1, 1))).map());
-        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000')}", query);
+        assertEquals("{'field':ISODate('2019-03-04T01:01:01.000Z')}", query);
 
         query = MongoOperations.bindQuery(Object.class, "field = :field and isOk = :isOk",
                 Parameters.with("field", "a value").and("isOk", true).map());

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/BugResource.java
@@ -1,5 +1,11 @@
 package io.quarkus.it.mongodb.panache.bugs;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -49,5 +55,28 @@ public class BugResource {
     @Path("6324/abstract")
     public Response testNeedReflectionAndAbstract() {
         return Response.ok(bug6324ConcreteRepository.listAll()).build();
+    }
+
+    @GET
+    @Path("dates")
+    public Response testDatesFormat() {
+        DateEntity dateEntity = new DateEntity();
+        dateEntity.persist();
+
+        // search on all possible fields
+        long millisInDay = 1000 * 60 * 60 * 24;
+        Date dateTomorrow = new Date(System.currentTimeMillis() + 1000 * millisInDay);
+        LocalDate localDateTomorrow = LocalDate.now().plus(1, ChronoUnit.DAYS);
+        LocalDateTime localDateTimeTomorrow = LocalDateTime.now().plus(1, ChronoUnit.DAYS);
+        Instant instantTomorrow = Instant.now().plus(1, ChronoUnit.DAYS);
+        DateEntity result = DateEntity
+                .find("dateDate < ?1 and localDate < ?2 and localDateTime < ?3 and instant < ?4",
+                        dateTomorrow, localDateTomorrow, localDateTimeTomorrow, instantTomorrow)
+                .firstResult();
+
+        if (result == null) {
+            return Response.status(404).build();
+        }
+        return Response.ok().build();
     }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/DateEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/bugs/DateEntity.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.mongodb.panache.bugs;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+
+/**
+ * An entity that have all the supported date format.
+ * Asserting #6566 and possibility other date issues.
+ */
+public class DateEntity extends PanacheMongoEntity {
+    public Date dateDate;
+    public LocalDate localDate;
+    public LocalDateTime localDateTime;
+    public Instant instant;
+
+    public DateEntity() {
+        dateDate = new Date();
+        localDate = LocalDate.now();
+        localDateTime = LocalDateTime.now();
+        instant = Instant.now();
+    }
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -318,6 +318,11 @@ class MongodbPanacheResourceTest {
     }
 
     @Test
+    public void testDatesFormat() {
+        get("/bugs/dates").then().statusCode(200);
+    }
+
+    @Test
     public void testNeedReflection() {
         get("/bugs/6324").then().statusCode(200);
 


### PR DESCRIPTION
Fixes #6566

This fix the issue with `Instant` and `LocalDateTime` in query parameters.

All dates are now handled in UTC correctly, so it fixes issue with `Date` parameters not in UTC.

`ZoneDateTime` nor `OffsetDateTime` are supported as they are not supported by the MongoDB codec, advise is to convert them to a `LocalDateTime` or an `Instant` prior to use them. They can be easily accepted as query parameter but I'm not sure it worth it as we cannot use them as an entity field.

@gsmet date handling is tricky, so I need careful review on this one :)