### PR TITLE
Avoid having to load ResteasyContextProvider class

### DIFF
--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.context.ResteasyContextProvider;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
@@ -41,7 +40,7 @@ class SmallRyeContextPropagationProcessor {
         List<ContextManagerExtension> discoveredExtensions = new ArrayList<>();
         for (Class<?> provider : ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
                 "META-INF/services/" + ThreadContextProvider.class.getName())) {
-            if (provider.equals(ResteasyContextProvider.class)) {
+            if (provider.getName().equals("org.jboss.resteasy.context.ResteasyContextProvider")) {
                 try {
                     Class.forName("org.jboss.resteasy.core.ResteasyContext", false,
                             Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
Reasteasy Context Propagation may not be in the classpath, so the previous code led to ClassNotFound error.