### PR TITLE
Fix broken Hibernate Search Quickstart

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AbstractDataSourceProducer.java
@@ -143,8 +143,12 @@ public abstract class AbstractDataSourceProducer {
                 agroalConnectionConfigurerHandle.get().disableSslSupport(dataSourceBuildTimeConfig.dbKind.get(),
                         dataSourceConfiguration);
             } else {
-                log.warnv("Agroal does not support disabling SSL for database kind {0}",
-                        dataSourceBuildTimeConfig.dbKind.get());
+                if (dataSourceBuildTimeConfig.dbKind.isPresent()) {
+                    log.warnv("Agroal does not support disabling SSL for database kind {0}",
+                            dataSourceBuildTimeConfig.dbKind.get());
+                } else {
+                    log.warn("Agroal does not support disabling SSL");
+                }
             }
         }
 


### PR DESCRIPTION
Example of failure can be see by following:
https://github.com/quarkusio/quarkus/issues/6588#issuecomment-593250181

Essentially the problem was that disabling ssl was causing a:
```
Caused by: java.util.NoSuchElementException: No value present
```