### PR TITLE
Gradle: prefer local deps as JARs when building runnable JARs

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/BasicMultiModuleTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/BasicMultiModuleTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class BasicMultiModuleTest extends QuarkusGradleTestBase {
+
+    @Test
+    public void testBasicMultiModuleBuild() throws Exception {
+
+        final File projectDir = getProjectDir("basic-multi-module-project");
+        
+        BuildResult build = GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments(arguments(":application:quarkusBuild"))
+                .withProjectDir(projectDir)
+                .build();
+        
+        final Path commonLibs = projectDir.toPath().resolve("common").resolve("build").resolve("libs");
+        assertThat(commonLibs).exists();
+        assertThat(commonLibs.resolve("common.jar")).exists();
+        
+        final Path applicationLib = projectDir.toPath().resolve("application").resolve("build").resolve("lib");
+        assertThat(applicationLib).exists();
+        assertThat(applicationLib.resolve("quarkus-basic-multi-module-build.common.jar")).exists();
+    }
+}

--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/QuarkusGradleTestBase.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/QuarkusGradleTestBase.java
@@ -1,0 +1,72 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+public class QuarkusGradleTestBase {
+
+    protected File getProjectDir(final String projectName) throws URISyntaxException, IOException, FileNotFoundException {
+        final URL projectUrl = Thread.currentThread().getContextClassLoader().getResource(projectName);
+        if(projectUrl == null) {
+            throw new IllegalStateException("Failed to locate test project " + projectName);
+        }
+        final File projectDir = new File(projectUrl.toURI());
+        if(!projectDir.isDirectory()) {
+            throw new IllegalStateException(projectDir + " is not a directory");
+        }
+
+        final File projectProps = new File(projectDir, "gradle.properties");
+        if(!projectProps.exists()) {
+            throw new IllegalStateException("Failed to locate " + projectProps);
+        }
+        final Properties props = new Properties();
+        try(InputStream is = new FileInputStream(projectProps)) {
+            props.load(is);
+        }
+        final String quarkusVersion = getQuarkusVersion();
+        props.setProperty("quarkusPlatformVersion", quarkusVersion);
+        props.setProperty("quarkusPluginVersion", quarkusVersion);
+        try(OutputStream os = new FileOutputStream(projectProps)) {
+            props.store(os, "Quarkus Gradle TS");
+        }
+        return projectDir;
+    }
+
+    protected String getQuarkusVersion() throws IOException {
+        final Path curDir = Paths.get("").toAbsolutePath().normalize();
+        final Path gradlePropsFile = curDir.resolve("gradle.properties");
+        Properties props = new Properties();
+        try(InputStream is = Files.newInputStream(gradlePropsFile)) {
+            props.load(is);
+        }
+        final String quarkusVersion = props.getProperty("version");
+        if(quarkusVersion == null) {
+            throw new IllegalStateException("Failed to locate Quarkus version in " + gradlePropsFile);
+        }
+        return quarkusVersion;
+    }
+
+    protected List<String> arguments(String... argument) {
+        List<String> arguments = new ArrayList<>();
+        arguments.addAll(Arrays.asList(argument));
+        String mavenRepoLocal = System.getProperty("maven.repo.local", System.getenv("MAVEN_LOCAL_REPO"));
+        if (mavenRepoLocal != null) {
+            arguments.add("-Dmaven.repo.local=" + mavenRepoLocal);
+        }
+        return arguments;
+    }
+}

--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
@@ -24,7 +24,7 @@ import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.generators.BuildTool;
 import io.quarkus.generators.SourceType;
 
-public class QuarkusPluginFunctionalTest {
+public class QuarkusPluginFunctionalTest extends QuarkusGradleTestBase {
 
     private File projectRoot;
 
@@ -63,16 +63,6 @@ public class QuarkusPluginFunctionalTest {
         assertThat(build.task(":build").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         // gradle build should not build the native image
         assertThat(build.task(":buildNative")).isNull();
-    }
-
-    private List<String> arguments(String... argument) {
-        List<String> arguments = new ArrayList<>();
-        arguments.addAll(Arrays.asList(argument));
-        String mavenRepoLocal = System.getProperty("maven.repo.local", System.getenv("MAVEN_LOCAL_REPO"));
-        if (mavenRepoLocal != null) {
-            arguments.add("-Dmaven.repo.local=" + mavenRepoLocal);
-        }
-        return arguments;
     }
 
     private void createProject(SourceType sourceType) throws IOException {

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'io.quarkus'
+}
+
+dependencies {
+    implementation project(":common")
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,22 @@
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.acme.common.CommonBean;
+
+@Path("/hello")
+public class HelloResource {
+
+    @Inject
+    CommonBean common;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello " + common.getName();
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>my-quarkus-project - 1.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme.quarkus.sample</li>
+                <li>ArtifactId: my-quarkus-project</li>
+                <li>Version: 1.0-SNAPSHOT</li>
+                <li>Quarkus Version: 999-SNAPSHOT</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/src/main/resources/application.properties
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/application/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/build.gradle
@@ -1,0 +1,50 @@
+buildscript {
+
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+}
+
+apply plugin: 'java'
+
+group = 'com.quarkus.demo'
+version = '1.0'
+
+
+subprojects {
+
+    apply plugin: 'java'
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    test {
+        dependsOn 'cleanTest'
+        dependsOn 'quarkusTestConfig'
+        useJUnitPlatform()
+        forkEvery 1
+    }
+
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+
+        implementation 'io.quarkus:quarkus-resteasy'
+
+        testImplementation 'io.quarkus:quarkus-junit5'
+        testImplementation 'io.rest-assured:rest-assured'
+
+        implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/common/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/common/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'io.quarkus'
+    id 'java-library'
+}
+
+dependencies {
+
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/common/src/main/java/org/acme/common/CommonBean.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/common/src/main/java/org/acme/common/CommonBean.java
@@ -1,0 +1,11 @@
+package org.acme.common;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class CommonBean {
+
+   public String getName() {
+       return "common";
+   }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/common/src/main/resources/META-INF/beans.xml
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/common/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+                      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+        bean-discovery-mode="all">
+
+</beans>

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/gradle.properties
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/settings.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-multi-module-project/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name = 'quarkus-basic-multi-module-build'
+
+include ':common'
+include ':application'
+

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -19,6 +20,7 @@ import java.util.Set;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
@@ -52,11 +54,13 @@ public class AppModelGradleResolver implements AppModelResolver {
     private AppModel appModel;
 
     private final Project project;
-    private final LaunchMode mode;
+    private final LaunchMode launchMode;
+    private final Map<AppArtifactKey, Task> projectDepJarTasks;
 
-    public AppModelGradleResolver(Project project, LaunchMode mode) {
+    public AppModelGradleResolver(Project project, LaunchMode mode, Map<AppArtifactKey, Task> projectDepJarTasks) {
         this.project = project;
-        this.mode = mode;
+        this.launchMode = mode;
+        this.projectDepJarTasks = projectDepJarTasks;
     }
 
     @Override
@@ -139,7 +143,7 @@ public class AppModelGradleResolver implements AppModelResolver {
         collectDependencies(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, appBuilder, directExtensionDeps, userDeps,
                 versionMap,
                 userModules);
-        if (mode == LaunchMode.TEST) {
+        if (launchMode == LaunchMode.TEST) {
             collectDependencies(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, appBuilder, directExtensionDeps, userDeps,
                     versionMap, userModules);
         }
@@ -213,27 +217,49 @@ public class AppModelGradleResolver implements AppModelResolver {
             if (!isDependency(a)) {
                 continue;
             }
-            final File f = a.getFile();
             userModules.put(getModuleId(a), a.getModuleVersion().getId());
-            AppDependency dependency = toAppDependency(a);
+
+            final AppDependency dependency = toAppDependency(a);
+            final AppArtifactKey artifactGa = new AppArtifactKey(dependency.getArtifact().getGroupId(),
+                    dependency.getArtifact().getArtifactId());
+
+            // If we are building a JAR then we should be including dependencies as JARs, not directories of classes
+            final Task jarTask = !LaunchMode.NORMAL.equals(launchMode) ? null : projectDepJarTasks.get(artifactGa);
+            if (jarTask != null) {
+                final Iterator<File> i = jarTask.getOutputs().getFiles().iterator();
+                if (!i.hasNext()) {
+                    project.getLogger()
+                            .warn("The jar task of " + artifactGa + " contains no output, falling back to classes dir "
+                                    + a.getFile());
+                } else {
+                    final Path jarPath = i.next().toPath();
+                    if (i.hasNext()) {
+                        project.getLogger().warn("The jar task of " + artifactGa
+                                + " produced more than one JAR which is not currently supported, falling back to classes dir "
+                                + a.getFile());
+                    } else {
+                        dependency.getArtifact().setPath(jarPath);
+                    }
+                }
+            }
+
             userDeps.add(dependency);
             versionMap
                     .put(new AppArtifactKey(dependency.getArtifact().getGroupId(), dependency.getArtifact().getArtifactId(),
                             dependency.getArtifact().getClassifier()), dependency);
 
             final Dependency dep;
-            if (f.isDirectory()) {
-                dep = processQuarkusDir(a, f.toPath().resolve(BootstrapConstants.META_INF), appBuilder);
+            final Path artifactPath = dependency.getArtifact().getPath();
+            if (Files.isDirectory(artifactPath)) {
+                dep = processQuarkusDir(a, artifactPath.resolve(BootstrapConstants.META_INF), appBuilder);
             } else {
-                try (FileSystem artifactFs = FileSystems.newFileSystem(f.toPath(), null)) {
+                try (FileSystem artifactFs = FileSystems.newFileSystem(artifactPath, null)) {
                     dep = processQuarkusDir(a, artifactFs.getPath(BootstrapConstants.META_INF), appBuilder);
                 } catch (IOException e) {
-                    throw new GradleException("Failed to process " + f, e);
+                    throw new GradleException("Failed to process " + artifactPath, e);
                 }
             }
-            if (dep != null &&
-                    directDeps.contains(new AppArtifactKey(dependency.getArtifact().getGroupId(),
-                            dependency.getArtifact().getArtifactId()))) {
+            if (dep != null && directDeps.contains(artifactGa)) {
                 directExtensionDeps.add(dep);
             }
         }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPluginExtension.java
@@ -3,9 +3,12 @@ package io.quarkus.gradle;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.plugins.Convention;
@@ -16,6 +19,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.tasks.Jar;
 
 import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.gradle.tasks.QuarkusGradleUtils;
 import io.quarkus.runtime.LaunchMode;
@@ -34,8 +38,14 @@ public class QuarkusPluginExtension {
 
     private File outputConfigDirectory;
 
+    private Map<AppArtifactKey, Task> projectDepJarTasks = new HashMap<>();
+
     public QuarkusPluginExtension(Project project) {
         this.project = project;
+    }
+
+    void addProjectDepJarTask(Project projectDep, Task jarTask) {
+        projectDepJarTasks.put(new AppArtifactKey(projectDep.getGroup().toString(), projectDep.getName()), jarTask);
     }
 
     public Path appJarOrClasses() {
@@ -141,7 +151,7 @@ public class QuarkusPluginExtension {
     }
 
     public AppModelResolver getAppModelResolver(LaunchMode mode) {
-        return new AppModelGradleResolver(project, mode);
+        return new AppModelGradleResolver(project, mode, projectDepJarTasks);
     }
 
     /**

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
@@ -6,7 +6,6 @@ import java.io.ObjectOutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -30,11 +29,6 @@ public class QuarkusGradleUtils {
     }
 
     public static String getClassesDir(SourceSet sourceSet, AbstractTask context) {
-        final Set<String> sourcePaths = new HashSet<>();
-        for (File sourceDir : sourceSet.getAllJava().getSrcDirs()) {
-            sourcePaths.add(sourceDir.getAbsolutePath());
-        }
-
         FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();
         Set<File> classDirFiles = classesDirs.getFiles();
         if (classDirFiles.size() == 1) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/model/AppArtifactKey.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/model/AppArtifactKey.java
@@ -173,12 +173,4 @@ public class AppArtifactKey implements Serializable {
         }
         return buf.toString();
     }
-
-    public static void main(String[] args) {
-        AppArtifactKey ga = fromString("g:a:c:t");
-        System.out.println(ga.getGroupId());
-        System.out.println(ga.getArtifactId());
-        System.out.println("'" + ga.getClassifier() + "'");
-        System.out.println(ga.getType());
-    }
 }


### PR DESCRIPTION
When building runnable JARs using Gradle, dependencies from the same project/workspace should be consumed as JARs, not as directories of classes

Fixes #7365 