### PR TITLE
refactor: Kubernetes extension now uses `quarkus.`

### DIFF
--- a/docs/src/main/asciidoc/kubernetes.adoc
+++ b/docs/src/main/asciidoc/kubernetes.adoc
@@ -8,7 +8,7 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 include::./attributes.adoc[]
 
 This guide covers generating and deploying Kubernetes resources based on sane defaults and user supplied configuration.
-In detail, it supports generating resources for <<Kubernetes>>, <<Openshift>> and <<Knative>>. Also it supports automatically <<deploying, Deployment>> these resources to the target platform.
+In detail, it supports generating resources for <<Kubernetes>>, <<Openshift>> and <<Quarkus.Knative.>. Also it supports automatically <<deploying, Deployment>> these resources to the target platform.
 
 == Prerequisites
 
@@ -59,7 +59,7 @@ By using the following configuration for example:
 
 [source]
 ----
-kubernetes.group=yourDockerUsername # this is optional and defaults to your username if not set. 
+quarkus.kubernetes.group=yourDockerUsername # this is optional and defaults to your username if not set.
 quarkus.application.name=test-quarkus-app # this is also optional and defaults to the project name if not set
 ----
 
@@ -169,7 +169,7 @@ To change the number of replicas from 1 to  3:
 
 [source]
 ----
-kubernetes.replicas=3 
+quarkus.kubernetes.replicas=3
 ----
 
 === Defining a docker registry and repository
@@ -178,8 +178,8 @@ The docker registry and the user of the docker image can be specified, with the 
 
 [source]
 ----
-kubernetes.group=myUser 
-docker.registry=http://my.docker-registry.net
+quarkus.kubernetes.group=myUser
+quarkus.docker.registry=http://my.docker-registry.net
 ----
 
 Note: These options used to be `quarkus.kubernetes.docker.registry` and `quarkus.kubernetes.group` respectively.
@@ -189,8 +189,7 @@ To add a new label to all generated resources, say `foo=bar`:
 
 [source]
 ----
-kubernetes.labels[0].key=foo
-kubernetes.labels[0].value=bar
+quarkus.kubernetes.labels.foo=bar
 ----
 
 === Customizing the readiness probe:
@@ -198,8 +197,8 @@ To set the initial delay of the probe to 20 seconds and the period to 45:
 
 [source]
 ----
-kubernetes.readiness-probe.initial-delay-seconds=20
-kubernetes.readiness-probe.period-seconds=45
+quarkus.kubernetes.readiness-probe.initial-delay-seconds=20
+quarkus.kubernetes.readiness-probe.period-seconds=45
 ----
 
 Here you can find a complete reference to all the available configuration options:
@@ -210,38 +209,37 @@ The table below describe all the available configuration options.
 
 .Kubernetes
 |====
-| Property                                   | Type                          | Description | Default Value
-| kubernetes.group                           | String                        |             |
-| kubernetes.name                            | String                        |             |
-| kubernetes.version                         | String                        |             |
-| kubernetes.init-containers                 | Container[]                   |             |
-| kubernetes.labels                          | Label[]                       |             |
-| kubernetes.annotations                     | Annotation[]                  |             |
-| kubernetes.env-vars                        | Env[]                         |             |
-| kubernetes.working-dir                     | String                        |             |
-| kubernetes.command                         | String[]                      |             |
-| kubernetes.arguments                       | String[]                      |             |
-| kubernetes.replicas                        | int                           |             | 1
-| kubernetes.service-account                 | String                        |             |
-| kubernetes.host                            | String                        |             |
-| kubernetes.ports                           | Port[]                        |             |
-| kubernetes.service-type                    | ServiceType                   |             | ClusterIP
-| kubernetes.pvc-volumes                     | PersistentVolumeClaimVolume[] |             |
-| kubernetes.secret-volumes                  | SecretVolume[]                |             |
-| kubernetes.config-map-volumes              | ConfigMapVolume[]             |             |
-| kubernetes.git-repo-volumes                | GitRepoVolume[]               |             |
-| kubernetes.aws-elastic-block-store-volumes | AwsElasticBlockStoreVolume[]  |             |
-| kubernetes.azure-disk-volumes              | AzureDiskVolume[]             |             |
-| kubernetes.azure-file-volumes              | AzureFileVolume[]             |             |
-| kubernetes.mounts                          | Mount[]                       |             |
-| kubernetes.image-pull-policy               | ImagePullPolicy               |             | IfNotPresent
-| kubernetes.image-pull-secrets              | String[]                      |             |
-| kubernetes.liveness-probe                  | Probe                         |             | ( see Probe )
-| kubernetes.readiness-probe                 | Probe                         |             | ( see Probe )
-| kubernetes.sidecars                        | Container[]                   |             |
-| kubernetes.expose                          | boolean                       |             | false
-| kubernetes.headless                        | boolean                       |             | false
-| kubernetes.auto-deploy-enabled             | boolean                       |             | false
+| Property                                           | Type                                      | Description | Default Value
+| quarkus.kubernetes.group                           | String                                    |             |
+| quarkus.kubernetes.name                            | String                                    |             |
+| quarkus.kubernetes.version                         | String                                    |             |
+| quarkus.kubernetes.init-containers                 | Map<String, Container>                    |             |
+| quarkus.kubernetes.labels                          | Map                                       |             |
+| quarkus.kubernetes.annotations                     | Map                                       |             |
+| quarkus.kubernetes.env-vars                        | Map<String, Env>                          |             |
+| quarkus.kubernetes.working-dir                     | String                                    |             |
+| quarkus.kubernetes.command                         | String[]                                  |             |
+| quarkus.kubernetes.arguments                       | String[]                                  |             |
+| quarkus.kubernetes.replicas                        | int                                       |             | 1
+| quarkus.kubernetes.service-account                 | String                                    |             |
+| quarkus.kubernetes.host                            | String                                    |             |
+| quarkus.kubernetes.ports                           | Map<String, Port>                         |             |
+| quarkus.kubernetes.service-type                    | ServiceType                               |             | ClusterIP
+| quarkus.kubernetes.pvc-volumes                     | Map<String, PersistentVolumeClaimVolume>  |             |
+| quarkus.kubernetes.secret-volumes                  | Map<String, SecretVolume>                 |             |
+| quarkus.kubernetes.config-map-volumes              | Map<String, ConfigMapVolume>              |             |
+| quarkus.kubernetes.git-repo-volumes                | Map<String, GitRepoVolume>                |             |
+| quarkus.kubernetes.aws-elastic-block-store-volumes | Map<String, AwsElasticBlockStoreVolume>   |             |
+| quarkus.kubernetes.azure-disk-volumes              | Map<String, AzureDiskVolume>              |             |
+| quarkus.kubernetes.azure-file-volumes              | Map<String, AzureFileVolume>              |             |
+| quarkus.kubernetes.mounts                          | Map<String, Mount>                        |             |
+| quarkus.kubernetes.image-pull-policy               | ImagePullPolicy                           |             | IfNotPresent
+| quarkus.kubernetes.image-pull-secrets              | String[]                                  |             |
+| quarkus.kubernetes.liveness-probe                  | Probe                                     |             | ( see Probe )
+| quarkus.kubernetes.readiness-probe                 | Probe                                     |             | ( see Probe )
+| quarkus.kubernetes.sidecars                        | Map<String, Container>                    |             |
+| quarkus.kubernetes.expose                          | boolean                                   |             | false
+| quarkus.kubernetes.headless                        | boolean                                   |             | false
 |====
 
 Properties that use non standard types, can be referenced by expanding the property.
@@ -249,8 +247,8 @@ For example to define a `kubernetes-readiness-probe` which is of type `Probe`:
 
 [source]
 ----
-kubernetes.readiness-probe.initial-delay-seconds=20
-kubernetes.readiness-probe.period-seconds=45
+quarkus.kubernetes.readiness-probe.initial-delay-seconds=20
+quarkus.kubernetes.readiness-probe.period-seconds=45
 ----
 
 In this example `initial-delay` and `period-seconds` are fields of the type `Probe`.
@@ -259,27 +257,10 @@ Below you will find tables describing all available types.
 
 ===== Basic Types
 
-.Annotation
-|====
-| Property | Type   | Description | Default Value 
-| key      | String |             |               
-| value    | String |             |               
-|====
-
-
-.Label
-|====
-| Property | Type   | Description | Default Value 
-| key      | String |             |               
-| value    | String |             |               
-|====
-
-
 .Env
 |====
 | Property  | Type   | Description | Default Value
-| name      | String |             |              
-| value     | String |             |              
+| value     | String |             |
 | secret    | String |             |              
 | configmap | String |             |              
 | field     | String |             |              
@@ -299,7 +280,6 @@ Below you will find tables describing all available types.
 .Port
 |====
 | Property        | Type     | Description | Default Value
-| name            | String   |             |
 | container-port  | int      |             |
 | host-port       | int      |             | 0
 | path            | String   |             | /
@@ -310,8 +290,7 @@ Below you will find tables describing all available types.
 |====
 | Property          | Type                                    | Description | Default Value
 | image             | String                                  |             |
-| name              | String                                  |             |
-| env-vars          | Env[]                                   |             |                                          
+| env-vars          | Env[]                                   |             |
 | working-dir       | String                                  |             |                                          
 | command           | String[]                                |             |
 | arguments         | String[]                                |             |
@@ -328,7 +307,6 @@ Below you will find tables describing all available types.
 .Mount
 |====
 | Property  | Type    | Description | Default Value
-| name      | String  |             |
 | path      | String  |             |
 | sub-path  | String  |             |               
 | read-only | boolean |             | false         
@@ -337,8 +315,7 @@ Below you will find tables describing all available types.
 .ConfigMapVolume
 |====
 | Property        | Type    | Description | Default Value
-| volume-name     | String  |             |
-| config-map-name | String  |             |               
+| config-map-name | String  |             |
 | default-mode    | int     |             | 384
 | optional        | boolean |             | false
 |====
@@ -346,8 +323,7 @@ Below you will find tables describing all available types.
 .SecretVolume
 |====
 | Property     | Type    | Description | Default Value
-| volume-name  | String  |             |               
-| secret-name  | String  |             |               
+| secret-name  | String  |             |
 | default-mode | int     |             | 384           
 | optional     | boolean |             | false
 |====
@@ -356,8 +332,7 @@ Below you will find tables describing all available types.
 .AzureDiskVolume
 |====
 | Property     | Type    | Description | Default Value
-| volume-name  | String  |             |               
-| disk-name    | String  |             |               
+| disk-name    | String  |             |
 | disk-uri     | String  |             |               
 | kind         | String  |             | Managed
 | caching-mode | String  |             | ReadWrite     
@@ -368,8 +343,7 @@ Below you will find tables describing all available types.
 .AwsElasticBlockStoreVolume
 |====
 | Property    | Type    | Description | Default Value
-| volume-name | String  |             |               
-| volume-id   | String  |             |               
+| volume-id   | String  |             |
 | partition   | int     |             |
 | fs-type     | String  |             | ext4          
 | read-only   | boolean |             | false         
@@ -378,7 +352,6 @@ Below you will find tables describing all available types.
 .GitRepoVolume
 |====
 | Property    | Type   | Description | Default Value
-| volume-name | String |             |               
 | repository  | String |             |
 | directory   | String |             |
 | revision    | String |             |
@@ -387,28 +360,15 @@ Below you will find tables describing all available types.
 .PersistentVolumeClaimVolume
 |====
 | Property    | Type    | Description | Default Value
-| volume-name | String  |             |              
-| claim-name  | String  |             |              
+| claim-name  | String  |             |
 | read-only   | boolean |             | false        
 |====
 .AzureFileVolume
 |====
 | Property    | Type    | Description | Default Value
-| volume-name | String  |             |              
-| share-name  | String  |             |              
+| share-name  | String  |             |
 | secret-name | String  |             |              
 | read-only   | boolean |             | false        
-|====
-
-== Docker
-
-.Docker 
-|====
-| Property           | Type    | Description | Default Value
-| docker.docker-file        | String  |             | Dockerfile
-| docker.registry           | String  |             |
-| docker.auto-push-enabled  | boolean |             | false
-| docker.auto-build-enabled | boolean |             | false
 |====
 
 === OpenShift
@@ -417,82 +377,68 @@ To enable the generation of OpenShift resources, you need to include OpenShift i
 
 [source]
 ----
-kubernetes.deployment.target=openshift
+quarkus.kubernetes.deployment-target=openshift
 ----
 
 If you need to generate resources for both platforms (vanilla Kubernetes and OpenShift), then you need to include both (coma separated).
 
 [source]
 ----
-kubernetes.deployment.target=kubernetes, openshift
+quarkus.kubernetes.deployment-target=kubernetes, openshift
 ----
 
 The OpenShift resources can be customized in a similar approach with Kubernetes.
 
 .Openshift
 |====
-| Property                                  | Type                          | Description | Default Value
-| openshift.group                           | String                        |             |
-| openshift.name                            | String                        |             |
-| openshift.version                         | String                        |             |
-| openshift.init-containers                 | Container[]                   |             |
-| openshift.labels                          | Label[]                       |             |
-| openshift.annotations                     | Annotation[]                  |             |
-| openshift.env-vars                        | Env[]                         |             |
-| openshift.working-dir                     | String                        |             |
-| openshift.command                         | String[]                      |             |
-| openshift.arguments                       | String[]                      |             |
-| openshift.replicas                        | int                           |             | 1
-| openshift.service-account                 | String                        |             |
-| openshift.host                            | String                        |             |
-| openshift.ports                           | Port[]                        |             |
-| openshift.service-type                    | ServiceType                   |             | ClusterIP
-| openshift.pvc-volumes                     | PersistentVolumeClaimVolume[] |             |
-| openshift.secret-volumes                  | SecretVolume[]                |             |
-| openshift.config-map-volumes              | ConfigMapVolume[]             |             |
-| openshift.git-repo-volumes                | GitRepoVolume[]               |             |
-| openshift.aws-elastic-block-store-volumes | AwsElasticBlockStoreVolume[]  |             |
-| openshift.azure-disk-volumes              | AzureDiskVolume[]             |             |
-| openshift.azure-file-volumes              | AzureFileVolume[]             |             |
-| openshift.mounts                          | Mount[]                       |             |
-| openshift.image-pull-policy               | ImagePullPolicy               |             | IfNotPresent
-| openshift.image-pull-secrets              | String[]                      |             |
-| openshift.liveness-probe                  | Probe                         |             | ( see Probe )
-| openshift.readiness-probe                 | Probe                         |             | ( see Probe )
-| openshift.sidecars                        | Container[]                   |             |
-| openshift.expose                          | boolean                       |             | false
-| openshift.headless                        | boolean                       |             | false
-| openshift.auto-deploy-enabled             | boolean                       |             | false
-|====
-
-.S2i
-|====
-| Property                | Type    | Description | Default Value
-| s2i.enabled             | boolean |             | true
-| s2i.docker-file         | String  |             | Dockerfile
-| s2i.registry            | String  |             |
-| s2i.builder-image       | String  |             | fabric8/s2i-java:2.3
-| s2i.build-env-vars      | Env[]   |             |
-| s2i.auto-push-enabled   | boolean |             | false
-| s2i.auto-build-enabled  | boolean |             | false
-| s2i.auto-deploy-enabled | boolean |             | false               
+| Property                                          | Type                                      | Description | Default Value
+| quarkus.openshift.group                           | String                                    |             |
+| quarkus.openshift.name                            | String                                    |             |
+| quarkus.openshift.version                         | String                                    |             |
+| quarkus.openshift.init-containers                 | Map<String, Container>                    |             |
+| quarkus.openshift.labels                          | Map                                       |             |
+| quarkus.openshift.annotations                     | Map                                       |             |
+| quarkus.openshift.env-vars                        | Map<String, Env>                          |             |
+| quarkus.openshift.working-dir                     | String                                    |             |
+| quarkus.openshift.command                         | String[]                                  |             |
+| quarkus.openshift.arguments                       | String[]                                  |             |
+| quarkus.openshift.replicas                        | int                                       |             | 1
+| quarkus.openshift.service-account                 | String                                    |             |
+| quarkus.openshift.host                            | String                                    |             |
+| quarkus.openshift.ports                           | Map<String, Port>                         |             |
+| quarkus.openshift.service-type                    | ServiceType                               |             | ClusterIP
+| quarkus.openshift.pvc-volumes                     | Map<String, PersistentVolumeClaimVolume>  |             |
+| quarkus.openshift.secret-volumes                  | Map<String, SecretVolume>                 |             |
+| quarkus.openshift.config-map-volumes              | Map<String, ConfigMapVolume>              |             |
+| quarkus.openshift.git-repo-volumes                | Map<String, GitRepoVolume>                |             |
+| quarkus.openshift.aws-elastic-block-store-volumes | Map<String, AwsElasticBlockStoreVolume>   |             |
+| quarkus.openshift.azure-disk-volumes              | Map<String, AzureDiskVolume>              |             |
+| quarkus.openshift.azure-file-volumes              | Map<String, AzureFileVolume>              |             |
+| quarkus.openshift.mounts                          | Map<String, Mount>                        |             |
+| quarkus.openshift.image-pull-policy               | ImagePullPolicy                           |             | IfNotPresent
+| quarkus.openshift.image-pull-secrets              | String[]                                  |             |
+| quarkus.openshift.liveness-probe                  | Probe                                     |             | ( see Probe )
+| quarkus.openshift.readiness-probe                 | Probe                                     |             | ( see Probe )
+| quarkus.openshift.sidecars                        | Map<String, Container>                    |             |
+| quarkus.openshift.expose                          | boolean                                   |             | false
+| quarkus.openshift.headless                        | boolean                                   |             | false
 |====
 
 === Knative
     
-To enable the generation of Knative resources, you need to include Knative in the target platforms:
+To enable the generation of Quarkus.Knative.resources, you need to include Knative in the target platforms:
 
 [source]
 ----
-kubernetes.deployment.target=knative
+quarkus.kubernetes.deployment.target=knative
 ----
 
 Following the execution of `./mvnw package` you will notice amongst the other files that are created, two files named
-`knative.json` and `knative.yml` in the `target/kubernetes/` directory.
+`quarkus.knative.json` and `knative.yml` in the `target/kubernetes/` directory.
 
-If you look at either file you will see that it contains a Knative `Service`.
+If you look at either file you will see that it contains a Quarkus.Knative.`Service`.
 
-The full source of the `knative.json` file looks something like this:
+The full source of the `quarkus.knative.json` file looks something like this:
 
 [source,json]
 ----
@@ -500,7 +446,7 @@ The full source of the `knative.json` file looks something like this:
   "apiVersion" : "v1",
   "kind" : "List",
   "items" : [ {
-    "apiVersion" : "serving.knative.dev/v1alpha1",
+    "apiVersion" : "serving.quarkus.knative.dev/v1alpha1",
     "kind" : "Service",
     "metadata" : {
       "labels" : {
@@ -508,7 +454,7 @@ The full source of the `knative.json` file looks something like this:
         "version" : "0.1-SNAPSHOT",
         "group" : "yourDockerUsername"
       },
-      "name" : "knative"
+      "name" : "quarkus.knative.
     },
     "spec" : {
       "runLatest" : {
@@ -532,35 +478,78 @@ The generated service can be customized using the following properties:
 
 .Knative
 |====
-| Property                                | Type                          | Description | Default Value
-| knative.group                           | String                        |             |
-| knative.name                            | String                        |             |
-| knative.version                         | String                        |             |
-| knative.labels                          | Label[]                       |             |
-| knative.annotations                     | Annotation[]                  |             |
-| knative.env-vars                        | Env[]                         |             |
-| knative.working-dir                     | String                        |             |
-| knative.command                         | String[]                      |             |
-| knative.arguments                       | String[]                      |             |
-| knative.service-account                 | String                        |             |
-| knative.host                            | String                        |             |
-| knative.ports                           | Port[]                        |             |
-| knative.service-type                    | ServiceType                   |             | ClusterIP
-| knative.pvc-volumes                     | PersistentVolumeClaimVolume[] |             |
-| knative.secret-volumes                  | SecretVolume[]                |             |
-| knative.config-map-volumes              | ConfigMapVolume[]             |             |
-| knative.git-repo-volumes                | GitRepoVolume[]               |             |
-| knative.aws-elastic-block-store-volumes | AwsElasticBlockStoreVolume[]  |             |
-| knative.azure-disk-volumes              | AzureDiskVolume[]             |             |
-| knative.azure-file-volumes              | AzureFileVolume[]             |             |
-| knative.mounts                          | Mount[]                       |             |
-| knative.image-pull-policy               | ImagePullPolicy               |             | IfNotPresent
-| knative.image-pull-secrets              | String[]                      |             |
-| knative.liveness-probe                  | Probe                         |             | ( see Probe )
-| knative.readiness-probe                 | Probe                         |             | ( see Probe )
-| knative.sidecars                        | Container[]                   |             |
-| knative.expose                          | boolean                       |             | false
+| Property                                        | Type                                      | Description | Default Value
+| quarkus.knative.group                           | String                                    |             |
+| quarkus.knative.name                            | String                                    |             |
+| quarkus.knative.version                         | String                                    |             |
+| quarkus.knative.init-containers                 | Map<String, Container>                    |             |
+| quarkus.knative.labels                          | Map                                       |             |
+| quarkus.knative.annotations                     | Map                                       |             |
+| quarkus.knative.env-vars                        | Map<String, Env>                          |             |
+| quarkus.knative.working-dir                     | String                                    |             |
+| quarkus.knative.command                         | String[]                                  |             |
+| quarkus.knative.arguments                       | String[]                                  |             |
+| quarkus.knative.replicas                        | int                                       |             | 1
+| quarkus.knative.service-account                 | String                                    |             |
+| quarkus.knative.host                            | String                                    |             |
+| quarkus.knative.ports                           | Map<String, Port>                         |             |
+| quarkus.knative.service-type                    | ServiceType                               |             | ClusterIP
+| quarkus.knative.pvc-volumes                     | Map<String, PersistentVolumeClaimVolume>  |             |
+| quarkus.knative.secret-volumes                  | Map<String, SecretVolume>                 |             |
+| quarkus.knative.config-map-volumes              | Map<String, ConfigMapVolume>              |             |
+| quarkus.knative.git-repo-volumes                | Map<String, GitRepoVolume>                |             |
+| quarkus.knative.aws-elastic-block-store-volumes | Map<String, AwsElasticBlockStoreVolume>   |             |
+| quarkus.knative.azure-disk-volumes              | Map<String, AzureDiskVolume>              |             |
+| quarkus.knative.azure-file-volumes              | Map<String, AzureFileVolume>              |             |
+| quarkus.knative.mounts                          | Map<String, Mount>                        |             |
+| quarkus.knative.image-pull-policy               | ImagePullPolicy                           |             | IfNotPresent
+| quarkus.knative.image-pull-secrets              | String[]                                  |             |
+| quarkus.knative.liveness-probe                  | Probe                                     |             | ( see Probe )
+| quarkus.knative.readiness-probe                 | Probe                                     |             | ( see Probe )
+| quarkus.knative.sidecars                        | Map<String, Container>                    |             |
 |====
+
+
+=== Deprecated configuration
+
+The following categories of configuration properties have been deprecated.
+
+==== Properties without the quarkus prefix
+
+In earlier versions of the extension, the `quarkus.` was missing from those properties. These properties are now deprecated.
+
+==== Docker and S2i properties
+
+The properties for configuring `docker` and `s2i` are also deprecated in favor of the new container-image extensions.
+
+==== Config group arrays
+
+Properties refering to config group arrays (e.g. kubernetes.labels[0], kubernetes.env-vars[0] etc) have been converted to maps, to align with the rest of the quarkus ecosystem.
+
+The code below demonstrates the change in `labels` config:
+
+[source]
+----
+# Old labels config:
+kubernetes.labels[0].name=foo
+kubernetes.labels[0].name=bar
+
+# New labels
+quarkus.kubernetes.labels.foo=bar
+----
+
+The code below demonstrates the change in `env-vars` config:
+
+[source]
+----
+# Old env-vars config:
+kubernetes.env-vars[0].name=foo
+kubernetes.env-vars[0].configmap=my-configmap
+
+# New env-vars
+quarkus.kubernetes.env-vars.foo.configmap=myconfigmap
+----
+
 
 == Deployment
 
@@ -584,7 +573,7 @@ Each time deployment is requested, a container build will be implicitly triggere
 
 === Deploying
 
-When deployment is enabled, the kubernetes extension will selected the resources specified by `kubernetes.deployment.target` and deploy them.
+When deployment is enabled, the kubernetes extension will selected the resources specified by `quarkus.kubernetes.deployment.target` and deploy them.
 This assumes that a `.kube/config` is available in your user directory that points to a real kubernetes cluster.
 In other words the extension will use whatever cluster `kubectl` uses. The same applies to credentials.
 

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AwsElasticBlockStoreVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AwsElasticBlockStoreVolumeConfig.java
@@ -1,0 +1,36 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class AwsElasticBlockStoreVolumeConfig {
+
+    /**
+     * The name of the disk to mount.
+     */
+    @ConfigItem
+    String volumeId;
+
+    /**
+     * The partition.
+     */
+    @ConfigItem
+    Optional<Integer> partition;
+
+    /**
+     * Filesystem type.
+     */
+    @ConfigItem(defaultValue = "ext4")
+    String fsType;
+
+    /**
+     * Wether the volumeName is read only or not.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean readOnly;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AwsElasticBlockStoreVolumeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AwsElasticBlockStoreVolumeConverter.java
@@ -1,0 +1,23 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.AwsElasticBlockStoreVolume;
+import io.dekorate.kubernetes.config.AwsElasticBlockStoreVolumeBuilder;
+
+public class AwsElasticBlockStoreVolumeConverter {
+
+    public static AwsElasticBlockStoreVolume convert(Map.Entry<String, AwsElasticBlockStoreVolumeConfig> e) {
+        return convert(e.getValue()).withVolumeName(e.getKey()).build();
+    }
+
+    private static AwsElasticBlockStoreVolumeBuilder convert(AwsElasticBlockStoreVolumeConfig c) {
+        AwsElasticBlockStoreVolumeBuilder b = new AwsElasticBlockStoreVolumeBuilder();
+        b.withVolumeId(c.volumeId);
+        b.withFsType(c.fsType);
+        b.withReadOnly(c.readOnly);
+        c.partition.ifPresent(p -> b.withPartition(p));
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureDiskVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureDiskVolumeConfig.java
@@ -1,0 +1,57 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class AzureDiskVolumeConfig {
+
+    public enum CachingMode {
+        ReadWrite,
+        ReadOnly,
+        None
+    }
+
+    public enum Kind {
+        Managed,
+        Shared
+    }
+
+    /**
+     * The name of the disk to mount.
+     */
+    @ConfigItem
+    String diskName;
+
+    /**
+     * The URI of the vhd blob object OR the resourceID of an Azure managed data disk if Kind is Managed
+     */
+    @ConfigItem
+    String diskURI;
+
+    /**
+     * Kind of disk.
+     */
+    @ConfigItem(defaultValue = "Managed")
+    Kind kind;
+
+    /**
+     * Disk caching mode.
+     */
+    @ConfigItem(defaultValue = "ReadWrite")
+    CachingMode cachingMode;
+
+    /**
+     * File system type.
+     */
+    @ConfigItem(defaultValue = "ext4")
+    String fsType;
+
+    /**
+     * Wether the volumeName is read only or not.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean readOnly;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureDiskVolumeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureDiskVolumeConverter.java
@@ -1,0 +1,25 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.AzureDiskVolume;
+import io.dekorate.kubernetes.config.AzureDiskVolumeBuilder;
+
+public class AzureDiskVolumeConverter {
+
+    public static AzureDiskVolume convert(Map.Entry<String, AzureDiskVolumeConfig> e) {
+        return convert(e.getValue()).withVolumeName(e.getKey()).build();
+    }
+
+    private static AzureDiskVolumeBuilder convert(AzureDiskVolumeConfig c) {
+        AzureDiskVolumeBuilder b = new AzureDiskVolumeBuilder();
+        b.withNewDiskName(c.diskName);
+        b.withDiskURI(c.diskURI);
+        b.withKind(c.kind.name());
+        b.withCachingMode(c.cachingMode.name());
+        b.withFsType(c.fsType);
+        b.withReadOnly(c.readOnly);
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureFileVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureFileVolumeConfig.java
@@ -1,0 +1,28 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class AzureFileVolumeConfig {
+
+    /**
+     * The share name.
+     */
+    @ConfigItem
+    String shareName;
+
+    /**
+     * The secret name.
+     */
+    @ConfigItem
+    String secretName;
+
+    /**
+     * Wether the volumeName is read only or not.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean readOnly;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureFileVolumeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/AzureFileVolumeConverter.java
@@ -1,0 +1,22 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.AzureFileVolume;
+import io.dekorate.kubernetes.config.AzureFileVolumeBuilder;
+
+public class AzureFileVolumeConverter {
+
+    public static AzureFileVolume convert(Map.Entry<String, AzureFileVolumeConfig> e) {
+        return convert(e.getValue()).withVolumeName(e.getKey()).build();
+    }
+
+    private static AzureFileVolumeBuilder convert(AzureFileVolumeConfig c) {
+        AzureFileVolumeBuilder b = new AzureFileVolumeBuilder();
+        b.withSecretName(c.secretName);
+        b.withShareName(c.shareName);
+        b.withReadOnly(c.readOnly);
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
@@ -1,0 +1,29 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ConfigMapVolumeConfig {
+
+    /**
+     * The name of the ConfigMap to mount.
+     */
+    @ConfigItem
+    String configMapName;
+
+    /**
+     * Default mode.
+     *
+     * @return The default mode.
+     */
+    @ConfigItem(defaultValue = "0600")
+    Integer defaultMode;
+
+    /**
+     * Optional
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean optional;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConverter.java
@@ -1,0 +1,23 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.ConfigMapVolume;
+import io.dekorate.kubernetes.config.ConfigMapVolumeBuilder;
+
+public class ConfigMapVolumeConverter {
+
+    public static ConfigMapVolume convert(Map.Entry<String, ConfigMapVolumeConfig> e) {
+        return convert(e.getValue()).withVolumeName(e.getKey()).build();
+    }
+
+    public static ConfigMapVolumeBuilder convert(ConfigMapVolumeConfig cm) {
+        ConfigMapVolumeBuilder b = new ConfigMapVolumeBuilder();
+        b.withConfigMapName(cm.configMapName);
+        b.withDefaultMode(cm.defaultMode);
+        b.withOptional(cm.optional);
+        return b;
+    }
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -3,6 +3,9 @@ package io.quarkus.kubernetes.deployment;
 public class Constants {
 
     static final String KUBERNETES = "kubernetes";
+    static final String OPENSHIFT = "openshift";
+    static final String KNATIVE = "knative";
+
     static final String DEPLOYMENT_TARGET = "kubernetes.deployment.target";
     static final String DEPLOY = "quarkus.kubernetes.deploy";
 }

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
@@ -1,0 +1,96 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.dekorate.kubernetes.annotation.ImagePullPolicy;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ContainerConfig {
+
+    /**
+     * The container image.
+     */
+    @ConfigItem
+    Optional<String> image;
+
+    /**
+     * Environment variables to add to all containers.
+     */
+    @ConfigItem
+    Map<String, EnvConfig> envVars;
+
+    /**
+     * Working directory.
+     */
+    @ConfigItem
+    Optional<String> workingDir;
+
+    /**
+     * The commands
+     */
+    @ConfigItem
+    Optional<List<String>> command;
+
+    /**
+     * The arguments
+     *
+     * @return The arguments.
+     */
+    @ConfigItem
+    Optional<List<String>> arguments;
+
+    /**
+     * The service account.
+     */
+    @ConfigItem
+    Optional<String> serviceAccount;
+
+    /**
+     * The host under which the application is going to be exposed.
+     *
+     */
+    @ConfigItem
+    Optional<String> host;
+
+    /**
+     * The application ports.
+     */
+    @ConfigItem
+    Map<String, PortConfig> ports;
+
+    /**
+     * Image pull policy.
+     */
+    @ConfigItem(defaultValue = "IfNotPresent")
+    ImagePullPolicy imagePullPolicy;
+
+    /**
+     * The image pull secret
+     */
+    @ConfigItem
+    Optional<List<String>> imagePullSecrets;
+
+    /**
+     * The liveness probe.
+     */
+    @ConfigItem
+    Optional<ProbeConfig> livenessProbe;
+
+    /**
+     * The readiness probe.
+     */
+    @ConfigItem
+    Optional<ProbeConfig> readinessProbe;
+
+    /**
+     * Volume mounts.
+     */
+    @ConfigItem
+    Map<String, MountConfig> mounts;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConverter.java
@@ -1,0 +1,26 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.Container;
+import io.dekorate.kubernetes.config.ContainerBuilder;
+
+public class ContainerConverter {
+
+    public static Container convert(Map.Entry<String, ContainerConfig> e) {
+        return convert(e.getValue()).withName(e.getKey()).build();
+    }
+
+    private static ContainerBuilder convert(ContainerConfig c) {
+        ContainerBuilder b = new ContainerBuilder();
+        c.image.ifPresent(i -> b.withImage(i));
+        c.workingDir.ifPresent(w -> b.withWorkingDir(w));
+        c.readinessProbe.ifPresent(p -> b.withReadinessProbe(ProbeConverter.convert(p)));
+        c.livenessProbe.ifPresent(p -> b.withLivenessProbe(ProbeConverter.convert(p)));
+        c.envVars.entrySet().forEach(e -> b.addToEnvVars(EnvConverter.convert(e)));
+        c.ports.entrySet().forEach(e -> b.addToPorts(PortConverter.convert(e)));
+        c.mounts.entrySet().forEach(e -> b.addToMounts(MountConverter.convert(e)));
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConfig.java
@@ -1,0 +1,41 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class EnvConfig {
+
+    /**
+     * The environment variable name.
+     */
+    @ConfigItem
+    Optional<String> name;
+
+    /**
+     * The environment variable value.
+     */
+    @ConfigItem
+    Optional<String> value;
+
+    /**
+     * The environment variable secret.
+     */
+    @ConfigItem
+    Optional<String> secret;
+
+    /**
+     * The environment variable config map.
+     */
+    @ConfigItem
+    Optional<String> configmap;
+
+    /**
+     * The environment variable field.
+     */
+    @ConfigItem
+    Optional<String> field;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
@@ -1,0 +1,25 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import io.dekorate.kubernetes.config.Env;
+import io.dekorate.kubernetes.config.EnvBuilder;
+
+public class EnvConverter {
+
+    public static Env convert(Map.Entry<String, EnvConfig> e) {
+        return convert(e.getValue()).withName(e.getKey().toUpperCase().replaceAll(Pattern.quote("-"), "_")).build();
+    }
+
+    private static EnvBuilder convert(EnvConfig env) {
+        EnvBuilder b = new EnvBuilder();
+        env.name.ifPresent(v -> b.withName(v));
+        env.value.ifPresent(v -> b.withValue(v));
+        env.secret.ifPresent(v -> b.withSecret(v));
+        env.configmap.ifPresent(v -> b.withConfigmap(v));
+        env.field.ifPresent(v -> b.withField(v));
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/GitRepoVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/GitRepoVolumeConfig.java
@@ -1,0 +1,30 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class GitRepoVolumeConfig {
+
+    /**
+     * Git repoistory URL.
+     */
+    @ConfigItem
+    String repository;
+
+    /**
+     * The directory of the repository to mount.
+     */
+    @ConfigItem
+    Optional<String> directory;
+
+    /**
+     * The commit hash to use.
+     */
+    @ConfigItem
+    Optional<String> revision;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -10,7 +10,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 @ConfigRoot
-public class KubernetesConfig implements PlatformConfiguration {
+public class KnativeConfig implements PlatformConfiguration {
 
     /**
      * The group of the application.
@@ -176,13 +176,6 @@ public class KubernetesConfig implements PlatformConfiguration {
      */
     @ConfigItem
     Map<String, ContainerConfig> containers;
-
-    /**
-     * The target deployment platform. Defaults to kubernetes. Can be kubernetes,
-     * openshift, knative or any combination of the above as comma separated list.
-     */
-    @ConfigItem(defaultValue = "kubernetes")
-    List<DeploymentTarget> deploymentTarget;
 
     public Optional<String> getGroup() {
         return group;

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
@@ -1,0 +1,117 @@
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.deployment.Constants.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.dekorate.utils.Strings;
+
+public class KubernetesConfigUtil {
+
+    private static final String DEKORATE_PREFIX = "dekorate.";
+    private static final String QUARKUS_PREFIX = "quarkus.";
+
+    //Most of quarkus prefixed properties are handled directly by the config items (KubenretesConfig, OpenshiftConfig, KnativeConfig)
+    //We just need group, name & version parsed here, as we don't have decorators for these (low level properties).
+    private static final Set<String> QUARKUS_PREFIX_WHITELIST = new HashSet<>(Arrays.asList("group", "name", "version"));
+
+    private static final Set<String> ALLOWED_GENERATORS = new HashSet<>(
+            Arrays.asList("kubernetes", "openshift", "knative", "docker", "s2i"));
+    private static final Set<String> IMAGE_GENERATORS = new HashSet<>(Arrays.asList("docker", "s2i"));
+
+    public static List<String> getDeploymentTargets() {
+        return getDeploymentTargets(toMap());
+    }
+
+    public static List<String> getDeploymentTargets(Map<String, Object> map) {
+        return Arrays.stream(map.getOrDefault(DEKORATE_PREFIX + DEPLOYMENT_TARGET, KUBERNETES).toString().split(","))
+                .map(String::trim)
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+    }
+
+    public static Optional<String> getDockerRegistry(Map<String, Object> map) {
+        return IMAGE_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".registry")).filter(Objects::nonNull)
+                .map(String::valueOf).findFirst();
+    }
+
+    public static Optional<String> getGroup(Map<String, Object> map) {
+        return ALLOWED_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".group")).filter(Objects::nonNull)
+                .map(String::valueOf).findFirst();
+    }
+
+    public static Optional<String> getName(Map<String, Object> map) {
+        return ALLOWED_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".name")).filter(Objects::nonNull)
+                .map(String::valueOf).findFirst();
+    }
+
+    /*
+     * Collects configuration properties for Kubernetes. Reads all properties and
+     * matches properties that match known Dekorate generators. These properties may
+     * or may not be prefixed with `quarkus.` though the prefixed ones take
+     * precedence.
+     *
+     * @return A map containing the properties.
+     */
+    public static Map<String, Object> toMap() {
+        Config config = ConfigProvider.getConfig();
+        Map<String, Object> result = new HashMap<>();
+
+        Map<String, Object> quarkusPrefixed = StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .filter(s -> s.startsWith(QUARKUS_PREFIX))
+                .map(s -> s.replaceFirst(QUARKUS_PREFIX, ""))
+                .filter(k -> ALLOWED_GENERATORS.contains(generatorName(k)))
+                .filter(k -> QUARKUS_PREFIX_WHITELIST.contains(propertyName(k)))
+                .filter(k -> config.getOptionalValue(QUARKUS_PREFIX + k, String.class).isPresent())
+                .collect(Collectors.toMap(k -> DEKORATE_PREFIX + k,
+                        k -> config.getValue(QUARKUS_PREFIX + k, String.class)));
+
+        Map<String, Object> unPrefixed = StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .filter(k -> ALLOWED_GENERATORS.contains(generatorName(k)))
+                .filter(k -> config.getOptionalValue(k, String.class).isPresent())
+                .collect(Collectors.toMap(k -> DEKORATE_PREFIX + k, k -> config.getValue(k, String.class)));
+
+        result.putAll(unPrefixed);
+        result.putAll(quarkusPrefixed);
+        return result;
+    }
+
+    /**
+     * Returns the name of the generators that can handle the specified key.
+     *
+     * @param key The key.
+     * @return The generator name or null if the key format is unexpected.
+     */
+    private static String generatorName(String key) {
+        if (Strings.isNullOrEmpty(key) || !key.contains(".")) {
+            return null;
+        }
+        return key.substring(0, key.indexOf("."));
+    }
+
+    /**
+     * Returns the name of the property stripped of all prefixes.
+     *
+     * @param key The key.
+     * @return The property name.
+     */
+    private static String propertyName(String key) {
+        if (Strings.isNullOrEmpty(key) || !key.contains(".")) {
+            return key;
+        }
+        return key.substring(key.lastIndexOf(".") + 1);
+    }
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConfig.java
@@ -1,0 +1,44 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class MountConfig {
+
+    /**
+     * The name of the volumeName to mount.
+     *
+     * @return The name.
+     */
+    @ConfigItem
+    Optional<String> name;
+
+    /**
+     * The path to mount.
+     *
+     * @return The path.
+     */
+    @ConfigItem
+    Optional<String> path;
+
+    /**
+     * Path within the volumeName from which the container's volumeName should be
+     * mounted.
+     *
+     * @return The subPath.
+     */
+    @ConfigItem
+    Optional<String> subPath;
+
+    /**
+     * ReadOnly
+     *
+     * @return True if mount is readonly, False otherwise.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean readOnly;
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/MountConverter.java
@@ -1,0 +1,22 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.Mount;
+import io.dekorate.kubernetes.config.MountBuilder;
+
+public class MountConverter {
+
+    public static Mount convert(Map.Entry<String, MountConfig> e) {
+        return convert(e.getValue()).withName(e.getKey()).build();
+    }
+
+    private static MountBuilder convert(MountConfig mount) {
+        MountBuilder b = new MountBuilder();
+        mount.path.ifPresent(v -> b.withPath(v));
+        mount.subPath.ifPresent(v -> b.withSubPath(v));
+        b.withReadOnly(mount.readOnly);
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -1,3 +1,4 @@
+
 package io.quarkus.kubernetes.deployment;
 
 import java.util.List;
@@ -10,7 +11,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 @ConfigRoot
-public class KubernetesConfig implements PlatformConfiguration {
+public class OpenshiftConfig implements PlatformConfiguration {
 
     /**
      * The group of the application.
@@ -176,13 +177,6 @@ public class KubernetesConfig implements PlatformConfiguration {
      */
     @ConfigItem
     Map<String, ContainerConfig> containers;
-
-    /**
-     * The target deployment platform. Defaults to kubernetes. Can be kubernetes,
-     * openshift, knative or any combination of the above as comma separated list.
-     */
-    @ConfigItem(defaultValue = "kubernetes")
-    List<DeploymentTarget> deploymentTarget;
 
     public Optional<String> getGroup() {
         return group;

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -1,0 +1,67 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.dekorate.kubernetes.annotation.ImagePullPolicy;
+import io.dekorate.kubernetes.annotation.ServiceType;
+
+public interface PlatformConfiguration {
+
+    Optional<String> getGroup();
+
+    Optional<String> getName();
+
+    Optional<String> getVersion();
+
+    Map<String, String> getLabels();
+
+    Map<String, String> getAnnotations();
+
+    Map<String, EnvConfig> getEnvVars();
+
+    Optional<String> getWorkingDir();
+
+    Optional<List<String>> getCommand();
+
+    Optional<List<String>> getArguments();
+
+    Optional<String> getServiceAccount();
+
+    Optional<String> getHost();
+
+    Map<String, PortConfig> getPorts();
+
+    ServiceType getServiceType();
+
+    ImagePullPolicy getImagePullPolicy();
+
+    Optional<List<String>> getImagePullSecrets();
+
+    Optional<ProbeConfig> getLivenessProbe();
+
+    Optional<ProbeConfig> getReadinessProbe();
+
+    Map<String, MountConfig> getMounts();
+
+    Map<String, SecretVolumeConfig> getSecretVolumes();
+
+    Map<String, ConfigMapVolumeConfig> getConfigMapVolumes();
+
+    Map<String, GitRepoVolumeConfig> getGitRepoVolumes();
+
+    Map<String, PvcVolumeConfig> getPvcVolumes();
+
+    Map<String, AwsElasticBlockStoreVolumeConfig> getAwsElasticBlockStoreVolumes();
+
+    Map<String, AzureFileVolumeConfig> getAzureFileVolumes();
+
+    Map<String, AzureDiskVolumeConfig> getAzureDiskVolumes();
+
+    Map<String, ContainerConfig> getInitContainers();
+
+    Map<String, ContainerConfig> getContainers();
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConfig.java
@@ -1,0 +1,39 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.dekorate.kubernetes.annotation.Protocol;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class PortConfig {
+
+    /**
+     * The port number. Refers to the container port.
+     */
+    @ConfigItem
+    Optional<Integer> containerPort;
+
+    /**
+     * The host port.
+     */
+    @ConfigItem
+    Optional<Integer> hostPort;
+
+    /**
+     * The application path (refers to web application path).
+     *
+     * @return The path, defaults to /.
+     */
+    @ConfigItem(defaultValue = "/")
+    Optional<String> path;
+
+    /**
+     * The protocol.
+     */
+    @ConfigItem(defaultValue = "TCP")
+    Protocol protocol;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PortConverter.java
@@ -1,0 +1,22 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.Port;
+import io.dekorate.kubernetes.config.PortBuilder;
+
+public class PortConverter {
+
+    public static Port convert(Map.Entry<String, PortConfig> e) {
+        return convert(e.getValue()).withName(e.getKey()).build();
+    }
+
+    private static PortBuilder convert(PortConfig port) {
+        PortBuilder b = new PortBuilder();
+        port.path.ifPresent(v -> b.withPath(v));
+        port.hostPort.ifPresent(v -> b.withHostPort(v));
+        port.containerPort.ifPresent(v -> b.withContainerPort(v));
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
@@ -1,0 +1,66 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ProbeConfig {
+
+    /**
+     * The http path to use for the probe For this to work, the container port also
+     * needs to be set
+     *
+     * Assuming the container port has been set (as per above comment), if
+     * execAction or tcpSocketAction are not set, an http probe will be used
+     * automatically even if no path is set (which will result in the root path
+     * being used)
+     */
+    @ConfigItem
+    Optional<String> httpActionPath;
+
+    /**
+     * The command to use for the probe.
+     */
+    @ConfigItem
+    Optional<String> execAction;
+
+    /**
+     * The tcp socket to use for the probe (the format is host:port).
+     */
+    @ConfigItem
+    Optional<String> tcpSocketAction;
+
+    /**
+     * The amount of time to wait in seconds before starting to probe.
+     */
+    @ConfigItem(defaultValue = "0")
+    Integer initialDelaySeconds;
+
+    /**
+     * The period in which the action should be called.
+     */
+    @ConfigItem(defaultValue = "30")
+    Integer periodSeconds;
+
+    /**
+     * The amount of time to wait for each action.
+     */
+    @ConfigItem(defaultValue = "10")
+    Integer timeoutSeconds;
+
+    /**
+     * The success threshold to use.
+     */
+    @ConfigItem(defaultValue = "1")
+    Integer successThreshold;
+
+    /**
+     * The failure threshold to use.
+     */
+    @ConfigItem(defaultValue = "3")
+    Integer failureThreshold;
+
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.config.Probe;
+import io.dekorate.kubernetes.config.ProbeBuilder;
+
+public class ProbeConverter {
+
+    public static Probe convert(ProbeConfig probe) {
+        ProbeBuilder b = new ProbeBuilder();
+        probe.httpActionPath.ifPresent(v -> b.withHttpActionPath(v));
+        probe.execAction.ifPresent(v -> b.withExecAction(v));
+        probe.tcpSocketAction.ifPresent(v -> b.withTcpSocketAction(v));
+        b.withInitialDelaySeconds(probe.initialDelaySeconds);
+        b.withPeriodSeconds(probe.periodSeconds);
+        b.withTimeoutSeconds(probe.timeoutSeconds);
+        b.withSuccessThreshold(probe.successThreshold);
+        b.withFailureThreshold(probe.failureThreshold);
+        return b.build();
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PvcVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PvcVolumeConfig.java
@@ -1,0 +1,29 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class PvcVolumeConfig {
+
+    /**
+     * The name of the claim to mount.
+     */
+    @ConfigItem
+    String claimName;
+
+    /**
+     * Default mode.
+     *
+     * @return The default mode.
+     */
+    @ConfigItem(defaultValue = "0600")
+    Integer defaultMode;
+
+    /**
+     * Optional
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean optional;
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PvcVolumeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/PvcVolumeConverter.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.PersistentVolumeClaimVolume;
+import io.dekorate.kubernetes.config.PersistentVolumeClaimVolumeBuilder;
+
+public class PvcVolumeConverter {
+
+    public static PersistentVolumeClaimVolume convert(Map.Entry<String, PvcVolumeConfig> e) {
+        return convert(e.getValue()).withVolumeName(e.getKey()).build();
+    }
+
+    public static PersistentVolumeClaimVolumeBuilder convert(PvcVolumeConfig c) {
+        PersistentVolumeClaimVolumeBuilder b = new PersistentVolumeClaimVolumeBuilder();
+        b.withClaimName(c.claimName);
+        b.withReadOnly(c.optional);
+        return b;
+    }
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
@@ -1,0 +1,25 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+
+public class SecretVolumeConfig {
+
+    /**
+     * The name of the secret to mount.
+     */
+    String secretName;
+
+    /**
+     * Default mode.
+     *
+     * @return The default mode.
+     */
+    @ConfigItem(defaultValue = "0600")
+    Integer defaultMode;
+
+    /**
+     * Optional
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean optional;
+}

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConverter.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConverter.java
@@ -1,0 +1,21 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.config.SecretVolume;
+import io.dekorate.kubernetes.config.SecretVolumeBuilder;
+
+public class SecretVolumeConverter {
+
+    public static SecretVolume convert(Map.Entry<String, SecretVolumeConfig> e) {
+        return convert(e.getValue()).withVolumeName(e.getKey()).build();
+    }
+
+    public static SecretVolumeBuilder convert(SecretVolumeConfig c) {
+        SecretVolumeBuilder b = new SecretVolumeBuilder();
+        b.withSecretName(c.secretName);
+        b.withDefaultMode(c.defaultMode);
+        b.withOptional(c.optional);
+        return b;
+    }
+}

--- a/integration-tests/kubernetes/invoker/src/it/openshift-s2i-build-and-deploy/src/main/resources/application.properties
+++ b/integration-tests/kubernetes/invoker/src/it/openshift-s2i-build-and-deploy/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 # Configuration file
 # key = value
-kubernetes.deployment.target=openshift
+quarkus.kubernetes.deployment-target=openshift
 quarkus.kubernetes-client.trust-certs=true

--- a/integration-tests/kubernetes/src/it/openshift-s2i-build-and-deploy/src/main/resources/application.properties
+++ b/integration-tests/kubernetes/src/it/openshift-s2i-build-and-deploy/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 # Configuration file
 # key = value
-kubernetes.deployment.target=openshift
+quarkus.kubernetes.deployment.target=openshift
 quarkus.kubernetes-client.trust-certs=true

--- a/integration-tests/kubernetes/standard/src/test/resources/knative.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/knative.properties
@@ -1,2 +1,2 @@
 # Configuration file
-kubernetes.deployment.target=knative
+quarkus.kubernetes.deployment-target=knative

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-application.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-application.properties
@@ -1,8 +1,6 @@
 quarkus.http.port=9090
-kubernetes.name=test-it
-kubernetes.labels[0].key=foo
-kubernetes.labels[0].value=bar
-kubernetes.env-vars[0].name=MY_ENV_VAR
-kubernetes.env-vars[0].value=SOMEVALUE
-kubernetes.group=grp
-docker.registry=quay.io
+quarkus.kubernetes.name=test-it
+quarkus.kubernetes.labels.foo=bar
+quarkus.kubernetes.env-vars.my-env-var.value=SOMEVALUE
+quarkus.container-image.group=grp
+quarkus.container-image.registry=quay.io

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-quarkus-app-name.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-quarkus-app-name.properties
@@ -1,11 +1,11 @@
 quarkus.application.name=test
-kubernetes.deployment.target=kubernetes,openshift
-kubernetes.name=foo
-kubernetes.group=bar
-kubernetes.version=1.0-kube
+quarkus.kubernetes.deployment-target=kubernetes,openshift
+quarkus.kubernetes.name=foo
+quarkus.kubernetes.group=bar
+quarkus.kubernetes.version=1.0-kube
 
-openshift.name=ofoo
-openshift.group=obar
-openshift.version=1.0-openshift
+quarkus.openshift.name=ofoo
+quarkus.openshift.group=obar
+quarkus.openshift.version=1.0-openshift
 
-s2i.name=s2ifoo
+quarkus.s2i.name=s2ifoo

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-sys-group.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-sys-group.properties
@@ -1,1 +1,1 @@
-kubernetes.group=grp
+quarkus.kubernetes.group=grp

--- a/integration-tests/kubernetes/standard/src/test/resources/openshift-with-application.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/openshift-with-application.properties
@@ -1,9 +1,7 @@
 quarkus.http.port=9090
-kubernetes.deployment.target=openshift
-openshift.name=test-it
-openshift.labels[0].key=foo
-openshift.labels[0].value=bar
-openshift.env-vars[0].name=MY_ENV_VAR
-openshift.env-vars[0].value=SOMEVALUE
-openshift.group=grp
-s2i.registry=quay.io
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.name=test-it
+quarkus.openshift.labels.foo=bar
+quarkus.openshift.env-vars.my-env-var.value=SOMEVALUE
+quarkus.openshift.group=grp
+quarkus.s2i.registry=quay.io

--- a/integration-tests/kubernetes/standard/src/test/resources/openshift.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/openshift.properties
@@ -1,1 +1,1 @@
-kubernetes.deployment.target=openshift
+quarkus.kubernetes.deployment-target=openshift


### PR DESCRIPTION
This pull request adds the `quarkus.` prefix to kubernetes related properties.
For backwards compatibility it still supports the prefix-less properties.

The change is also applied in the docs & tests.