### PR TITLE
Remove redundant synchronized block

### DIFF
--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -282,13 +282,8 @@ public class InfinispanClientProducer {
         if (cacheManager != null) {
             return cacheManager;
         }
-        synchronized (this) {
-            if (cacheManager != null) {
-                return cacheManager;
-            }
-            initialize();
-            return cacheManager;
-        }
+        initialize();
+        return cacheManager;
     }
 
     void configure(Properties properties) {


### PR DESCRIPTION
Looks like an old attempt at double-checked locking got synchronized at method level anyway, or am I missing something?

Removing synchronizedception