### PR TITLE
add short-name to reactive-messaging-amqp extension metadata

### DIFF
--- a/extensions/smallrye-reactive-messaging-amqp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 ---
 name: "SmallRye Reactive Messaging - AMQP Connector"
 metadata:
+  short-name: "amqp"
   keywords:
   - "amqp"
   - "reactive-amqp"


### PR DESCRIPTION
The guide at https://quarkus.io/guides/amqp for the reactive-messaging-amqp extension indicates use of -Dextensions="amqp" when creating application template with quarkus-maven-plugin. When other extensions (e.g. in quarkus platform) also reference AMQP in their details the existing creation command fails as quarkus-maven-plugin detects multiple extensions.

The same scenario of multiple extensions exists for the reactive-messaging-kafka extension and its guide https://quarkus.io/guides/kafka, however in practice the scenario with -Dextensions="kafka" actually does work regardless.

The difference seems to be that the reactive-messaging-kafka extension defines an additional short-name metadata at:
https://github.com/quarkusio/quarkus/blob/1.2.1.Final/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/resources/META-INF/quarkus-extension.yaml#L4

This PR makes similar addition to the reactive-messaging-amqp extension to maintain the historic behaviour.