### PR TITLE
feat: don't display registry warning for s2i

### DIFF
--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
@@ -35,6 +35,18 @@ public final class ImageUtil {
         return sb.toString();
     }
 
+    /*
+     * Checks if the specified image has a registry part.
+     * 
+     * @param image the image
+     * 
+     * @return true if registry is part of the image, false otherwise
+     */
+    public static boolean hasRegistry(String image) {
+        String r = getRegistry(image);
+        return r != null && !r.isEmpty();
+    }
+
     /**
      * Return the registry part of the docker image.
      * 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployerPrerequisite.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployerPrerequisite.java
@@ -20,13 +20,6 @@ public class KubernetesDeployerPrerequisite {
         buildRequestProducer.produce(new ContainerImageBuildRequestBuildItem());
         if (containerImage.getRegistry().isPresent()) {
             pushRequestProducer.produce(new ContainerImagePushRequestBuildItem());
-        } else {
-            log.warn(
-                    "A Kubernetes deployment was requested, but the container image to be built will not be pushed to any registry"
-                            +
-                            " because \"quarkus.container-image.registry\" has not been set. The Kubernetes deployment will only work properly"
-                            +
-                            " if the cluster is using the local Docker daemon.");
         }
     }
 }


### PR DESCRIPTION
Currently we display a warning about docker registry being a requirement for `kubernetes ` deployment. 

This is not the case for s2i and we should not display such warning for s2i builds.