### PR TITLE
Partially revert "Fix issue getting config from fork join pool"

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -728,6 +728,8 @@ public final class RunTimeConfigurationGenerator {
         }
 
         private void installConfiguration(ResultHandle config, MethodCreator methodCreator) {
+            // install config
+            methodCreator.invokeStaticMethod(QCF_SET_CONFIG, config);
             // now invalidate the cached config, so the next one to load the config gets the new one
             final ResultHandle configProviderResolver = methodCreator.invokeStaticMethod(CPR_INSTANCE);
             try (TryBlock getConfigTry = methodCreator.tryBlock()) {
@@ -737,8 +739,6 @@ public final class RunTimeConfigurationGenerator {
                 // ignore
                 getConfigTry.addCatch(IllegalStateException.class);
             }
-            // install config
-            methodCreator.invokeStaticMethod(QCF_SET_CONFIG, config);
         }
 
         private void generateDefaultValuesConfigSourceClass(ConfigPatternMap<Container> patternMap, String className) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigFactory.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigFactory.java
@@ -36,16 +36,8 @@ public final class QuarkusConfigFactory extends SmallRyeConfigFactory {
     }
 
     public static void setConfig(SmallRyeConfig config) {
-        //This is a hack, but there is not a great deal that can be done about it
-        //it is possible that when running in test/dev mode some code will be run with the system TCCL
-        //e.g. when using the fork join pool
-        //if this happens any use of config will fail, as the system class loader will resolve the
-        //wrong instance of the config classes
         if (QuarkusConfigFactory.config != null) {
             ConfigProviderResolver.instance().releaseConfig(QuarkusConfigFactory.config);
-        }
-        if (config != null) {
-            ConfigProviderResolver.instance().registerConfig(config, ClassLoader.getSystemClassLoader());
         }
         QuarkusConfigFactory.config = config;
     }


### PR DESCRIPTION
This partially reverts commit b2bfc3bf3779423e207a1524e07154df2f421e78.  The commit causes the config to be set incorrectly.  We should revisit the symptom to determine the correct fix.