### PR TITLE
Implement Context Propagation support for Mutiny

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -126,7 +126,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <test-containers.version>1.12.4</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <mutiny.version>0.3.1</mutiny.version>
+        <mutiny.version>0.4.0</mutiny.version>
         <axle-client.version>0.0.12</axle-client.version>
         <mutiny-client.version>0.0.12</mutiny-client.version>
         <kafka2.version>2.4.0</kafka2.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2506,6 +2506,11 @@
                 <artifactId>smallrye-reactive-converter-api</artifactId>
                 <version>${smallrye-converter-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-reactive-converter-rxjava2</artifactId>
+                <version>${smallrye-converter-api.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -996,6 +996,11 @@
                 <version>${mutiny.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>mutiny-context-propagation</artifactId>
+                <version>${mutiny.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-mutiny</artifactId>
                 <version>${project.version}</version>

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -24,16 +24,23 @@ values that used to be in thread-locals, and restoring them when your code is ca
 
 == Setting it up
 
-If you are using link:https://github.com/eclipse/microprofile-reactive-streams-operators[SmallRye Reactive Streams Operators]
-(the `quarkus-smallrye-reactive-streams-operators` module),
-you get automatic context propagation for all your streams, because the `quarkus-smallrye-context-propagation` 
-module is automatically imported.
+If you are using link:http://smallrye.io/smallrye-mutiny[Mutiny] (the `quarkus-mutiny` extension), you just need to add the
+the `quarkus-smallrye-context-propagation` extension to enable context propagation.
 
-If you are not using SmallRye Reactive Streams Operators, add the following to your `pom.xml`:
+In other words, add the following dependencies to your `pom.xml`:
 
 [source,xml]
 --
 <dependencies>
+    <!-- Mutiny and RestEasy support extensions if not already included -->
+    <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-mutiny</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-resteasy-mutiny</artifactId>
+    </dependency>
     <!-- Context Propagation extension -->
     <dependency>
         <groupId>io.quarkus</groupId>
@@ -44,42 +51,42 @@ If you are not using SmallRye Reactive Streams Operators, add the following to y
 
 With this, you will get context propagation for ArC, RESTEasy and transactions, if you are using them.
 
-== Usage example with SmallRye Reactive Streams Operators
+== Usage example with Mutiny
 
-If you are using SmallRye Reactive Streams Operators (the `quarkus-smallrye-reactive-streams-operators` module),
-you get context propagation out of the box, so, for example, let's write a REST endpoint that reads the next
-3 items from a link:kafka[Kafka topic], stores them in a database using
+Let's write a REST endpoint that reads the next 3 items from a link:kafka[Kafka topic], stores them in a database using
 link:hibernate-orm-panache[Hibernate ORM with Panache] (all in the same transaction) before returning
 them to the client, you can do it like this:
 
 [source,java]
 --
-    // Get the price-stream Kafka topic
+    // Get the prices stream
     @Inject
-    @Channel("price-stream") Publisher<Double> prices;
+    @Channel("prices") Publisher<Double> prices;
 
     @Transactional
     @GET
     @Path("/prices")
-    public Publisher<Double> prices() throws SystemException {
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @SseElementType(MediaType.TEXT_PLAIN)
+    public Publisher<Double> prices() {
         // get the next three prices from the price stream
-        return ReactiveStreams.fromPublisher(prices)
-                .limit(3)
+        return Multi.createFrom().publisher(prices)
+                .transform().byTakingFirstItems(3)
                 .map(price -> {
                     // store each price before we send them
                     Price priceEntity = new Price();
                     priceEntity.value = price;
-                    // here we are all in the same transaction 
+                    // here we are all in the same transaction
                     // thanks to context propagation
                     priceEntity.persist();
-                    
                     return price;
-                })
-                .buildRs();
+                    // the transaction is committed once the stream completes
+                });
     }
 --
 
-Notice that thanks to automatic support for context propagation with Reactive Streams Operators this works out of the box.
+Notice that thanks to Mutiny support for context propagation, this works out of the box.
+The 3 items are persisted using the same transaction and this transaction is committed when the stream completes.
 
 == Usage example for `CompletionStage`
 

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -1,12 +1,29 @@
 package io.quarkus.mutiny.deployment;
 
+import org.jboss.jandex.DotName;
+
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.mutiny.converters.MultiConverter;
+import io.quarkus.mutiny.converters.UniConverter;
+import io.smallrye.reactive.converters.ReactiveTypeConverter;
 
 public class MutinyProcessor {
 
     @BuildStep
     public FeatureBuildItem registerFeature() {
         return new FeatureBuildItem(FeatureBuildItem.MUTINY);
+    }
+
+    private static final DotName REACTIVE_TYPE_CONVERTER = DotName.createSimple(ReactiveTypeConverter.class.getName());
+
+    @BuildStep
+    public void registerReactiveConverters(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(new ServiceProviderBuildItem(REACTIVE_TYPE_CONVERTER.toString(),
+                UniConverter.class.getName()));
+        serviceProvider.produce(new ServiceProviderBuildItem(REACTIVE_TYPE_CONVERTER.toString(),
+                MultiConverter.class.getName()));
     }
 }

--- a/extensions/mutiny/runtime/pom.xml
+++ b/extensions/mutiny/runtime/pom.xml
@@ -23,7 +23,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-converter-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/converters/MultiConverter.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/converters/MultiConverter.java
@@ -1,0 +1,54 @@
+package io.quarkus.mutiny.converters;
+
+import java.util.concurrent.CompletionStage;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.converters.ReactiveTypeConverter;
+
+@SuppressWarnings("rawtypes")
+public class MultiConverter implements ReactiveTypeConverter<Multi> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <X> CompletionStage<X> toCompletionStage(Multi instance) {
+        return instance.toUni().subscribeAsCompletionStage();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <X> Publisher<X> toRSPublisher(Multi instance) {
+        return instance;
+    }
+
+    @Override
+    public <X> Multi fromCompletionStage(CompletionStage<X> cs) {
+        return Multi.createFrom().completionStage(cs);
+    }
+
+    @Override
+    public <X> Multi fromPublisher(Publisher<X> publisher) {
+        return Multi.createFrom().publisher(publisher);
+    }
+
+    @Override
+    public Class<Multi> type() {
+        return Multi.class;
+    }
+
+    @Override
+    public boolean emitItems() {
+        return true;
+    }
+
+    @Override
+    public boolean emitAtMostOneItem() {
+        return false;
+    }
+
+    @Override
+    public boolean supportNullValue() {
+        return false;
+    }
+}

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/converters/UniConverter.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/converters/UniConverter.java
@@ -1,0 +1,54 @@
+package io.quarkus.mutiny.converters;
+
+import java.util.concurrent.CompletionStage;
+
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.converters.ReactiveTypeConverter;
+
+@SuppressWarnings("rawtypes")
+public class UniConverter implements ReactiveTypeConverter<Uni> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <X> CompletionStage<X> toCompletionStage(Uni instance) {
+        return instance.subscribeAsCompletionStage();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <X> Publisher<X> toRSPublisher(Uni instance) {
+        return instance.toMulti();
+    }
+
+    @Override
+    public <X> Uni fromCompletionStage(CompletionStage<X> cs) {
+        return Uni.createFrom().completionStage(cs);
+    }
+
+    @Override
+    public <X> Uni fromPublisher(Publisher<X> publisher) {
+        return Uni.createFrom().publisher(publisher);
+    }
+
+    @Override
+    public Class<Uni> type() {
+        return Uni.class;
+    }
+
+    @Override
+    public boolean emitItems() {
+        return true;
+    }
+
+    @Override
+    public boolean emitAtMostOneItem() {
+        return true;
+    }
+
+    @Override
+    public boolean supportNullValue() {
+        return true;
+    }
+}

--- a/extensions/mutiny/runtime/src/main/resources/META-INF/services/io.smallrye.reactive.converters.ReactiveTypeConverter
+++ b/extensions/mutiny/runtime/src/main/resources/META-INF/services/io.smallrye.reactive.converters.ReactiveTypeConverter
@@ -1,0 +1,2 @@
+io.quarkus.mutiny.converters.MultiConverter
+io.quarkus.mutiny.converters.UniConverter

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -125,7 +125,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
             if (!throwing && ret != null) {
                 ReactiveTypeConverter<Object> converter = null;
                 if (ret instanceof CompletionStage == false
-                        && ret instanceof Publisher == false) {
+                        && (ret instanceof Publisher == false || ic.getMethod().getReturnType() != Publisher.class)) {
                     @SuppressWarnings({ "rawtypes", "unchecked" })
                     Optional<ReactiveTypeConverter<Object>> lookup = Registry.lookup((Class) ret.getClass());
                     if (lookup.isPresent()) {

--- a/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/MutinyResource.java
+++ b/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/MutinyResource.java
@@ -3,8 +3,10 @@ package io.quarkus.resteasy.mutiny.test;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.annotations.Stream;
 
@@ -38,5 +40,22 @@ public class MutinyResource {
     @GET
     public Uni<Integer> injectionAsync(@Async @Context Integer value) {
         return Uni.createFrom().item(value);
+    }
+
+    @Path("web-failure")
+    @GET
+    public Uni<String> failing() {
+        return Uni.createFrom().item("not ok")
+                .onItem().failWith(s -> new WebApplicationException(
+                        Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(s).build()));
+    }
+
+    @Path("app-failure")
+    @GET
+    public Uni<String> failingBecauseOfApplicationCode() {
+        return Uni.createFrom().item("not ok")
+                .onItem().apply(s -> {
+                    throw new IllegalStateException("BOOM!");
+                });
     }
 }

--- a/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/RestEasyMutinyTest.java
+++ b/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/RestEasyMutinyTest.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -58,6 +59,18 @@ public class RestEasyMutinyTest {
 
         data = client.target(url.toExternalForm() + "/injection-async").request().get(Integer.class);
         Assertions.assertEquals((Integer) 42, data);
+    }
+
+    @Test
+    public void testFailingWithWebApplicationException() {
+        Response response = client.target(url.toExternalForm() + "/web-failure").request().get();
+        Assertions.assertEquals(response.getStatus(), Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+    }
+
+    @Test
+    public void testFailingWithApplicationFailure() {
+        Response response = client.target(url.toExternalForm() + "/app-failure").request().get();
+        Assertions.assertEquals(response.getStatus(), 500);
     }
 
 }

--- a/extensions/smallrye-context-propagation/deployment/pom.xml
+++ b/extensions/smallrye-context-propagation/deployment/pom.xml
@@ -56,7 +56,12 @@
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-converter-rxjava2</artifactId>
-            <version>1.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- For Mutiny tests -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- For DB -->

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
@@ -1,0 +1,461 @@
+package io.quarkus.context.test.mutiny;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.jboss.resteasy.annotations.Stream;
+import org.jboss.resteasy.annotations.Stream.MODE;
+import org.junit.jupiter.api.Assertions;
+import org.reactivestreams.Publisher;
+import org.wildfly.common.Assert;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.context.test.RequestBean;
+import io.quarkus.hibernate.orm.panache.Panache;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+@Path("/mutiny-context")
+@Produces(MediaType.TEXT_PLAIN)
+public class MutinyContextEndpoint {
+
+    @Inject
+    RequestBean doNotRemoveMe;
+    @Inject
+    ManagedExecutor all;
+    @Inject
+    ThreadContext allTc;
+    @Inject
+    HttpServletRequest servletRequest;
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @PreDestroy
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    @GET
+    @Path("/resteasy-uni-cs")
+    public Uni<String> resteasyContextPropagationWithUniCreatedFromCSWithManagedExecutor(@Context UriInfo uriInfo) {
+        CompletableFuture<String> ret = all.completedFuture("OK");
+        return Uni.createFrom().completionStage(ret)
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onItem().apply(s -> {
+                    Assertions.assertNotNull(uriInfo.getAbsolutePath());
+                    try {
+                        Assertions.assertTrue(
+                                uriInfo.getAbsolutePath().toURL().toExternalForm().contains("/resteasy-uni-cs"));
+                    } catch (MalformedURLException e) {
+                        throw new AssertionError(e);
+                    }
+                    return s;
+                });
+    }
+
+    @GET
+    @Path("/resteasy-uni")
+    public Uni<String> resteasyContextPropagation(@Context UriInfo uriInfo) {
+        return Uni.createFrom().item("OK")
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .onItem().apply(s -> {
+                    Assertions.assertNotNull(uriInfo.getAbsolutePath());
+                    try {
+                        Assertions.assertTrue(
+                                uriInfo.getAbsolutePath().toURL().toExternalForm().contains("/resteasy-uni"));
+                    } catch (MalformedURLException e) {
+                        throw new AssertionError(e);
+                    }
+                    return s;
+                });
+    }
+
+    @GET
+    @Path("/resteasy-tc-uni-cs")
+    public Uni<String> resteasyThreadContextWithCS(@Context UriInfo uriInfo) {
+        CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
+        return Uni.createFrom().completionStage(ret)
+                .emitOn(executor)
+                .onItem().apply(s -> {
+                    uriInfo.getAbsolutePath();
+                    return s;
+                });
+    }
+
+    @GET
+    @Path("/servlet-uni")
+    public Uni<String> servletContextPropagation(@Context UriInfo uriInfo) {
+        return Uni.createFrom().item("OK")
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .map(text -> {
+                    Assertions.assertNotNull(servletRequest.getContentType());
+                    return text;
+                })
+                .onFailure().invoke(t -> System.out.println("Got failure " + t.getMessage()));
+    }
+
+    @GET
+    @Path("/servlet-uni-cs")
+    public Uni<String> servletContextPropagationWithUniCreatedFromCSWithManagedExecutor(@Context UriInfo uriInfo) {
+        CompletableFuture<String> ret = all.completedFuture("OK");
+        return Uni.createFrom().completionStage(() -> ret)
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .map(text -> {
+                    Assertions.assertNotNull(servletRequest.getContentType());
+                    return text;
+                });
+    }
+
+    @GET
+    @Path("/servlet-tc-uni-cs")
+    public Uni<String> servletThreadContext(@Context UriInfo uriInfo) {
+        CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
+        return Uni.createFrom().completionStage(() -> ret)
+                .emitOn(executor)
+                .map(text -> {
+                    Assertions.assertNotNull(servletRequest.getContentType());
+                    return text;
+                });
+    }
+
+    @GET
+    @Path("/arc-uni")
+    public Uni<String> arcContextPropagation() {
+        Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
+        return Uni.createFrom().item("OK")
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .map(text -> {
+                    RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+                    Assertions.assertEquals(previousValue, instance2.callMe());
+                    return text;
+                });
+    }
+
+    @GET
+    @Path("/arc-uni-cs")
+    public Uni<String> arcContextPropagationWithUniCreatedFromCSWithManagedExecutor() {
+        Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
+        CompletableFuture<String> ret = all.completedFuture("OK");
+        return Uni.createFrom().completionStage(() -> ret)
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .map(text -> {
+                    RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+                    Assertions.assertEquals(previousValue, instance2.callMe());
+                    return text;
+                });
+    }
+
+    @GET
+    @Path("/arc-tc-uni")
+    public Uni<String> arcContextPropagationWithThreadContext() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
+        CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
+        return Uni.createFrom().completionStage(() -> ret)
+                .emitOn(executor)
+                .map(text -> {
+                    RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+                    Assertions.assertEquals(previousValue, instance2.callMe());
+                    return text;
+                });
+    }
+
+    @Inject
+    MutinyTransactionalBean txBean;
+
+    @Transactional
+    @GET
+    @Path("/transaction-uni")
+    public Uni<String> contextPropagationWithTxAndUni() throws SystemException {
+        SomeEntity.deleteAll();
+        Uni<String> ret = Uni.createFrom().item("OK");
+        SomeEntity entity = new SomeEntity();
+        entity.name = "Stef";
+        entity.persist();
+        Transaction t1 = Panache.getTransactionManager().getTransaction();
+        Assertions.assertNotNull(t1);
+
+        return ret
+                .emitOn(executor)
+                .map(text -> {
+                    Assertions.assertEquals(1, SomeEntity.count());
+                    Transaction t2;
+                    try {
+                        t2 = Panache.getTransactionManager().getTransaction();
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    Assertions.assertEquals(t1, t2);
+                    return text;
+                });
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-uni-cs")
+    public Uni<String> contextPropagationWithTxAndUniCreatedFromCS() throws SystemException {
+        Uni<String> ret = Uni.createFrom().completionStage(all.completedFuture("OK"));
+        SomeOtherEntity entity = new SomeOtherEntity();
+        entity.name = "Stef";
+        entity.persist();
+        Transaction t1 = Panache.getTransactionManager().getTransaction();
+        Assertions.assertNotNull(t1);
+
+        return ret
+                .emitOn(executor)
+                .map(text -> {
+                    Assertions.assertEquals(1, SomeOtherEntity.count());
+                    Transaction t2;
+                    try {
+                        t2 = Panache.getTransactionManager().getTransaction();
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    Assertions.assertEquals(t1, t2);
+                    return text;
+                });
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-tc-uni")
+    public Uni<String> transactionPropagationWithThreadContextAndUniCreatedFromCS() throws SystemException {
+        CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
+        SomeEntity entity = new SomeEntity();
+        entity.name = "Stef";
+        entity.persist();
+        Transaction t1 = Panache.getTransactionManager().getTransaction();
+        Assertions.assertNotNull(t1);
+
+        return Uni.createFrom().completionStage(ret)
+                .emitOn(executor)
+                .map(text -> {
+                    Assertions.assertEquals(1, SomeEntity.count());
+                    Transaction t2;
+                    try {
+                        t2 = Panache.getTransactionManager().getTransaction();
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    Assertions.assertEquals(t1, t2);
+                    return text;
+                });
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction2-uni")
+    public Uni<String> transactionTest2() {
+        Uni<String> ret = Uni.createFrom().item("OK");
+
+        // check that the first transaction was committed
+        Assertions.assertEquals(1, SomeEntity.count());
+        // now delete our entity, but throw an exception to rollback
+        Assertions.assertEquals(1, SomeEntity.deleteAll());
+
+        return ret
+                .emitOn(executor)
+                .onItem().failWith(s -> new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction2-uni-cs")
+    public Uni<String> transactionTest2WithUniCreatedFromCS() {
+        Uni<String> ret = Uni.createFrom().completionStage(all.completedFuture("OK"));
+
+        // check that the first transaction was committed
+        Assertions.assertEquals(1, SomeOtherEntity.count());
+        // now delete our entity, but throw an exception to rollback
+        Assertions.assertEquals(1, SomeOtherEntity.deleteAll());
+
+        return ret
+                .emitOn(executor)
+                .onItem().failWith(s -> new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction3-uni")
+    public Uni<String> transactionTest3() {
+        Uni<String> ret = Uni.createFrom()
+                .failure(new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
+
+        // check that the second transaction was not committed
+        Assertions.assertEquals(1, SomeEntity.count());
+        // now delete our entity, but throw an exception to rollback
+        Assertions.assertEquals(1, SomeEntity.deleteAll());
+
+        return ret;
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction3-uni-cs")
+    public Uni<String> transactionTest3WithUniCreatedFromCS() {
+        CompletableFuture<String> future = all
+                .failedFuture(new WebApplicationException(Response.status(Response.Status.CONFLICT).build()));
+        Uni<String> ret = Uni.createFrom().completionStage(future);
+
+        // check that the second transaction was not committed
+        Assertions.assertEquals(1, SomeOtherEntity.count());
+        // now delete our entity, but throw an exception to rollback
+        Assertions.assertEquals(1, SomeOtherEntity.deleteAll());
+
+        return ret;
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction4")
+    public String transactionTest4() {
+        // check that the third transaction was not committed
+        Assertions.assertEquals(1, SomeEntity.count());
+        // now delete our entity
+        Assertions.assertEquals(1, SomeEntity.deleteAll());
+
+        return "OK";
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction4-cs")
+    public String transactionTest4CS() {
+        // check that the third transaction was not committed
+        Assertions.assertEquals(1, SomeOtherEntity.count());
+        // now delete our entity
+        Assertions.assertEquals(1, SomeOtherEntity.deleteAll());
+
+        return "OK";
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-new-sync")
+    public Uni<String> newTransactionPropagationSynchronous() throws SystemException {
+        Uni<String> ret = Uni.createFrom().item("OK");
+        Transaction t1 = Panache.getTransactionManager().getTransaction();
+        Assertions.assertNotNull(t1);
+
+        txBean.doInTx();
+
+        // We should see the transaction already committed even if we're async
+        Assertions.assertEquals(1, Person.deleteAll());
+        return ret;
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-new-uni")
+    public Uni<String> newTransactionPropagationWithUni() throws SystemException {
+        Person entity = new Person();
+        entity.name = "Stef";
+        entity.persist();
+        Transaction t1 = Panache.getTransactionManager().getTransaction();
+        Assertions.assertNotNull(t1);
+        // our entity
+        Assertions.assertEquals(1, Person.count());
+
+        return txBean.doInTxUni()
+                // this makes sure we get executed in another scheduler
+                .emitOn(executor)
+                .map(text -> {
+                    // make sure we don't see the other transaction's entity
+                    Transaction t2;
+                    try {
+                        t2 = Panache.getTransactionManager().getTransaction();
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    Assertions.assertEquals(t1, t2);
+                    try {
+                        Assertions.assertEquals(Status.STATUS_ACTIVE, t2.getStatus());
+                    } catch (SystemException e) {
+                        throw new AssertionError(e);
+                    }
+                    return text;
+                });
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-uni-2")
+    public Uni<String> transactionPropagationWithUni() {
+        Uni<String> ret = Uni.createFrom().item("OK");
+        // now delete both entities
+        Assertions.assertEquals(2, Person.deleteAll());
+        return ret;
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-multi")
+    @Stream(value = MODE.RAW)
+    public Multi<String> transactionPropagationWithMulti() throws SystemException {
+        Person entity = new Person();
+        entity.name = "Stef";
+        entity.persist();
+        Transaction t1 = Panache.getTransactionManager().getTransaction();
+        Assertions.assertNotNull(t1);
+        // our entity
+        Assertions.assertEquals(1, Person.count());
+
+        return txBean.doInTxMulti()
+                // this makes sure we get executed in another scheduler
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .map(text -> {
+                    // make sure we don't see the other transaction's entity
+                    Transaction t2;
+                    try {
+                        t2 = Panache.getTransactionManager().getTransaction();
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    Assertions.assertEquals(t1, t2);
+                    try {
+                        Assertions.assertEquals(Status.STATUS_ACTIVE, t2.getStatus());
+                    } catch (SystemException e) {
+                        throw new AssertionError(e);
+                    }
+                    return text;
+                });
+    }
+
+    @Transactional
+    @GET
+    @Path("/transaction-multi-2")
+    public Publisher<String> transactionPropagationWithMulti2() {
+        Multi<String> ret = Multi.createFrom().item("OK");
+        // now delete both entities
+        Assertions.assertEquals(2, Person.deleteAll());
+        return ret;
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/MutinyContextPropagationTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/MutinyContextPropagationTest.java
@@ -1,0 +1,156 @@
+package io.quarkus.context.test.mutiny;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import javax.ws.rs.core.Response;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.context.test.CompletionExceptionMapper;
+import io.quarkus.context.test.RequestBean;
+import io.quarkus.context.test.TestResources;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * Tests Mutiny context propagation of basic contexts (Arc, RestEasy, server, transaction) via either
+ * {@link org.eclipse.microprofile.context.ManagedExecutor} (ME) or
+ * {@link org.eclipse.microprofile.context.ThreadContext} (TC).
+ */
+public class MutinyContextPropagationTest {
+    private static Class[] testClasses = {
+            MutinyContextEndpoint.class, RequestBean.class, SomeEntity.class, SomeOtherEntity.class, Person.class,
+            TestResources.class,
+            CompletionExceptionMapper.class,
+            MutinyTransactionalBean.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(testClasses)
+                    .addAsResource("application.properties"));
+
+    @Test
+    public void testRESTEasyContextPropagation() {
+        RestAssured.when().get("/mutiny-context/resteasy-uni").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testRESTEasyMEContextPropagationWithUniCreatedFromCS() {
+        RestAssured.when().get("/mutiny-context/resteasy-uni-cs").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testRESTEasyTCContextPropagationWithUniCreatedFromCS() {
+        RestAssured.when().get("/mutiny-context/resteasy-tc-uni-cs").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testServletContextPropagation() {
+        RestAssured
+                .given()
+                .header("Content-Type", "acme/acme")
+                .when()
+                .get("/mutiny-context/servlet-uni")
+                .then().statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testServletMEContextPropagationWithUniCreatedFromCS() {
+        RestAssured
+                .given()
+                .header("Content-Type", "acme/acme")
+                .when()
+                .get("/mutiny-context/servlet-uni-cs")
+                .then().statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testServletTCContextPropagationWithUniCreatedFromCS() {
+        RestAssured
+                .given()
+                .header("Content-Type", "acme/acme")
+                .when()
+                .get("/mutiny-context/servlet-tc-uni-cs")
+                .then().statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testArcContextPropagationWithUni() {
+        RestAssured.when().get("/mutiny-context/arc-uni").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testArcContextPropagationWithUniCreatedFromCSAndME() {
+        RestAssured.when().get("/mutiny-context/arc-uni-cs").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testArcTCContextPropagation() {
+        RestAssured.when().get("/mutiny-context/arc-tc-uni").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionPropagationWithUni() {
+        RestAssured.when().get("/mutiny-context/transaction-uni").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+        RestAssured.when().get("/mutiny-context/transaction2-uni").then()
+                .statusCode(Response.Status.CONFLICT.getStatusCode());
+        RestAssured.when().get("/mutiny-context/transaction3-uni").then()
+                .statusCode(Response.Status.CONFLICT.getStatusCode());
+        RestAssured.when().get("/mutiny-context/transaction4").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionPropagationWithUniCreatedFromCS() {
+        RestAssured.when().get("/mutiny-context/transaction-uni-cs").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+        RestAssured.when().get("/mutiny-context/transaction2-uni-cs").then()
+                .statusCode(Response.Status.CONFLICT.getStatusCode());
+        RestAssured.when().get("/mutiny-context/transaction3-uni-cs").then()
+                .statusCode(Response.Status.CONFLICT.getStatusCode());
+        RestAssured.when().get("/mutiny-context/transaction4-cs").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionTCContextPropagation() {
+        RestAssured.when().get("/mutiny-context/transaction-tc-uni").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionNewContextPropagationSync() {
+        RestAssured.when().get("/mutiny-context/transaction-new-sync").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionContextPropagationAsyncUni() {
+        RestAssured.when().get("/mutiny-context/transaction-new-uni").then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body(equalTo("OK"));
+        RestAssured.when().get("/mutiny-context/transaction-uni-2").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testTransactionContextPropagationMulti() {
+        RestAssured.when().get("/mutiny-context/transaction-multi").then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body(equalTo("OK"));
+        RestAssured.when().get("/mutiny-context/transaction-multi-2").then()
+                .statusCode(Response.Status.OK.getStatusCode());
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/MutinyTransactionalBean.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/MutinyTransactionalBean.java
@@ -1,0 +1,50 @@
+package io.quarkus.context.test.mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import org.junit.jupiter.api.Assertions;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MutinyTransactionalBean {
+
+    @Inject
+    TransactionManager tm;
+
+    @Transactional(value = TxType.REQUIRES_NEW)
+    public void doInTx() {
+        Assertions.assertEquals(0, Person.count());
+
+        Person entity = new Person();
+        entity.name = "Stef";
+        entity.persist();
+    }
+
+    @Transactional(value = TxType.REQUIRES_NEW)
+    public Uni<String> doInTxUni() {
+        Assertions.assertEquals(0, Person.count());
+
+        Person entity = new Person();
+        entity.name = "Stef";
+        entity.persist();
+
+        return Uni.createFrom().item("OK");
+    }
+
+    @Transactional(value = TxType.REQUIRES_NEW)
+    public Multi<String> doInTxMulti() {
+        Assertions.assertEquals(0, Person.count());
+
+        Person entity = new Person();
+        entity.name = "Stef";
+        entity.persist();
+
+        return Multi.createFrom().items("OK");
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/Person.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/Person.java
@@ -1,0 +1,11 @@
+package io.quarkus.context.test.mutiny;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Person extends PanacheEntity {
+
+    public String name;
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/SomeEntity.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/SomeEntity.java
@@ -1,0 +1,12 @@
+package io.quarkus.context.test.mutiny;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class SomeEntity extends PanacheEntity {
+
+    public String name;
+
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/SomeOtherEntity.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/mutiny/SomeOtherEntity.java
@@ -1,0 +1,12 @@
+package io.quarkus.context.test.mutiny;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class SomeOtherEntity extends PanacheEntity {
+
+    public String name;
+
+}

--- a/extensions/smallrye-context-propagation/runtime/pom.xml
+++ b/extensions/smallrye-context-propagation/runtime/pom.xml
@@ -39,6 +39,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny-context-propagation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>

--- a/extensions/smallrye-reactive-messaging/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging/deployment/pom.xml
@@ -65,6 +65,16 @@
       <artifactId>quarkus-vertx-http-deployment</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>quarkus-vertx-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-axle-generator</artifactId>
         </dependency>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -39,7 +39,7 @@
         <version.gizmo>1.0.2.Final</version.gizmo>
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
         <version.reactivestreams>1.0.3</version.reactivestreams>
-        <version.mutiny>0.3.1</version.mutiny>
+        <version.mutiny>0.4.0</version.mutiny>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     </properties>
 

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -105,6 +105,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny</artifactId>
+        </dependency>
 
         <!-- JPA -->
         <dependency>

--- a/integration-tests/main/src/main/java/io/quarkus/it/context/MutinyContextPropagationResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/context/MutinyContextPropagationResource.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.context;
+
+import javax.inject.Inject;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.wildfly.common.Assert;
+
+import io.quarkus.arc.Arc;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+@Path("context-propagation-mutiny")
+public class MutinyContextPropagationResource {
+
+    @Inject
+    RequestBean doNotRemove;
+    @Inject
+    ManagedExecutor allExec;
+    @Inject
+    TransactionManager transactionManager;
+
+    @Transactional
+    @GET
+    public Uni<String> test(@Context UriInfo uriInfo) throws SystemException {
+        Uni<String> ret = Uni.createFrom().item("OK");
+        // Transaction
+        Transaction t1 = transactionManager.getTransaction();
+        Assert.assertTrue(t1 != null);
+        Assert.assertTrue(t1.getStatus() == Status.STATUS_ACTIVE);
+        // ArC
+        Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
+        RequestBean rb1 = Arc.container().instance(RequestBean.class).get();
+        Assert.assertTrue(rb1 != null);
+        String rbValue = rb1.callMe();
+
+        return ret
+                .emitOn(Infrastructure.getDefaultExecutor())
+                .map(text -> {
+                    // RESTEasy
+                    uriInfo.getAbsolutePath();
+                    // ArC
+                    RequestBean rb2 = Arc.container().instance(RequestBean.class).get();
+                    Assert.assertTrue(rb2 != null);
+                    Assert.assertTrue(rb2.callMe().contentEquals(rbValue));
+                    // Transaction
+                    Transaction t2;
+                    try {
+                        t2 = transactionManager.getTransaction();
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    Assert.assertTrue(t1 == t2);
+                    try {
+                        Assert.assertTrue(t2.getStatus() == Status.STATUS_ACTIVE);
+                    } catch (SystemException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return text;
+                });
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ContextPropagationTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ContextPropagationTestCase.java
@@ -14,4 +14,9 @@ public class ContextPropagationTestCase {
     public void testContextPropagation() throws Exception {
         RestAssured.when().get("/context-propagation").then().body(is("OK"));
     }
+
+    @Test
+    public void testContextPropagationWithMutiny() throws Exception {
+        RestAssured.when().get("/context-propagation-mutiny").then().body(is("OK"));
+    }
 }


### PR DESCRIPTION
This PR enables the support for Context Propagation when using Mutiny.
It includes:

* a bit of functional code (reactive converters, a small change in the transactional filter...)
* a few tests
* ITs
* documentation update