### PR TITLE
Implement Mutiny support for the mailer service

### DIFF
--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -100,9 +100,15 @@ ReactiveMailer reactiveMailer;
 There are 2 APIs:
 
 * `io.quarkus.mailer.Mailer` provides the imperative (blocking and synchronous) API;
-* `io.quarkus.mailer.ReactiveMailer` provides the reactive (non-blocking and asynchronous) API
+* `io.quarkus.mailer.reactive.ReactiveMailer` provides the reactive (non-blocking and asynchronous) API
 
 NOTE: The two APIs are equivalent feature-wise. Actually the `Mailer` implementation is built on top of the `ReactiveMailer` implementation.
+
+[NOTE]
+.Deprecation
+====
+`io.quarkus.mailer.ReactiveMailer` is deprecated in favor of `io.quarkus.mailer.reactive.ReactiveMailer`.
+====
 
 To send a simple email, proceed as follows:
 
@@ -111,7 +117,7 @@ To send a simple email, proceed as follows:
 // Imperative API:
 mailer.send(Mail.withText("to@acme.org", "A simple email from quarkus", "This is my body."));
 // Reactive API:
-CompletionStage<Void> stage = reactiveMailer.send(Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body."));
+Uni<Void> stage = reactiveMailer.send(Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body."));
 ----
 
 For example, you can use the `Mailer` in a JAX-RS endpoint as follows:
@@ -130,8 +136,14 @@ public Response sendASimpleEmail() {
 public CompletionStage<Response> sendASimpleEmailAsync() {
     return reactiveMailer.send(
             Mail.withText("to@acme.org", "A reactive email from quarkus", "This is my body"))
+            .subscribeAsCompletionStage()
             .thenApply(x -> Response.accepted().build());
 }
+----
+
+[NOTE]
+----
+With the `quarkus-resteasy-mutiny` extension, you can return an instance of `Uni` directly.
 ----
 
 With such a JAX-RS resource, you can check that everything is working with:
@@ -215,6 +227,7 @@ public CompletionStage<Response> send() {
        // the template looks like: Hello {name}!
        .data("name", "John") <3>
        .send() <4>
+       .subscribeAsCompletionStage()
        .thenApply(x -> Response.accepted().build());
 }
 ----
@@ -325,8 +338,9 @@ If you need fine control on how the mail is sent, for instance if you need to re
 
 Three API flavors are exposed:
 
-* the Axle client (`io.vertx.axle.ext.mail.MailClient`), using `CompletionStage` and Reactive Streams `Publisher`
-* the RX Java 2 client (`io.vertx.reactivex.ext.mail.MailClient`)
+* the Mutiny client (`io.vertx.mutiny.ext.mail.MailClient`)
+* the Axle client (`io.vertx.axle.ext.mail.MailClient`), using `CompletionStage` and Reactive Streams `Publisher` - deprecated, it is recommended to switch to the Mutiny client
+* the RX Java 2 client (`io.vertx.reactivex.ext.mail.MailClient`) - deprecated, it is recommended to switch to the Mutiny client
 * the bare client (`io.vertx.ext.mail.MailClient`)
 
 Check the link:vertx[Using Vert.x guide] for further details about these different APIs and how to select the most suitable for you.

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.mailer.runtime.MailConfig;
 import io.quarkus.mailer.runtime.MailConfigRecorder;
 import io.quarkus.mailer.runtime.MailTemplateProducer;
 import io.quarkus.mailer.runtime.MockMailboxImpl;
+import io.quarkus.mailer.runtime.MutinyMailerImpl;
 import io.quarkus.mailer.runtime.ReactiveMailerImpl;
 import io.quarkus.qute.deployment.QuteProcessor;
 import io.quarkus.qute.deployment.TemplatePathBuildItem;
@@ -49,8 +50,8 @@ public class MailerProcessor {
     @BuildStep
     AdditionalBeanBuildItem registerMailers() {
         return AdditionalBeanBuildItem.builder()
-                .addBeanClasses(ReactiveMailerImpl.class, BlockingMailerImpl.class, MockMailboxImpl.class,
-                        MailTemplateProducer.class)
+                .addBeanClasses(ReactiveMailerImpl.class, MutinyMailerImpl.class, BlockingMailerImpl.class,
+                        MockMailboxImpl.class, MailTemplateProducer.class)
                 .build();
     }
 
@@ -93,7 +94,7 @@ public class MailerProcessor {
             List<TemplatePathBuildItem> templatePaths, ValidationPhaseBuildItem validationPhase,
             BuildProducer<ValidationErrorBuildItem> validationErrors) {
 
-        Set<String> filePaths = new HashSet<String>();
+        Set<String> filePaths = new HashSet<>();
         for (TemplatePathBuildItem templatePath : templatePaths) {
             String filePath = templatePath.getPath();
             if (File.separatorChar != '/') {

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -25,6 +25,14 @@
             <artifactId>quarkus-qute</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-mail-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-axle-mail-client</artifactId>
         </dependency>

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/ReactiveMailer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/ReactiveMailer.java
@@ -4,7 +4,11 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * A mailer to send email asynchronously.
+ *
+ * @deprecated Use {@link io.quarkus.mailer.reactive.ReactiveMailer} instead. This class is going to be removed in a
+ *             future version.
  */
+@Deprecated
 public interface ReactiveMailer {
 
     /**

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/reactive/ReactiveMailer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/reactive/ReactiveMailer.java
@@ -1,0 +1,19 @@
+package io.quarkus.mailer.reactive;
+
+import io.quarkus.mailer.Mail;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * A mailer to send email asynchronously.
+ */
+public interface ReactiveMailer {
+
+    /**
+     * Sends the given emails.
+     *
+     * @param mails the emails to send, must not be {@code null}, must not contain {@code null}
+     * @return a {@link Uni} indicating when the mails have been sent. The {@link Uni} may fire a failure if the
+     *         emails cannot be sent.
+     */
+    Uni<Void> send(Mail... mails);
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailConfigRecorder.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailConfigRecorder.java
@@ -26,10 +26,10 @@ public class MailConfigRecorder {
         return new RuntimeValue<>(client);
     }
 
-    public RuntimeValue<ReactiveMailerImpl> configureTheMailer(BeanContainer container, MailConfig config,
+    public RuntimeValue<MutinyMailerImpl> configureTheMailer(BeanContainer container, MailConfig config,
             LaunchMode launchMode) {
 
-        ReactiveMailerImpl mailer = container.instance(ReactiveMailerImpl.class);
+        MutinyMailerImpl mailer = container.instance(MutinyMailerImpl.class);
 
         // mock defaults to true on DEV and TEST
         mailer.configure(config.from, config.bounceAddress, config.mock.orElse(launchMode.isDevOrTest()));
@@ -39,7 +39,7 @@ public class MailConfigRecorder {
 
     void initialize(Vertx vertx, MailConfig config) {
         io.vertx.ext.mail.MailConfig cfg = toVertxMailConfig(config);
-        client = MailClient.createNonShared(vertx, cfg);
+        client = MailClient.createShared(vertx, cfg);
     }
 
     private io.vertx.ext.mail.MailConfig toVertxMailConfig(MailConfig config) {

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateProducer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateProducer.java
@@ -14,7 +14,6 @@ import javax.inject.Singleton;
 import org.jboss.logging.Logger;
 
 import io.quarkus.mailer.MailTemplate;
-import io.quarkus.mailer.ReactiveMailer;
 import io.quarkus.qute.api.ResourcePath;
 import io.quarkus.qute.api.VariantTemplate;
 
@@ -24,7 +23,7 @@ public class MailTemplateProducer {
     private static final Logger LOGGER = Logger.getLogger(MailTemplateProducer.class);
 
     @Inject
-    ReactiveMailer mailer;
+    MutinyMailerImpl mailer;
 
     @Any
     Instance<VariantTemplate> template;
@@ -66,7 +65,7 @@ public class MailTemplateProducer {
             }
         }
         if (path == null || path.value().isEmpty()) {
-            throw new IllegalStateException("No template reource path specified");
+            throw new IllegalStateException("No template resource path specified");
         }
         final String name = path.value();
         return new MailTemplate() {

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MockMailboxImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MockMailboxImpl.java
@@ -4,13 +4,12 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.MockMailbox;
+import io.smallrye.mutiny.Uni;
 
 /**
  * Mock mailbox bean, will be populated if mocking emails.
@@ -21,7 +20,7 @@ public class MockMailboxImpl implements MockMailbox {
     private Map<String, List<Mail>> sentMessages = new HashMap<>();
     private int sentMessagesCount;
 
-    CompletionStage<Void> send(Mail email) {
+    Uni<Void> send(Mail email) {
         if (email.getTo() != null) {
             for (String to : email.getTo()) {
                 send(email, to);
@@ -37,15 +36,12 @@ public class MockMailboxImpl implements MockMailbox {
                 send(email, to);
             }
         }
-        return CompletableFuture.completedFuture(null);
+        return Uni.createFrom().item(() -> null);
     }
 
     private void send(Mail sentMail, String to) {
-        List<Mail> mails = sentMessages.get(to);
-        if (mails == null) {
-            mails = new LinkedList<>();
-            sentMessages.put(to, mails);
-        }
+        List<Mail> mails = sentMessages
+                .computeIfAbsent(to, k -> new LinkedList<>());
         sentMessagesCount++;
         mails.add(sentMail);
     }

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
@@ -1,0 +1,189 @@
+package io.quarkus.mailer.runtime;
+
+import static java.util.Arrays.stream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.logging.Logger;
+import org.reactivestreams.Publisher;
+
+import io.quarkus.mailer.Attachment;
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.reactive.ReactiveMailer;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.OpenOptions;
+import io.vertx.ext.mail.MailAttachment;
+import io.vertx.ext.mail.MailMessage;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.file.AsyncFile;
+import io.vertx.mutiny.ext.mail.MailClient;
+
+@ApplicationScoped
+public class MutinyMailerImpl implements ReactiveMailer {
+
+    private static final Logger LOGGER = Logger.getLogger("quarkus-mailer");
+
+    @Inject
+    MailClient client;
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    MockMailboxImpl mockMailbox;
+
+    /**
+     * Default from value.
+     */
+    private volatile String from;
+
+    /**
+     * Default bounce address.
+     */
+    private volatile String bounceAddress;
+
+    /**
+     * If {@code true}, mails are not sent to the server, the body is printed in the console.
+     */
+    private volatile boolean mock;
+
+    @Override
+    public Uni<Void> send(Mail... mails) {
+        if (mails == null) {
+            throw new IllegalArgumentException("The `mails` parameter must not be `null`");
+        }
+
+        List<Uni<Void>> unis = stream(mails)
+                .map(mail -> toMailMessage(mail)
+                        .onItem().produceUni(mailMessage -> send(mail, mailMessage)))
+                .collect(Collectors.toList());
+
+        return Uni.combine().all().unis(unis).combinedWith(results -> null);
+
+    }
+
+    private Uni<Void> send(Mail mail, MailMessage message) {
+        if (mock) {
+            LOGGER.infof("Sending email %s from %s to %s, text body: \n%s\nhtml body: \n%s",
+                    message.getSubject(), message.getFrom(), message.getTo(),
+                    message.getText() == null ? "<empty>" : message.getText(),
+                    message.getHtml() == null ? "<empty>" : message.getHtml());
+            return mockMailbox.send(mail);
+        } else {
+            return client.sendMail(message)
+                    .onItem().ignore().andContinueWithNull();
+        }
+    }
+
+    private Uni<MailMessage> toMailMessage(Mail mail) {
+        MailMessage message = new MailMessage();
+
+        if (mail.getBounceAddress() != null) {
+            message.setBounceAddress(mail.getBounceAddress());
+        } else {
+            message.setBounceAddress(this.bounceAddress);
+        }
+
+        if (mail.getFrom() != null) {
+            message.setFrom(mail.getFrom());
+        } else {
+            message.setFrom(this.from);
+        }
+        message.setTo(mail.getTo());
+        message.setCc(mail.getCc());
+        message.setBcc(mail.getBcc());
+        message.setSubject(mail.getSubject());
+        message.setText(mail.getText());
+        message.setHtml(mail.getHtml());
+        message.setHeaders(toMultimap(mail.getHeaders()));
+        if (mail.getReplyTo() != null) {
+            message.addHeader("Reply-To", mail.getReplyTo());
+        }
+
+        List<Uni<?>> stages = new ArrayList<>();
+        List<MailAttachment> attachments = new CopyOnWriteArrayList<>();
+        List<MailAttachment> inline = new CopyOnWriteArrayList<>();
+        for (Attachment attachment : mail.getAttachments()) {
+            if (attachment.isInlineAttachment()) {
+                stages.add(
+                        toMailAttachment(attachment).onItem().invoke(inline::add));
+            } else {
+                stages.add(
+                        toMailAttachment(attachment).onItem().invoke(attachments::add));
+            }
+        }
+
+        if (stages.isEmpty()) {
+            message.setAttachment(attachments);
+            message.setInlineAttachment(inline);
+            return Uni.createFrom().item(message);
+        }
+
+        return Uni.combine().all().unis(stages).combinedWith(res -> {
+            message.setAttachment(attachments);
+            message.setInlineAttachment(inline);
+            return message;
+        });
+    }
+
+    private MultiMap toMultimap(Map<String, List<String>> headers) {
+        MultiMap mm = MultiMap.caseInsensitiveMultiMap();
+        headers.forEach(mm::add);
+        return mm;
+    }
+
+    private Uni<MailAttachment> toMailAttachment(Attachment attachment) {
+        MailAttachment attach = new MailAttachment();
+        attach.setName(attachment.getName());
+        attach.setContentId(attachment.getContentId());
+        attach.setDescription(attachment.getDescription());
+        attach.setDisposition(attachment.getDisposition());
+        attach.setContentType(attachment.getContentType());
+
+        if ((attachment.getFile() == null && attachment.getData() == null) // No content
+                || (attachment.getFile() != null && attachment.getData() != null)) // Too much content
+        {
+
+            throw new IllegalArgumentException("An attachment must contain either a file or a raw data");
+        }
+
+        return getAttachmentStream(vertx, attachment)
+                .onItem().apply(attach::setData);
+    }
+
+    public static Uni<Buffer> getAttachmentStream(Vertx vertx, Attachment attachment) {
+        if (attachment.getFile() != null) {
+            Uni<AsyncFile> open = vertx.fileSystem().open(attachment.getFile().getAbsolutePath(),
+                    new OpenOptions().setRead(true).setCreate(false));
+            return open
+                    .flatMap(af -> af.toMulti()
+                            .map(io.vertx.mutiny.core.buffer.Buffer::getDelegate)
+                            .on().termination((r, f) -> af.close())
+                            .collectItems().in(Buffer::buffer, Buffer::appendBuffer));
+        } else if (attachment.getData() != null) {
+            Publisher<Byte> data = attachment.getData();
+            return Multi.createFrom().publisher(data)
+                    .collectItems().in(Buffer::buffer, Buffer::appendByte);
+        } else {
+            return Uni.createFrom().failure(new IllegalArgumentException("Attachment has no data"));
+        }
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    void configure(Optional<String> from, Optional<String> bounceAddress, boolean mock) {
+        this.from = from.orElse(null);
+        this.bounceAddress = bounceAddress.orElse(null);
+        this.mock = mock;
+    }
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/ReactiveMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/ReactiveMailerImpl.java
@@ -1,189 +1,21 @@
 package io.quarkus.mailer.runtime;
 
-import static java.util.Arrays.stream;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.jboss.logging.Logger;
-import org.reactivestreams.Publisher;
-
-import io.quarkus.mailer.Attachment;
 import io.quarkus.mailer.Mail;
-import io.quarkus.mailer.ReactiveMailer;
-import io.vertx.axle.core.Vertx;
-import io.vertx.axle.core.file.AsyncFile;
-import io.vertx.axle.ext.mail.MailClient;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.file.OpenOptions;
-import io.vertx.ext.mail.MailAttachment;
-import io.vertx.ext.mail.MailMessage;
+import io.quarkus.mailer.reactive.ReactiveMailer;
 
 @ApplicationScoped
-public class ReactiveMailerImpl implements ReactiveMailer {
-
-    private static final Logger LOGGER = Logger.getLogger("quarkus-mailer");
+public class ReactiveMailerImpl implements io.quarkus.mailer.ReactiveMailer {
 
     @Inject
-    MailClient client;
-
-    @Inject
-    Vertx vertx;
-
-    @Inject
-    MockMailboxImpl mockMailbox;
-
-    /**
-     * Default from value.
-     */
-    private volatile String from;
-
-    /**
-     * Default bounce address.
-     */
-    private volatile String bounceAddress;
-
-    /**
-     * If {@code true}, mails are not sent to the server, the body is printed in the console.
-     */
-    private volatile boolean mock;
+    ReactiveMailer client;
 
     @Override
     public CompletionStage<Void> send(Mail... mails) {
-        if (mails == null) {
-            throw new IllegalArgumentException("The `mails` parameter must not be `null`");
-        }
-
-        return allOf(
-                stream(mails)
-                        .map(mail -> toMailMessage(mail).thenCompose(mailMessage -> send(mail, mailMessage)))
-                        .collect(Collectors.toList()));
-    }
-
-    private CompletionStage<Void> send(Mail mail, MailMessage message) {
-        if (mock) {
-            LOGGER.infof("Sending email %s from %s to %s, text body: \n%s\nhtml body: \n%s",
-                    message.getSubject(), message.getFrom(), message.getTo(),
-                    message.getText(), message.getHtml());
-            return mockMailbox.send(mail);
-        } else {
-            return client.sendMail(message)
-                    .thenAccept(x -> {
-                    }); // Discard result.
-        }
-    }
-
-    private CompletionStage<MailMessage> toMailMessage(Mail mail) {
-        MailMessage message = new MailMessage();
-
-        if (mail.getBounceAddress() != null) {
-            message.setBounceAddress(mail.getBounceAddress());
-        } else {
-            message.setBounceAddress(this.bounceAddress);
-        }
-
-        if (mail.getFrom() != null) {
-            message.setFrom(mail.getFrom());
-        } else {
-            message.setFrom(this.from);
-        }
-        message.setTo(mail.getTo());
-        message.setCc(mail.getCc());
-        message.setBcc(mail.getBcc());
-        message.setSubject(mail.getSubject());
-        message.setText(mail.getText());
-        message.setHtml(mail.getHtml());
-        message.setHeaders(toMultimap(mail.getHeaders()));
-        if (mail.getReplyTo() != null) {
-            message.addHeader("Reply-To", mail.getReplyTo());
-        }
-
-        List<CompletionStage<?>> stages = new ArrayList<>();
-        List<MailAttachment> attachments = new CopyOnWriteArrayList<>();
-        List<MailAttachment> inline = new CopyOnWriteArrayList<>();
-        for (Attachment attachment : mail.getAttachments()) {
-            if (attachment.isInlineAttachment()) {
-                stages.add(toMailAttachment(attachment).thenAccept(inline::add));
-            } else {
-                stages.add(toMailAttachment(attachment).thenAccept(attachments::add));
-            }
-        }
-
-        return allOf(stages).thenApply(x -> {
-            message.setAttachment(attachments);
-            message.setInlineAttachment(inline);
-            return message;
-        });
-    }
-
-    private MultiMap toMultimap(Map<String, List<String>> headers) {
-        MultiMap mm = MultiMap.caseInsensitiveMultiMap();
-        headers.forEach(mm::add);
-        return mm;
-    }
-
-    private CompletionStage<MailAttachment> toMailAttachment(Attachment attachment) {
-        MailAttachment attach = new MailAttachment();
-        attach.setName(attachment.getName());
-        attach.setContentId(attachment.getContentId());
-        attach.setDescription(attachment.getDescription());
-        attach.setDisposition(attachment.getDisposition());
-        attach.setContentType(attachment.getContentType());
-
-        if ((attachment.getFile() == null && attachment.getData() == null) // No content
-                || (attachment.getFile() != null && attachment.getData() != null)) // Too much content
-        {
-
-            throw new IllegalArgumentException("An attachment must contain either a file or a raw data");
-        }
-
-        return getAttachmentStream(vertx, attachment).thenApply(attach::setData);
-    }
-
-    public static CompletionStage<Buffer> getAttachmentStream(Vertx vertx, Attachment attachment) {
-        if (attachment.getFile() != null) {
-            CompletionStage<AsyncFile> open = vertx.fileSystem().open(attachment.getFile().getAbsolutePath(),
-                    new OpenOptions().setRead(true).setCreate(false));
-            return ReactiveStreams
-                    .fromCompletionStage(open)
-                    .flatMap(af -> af.toPublisherBuilder().map(io.vertx.axle.core.buffer.Buffer::getDelegate)
-                            .onTerminate(af::close))
-                    .collect(Buffer::buffer, Buffer::appendBuffer)
-                    .run();
-        } else if (attachment.getData() != null) {
-            Publisher<Byte> data = attachment.getData();
-            return ReactiveStreams.fromPublisher(data)
-                    .collect(Buffer::buffer, Buffer::appendByte)
-                    .run();
-        } else {
-            CompletableFuture<Buffer> future = new CompletableFuture<>();
-            future.completeExceptionally(new IllegalArgumentException("Attachment has no data"));
-            return future;
-        }
-    }
-
-    private static CompletionStage<Void> allOf(List<CompletionStage<?>> stages) {
-        CompletableFuture<?>[] array = stages.stream()
-                .map(CompletionStage::toCompletableFuture)
-                .toArray(CompletableFuture[]::new);
-        return CompletableFuture.allOf(array);
-    }
-
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    void configure(Optional<String> from, Optional<String> bounceAddress, boolean mock) {
-        this.from = from.orElse(null);
-        this.bounceAddress = bounceAddress.orElse(null);
-        this.mock = mock;
+        return client.send(mails).subscribeAsCompletionStage();
     }
 }

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MockMailerImplTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/runtime/MockMailerImplTest.java
@@ -2,12 +2,9 @@ package io.quarkus.mailer.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import javax.mail.MessagingException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.mailer.Mail;
-import io.vertx.axle.core.Vertx;
+import io.vertx.mutiny.core.Vertx;
 
 class MockMailerImplTest {
 
@@ -23,7 +20,8 @@ class MockMailerImplTest {
     private static final String TO = "foo@quarkus.io";
 
     private static Vertx vertx;
-    private ReactiveMailerImpl mailer;
+    private MutinyMailerImpl mailer;
+    private ReactiveMailerImpl legacyMailer;
 
     @BeforeAll
     static void start() {
@@ -32,23 +30,36 @@ class MockMailerImplTest {
 
     @AfterAll
     static void stop() {
-        vertx.close().toCompletableFuture().join();
+        vertx.close().await().indefinitely();
     }
 
     @BeforeEach
     void init() {
-        mailer = new ReactiveMailerImpl();
+        mailer = new MutinyMailerImpl();
         mailer.configure(Optional.of(FROM), Optional.empty(), true);
         mailer.vertx = vertx;
         mailer.mockMailbox = new MockMailboxImpl();
-
         mailer.mockMailbox.clear();
+        legacyMailer = new ReactiveMailerImpl();
+        legacyMailer.client = mailer;
     }
 
     @Test
-    void testTextMail() throws MessagingException, IOException {
+    void testTextMail() {
         String content = UUID.randomUUID().toString();
-        mailer.send(Mail.withText(TO, "Test", content)).toCompletableFuture().join();
+        mailer.send(Mail.withText(TO, "Test", content)).await().indefinitely();
+
+        List<Mail> sent = mailer.mockMailbox.getMessagesSentTo(TO);
+        assertThat(sent).hasSize(1);
+        Mail actual = sent.get(0);
+        assertThat(actual.getText()).contains(content);
+        assertThat(actual.getSubject()).isEqualTo("Test");
+    }
+
+    @Test
+    void testTextMailLegacy() {
+        String content = UUID.randomUUID().toString();
+        legacyMailer.send(Mail.withText(TO, "Test", content)).toCompletableFuture().join();
 
         List<Mail> sent = mailer.mockMailbox.getMessagesSentTo(TO);
         assertThat(sent).hasSize(1);
@@ -60,8 +71,18 @@ class MockMailerImplTest {
     @Test
     void testWithSeveralMails() {
         Mail mail1 = Mail.withText(TO, "Mail 1", "Mail 1").addCc("cc@quarkus.io").addBcc("bcc@quarkus.io");
-        Mail mail2 = Mail.withHtml(TO, "Mail 2", "<strong>Mail 2</strong>").addCc("cc2@quarkus.io").addBcc("bcc2@quarkus.io");
-        mailer.send(mail1, mail2).toCompletableFuture().join();
+        Mail mail2 = Mail.withHtml(TO, "Mail 2", "<strong>Mail 2</strong>").addCc("cc2@quarkus.io")
+                .addBcc("bcc2@quarkus.io");
+        mailer.send(mail1, mail2).await().indefinitely();
+        assertThat(mailer.mockMailbox.getTotalMessagesSent()).isEqualTo(6);
+    }
+
+    @Test
+    void testWithSeveralMailsLegacy() {
+        Mail mail1 = Mail.withText(TO, "Mail 1", "Mail 1").addCc("cc@quarkus.io").addBcc("bcc@quarkus.io");
+        Mail mail2 = Mail.withHtml(TO, "Mail 2", "<strong>Mail 2</strong>").addCc("cc2@quarkus.io")
+                .addBcc("bcc2@quarkus.io");
+        legacyMailer.send(mail1, mail2).toCompletableFuture().join();
         assertThat(mailer.mockMailbox.getTotalMessagesSent()).isEqualTo(6);
     }
 }


### PR DESCRIPTION
* Implement the Mutiny API
* Deprecated the previous API
* Update tests and documentation

These changes are backward compatible. 

I've also updated:
* the mock mailer to print `<empty>` instead of `null` 
* fix a few logged messages

The template support still returns a `CompletionStage`. It will be covered once #7101 is merged. This would be a breaking change. 
