### PR TITLE
feat: Hibernate with Panache ranged query

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -440,6 +440,31 @@ return Person.find("status", Status.Alive)
 
 The `PanacheQuery` type has many other methods to deal with paging and returning streams.
 
+=== Using a range instead of pages
+
+`PanacheQuery` also allows range-based queries.
+
+[source,java]
+----
+// create a query for all living persons
+PanacheQuery<Person> livingPersons = Person.find("status", Status.Alive);
+
+// make it use a range: start at index 0 until index 24 (inclusive).
+livingPersons.range(0, 24);
+
+// get the range
+List<Person> firstRange = livingPersons.list();
+
+// to get the next range, you need to call range again
+List<Person> secondRange = livingPersons.range(25, 49).list();
+----
+
+[WARNING]
+----
+You cannot mix ranges and pages: if you use a range, all methods that depend on having a current page will throw an `UnsupportedOperationException`;
+you can switch back to paging using `page(Page)` or `page(int, int)`.
+----
+
 === Sorting
 
 All methods accepting a query string also accept the following simplified query form:

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -441,6 +441,31 @@ return Person.find("status", Status.Alive)
 
 The `PanacheQuery` type has many other methods to deal with paging and returning streams.
 
+=== Using a range instead of pages
+
+`PanacheQuery` also allows range-based queries.
+
+[source,java]
+----
+// create a query for all living persons
+PanacheQuery<Person> livingPersons = Person.find("status", Status.Alive);
+
+// make it use a range: start at index 0 until index 24 (inclusive).
+livingPersons.range(0, 24);
+
+// get the range
+List<Person> firstRange = livingPersons.list();
+
+// to get the next range, you need to call range again
+List<Person> secondRange = livingPersons.range(25, 49).list();
+----
+
+[WARNING]
+----
+You cannot mix ranges and pages: if you use a range, all methods that depend on having a current page will throw an `UnsupportedOperationException`;
+you can switch back to paging using `page(Page)` or `page(int, int)`.
+----
+
 === Sorting
 
 All methods accepting a query string also accept an optional `Sort` parameter, which allows you to abstract your sorting:

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
@@ -117,6 +117,16 @@ public interface PanacheQuery<Entity> {
     public Page page();
 
     /**
+     * Switch the query to use a fixed range (start index - last index) instead of a page.
+     * As the range is fixed, subsequent pagination of the query is not possible.
+     *
+     * @param startIndex the index of the first element, starting at 0
+     * @param lastIndex the index of the last element
+     * @return this query, modified
+     */
+    public <T extends Entity> PanacheQuery<T> range(int startIndex, int lastIndex);
+
+    /**
      * Define the locking strategy used for this query.
      *
      * @param lockModeType the locking strategy to be used for this query.

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -12,6 +12,7 @@ import javax.persistence.Query;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Range;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
@@ -27,6 +28,8 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     private Page page;
     private Long count;
 
+    private Range range;
+
     PanacheQueryImpl(EntityManager em, javax.persistence.Query jpaQuery, String query, Object paramsArrayOrMap) {
         this.em = em;
         this.jpaQuery = jpaQuery;
@@ -41,7 +44,7 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @SuppressWarnings("unchecked")
     public <T extends Entity> PanacheQuery<T> page(Page page) {
         this.page = page;
-        jpaQuery.setFirstResult(page.index * page.size);
+        this.range = null; // reset the range to be able to switch from range to page
         return (PanacheQuery<T>) this;
     }
 
@@ -52,36 +55,43 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public <T extends Entity> PanacheQuery<T> nextPage() {
+        checkNotInRange();
         return page(page.next());
     }
 
     @Override
     public <T extends Entity> PanacheQuery<T> previousPage() {
+        checkNotInRange();
         return page(page.previous());
     }
 
     @Override
     public <T extends Entity> PanacheQuery<T> firstPage() {
+        checkNotInRange();
         return page(page.first());
     }
 
     @Override
     public <T extends Entity> PanacheQuery<T> lastPage() {
+        checkNotInRange();
         return page(page.index(pageCount() - 1));
     }
 
     @Override
     public boolean hasNextPage() {
+        checkNotInRange();
         return page.index < (pageCount() - 1);
     }
 
     @Override
     public boolean hasPreviousPage() {
+        checkNotInRange();
         return page.index > 0;
     }
 
     @Override
     public int pageCount() {
+        checkNotInRange();
         long count = count();
         if (count == 0)
             return 1; // a single page of zero results
@@ -90,7 +100,23 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public Page page() {
+        checkNotInRange();
         return page;
+    }
+
+    private void checkNotInRange() {
+        if (range != null) {
+            throw new UnsupportedOperationException("Cannot call a page related method in a ranged query, " +
+                    "call page(Page) or page(int, int) to initiate pagination first");
+        }
+    }
+
+    @Override
+    public <T extends Entity> PanacheQuery<T> range(int startIndex, int lastIndex) {
+        this.range = Range.of(startIndex, lastIndex);
+        // reset the page to its default to be able to switch from page to range
+        this.page = new Page(0, Integer.MAX_VALUE);
+        return (PanacheQuery<T>) this;
     }
 
     @Override
@@ -133,20 +159,20 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Entity> List<T> list() {
-        jpaQuery.setMaxResults(page.size);
+        manageOffsets();
         return jpaQuery.getResultList();
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Entity> Stream<T> stream() {
-        jpaQuery.setMaxResults(page.size);
+        manageOffsets();
         return jpaQuery.getResultStream();
     }
 
     @Override
     public <T extends Entity> T firstResult() {
-        jpaQuery.setMaxResults(1);
+        manageOffsets(1);
         List<T> list = jpaQuery.getResultList();
         return list.isEmpty() ? null : list.get(0);
     }
@@ -159,19 +185,40 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Entity> T singleResult() {
-        jpaQuery.setMaxResults(page.size);
+        manageOffsets();
         return (T) jpaQuery.getSingleResult();
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Entity> Optional<T> singleResultOptional() {
-        jpaQuery.setMaxResults(2);
+        manageOffsets(2);
         List<T> list = jpaQuery.getResultList();
         if (list.size() == 2) {
             throw new NonUniqueResultException();
         }
 
         return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+    }
+
+    private void manageOffsets() {
+        if (range != null) {
+            jpaQuery.setFirstResult(range.getStartIndex());
+            // range is 0 based, so we add 1
+            jpaQuery.setMaxResults(range.getLastIndex() - range.getStartIndex() + 1);
+        } else {
+            jpaQuery.setFirstResult(page.index * page.size);
+            jpaQuery.setMaxResults(page.size);
+        }
+    }
+
+    private void manageOffsets(int maxResults) {
+        if (range != null) {
+            jpaQuery.setFirstResult(range.getStartIndex());
+            jpaQuery.setMaxResults(maxResults);
+        } else {
+            jpaQuery.setFirstResult(page.index * page.size);
+            jpaQuery.setMaxResults(maxResults);
+        }
     }
 }

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
@@ -116,6 +116,16 @@ public interface PanacheQuery<Entity> {
      */
     public Page page();
 
+    /**
+     * Switch the query to use a fixed range (start index - last index) instead of a page.
+     * As the range is fixed, subsequent pagination of the query is not possible.
+     *
+     * @param startIndex the index of the first element, starting at 0
+     * @param lastIndex the index of the last element
+     * @return this query, modified
+     */
+    public <T extends Entity> PanacheQuery<T> range(int startIndex, int lastIndex);
+
     // Results
 
     /**

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheQuery.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheQuery.java
@@ -110,6 +110,16 @@ public interface ReactivePanacheQuery<Entity> {
      */
     public Page page();
 
+    /**
+     * Switch the query to use a fixed range (start index - last index) instead of a page.
+     * As the range is fixed, subsequent pagination of the query is not possible.
+     *
+     * @param startIndex the index of the first element, starting at 0
+     * @param lastIndex the index of the last element
+     * @return this query, modified
+     */
+    public <T extends Entity> ReactivePanacheQuery<T> range(int startIndex, int lastIndex);
+
     // Results
 
     /**

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Range.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Range.java
@@ -1,0 +1,36 @@
+package io.quarkus.panache.common;
+
+/**
+ * <p>
+ * Utility class to represent ranging information. Range instances are immutable.
+ * </p>
+ *
+ * <p>
+ * Usage:
+ * </p>
+ *
+ * <code><pre>
+ * Range range = Range.of(0, 5);
+ * </pre></code>
+ */
+public class Range {
+    private final int startIndex;
+    private final int lastIndex;
+
+    public Range(int startIndex, int lastIndex) {
+        this.startIndex = startIndex;
+        this.lastIndex = lastIndex;
+    }
+
+    public static Range of(int startIndex, int lastIndex) {
+        return new Range(startIndex, lastIndex);
+    }
+
+    public int getStartIndex() {
+        return startIndex;
+    }
+
+    public int getLastIndex() {
+        return lastIndex;
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -200,6 +200,10 @@ public class TestEndpoint {
         testPaging(Person.findAll());
         testPaging(Person.find("ORDER BY name"));
 
+        // range
+        testRange(Person.findAll());
+        testRange(Person.find("ORDER BY name"));
+
         try {
             Person.findAll().singleResult();
             Assertions.fail("singleResult should have thrown");
@@ -633,6 +637,10 @@ public class TestEndpoint {
         testPaging(personDao.findAll());
         testPaging(personDao.find("ORDER BY name"));
 
+        //range
+        testRange(personDao.findAll());
+        testRange(personDao.find("ORDER BY name"));
+
         try {
             personDao.findAll().singleResult();
             Assertions.fail("singleResult should have thrown");
@@ -851,6 +859,49 @@ public class TestEndpoint {
 
         Assertions.assertEquals(7, query.count());
         Assertions.assertEquals(3, query.pageCount());
+
+        // mix page with range
+        persons = query.page(0, 3).range(0, 1).list();
+        Assertions.assertEquals(2, persons.size());
+        Assertions.assertEquals("stef0", persons.get(0).name);
+        Assertions.assertEquals("stef1", persons.get(1).name);
+    }
+
+    private void testRange(PanacheQuery<Person> query) {
+        List<Person> persons = query.range(0, 2).list();
+        Assertions.assertEquals(3, persons.size());
+        Assertions.assertEquals("stef0", persons.get(0).name);
+        Assertions.assertEquals("stef1", persons.get(1).name);
+        Assertions.assertEquals("stef2", persons.get(2).name);
+
+        persons = query.range(3, 5).list();
+        Assertions.assertEquals(3, persons.size());
+        Assertions.assertEquals("stef3", persons.get(0).name);
+        Assertions.assertEquals("stef4", persons.get(1).name);
+        Assertions.assertEquals("stef5", persons.get(2).name);
+
+        persons = query.range(6, 8).list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals("stef6", persons.get(0).name);
+
+        persons = query.range(8, 12).list();
+        Assertions.assertEquals(0, persons.size());
+
+        // mix range with page
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).nextPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).previousPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).pageCount());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).lastPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).firstPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).hasPreviousPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).hasNextPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).page());
+        // this is valid as we switch from range to page
+        persons = query.range(0, 2).page(0, 3).list();
+        Assertions.assertEquals(3, persons.size());
+        Assertions.assertEquals("stef0", persons.get(0).name);
+        Assertions.assertEquals("stef1", persons.get(1).name);
+        Assertions.assertEquals("stef2", persons.get(2).name);
     }
 
     @GET


### PR DESCRIPTION
This is a ~draft~ implementation of Range queries, that fixes #3870 

~It introduce a `Findable` interface that is returned by the `range()` that only contains query result related methods.~

/cc @emmanuelbernard @FroMage if you validate the design I'll implement it for MongoDB also.
