### PR TITLE
Enable missing build profiles for native integration tests

### DIFF
--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -42,7 +42,7 @@ jobs:
         run: mvn -B install -DskipTests -DskipITs -Dno-format
 
       - name: Run integration tests in native
-        run: mvn -B  --settings azure-mvn-settings.xml verify -f integration-tests/pom.xml -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j
+        run: mvn -B --settings azure-mvn-settings.xml verify -f integration-tests/pom.xml -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dtest-mssql -Dtest-mariadb -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test"
 
       - name: Report
         if: always()


### PR DESCRIPTION
Some native integration tests are currently skipped in the JDK 11 GH action because the build profiles are not enabled. This fixes that issue.

I also found out that the `logging-gelf` integration tests are never executed even in JVM mode.

cc @gsmet @geoand 