### PR TITLE
Remove wrong and unused dependency from the bom

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2219,21 +2219,6 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-mutiny-generator</artifactId>
-                <version>${mutiny-client.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-mutiny-vertx-core</artifactId>
                 <version>${mutiny-client.version}</version>
                 <exclusions>


### PR DESCRIPTION
@michalszynkiewicz found that yesterday. The BOM was defining a dependency on a non-existing artifact. I introduced that bug during the introduction of Mutiny. As the dependency was not used, it never attempted to resolve it (which would have failed).

This PR just removes the dependency. 