### PR TITLE
devtools commands to accept platform descriptor as an argument

### DIFF
--- a/devtools/aesh/src/main/java/io/quarkus/cli/commands/AddExtensionCommand.java
+++ b/devtools/aesh/src/main/java/io/quarkus/cli/commands/AddExtensionCommand.java
@@ -13,9 +13,10 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 import org.aesh.io.Resource;
 
-import io.quarkus.cli.commands.legacy.LegacyQuarkusCommandInvocation;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.dependencies.Extension;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
 
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
@@ -38,17 +39,18 @@ public class AddExtensionCommand implements Command<CommandInvocation> {
             commandInvocation.println(commandInvocation.getHelpInfo("quarkus add-extension"));
             return CommandResult.SUCCESS;
         } else {
-            final QuarkusCommandInvocation quarkusInvocation = new LegacyQuarkusCommandInvocation();
-            if (!findExtension(extension, quarkusInvocation.getPlatformDescriptor().getExtensions())) {
+
+            final QuarkusPlatformDescriptor platformDescr = QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor();
+            if (!findExtension(extension, platformDescr.getExtensions())) {
                 commandInvocation.println("Can not find any extension named: " + extension);
                 return CommandResult.SUCCESS;
             }
             if (pom.isLeaf()) {
                 try {
-                    quarkusInvocation.setValue(AddExtensions.EXTENSIONS, Collections.singleton(extension));
                     final File pomFile = new File(pom.getAbsolutePath());
-                    AddExtensions project = new AddExtensions(new FileProjectWriter(pomFile.getParentFile()));
-                    QuarkusCommandOutcome result = project.execute(quarkusInvocation);
+                    AddExtensions project = new AddExtensions(new FileProjectWriter(pomFile.getParentFile()), platformDescr)
+                            .extensions(Collections.singleton(extension));
+                    QuarkusCommandOutcome result = project.execute();
                     if (!result.isSuccess()) {
                         throw new CommandException("Unable to add an extension matching " + extension);
                     }

--- a/devtools/aesh/src/main/java/io/quarkus/cli/commands/ListExtensionsCommand.java
+++ b/devtools/aesh/src/main/java/io/quarkus/cli/commands/ListExtensionsCommand.java
@@ -15,6 +15,7 @@ import io.quarkus.cli.commands.file.BuildFile;
 import io.quarkus.cli.commands.file.GradleBuildFile;
 import io.quarkus.cli.commands.file.MavenBuildFile;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
+import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
 
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
@@ -54,7 +55,8 @@ public class ListExtensionsCommand implements Command<CommandInvocation> {
                         }
                     }
                 }
-                new ListExtensions(buildFile).listExtensions(all, format, searchPattern);
+                new ListExtensions(buildFile, QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor())
+                        .listExtensions(all, format, searchPattern);
             } catch (IOException e) {
                 throw new CommandException("Unable to list extensions", e);
             }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusAddExtension.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusAddExtension.java
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.cli.commands.AddExtensions;
-import io.quarkus.cli.commands.QuarkusCommandInvocation;
 import io.quarkus.cli.commands.file.GradleBuildFile;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
 
@@ -36,20 +35,16 @@ public class QuarkusAddExtension extends QuarkusPlatformTask {
 
     @TaskAction
     public void addExtension() {
-        execute();
-    }
-
-    @Override
-    protected void doExecute(QuarkusCommandInvocation invocation) {
         Set<String> extensionsSet = getExtensionsToAdd()
                 .stream()
                 .flatMap(ext -> stream(ext.split(",")))
                 .map(String::trim)
                 .collect(toSet());
-        invocation.setValue(AddExtensions.EXTENSIONS, extensionsSet);
+
         try {
-            new AddExtensions(new GradleBuildFile(new FileProjectWriter(getProject().getProjectDir())))
-                    .execute(invocation);
+            new AddExtensions(new GradleBuildFile(new FileProjectWriter(getProject().getProjectDir())), platformDescriptor())
+                    .extensions(extensionsSet)
+                    .execute();
         } catch (Exception e) {
             throw new GradleException("Failed to add extensions " + getExtensionsToAdd(), e);
         }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
@@ -7,7 +7,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.cli.commands.ListExtensions;
-import io.quarkus.cli.commands.QuarkusCommandInvocation;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.gradle.GradleBuildFileFromConnector;
 
@@ -57,17 +56,13 @@ public class QuarkusListExtensions extends QuarkusPlatformTask {
 
     @TaskAction
     public void listExtensions() {
-        execute();
-    }
-
-    @Override
-    protected void doExecute(QuarkusCommandInvocation invocation) {
-        invocation.setValue(ListExtensions.ALL, isAll())
-                .setValue(ListExtensions.FORMAT, getFormat())
-                .setValue(ListExtensions.SEARCH, getSearchPattern());
         try {
-            new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(getProject().getProjectDir())))
-                    .execute(invocation);
+            new ListExtensions(new GradleBuildFileFromConnector(new FileProjectWriter(getProject().getProjectDir())),
+                    platformDescriptor())
+                            .all(isAll())
+                            .format(getFormat())
+                            .search(getSearchPattern())
+                            .execute();
         } catch (Exception e) {
             throw new GradleException("Unable to list extensions", e);
         }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -6,10 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
-import io.quarkus.cli.commands.QuarkusCommandInvocation;
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import io.quarkus.platform.descriptor.resolver.json.QuarkusJsonPlatformDescriptorResolver;
-import io.quarkus.platform.tools.MessageWriter;
 
 public abstract class QuarkusPlatformTask extends QuarkusTask {
 
@@ -17,15 +15,7 @@ public abstract class QuarkusPlatformTask extends QuarkusTask {
         super(description);
     }
 
-    protected void execute() {
-        final MessageWriter msgWriter = new GradleMessageWriter(getProject().getLogger());
-        final QuarkusPlatformDescriptor platformDescr = getPlatformDescriptor(msgWriter);
-        doExecute(new QuarkusCommandInvocation(platformDescr, msgWriter));
-    }
-
-    protected abstract void doExecute(QuarkusCommandInvocation invocation);
-
-    private QuarkusPlatformDescriptor getPlatformDescriptor(MessageWriter msgWriter) {
+    protected QuarkusPlatformDescriptor platformDescriptor() {
         final Path currentDir = getProject().getProjectDir().toPath();
 
         final Path gradlePropsPath = currentDir.resolve("gradle.properties");
@@ -43,7 +33,7 @@ public abstract class QuarkusPlatformTask extends QuarkusTask {
 
         return QuarkusJsonPlatformDescriptorResolver.newInstance()
                 .setArtifactResolver(extension().getAppModelResolver())
-                .setMessageWriter(msgWriter)
+                .setMessageWriter(new GradleMessageWriter(getProject().getLogger()))
                 .resolveFromBom(
                         getRequiredProperty(props, "quarkusPlatformGroupId"),
                         getRequiredProperty(props, "quarkusPlatformArtifactId"),

--- a/devtools/maven/src/main/java/io/quarkus/maven/AddExtensionMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AddExtensionMojo.java
@@ -11,11 +11,13 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import io.quarkus.cli.commands.AddExtensionResult;
 import io.quarkus.cli.commands.AddExtensions;
+import io.quarkus.cli.commands.QuarkusCommandOutcome;
 import io.quarkus.cli.commands.file.BuildFile;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.generators.BuildTool;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.tools.MessageWriter;
 
 /**
  * Allow adding an extension to an existing pom.xml file.
@@ -47,7 +49,8 @@ public class AddExtensionMojo extends BuildFileMojoBase {
     }
 
     @Override
-    public void doExecute(BuildFile buildFile) throws MojoExecutionException {
+    public void doExecute(BuildFile buildFile, QuarkusPlatformDescriptor platformDescr, MessageWriter log)
+            throws MojoExecutionException {
 
         if (buildFile == null) {
             try {
@@ -66,12 +69,13 @@ public class AddExtensionMojo extends BuildFileMojoBase {
         }
 
         try {
-            final AddExtensionResult result = new AddExtensions(buildFile)
-                    .addExtensions(ext.stream().map(String::trim).collect(Collectors.toSet()));
-            if (!result.succeeded()) {
+            final QuarkusCommandOutcome outcome = new AddExtensions(buildFile, platformDescr)
+                    .extensions(ext.stream().map(String::trim).collect(Collectors.toSet()))
+                    .execute();
+            if (!outcome.isSuccess()) {
                 throw new MojoExecutionException("Unable to add extensions");
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new MojoExecutionException("Unable to update the pom.xml file", e);
         }
     }

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -53,7 +53,13 @@ public final class CreateUtils {
     static QuarkusPlatformDescriptor setGlobalPlatformDescriptor(final String bomGroupId, final String bomArtifactId,
             final String bomVersion,
             MavenArtifactResolver mvn, Log log) throws MojoExecutionException {
+        final QuarkusPlatformDescriptor platform = resolvePlatformDescriptor(bomGroupId, bomArtifactId, bomVersion, mvn, log);
+        QuarkusPlatformConfig.defaultConfigBuilder().setPlatformDescriptor(platform).build();
+        return platform;
+    }
 
+    static QuarkusPlatformDescriptor resolvePlatformDescriptor(final String bomGroupId, final String bomArtifactId,
+            final String bomVersion, MavenArtifactResolver mvn, Log log) throws MojoExecutionException {
         final QuarkusJsonPlatformDescriptorResolver platformResolver = QuarkusJsonPlatformDescriptorResolver.newInstance()
                 .setMessageWriter(new MojoMessageWriter(log))
                 .setArtifactResolver(new BootstrapAppModelResolver(mvn));
@@ -79,8 +85,6 @@ public final class CreateUtils {
         } else {
             platform = platformResolver.resolveFromBom(groupId, artifactId, version);
         }
-
-        QuarkusPlatformConfig.defaultConfigBuilder().setPlatformDescriptor(platform).build();
         return platform;
     }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
@@ -1,13 +1,13 @@
 package io.quarkus.maven;
 
-import java.io.IOException;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import io.quarkus.cli.commands.ListExtensions;
 import io.quarkus.cli.commands.file.BuildFile;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.tools.MessageWriter;
 
 /**
  * List the available extensions.
@@ -38,10 +38,15 @@ public class ListExtensionsMojo extends BuildFileMojoBase {
     protected String searchPattern;
 
     @Override
-    public void doExecute(BuildFile buildFile) throws MojoExecutionException {
+    public void doExecute(BuildFile buildFile, QuarkusPlatformDescriptor platformDescr, MessageWriter log)
+            throws MojoExecutionException {
         try {
-            new ListExtensions(buildFile).listExtensions(all, format, searchPattern);
-        } catch (IOException e) {
+            new ListExtensions(buildFile, platformDescr)
+                    .all(all)
+                    .format(format)
+                    .search(searchPattern)
+                    .execute();
+        } catch (Exception e) {
             throw new MojoExecutionException("Failed to list extensions", e);
         }
     }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensionResult.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensionResult.java
@@ -1,5 +1,12 @@
 package io.quarkus.cli.commands;
 
+/**
+ * @deprecated in 1.3.0.CR1
+ *             This class was replaced with {@link QuarkusCommandOutcome} as the generic outcome of a project manipulating
+ *             command.
+ * @see QuarkusCommand
+ */
+@Deprecated
 public class AddExtensionResult {
 
     private final boolean updated;

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensions.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensions.java
@@ -2,194 +2,82 @@ package io.quarkus.cli.commands;
 
 import io.quarkus.cli.commands.file.BuildFile;
 import io.quarkus.cli.commands.file.MavenBuildFile;
-import io.quarkus.cli.commands.legacy.LegacyQuarkusCommandInvocation;
 import io.quarkus.cli.commands.writer.ProjectWriter;
-import io.quarkus.dependencies.Extension;
 import io.quarkus.generators.BuildTool;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
-public class AddExtensions implements QuarkusCommand {
+/**
+ * Instances of this class are not thread-safe. They are created per single invocation.
+ */
+public class AddExtensions {
 
     public static final String NAME = "add-extensions";
     public static final String EXTENSIONS = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "extensions");
     public static final String OUTCOME_UPDATED = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME, "outcome", "updated");
 
-    private BuildFile buildFile;
-    private final static Printer PRINTER = new Printer();
+    private final QuarkusCommandInvocation invocation;
 
-    public AddExtensions(final ProjectWriter writer) throws IOException {
-        this(new MavenBuildFile(writer));
-    }
-
-    public AddExtensions(final ProjectWriter writer, final BuildTool buildTool) throws IOException {
-        this.buildFile = buildTool.createBuildFile(writer);
-    }
-
-    public AddExtensions(final BuildFile buildFile) throws IOException {
-        this.buildFile = buildFile;
+    /**
+     * @deprecated in 1.3.0.CR1
+     *             Please use the variant that accepts {@link QuarkusPlatformDescriptor} as an argument.
+     */
+    @Deprecated
+    public AddExtensions(ProjectWriter writer) throws IOException {
+        this(writer, QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor());
     }
 
     /**
-     * Selection algorithm.
-     *
-     * @param query the query
-     * @param extensions the extension list
-     * @param labelLookup whether or not the query must be tested against the labels of the extensions. Should
-     *        be {@code false} by default.
-     * @return the list of matching candidates and whether or not a match has been found.
+     * @deprecated in 1.3.0.CR1
+     *             Please use the variant that accepts {@link QuarkusPlatformDescriptor} as an argument.
      */
-    static SelectionResult select(String query, List<Extension> extensions, boolean labelLookup) {
-        String q = query.trim().toLowerCase();
-
-        // Try exact matches
-        Set<Extension> matchesNameOrArtifactId = extensions.stream()
-                .filter(extension -> extension.getName().equalsIgnoreCase(q) || matchesArtifactId(extension.getArtifactId(), q))
-                .collect(Collectors.toSet());
-        if (matchesNameOrArtifactId.size() == 1) {
-            return new SelectionResult(matchesNameOrArtifactId, true);
-        }
-
-        extensions = extensions.stream().filter(e -> !e.isUnlisted()).collect(Collectors.toList());
-
-        // Try short names
-        Set<Extension> matchesShortName = extensions.stream().filter(extension -> matchesShortName(extension, q))
-                .collect(Collectors.toSet());
-
-        if (matchesShortName.size() == 1 && matchesNameOrArtifactId.isEmpty()) {
-            return new SelectionResult(matchesShortName, true);
-        }
-
-        // Partial matches on name, artifactId and short names
-        Set<Extension> partialMatches = extensions.stream().filter(extension -> extension.getName().toLowerCase().contains(q)
-                || extension.getArtifactId().toLowerCase().contains(q)
-                || extension.getShortName().toLowerCase().contains(q)).collect(Collectors.toSet());
-        // Even if we have a single partial match, if the name, artifactId and short names are ambiguous, so not
-        // consider it as a match.
-        if (partialMatches.size() == 1 && matchesNameOrArtifactId.isEmpty() && matchesShortName.isEmpty()) {
-            return new SelectionResult(partialMatches, true);
-        }
-
-        // find by labels
-        List<Extension> matchesLabels;
-        if (labelLookup) {
-            matchesLabels = extensions.stream()
-                    .filter(extension -> extension.labelsForMatching().contains(q)).collect(Collectors.toList());
-        } else {
-            matchesLabels = Collections.emptyList();
-        }
-
-        // find by pattern
-        Set<Extension> matchesPatterns;
-        Pattern pattern = toRegex(q);
-        if (pattern != null) {
-            matchesPatterns = extensions.stream()
-                    .filter(extension -> pattern.matcher(extension.getName().toLowerCase()).matches()
-                            || pattern.matcher(extension.getArtifactId().toLowerCase()).matches()
-                            || pattern.matcher(extension.getShortName().toLowerCase()).matches()
-                            || matchLabels(pattern, extension.getKeywords()))
-                    .collect(Collectors.toSet());
-            return new SelectionResult(matchesPatterns, true);
-        } else {
-            matchesPatterns = Collections.emptySet();
-        }
-
-        Set<Extension> candidates = new LinkedHashSet<>();
-        candidates.addAll(matchesNameOrArtifactId);
-        candidates.addAll(matchesShortName);
-        candidates.addAll(partialMatches);
-        candidates.addAll(matchesLabels);
-        candidates.addAll(matchesPatterns);
-        return new SelectionResult(candidates, false);
+    @Deprecated
+    public AddExtensions(BuildFile buildFile) throws IOException {
+        this(buildFile, QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor());
     }
 
-    private static boolean matchLabels(Pattern pattern, List<String> labels) {
-        boolean matches = false;
-        // if any label match it's ok
-        for (String label : labels) {
-            matches = matches || pattern.matcher(label.toLowerCase()).matches();
-        }
-        return matches;
+    /**
+     * @deprecated in 1.3.0.CR1
+     *             Please use the variant that accepts {@link QuarkusPlatformDescriptor} as an argument.
+     */
+    @Deprecated
+    public AddExtensions(final ProjectWriter writer, final BuildTool buildTool)
+            throws IOException {
+        this(writer, buildTool, QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor());
     }
 
-    private static Pattern toRegex(final String str) {
-        try {
-            String wildcardToRegex = wildcardToRegex(str);
-            if (wildcardToRegex != null && !wildcardToRegex.isEmpty()) {
-                return Pattern.compile(wildcardToRegex);
-            }
-        } catch (PatternSyntaxException e) {
-            //ignore it
-        }
-        return null;
+    public AddExtensions(final ProjectWriter writer, QuarkusPlatformDescriptor platformDescr) throws IOException {
+        this(new MavenBuildFile(writer), platformDescr);
     }
 
-    public static String wildcardToRegex(String wildcard) {
-        if (wildcard == null || wildcard.isEmpty()) {
-            return null;
-        }
-        // don't try with file match char in pattern
-        if (!(wildcard.contains("*") || wildcard.contains("?"))) {
-            return null;
-        }
-        StringBuffer s = new StringBuffer(wildcard.length());
-        s.append("^.*");
-        for (int i = 0, is = wildcard.length(); i < is; i++) {
-            char c = wildcard.charAt(i);
-            switch (c) {
-                case '*':
-                    s.append(".*");
-                    break;
-                case '?':
-                    s.append(".");
-                    break;
-                case '^': // escape character in cmd.exe
-                    s.append("\\");
-                    break;
-                // escape special regexp-characters
-                case '(':
-                case ')':
-                case '[':
-                case ']':
-                case '$':
-                case '.':
-                case '{':
-                case '}':
-                case '|':
-                case '\\':
-                    s.append("\\");
-                    s.append(c);
-                    break;
-                default:
-                    s.append(c);
-                    break;
-            }
-        }
-        s.append(".*$");
-        return (s.toString());
+    public AddExtensions(final ProjectWriter writer, final BuildTool buildTool, QuarkusPlatformDescriptor platformDescr)
+            throws IOException {
+        this(buildTool.createBuildFile(writer), platformDescr);
     }
 
-    private static boolean matchesShortName(Extension extension, String q) {
-        return q.equalsIgnoreCase(extension.getShortName());
+    public AddExtensions(final BuildFile buildFile, QuarkusPlatformDescriptor platformDescr) {
+        invocation = new QuarkusCommandInvocation(platformDescr);
+        invocation.setBuildFile(buildFile);
     }
 
-    private static boolean matchesArtifactId(String artifactId, String q) {
-        return artifactId.equalsIgnoreCase(q) ||
-                artifactId.equalsIgnoreCase("quarkus-" + q);
+    public AddExtensions extensions(Set<String> extensions) {
+        invocation.setValue(EXTENSIONS, extensions);
+        return this;
     }
 
+    /**
+     * @deprecated in 1.3.0.CR1
+     *             Please call {@link #extensions(Set)} and then {@link #execute()}
+     */
+    @Deprecated
     public AddExtensionResult addExtensions(final Set<String> extensions) throws IOException {
         final QuarkusCommandOutcome outcome;
         try {
-            outcome = execute(new LegacyQuarkusCommandInvocation().setValue(EXTENSIONS, extensions));
+            outcome = extensions(extensions).execute();
         } catch (QuarkusCommandException e) {
             throw new IOException("Failed to list extensions", e);
         }
@@ -197,66 +85,7 @@ public class AddExtensions implements QuarkusCommand {
 
     }
 
-    @Override
-    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
-
-        final Set<String> extensions = invocation.getValue(EXTENSIONS, Collections.emptySet());
-        if (extensions.isEmpty()) {
-            return QuarkusCommandOutcome.success().setValue(OUTCOME_UPDATED, false);
-        }
-
-        boolean updated = false;
-        boolean success = true;
-
-        final List<Extension> registry = invocation.getPlatformDescriptor().getExtensions();
-
-        try {
-            for (String query : extensions) {
-
-                if (query.contains(":")) {
-                    // GAV case.
-                    updated = buildFile.addExtensionAsGAV(query) || updated;
-                } else {
-                    SelectionResult result = select(query, registry, false);
-                    if (!result.matches()) {
-                        StringBuilder sb = new StringBuilder();
-                        // We have 3 cases, we can still have a single candidate, but the match is on label
-                        // or we have several candidates, or none
-                        Set<Extension> candidates = result.getExtensions();
-                        if (candidates.isEmpty()) {
-                            // No matches at all.
-                            PRINTER.nok(" Cannot find a dependency matching '" + query + "', maybe a typo?");
-                            success = false;
-                        } else {
-                            sb.append(Printer.NOK).append(" Multiple extensions matching '").append(query).append("'");
-                            result.getExtensions()
-                                    .forEach(extension -> sb.append(System.lineSeparator()).append("     * ")
-                                            .append(extension.managementKey()));
-                            sb.append(System.lineSeparator())
-                                    .append("     Be more specific e.g using the exact name or the full GAV.");
-                            PRINTER.print(sb.toString());
-                            success = false;
-                        }
-                    } else { // Matches.
-                        for (Extension extension : result) {
-                            // Don't set success to false even if the dependency is not added; as it's should be idempotent.
-                            updated = buildFile.addDependency(invocation.getPlatformDescriptor(), extension) || updated;
-                        }
-                    }
-                }
-            }
-        } catch (IOException e) {
-            throw new QuarkusCommandException("Failed to add extensions", e);
-        }
-
-        if (updated) {
-            try {
-                buildFile.close();
-            } catch (IOException e) {
-                throw new QuarkusCommandException("Failed to update the project", e);
-            }
-        }
-
-        return new QuarkusCommandOutcome(success).setValue(OUTCOME_UPDATED, updated);
+    public QuarkusCommandOutcome execute() throws QuarkusCommandException {
+        return new AddExtensionsCommandHandler().execute(invocation);
     }
 }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensionsCommandHandler.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/AddExtensionsCommandHandler.java
@@ -1,0 +1,233 @@
+package io.quarkus.cli.commands;
+
+import io.quarkus.cli.commands.file.BuildFile;
+import io.quarkus.dependencies.Extension;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+/**
+ * This class is thread-safe. It extracts extensions to be added to the project from an instance of
+ * {@link QuarkusCommandInvocation}.
+ */
+public class AddExtensionsCommandHandler implements QuarkusCommand {
+
+    final static Printer PRINTER = new Printer();
+
+    @Override
+    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
+
+        final Set<String> extensions = invocation.getValue(AddExtensions.EXTENSIONS, Collections.emptySet());
+        if (extensions.isEmpty()) {
+            return QuarkusCommandOutcome.success().setValue(AddExtensions.OUTCOME_UPDATED, false);
+        }
+
+        boolean updated = false;
+        boolean success = true;
+
+        final List<Extension> registry = invocation.getPlatformDescriptor().getExtensions();
+
+        final BuildFile buildFile = invocation.getBuildFile();
+        try {
+            for (String query : extensions) {
+
+                if (query.contains(":")) {
+                    // GAV case.
+                    updated = buildFile.addExtensionAsGAV(query) || updated;
+                } else {
+                    SelectionResult result = select(query, registry, false);
+                    if (!result.matches()) {
+                        StringBuilder sb = new StringBuilder();
+                        // We have 3 cases, we can still have a single candidate, but the match is on label
+                        // or we have several candidates, or none
+                        Set<Extension> candidates = result.getExtensions();
+                        if (candidates.isEmpty()) {
+                            // No matches at all.
+                            PRINTER.nok(" Cannot find a dependency matching '" + query + "', maybe a typo?");
+                            success = false;
+                        } else {
+                            sb.append(Printer.NOK).append(" Multiple extensions matching '").append(query).append("'");
+                            result.getExtensions()
+                                    .forEach(extension -> sb.append(System.lineSeparator()).append("     * ")
+                                            .append(extension.managementKey()));
+                            sb.append(System.lineSeparator())
+                                    .append("     Be more specific e.g using the exact name or the full GAV.");
+                            PRINTER.print(sb.toString());
+                            success = false;
+                        }
+                    } else { // Matches.
+                        for (Extension extension : result) {
+                            // Don't set success to false even if the dependency is not added; as it's should be idempotent.
+                            updated = buildFile.addDependency(invocation.getPlatformDescriptor(), extension) || updated;
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new QuarkusCommandException("Failed to add extensions", e);
+        }
+
+        if (updated) {
+            try {
+                buildFile.close();
+            } catch (IOException e) {
+                throw new QuarkusCommandException("Failed to update the project", e);
+            }
+        }
+
+        return new QuarkusCommandOutcome(success).setValue(AddExtensions.OUTCOME_UPDATED, updated);
+    }
+
+    /**
+     * Selection algorithm.
+     *
+     * @param query the query
+     * @param extensions the extension list
+     * @param labelLookup whether or not the query must be tested against the labels of the extensions. Should
+     *        be {@code false} by default.
+     * @return the list of matching candidates and whether or not a match has been found.
+     */
+    static SelectionResult select(String query, List<Extension> extensions, boolean labelLookup) {
+        String q = query.trim().toLowerCase();
+
+        // Try exact matches
+        Set<Extension> matchesNameOrArtifactId = extensions.stream()
+                .filter(extension -> extension.getName().equalsIgnoreCase(q) || matchesArtifactId(extension.getArtifactId(), q))
+                .collect(Collectors.toSet());
+        if (matchesNameOrArtifactId.size() == 1) {
+            return new SelectionResult(matchesNameOrArtifactId, true);
+        }
+
+        extensions = extensions.stream().filter(e -> !e.isUnlisted()).collect(Collectors.toList());
+
+        // Try short names
+        Set<Extension> matchesShortName = extensions.stream().filter(extension -> matchesShortName(extension, q))
+                .collect(Collectors.toSet());
+
+        if (matchesShortName.size() == 1 && matchesNameOrArtifactId.isEmpty()) {
+            return new SelectionResult(matchesShortName, true);
+        }
+
+        // Partial matches on name, artifactId and short names
+        Set<Extension> partialMatches = extensions.stream().filter(extension -> extension.getName().toLowerCase().contains(q)
+                || extension.getArtifactId().toLowerCase().contains(q)
+                || extension.getShortName().toLowerCase().contains(q)).collect(Collectors.toSet());
+        // Even if we have a single partial match, if the name, artifactId and short names are ambiguous, so not
+        // consider it as a match.
+        if (partialMatches.size() == 1 && matchesNameOrArtifactId.isEmpty() && matchesShortName.isEmpty()) {
+            return new SelectionResult(partialMatches, true);
+        }
+
+        // find by labels
+        List<Extension> matchesLabels;
+        if (labelLookup) {
+            matchesLabels = extensions.stream()
+                    .filter(extension -> extension.labelsForMatching().contains(q)).collect(Collectors.toList());
+        } else {
+            matchesLabels = Collections.emptyList();
+        }
+
+        // find by pattern
+        Set<Extension> matchesPatterns;
+        Pattern pattern = toRegex(q);
+        if (pattern != null) {
+            matchesPatterns = extensions.stream()
+                    .filter(extension -> pattern.matcher(extension.getName().toLowerCase()).matches()
+                            || pattern.matcher(extension.getArtifactId().toLowerCase()).matches()
+                            || pattern.matcher(extension.getShortName().toLowerCase()).matches()
+                            || matchLabels(pattern, extension.getKeywords()))
+                    .collect(Collectors.toSet());
+            return new SelectionResult(matchesPatterns, true);
+        } else {
+            matchesPatterns = Collections.emptySet();
+        }
+
+        Set<Extension> candidates = new LinkedHashSet<>();
+        candidates.addAll(matchesNameOrArtifactId);
+        candidates.addAll(matchesShortName);
+        candidates.addAll(partialMatches);
+        candidates.addAll(matchesLabels);
+        candidates.addAll(matchesPatterns);
+        return new SelectionResult(candidates, false);
+    }
+
+    private static boolean matchLabels(Pattern pattern, List<String> labels) {
+        boolean matches = false;
+        // if any label match it's ok
+        for (String label : labels) {
+            matches = matches || pattern.matcher(label.toLowerCase()).matches();
+        }
+        return matches;
+    }
+
+    private static Pattern toRegex(final String str) {
+        try {
+            String wildcardToRegex = wildcardToRegex(str);
+            if (wildcardToRegex != null && !wildcardToRegex.isEmpty()) {
+                return Pattern.compile(wildcardToRegex);
+            }
+        } catch (PatternSyntaxException e) {
+            //ignore it
+        }
+        return null;
+    }
+
+    private static String wildcardToRegex(String wildcard) {
+        if (wildcard == null || wildcard.isEmpty()) {
+            return null;
+        }
+        // don't try with file match char in pattern
+        if (!(wildcard.contains("*") || wildcard.contains("?"))) {
+            return null;
+        }
+        StringBuffer s = new StringBuffer(wildcard.length());
+        s.append("^.*");
+        for (int i = 0, is = wildcard.length(); i < is; i++) {
+            char c = wildcard.charAt(i);
+            switch (c) {
+                case '*':
+                    s.append(".*");
+                    break;
+                case '?':
+                    s.append(".");
+                    break;
+                case '^': // escape character in cmd.exe
+                    s.append("\\");
+                    break;
+                // escape special regexp-characters
+                case '(':
+                case ')':
+                case '[':
+                case ']':
+                case '$':
+                case '.':
+                case '{':
+                case '}':
+                case '|':
+                case '\\':
+                    s.append("\\");
+                    s.append(c);
+                    break;
+                default:
+                    s.append(c);
+                    break;
+            }
+        }
+        s.append(".*$");
+        return (s.toString());
+    }
+
+    private static boolean matchesShortName(Extension extension, String q) {
+        return q.equalsIgnoreCase(extension.getShortName());
+    }
+
+    private static boolean matchesArtifactId(String artifactId, String q) {
+        return artifactId.equalsIgnoreCase(q) ||
+                artifactId.equalsIgnoreCase("quarkus-" + q);
+    }
+}

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/CreateProject.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/CreateProject.java
@@ -1,164 +1,31 @@
 package io.quarkus.cli.commands;
 
-import static io.quarkus.generators.ProjectGenerator.BOM_ARTIFACT_ID;
-import static io.quarkus.generators.ProjectGenerator.BOM_GROUP_ID;
-import static io.quarkus.generators.ProjectGenerator.BOM_VERSION;
-import static io.quarkus.generators.ProjectGenerator.BUILD_FILE;
 import static io.quarkus.generators.ProjectGenerator.CLASS_NAME;
 import static io.quarkus.generators.ProjectGenerator.IS_SPRING;
-import static io.quarkus.generators.ProjectGenerator.PACKAGE_NAME;
 import static io.quarkus.generators.ProjectGenerator.PROJECT_ARTIFACT_ID;
 import static io.quarkus.generators.ProjectGenerator.PROJECT_GROUP_ID;
 import static io.quarkus.generators.ProjectGenerator.PROJECT_VERSION;
-import static io.quarkus.generators.ProjectGenerator.QUARKUS_VERSION;
 import static io.quarkus.generators.ProjectGenerator.SOURCE_TYPE;
 
 import io.quarkus.cli.commands.file.BuildFile;
-import io.quarkus.cli.commands.file.MavenBuildFile;
-import io.quarkus.cli.commands.legacy.LegacyQuarkusCommandInvocation;
 import io.quarkus.cli.commands.writer.ProjectWriter;
 import io.quarkus.generators.BuildTool;
-import io.quarkus.generators.ProjectGeneratorRegistry;
 import io.quarkus.generators.SourceType;
-import io.quarkus.generators.rest.BasicRestProjectGenerator;
-import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
-import org.apache.maven.model.Model;
+import javax.lang.model.SourceVersion;
 
 /**
+ * Instances of this class are not thread-safe. They are created per invocation.
+ *
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
  */
-public class CreateProject implements QuarkusCommand {
-
-    private ProjectWriter writer;
-    private String groupId;
-    private String artifactId;
-    private String version;
-    private SourceType sourceType = SourceType.JAVA;
-    private BuildFile buildFile;
-    private BuildTool buildTool;
-    private String className;
-    private Set<String> extensions;
-
-    private Model model;
-
-    public CreateProject(final ProjectWriter writer) {
-        this.writer = writer;
-    }
-
-    public CreateProject groupId(String groupId) {
-        this.groupId = groupId;
-        return this;
-    }
-
-    public CreateProject artifactId(String artifactId) {
-        this.artifactId = artifactId;
-        return this;
-    }
-
-    public CreateProject version(String version) {
-        this.version = version;
-        return this;
-    }
-
-    public CreateProject sourceType(SourceType sourceType) {
-        this.sourceType = sourceType;
-        return this;
-    }
-
-    public CreateProject className(String className) {
-        this.className = className;
-        return this;
-    }
-
-    public CreateProject extensions(Set<String> extensions) {
-        this.extensions = extensions;
-        return this;
-    }
-
-    public CreateProject buildFile(BuildFile buildFile) {
-        this.buildFile = buildFile;
-        return this;
-    }
-
-    public CreateProject buildTool(BuildTool buildTool) {
-        this.buildTool = buildTool;
-        return this;
-    }
-
-    public Model getModel() {
-        return model;
-    }
-
-    public boolean doCreateProject(final Map<String, Object> context) throws IOException {
-        try {
-            return execute(new LegacyQuarkusCommandInvocation(context)).isSuccess();
-        } catch (QuarkusCommandException e) {
-            throw new IOException("Failed to create project", e);
-        }
-    }
-
-    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
-        if (!writer.init()) {
-            return QuarkusCommandOutcome.failure();
-        }
-
-        final Properties quarkusProps = ToolsUtils.readQuarkusProperties(invocation.getPlatformDescriptor());
-        quarkusProps.forEach((k, v) -> invocation.setProperty(k.toString().replace("-", "_"), v.toString()));
-
-        invocation.setProperty(PROJECT_GROUP_ID, groupId);
-        invocation.setProperty(PROJECT_ARTIFACT_ID, artifactId);
-        invocation.setProperty(PROJECT_VERSION, version);
-        invocation.setProperty(BOM_GROUP_ID, invocation.getPlatformDescriptor().getBomGroupId());
-        invocation.setProperty(BOM_ARTIFACT_ID, invocation.getPlatformDescriptor().getBomArtifactId());
-
-        try (BuildFile buildFile = getBuildFile()) {
-            String bomVersion = invocation.getPlatformDescriptor().getBomVersion();
-
-            invocation.setProperty(BOM_VERSION, bomVersion);
-            invocation.setProperty(QUARKUS_VERSION, invocation.getPlatformDescriptor().getQuarkusVersion());
-            invocation.setValue(SOURCE_TYPE, sourceType);
-            invocation.setValue(BUILD_FILE, buildFile);
-
-            if (extensions != null && extensions.stream().anyMatch(e -> e.toLowerCase().contains("spring-web"))) {
-                invocation.setValue(IS_SPRING, Boolean.TRUE);
-            }
-
-            if (className != null) {
-                className = sourceType.stripExtensionFrom(className);
-                int idx = className.lastIndexOf('.');
-                if (idx >= 0) {
-                    final String packageName = className.substring(0, idx);
-                    className = className.substring(idx + 1);
-                    invocation.setProperty(PACKAGE_NAME, packageName);
-                }
-                invocation.setProperty(CLASS_NAME, className);
-            }
-
-            ProjectGeneratorRegistry.get(BasicRestProjectGenerator.NAME).generate(writer, invocation);
-
-            // call close at the end to save file
-            buildFile.completeFile(groupId, artifactId, version, invocation.getPlatformDescriptor(), quarkusProps);
-        } catch (IOException e) {
-            throw new QuarkusCommandException("Failed to create project", e);
-        }
-        return QuarkusCommandOutcome.success();
-    }
-
-    private BuildFile getBuildFile() throws IOException {
-        if (buildFile == null) {
-            if (buildTool == null) {
-                buildFile = new MavenBuildFile(writer);
-            } else {
-                buildFile = buildTool.createBuildFile(writer);
-            }
-        }
-        return buildFile;
-    }
+public class CreateProject {
 
     public static SourceType determineSourceType(Set<String> extensions) {
         Optional<SourceType> sourceType = extensions.stream()
@@ -167,5 +34,106 @@ public class CreateProject implements QuarkusCommand {
                 .map(e -> e.orElse(SourceType.JAVA))
                 .findAny();
         return sourceType.orElse(SourceType.JAVA);
+    }
+
+    private static boolean isSpringStyle(Collection<String> extensions) {
+        return extensions != null && extensions.stream().anyMatch(e -> e.toLowerCase().contains("spring-web"));
+    }
+
+    private QuarkusCommandInvocation invocation;
+
+    /**
+     * @deprecated since 1.3.0.CR1
+     *             Please use {@link #CreateProject(ProjectWriter, QuarkusPlatformDescriptor)} instead.
+     */
+    @Deprecated
+    public CreateProject(ProjectWriter writer) {
+        this(writer, QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor());
+    }
+
+    public CreateProject(final ProjectWriter writer, QuarkusPlatformDescriptor platformDescr) {
+        invocation = new QuarkusCommandInvocation(platformDescr);
+        invocation.setProjectWriter(writer);
+    }
+
+    public CreateProject groupId(String groupId) {
+        setProperty(PROJECT_GROUP_ID, groupId);
+        return this;
+    }
+
+    public CreateProject artifactId(String artifactId) {
+        setProperty(PROJECT_ARTIFACT_ID, artifactId);
+        return this;
+    }
+
+    public CreateProject version(String version) {
+        setProperty(PROJECT_VERSION, version);
+        return this;
+    }
+
+    public CreateProject sourceType(SourceType sourceType) {
+        invocation.setValue(SOURCE_TYPE, sourceType);
+        return this;
+    }
+
+    public CreateProject className(String className) {
+        if (className == null) {
+            return this;
+        }
+        if (!(SourceVersion.isName(className) && !SourceVersion.isKeyword(className))) {
+            throw new IllegalArgumentException(className + " is not a valid class name");
+        }
+        setProperty(CLASS_NAME, className);
+        return this;
+    }
+
+    /**
+     * @deprecated in 1.3.0.CR
+     */
+    @Deprecated
+    public CreateProject extensions(Set<String> extensions) {
+        if (isSpringStyle(extensions)) {
+            invocation.setValue(IS_SPRING, true);
+        }
+        return this;
+    }
+
+    public CreateProject setProperty(String name, String value) {
+        invocation.setProperty(name, value);
+        return this;
+    }
+
+    public CreateProject setValue(String name, Object value) {
+        invocation.setValue(name, value);
+        return this;
+    }
+
+    public CreateProject buildFile(BuildFile buildFile) {
+        invocation.setBuildFile(buildFile);
+        return this;
+    }
+
+    public CreateProject buildTool(BuildTool buildTool) {
+        invocation.setBuildTool(buildTool);
+        return this;
+    }
+
+    public boolean doCreateProject(final Map<String, Object> context) throws IOException {
+        if (context != null && !context.isEmpty()) {
+            for (Map.Entry<String, Object> entry : context.entrySet()) {
+                if (entry.getValue() != null) {
+                    invocation.setProperty(entry.getKey(), entry.getValue().toString());
+                }
+            }
+        }
+        try {
+            return execute().isSuccess();
+        } catch (QuarkusCommandException e) {
+            throw new IOException("Failed to create project", e);
+        }
+    }
+
+    public QuarkusCommandOutcome execute() throws QuarkusCommandException {
+        return new CreateProjectCommandHandler().execute(invocation);
     }
 }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/CreateProjectCommandHandler.java
@@ -1,0 +1,78 @@
+package io.quarkus.cli.commands;
+
+import static io.quarkus.generators.ProjectGenerator.BOM_ARTIFACT_ID;
+import static io.quarkus.generators.ProjectGenerator.BOM_GROUP_ID;
+import static io.quarkus.generators.ProjectGenerator.BOM_VERSION;
+import static io.quarkus.generators.ProjectGenerator.BUILD_FILE;
+import static io.quarkus.generators.ProjectGenerator.CLASS_NAME;
+import static io.quarkus.generators.ProjectGenerator.PACKAGE_NAME;
+import static io.quarkus.generators.ProjectGenerator.PROJECT_ARTIFACT_ID;
+import static io.quarkus.generators.ProjectGenerator.PROJECT_GROUP_ID;
+import static io.quarkus.generators.ProjectGenerator.PROJECT_VERSION;
+import static io.quarkus.generators.ProjectGenerator.QUARKUS_VERSION;
+import static io.quarkus.generators.ProjectGenerator.SOURCE_TYPE;
+
+import io.quarkus.cli.commands.file.BuildFile;
+import io.quarkus.cli.commands.writer.ProjectWriter;
+import io.quarkus.generators.ProjectGeneratorRegistry;
+import io.quarkus.generators.SourceType;
+import io.quarkus.generators.rest.BasicRestProjectGenerator;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.tools.ToolsUtils;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Instances of this class are thread-safe. They create a new project extracting all the necessary properties from an instance
+ * of {@link QuarkusCommandInvocation}.
+ */
+public class CreateProjectCommandHandler implements QuarkusCommand {
+
+    @Override
+    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
+        final ProjectWriter projectWriter = invocation.getProjectWriter();
+        if (projectWriter == null) {
+            throw new IllegalStateException("Project writer has not been provided");
+        }
+        if (!projectWriter.init()) {
+            return QuarkusCommandOutcome.failure();
+        }
+
+        final QuarkusPlatformDescriptor platformDescr = invocation.getPlatformDescriptor();
+        invocation.setProperty(BOM_GROUP_ID, platformDescr.getBomGroupId());
+        invocation.setProperty(BOM_ARTIFACT_ID, platformDescr.getBomArtifactId());
+        invocation.setProperty(QUARKUS_VERSION, platformDescr.getQuarkusVersion());
+        invocation.setProperty(BOM_VERSION, platformDescr.getBomVersion());
+
+        final Properties quarkusProps = ToolsUtils.readQuarkusProperties(platformDescr);
+        quarkusProps.forEach((k, v) -> invocation.setProperty(k.toString().replace("-", "_"), v.toString()));
+
+        try (BuildFile buildFile = invocation.getBuildFile()) {
+            invocation.setValue(BUILD_FILE, buildFile);
+
+            String className = invocation.getProperty(CLASS_NAME);
+            if (className != null) {
+                className = invocation.getValue(SOURCE_TYPE, SourceType.JAVA).stripExtensionFrom(className);
+                int idx = className.lastIndexOf('.');
+                if (idx >= 0) {
+                    String pkgName = invocation.getProperty(PACKAGE_NAME);
+                    if (pkgName == null) {
+                        invocation.setProperty(PACKAGE_NAME, className.substring(0, idx));
+                    }
+                    className = className.substring(idx + 1);
+                }
+                invocation.setProperty(CLASS_NAME, className);
+            }
+            ProjectGeneratorRegistry.get(BasicRestProjectGenerator.NAME).generate(projectWriter, invocation);
+
+            // call close at the end to save file
+            buildFile.completeFile(invocation.getProperty(PROJECT_GROUP_ID),
+                    invocation.getProperty(PROJECT_ARTIFACT_ID),
+                    invocation.getProperty(PROJECT_VERSION),
+                    platformDescr, quarkusProps);
+        } catch (IOException e) {
+            throw new QuarkusCommandException("Failed to create project", e);
+        }
+        return QuarkusCommandOutcome.success();
+    }
+}

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ListExtensions.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ListExtensions.java
@@ -1,191 +1,79 @@
 package io.quarkus.cli.commands;
 
 import io.quarkus.cli.commands.file.BuildFile;
-import io.quarkus.cli.commands.file.GradleBuildFile;
-import io.quarkus.cli.commands.legacy.LegacyQuarkusCommandInvocation;
-import io.quarkus.dependencies.Extension;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import io.quarkus.platform.tools.ToolsConstants;
 import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.maven.model.Dependency;
 
-public class ListExtensions implements QuarkusCommand {
+/**
+ * Instances of this class are not thread-safe. They are created per single invocation.
+ */
+public class ListExtensions {
     public static final String NAME = "list-extensions";
     private static final String PARAM_PREFIX = ToolsUtils.dotJoin(ToolsConstants.QUARKUS, NAME);
     public static final String ALL = ToolsUtils.dotJoin(PARAM_PREFIX, "all");
     public static final String FORMAT = ToolsUtils.dotJoin(PARAM_PREFIX, "format");
     public static final String SEARCH = ToolsUtils.dotJoin(PARAM_PREFIX, "search");
 
-    private static final String FULL_FORMAT = "%-8s %-50s %-50s %-25s%n%s";
-    private static final String CONCISE_FORMAT = "%-50s %-50s";
-    private static final String NAME_FORMAT = "%-50s";
-    private BuildFile buildFile = null;
+    private final QuarkusCommandInvocation invocation;
+    private final ListExtensionsCommandHandler handler = new ListExtensionsCommandHandler();
 
+    /**
+     * @deprecated since 1.3.0.CR1
+     *             Please use {@link #ListExtensions(BuildFile, QuarkusPlatformDescriptor)} instead.
+     */
+    @Deprecated
     public ListExtensions(final BuildFile buildFile) throws IOException {
+        this(buildFile, QuarkusPlatformConfig.getGlobalDefault().getPlatformDescriptor());
+    }
+
+    public ListExtensions(final BuildFile buildFile, QuarkusPlatformDescriptor platformDescr) throws IOException {
+        this.invocation = new QuarkusCommandInvocation(platformDescr);
         if (buildFile != null) {
-            this.buildFile = buildFile;
+            invocation.setBuildFile(buildFile);
         }
     }
 
+    public ListExtensions all(boolean all) {
+        invocation.setValue(ALL, all);
+        return this;
+    }
+
+    public ListExtensions format(String format) {
+        invocation.setValue(FORMAT, format);
+        return this;
+    }
+
+    public ListExtensions search(String search) {
+        invocation.setValue(SEARCH, search);
+        return this;
+    }
+
+    /**
+     * @deprecated in 1.3.0.CR1
+     *             Please use {@link #all(boolean)}, {@link #format(String)} and {@link #search(String)} respectively.
+     */
+    @Deprecated
     public void listExtensions(boolean all, String format, String search) throws IOException {
+        all(all);
+        format(format);
+        search(search);
         try {
-            execute(new LegacyQuarkusCommandInvocation()
-                    .setValue(ALL, all)
-                    .setValue(FORMAT, format)
-                    .setValue(SEARCH, search));
+            execute();
         } catch (QuarkusCommandException e) {
             throw new IOException("Failed to list extensions", e);
         }
     }
 
-    @Override
-    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
-
-        final boolean all = invocation.getValue(ALL, true);
-        final String format = invocation.getValue(FORMAT, "concise");
-        final String search = invocation.getValue(SEARCH, "*");
-
-        Map<String, Dependency> installed;
-        try {
-            installed = findInstalled();
-        } catch (IOException e) {
-            throw new QuarkusCommandException("Failed to determine the list of installed extensions", e);
-        }
-
-        Stream<Extension> extensionsStream = invocation.getPlatformDescriptor().getExtensions().stream();
-        extensionsStream = extensionsStream.filter(e -> filterUnlisted(e));
-        if (search != null && !"*".equalsIgnoreCase(search)) {
-            final Pattern searchPattern = Pattern.compile(".*" + search + ".*", Pattern.CASE_INSENSITIVE);
-            extensionsStream = extensionsStream.filter(e -> filterBySearch(searchPattern, e));
-        }
-        List<Extension> loadedExtensions = extensionsStream.collect(Collectors.toList());
-
-        if (loadedExtensions.isEmpty()) {
-            System.out.println("No extension found with this pattern");
-        } else {
-            String extensionStatus = all ? "available" : "installable";
-            System.out.println(String.format("%nCurrent Quarkus extensions %s: ", extensionStatus));
-
-            Consumer<String[]> currentFormatter;
-            switch (format.toLowerCase()) {
-                case "name":
-                    currentFormatter = this::nameFormatter;
-                    break;
-                case "full":
-                    currentFormatter = this::fullFormatter;
-                    currentFormatter.accept(new String[] { "Status", "Extension", "ArtifactId", "Updated Version", "Guide" });
-                    break;
-                case "concise":
-                default:
-                    currentFormatter = this::conciseFormatter;
-            }
-
-            loadedExtensions.forEach(extension -> display(extension, installed, all, currentFormatter));
-
-            if ("concise".equalsIgnoreCase(format)) {
-                if (this.buildFile instanceof GradleBuildFile) {
-                    System.out.println("\nTo get more information, append --format=full to your command line.");
-                } else {
-                    System.out
-                            .println("\nTo get more information, append -Dquarkus.extension.format=full to your command line.");
-                }
-            }
-
-            if (this.buildFile instanceof GradleBuildFile) {
-                System.out.println("\nAdd an extension to your project by adding the dependency to your " +
-                        "build.gradle or use `./gradlew addExtension --extensions=\"artifactId\"`");
-            } else {
-                System.out.println("\nAdd an extension to your project by adding the dependency to your " +
-                        "pom.xml or use `./mvnw quarkus:add-extension -Dextensions=\"artifactId\"`");
-            }
-        }
-
-        return QuarkusCommandOutcome.success();
-    }
-
-    private boolean filterUnlisted(Extension e) {
-        return !e.getMetadata().containsKey("unlisted");
+    public QuarkusCommandOutcome execute() throws QuarkusCommandException {
+        return handler.execute(invocation);
     }
 
     public Map<String, Dependency> findInstalled() throws IOException {
-        if (buildFile != null) {
-            return buildFile.findInstalled();
-        } else {
-            return Collections.emptyMap();
-        }
-    }
-
-    private boolean filterBySearch(final Pattern searchPattern, Extension e) {
-        return searchPattern.matcher(e.getName()).matches();
-    }
-
-    private void conciseFormatter(String[] cols) {
-        System.out.println(String.format(CONCISE_FORMAT, cols[1], cols[2], cols[4]));
-    }
-
-    private void fullFormatter(String[] cols) {
-        System.out.println(String.format(FULL_FORMAT, cols[0], cols[1], cols[2], cols[3], cols[4]));
-    }
-
-    private void nameFormatter(String[] cols) {
-        System.out.println(String.format(NAME_FORMAT, cols[2]));
-    }
-
-    private void display(Extension extension, final Map<String, Dependency> installed, boolean all,
-            Consumer<String[]> formatter) {
-        final Dependency dependency = installed.get(extension.getGroupId() + ":" + extension.getArtifactId());
-        if (!all && dependency != null) {
-            return;
-        }
-
-        String label = "";
-        String version = "";
-
-        final String extracted = extractVersion(dependency);
-        if (extracted != null) {
-            if (extracted.equalsIgnoreCase(extension.getVersion())) {
-                label = "current";
-                version = String.format("%s", extracted);
-            } else {
-                label = "update";
-                version = String.format("%s <> %s", extracted, extension.getVersion());
-            }
-        }
-
-        String[] result = new String[] { label, extension.getName(), extension.getArtifactId(), version, extension.getGuide() };
-
-        for (int i = 0; i < result.length; i++) {
-            result[i] = Objects.toString(result[i], "");
-        }
-
-        formatter.accept(result);
-    }
-
-    private String extractVersion(final Dependency dependency) {
-        String version = dependency != null ? dependency.getVersion() : null;
-        if (version != null && version.startsWith("$")) {
-            String value = null;
-            try {
-                value = (String) buildFile.getProperty(propertyName(version));
-            } catch (IOException e) {
-                // ignore this error.
-            }
-            if (value != null) {
-                version = value;
-            }
-        }
-        return version;
-    }
-
-    private String propertyName(final String variable) {
-        return variable.substring(2, variable.length() - 1);
+        return handler.findInstalled(invocation);
     }
 }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ListExtensionsCommandHandler.java
@@ -1,0 +1,171 @@
+package io.quarkus.cli.commands;
+
+import io.quarkus.cli.commands.file.BuildFile;
+import io.quarkus.cli.commands.file.GradleBuildFile;
+import io.quarkus.dependencies.Extension;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.maven.model.Dependency;
+
+/**
+ * Instances of this class are thread-safe. It lists extensions according to the options passed in as properties of
+ * {@link QuarkusCommandInvocation}
+ */
+public class ListExtensionsCommandHandler implements QuarkusCommand {
+
+    private static final String FULL_FORMAT = "%-8s %-50s %-50s %-25s%n%s";
+    private static final String CONCISE_FORMAT = "%-50s %-50s";
+    private static final String NAME_FORMAT = "%-50s";
+
+    @Override
+    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
+
+        final boolean all = invocation.getValue(ListExtensions.ALL, true);
+        final String format = invocation.getValue(ListExtensions.FORMAT, "concise");
+        final String search = invocation.getValue(ListExtensions.SEARCH, "*");
+
+        Map<String, Dependency> installed;
+        try {
+            installed = findInstalled(invocation);
+        } catch (IOException e) {
+            throw new QuarkusCommandException("Failed to determine the list of installed extensions", e);
+        }
+
+        Stream<Extension> extensionsStream = invocation.getPlatformDescriptor().getExtensions().stream();
+        extensionsStream = extensionsStream.filter(e -> filterUnlisted(e));
+        if (search != null && !"*".equalsIgnoreCase(search)) {
+            final Pattern searchPattern = Pattern.compile(".*" + search + ".*", Pattern.CASE_INSENSITIVE);
+            extensionsStream = extensionsStream.filter(e -> filterBySearch(searchPattern, e));
+        }
+        List<Extension> loadedExtensions = extensionsStream.collect(Collectors.toList());
+
+        if (loadedExtensions.isEmpty()) {
+            System.out.println("No extension found with this pattern");
+        } else {
+            String extensionStatus = all ? "available" : "installable";
+            System.out.println(String.format("%nCurrent Quarkus extensions %s: ", extensionStatus));
+
+            Consumer<String[]> currentFormatter;
+            switch (format.toLowerCase()) {
+                case "name":
+                    currentFormatter = this::nameFormatter;
+                    break;
+                case "full":
+                    currentFormatter = this::fullFormatter;
+                    currentFormatter.accept(new String[] { "Status", "Extension", "ArtifactId", "Updated Version", "Guide" });
+                    break;
+                case "concise":
+                default:
+                    currentFormatter = this::conciseFormatter;
+            }
+
+            final BuildFile buildFile = invocation.getBuildFile();
+            loadedExtensions.forEach(extension -> display(extension, installed, all, currentFormatter, buildFile));
+
+            if ("concise".equalsIgnoreCase(format)) {
+                if (buildFile instanceof GradleBuildFile) {
+                    System.out.println("\nTo get more information, append --format=full to your command line.");
+                } else {
+                    System.out
+                            .println("\nTo get more information, append -Dquarkus.extension.format=full to your command line.");
+                }
+            }
+
+            if (buildFile instanceof GradleBuildFile) {
+                System.out.println("\nAdd an extension to your project by adding the dependency to your " +
+                        "build.gradle or use `./gradlew addExtension --extensions=\"artifactId\"`");
+            } else {
+                System.out.println("\nAdd an extension to your project by adding the dependency to your " +
+                        "pom.xml or use `./mvnw quarkus:add-extension -Dextensions=\"artifactId\"`");
+            }
+        }
+
+        return QuarkusCommandOutcome.success();
+    }
+
+    Map<String, Dependency> findInstalled(QuarkusCommandInvocation invocation) throws IOException {
+        final BuildFile buildFile = invocation.getBuildFile(false);
+        if (buildFile != null) {
+            return buildFile.findInstalled();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    private boolean filterUnlisted(Extension e) {
+        return !e.getMetadata().containsKey("unlisted");
+    }
+
+    private boolean filterBySearch(final Pattern searchPattern, Extension e) {
+        return searchPattern.matcher(e.getName()).matches();
+    }
+
+    private void conciseFormatter(String[] cols) {
+        System.out.println(String.format(CONCISE_FORMAT, cols[1], cols[2], cols[4]));
+    }
+
+    private void fullFormatter(String[] cols) {
+        System.out.println(String.format(FULL_FORMAT, cols[0], cols[1], cols[2], cols[3], cols[4]));
+    }
+
+    private void nameFormatter(String[] cols) {
+        System.out.println(String.format(NAME_FORMAT, cols[2]));
+    }
+
+    private void display(Extension extension, final Map<String, Dependency> installed, boolean all,
+            Consumer<String[]> formatter, BuildFile buildFile) {
+        final Dependency dependency = installed.get(extension.getGroupId() + ":" + extension.getArtifactId());
+        if (!all && dependency != null) {
+            return;
+        }
+
+        String label = "";
+        String version = "";
+
+        final String extracted = extractVersion(dependency, buildFile);
+        if (extracted != null) {
+            if (extracted.equalsIgnoreCase(extension.getVersion())) {
+                label = "current";
+                version = String.format("%s", extracted);
+            } else {
+                label = "update";
+                version = String.format("%s <> %s", extracted, extension.getVersion());
+            }
+        }
+
+        String[] result = new String[] { label, extension.getName(), extension.getArtifactId(), version, extension.getGuide() };
+
+        for (int i = 0; i < result.length; i++) {
+            result[i] = Objects.toString(result[i], "");
+        }
+
+        formatter.accept(result);
+    }
+
+    private String extractVersion(final Dependency dependency, BuildFile buildFile) {
+        String version = dependency != null ? dependency.getVersion() : null;
+        if (version != null && version.startsWith("$")) {
+            String value = null;
+            try {
+                value = (String) buildFile.getProperty(propertyName(version));
+            } catch (IOException e) {
+                // ignore this error.
+            }
+            if (value != null) {
+                version = value;
+            }
+        }
+        return version;
+    }
+
+    private String propertyName(final String variable) {
+        return variable.substring(2, variable.length() - 1);
+    }
+}

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ValueMap.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/ValueMap.java
@@ -48,6 +48,11 @@ public class ValueMap<V extends ValueMap<V>> {
         return Boolean.parseBoolean(value.toString());
     }
 
+    public boolean valueIs(String name, Object o) {
+        final Object value = values.get(name);
+        return o == null ? value == null : o.equals(value);
+    }
+
     public boolean hasValue(String name) {
         return values.getOrDefault(name, NOT_SET) != NOT_SET;
     }

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/legacy/LegacyQuarkusCommandInvocation.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/legacy/LegacyQuarkusCommandInvocation.java
@@ -5,6 +5,11 @@ import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * @deprecated since 1.3.0.CR1
+ *             Please use {@link QuarkusCommandInvocation} instead
+ */
+@Deprecated
 public class LegacyQuarkusCommandInvocation extends QuarkusCommandInvocation {
 
     public LegacyQuarkusCommandInvocation() {

--- a/independent-projects/tools/common/src/main/java/io/quarkus/generators/ProjectGenerator.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/generators/ProjectGenerator.java
@@ -25,6 +25,11 @@ public interface ProjectGenerator {
 
     String getName();
 
+    /**
+     * @deprecated since 1.3.0.CR1
+     *             Please use {@link #generate(ProjectWriter, QuarkusCommandInvocation)} instead.
+     */
+    @Deprecated
     default void generate(ProjectWriter writer, Map<String, Object> parameters) throws IOException {
         generate(writer, new LegacyQuarkusCommandInvocation(parameters));
     }

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AbstractAddExtensionsTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AbstractAddExtensionsTest.java
@@ -19,7 +19,7 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void addSomeValidExtensions() throws IOException {
+    void addSomeValidExtensions() throws Exception {
         createProject();
         addExtensions(asList("jdbc-postgre", "agroal", "quarkus-arc", " hibernate-validator",
                 "commons-io:commons-io:2.6"));
@@ -32,7 +32,7 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void testPartialMatches() throws IOException {
+    void testPartialMatches() throws Exception {
         createProject();
         addExtensions(asList("orm-pana", "jdbc-postgre", "arc"));
 
@@ -43,12 +43,13 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void testRegexpMatches() throws IOException {
+    void testRegexpMatches() throws Exception {
         createProject();
 
-        final AddExtensionResult result = addExtensions(asList("Sm??lRye**"));
+        final QuarkusCommandOutcome result = addExtensions(asList("Sm??lRye**"));
 
-        Assertions.assertTrue(result.isUpdated());
+        Assertions.assertTrue(result.isSuccess());
+        Assertions.assertTrue(result.valueIs(AddExtensions.OUTCOME_UPDATED, true));
 
         final T project = readProject();
         hasDependency(project, "quarkus-smallrye-reactive-messaging");
@@ -66,48 +67,48 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void addMissingExtension() throws IOException {
+    void addMissingExtension() throws Exception {
         createProject();
 
-        final AddExtensionResult result = addExtensions(Collections.singletonList("missing"));
+        final QuarkusCommandOutcome result = addExtensions(Collections.singletonList("missing"));
 
         final T project = readProject();
         doesNotHaveDependency(project, "quarkus-missing");
-        Assertions.assertFalse(result.succeeded());
-        Assertions.assertFalse(result.isUpdated());
+        Assertions.assertFalse(result.isSuccess());
+        Assertions.assertFalse(result.valueIs(AddExtensions.OUTCOME_UPDATED, true));
     }
 
     @Test
-    void addExtensionTwiceInOneBatch() throws IOException {
+    void addExtensionTwiceInOneBatch() throws Exception {
         createProject();
-        final AddExtensionResult result = addExtensions(asList("agroal", "agroal"));
+        final QuarkusCommandOutcome result = addExtensions(asList("agroal", "agroal"));
         final T project = readProject();
         hasDependency(project, "quarkus-agroal");
         Assertions.assertEquals(1,
                 countDependencyOccurrences(project, getPluginGroupId(), "quarkus-agroal", null));
-        Assertions.assertTrue(result.isUpdated());
-        Assertions.assertTrue(result.succeeded());
+        Assertions.assertTrue(result.valueIs(AddExtensions.OUTCOME_UPDATED, true));
+        Assertions.assertTrue(result.isSuccess());
     }
 
     @Test
-    void addExtensionTwiceInTwoBatches() throws IOException {
+    void addExtensionTwiceInTwoBatches() throws Exception {
         createProject();
 
-        final AddExtensionResult result1 = addExtensions(Collections.singletonList("agroal"));
+        final QuarkusCommandOutcome result1 = addExtensions(Collections.singletonList("agroal"));
         final T project1 = readProject();
         hasDependency(project1, "quarkus-agroal");
         Assertions.assertEquals(1,
                 countDependencyOccurrences(project1, getPluginGroupId(), "quarkus-agroal", null));
-        Assertions.assertTrue(result1.isUpdated());
-        Assertions.assertTrue(result1.succeeded());
+        Assertions.assertTrue(result1.valueIs(AddExtensions.OUTCOME_UPDATED, true));
+        Assertions.assertTrue(result1.isSuccess());
 
-        final AddExtensionResult result2 = addExtensions(Collections.singletonList("agroal"));
+        final QuarkusCommandOutcome result2 = addExtensions(Collections.singletonList("agroal"));
         final T project2 = readProject();
         hasDependency(project2, "quarkus-agroal");
         Assertions.assertEquals(1,
                 countDependencyOccurrences(project2, getPluginGroupId(), "quarkus-agroal", null));
-        Assertions.assertFalse(result2.isUpdated());
-        Assertions.assertTrue(result2.succeeded());
+        Assertions.assertFalse(result2.valueIs(AddExtensions.OUTCOME_UPDATED, true));
+        Assertions.assertTrue(result2.isSuccess());
     }
 
     /**
@@ -115,38 +116,38 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
      * The `arc` query was matching ArC but also hibernate-search-elasticsearch.
      */
     @Test
-    void testPartialMatchConflict() throws IOException {
+    void testPartialMatchConflict() throws Exception {
         createProject();
 
-        final AddExtensionResult result = addExtensions(Collections.singletonList("arc"));
+        final QuarkusCommandOutcome result = addExtensions(Collections.singletonList("arc"));
 
-        Assertions.assertTrue(result.isUpdated());
-        Assertions.assertTrue(result.succeeded());
+        Assertions.assertTrue(result.valueIs(AddExtensions.OUTCOME_UPDATED, true));
+        Assertions.assertTrue(result.isSuccess());
         final T project = readProject();
         hasDependency(project, "quarkus-arc");
 
-        final AddExtensionResult result2 = addExtensions(Collections.singletonList("elasticsearch"));
+        final QuarkusCommandOutcome result2 = addExtensions(Collections.singletonList("elasticsearch"));
 
-        Assertions.assertTrue(result2.isUpdated());
-        Assertions.assertTrue(result2.succeeded());
+        Assertions.assertTrue(result2.valueIs(AddExtensions.OUTCOME_UPDATED, true));
+        Assertions.assertTrue(result2.isSuccess());
         final T project2 = readProject();
         hasDependency(project2, "quarkus-hibernate-search-elasticsearch");
     }
 
     @Test
-    void addExistingAndMissingExtensions() throws IOException {
+    void addExistingAndMissingExtensions() throws Exception {
         createProject();
-        final AddExtensionResult result = addExtensions(asList("missing", "agroal"));
+        final QuarkusCommandOutcome result = addExtensions(asList("missing", "agroal"));
 
         final T project = readProject();
         doesNotHaveDependency(project, "quarkus-missing");
         hasDependency(project, "quarkus-agroal");
-        Assertions.assertFalse(result.succeeded());
-        Assertions.assertTrue(result.isUpdated());
+        Assertions.assertFalse(result.isSuccess());
+        Assertions.assertTrue(result.valueIs(AddExtensions.OUTCOME_UPDATED, true));
     }
 
     @Test
-    void addDuplicatedExtension() throws IOException {
+    void addDuplicatedExtension() throws Exception {
         createProject();
 
         addExtensions(asList("agroal", "jdbc", "non-exist-ent"));
@@ -158,7 +159,7 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void addDuplicatedExtensionUsingGAV() throws IOException {
+    void addDuplicatedExtensionUsingGAV() throws Exception {
         createProject();
 
         addExtensions(asList("org.acme:acme:1", "org.acme:acme:1"));
@@ -170,7 +171,7 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void testVertx() throws IOException {
+    void testVertx() throws Exception {
         createProject();
 
         addExtensions(Collections.singletonList("vertx"));
@@ -180,7 +181,7 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
     }
 
     @Test
-    void testVertxWithDot() throws IOException {
+    void testVertxWithDot() throws Exception {
         createProject();
 
         addExtensions(Collections.singletonList("vert.x"));
@@ -201,11 +202,11 @@ abstract class AbstractAddExtensionsTest<T> extends PlatformAwareTestBase {
         Assertions.assertTrue(countDependencyOccurrences(project, getPluginGroupId(), artifactId, null) == 0);
     }
 
-    protected abstract T createProject() throws IOException;
+    protected abstract T createProject() throws IOException, QuarkusCommandException;
 
     protected abstract T readProject() throws IOException;
 
-    protected abstract AddExtensionResult addExtensions(List<String> extensions) throws IOException;
+    protected abstract QuarkusCommandOutcome addExtensions(List<String> extensions) throws IOException, QuarkusCommandException;
 
     protected abstract long countDependencyOccurrences(T project, String groupId, String artifactId, String version);
 }

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddExtensionsSelectTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddExtensionsSelectTest.java
@@ -24,11 +24,11 @@ class AddExtensionsSelectTest {
 
         List<Extension> extensions = asList(e1, e2, e3);
         Collections.shuffle(extensions);
-        SelectionResult matches = AddExtensions.select("foo", extensions, true);
+        SelectionResult matches = AddExtensionsCommandHandler.select("foo", extensions, true);
         Assertions.assertFalse(matches.matches());
         Assertions.assertEquals(2, matches.getExtensions().size());
 
-        matches = AddExtensions.select("foo", extensions, false);
+        matches = AddExtensionsCommandHandler.select("foo", extensions, false);
         Assertions.assertFalse(matches.matches());
         Assertions.assertEquals(0, matches.getExtensions().size());
     }
@@ -44,7 +44,7 @@ class AddExtensionsSelectTest {
 
         List<Extension> extensions = asList(e1, e2);
         Collections.shuffle(extensions);
-        SelectionResult matches = AddExtensions.select("foo", extensions, true);
+        SelectionResult matches = AddExtensionsCommandHandler.select("foo", extensions, true);
         Assertions.assertFalse(matches.matches());
         Assertions.assertEquals(1, matches.getExtensions().size());
     }
@@ -63,11 +63,11 @@ class AddExtensionsSelectTest {
 
         List<Extension> extensions = asList(e1, e2, e3);
         Collections.shuffle(extensions);
-        SelectionResult matches = AddExtensions.select("foo", extensions, false);
+        SelectionResult matches = AddExtensionsCommandHandler.select("foo", extensions, false);
         Assertions.assertFalse(matches.matches());
         Assertions.assertEquals(2, matches.getExtensions().size());
 
-        matches = AddExtensions.select("foo", extensions, true);
+        matches = AddExtensionsCommandHandler.select("foo", extensions, true);
         Assertions.assertFalse(matches.matches());
         Assertions.assertEquals(3, matches.getExtensions().size());
 
@@ -88,7 +88,7 @@ class AddExtensionsSelectTest {
 
         List<Extension> extensions = asList(e1, e2, e3);
         Collections.shuffle(extensions);
-        SelectionResult matches = AddExtensions.select("foo", extensions, false);
+        SelectionResult matches = AddExtensionsCommandHandler.select("foo", extensions, false);
         Assertions.assertTrue(matches.matches());
         Assertions.assertEquals(1, matches.getExtensions().size());
         Assertions.assertTrue(matches.iterator().hasNext());
@@ -111,7 +111,7 @@ class AddExtensionsSelectTest {
 
         List<Extension> extensions = asList(e1, e2, e3);
         Collections.shuffle(extensions);
-        SelectionResult matches = AddExtensions.select("foo", extensions, false);
+        SelectionResult matches = AddExtensionsCommandHandler.select("foo", extensions, false);
         Assertions.assertEquals(1, matches.getExtensions().size());
         Assertions.assertTrue(matches.iterator().hasNext());
         Assertions.assertTrue(matches.iterator().next().getArtifactId().equalsIgnoreCase("quarkus-foo"));
@@ -133,10 +133,10 @@ class AddExtensionsSelectTest {
 
         List<Extension> extensions = asList(e1, e2, e3);
         Collections.shuffle(extensions);
-        SelectionResult matches = AddExtensions.select("quarkus-foo", extensions, true);
+        SelectionResult matches = AddExtensionsCommandHandler.select("quarkus-foo", extensions, true);
         Assertions.assertEquals(2, matches.getExtensions().size());
 
-        matches = AddExtensions.select("quarkus-foo-unlisted", extensions, true);
+        matches = AddExtensionsCommandHandler.select("quarkus-foo-unlisted", extensions, true);
         Assertions.assertEquals(1, matches.getExtensions().size());
 
     }

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddGradleExtensionsTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddGradleExtensionsTest.java
@@ -5,7 +5,6 @@ import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.generators.BuildTool;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
@@ -18,15 +17,15 @@ class AddGradleExtensionsTest extends AbstractAddExtensionsTest<List<String>> {
     }
 
     @Override
-    protected List<String> createProject() throws IOException {
+    protected List<String> createProject() throws IOException, QuarkusCommandException {
         CreateProjectTest.delete(getProjectPath().toFile());
         final FileProjectWriter writer = new FileProjectWriter(getProjectPath().toFile());
-        new CreateProject(writer)
+        new CreateProject(writer, getPlatformDescriptor())
+                .buildFile(new GradleBuildFile(writer))
                 .groupId("org.acme")
                 .artifactId("add-gradle-extension-test")
                 .version("0.0.1-SNAPSHOT")
-                .buildFile(new GradleBuildFile(writer))
-                .doCreateProject(new HashMap<>());
+                .execute();
         return readProject();
     }
 
@@ -36,9 +35,10 @@ class AddGradleExtensionsTest extends AbstractAddExtensionsTest<List<String>> {
     }
 
     @Override
-    protected AddExtensionResult addExtensions(final List<String> extensions) throws IOException {
-        return new AddExtensions(new FileProjectWriter(getProjectPath().toFile()), BuildTool.GRADLE)
-                .addExtensions(new HashSet<>(extensions));
+    protected QuarkusCommandOutcome addExtensions(final List<String> extensions) throws IOException, QuarkusCommandException {
+        return new AddExtensions(new FileProjectWriter(getProjectPath().toFile()), BuildTool.GRADLE, getPlatformDescriptor())
+                .extensions(new HashSet<>(extensions))
+                .execute();
     }
 
     @Override

--- a/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddMavenExtensionsTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/cli/commands/AddMavenExtensionsTest.java
@@ -4,7 +4,6 @@ import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.maven.utilities.MojoUtils;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -13,14 +12,14 @@ import org.apache.maven.model.Model;
 class AddMavenExtensionsTest extends AbstractAddExtensionsTest<Model> {
 
     @Override
-    protected Model createProject() throws IOException {
+    protected Model createProject() throws IOException, QuarkusCommandException {
         final File pom = getProjectPath().resolve("pom.xml").toFile();
         CreateProjectTest.delete(getProjectPath().toFile());
-        new CreateProject(new FileProjectWriter(getProjectPath().toFile()))
+        new CreateProject(new FileProjectWriter(getProjectPath().toFile()), getPlatformDescriptor())
                 .groupId("org.acme")
                 .artifactId("add-maven-extension-test")
                 .version("0.0.1-SNAPSHOT")
-                .doCreateProject(new HashMap<>());
+                .execute();
         return MojoUtils.readPom(pom);
     }
 
@@ -30,9 +29,10 @@ class AddMavenExtensionsTest extends AbstractAddExtensionsTest<Model> {
     }
 
     @Override
-    protected AddExtensionResult addExtensions(List<String> extensions) throws IOException {
-        return new AddExtensions(new FileProjectWriter(getProjectPath().toFile()))
-                .addExtensions(new HashSet<>(extensions));
+    protected QuarkusCommandOutcome addExtensions(List<String> extensions) throws IOException, QuarkusCommandException {
+        return new AddExtensions(new FileProjectWriter(getProjectPath().toFile()), getPlatformDescriptor())
+                .extensions(new HashSet<>(extensions))
+                .execute();
     }
 
     @Override

--- a/independent-projects/tools/common/src/test/java/io/quarkus/generators/rest/BasicRestProjectGeneratorTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/generators/rest/BasicRestProjectGeneratorTest.java
@@ -16,18 +16,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.cli.commands.PlatformAwareTestBase;
+import io.quarkus.cli.commands.QuarkusCommandInvocation;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
 import io.quarkus.cli.commands.writer.ProjectWriter;
 import io.quarkus.generators.SourceType;
 import io.quarkus.maven.utilities.MojoUtils;
 import java.io.File;
 import java.nio.file.Files;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -40,16 +38,15 @@ import org.junit.jupiter.api.Timeout;
 
 class BasicRestProjectGeneratorTest extends PlatformAwareTestBase {
 
-    private final Map<String, Object> BASIC_PROJECT_CONTEXT = ImmutableMap.<String, Object> builder()
-            .put(PROJECT_GROUP_ID, "org.example")
-            .put(PROJECT_ARTIFACT_ID, "quarkus-app")
-            .put(PROJECT_VERSION, "0.0.1-SNAPSHOT")
-            .put(BOM_VERSION, getBomVersion())
-            .put(SOURCE_TYPE, SourceType.JAVA)
-            .put(PACKAGE_NAME, "org.example")
-            .put(CLASS_NAME, "ExampleResource")
-            .put("path", "/hello")
-            .build();
+    private final QuarkusCommandInvocation BASIC_PROJECT_CONTEXT = new QuarkusCommandInvocation(getPlatformDescriptor())
+            .setProperty(PROJECT_GROUP_ID, "org.example")
+            .setProperty(PROJECT_ARTIFACT_ID, "quarkus-app")
+            .setProperty(PROJECT_VERSION, "0.0.1-SNAPSHOT")
+            .setProperty(BOM_VERSION, getBomVersion())
+            .setProperty(PACKAGE_NAME, "org.example")
+            .setProperty(CLASS_NAME, "ExampleResource")
+            .setProperty("path", "/hello")
+            .setValue(SOURCE_TYPE, SourceType.JAVA);
 
     @Test
     @Timeout(2)
@@ -119,9 +116,8 @@ class BasicRestProjectGeneratorTest extends PlatformAwareTestBase {
 
         when(mockWriter.mkdirs(anyString())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0, String.class));
 
-        Map<String, Object> springContext = new HashMap<>();
-        springContext.putAll(BASIC_PROJECT_CONTEXT);
-        springContext.put(IS_SPRING, Boolean.TRUE);
+        QuarkusCommandInvocation springContext = new QuarkusCommandInvocation(BASIC_PROJECT_CONTEXT);
+        springContext.setValue(IS_SPRING, Boolean.TRUE);
         basicRestProjectGenerator.generate(mockWriter, springContext);
 
         verify(mockWriter, times(1)).write(eq("src/main/java/org/example/ExampleResource.java"),

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/MojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/MojoTestBase.java
@@ -47,11 +47,11 @@ public class MojoTestBase {
         if (tc.isDirectory()) {
             boolean delete = tc.delete();
             Logger.getLogger(MojoTestBase.class.getName())
-                    .log(Level.FINE, "test-classes deleted? " + delete);
+                    .log(Level.FINE, "test-classes deleted? %s", delete);
         }
         boolean mkdirs = tc.mkdirs();
         Logger.getLogger(MojoTestBase.class.getName())
-                .log(Level.FINE, "test-classes created? " + mkdirs);
+                .log(Level.FINE, "test-classes created? %s", mkdirs);
         return tc;
     }
 
@@ -68,7 +68,7 @@ public class MojoTestBase {
         if (!tc.isDirectory()) {
             boolean mkdirs = tc.mkdirs();
             Logger.getLogger(MojoTestBase.class.getName())
-                    .log(Level.FINE, "test-classes created? " + mkdirs);
+                    .log(Level.FINE, "test-classes created? %s", mkdirs);
         }
 
         File in = new File(tc, name);


### PR DESCRIPTION
This commit completes the refactoring of project manipulating commands to allow passing QuarkusPlatformDescriptor as an argument instead of relying on a globally shared (using a static or thread-local var) instance of it. It also introduces thread-safe handlers for each command. The legacy commands are now collecting the input into an instance of QuarkusCommandInvocation and simply pass it to the corresponding command handler for execution.