### PR TITLE
Reduce log level and use JBoss logger

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -12,10 +12,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jboss.logging.Logger;
 import org.wildfly.common.cpu.ProcessorInfo;
 
 import io.netty.channel.EventLoopGroup;
@@ -135,7 +135,7 @@ public class VertxCoreRecorder {
     }
 
     private static Vertx logVertxInitialization(Vertx vertx) {
-        LOGGER.info(() -> String.format("Vertx has Native Transport Enabled: %s", vertx.isNativeTransportEnabled()));
+        LOGGER.debugf("Vertx has Native Transport Enabled: %s", vertx.isNativeTransportEnabled());
         return vertx;
     }
 


### PR DESCRIPTION
When using `master` branch of Quarkus, I have now started seeing this log message (at INFO level) everytime the application boots (like in dev mode):
```
2020-02-29 10:33:05,924 INFO  [io.qua.ver.cor.run.VertxCoreRecorder] (main) Vertx has Native Transport Enabled: false
```
I don't think this should be logged at `INFO`. 

The commit in this PR changes that log level to `DEBUG`. While doing so, I also noticed that this class was using `java.util.logging` instead of JBoss logger. So to be consistent with other code in Quarkus, I have updated the logger import too.