### PR TITLE
Be nice to people mentioning lower case log levels

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -120,8 +120,9 @@ public class LoggingSetupRecorder {
             final String name = entry.getKey();
             final Logger categoryLogger = logContext.getLogger(name);
             final CategoryConfig categoryConfig = entry.getValue();
-            if (!"inherit".equals(categoryConfig.level)) {
-                categoryLogger.setLevelName(categoryConfig.level);
+            final String levelName = categoryConfig.level.toUpperCase(Locale.ROOT);
+            if (!"INHERIT".equals(categoryConfig.level)) {
+                categoryLogger.setLevelName(levelName);
             }
             categoryLogger.setUseParentHandlers(categoryConfig.useParentHandlers);
             if (categoryConfig.handlers.isPresent()) {


### PR DESCRIPTION

currently if one sets

    quarkus.log.category."something.something".level=trace

you get a nasty looking stacktrace, as the logger configuration only accepts levels in all uppercase: `TRACE`