### PR TITLE
Document how to protect routes in Quarkus

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -319,6 +319,12 @@ If you want to disable this behavior and map resources on-demand, you can use th
 quarkus.keycloak.policy-enforcer.lazy-load-paths=true
 ----
 
+== More About Configuring Protected Resources 
+
+In the default configuration, Keycloak is responsible for managing the roles and deciding who can access which routes. 
+
+To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the link:security-openid-connect[Using OpenID Connect Adapter to Protect JAX-RS Applications] guide. For more details, check the link:security[Security guide].
+
 == References
 
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]


### PR DESCRIPTION
Fix #7240

This adds a short section to the [Keycloak tutorial](https://quarkus.io/guides/security-keycloak-authorization) about optionally protecting routes with the Quarkus `application.properties` file. It mostly just links to other excellent Quarkus tutorials.