### PR TITLE
Quarkus recommended labels

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -142,7 +142,7 @@
         <awssdk.version>2.10.70</awssdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.61</kotlin.version>
-        <dekorate.version>0.10.11</dekorate.version>
+        <dekorate.version>0.11.2</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>

--- a/docs/src/main/asciidoc/kubernetes.adoc
+++ b/docs/src/main/asciidoc/kubernetes.adoc
@@ -35,7 +35,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
 cd kubernetes-quickstart
 ----
 
-=== Kubernetes
+== Kubernetes
 
 Quarkus offers the ability to automatically generate Kubernetes resources based on sane defaults and user supplied configuration. The implementation that takes care
 of generating the actual Kubernetes resources is provided by https://github.com/dekorateio/dekorate/[dekorate]. Currently it supports the generation of resources for
@@ -51,19 +51,8 @@ When we added the `kubernetes` extension to the command line invocation above, t
     </dependency>
 ----
 
-By adding this dependency, we now have the ability to configure the Kubernetes resource generation and application using the usual `application.properties` approach that Quarkus provides.
-The configuration items that are available can be found in: `io.quarkus.kubernetes.deployment.KubernetesConfig` class.
-Furthermore, the items provided by `io.quarkus.deployment.ApplicationConfig` affect the Kubernetes resources.
-
-By using the following configuration for example:
-
-[source]
-----
-quarkus.kubernetes.group=yourDockerUsername # this is optional and defaults to your username if not set.
-quarkus.application.name=test-quarkus-app # this is also optional and defaults to the project name if not set
-----
-
-and following the execution of `./mvnw package` you will notice amongst the other files that are created, two files named
+By adding this dependency, we enable the generation of Kubernetes manifests each time we perform a build.
+For example, following the execution of `./mvnw package` you will notice amongst the other files that are created, two files named
 `kubernetes.json` and `kubernetes.yml` in the `target/kubernetes/` directory.
 
 If you look at either file you will see that it contains both a Kubernetes `Deployment` and a `Service`.
@@ -73,16 +62,17 @@ The full source of the `kubernetes.json` file looks something like this:
 [source,json]
 ----
 {
-  "apiVersion" : "v1",
-  "kind" : "List",
-  "items" : [ {
+  {
     "apiVersion" : "apps/v1",
     "kind" : "Deployment",
     "metadata" : {
+      "annotations": {
+       "app.quarkus.io/vcs-url" : "<some url>",
+       "app.quarkus.io/commit-id" : "<some git SHA>",
+      },
       "labels" : {
-        "app" : "test-quarkus-app",
-        "version" : "1.0-SNAPSHOT",
-        "group" : "yourDockerUsername"
+        "app.kubernetes.io/name" : "test-quarkus-app",
+        "app.kubernetes.io/version" : "1.0-SNAPSHOT",
       },
       "name" : "test-quarkus-app"
     },
@@ -90,17 +80,15 @@ The full source of the `kubernetes.json` file looks something like this:
       "replicas" : 1,
       "selector" : {
         "matchLabels" : {
-          "app" : "test-quarkus-app",
-          "version" : "1.0-SNAPSHOT",
-          "group" : "yourDockerUsername"
+          "app.kubernetes.io/name" : "test-quarkus-app",
+          "app.kubernetes.io/version" : "1.0-SNAPSHOT",
         }
       },
       "template" : {
         "metadata" : {
           "labels" : {
-            "app" : "test-quarkus-app",
-            "version" : "1.0-SNAPSHOT",
-            "group" : "yourDockerUsername"
+            "app.kubernetes.io/name" : "test-quarkus-app",
+            "app.kubernetes.io/version" : "1.0-SNAPSHOT"
           }
         },
         "spec" : {
@@ -120,17 +108,204 @@ The full source of the `kubernetes.json` file looks something like this:
         }
       }
     }
-  } ]
+  },
+  {
+  "apiVersion" : "v1",
+  "kind" : "Service",
+    "metadata" : {
+      "annotations": {
+       "app.quarkus.io/vcs-url" : "<some url>",
+       "app.quarkus.io/commit-id" : "<some git SHA>",
+      },
+      "labels" : {
+        "app.kubernetes.io/name" : "test-quarkus-app",
+        "app.kubernetes.io/version" : "1.0-SNAPSHOT",
+      },
+      "name" : "test-quarkus-app"
+    },
+  "spec" : {
+    "ports" : [ {
+      "name" : "http",
+      "port" : 8080,
+      "targetPort" : 8080
+    } ],
+    "selector" : {
+      "app.kubernetes.io/name" : "test-quarkus-app",
+      "app.kubernetes.io/version" : "1.0-SNAPSHOT"
+    },
+    "type" : "ClusterIP"
+  }
+ }
 }
 ----
 
 An important thing to note about the `Deployment` is that is uses `yourDockerUsername/test-quarkus-app:1.0-SNAPSHOT` as the Docker image of the `Pod`.
+The name of the image is controlled by the container-image extension and can be customized using the usual `application.properties`.
 
-Also the `Service` is configured to use container port `8080` (which is automatically picked up by the standard Quarkus configuration).
+For example with a configuration like:
+
+[source]
+----
+quarkus.container-image.group=quarkus #optional, default to the system user name
+quarkus.container-image.name=demo-app #optional, defaults to the application name
+quarkus.container-image.tag=1.0       #optional, defaults to the application version
+----
+
+The image that will be used in the generated manifests will be `quarkus/demo-app:1.0`
+
+=== Defining a Docker registry
+
+The Docker registry can be specified with the following property:
+
+[source]
+----
+quarkus.container-image.registry=http://my.docker-registry.net
+----
+
+By adding this property along with the rest of the container-image properties of the previous section, the generated manifests will use the image `http://my.docker-registry.net/quarkus/demo-app:1.0`.
+
+
+The image is not the only thing that can be customized in the generated manifests. The kubernetes extension provides a rich set of configuration properties that allow customization.
+
+=== Labels and Annotations
+
+==== Labels
+
+The generated manifests use the Kubernetes link:https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels[recommended labels].
+These labels can be customized using `quarkus.kubernetes.name`, `quarkus.kubernetes.version` and `quarkus.kubernetes.part-of`.
+For example by adding the following configuration to your `application.properties`:
+
+[source]
+----
+quarkus.kubernetes.part-of=todo-app
+quarkus.kubernetes.name=todo-rest
+quarkus.kubernetes.version=1.0-rc.1
+----
+
+The generated generated resources will have the labels:
+
+[source, json]
+----
+  "labels" : {
+    "app.kubernetes.io/part-of" : "todo-app",
+    "app.kubernetes.io/name" : "todo-rest",
+    "app.kubernetes.io/version" : "1.0-rc.1"
+  }
+----
+
+==== Custom Labels
+
+To add additional custom labels, for example `foo=bar`:
+
+[source]
+----
+quarkus.kubernetes.labels.foo=bar
+----
+
+====  Annotations
+
+Out of the box, the generated resources will be annotated with version control related information that can be used either by tooling, or by the user for troubleshooting purposes.
+
+[source, json]
+----
+  "annotations": {
+    "app.quarkus.io/vcs-url" : "<some url>",
+    "app.quarkus.io/commit-id" : "<some git SHA>",
+   }
+----
+
+==== Custom Annotations
+
+Custom annotations can be added in a way similar to labels. For example to add the annotation `foo=bar`:
+
+
+[source]
+----
+quarkus.kubernetes.annotations.foo=bar
+----
+
+==== Environment variables
+
+Kubernetes provides multiple ways of defining environment variables:
+
+- key value pairs
+- from Secret
+- from ConfigMap
+- from fields
+
+To add a key value pair as an environment variable in the generated resources:
+
+[source]
+----
+quarkus.kubernetes.env-vars.my-env-var.value=foobar
+----
+
+The command above will add `MY_ENV_VAR=foobar` as an environment variable.
+Please note that the key `my-env-var` will be converted to uppercase and dashes will be replaced by underscores resulting in `MY_ENV_VAR`.
+
+You may also have noticed that in contrast to labels and annotations for environment variables you don't just use a `key=value` approach.
+That is because for environment variables there are additional options rather than just setting a value.
+
+===== Environment variables from Secret
+
+To add all key value pairs of a `Secret` as environment variables:
+
+[source]
+----
+quarkus.kubernetes.env-vars.my-env-var.secret=my-secret
+----
+
+===== Environment variables from ConfigMap
+
+To add all key value pairs of a `ConfigMap` as environment variables:
+
+[source]
+----
+quarkus.kubernetes.env-vars.my-env-var.configmap=my-secret
+----
+
+
+==== Mounting volumes
+
+The Kubernetes extension allows the user to configure both volumes and mounts for the application.
+
+Any volume can be mounted with a simple configuration:
+
+[source]
+----
+quarkus.kubernetes.mounts.my-volume.path=/where/to/mount
+----
+
+This will add a mount to my pod for volume `my-volume` to path `/where/to/mount`.
+
+The volumes themselves can be configured as shown in the sections below:
+
+===== Secret volumes
+
+[source]
+----
+quarkus.kubernetes.secret-volumes.my-volume.secret-name=my-secret
+----
+
+===== ConfigMap volumes
+
+[source]
+----
+quarkus.kubernetes.config-map-volumes.my-volume.config-map-name=my-secret
+----
+
+=== Changing the number of replicas:
+
+To change the number of replicas from 1 to 3:
+
+[source]
+----
+quarkus.kubernetes.replicas=3
+----
 
 === Add readiness and liveness probes
 
-By default the Kubernetes resources do not contain readiness and liveness probes in the generated `Deployment`. Adding them however is just a matter of adding the Smallrye Health extension like so:
+By default the Kubernetes resources do not contain readiness and liveness probes in the generated `Deployment`. Adding them however is just a matter of adding the SmallRye Health extension like so:
 
 [source,xml]
 ----
@@ -143,9 +318,20 @@ By default the Kubernetes resources do not contain readiness and liveness probes
 The values of the generated probes will be determined by the configured health properties: `quarkus.smallrye-health.root-path`, `quarkus.smallrye-health.liveness-path` and `quarkus.smallrye-health.readiness-path`.
 More information about the health extension can be found in the relevant link:microprofile-health[guide].
 
+=== Customizing the readiness probe:
+To set the initial delay of the probe to 20 seconds and the period to 45:
+
+[source]
+----
+quarkus.kubernetes.readiness-probe.initial-delay-seconds=20
+quarkus.kubernetes.readiness-probe.period-seconds=45
+----
+
+Here you can find a complete reference to all the available configuration options:
+
 === Using the Kubernetes client
 
-Applications that are deployed to Kubernetes and need to access the API server, will usually make use of the `kubernetes-client` extension:
+Applications that are deployed to Kubernetes and need to access the API server will usually make use of the `kubernetes-client` extension:
 
 [source,xml]
 ----
@@ -164,55 +350,16 @@ If more roles are required, they will have to be added manually.
 The Kubernetes extension allows tuning the generated manifest, using the `application.properties` file.
 Here are some examples:
 
-=== Changing the number of replicas:
-To change the number of replicas from 1 to  3:
-
-[source]
-----
-quarkus.kubernetes.replicas=3
-----
-
-=== Defining a docker registry and repository
-
-The docker registry and the user of the docker image can be specified, with the following properties:
-
-[source]
-----
-quarkus.kubernetes.group=myUser
-quarkus.docker.registry=http://my.docker-registry.net
-----
-
-Note: These options used to be `quarkus.kubernetes.docker.registry` and `quarkus.kubernetes.group` respectively.
-
-=== Adding labels:
-To add a new label to all generated resources, say `foo=bar`:
-
-[source]
-----
-quarkus.kubernetes.labels.foo=bar
-----
-
-=== Customizing the readiness probe:
-To set the initial delay of the probe to 20 seconds and the period to 45:
-
-[source]
-----
-quarkus.kubernetes.readiness-probe.initial-delay-seconds=20
-quarkus.kubernetes.readiness-probe.period-seconds=45
-----
-
-Here you can find a complete reference to all the available configuration options:
-
-==== Configuration options
+== Configuration options
 
 The table below describe all the available configuration options.
 
 .Kubernetes
 |====
 | Property                                           | Type                                      | Description | Default Value
-| quarkus.kubernetes.group                           | String                                    |             | ${quarkus.container-image.group} 
 | quarkus.kubernetes.name                            | String                                    |             | ${quarkus.container-image.name}
 | quarkus.kubernetes.version                         | String                                    |             | ${quarkus.container-image.tag}
+| quarkus.kubernetes.part-of                         | String                                    |             |
 | quarkus.kubernetes.init-containers                 | Map<String, Container>                    |             | 
 | quarkus.kubernetes.labels                          | Map                                       |             |
 | quarkus.kubernetes.annotations                     | Map                                       |             |
@@ -255,7 +402,7 @@ In this example `initial-delay` and `period-seconds` are fields of the type `Pro
 Below you will find tables describing all available types.
 
 
-===== Basic Types
+=== Basic Types
 
 .Env
 |====
@@ -302,7 +449,7 @@ Below you will find tables describing all available types.
 |====
 
 
-== Mounts and Volumes
+=== Mounts and Volumes
 
 .Mount
 |====
@@ -371,7 +518,7 @@ Below you will find tables describing all available types.
 | read-only   | boolean |             | false        
 |====
 
-=== OpenShift
+== OpenShift
 
 To enable the generation of OpenShift resources, you need to include OpenShift in the target platforms:
 
@@ -394,9 +541,9 @@ The OpenShift resources can be customized in a similar approach with Kubernetes.
 .Openshift
 |====
 | Property                                          | Type                                      | Description | Default Value
-| quarkus.openshift.group                           | String                                    |             | ${quarkus.container-image.group} 
 | quarkus.openshift.name                            | String                                    |             | ${quarkus.container-image.name}
 | quarkus.openshift.version                         | String                                    |             | ${quarkus.container-image.tag}
+| quarkus.openshift.part-of                         | String                                    |             |
 | quarkus.openshift.init-containers                 | Map<String, Container>                    |             |
 | quarkus.openshift.labels                          | Map                                       |             |
 | quarkus.openshift.annotations                     | Map                                       |             |
@@ -426,13 +573,13 @@ The OpenShift resources can be customized in a similar approach with Kubernetes.
 | quarkus.openshift.headless                        | boolean                                   |             | false
 |====
 
-=== Knative
+== Knative
     
 To enable the generation of Quarkus.Knative.resources, you need to include Knative in the target platforms:
 
 [source]
 ----
-quarkus.kubernetes.deployment.target=knative
+quarkus.kubernetes.deployment-target=knative
 ----
 
 Following the execution of `./mvnw package` you will notice amongst the other files that are created, two files named
@@ -445,16 +592,17 @@ The full source of the `quarkus.knative.json` file looks something like this:
 [source,json]
 ----
 {
-  "apiVersion" : "v1",
-  "kind" : "List",
-  "items" : [ {
+  {
     "apiVersion" : "serving.quarkus.knative.dev/v1alpha1",
     "kind" : "Service",
     "metadata" : {
+      "annotations": {
+       "app.quarkus.io/vcs-url" : "<some url>",
+       "app.quarkus.io/commit-id" : "<some git SHA>"
+      },
       "labels" : {
-        "app" : "test-quarkus-app",
-        "version" : "0.1-SNAPSHOT",
-        "group" : "yourDockerUsername"
+        "app.kubernetes.io/name" : "test-quarkus-app",
+        "app.kubernetes.io/version" : "1.0-SNAPSHOT"
       },
       "name" : "quarkus.knative.
     },
@@ -472,7 +620,7 @@ The full source of the `quarkus.knative.json` file looks something like this:
         }
       }
     }
-  } ]
+  }
 }
 ----
 
@@ -481,9 +629,9 @@ The generated service can be customized using the following properties:
 .Knative
 |====
 | Property                                        | Type                                      | Description | Default Value
-| quarkus.knative.group                           | String                                    |             | ${quarkus.container-image.group} 
 | quarkus.knative.name                            | String                                    |             | ${quarkus.container-image.name}
 | quarkus.knative.version                         | String                                    |             | ${quarkus.container-image.tag}
+| quarkus.knative.part-of                         | String                                    |             |
 | quarkus.knative.init-containers                 | Map<String, Container>                    |             |
 | quarkus.knative.labels                          | Map                                       |             |
 | quarkus.knative.annotations                     | Map                                       |             |
@@ -534,7 +682,7 @@ The code below demonstrates the change in `labels` config:
 ----
 # Old labels config:
 kubernetes.labels[0].name=foo
-kubernetes.labels[0].name=bar
+kubernetes.labels[0].value=bar
 
 # New labels
 quarkus.kubernetes.labels.foo=bar

--- a/extensions/container-image/container-image-s2i/deployment/pom.xml
+++ b/extensions/container-image/container-image-s2i/deployment/pom.xml
@@ -16,11 +16,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-spi</artifactId>
+            <artifactId>quarkus-kubernetes-client-deployment-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-client-spi</artifactId>
+            <artifactId>quarkus-kubernetes-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientErrorHanlder.java
+++ b/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientErrorHanlder.java
@@ -1,0 +1,22 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.jboss.logging.Logger;
+
+public class KubernetesClientErrorHanlder {
+
+    private static final Logger LOG = Logger.getLogger(KubernetesClientErrorHanlder.class);
+
+    public static void handle(Exception e) {
+        if (e.getCause() instanceof SSLHandshakeException) {
+            LOG.error(
+                    "The application could not be deployed to the cluster because the Kubernetes API Server certificates are not trusted. The certificates can be configured using the relevant configuration propertiers under the 'quarkus.kubernetes-client' config root, or \"quarkus.kubernetes-client.trust-certs=true\" can be set to explicitly trust the certificates (not recommended)");
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/extensions/kubernetes/openshift/deployment/src/main/java/io/quarkus/openshift/deployment/Constants.java
+++ b/extensions/kubernetes/openshift/deployment/src/main/java/io/quarkus/openshift/deployment/Constants.java
@@ -2,5 +2,5 @@ package io.quarkus.openshift.deployment;
 
 public class Constants {
     static final String OPENSHIFT = "openshift";
-    static final String DEPLOYMENT_CONFIG = "openshift";
+    static final String DEPLOYMENT_CONFIG = "DeploymentConfig";
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyContainerImageDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyContainerImageDecorator.java
@@ -1,0 +1,37 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.deps.kubernetes.api.model.ContainerFluent;
+import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
+import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
+import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
+import io.dekorate.kubernetes.decorator.ApplyImageDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+
+/**
+ * A decorator for applying an image to a container capable of overriding the internal {@link ApplyImageDecorator}.
+ */
+public class ApplyContainerImageDecorator extends ApplicationContainerDecorator<ContainerFluent> {
+    private final String image;
+
+    public ApplyContainerImageDecorator(String containerName, String image) {
+        super((String) null, containerName);
+        this.image = image;
+    }
+
+    public ApplyContainerImageDecorator(String deploymentName, String containerName, String image) {
+        super(deploymentName, containerName);
+        this.image = image;
+    }
+
+    public void andThenVisit(ContainerFluent container) {
+        container.withImage(this.image);
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class, AddSidecarDecorator.class, AddInitContainerDecorator.class,
+                ApplyImageDecorator.class };
+    }
+
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -19,4 +19,10 @@ public class Constants {
     static final String DEPLOY = "quarkus.kubernetes.deploy";
 
     static final String QUARKUS = "quarkus";
+
+    static final String QUARKUS_ANNOTATIONS_COMMIT_ID = "app.quarkus.io/commit-id";
+    static final String QUARKUS_ANNOTATIONS_VCS_URL = "app.quarkus.io/vcs-url";
+    static final String QUARKUS_ANNOTATIONS_BUILD_TIMESTAMP = "app.quarkus.io/build-timestamp";
+
+    static final String OPENSHIFT_ANNOTATIONS_VCS_URL = "app.openshift.io/vcs-url";
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -11,11 +11,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 
 @ConfigRoot
 public class KnativeConfig implements PlatformConfiguration {
+
     /**
-     * The group of the application.
+     * The name of the group this component belongs too
      */
-    @ConfigItem(defaultValue = "${quarkus.container-image.group}")
-    Optional<String> group;
+    @ConfigItem
+    Optional<String> partOf;
 
     /**
      * The name of the application. This value will be used for naming Kubernetes
@@ -184,8 +185,8 @@ public class KnativeConfig implements PlatformConfiguration {
     @ConfigItem
     Map<String, ContainerConfig> containers;
 
-    public Optional<String> getGroup() {
-        return group;
+    public Optional<String> getPartOf() {
+        return partOf;
     }
 
     public Optional<String> getName() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -13,10 +13,10 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class KubernetesConfig implements PlatformConfiguration {
 
     /**
-     * The group of the application.
+     * The name of the group this component belongs too
      */
-    @ConfigItem(defaultValue = "${quarkus.container-image.group}")
-    Optional<String> group;
+    @ConfigItem
+    Optional<String> partOf;
 
     /**
      * The name of the application. This value will be used for naming Kubernetes
@@ -193,8 +193,8 @@ public class KubernetesConfig implements PlatformConfiguration {
     @ConfigItem(defaultValue = "kubernetes")
     List<String> deploymentTarget;
 
-    public Optional<String> getGroup() {
-        return group;
+    public Optional<String> getPartOf() {
+        return partOf;
     }
 
     public Optional<String> getName() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -30,7 +28,6 @@ public class KubernetesConfigUtil {
 
     private static final Set<String> ALLOWED_GENERATORS = new HashSet<>(
             Arrays.asList(KUBERNETES, OPENSHIFT, KNATIVE, DOCKER, S2I));
-    private static final Set<String> IMAGE_GENERATORS = new HashSet<>(Arrays.asList(DOCKER, S2I));
 
     public static List<String> getDeploymentTargets() {
         Config config = ConfigProvider.getConfig();
@@ -40,21 +37,6 @@ public class KubernetesConfigUtil {
                 .map(String::trim)
                 .map(String::toLowerCase)
                 .collect(Collectors.toList());
-    }
-
-    public static Optional<String> getDockerRegistry(Map<String, Object> map) {
-        return IMAGE_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".registry")).filter(Objects::nonNull)
-                .map(String::valueOf).findFirst();
-    }
-
-    public static Optional<String> getGroup(Map<String, Object> map) {
-        return ALLOWED_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".part-of")).filter(Objects::nonNull)
-                .map(String::valueOf).findFirst();
-    }
-
-    public static Optional<String> getName(Map<String, Object> map) {
-        return ALLOWED_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".name")).filter(Objects::nonNull)
-                .map(String::valueOf).findFirst();
     }
 
     /*
@@ -72,6 +54,7 @@ public class KubernetesConfigUtil {
         // Most of quarkus prefixed properties are handled directly by the config items (KubernetesConfig, OpenshiftConfig, KnativeConfig)
         // We just need group, name & version parsed here, as we don't have decorators for these (low level properties).
         Map<String, Object> quarkusPrefixed = new HashMap<>();
+
         Arrays.stream(platformConfigurations).forEach(p -> {
             p.getPartOf().ifPresent(g -> quarkusPrefixed.put(DEKORATE_PREFIX + p.getConfigName() + ".part-of", g));
             p.getName().ifPresent(n -> quarkusPrefixed.put(DEKORATE_PREFIX + p.getConfigName() + ".name", n));
@@ -82,6 +65,14 @@ public class KubernetesConfigUtil {
                 .filter(k -> ALLOWED_GENERATORS.contains(generatorName(k)))
                 .filter(k -> config.getOptionalValue(k, String.class).isPresent())
                 .collect(Collectors.toMap(k -> DEKORATE_PREFIX + k, k -> config.getValue(k, String.class)));
+
+        for (String generator : ALLOWED_GENERATORS) {
+            String oldKey = DEKORATE_PREFIX + generator + ".group";
+            String newKey = DEKORATE_PREFIX + generator + ".part-of";
+            if (unPrefixed.containsKey(oldKey)) {
+                unPrefixed.put(newKey, unPrefixed.get(oldKey));
+            }
+        }
 
         result.putAll(unPrefixed);
         result.putAll(quarkusPrefixed);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
@@ -48,7 +48,7 @@ public class KubernetesConfigUtil {
     }
 
     public static Optional<String> getGroup(Map<String, Object> map) {
-        return ALLOWED_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".group")).filter(Objects::nonNull)
+        return ALLOWED_GENERATORS.stream().map(g -> map.get(DEKORATE_PREFIX + g + ".part-of")).filter(Objects::nonNull)
                 .map(String::valueOf).findFirst();
     }
 
@@ -73,7 +73,7 @@ public class KubernetesConfigUtil {
         // We just need group, name & version parsed here, as we don't have decorators for these (low level properties).
         Map<String, Object> quarkusPrefixed = new HashMap<>();
         Arrays.stream(platformConfigurations).forEach(p -> {
-            p.getGroup().ifPresent(g -> quarkusPrefixed.put(DEKORATE_PREFIX + p.getConfigName() + ".group", g));
+            p.getPartOf().ifPresent(g -> quarkusPrefixed.put(DEKORATE_PREFIX + p.getConfigName() + ".part-of", g));
             p.getName().ifPresent(n -> quarkusPrefixed.put(DEKORATE_PREFIX + p.getConfigName() + ".name", n));
             p.getVersion().ifPresent(v -> quarkusPrefixed.put(DEKORATE_PREFIX + p.getConfigName() + ".version", v));
         });

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -27,6 +27,7 @@ import io.dekorate.deps.kubernetes.client.KubernetesClient;
 import io.dekorate.deps.kubernetes.client.KubernetesClientException;
 import io.dekorate.utils.Clients;
 import io.dekorate.utils.Serialization;
+import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageResultBuildItem;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -46,6 +47,7 @@ public class KubernetesDeployer {
 
     @BuildStep(onlyIf = { IsNormal.class, KubernetesDeploy.class })
     public void deploy(KubernetesClientBuildItem kubernetesClient,
+            ContainerImageInfoBuildItem containerImageInfo,
             List<ContainerImageResultBuildItem> containerImageResults,
             List<KubernetesDeploymentTargetBuildItem> kubernetesDeploymentTargetBuildItems,
             OutputTargetBuildItem outputTarget,
@@ -73,7 +75,7 @@ public class KubernetesDeployer {
         //Get any build item but if the build was s2i, use openshift
         KubernetesDeploymentTargetBuildItem deploymentTarget = kubernetesDeploymentTargetBuildItems
                 .stream()
-                .filter(d -> !"s2i".equals(containerImageResult.getProvider()) || OPENSHIFT.equals(d.getName()))
+                .filter(d -> !S2I.equals(containerImageResult.getProvider()) || OPENSHIFT.equals(d.getName()))
                 .findFirst()
                 .orElse(new KubernetesDeploymentTargetBuildItem(KUBERNETES, DEPLOYMENT));
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.net.ssl.SSLHandshakeException;
-
 import org.jboss.logging.Logger;
 
 import io.dekorate.deps.kubernetes.api.model.HasMetadata;
@@ -34,6 +32,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.pkg.builditem.DeploymentResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.kubernetes.client.deployment.KubernetesClientErrorHanlder;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem;
 
@@ -106,12 +105,7 @@ public class KubernetesDeployer {
         } catch (FileNotFoundException e) {
             throw new IllegalStateException("Can't find generated kubernetes manifest: " + manifest.getAbsolutePath());
         } catch (KubernetesClientException e) {
-            if (e.getCause() instanceof SSLHandshakeException) {
-                String message = "The application could not be deployed to the cluster because the Kubernetes API Server certificates are not trusted. The certificates can be configured using the relevant configuration propertiers under the 'quarkus.kubernetes-client' config root, or \"quarkus.kubernetes-client.trust-certs=true\" can be set to explicitly trust the certificates (not recommended)";
-                log.error(message);
-                throw new RuntimeException(e.getCause());
-            }
-            log.error("Unable to deploy the application to the Kubernetes cluster: " + e.getMessage());
+            KubernetesClientErrorHanlder.handle(e);
             throw e;
         } catch (IOException e) {
             throw new RuntimeException("Error closing file: " + manifest.getAbsolutePath());

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -14,10 +14,10 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class OpenshiftConfig implements PlatformConfiguration {
 
     /**
-     * The group of the application.
+     * The name of the group this component belongs too
      */
-    @ConfigItem(defaultValue = "${quarkus.container-image.group}")
-    Optional<String> group;
+    @ConfigItem
+    Optional<String> partOf;
 
     /**
      * The name of the application. This value will be used for naming Kubernetes
@@ -186,8 +186,8 @@ public class OpenshiftConfig implements PlatformConfiguration {
     @ConfigItem
     Map<String, ContainerConfig> containers;
 
-    public Optional<String> getGroup() {
-        return group;
+    public Optional<String> getPartOf() {
+        return partOf;
     }
 
     public Optional<String> getName() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -10,7 +10,7 @@ import io.dekorate.kubernetes.annotation.ServiceType;
 
 public interface PlatformConfiguration {
 
-    Optional<String> getGroup();
+    Optional<String> getPartOf();
 
     Optional<String> getName();
 

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithDeprecatedPropertiesTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithDeprecatedPropertiesTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithDeprecatedPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("kubernetes-with-deprecated-properties")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-deprecated.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getLabels()).contains(entry("app.kubernetes.io/part-of", "grp"));
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithQuarkusAppNameTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithQuarkusAppNameTest.java
@@ -42,7 +42,8 @@ public class KubernetesWithQuarkusAppNameTest {
         assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
             assertThat(d.getMetadata()).satisfies(m -> {
                 assertThat(m.getName()).isEqualTo("foo");
-                assertThat(m.getLabels()).contains(entry("app", "foo"), entry("version", "1.0-kube"));
+                assertThat(m.getLabels()).contains(entry("app.kubernetes.io/name", "foo"),
+                        entry("app.kubernetes.io/version", "1.0-kube"));
             });
         });
 
@@ -50,7 +51,8 @@ public class KubernetesWithQuarkusAppNameTest {
                 .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
         assertThat(openshiftList).allSatisfy(h -> {
             assertThat(h.getMetadata().getName()).isIn("ofoo", "s2ifoo", "s2i-java");
-            assertThat(h.getMetadata().getLabels()).contains(entry("app", "ofoo"), entry("version", "1.0-openshift"));
+            assertThat(h.getMetadata().getLabels()).contains(entry("app.kubernetes.io/name", "ofoo"),
+                    entry("app.kubernetes.io/version", "1.0-openshift"));
         });
     }
 }

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSysGroupTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSysGroupTest.java
@@ -41,7 +41,7 @@ public class KubernetesWithSysGroupTest {
 
         assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
             assertThat(d.getMetadata()).satisfies(m -> {
-                assertThat(m.getLabels()).contains(entry("group", "grp"));
+                assertThat(m.getLabels()).contains(entry("app.kubernetes.io/part-of", "grp"));
             });
         });
     }

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-deprecated.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-deprecated.properties
@@ -1,0 +1,1 @@
+kubernetes.group=grp

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-quarkus-app-name.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-quarkus-app-name.properties
@@ -1,8 +1,8 @@
 quarkus.application.name=test
 quarkus.kubernetes.deployment-target=kubernetes,openshift
 quarkus.kubernetes.name=foo
-quarkus.kubernetes.group=bar
 quarkus.kubernetes.version=1.0-kube
+quarkus.kubernetes.part-of=bar
 
 quarkus.openshift.name=ofoo
 quarkus.openshift.group=obar

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-sys-group.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-sys-group.properties
@@ -1,1 +1,1 @@
-quarkus.kubernetes.group=grp
+quarkus.kubernetes.part-of=grp


### PR DESCRIPTION
Fixes: #7482 

This pull request brings in the following changes:

i) Adopts the recommended kubernetes labels (`app.kubernetes.io/name` & `app.kubernetes.io/version`).
ii) Adopts the recommended openshift annotations (`app.openshift.io/vcs-url`).
iii) Adds and groups other annotations under `app.quarkus.io` (e.g. `app.quarkus.io/commit-id` and `app.quarkus.io/build-timestamp).

Additionally, it replaces the `group` property from `KubernetesConfig`, `OpenshiftConfig` and `KnativeConfig` to `part-of` so that that it matches the label `app.kubernetes.io/part-of` and also to limit confusion the the `quarkus.container-image.group`.

Last it documents all the above and align the kubernetes docs with all the changes of the last couple of weeks.