### PR TITLE
Support OIDC client_secret_post client authentication

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -172,10 +172,20 @@ public class OidcTenantConfig {
     public static class Credentials {
 
         /**
-         * The client secret
+         * Client secret which is used for a 'client_secret_basic' authentication method.
+         * Note that a 'client-secret' can be used instead but both properties are mutually exclusive.
          */
         @ConfigItem
         Optional<String> secret = Optional.empty();
+
+        /**
+         * Client secret credentials which can be used for the 'client_secret_basic' (default)
+         * and 'client_secret_post' authentication methods.
+         * Note that a 'secret.value' property can be used instead to support the 'client_secret_basic' method
+         * but both properties are mutually exclusive.
+         */
+        @ConfigItem
+        Secret clientSecret = new Secret();
 
         public Optional<String> getSecret() {
             return secret;
@@ -183,6 +193,64 @@ public class OidcTenantConfig {
 
         public void setSecret(String secret) {
             this.secret = Optional.of(secret);
+        }
+
+        public Secret getClientSecret() {
+            return clientSecret;
+        }
+
+        public void setClientSecret(Secret clientSecret) {
+            this.clientSecret = clientSecret;
+        }
+
+        @ConfigGroup
+        public static class Secret {
+
+            /**
+             * Client secret authentication methods which specify how a client id and client secret
+             * have to be used to authenticate a client.
+             *
+             * @see <a href=
+             *      "https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication</a>
+             */
+            public static enum Method {
+                /**
+                 * client_secret_basic (default)
+                 */
+                BASIC,
+                /**
+                 * client_secret_post
+                 */
+                POST
+            }
+
+            /**
+             * The client secret
+             */
+            @ConfigItem
+            Optional<String> value = Optional.empty();
+
+            /**
+             * Authentication method.
+             */
+            @ConfigItem
+            Optional<Method> method = Optional.empty();
+
+            public Optional<String> getValue() {
+                return value;
+            }
+
+            public void setValue(String value) {
+                this.value = Optional.of(value);
+            }
+
+            public Optional<Method> getMethod() {
+                return method;
+            }
+
+            public void setMethod(Method method) {
+                this.method = Optional.of(method);
+            }
         }
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 # Default tenant configuration
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email,phone
 quarkus.oidc.authentication.redirect-path=/web-app
 # Several tests here start from /index.html (state cookie is available)
@@ -16,7 +17,8 @@ quarkus.oidc.application-type=web-app
 # Tenant which does not need to restore a request path after redirect
 quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-1.client-id=quarkus-app
-quarkus.oidc.tenant-1.credentials.secret=secret
+quarkus.oidc.tenant-1.credentials.client-secret.value=secret
+quarkus.oidc.tenant-1.credentials.client-secret.method=post
 quarkus.oidc.tenant-1.token.issuer=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-1.authentication.redirect-path=/web-app/callback-after-redirect
 quarkus.oidc.tenant-1.authentication.restore-path-after-redirect=false
@@ -25,7 +27,7 @@ quarkus.oidc.tenant-1.application-type=web-app
 # Tenant which does not need to restore a request path after redirect with a different redirect path root
 quarkus.oidc.tenant-2.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-2.client-id=quarkus-app
-quarkus.oidc.tenant-2.credentials.secret=secret
+quarkus.oidc.tenant-2.credentials.client-secret.value=secret
 quarkus.oidc.tenant-2.token.issuer=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-2.authentication.redirect-path=/web-app2
 quarkus.oidc.tenant-2.authentication.restore-path-after-redirect=false

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -97,8 +97,6 @@ public class CodeFlowTest {
 
             webClient.getPage("http://localhost:8081/index.html");
 
-            Cookie sessionCookie = getSessionCookie(webClient);
-
             page = webClient.getPage("http://localhost:8081/index.html");
 
             assertEquals("Log in to quarkus", page.getTitleText());

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -89,10 +89,10 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         ClientRepresentation client = new ClientRepresentation();
 
         client.setClientId(clientId);
-        client.setPublicClient(true);
-        client.setDirectAccessGrantsEnabled(true);
         client.setEnabled(true);
         client.setRedirectUris(Arrays.asList("*"));
+        client.setClientAuthenticatorType("client-secret");
+        client.setSecret("secret");
 
         return client;
     }


### PR DESCRIPTION
Fixes #6747.

This PR provides a workaround to support `quarkus-oidc` `web-app` applications working with the IDPs like ForgeRock (or other IDPs) which may require `client_secret_post` (`client_id` and `client_secret` posted as form url encoded parameters).

Along the way a `credentials.type` property is introduced. It will be very straightforward to support `client_secret_jwt`, which I will do a bit later.