### PR TITLE
Align naming in container-image & kubernetes extensions

### DIFF
--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -67,11 +67,11 @@ The creation of such objects is being taken care of by the Quarkus kubernetes ex
 
 == Building
 
-To build a container image for your project, you just need to specify `quarkus.container-image.execution=build` either to the `application.properties` or as a system property.
+To build a container image for your project, you just need to specify `quarkus.container-image.build=true` either to the `application.properties` or as a system property.
 
 [source, subs=attributes+]
 ----
-mvn clean package -Dquarkus.container-image.execution=build
+mvn clean package -Dquarkus.container-image.build=true
 ----
 
 Setting the environment variable `QUARKUS_CONTAINER_IMAGE_EXECUTION` to `build` can be used instead of the system propery.

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -18,7 +18,6 @@ import java.util.function.Function;
 import org.jboss.logging.Logger;
 
 import io.quarkus.container.image.deployment.ContainerImageConfig;
-import io.quarkus.container.image.deployment.ContainerImageConfig.Execution;
 import io.quarkus.container.image.deployment.util.ImageUtil;
 import io.quarkus.container.image.deployment.util.NativeBinaryUtil;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
@@ -53,7 +52,8 @@ public class DockerProcessor {
             // used to ensure that the jar has been built
             JarBuildItem jar) {
 
-        if (containerImageConfig.execution == Execution.NONE && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
+                && !pushRequest.isPresent()) {
             return;
         }
 
@@ -81,7 +81,8 @@ public class DockerProcessor {
             // used to ensure that the native binary has been built
             NativeImageBuildItem nativeImage) {
 
-        if (containerImageConfig.execution == Execution.NONE && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
+                && !pushRequest.isPresent()) {
             return;
         }
 
@@ -113,7 +114,7 @@ public class DockerProcessor {
             throw dockerException(buildArgs);
         }
 
-        if (pushRequested || containerImageConfig.execution == ContainerImageConfig.Execution.PUSH) {
+        if (pushRequested || containerImageConfig.push) {
             // Check if we need to login first
             if (containerImageConfig.username.isPresent() && containerImageConfig.password.isPresent()) {
                 boolean loginSuccessful = ExecUtil.exec("docker", "-u", containerImageConfig.username.get(),

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -32,7 +32,6 @@ import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
 
 import io.quarkus.bootstrap.util.ZipUtils;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
-import io.quarkus.container.image.deployment.ContainerImageConfig.Execution;
 import io.quarkus.container.image.deployment.util.NativeBinaryUtil;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
@@ -65,7 +64,8 @@ public class JibProcessor {
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,
             BuildProducer<ContainerImageResultBuildItem> containerImageResultProducer) {
 
-        if (containerImageConfig.execution == Execution.NONE && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
+                && !pushRequest.isPresent()) {
             return;
         }
 
@@ -91,7 +91,8 @@ public class JibProcessor {
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,
             BuildProducer<ContainerImageResultBuildItem> containerImageResultProducer) {
 
-        if (containerImageConfig.execution == Execution.NONE && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
+                && !pushRequest.isPresent()) {
             return;
         }
 
@@ -118,7 +119,7 @@ public class JibProcessor {
             log.info("Starting container image build");
             JibContainer container = jibContainerBuilder.containerize(containerizer);
             log.infof("%s container image %s (%s)\n",
-                    containerImageConfig.execution == ContainerImageConfig.Execution.PUSH ? "Pushed" : "Created",
+                    containerImageConfig.push ? "Pushed" : "Created",
                     container.getTargetImage(),
                     container.getDigest());
             return container;
@@ -132,7 +133,7 @@ public class JibProcessor {
         Containerizer containerizer;
         ImageReference imageReference = getImageReference(containerImageConfig, applicationInfo);
 
-        if (pushRequested || containerImageConfig.execution == ContainerImageConfig.Execution.PUSH) {
+        if (pushRequested || containerImageConfig.push) {
             CredentialRetrieverFactory credentialRetrieverFactory = CredentialRetrieverFactory.forImage(imageReference,
                     log::info);
             RegistryImage registryImage = RegistryImage.named(imageReference);

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -30,7 +30,6 @@ import io.dekorate.utils.Packaging;
 import io.dekorate.utils.Serialization;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
-import io.quarkus.container.image.deployment.ContainerImageConfig.Execution;
 import io.quarkus.container.image.deployment.util.ImageUtil;
 import io.quarkus.container.spi.BaseImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
@@ -110,7 +109,8 @@ public class S2iProcessor {
             // used to ensure that the jar has been built
             JarBuildItem jar) {
 
-        if (containerImageConfig.execution == Execution.NONE && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
+                && !pushRequest.isPresent()) {
             return;
         }
 
@@ -146,7 +146,8 @@ public class S2iProcessor {
             BuildProducer<ContainerImageResultBuildItem> containerImageResultProducer,
             NativeImageBuildItem nativeImageBuildItem) {
 
-        if (containerImageConfig.execution == Execution.NONE && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
+                && !pushRequest.isPresent()) {
             return;
         }
 

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
@@ -51,22 +51,14 @@ public class ContainerImageConfig {
     public boolean insecure;
 
     /**
-     * Controls what kind of execution is needed.
-     * <ul>
-     * <li>{@link io.quarkus.container.image.deployment.ContainerImageConfig.Execution#NONE} means that no container image will
-     * be created</li>
-     * <li>{@link io.quarkus.container.image.deployment.ContainerImageConfig.Execution#BUILD} will result in a container image
-     * being created locally</li>
-     * <li>{@link io.quarkus.container.image.deployment.ContainerImageConfig.Execution#PUSH} will result in a container image
-     * being pushed to the specified registry</li>
-     * </ul>
+     * Whether or not a image build will be performed.
      */
-    @ConfigItem(defaultValue = "none")
-    public Execution execution;
+    @ConfigItem(defaultValue = "false")
+    public boolean build;
 
-    public enum Execution {
-        NONE,
-        BUILD,
-        PUSH
-    }
+    /**
+     * Whether or not an image push will be performed.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean push;
 }

--- a/integration-tests/container-image/src/it/container-build-docker/invoker.properties
+++ b/integration-tests/container-image/src/it/container-build-docker/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=clean package -Dquarkus.container-image.execution=build
+invoker.goals=clean package -Dquarkus.container-image.build=true

--- a/integration-tests/container-image/src/it/container-build-jib/invoker.properties
+++ b/integration-tests/container-image/src/it/container-build-jib/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=clean package -Dquarkus.container-image.execution=build
+invoker.goals=clean package -Dquarkus.container-image.build=true


### PR DESCRIPTION
Trigger property for `build` & `push` feel very different to the `deploy` trigger.
This pull request changes the way `build` and `push` are triggered so that naming is more consistent across related extensions.