### PR TITLE
S2i improvements

### DIFF
--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.container.image.s2i.deployment;
 
+import java.time.Duration;
 import java.util.List;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -49,6 +50,12 @@ public class S2iConfig {
      */
     @ConfigItem(defaultValue = "/home/quarkus/application")
     public String nativeBinaryPath;
+
+    /**
+     * The build timeout.
+     */
+    @ConfigItem(defaultValue = "PT5M")
+    Duration buildTimeout;
 
     /**
      * Check if baseJvmImage is the default

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
@@ -41,7 +41,7 @@ public class S2iConfig {
      * The path to where the jar is added during the assemble phase.
      * This is dependant on the s2i image and should be supplied if a non default image is used.
      */
-    @ConfigItem(defaultValue = "/deployments/${quarkus.application.name}-${quarkus.application.version:1.0.0-for-tests}-runner.jar")
+    @ConfigItem(defaultValue = "/deployments/application${quarkus.package.runner-suffix}.jar")
     public String jarPath;
 
     /**

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -130,8 +130,16 @@ public class S2iProcessor {
 
         Path artifactPath = out.getOutputDirectory()
                 .resolve(String.format(JAR_ARTIFACT_FORMAT, out.getBaseName(), packageConfig.runnerSuffix));
+        Path applicationJarPath = out.getOutputDirectory()
+                .resolve(String.format(JAR_ARTIFACT_FORMAT, "application", packageConfig.runnerSuffix));
 
-        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), artifactPath,
+        try {
+            Files.copy(artifactPath, applicationJarPath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            throw new RuntimeException("Error preparing the s2i build archive.", e);
+        }
+
+        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), applicationJarPath,
                 out.getOutputDirectory().resolve("lib"));
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "jar-container", Collections.emptyMap()));
         containerImageResultProducer.produce(
@@ -168,8 +176,16 @@ public class S2iProcessor {
 
         Path artifactPath = out.getOutputDirectory()
                 .resolve(String.format(NATIVE_ARTIFACT_FORMAT, out.getBaseName(), packageConfig.runnerSuffix));
+        Path applicationImagePath = out.getOutputDirectory()
+                .resolve(String.format(NATIVE_ARTIFACT_FORMAT, "application", packageConfig.runnerSuffix));
 
-        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), artifactPath);
+        try {
+            Files.copy(artifactPath, applicationImagePath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            throw new RuntimeException("Error preparing the s2i build archive.", e);
+        }
+
+        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), applicationImagePath);
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container", Collections.emptyMap()));
         containerImageResultProducer.produce(
                 new ContainerImageResultBuildItem(null, ImageUtil.getRepository(image), ImageUtil.getTag(image)));

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -4,8 +4,10 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,6 +22,7 @@ import io.dekorate.deps.kubernetes.api.model.HasMetadata;
 import io.dekorate.deps.kubernetes.api.model.KubernetesList;
 import io.dekorate.deps.kubernetes.api.model.Secret;
 import io.dekorate.deps.kubernetes.client.KubernetesClient;
+import io.dekorate.deps.okhttp3.internal.http2.StreamResetException;
 import io.dekorate.deps.openshift.api.model.Build;
 import io.dekorate.deps.openshift.api.model.BuildConfig;
 import io.dekorate.deps.openshift.api.model.ImageStream;
@@ -48,6 +51,7 @@ import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.deployment.util.ExecUtil;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesCommandBuildItem;
 
@@ -177,7 +181,16 @@ public class S2iProcessor {
             Path output,
             Path... additional) {
 
-        File tar = Packaging.packageFile(output, additional);
+        File tar;
+        try {
+            File original = Packaging.packageFile(output, additional);
+            //Let's rename the archive and give it a more descriptive name, as it may appear in the logs.
+            tar = Files.createTempFile("quarkus-", "-s2i").toFile();
+            Files.move(original.toPath(), tar.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            throw new RuntimeException("Error creating the s2i binary build archive.", e);
+        }
+
         KubernetesClient client = Clients.fromConfig(kubernetesClient.getClient().getConfiguration());
         KubernetesList kubernetesList = Serialization
                 .unmarshalAsList(new ByteArrayInputStream(openshiftManifests.getData()));
@@ -230,15 +243,30 @@ public class S2iProcessor {
      * @param binaryFile The binary file.
      */
     private static void s2iBuild(OpenShiftClient client, BuildConfig buildConfig, File binaryFile, S2iConfig s2iConfig) {
-        Build build = client.buildConfigs().withName(buildConfig.getMetadata().getName()).instantiateBinary()
-                .withTimeoutInMillis(s2iConfig.buildTimeout.toMillis()).fromFile(binaryFile);
+        Build build;
+        try {
+            build = client.buildConfigs().withName(buildConfig.getMetadata().getName()).instantiateBinary()
+                    .withTimeoutInMillis(s2iConfig.buildTimeout.toMillis()).fromFile(binaryFile);
+        } catch (Exception e) {
+            if (e.getCause() instanceof StreamResetException) {
+                LOG.warn("Stream was reset while building. Falling back to building with the 'oc' binary.");
+                if (!ExecUtil.exec("oc", "start-build", buildConfig.getMetadata().getName(), "--from-archive",
+                        binaryFile.toPath().toAbsolutePath().toString())) {
+                    throw s2iException(e);
+                }
+                return;
+            } else {
+                throw s2iException(e);
+            }
+        }
+
         try (BufferedReader reader = new BufferedReader(
                 client.builds().withName(build.getMetadata().getName()).getLogReader())) {
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                 System.out.println(line);
             }
         } catch (IOException e) {
-            s2iException(e);
+            throw s2iException(e);
         }
     }
 


### PR DESCRIPTION
This pull request adds a few tiny improvements:

1. make build timeout configurable
2. use a better name for the build archive (it may appear in the logs and docker-xxxx is misleading).
3. Fallback to `oc` binary  builds when java client hits stream reset errors.