### PR TITLE
Adds Maven cheats

### DIFF
--- a/devtools/cheat/maven-quarkus
+++ b/devtools/cheat/maven-quarkus
@@ -1,0 +1,37 @@
+---
+tags: [quarkus]
+---
+
+# To generate a project
+mvn io.quarkus:quarkus-maven-plugin:<version>.Final:create \
+    -DprojectGroupId=<groupId> \
+    -DprojectArtifactId=<artifactId> \
+    -DprojectVersion=<version> \
+    -DclassName="<resource>"
+
+# List extensions
+mvn quarkus:list-extensions
+
+# Add extension
+mvn quarkus:add-extension -Dextensions="<extension-name>, <extension-name>"
+
+# Development mode
+mvn compile quarkus:dev
+
+# Building a native executable
+mvn package -Pnative
+
+# Building a container friendly executable
+mvn package -Dnative -Dquarkus.native.container-build=true
+
+# UberJAR
+mvn package -Dquarkus.package.uber-jar=true
+
+# Create a container image
+# With any of the quarkus-container-image-jib, quarkus-container-image-docker, quarkus-container-image-s2i installed.
+mvn package -Dquarkus.container-image.build=true \
+            -Dquarkus.container-image.push=true \
+            -Dquarkus.container-image.registry=<registry_hostname>
+
+# Deploy to Kubernetes
+mvn package -Dquarkus.kubernetes.deploy=true


### PR DESCRIPTION
Hello, recently I have found this project (https://github.com/cheat/cheat) which is really interesting as it helps in creating `man` like pages but really easy and not only supports CLI but also snippets. The description of the project says: "cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember."

I created a cheat for Maven Quarkus options, you can see the record in the next link: https://asciinema.org/a/304529

If you like the idea, I would create one in the same PR for Gradle and also create a doc about how to install cheat (it is written in Go so easy to install, how to install the Quarkus cheats and of course I will create an issue to have everything linked.

Then in the future, we can always improve with more cheats like quarkus-metrics, quarkus-logging, quarkus-panache, ...

WDYT?