### PR TITLE
Prevent redirect loops and support a cookie path parameter

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -269,6 +269,13 @@ public class OidcTenantConfig {
         @ConfigItem
         public Map<String, String> extraParams;
 
+        /**
+         * Cookie path parameter value which, if set, will be used for the session and state cookies.
+         * It may need to be set when the redirect path has a root different to that of the original request URL.
+         */
+        @ConfigItem
+        public Optional<String> cookiePath = Optional.empty();
+
         public Optional<String> getRedirectPath() {
             return redirectPath;
         }
@@ -299,6 +306,14 @@ public class OidcTenantConfig {
 
         public void setRestorePathAfterRedirect(boolean restorePathAfterRedirect) {
             this.restorePathAfterRedirect = restorePathAfterRedirect;
+        }
+
+        public Optional<String> getCookiePath() {
+            return cookiePath;
+        }
+
+        public void setCookiePath(Optional<String> cookiePath) {
+            this.cookiePath = cookiePath;
         }
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationCompletionException.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AuthenticationCompletionException.java
@@ -1,0 +1,26 @@
+package io.quarkus.vertx.http.runtime.security;
+
+/**
+ * Exception indicating that a user authentication flow has not been completed and no further challenge is required.
+ * For example, it is used to avoid the redirect loops during an OIDC authorization code flow after the user has
+ * already authenticated at the IDP site but the redirect back to Quarkus has the invalid state parameter or cookie
+ * or if the code flow can not be completed.
+ */
+public class AuthenticationCompletionException extends RuntimeException {
+
+    public AuthenticationCompletionException() {
+
+    }
+
+    public AuthenticationCompletionException(String errorMessage) {
+        this(errorMessage, null);
+    }
+
+    public AuthenticationCompletionException(Throwable cause) {
+        this(null, cause);
+    }
+
+    public AuthenticationCompletionException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -48,6 +48,9 @@ public class HttpSecurityRecorder {
                                         event.response().end();
                                     }
                                 });
+                            } else if (throwable instanceof AuthenticationCompletionException) {
+                                event.response().setStatusCode(401);
+                                event.response().end();
                             } else if (throwable instanceof AuthenticationRedirectException) {
                                 AuthenticationRedirectException redirectEx = (AuthenticationRedirectException) throwable;
                                 event.response().setStatusCode(redirectEx.getCode());

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.keycloak;
 
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import io.quarkus.oidc.TenantResolver;
@@ -10,6 +12,12 @@ public class CustomTenantResolver implements TenantResolver {
 
     @Override
     public String resolve(RoutingContext context) {
-        return context.request().path().contains("callback-") ? "tenant-1" : null;
+        List<String> tenantId = context.queryParam("tenantId");
+        if (!tenantId.isEmpty()) {
+            return tenantId.get(0).isEmpty() ? null : tenantId.get(0);
+        }
+
+        String path = context.request().path();
+        return path.contains("callback-") ? "tenant-1" : path.contains("/web-app2") ? "tenant-2" : null;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource2.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource2.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.security.Authenticated;
+
+@Path("/web-app2")
+@Authenticated
+public class ProtectedResource2 {
+
+    @Inject
+    @IdToken
+    JsonWebToken idToken;
+
+    @GET
+    public String getName() {
+        return "web-app2:" + idToken.getName();
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -18,6 +18,25 @@ quarkus.oidc.tenant-1.authentication.redirect-path=/web-app/callback-after-redir
 quarkus.oidc.tenant-1.authentication.restore-path-after-redirect=false
 quarkus.oidc.tenant-1.application-type=web-app
 
+# Tenant which does not need to restore a request path after redirect with a different redirect path root
+quarkus.oidc.tenant-2.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-2.client-id=quarkus-app
+quarkus.oidc.tenant-2.credentials.secret=secret
+quarkus.oidc.tenant-2.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-2.authentication.redirect-path=/web-app2
+quarkus.oidc.tenant-2.authentication.restore-path-after-redirect=false
+quarkus.oidc.tenant-2.authentication.cookie-path=/
+quarkus.oidc.tenant-2.application-type=web-app
+
+# Tenant which is only used to test that the failed token request will not cause a redirect loop.
+quarkus.oidc.tenant-3.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-3.client-id=quarkus-app
+quarkus.oidc.tenant-3.credentials.secret=secret
+quarkus.oidc.tenant-3.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-3.authentication.redirect-path=/some/other/path
+quarkus.oidc.tenant-3.authentication.restore-path-after-redirect=false
+quarkus.oidc.tenant-3.application-type=web-app
+
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated
 

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URI;
@@ -11,6 +12,7 @@ import java.net.URI;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebRequest;
@@ -153,6 +155,72 @@ public class CodeFlowTest {
             // HtmlUnit logs that a 'q_auth' cookie path parameter 'path' is set to 'path:/web-app'.
             // If really needed we can get the session and state cookie properties configurable.
             // assertNull(getStateCookie(webClient));
+        }
+    }
+
+    @Test
+    public void testIdTokenInjectionWithoutRestoredPathDifferentRoot() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/callback-before-redirect?tenantId=tenant-2");
+            assertNotNull(getStateCookieStateParam(webClient));
+            assertNull(getStateCookieSavedPath(webClient));
+
+            assertEquals("Log in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("web-app2:alice", page.getBody().asText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testAuthenticationCompletionFailedNoStateCookie() throws IOException, InterruptedException {
+        // tenant-3 configuration uses a '/some/other/path' redirect parameter which does not have the same root
+        // as the original request which is 'web-app', as a result, when the user is returned back to Quarkus
+        // to '/some/other/path' no state cookie is detected.
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/callback-before-redirect?tenantId=tenant-3");
+            assertEquals("Log in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            try {
+                loginForm.getInputByName("login").click();
+                fail("401 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+            }
+        }
+    }
+
+    @Test
+    public void testAuthenticationCompletionFailedWrongRedirectUri() throws IOException, InterruptedException {
+        // CustomTenantResolver will return null for an empty tenantId which will lead to the default configuration
+        // being used and result in '/web-app/callback-before-redirect' be used as an initial redirect_uri parameter.
+        // When the user is redirected back, CustomTenantResolver will resolve a 'tenant-1' configuration with
+        // a redirect_uri '/web-app/callback-after-redirect' which will cause a code to token exchange failure
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/callback-before-redirect?tenantId");
+            assertEquals("Log in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            try {
+                page = loginForm.getInputByName("login").click();
+                fail("401 status error is expected: " + page.getBody().asText());
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+            }
         }
     }
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -13,7 +13,6 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
         if ("tenant-d".equals(context.request().path().split("/")[2])) {
             OidcTenantConfig config = new OidcTenantConfig();
             config.setTenantId("tenant-id");
-            ;
             config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-d");
             config.setClientId("quarkus-d");
             OidcTenantConfig.Credentials credentials = new OidcTenantConfig.Credentials();


### PR DESCRIPTION
Fixes #6802.

This PR makes the following changes:
- Introduces `AuthenticationCompletionException` to avoid a confusing redirect loop in all the cases when, after the user has already authenticated at the IDP site, the last phase of the authentication flow fails. Two main cases are: missing the state cookie or a code to token exchange failure due to the redirect_uri mismatch. Both of these cases are tested and the log warnings are issued. (I was thinking for a moment to avoid introducing a new exception and instead set a routing context flag and then react to it in the challenge method but decided that having an exception was cleaner)
 
In fact, with the last case (code to token exchange) I've managed, in a weird way, before the fix, to have a test application method successfully invoked despite a code grant failure (multi-tenancy case where after the tenant specific failure a redirect loop has started and a default configuration was picked up). Which is a **major security issue** and has to be fixed before the users will start stressing the multi-tenancy with 1.3.0.

- `cookie-path` property is added and tested to address the case where the `redirect-path` has a root different that of the original request URL which would otherwise cause a redirect loop (before the fix) or `401` with a fix due to a missing state cookie

- Updated `DefaultTenantConfigResolver` to log a debug message when `TenantResolver` returns a non-empty `tenantId` and no matching tenant configuration has been found; I've spent a lot of time figuring out the test issues after I've mistyped `tenant-3` as `tenant3`. I've actually wanted to throw an exception but it might be too forceful for the truly dynamic situations tested in the `oidc-tenancy` (Single ConcurrentHashMap is an alternative but it feels it is not too bad having the dedicated static and dynamic maps)

- Updated `DefaultTenantConfigResolver` to keep `TenantConfigContext`s created with the help from `TenantConfigResolver` in its own map to avoid a possible thread safety issue (one thread gets `TenantConfigResolver` statically created at the startup, another one puts a new `TenantConfigContext`) and updated a lock to minimize a possible contention too.