### PR TITLE
Remove obsolete throws Exception from tests of quarkus-smallrye-jwt extension

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsUnitTest.java
@@ -40,10 +40,9 @@ public class DefaultGroupsUnitTest {
      * Validate a request with MP-JWT without a 'groups' claim is successful
      * due to the default value being provided in the configuration
      *
-     * @throws Exception
      */
     @Test
-    public void echoGroups() throws Exception {
+    public void echoGroups() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .get("/endp/echo").andReturn();

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtAuthUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtAuthUnitTest.java
@@ -62,10 +62,9 @@ public class JwtAuthUnitTest {
     /**
      * Verify that the injected token issuer claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyIssuerClaim() throws Exception {
+    public void verifyIssuerClaim() {
         Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtCookieUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtCookieUnitTest.java
@@ -39,10 +39,9 @@ public class JwtCookieUnitTest {
     /**
      * Validate a request with MP-JWT token in a Cookie header is successful
      *
-     * @throws Exception
      */
     @Test
-    public void echoGroups() throws Exception {
+    public void echoGroups() {
         io.restassured.response.Response response = RestAssured.given()
                 .header("Cookie", "cookie_a=" + token)
                 .get("/endp/echo").andReturn();

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PrimitiveInjectionUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PrimitiveInjectionUnitTest.java
@@ -23,7 +23,7 @@ import io.restassured.RestAssured;
  * Tests that claims can be injected as primitive types into @RequestScoped beans
  */
 public class PrimitiveInjectionUnitTest {
-    private static Class[] testClasses = {
+    private static Class<?>[] testClasses = {
             PrimitiveInjectionEndpoint.class,
             TokenUtils.class
     };
@@ -60,11 +60,9 @@ public class PrimitiveInjectionUnitTest {
 
     /**
      * Verify that the token issuer claim is as expected
-     *
-     * @throws Exception
      */
     @Test()
-    public void verifyIssuerClaim() throws Exception {
+    public void verifyIssuerClaim() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -81,11 +79,9 @@ public class PrimitiveInjectionUnitTest {
 
     /**
      * Verify that the injected raw token claim is as expected
-     *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedRawToken() throws Exception {
+    public void verifyInjectedRawToken() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -102,11 +98,9 @@ public class PrimitiveInjectionUnitTest {
 
     /**
      * Verify that the token jti claim is as expected
-     *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedJTI() throws Exception {
+    public void verifyInjectedJTI() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -123,11 +117,9 @@ public class PrimitiveInjectionUnitTest {
 
     /**
      * Verify that the token upn claim is as expected
-     *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedUPN() throws Exception {
+    public void verifyInjectedUPN() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -144,15 +136,13 @@ public class PrimitiveInjectionUnitTest {
 
     /**
      * Verify that the token aud claim is as expected
-     *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedAudience() throws Exception {
+    public void verifyInjectedAudience() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
-                .queryParam(Claims.aud.name(), new String[] { "s6BhdRkqt3" })
+                .queryParam(Claims.aud.name(), "s6BhdRkqt3")
                 .queryParam(Claims.auth_time.name(), authTimeClaim)
                 .get("/endp/verifyInjectedAudience").andReturn();
 
@@ -166,15 +156,13 @@ public class PrimitiveInjectionUnitTest {
     /**
      * Verify that the token aud claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedGroups() throws Exception {
+    public void verifyInjectedGroups() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
-                .queryParam(Claims.groups.name(), new String[] {
-                        "Echoer", "Tester", "group1", "group2" })
+                .queryParam(Claims.groups.name(), "Echoer", "Tester", "group1", "group2")
                 .queryParam(Claims.auth_time.name(), authTimeClaim)
                 .get("/endp/verifyInjectedGroups").andReturn();
 
@@ -188,10 +176,9 @@ public class PrimitiveInjectionUnitTest {
     /**
      * Verify that the token iat claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedIssuedAt() throws Exception {
+    public void verifyInjectedIssuedAt() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -209,10 +196,9 @@ public class PrimitiveInjectionUnitTest {
     /**
      * Verify that the token exp claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedExpiration() throws Exception {
+    public void verifyInjectedExpiration() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -230,10 +216,9 @@ public class PrimitiveInjectionUnitTest {
     /**
      * Verify that the token customString claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedCustomString() throws Exception {
+    public void verifyInjectedCustomString() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -251,10 +236,9 @@ public class PrimitiveInjectionUnitTest {
     /**
      * Verify that the token customString claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedCustomDouble() throws Exception {
+    public void verifyInjectedCustomDouble() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PrincipalInjectionUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PrincipalInjectionUnitTest.java
@@ -54,10 +54,9 @@ public class PrincipalInjectionUnitTest {
     /**
      * Verify that the injected authenticated principal is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyInjectedPrincipal() throws Exception {
+    public void verifyInjectedPrincipal() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RequiredClaimsUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RequiredClaimsUnitTest.java
@@ -58,10 +58,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token issuer claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyIssuerClaim() throws Exception {
+    public void verifyIssuerClaim() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -79,10 +78,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token sub claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifySubClaim() throws Exception {
+    public void verifySubClaim() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -101,10 +99,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token jti claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyJTI() throws Exception {
+    public void verifyJTI() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -123,10 +120,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token upn claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyUPN() throws Exception {
+    public void verifyUPN() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -145,10 +141,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token aud claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyAudience() throws Exception {
+    public void verifyAudience() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -167,10 +162,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token aud claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyAudience2() throws Exception {
+    public void verifyAudience2() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -189,10 +183,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token iat claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyIssuedAt() throws Exception {
+    public void verifyIssuedAt() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -211,10 +204,9 @@ public class RequiredClaimsUnitTest {
     /**
      * Verify that the token exp claim is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void verifyExpiration() throws Exception {
+    public void verifyExpiration() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RolesAllowedUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/RolesAllowedUnitTest.java
@@ -16,7 +16,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
 public class RolesAllowedUnitTest {
-    private static Class[] testClasses = {
+    private static Class<?>[] testClasses = {
             RolesEndpoint.class,
             TokenUtils.class
     };
@@ -93,10 +93,9 @@ public class RolesAllowedUnitTest {
     /**
      * Verify that the injected authenticated principal is as expected
      *
-     * @throws Exception
      */
     @Test()
-    public void callEchoBASIC() throws Exception {
+    public void callEchoBASIC() {
         Response response = RestAssured.given().auth()
                 .basic("jdoe@example.com", "password")
                 .when()
@@ -109,10 +108,9 @@ public class RolesAllowedUnitTest {
     /**
      * Validate a request with MP-JWT succeeds with HTTP_OK, and replies with hello, user={token upn claim}
      *
-     * @throws Exception
      */
     @Test()
-    public void callEcho() throws Exception {
+    public void callEcho() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -128,10 +126,9 @@ public class RolesAllowedUnitTest {
     /**
      * Validate a request with MP-JWT but no associated role fails with HTTP_FORBIDDEN
      *
-     * @throws Exception
      */
     @Test()
-    public void callEcho2() throws Exception {
+    public void callEcho2() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -146,10 +143,9 @@ public class RolesAllowedUnitTest {
     /**
      * Validate a request with MP-JWT is able to access checkIsUserInRole with HTTP_OK
      *
-     * @throws Exception
      */
     @Test()
-    public void checkIsUserInRole() throws Exception {
+    public void checkIsUserInRole() {
 
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
@@ -222,10 +218,9 @@ public class RolesAllowedUnitTest {
     /**
      * Validate a request with MP-JWT SecurityContext.getUserPrincipal() is a JsonWebToken
      *
-     * @throws Exception
      */
     @Test()
-    public void getPrincipalClass() throws Exception {
+    public void getPrincipalClass() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -241,10 +236,9 @@ public class RolesAllowedUnitTest {
      * This test requires that the server provide a mapping from the group1 grant in the token to a Group1MappedRole
      * application declared role.
      *
-     * @throws Exception
      */
     @Test()
-    public void testNeedsGroup1Mapping() throws Exception {
+    public void testNeedsGroup1Mapping() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()
@@ -258,10 +252,9 @@ public class RolesAllowedUnitTest {
     /**
      * Validate that accessing secured method has HTTP_OK and injected JsonWebToken principal
      *
-     * @throws Exception
      */
     @Test()
-    public void getInjectedPrincipal() throws Exception {
+    public void getInjectedPrincipal() {
         io.restassured.response.Response response = RestAssured.given().auth()
                 .oauth2(token)
                 .when()


### PR DESCRIPTION
As requested in #7485, I cut out the changes of fixing several warnings in the tests of the quarkus-smallrye-jwt extension.