### PR TITLE
Cleanup in the bootstrap code around maven resolver and workspace discovery

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -61,7 +61,7 @@ public class QuarkusBootstrap implements Serializable {
     private final Mode mode;
     private final boolean offline;
     private final boolean test;
-    private final boolean localProjectDiscovery;
+    private final Boolean localProjectDiscovery;
 
     private final ClassLoader baseClassLoader;
     private final AppModelResolver appModelResolver;
@@ -204,7 +204,7 @@ public class QuarkusBootstrap implements Serializable {
         Mode mode = Mode.PROD;
         boolean offline;
         boolean test;
-        boolean localProjectDiscovery;
+        Boolean localProjectDiscovery;
         Path targetDirectory;
         AppModelResolver appModelResolver;
         VersionUpdateNumber versionUpdateNumber = VersionUpdateNumber.MICRO;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -150,7 +150,6 @@ public class QuarkusDevModeTest
             DevModeContext context = exportArchive(deploymentDir, projectSourceRoot);
             context.setTest(true);
             context.setAbortOnFailedStart(true);
-            context.setLocalProjectDiscovery(true);
             devModeMain = new DevModeMain(context);
             devModeMain.start();
         } catch (Exception e) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -80,7 +80,7 @@ public class QuarkusTestExtension
             CuratedApplication curatedApplication = runnerBuilder
                     .setTest(true)
                     .setProjectRoot(new File("").toPath())
-                    .setLocalProjectDiscovery(true).build()
+                    .build()
                     .bootstrap();
             Timing.staticInitStarted(curatedApplication.getBaseRuntimeClassLoader());
             AugmentAction augmentAction = curatedApplication.createAugmentor(TestBuildChainFunction.class.getName(),


### PR DESCRIPTION
* a fallback to resolving an application model from the classpath was removed, if the execution flow reaches that point something is definitely wrong and most probably will end up failing later;
* resolved workspace discovery in BootstrapAppModelFactory is cached now to avoid loading it multiple times for the same factory (helps optimize launching apps in dev mode);
* unless explicitly enabled or disabled, local workspace discovery is enabled by default for the test and dev modes and disabled otherwise.