### PR TITLE
fixes #6948 (@Inject Injection into EntityListener not working)

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -51,6 +51,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
 import io.quarkus.arc.deployment.ResourceAnnotationBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -155,6 +156,8 @@ public final class HibernateOrmProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<JpaEntitiesBuildItem> domainObjectsProducer,
             BuildProducer<BeanContainerListenerBuildItem> beanContainerListener,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeanBuildItemProducer,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemBuildProducer,
             List<HibernateOrmIntegrationBuildItem> integrations,
             LaunchModeBuildItem launchMode) throws Exception {
 
@@ -183,8 +186,9 @@ public final class HibernateOrmProcessor {
             }
         }
 
-        JpaJandexScavenger scavenger = new JpaJandexScavenger(reflectiveClass, explicitDescriptors, compositeIndex,
-                nonJpaModelClasses, ignorableNonIndexedClasses);
+        JpaJandexScavenger scavenger = new JpaJandexScavenger(reflectiveClass, unremovableBeanBuildItemProducer,
+                additionalBeanBuildItemBuildProducer, explicitDescriptors, compositeIndex, nonJpaModelClasses,
+                ignorableNonIndexedClasses);
         final JpaEntitiesBuildItem domainObjects = scavenger.discoverModelAndRegisterForReflection();
 
         // remember how to run the enhancers later

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/EntityListenerInjectionTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/EntityListenerInjectionTestCase.java
@@ -1,0 +1,54 @@
+package io.quarkus.hibernate.orm.entitylistener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EntityListenerInjectionTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FooBean.class, FooEntity.class, FooListener.class)
+                    .addAsResource("application.properties"));
+
+    @BeforeEach
+    public void activateRequestContext() {
+        Arc.container().requestContext().activate();
+    }
+
+    @AfterEach
+    public void terminateRequestContext() {
+        Arc.container().requestContext().terminate();
+    }
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    @Transactional
+    public void shouldNotCrash() {
+        FooEntity o = new FooEntity();
+        em.persist(o);
+    }
+
+    @Test
+    @Transactional
+    public void shouldInvokeEntityListener() {
+        FooEntity o = new FooEntity();
+        em.persist(o);
+        assertEquals("Yeah!", o.getData());
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/FooBean.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/FooBean.java
@@ -1,0 +1,11 @@
+package io.quarkus.hibernate.orm.entitylistener;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class FooBean {
+
+    public String pleaseDoNotCrash() {
+        return "Yeah!";
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/FooEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/FooEntity.java
@@ -1,0 +1,32 @@
+package io.quarkus.hibernate.orm.entitylistener;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.Id;
+
+@Entity
+@EntityListeners(FooListener.class)
+public class FooEntity {
+
+    @Id
+    private String id = UUID.randomUUID().toString();
+    private String data;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/FooListener.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/entitylistener/FooListener.java
@@ -1,0 +1,20 @@
+package io.quarkus.hibernate.orm.entitylistener;
+
+import javax.inject.Inject;
+import javax.persistence.PrePersist;
+
+public class FooListener {
+
+    @Inject
+    FooBean fooBean;
+
+    public FooListener() {
+
+    }
+
+    @PrePersist
+    public void prePersist(FooEntity entity) {
+        String data = this.fooBean.pleaseDoNotCrash();
+        entity.setData(data);
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.persistence.PersistenceException;
 import javax.persistence.SharedCacheMode;
 import javax.persistence.spi.PersistenceUnitTransactionType;
@@ -79,6 +80,7 @@ import org.infinispan.quarkus.hibernate.cache.QuarkusInfinispanRegionFactory;
 
 import io.quarkus.hibernate.orm.runtime.BuildTimeSettings;
 import io.quarkus.hibernate.orm.runtime.IntegrationSettings;
+import io.quarkus.hibernate.orm.runtime.boot.fakebeanmanager.FakeBeanManagerEmulator;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusJtaPlatform;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrations;
 import io.quarkus.hibernate.orm.runtime.proxies.ProxyDefinitions;
@@ -321,6 +323,9 @@ public class FastBootMetadataBuilder {
 
         cfg.put(org.hibernate.cfg.AvailableSettings.CACHE_REGION_FACTORY,
                 QuarkusInfinispanRegionFactory.class.getName());
+
+        // without this, EntityListeners cannot use @Inject
+        cfg.put(AvailableSettings.CDI_BEAN_MANAGER, new FakeBeanManagerEmulator(CDI.current()));
 
         HibernateOrmIntegrations.contributeBootProperties((k, v) -> cfg.put(k, v));
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeAnnotatedType.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeAnnotatedType.java
@@ -1,0 +1,63 @@
+package io.quarkus.hibernate.orm.runtime.boot.fakebeanmanager;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
+
+public class FakeAnnotatedType<T> implements AnnotatedType<T> {
+    private final Class<T> type;
+
+    public FakeAnnotatedType(Class<T> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Class<T> getJavaClass() {
+        return type;
+    }
+
+    @Override
+    public Set<AnnotatedConstructor<T>> getConstructors() {
+        return null;
+    }
+
+    @Override
+    public Set<AnnotatedMethod<? super T>> getMethods() {
+        return null;
+    }
+
+    @Override
+    public Set<AnnotatedField<? super T>> getFields() {
+        return null;
+    }
+
+    @Override
+    public Type getBaseType() {
+        return null;
+    }
+
+    @Override
+    public Set<Type> getTypeClosure() {
+        return null;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
+        return null;
+    }
+
+    @Override
+    public Set<Annotation> getAnnotations() {
+        return null;
+    }
+
+    @Override
+    public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+        return false;
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeBeanManagerEmulator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeBeanManagerEmulator.java
@@ -1,0 +1,270 @@
+package io.quarkus.hibernate.orm.runtime.boot.fakebeanmanager;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Set;
+
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMember;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedParameter;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanAttributes;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.spi.Decorator;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
+import javax.enterprise.inject.spi.InterceptionFactory;
+import javax.enterprise.inject.spi.InterceptionType;
+import javax.enterprise.inject.spi.Interceptor;
+import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.ProducerFactory;
+
+/**
+ * Fakes BeanManager methods that Hibernate requires in Jpa/CDI mode but Quarkus-Arc does not support.
+ */
+public class FakeBeanManagerEmulator implements BeanManager {
+
+    private final BeanManager delegate;
+    private final CDI<Object> cdi;
+
+    public FakeBeanManagerEmulator(CDI<Object> cdi) {
+        this.delegate = cdi.getBeanManager();
+        this.cdi = cdi;
+    }
+
+    /**
+     * Fake method.
+     */
+    @Override
+    public <T> CreationalContext<T> createCreationalContext(Contextual<T> contextual) {
+        return new FakeCreationalContext<>();
+    }
+
+    /**
+     * Fake method.
+     */
+    @Override
+    public <T> AnnotatedType<T> createAnnotatedType(Class<T> type) {
+        return new FakeAnnotatedType<>(type);
+    }
+
+    /**
+     * Fake method.
+     */
+    @Override
+    public <T> InjectionTarget<T> createInjectionTarget(AnnotatedType<T> type) {
+        return new FakeInjectionTarget<>(type, cdi);
+    }
+
+    @Override
+    public Object getReference(Bean<?> bean, Type beanType, CreationalContext<?> ctx) {
+        return delegate.getReference(bean, beanType, ctx);
+    }
+
+    @Override
+    public Object getInjectableReference(InjectionPoint ij, CreationalContext<?> ctx) {
+        return delegate.getInjectableReference(ij, ctx);
+    }
+
+    @Override
+    public Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers) {
+        return delegate.getBeans(beanType, qualifiers);
+    }
+
+    @Override
+    public Set<Bean<?>> getBeans(String name) {
+        return delegate.getBeans(name);
+    }
+
+    @Override
+    public Bean<?> getPassivationCapableBean(String id) {
+        return delegate.getPassivationCapableBean(id);
+    }
+
+    @Override
+    public <X> Bean<? extends X> resolve(Set<Bean<? extends X>> beans) {
+        return delegate.resolve(beans);
+    }
+
+    @Override
+    public void validate(InjectionPoint injectionPoint) {
+        delegate.validate(injectionPoint);
+    }
+
+    @Override
+    public void fireEvent(Object event, Annotation... qualifiers) {
+        delegate.fireEvent(event, qualifiers);
+    }
+
+    @Override
+    public <T> Set<ObserverMethod<? super T>> resolveObserverMethods(T event, Annotation... qualifiers) {
+        return delegate.resolveObserverMethods(event, qualifiers);
+    }
+
+    @Override
+    public List<Decorator<?>> resolveDecorators(Set<Type> types, Annotation... qualifiers) {
+        return delegate.resolveDecorators(types, qualifiers);
+    }
+
+    @Override
+    public List<Interceptor<?>> resolveInterceptors(InterceptionType type, Annotation... interceptorBindings) {
+        return delegate.resolveInterceptors(type, interceptorBindings);
+    }
+
+    @Override
+    public boolean isScope(Class<? extends Annotation> annotationType) {
+        return delegate.isScope(annotationType);
+    }
+
+    @Override
+    public boolean isNormalScope(Class<? extends Annotation> annotationType) {
+        return delegate.isNormalScope(annotationType);
+    }
+
+    @Override
+    public boolean isPassivatingScope(Class<? extends Annotation> annotationType) {
+        return delegate.isPassivatingScope(annotationType);
+    }
+
+    @Override
+    public boolean isQualifier(Class<? extends Annotation> annotationType) {
+        return delegate.isQualifier(annotationType);
+    }
+
+    @Override
+    public boolean isInterceptorBinding(Class<? extends Annotation> annotationType) {
+        return delegate.isInterceptorBinding(annotationType);
+    }
+
+    @Override
+    public boolean isStereotype(Class<? extends Annotation> annotationType) {
+        return delegate.isStereotype(annotationType);
+    }
+
+    @Override
+    public Set<Annotation> getInterceptorBindingDefinition(Class<? extends Annotation> bindingType) {
+        return delegate.getInterceptorBindingDefinition(bindingType);
+    }
+
+    @Override
+    public Set<Annotation> getStereotypeDefinition(Class<? extends Annotation> stereotype) {
+        return delegate.getStereotypeDefinition(stereotype);
+    }
+
+    @Override
+    public boolean areQualifiersEquivalent(Annotation qualifier1, Annotation qualifier2) {
+        return delegate.areQualifiersEquivalent(qualifier1, qualifier2);
+    }
+
+    @Override
+    public boolean areInterceptorBindingsEquivalent(Annotation interceptorBinding1,
+            Annotation interceptorBinding2) {
+        return delegate.areInterceptorBindingsEquivalent(interceptorBinding1, interceptorBinding2);
+    }
+
+    @Override
+    public int getQualifierHashCode(Annotation qualifier) {
+        return delegate.getQualifierHashCode(qualifier);
+    }
+
+    @Override
+    public int getInterceptorBindingHashCode(Annotation interceptorBinding) {
+        return delegate.getInterceptorBindingHashCode(interceptorBinding);
+    }
+
+    @Override
+    public Context getContext(Class<? extends Annotation> scopeType) {
+        return delegate.getContext(scopeType);
+    }
+
+    @Override
+    public ELResolver getELResolver() {
+        return delegate.getELResolver();
+    }
+
+    @Override
+    public ExpressionFactory wrapExpressionFactory(ExpressionFactory expressionFactory) {
+        return delegate.wrapExpressionFactory(expressionFactory);
+    }
+
+    @Override
+    public <T> InjectionTargetFactory<T> getInjectionTargetFactory(AnnotatedType<T> annotatedType) {
+        return delegate.getInjectionTargetFactory(annotatedType);
+    }
+
+    @Override
+    public <X> ProducerFactory<X> getProducerFactory(AnnotatedField<? super X> field, Bean<X> declaringBean) {
+        return delegate.getProducerFactory(field, declaringBean);
+    }
+
+    @Override
+    public <X> ProducerFactory<X> getProducerFactory(AnnotatedMethod<? super X> method, Bean<X> declaringBean) {
+        return delegate.getProducerFactory(method, declaringBean);
+    }
+
+    @Override
+    public <T> BeanAttributes<T> createBeanAttributes(AnnotatedType<T> type) {
+        return delegate.createBeanAttributes(type);
+    }
+
+    @Override
+    public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> type) {
+        return delegate.createBeanAttributes(type);
+    }
+
+    @Override
+    public <T> Bean<T> createBean(BeanAttributes<T> attributes, Class<T> beanClass,
+            InjectionTargetFactory<T> injectionTargetFactory) {
+        return delegate.createBean(attributes, beanClass, injectionTargetFactory);
+    }
+
+    @Override
+    public <T, X> Bean<T> createBean(BeanAttributes<T> attributes, Class<X> beanClass,
+            ProducerFactory<X> producerFactory) {
+        return delegate.createBean(attributes, beanClass, producerFactory);
+    }
+
+    @Override
+    public InjectionPoint createInjectionPoint(AnnotatedField<?> field) {
+        return delegate.createInjectionPoint(field);
+    }
+
+    @Override
+    public InjectionPoint createInjectionPoint(AnnotatedParameter<?> parameter) {
+        return delegate.createInjectionPoint(parameter);
+    }
+
+    @Override
+    public <T extends Extension> T getExtension(Class<T> extensionClass) {
+        return delegate.getExtension(extensionClass);
+    }
+
+    @Override
+    public <T> InterceptionFactory<T> createInterceptionFactory(CreationalContext<T> ctx, Class<T> clazz) {
+        return delegate.createInterceptionFactory(ctx, clazz);
+    }
+
+    @Override
+    public Event<Object> getEvent() {
+        return delegate.getEvent();
+    }
+
+    @Override
+    public Instance<Object> createInstance() {
+        return delegate.createInstance();
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeCreationalContext.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeCreationalContext.java
@@ -1,0 +1,15 @@
+package io.quarkus.hibernate.orm.runtime.boot.fakebeanmanager;
+
+import javax.enterprise.context.spi.CreationalContext;
+
+class FakeCreationalContext<T> implements CreationalContext<T> {
+    @Override
+    public void push(T incompleteInstance) {
+
+    }
+
+    @Override
+    public void release() {
+
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeInjectionTarget.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/fakebeanmanager/FakeInjectionTarget.java
@@ -1,0 +1,50 @@
+package io.quarkus.hibernate.orm.runtime.boot.fakebeanmanager;
+
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+
+public class FakeInjectionTarget<T> implements InjectionTarget<T> {
+    private final AnnotatedType<T> type;
+    private CDI<Object> cdi;
+
+    public FakeInjectionTarget(AnnotatedType<T> type, CDI<Object> cdi) {
+        this.type = type;
+        this.cdi = cdi;
+    }
+
+    @Override
+    public void inject(T instance, CreationalContext<T> ctx) {
+
+    }
+
+    @Override
+    public void postConstruct(T instance) {
+
+    }
+
+    @Override
+    public void preDestroy(T instance) {
+
+    }
+
+    @Override
+    public T produce(CreationalContext<T> ctx) {
+        return cdi.select(type.getJavaClass()).get();
+    }
+
+    @Override
+    public void dispose(T instance) {
+        cdi.destroy(instance);
+
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return null;
+    }
+}


### PR DESCRIPTION
I did some digging around and the (imho) root cause for this not working is that Quarkus uses the Arc CDI implementation that is lacking some features hibernate requires.

This PR is implements a BeanManager wrapper that emulates just enough for EntityListeners to work.

Also I added some quarkus-deployment code to at least prevent the EntityListener bean from being removed due to quarkus marking it as unused.

I consider this a more-or-less ugly hack... but this feature imho cannot reasonably be implemented without lots of programming/refactoring in hibernate.
