### PR TITLE
Bootstrap/workspace discovery: check parent dir for pom.xml

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -80,25 +80,20 @@ public class LocalProject {
 
     private static Model loadRootModel(Path currentProjectDir) throws BootstrapException {
         Path pomXml = currentProjectDir.resolve(POM_XML);
-        Model model = readModel(pomXml);
-        Parent parent = model.getParent();
-        while (parent != null) {
-            if (parent.getRelativePath() != null && !parent.getRelativePath().isEmpty()) {
+        Model model = null;
+        while (Files.exists(pomXml)) {
+            model = readModel(pomXml);
+            final Parent parent = model.getParent();
+            if (parent != null
+                    && parent.getRelativePath() != null
+                    && !parent.getRelativePath().isEmpty()) {
                 pomXml = pomXml.getParent().resolve(parent.getRelativePath()).normalize();
-                if (!Files.exists(pomXml)) {
-                    return model;
-                }
                 if (Files.isDirectory(pomXml)) {
                     pomXml = pomXml.resolve(POM_XML);
                 }
             } else {
                 pomXml = pomXml.getParent().getParent().resolve(POM_XML);
-                if (!Files.exists(pomXml)) {
-                    return model;
-                }
             }
-            model = readModel(pomXml);
-            parent = model.getParent();
         }
         return model;
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -107,10 +107,10 @@ public class LocalWorkspaceDiscoveryTest {
         assertEquals("independent", project.getArtifactId());
         assertEquals(MvnProjectBuilder.DEFAULT_VERSION, project.getVersion());
         final Map<AppArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
-        assertEquals(1, projects.size());
+        assertEquals(6, projects.size());
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "independent")));
 
-        assertLocalDeps(project);
+        assertLocalDeps(project, "root-module-not-direct-child", "root-no-parent-module", "root-module-with-parent");
     }
 
     @Test
@@ -135,9 +135,9 @@ public class LocalWorkspaceDiscoveryTest {
         assertEquals(MvnProjectBuilder.DEFAULT_VERSION, project.getVersion());
         assertNotNull(project.getWorkspace());
         final Map<AppArtifactKey, LocalProject> projects = project.getWorkspace().getProjects();
-        assertEquals(1, projects.size());
+        assertEquals(5, projects.size());
         assertTrue(projects.containsKey(new AppArtifactKey(MvnProjectBuilder.DEFAULT_GROUP_ID, "root-no-parent-module")));
-        assertLocalDeps(project);
+        assertLocalDeps(project, "root-module-not-direct-child");
     }
 
     @Test


### PR DESCRIPTION
Even if project's pom does not define any parent pom, the parent dir should still be checked to contain pom.xml and if it does, treat it as the parent pom.

We actually had it working this way originally but our dev mode setup at the time (registering the whole workspace to be checked for changes) was not as well done as today and it created issues. Now that we watch only the current project and its deps only it should be ok to go back and support parent POMs that aren't explicitly declared as such.

Fixes #7195 