### PR TITLE
Minor cleanup to log level configuration

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/CategoryConfig.java
@@ -13,7 +13,7 @@ public class CategoryConfig {
      * The log level level for this category
      */
     @ConfigItem(defaultValue = "inherit")
-    String level;
+    InheritableLevel level;
 
     /**
      * The names of the handlers to link to this category.

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
@@ -1,0 +1,92 @@
+package io.quarkus.runtime.logging;
+
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.LogContext;
+
+/**
+ * A level that may be inheritable.
+ */
+public abstract class InheritableLevel {
+    InheritableLevel() {
+    }
+
+    public static InheritableLevel of(String str) {
+        if (str.equalsIgnoreCase("inherited")) {
+            return Inherited.INSTANCE;
+        } else {
+            return new ActualLevel(LogContext.getLogContext().getLevelForName(str.toUpperCase(Locale.ROOT)));
+        }
+    }
+
+    public abstract boolean isInherited();
+
+    public abstract Level getLevel();
+
+    public abstract String toString();
+
+    public final boolean equals(Object obj) {
+        return obj instanceof InheritableLevel && equals((InheritableLevel) obj);
+    }
+
+    public abstract boolean equals(InheritableLevel other);
+
+    public abstract int hashCode();
+
+    static final class ActualLevel extends InheritableLevel {
+        final Level level;
+
+        ActualLevel(Level level) {
+            this.level = level;
+        }
+
+        public boolean isInherited() {
+            return false;
+        }
+
+        public Level getLevel() {
+            return level;
+        }
+
+        public String toString() {
+            return level.toString();
+        }
+
+        public boolean equals(final InheritableLevel other) {
+            return other instanceof ActualLevel && level.equals(((ActualLevel) other).level);
+        }
+
+        public int hashCode() {
+            return level.hashCode();
+        }
+    }
+
+    static final class Inherited extends InheritableLevel {
+        static final Inherited INSTANCE = new Inherited();
+
+        private Inherited() {
+        }
+
+        public boolean isInherited() {
+            return true;
+        }
+
+        public Level getLevel() {
+            throw new NoSuchElementException();
+        }
+
+        public String toString() {
+            return "inherited";
+        }
+
+        public boolean equals(final InheritableLevel other) {
+            return other instanceof Inherited;
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.runtime.logging;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 
 import io.quarkus.runtime.annotations.ConfigDocSection;
@@ -16,10 +15,10 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public final class LogConfig {
 
     /**
-     * The default log level
+     * The log level of the root category, which is used as the default log level for all categories.
      */
-    @ConfigItem
-    public Optional<Level> level;
+    @ConfigItem(defaultValue = "INFO")
+    public Level level;
 
     /**
      * The default minimum log level

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -69,7 +69,7 @@ public class LoggingSetupRecorder {
     public LoggingSetupRecorder() {
     }
 
-    @SuppressWarnings("unsed") //called via reflection, as it is in an isolated CL
+    @SuppressWarnings("unused") //called via reflection, as it is in an isolated CL
     public static void handleFailedStart() {
         LogConfig config = new LogConfig();
         ConfigInstantiator.handleObject(config);
@@ -85,7 +85,7 @@ public class LoggingSetupRecorder {
         final LogContext logContext = LogContext.getLogContext();
         final Logger rootLogger = logContext.getLogger("");
 
-        rootLogger.setLevel(config.level.orElse(Level.INFO));
+        rootLogger.setLevel(config.level);
 
         ErrorManager errorManager = new OnlyOnceErrorManager();
         final Map<String, CleanupFilterConfig> filters = config.filters;
@@ -120,9 +120,8 @@ public class LoggingSetupRecorder {
             final String name = entry.getKey();
             final Logger categoryLogger = logContext.getLogger(name);
             final CategoryConfig categoryConfig = entry.getValue();
-            final String levelName = categoryConfig.level.toUpperCase(Locale.ROOT);
-            if (!"INHERIT".equals(levelName)) {
-                categoryLogger.setLevelName(levelName);
+            if (!categoryConfig.level.isInherited()) {
+                categoryLogger.setLevel(categoryConfig.level.getLevel());
             }
             categoryLogger.setUseParentHandlers(categoryConfig.useParentHandlers);
             if (categoryConfig.handlers.isPresent()) {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/GenerateConfigIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/GenerateConfigIT.java
@@ -37,7 +37,7 @@ class GenerateConfigIT extends QuarkusPlatformAwareMojoTestBase {
 
         String file = loadFile("test.properties");
         Assertions.assertTrue(file.contains("#quarkus.log.level"));
-        Assertions.assertTrue(file.contains("The default log level"));
+        Assertions.assertTrue(file.contains("The log level of the root category"));
         Assertions.assertTrue(file.contains("#quarkus.thread-pool.growth-resistance=0"));
         Assertions.assertTrue(file.contains("The executor growth resistance"));
 
@@ -45,7 +45,7 @@ class GenerateConfigIT extends QuarkusPlatformAwareMojoTestBase {
         //the existing file should not add properties that already exist
         file = loadFile("application.properties");
         Assertions.assertTrue(file.contains("quarkus.log.level=INFO"));
-        Assertions.assertFalse(file.contains("The default log level"));
+        Assertions.assertFalse(file.contains("The log level of the root category"));
         Assertions.assertTrue(file.contains("#quarkus.thread-pool.growth-resistance=0"));
         Assertions.assertTrue(file.contains("The executor growth resistance"));
     }


### PR DESCRIPTION
Allows the converter to validate rather than doing so at usage time; also, allow the default log level to appear in the configuration documentation.