### PR TITLE
Add code example for java 11 native dockerfile to native-and-ssl guide

### DIFF
--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -203,6 +203,7 @@ When working with containers, the idea is to bundle both the SunEC library and t
 
 You can for example modify your `Dockerfile.native` as follows to copy the required files to your final image:
 
+==== Java 8
 [source, subs=attributes+]
 ----
 FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version}-java8 as nativebuilder
@@ -214,7 +215,24 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY --from=nativebuilder /tmp/ssl-libs/ /work/
 COPY target/*-runner /work/application
-RUN chmod 775 /work
+RUN chmod 775 /work /work/application
+EXPOSE 8080
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Djava.library.path=/work/lib", "-Djavax.net.ssl.trustStore=/work/cacerts"]
+----
+
+==== Java 11
+[source, subs=attributes+]
+----
+FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-version}-java11 as nativebuilder
+RUN mkdir -p /tmp/ssl-libs/lib \
+  && cp /opt/graalvm/lib/security/cacerts /tmp/ssl-libs \
+  && cp /opt/graalvm/lib/libsunec.so /tmp/ssl-libs/lib/
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /work/
+COPY --from=nativebuilder /tmp/ssl-libs/ /work/
+COPY target/*-runner /work/application
+RUN chmod 775 /work /work/application
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Djava.library.path=/work/lib", "-Djavax.net.ssl.trustStore=/work/cacerts"]
 ----


### PR DESCRIPTION
In the Java 11 GraalVM image, the location of cacerts and libsunec.so is different. I added a code sample showing the paths to be used if Java 11 is used.