### PR TITLE
enable support for AMQP in the quarkus-artemis-test module

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -157,6 +157,7 @@
         <mongo-reactivestreams-client.version>1.13.0</mongo-reactivestreams-client.version>
         <mongo-crypt.version>1.0.0</mongo-crypt.version>
         <artemis.version>2.11.0</artemis.version>
+        <proton-j.version>0.33.2</proton-j.version>
         <okhttp.version>3.14.6</okhttp.version>
         <sentry.version>1.7.28</sentry.version>
         <!-- Used for integration tests, to make sure webjars work-->
@@ -1459,6 +1460,16 @@
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-server</artifactId>
                 <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-amqp-protocol</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.qpid</groupId>
+                <artifactId>proton-j</artifactId>
+                <version>${proton-j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/test-framework/artemis/pom.xml
+++ b/test-framework/artemis/pom.xml
@@ -42,6 +42,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-amqp-protocol</artifactId>
+            <exclusions>
+                <exclusion>
+                   <groupId>org.apache.activemq</groupId>
+                   <artifactId>artemis-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
As discussed on Zulip, there is a quarkus-test-artemis module at test-framework/artemis/pom.xml for using an embedded Artemis broker in testing, but it only supports the brokers Core protocol. This PR adds the brokers AMQP protocol module also, allowing existing extensions using AMQP to utilise quarkus-test-artemis without having to do this themselves more awkwardly.