### PR TITLE
Avoid annoying Warning logs when Sentry is disabled

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -159,7 +159,7 @@
         <artemis.version>2.11.0</artemis.version>
         <proton-j.version>0.33.2</proton-j.version>
         <okhttp.version>3.14.6</okhttp.version>
-        <sentry.version>1.7.28</sentry.version>
+        <sentry.version>1.7.30</sentry.version>
         <!-- Used for integration tests, to make sure webjars work-->
         <bootstrap.version>3.1.0</bootstrap.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>

--- a/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerCustomTest.java
+++ b/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerCustomTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import io.sentry.Sentry;
 import io.sentry.jul.SentryHandler;
 import io.sentry.jvmti.FrameCache;
 
@@ -25,6 +26,8 @@ public class SentryLoggerCustomTest {
         assertThat(sentryHandler).isNotNull();
         assertThat(sentryHandler.getLevel()).isEqualTo(org.jboss.logmanager.Level.TRACE);
         assertThat(FrameCache.shouldCacheThrowable(new IllegalStateException("Test frame"), 1)).isTrue();
+        assertThat(Sentry.getStoredClient()).isNotNull();
+        assertThat(Sentry.isInitialized()).isTrue();
     }
 
     @AfterAll

--- a/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerDisabledTest.java
+++ b/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerDisabledTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import io.sentry.Sentry;
 import io.sentry.jul.SentryHandler;
 
 public class SentryLoggerDisabledTest {
@@ -22,6 +23,8 @@ public class SentryLoggerDisabledTest {
     public void sentryLoggerDisabledTest() {
         final SentryHandler sentryHandler = getSentryHandler();
         assertThat(sentryHandler).isNull();
+        assertThat(Sentry.getStoredClient()).isNotNull();
+        assertThat(Sentry.isInitialized()).isTrue();
     }
 
     @AfterAll

--- a/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerTest.java
+++ b/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.runtime.logging.InitialConfigurator;
 import io.quarkus.test.QuarkusUnitTest;
+import io.sentry.Sentry;
 import io.sentry.jul.SentryHandler;
 import io.sentry.jvmti.FrameCache;
 
@@ -32,6 +33,8 @@ public class SentryLoggerTest {
         assertThat(sentryHandler).isNotNull();
         assertThat(sentryHandler.getLevel()).isEqualTo(org.jboss.logmanager.Level.WARN);
         assertThat(FrameCache.shouldCacheThrowable(new IllegalStateException("Test frame"), 1)).isFalse();
+        assertThat(Sentry.getStoredClient()).isNotNull();
+        assertThat(Sentry.isInitialized()).isTrue();
     }
 
     public static SentryHandler getSentryHandler() {


### PR DESCRIPTION
Those warning logs are not supposed to be visible when Sentry is disabled:
```
2020-02-21 17:13:08,062 WARN  [io.sen.dsn.Dsn] (executor-thread-1) *** Couldn't find a suitable DSN, Sentry operations will do nothing! See documentation: https://docs.sentry.io/clients/java/ ***
2020-02-21 17:13:08,072 WARN  [io.sen.DefaultSentryClientFactory] (executor-thread-1) No 'stacktrace.app.packages' was configured, this option is highly recommended as it affects stacktrace grouping and display on Sentry. See documentation: https://docs.sentry.io/cl
```