### PR TITLE
exclude hikari from the quartz extension

### DIFF
--- a/extensions/quartz/runtime/pom.xml
+++ b/extensions/quartz/runtime/pom.xml
@@ -33,7 +33,11 @@
             <exclusions>
                 <exclusion>
                     <groupId>com.zaxxer</groupId>
-                    <artifactId>HikariCP-java6</artifactId>
+                    <artifactId>HikariCP</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP-java7</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.mchange</groupId>


### PR DESCRIPTION
Since we added exclusion for hikari to quartz, it changed from using java6 to java7 version.