### PR TITLE
Reverse the dependency between context propagation and mutiny.

### DIFF
--- a/extensions/mutiny/runtime/pom.xml
+++ b/extensions/mutiny/runtime/pom.xml
@@ -24,6 +24,20 @@
             <artifactId>mutiny</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-context-propagation</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny-context-propagation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-converter-api</artifactId>
         </dependency>

--- a/extensions/smallrye-context-propagation/deployment/pom.xml
+++ b/extensions/smallrye-context-propagation/deployment/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>quarkus-undertow-deployment</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- For Single tests -->        
+        <!-- For RX Java tests -->
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
@@ -59,6 +59,11 @@
             <scope>test</scope>
         </dependency>
         <!-- For Mutiny tests -->
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny-context-propagation</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>

--- a/extensions/smallrye-context-propagation/runtime/pom.xml
+++ b/extensions/smallrye-context-propagation/runtime/pom.xml
@@ -39,10 +39,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>mutiny-context-propagation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>


### PR DESCRIPTION
This fixes the quickstart issues.