### PR TITLE
Revert "Bump kubernetes-client-bom from 4.7.1 to 4.8.0"

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -164,7 +164,7 @@
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
         <kogito.version>0.7.1</kogito.version>
-        <kubernetes-client.version>4.8.0</kubernetes-client.version>
+        <kubernetes-client.version>4.7.1</kubernetes-client.version>
         <sundr.version>0.19.1</sundr.version> <!-- this is to avoid annoying pop-up in eclipse about failure to init Velocity logging -->
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <wiremock.version>2.24.1</wiremock.version>


### PR DESCRIPTION
Reverts quarkusio/quarkus#7206

I can't build the project locally with the bump to `4.8.0`