### PR TITLE
feat: read only transactions

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -93,6 +93,7 @@ import io.quarkus.hibernate.orm.runtime.TransactionEntityManagers;
 import io.quarkus.hibernate.orm.runtime.boot.scan.QuarkusScanner;
 import io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect;
 import io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect;
+import io.quarkus.hibernate.orm.runtime.interceptors.ReadOnlyTransactionInterceptor;
 import io.quarkus.hibernate.orm.runtime.metrics.HibernateCounter;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.smallrye.metrics.deployment.spi.MetricBuildItem;
@@ -309,6 +310,8 @@ public final class HibernateOrmProcessor {
                 .addBeanClasses(JPAConfig.class, TransactionEntityManagers.class,
                         RequestScopedEntityManagerHolder.class)
                 .build());
+
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(ReadOnlyTransactionInterceptor.class));
 
         if (descriptors.size() == 1) {
             // There is only one persistence unit - register CDI beans for EM and EMF if no

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ReadOnlyTransactionTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ReadOnlyTransactionTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.hibernate.orm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.transaction.Transactional;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.enhancer.Address;
+import io.quarkus.narayana.jta.runtime.TransactionConfiguration;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ReadOnlyTransactionTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(Address.class)
+                    .addAsResource("application.properties"));
+
+    @Inject
+    EntityManager entityManager;
+
+    @BeforeEach
+    @Transactional
+    void init() {
+        Address adr = new Address();
+        adr.setStreet("rue de Paris");
+        entityManager.persist(adr);
+        entityManager.flush();
+    }
+
+    @AfterEach
+    @Transactional
+    void destroy() {
+        int deleted = entityManager.createQuery("delete from Address where street = 'rue de Paris'").executeUpdate();
+        assertEquals(1, deleted);
+        entityManager.flush();
+    }
+
+    @Test
+    @Transactional
+    @TransactionConfiguration(readOnly = true)
+    public void testRO() {
+        TypedQuery<Address> query = entityManager.createQuery("from Address where street = 'rue de Paris'", Address.class);
+        Address result = query.getSingleResult();
+        assertNotNull(result);
+
+        Session session = entityManager.unwrap(Session.class);
+        assertTrue(session.isDefaultReadOnly());
+        assertEquals(FlushMode.MANUAL, session.getHibernateFlushMode());
+
+        assertThrows(Exception.class, () -> forceRO());
+    }
+
+    @Transactional
+    @TransactionConfiguration(readOnly = false)
+    public void forceRO() {
+        Address adr = new Address();
+        adr.setStreet("rue du paradis");
+        entityManager.persist(adr);
+        entityManager.flush();
+    }
+
+    @Test
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionConfiguration(readOnly = true)
+    public void testSubTransactions() {
+        TypedQuery<Address> query = entityManager.createQuery("from Address where street = 'rue de Paris'", Address.class);
+        Address result = query.getSingleResult();
+        assertNotNull(result);
+
+        System.out.println(entityManager);
+
+        Session session = entityManager.unwrap(Session.class);
+        assertTrue(session.isDefaultReadOnly());
+        assertEquals(FlushMode.MANUAL, session.getHibernateFlushMode());
+
+        // don't know what will happen here ...
+        newTransaction();
+    }
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionConfiguration(readOnly = false)
+    public void newTransaction() {
+        Session session = entityManager.unwrap(Session.class);
+        assertFalse(session.isDefaultReadOnly());
+        assertEquals(FlushMode.AUTO, session.getHibernateFlushMode());
+
+        Address adr = new Address();
+        adr.setStreet("rue du paradis");
+        entityManager.persist(adr);
+        entityManager.flush();
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/interceptors/ReadOnlyTransactionInterceptor.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/interceptors/ReadOnlyTransactionInterceptor.java
@@ -1,0 +1,42 @@
+package io.quarkus.hibernate.orm.runtime.interceptors;
+
+import java.io.Serializable;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+
+import io.quarkus.narayana.jta.runtime.TransactionConfiguration;
+
+@Interceptor
+@Transactional
+@TransactionConfiguration(readOnly = true)
+@Priority(Interceptor.Priority.PLATFORM_BEFORE + 250)
+public class ReadOnlyTransactionInterceptor implements Serializable {
+    @Inject
+    EntityManager entityManager;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        Session session = entityManager.unwrap(Session.class);
+        boolean previousReadOnly = session.isDefaultReadOnly();
+        FlushMode previousMode = session.getHibernateFlushMode();
+
+        session.setDefaultReadOnly(true);
+        session.setHibernateFlushMode(FlushMode.MANUAL);
+
+        try {
+            return ic.proceed();
+        } finally {
+            session.setDefaultReadOnly(previousReadOnly);
+            session.setFlushMode(previousMode);
+        }
+    }
+}

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/TransactionConfiguration.java
@@ -6,6 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.interceptor.InterceptorBinding;
+
 /**
  * This annotation can be used to configure a different transaction timeout than the default one for a method or a class.
  * <p>
@@ -15,6 +17,7 @@ import java.lang.annotation.Target;
  * The configuration defined on a method takes precedence over the configuration defined on a class.
  */
 @Inherited
+@InterceptorBinding
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface TransactionConfiguration {
@@ -31,4 +34,12 @@ public @interface TransactionConfiguration {
      * @return The transaction timeout in seconds.
      */
     int timeout() default UNSET_TIMEOUT;
+
+    /**
+     * Whether or not the transaction performs read only operations on the underlying transactional resource.
+     * Depending on the transactional resource, optimizations can be performed in case of read only transactions.
+     *
+     * @return true if read only.
+     */
+    boolean readOnly() default false;
 }

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -257,8 +257,8 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
     private void checkConfiguration(InvocationContext ic) {
         TransactionConfiguration configAnnotation = getTransactionConfiguration(ic);
-        if (configAnnotation != null && configAnnotation.timeout() != TransactionConfiguration.UNSET_TIMEOUT) {
-            throw new RuntimeException("Changing timeout via @TransactionConfiguration can only be done " +
+        if (configAnnotation != null) {
+            throw new RuntimeException("Changing timeout or readOnly via @TransactionConfiguration can only be done " +
                     "at the entry level of a transaction");
         }
     }


### PR DESCRIPTION
Fixes #6414

@FroMage @Sanne this is a prototype of read only transaction support.
It uses a CDI interceptor inside the Hibernate extension to set some optimization at the session level.

Please advise if it is the right way to do this.

I don't know if adding a CDI interceptor is OK, I don't know the tradeoff (preformance cost ?)