### PR TITLE
Resolve Gradle's project's classes dir in case the JAR isn't availablable

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -15,7 +15,6 @@ import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
-import io.quarkus.bootstrap.resolver.AppModelResolverException;
 
 public class QuarkusBuild extends QuarkusTask {
 
@@ -54,13 +53,9 @@ public class QuarkusBuild extends QuarkusTask {
         getLogger().lifecycle("building quarkus runner");
 
         final AppArtifact appArtifact = extension().getAppArtifact();
+        appArtifact.setPath(extension().appJarOrClasses());
         final AppModelResolver modelResolver = extension().getAppModelResolver();
-        try {
-            // this needs to be done otherwise the app artifact doesn't get a proper path
-            modelResolver.resolveModel(appArtifact);
-        } catch (AppModelResolverException e) {
-            throw new GradleException("Failed to resolve application model " + appArtifact + " dependencies", e);
-        }
+
         final Properties realProperties = getBuildSystemProperties(appArtifact);
 
         boolean clear = false;

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
@@ -1,19 +1,80 @@
 package io.quarkus.gradle.tasks;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.AbstractTask;
+import org.gradle.api.tasks.SourceSet;
 
 import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.util.IoUtils;
 
 public class QuarkusGradleUtils {
 
-    public static Path serializeAppModel(final AppModel appModel) throws IOException {
-        final Path serializedModel = Files.createTempFile("quarkus-", "-gradle-test");
+    private static final String ERROR_COLLECTING_PROJECT_CLASSES = "Failed to collect project's classes in a temporary dir";
+
+    public static Path serializeAppModel(final AppModel appModel, AbstractTask context) throws IOException {
+        final Path serializedModel = context.getTemporaryDir().toPath().resolve("quarkus-app-model.dat");
         try (ObjectOutputStream out = new ObjectOutputStream(Files.newOutputStream(serializedModel))) {
             out.writeObject(appModel);
         }
         return serializedModel;
+    }
+
+    public static String getClassesDir(SourceSet sourceSet, AbstractTask context) {
+        final Set<String> sourcePaths = new HashSet<>();
+        for (File sourceDir : sourceSet.getAllJava().getSrcDirs()) {
+            sourcePaths.add(sourceDir.getAbsolutePath());
+        }
+
+        FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();
+        Set<File> classDirFiles = classesDirs.getFiles();
+        if (classDirFiles.size() == 1) {
+            return classesDirs.getAsPath();
+        }
+
+        Path classesDir = null;
+        final Iterator<File> i = classDirFiles.iterator();
+        int dirCount = 0;
+        while (i.hasNext()) {
+            final File next = i.next();
+            if (!next.exists()) {
+                continue;
+            }
+            try {
+                switch (dirCount++) {
+                    case 0:
+                        classesDir = next.toPath();
+                        break;
+                    case 1:
+                        //there does not seem to be any sane way of dealing with multiple output dirs, as there does not seem
+                        //to be a way to map them. We will need to address this at some point, but for now we just stick them
+                        //all in a temp dir
+                        final Path tmpClassesDir = context.getTemporaryDir().toPath().resolve("quarkus-app-classes");
+                        if (Files.exists(tmpClassesDir)) {
+                            IoUtils.recursiveDelete(tmpClassesDir);
+                        }
+                        IoUtils.copy(classesDir, tmpClassesDir);
+                        classesDir = tmpClassesDir;
+                    default:
+                        IoUtils.copy(next.toPath(), classesDir);
+
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(ERROR_COLLECTING_PROJECT_CLASSES, e);
+            }
+        }
+        if (classesDir == null) {
+            throw new IllegalStateException("Failed to locate classes directory in the project");
+        }
+        return classesDir.toString();
     }
 }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusTestConfig.java
@@ -27,7 +27,7 @@ public class QuarkusTestConfig extends QuarkusTask {
                     .toAbsolutePath()
                     .toString();
 
-            final Path serializedModel = QuarkusGradleUtils.serializeAppModel(deploymentDeps);
+            final Path serializedModel = QuarkusGradleUtils.serializeAppModel(deploymentDeps, this);
 
             for (Test test : getProject().getTasks().withType(Test.class)) {
                 final Map<String, Object> props = test.getSystemProperties();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
@@ -22,6 +22,7 @@ public class DirectoryClassPathElement extends AbstractClassPathElement {
     private final Path root;
 
     public DirectoryClassPathElement(Path root) {
+        assert root != null : "root is null";
         this.root = root;
     }
 
@@ -101,5 +102,10 @@ public class DirectoryClassPathElement extends AbstractClassPathElement {
     @Override
     public void close() throws IOException {
         //noop
+    }
+
+    @Override
+    public String toString() {
+        return root.toAbsolutePath().toString();
     }
 }


### PR DESCRIPTION
This is another way of fixing what #7353 is meant to fix.
It looks like the NPE during the serialization of the model happens only for the application's main module. The rest of the modules appear to be properly resolved as their classes dirs.
This PR resolves the classes dir of the main module the same way we do it in `quarkusDev`.

Fixes #7290
Fixes #7357