### PR TITLE
Update Swagger-ui to 3.25.0

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-reactive-streams-operators.version>1.0.10</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.10</smallrye-converter-api.version>
         <smallrye-reactive-messaging.version>1.1.0</smallrye-reactive-messaging.version>
-        <swagger-ui.version>3.24.3</swagger-ui.version>
+        <swagger-ui.version>3.25.0</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>


### PR DESCRIPTION
I tested this change locally using the `openapi-swaggerui-quickstart` project.

Works as expected.
![image](https://user-images.githubusercontent.com/1223135/75183238-65775980-5742-11ea-8ab4-3ee0b22c7fef.png)
