### PR TITLE
refactor: KubernetesDeploy no longer uses kubectl.

### DIFF
--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
@@ -1,11 +1,17 @@
 package io.quarkus.kubernetes.client.runtime;
 
+import java.time.Duration;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 public class KubernetesClientUtils {
+
+    private static final String PREFIX = "quarkus.kubernetes-client.";
 
     public static Config createConfig(KubernetesClientBuildConfig buildConfig) {
         Config base = new Config();
@@ -38,5 +44,48 @@ public class KubernetesClientUtils {
 
     public static KubernetesClient createClient(KubernetesClientBuildConfig buildConfig) {
         return new DefaultKubernetesClient(createConfig(buildConfig));
+    }
+
+    public static KubernetesClient createClient() {
+        org.eclipse.microprofile.config.Config config = ConfigProvider.getConfig();
+        Config base = new Config();
+        return new DefaultKubernetesClient(new ConfigBuilder()
+                .withTrustCerts(config.getOptionalValue(PREFIX + "trust-certs", Boolean.class).orElse(base.isTrustCerts()))
+                .withWatchReconnectLimit(config.getOptionalValue(PREFIX + "watch-reconnect-limit", Integer.class)
+                        .orElse(base.getWatchReconnectLimit()))
+                .withWatchReconnectInterval((int) config.getOptionalValue(PREFIX + "watch-reconnect-interval", Duration.class)
+                        .orElse(Duration.ofMillis(base.getWatchReconnectInterval())).toMillis())
+                .withConnectionTimeout((int) config.getOptionalValue(PREFIX + "connection-timeout", Duration.class)
+                        .orElse(Duration.ofMillis(base.getConnectionTimeout())).toMillis())
+                .withRequestTimeout((int) config.getOptionalValue(PREFIX + "request-timeout", Duration.class)
+                        .orElse(Duration.ofMillis(base.getRequestTimeout())).toMillis())
+                .withRollingTimeout((int) config.getOptionalValue(PREFIX + "rolling-timeout", Duration.class)
+                        .orElse(Duration.ofMillis(base.getRollingTimeout())).toMillis())
+                .withMasterUrl(config.getOptionalValue(PREFIX + "master-url", String.class).orElse(base.getMasterUrl()))
+                .withNamespace(config.getOptionalValue(PREFIX + "namespace", String.class).orElse(base.getNamespace()))
+                .withUsername(config.getOptionalValue(PREFIX + "username", String.class).orElse(base.getUsername()))
+                .withPassword(config.getOptionalValue(PREFIX + "password", String.class).orElse(base.getPassword()))
+                .withCaCertFile(config.getOptionalValue(PREFIX + "ca-cert-file", String.class).orElse(base.getCaCertFile()))
+                .withCaCertData(config.getOptionalValue(PREFIX + "ca-cert-data", String.class).orElse(base.getCaCertData()))
+                .withClientCertFile(
+                        config.getOptionalValue(PREFIX + "client-cert-file", String.class).orElse(base.getClientCertFile()))
+                .withClientCertData(
+                        config.getOptionalValue(PREFIX + "client-cert-data", String.class).orElse(base.getClientCertData()))
+                .withClientKeyFile(
+                        config.getOptionalValue(PREFIX + "client-key-file", String.class).orElse(base.getClientKeyFile()))
+                .withClientKeyData(
+                        config.getOptionalValue(PREFIX + "client-key-data", String.class).orElse(base.getClientKeyData()))
+                .withClientKeyPassphrase(config.getOptionalValue(PREFIX + "client-key-passphrase", String.class)
+                        .orElse(base.getClientKeyPassphrase()))
+                .withClientKeyAlgo(
+                        config.getOptionalValue(PREFIX + "client-key-algo", String.class).orElse(base.getClientKeyAlgo()))
+                .withHttpProxy(config.getOptionalValue(PREFIX + "http-proxy", String.class).orElse(base.getHttpProxy()))
+                .withHttpsProxy(config.getOptionalValue(PREFIX + "https-proxy", String.class).orElse(base.getHttpsProxy()))
+                .withProxyUsername(
+                        config.getOptionalValue(PREFIX + "proxy-username", String.class).orElse(base.getProxyUsername()))
+                .withProxyPassword(
+                        config.getOptionalValue(PREFIX + "proxy-password", String.class).orElse(base.getProxyPassword()))
+                .withNoProxy(config.getOptionalValue(PREFIX + "no-proxy", String[].class).orElse(base.getNoProxy()))
+                .build());
     }
 }

--- a/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
+++ b/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
@@ -3,36 +3,20 @@ package io.quarkus.kubernetes.deployment;
 
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOY;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
-import io.quarkus.container.image.deployment.ContainerImageConfig;
-import io.quarkus.deployment.util.ExecUtil;
+import io.fabric8.kubernetes.api.model.RootPaths;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.kubernetes.client.runtime.KubernetesClientUtils;
 
 public class KubernetesDeploy implements BooleanSupplier {
 
     private final Logger LOGGER = Logger.getLogger(KubernetesDeploy.class);
     private static boolean serverFound = false;
-
-    private KubernetesConfig kubernetesConfig;
-    private ContainerImageConfig containerImageConfig;
-
-    KubernetesDeploy(ContainerImageConfig containerImageConfig, KubernetesConfig kubernetesConfig) {
-        this.containerImageConfig = containerImageConfig;
-        this.kubernetesConfig = kubernetesConfig;
-    }
 
     @Override
     public boolean getAsBoolean() {
@@ -41,70 +25,19 @@ public class KubernetesDeploy implements BooleanSupplier {
             return false;
         }
 
-        //No need to perform the check multiple times.
+        // No need to perform the check multiple times.
         if (serverFound) {
             return true;
         }
-        OutputFilter filter = new OutputFilter();
+        final KubernetesClient client = KubernetesClientUtils.createClient();
         try {
-            if (kubernetesConfig.getDeploymentTarget().contains(DeploymentTarget.OPENSHIFT)) {
-                if (ExecUtil.exec(new File("."), filter, "oc", "version")) {
-                    Optional<String> version = getServerVersionFromOc(filter.getLines());
-                    version.ifPresent(v -> LOGGER.info("Found Kubernetes version:" + v));
-                    serverFound = true;
-                    return true;
-                }
-            }
-            if (ExecUtil.exec(new File("."), filter, "kubectl", "version")) {
-                Optional<String> version = getServerVersionFromKubectl(filter.getLines());
-                version.ifPresent(v -> LOGGER.info("Found Kubernetes version:" + v));
-                serverFound = true;
-                return true;
-            }
+            //Let's check id we can connect.
+            RootPaths paths = client.rootPaths();
+            LOGGER.info("Found kubernetes server.");
+            serverFound = true;
+            return true;
         } catch (Exception e) {
             return false;
-        }
-        return false;
-    }
-
-    private static Optional<String> getServerVersionFromOc(List<String> lines) {
-        return lines.stream()
-                .filter(l -> l.startsWith("kubernetes"))
-                .map(l -> l.split(" "))
-                .filter(a -> a.length > 2)
-                .map(a -> a[1])
-                .findFirst();
-    }
-
-    private static Optional<String> getServerVersionFromKubectl(List<String> lines) {
-        return lines.stream()
-                .filter(l -> l.startsWith("Server Version"))
-                .map(l -> l.split("\""))
-                .filter(a -> a.length > 5)
-                .map(a -> a[5])
-                .findFirst();
-    }
-
-    private static class OutputFilter implements Function<InputStream, Runnable> {
-        private final List<String> list = new ArrayList();
-
-        @Override
-        public Runnable apply(InputStream is) {
-            return () -> {
-                try (InputStreamReader isr = new InputStreamReader(is);
-                        BufferedReader reader = new BufferedReader(isr)) {
-
-                    for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-                        list.add(line);
-                    }
-                } catch (IOException e) {
-                    throw new RuntimeException("Error reading stream.", e);
-                }
-            };
-        }
-
-        public List<String> getLines() {
-            return list;
         }
     }
 }


### PR DESCRIPTION
This pull request uses the java kuberentes-client instead of `kubectl` / `oc` in KubernetesDeploy.