### PR TITLE
Upgrade Maven resolver related dependencies used by bootstrap

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -67,13 +67,13 @@
         <asm.version>7.3.1</asm.version>
         <commons-io.version>2.6</commons-io.version>
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
-        <maven-core.version>3.5.4</maven-core.version>
-        <maven-resolver.version>1.1.1</maven-resolver.version>
-        <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
+        <maven-core.version>3.6.3</maven-core.version>
+        <maven-resolver.version>1.4.1</maven-resolver.version>
+        <maven-toolchain.version>3.0.0</maven-toolchain.version>
         <guava.version>27.0.1-jre</guava.version>
-        <plexus-utils.version>3.0.24</plexus-utils.version>
-        <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
-        <plexus-component-annotations.version>1.7.1</plexus-component-annotations.version>
+        <plexus-utils.version>3.2.1</plexus-utils.version>
+        <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
+        <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
         <graal-sdk.version>19.3.1</graal-sdk.version>
         <gizmo.version>1.0.2.Final</gizmo.version>

--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -42,6 +42,10 @@
                     <groupId>javax.enterprise</groupId>
                     <artifactId>cdi-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-classworlds</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
+++ b/extensions/spring-di/deployment/src/main/java/io/quarkus/spring/di/deployment/SpringDIProcessor.java
@@ -265,7 +265,10 @@ public class SpringDIProcessor {
                 visitAnnotation(annotation, index, deps, visited, ret);
             }
         }
-        ret.add(index.getClassByName(clazz));
+        final ClassInfo classInfo = index.getClassByName(clazz);
+        if (classInfo != null) {
+            ret.add(classInfo);
+        }
     }
 
     /**

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
@@ -156,7 +156,6 @@ public class MavenRepoInitializer {
     }
 
     public static RepositorySystem getRepositorySystem(boolean offline, WorkspaceModelResolver wsModelResolver) {
-
         final DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
         if (!offline) {
             locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -27,10 +27,10 @@
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <junit.version>5.5.2</junit.version>
-        <maven-core.version>3.5.4</maven-core.version>
-        <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
-        <maven-resolver.version>1.1.1</maven-resolver.version>
-        <maven-wagon.version>3.0.0</maven-wagon.version>
+        <maven-core.version>3.6.3</maven-core.version>
+        <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
+        <maven-resolver.version>1.4.1</maven-resolver.version>
+        <maven-wagon.version>3.3.4</maven-wagon.version>
         <plexus-cypher.version>1.7</plexus-cypher.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
@@ -136,6 +136,10 @@
                         <groupId>javax.enterprise</groupId>
                         <artifactId>cdi-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-classworlds</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -169,6 +173,12 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-settings-builder</artifactId>
                 <version>${maven-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>

--- a/independent-projects/tools/common/pom.xml
+++ b/independent-projects/tools/common/pom.xml
@@ -51,6 +51,10 @@
                     <groupId>javax.inject</groupId>
                     <artifactId>javax.inject</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-classworlds</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/tcks/microprofile-opentracing/base/pom.xml
+++ b/tcks/microprofile-opentracing/base/pom.xml
@@ -142,6 +142,10 @@
                     <groupId>org.sonatype.plexus</groupId>
                     <artifactId>plexus-sec-dispatcher</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
 to those used by/compatible with Maven 3.6.3 release

Fixes #3539
Fixes #7458 