### PR TITLE
Bug report template - add build tool bullet to the environment list

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,6 +37,7 @@ Steps to reproduce the behavior:
  - Output of `java -version`: 
  - GraalVM version (if different from Java): 
  - Quarkus version or git rev: 
+ - Build tool (ie. output of `mvnw --version` or `gradlew --version`): 
 
 **Additional context**
 (Add any other context about the problem here.)


### PR DESCRIPTION
Recently, I've seen quite a lot of gradle-related issues. That's why I think it would make sense to instruct the users to add "build tool" info when reporting bugs. This can save some time and comments like "works fine with maven"...