### PR TITLE
Synchronize Execution#diagnostics list internally

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildContext.java
@@ -187,9 +187,7 @@ public final class BuildContext {
      */
     public void note(Location location, String format, Object... args) {
         final List<Diagnostic> list = execution.getDiagnostics();
-        synchronized (list) {
-            list.add(new Diagnostic(Diagnostic.Level.NOTE, location, format, args));
-        }
+        list.add(new Diagnostic(Diagnostic.Level.NOTE, location, format, args));
     }
 
     /**
@@ -201,9 +199,7 @@ public final class BuildContext {
      */
     public void warn(Location location, String format, Object... args) {
         final List<Diagnostic> list = execution.getDiagnostics();
-        synchronized (list) {
-            list.add(new Diagnostic(Diagnostic.Level.WARN, location, format, args));
-        }
+        list.add(new Diagnostic(Diagnostic.Level.WARN, location, format, args));
     }
 
     /**
@@ -215,9 +211,7 @@ public final class BuildContext {
      */
     public void error(Location location, String format, Object... args) {
         final List<Diagnostic> list = execution.getDiagnostics();
-        synchronized (list) {
-            list.add(new Diagnostic(Diagnostic.Level.ERROR, location, format, args));
-        }
+        list.add(new Diagnostic(Diagnostic.Level.ERROR, location, format, args));
         execution.setErrorReported();
     }
 
@@ -279,10 +273,7 @@ public final class BuildContext {
                     buildStep.execute(this);
                 } catch (Throwable t) {
                     final List<Diagnostic> list = execution.getDiagnostics();
-                    synchronized (list) {
-                        list.add(
-                                new Diagnostic(Diagnostic.Level.ERROR, t, null, "Build step %s threw an exception", buildStep));
-                    }
+                    list.add(new Diagnostic(Diagnostic.Level.ERROR, t, null, "Build step %s threw an exception", buildStep));
                     execution.setErrorReported();
                 } finally {
                     running = false;

--- a/core/builder/src/main/java/io/quarkus/builder/Execution.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Execution.java
@@ -32,7 +32,7 @@ final class Execution {
     private final Set<ItemId> finalIds;
     private final ConcurrentHashMap<StepInfo, BuildContext> contextCache = new ConcurrentHashMap<>();
     private final EnhancedQueueExecutor executor;
-    private final List<Diagnostic> diagnostics = new ArrayList<>();
+    private final List<Diagnostic> diagnostics = Collections.synchronizedList(new ArrayList<>());
     private final String buildTargetName;
     private final AtomicBoolean errorReported = new AtomicBoolean();
     private final AtomicInteger lastStepCount = new AtomicInteger();


### PR DESCRIPTION
Use a synchronized list for `Execution#diagnostics` in order to unburden consumers of the getter from worrying about concurrency.