### PR TITLE
Add oidc-code-flow dev mode test

### DIFF
--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-oidc-deployment</artifactId>
     <name>Quarkus - OpenID Connect Adapter - Deployment</name>
 
+    <properties>
+        <keycloak.url>http://localhost:8180/auth</keycloak.url>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -53,9 +57,35 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -69,7 +99,103 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>test-keycloak</id>
+            <activation>
+                <property>
+                    <name>test-keycloak</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <systemPropertyVariables>
+                                <keycloak.url>${keycloak.url}</keycloak.url>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
+        <profile>
+            <id>docker-keycloak</id>
+            <activation>
+                <property>
+                    <name>docker</name>
+                </property>
+            </activation>
+            <properties>
+                <keycloak.url>http://localhost:8180/auth</keycloak.url>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${keycloak.docker.image}</name>
+                                    <alias>quarkus-test-keycloak</alias>
+                                    <run>
+                                        <ports>
+                                            <port>8180:8080</port>
+                                        </ports>
+                                        <env>
+                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
+                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                        </env>
+                                        <log>
+                                            <prefix>Keycloak:</prefix>
+                                            <date>default</date>
+                                            <color>cyan</color>
+                                        </log>
+                                        <wait>
+                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <http>
+                                                <url>http://localhost:8180</url>
+                                            </http>
+                                            <time>100000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                            <allContainers>true</allContainers>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>docker-start</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>docker-stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 </project>

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -1,0 +1,68 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(KeycloakDevModeRealmResourceManager.class)
+public class CodeFlowDevModeTestCase {
+
+    private static Class<?>[] testClasses = {
+            ProtectedResource.class
+    };
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("application-dev-mode.properties", "application.properties"));
+
+    @Test
+    public void testAccessAndRefreshTokenInjectionDevMode() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            try {
+                webClient.getPage("http://localhost:8080/web-app");
+                fail("Exception is expected because the invalid client_id is used");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertTrue(ex.getResponse().getContentAsString().contains("Client not found"));
+            }
+
+            test.modifyResourceFile("application.properties", s -> s.replace("client-dev", "client-dev-mode"));
+
+            HtmlPage page = webClient.getPage("http://localhost:8080/web-app");
+
+            assertEquals("Log in to devmode", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice-dev-mode");
+            loginForm.getInputByName("password").setValueAttribute("alice-dev-mode");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("alice-dev-mode", page.getBody().asText());
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/KeycloakDevModeRealmResourceManager.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/KeycloakDevModeRealmResourceManager.java
@@ -1,0 +1,123 @@
+package io.quarkus.oidc.test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.RolesRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.util.JsonSerialization;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.restassured.RestAssured;
+
+public class KeycloakDevModeRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_REALM = "devmode";
+
+    @Override
+    public Map<String, String> start() {
+
+        try {
+
+            RealmRepresentation realm = createRealm(KEYCLOAK_REALM);
+
+            realm.getClients().add(createClient("client-dev-mode"));
+            realm.getUsers().add(createUser("alice-dev-mode", "user"));
+
+            RestAssured
+                    .given()
+                    .auth().oauth2(getAdminAccessToken())
+                    .contentType("application/json")
+                    .body(JsonSerialization.writeValueAsBytes(realm))
+                    .when()
+                    .post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
+                    .statusCode(201);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return Collections.emptyMap();
+    }
+
+    private static String getAdminAccessToken() {
+        return RestAssured
+                .given()
+                .param("grant_type", "password")
+                .param("username", "admin")
+                .param("password", "admin")
+                .param("client_id", "admin-cli")
+                .when()
+                .post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
+                .as(AccessTokenResponse.class).getToken();
+    }
+
+    private static RealmRepresentation createRealm(String name) {
+        RealmRepresentation realm = new RealmRepresentation();
+
+        realm.setRealm(name);
+        realm.setEnabled(true);
+        realm.setUsers(new ArrayList<>());
+        realm.setClients(new ArrayList<>());
+        realm.setSsoSessionMaxLifespan(2); // sec
+        realm.setAccessTokenLifespan(3); // 3 seconds
+
+        RolesRepresentation roles = new RolesRepresentation();
+        List<RoleRepresentation> realmRoles = new ArrayList<>();
+
+        roles.setRealm(realmRoles);
+        realm.setRoles(roles);
+
+        realm.getRoles().getRealm().add(new RoleRepresentation("user", null, false));
+        return realm;
+    }
+
+    private static ClientRepresentation createClient(String clientId) {
+        ClientRepresentation client = new ClientRepresentation();
+
+        client.setClientId(clientId);
+        client.setPublicClient(true);
+        client.setDirectAccessGrantsEnabled(true);
+        client.setEnabled(true);
+        client.setRedirectUris(Arrays.asList("*"));
+
+        return client;
+    }
+
+    private static UserRepresentation createUser(String username, String... realmRoles) {
+        UserRepresentation user = new UserRepresentation();
+
+        user.setUsername(username);
+        user.setEnabled(true);
+        user.setCredentials(new ArrayList<>());
+        user.setRealmRoles(Arrays.asList(realmRoles));
+
+        CredentialRepresentation credential = new CredentialRepresentation();
+
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue(username);
+        credential.setTemporary(false);
+
+        user.getCredentials().add(credential);
+
+        return user;
+    }
+
+    @Override
+    public void stop() {
+
+        RestAssured
+                .given()
+                .auth().oauth2(getAdminAccessToken())
+                .when()
+                .delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + KEYCLOAK_REALM).thenReturn().prettyPrint();
+    }
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResource.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/ProtectedResource.java
@@ -1,0 +1,24 @@
+package io.quarkus.oidc.test;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.security.Authenticated;
+
+@Path("/web-app")
+@Authenticated
+public class ProtectedResource {
+
+    @Inject
+    @IdToken
+    JsonWebToken idToken;
+
+    @GET
+    public String getName() {
+        return idToken.getName();
+    }
+}

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -1,0 +1,4 @@
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/devmode
+# This is a wrong client-id, will be updated to 'client-dev-mode' in the dev mode test
+quarkus.oidc.client-id=client-dev
+quarkus.oidc.application-type=web-app


### PR DESCRIPTION
Fixes #6965.

This test is like the tests in the `oidc-code-flow`. The difference is that it starts with the invalid `client_id` (`client-dev` as opposed to `client-dev-mode` created in Keycloak). As such the exception is expected at the beginning of the test. Next the `client_id` is updated and the test then passes as expected.