### PR TITLE
Fix broken YAML for Boring Cyborg

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -125,7 +125,7 @@ labelPRBasedOnFilePath:
         - integration-tests/infinispan-cache-jpa/**/*
         - integration-tests/infinispan-client/**/*
         - integration-tests/infinispan-embedded/**/*
-     area/infra-automation:
+    area/infra-automation:
         - .github/**/*
         - azure-mvn-settings.xml
         - azure-pipelines.yml


### PR DESCRIPTION
The YAML had an indent which made YAML invalid because of which the bot failed with following error. This PR fixes it.

Error:

```
01:58:43.491Z ERROR event: (id=5ad63a80-5cd5-11ea-95d9-d94688c3d3d4)
2020-03-03T01:58:43.492113+00:00 app[web.1]: bad indentation of a mapping entry at line 128, column 6:
2020-03-03T01:58:43.492114+00:00 app[web.1]: area/infra-automation:
2020-03-03T01:58:43.492114+00:00 app[web.1]: ^
2020-03-03T01:58:43.492114+00:00 app[web.1]: --
2020-03-03T01:58:43.492115+00:00 app[web.1]: YAMLException: bad indentation of a mapping entry at line 128, column 6:
2020-03-03T01:58:43.492115+00:00 app[web.1]: area/infra-automation:
2020-03-03T01:58:43.492116+00:00 app[web.1]: ^
2020-03-03T01:58:43.492116+00:00 app[web.1]: at generateError (/app/node_modules/js-yaml/lib/js-yaml/loader.js:167:10)
2020-03-03T01:58:43.492116+00:00 app[web.1]: at throwError (/app/node_modules/js-yaml/lib/js-yaml/loader.js:173:9)
2020-03-03T01:58:43.492117+00:00 app[web.1]: at readBlockMapping (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1107:7)
2020-03-03T01:58:43.492117+00:00 app[web.1]: at composeNode (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1359:12)
2020-03-03T01:58:43.492118+00:00 app[web.1]: at readBlockMapping (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1089:11)
2020-03-03T01:58:43.492118+00:00 app[web.1]: at composeNode (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1359:12)
2020-03-03T01:58:43.492119+00:00 app[web.1]: at readDocument (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1519:3)
2020-03-03T01:58:43.492119+00:00 app[web.1]: at loadDocuments (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1575:5)
2020-03-03T01:58:43.492119+00:00 app[web.1]: at load (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1596:19)
2020-03-03T01:58:43.492120+00:00 app[web.1]: at Object.safeLoad (/app/node_modules/js-yaml/lib/js-yaml/loader.js:1618:10)
2020-03-03T01:58:43.492120+00:00 app[web.1]: at Context.<anonymous> (/app/node_modules/probot/lib/context.js:249:65)
2020-03-03T01:58:43.492121+00:00 app[web.1]: at step (/app/node_modules/probot/lib/context.js:33:23)
2020-03-03T01:58:43.492121+00:00 app[web.1]: at Object.next (/app/node_modules/probot/lib/context.js:14:53)
2020-03-03T01:58:43.492121+00:00 app[web.1]: at fulfilled (/app/node_modules/probot/lib/context.js:5:58)
```