### PR TITLE
Unify extension definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,31 @@ then change into the `coverage-report` directory and run `mvn package`. The code
 This currently does not work on Windows as it uses a shell script to copy all the classes and files into the code coverage
 module.
 
+## Extensions
+
+### Descriptions
+
+Extensions descriptions (in the `runtime/pom.xml` description or in the YAML `quarkus-extension.yaml`)
+are used to describe the extension and are visible in https://code.quarkus.io.
+Try and pay attention to it.
+Here are a few recommendation guidelines:
+
+- keep it relatively short so that no hover is required to read it
+- describe the function over the technology
+- use an action / verb to start the sentence
+- do no conjugate the action verb (`Connect foo`, not `Connects foo` nor `Connecting foo`)
+- connectors (JDBC / reactive) etc tend to start with Connect
+- do not mention `Quarkus`
+- do not mention `extension`
+- avoid repeating the extension name
+
+Bad examples and the corresponding good example:
+
+- "AWS Lambda" (use "Write AWS Lambda functions")
+- "Extension for building container images with Docker" (use "Build container images with Docker")
+- "PostgreSQL database connector" (use "Connect to the PostgreSQL database via JDBC")
+- "Asynchronous messaging for Reactive Streams" (use "Produce and consume messages and implement event driven and data streaming applications")
+
 ## The small print
 
 This project is an open source project, please act responsibly, be nice, polite and enjoy!

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-agroal</artifactId>
     <name>Quarkus - Agroal - Runtime</name>
-    <description>Pool your database connections (included in Hibernate ORM)</description>
+    <description>Pool JDBC database connections (included in Hibernate ORM)</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/amazon-lambda-http/runtime/pom.xml
+++ b/extensions/amazon-lambda-http/runtime/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>quarkus-amazon-lambda-http</artifactId>
     <name>Quarkus - Amazon Lambda HTTP - Runtime</name>
-    <description>Allows Java applications written for a servlet container to run in AWS Lambda</description>
+    <description>Allow applications written for a servlet container to run in AWS Lambda</description>
 
     <dependencies>
         <dependency>

--- a/extensions/amazon-lambda/runtime/pom.xml
+++ b/extensions/amazon-lambda/runtime/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>quarkus-amazon-lambda</artifactId>
     <name>Quarkus - Amazon Lambda - Runtime</name>
-    <description>AWS Lambda support</description>
+    <description>Write AWS Lambda functions</description>
 
     <dependencies>
         <dependency>

--- a/extensions/artemis-jms/runtime/pom.xml
+++ b/extensions/artemis-jms/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-artemis-jms</artifactId>
     <name>Quarkus - Artemis - JMS - Runtime</name>
-    <description>Use ActiveMQ Artemis as a JMS implementation</description>
+    <description>Use JMS APIs to connect to ActiveMQ Artemis via its native protocol</description>
 
     <dependencies>
         <dependency>

--- a/extensions/azure-functions-http/runtime/pom.xml
+++ b/extensions/azure-functions-http/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-azure-functions-http</artifactId>
     <name>Quarkus - HTTP Azure Functions - Runtime</name>
-    <description>This package contains all Java interfaces and annotations to interact with Microsoft Azure functions runtime.</description>
+    <description>Write Microsoft Azure functions</description>
 
     <dependencies>
         <dependency>

--- a/extensions/cache/runtime/pom.xml
+++ b/extensions/cache/runtime/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>quarkus-cache</artifactId>
     <name>Quarkus - Cache - Runtime</name>
-    <description>Enable application data caching in any CDI managed bean of your Quarkus application</description>
+    <description>Enable application data caching in CDI beans</description>
 
     <dependencies>
         <dependency>

--- a/extensions/container-image/container-image-docker/runtime/pom.xml
+++ b/extensions/container-image/container-image-docker/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-container-image-docker</artifactId>
     <name>Quarkus - Container - Image - Docker</name>
-    <description>Extension for building container images with Docker</description>
+    <description>Build container images of your application using Docker</description>
 
 
     <build>

--- a/extensions/container-image/container-image-jib/runtime/pom.xml
+++ b/extensions/container-image/container-image-jib/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-container-image-jib</artifactId>
     <name>Quarkus - Container - Image - Jib</name>
-    <description>Extension for building container images with Jib</description>
+    <description>Build container images of your application using Jib</description>
 
 
     <build>

--- a/extensions/container-image/container-image-s2i/runtime/pom.xml
+++ b/extensions/container-image/container-image-s2i/runtime/pom.xml
@@ -11,8 +11,8 @@
     </parent>
 
     <artifactId>quarkus-container-image-s2i</artifactId>
-    <name>Quarkus - Container - Image - S2i</name>
-    <description>Extension for building container images with s2i</description>
+    <name>Quarkus - Container - Image - S2I</name>
+    <description>Build container images of your application using OpenShift S2I</description>
 
 
     <build>

--- a/extensions/container-image/container-image-s2i/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/container-image/container-image-s2i/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Container Image S2i"
+name: "Container Image S2I"
 metadata:
   keywords:
     - "s2i"

--- a/extensions/elytron-security-jdbc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/elytron-security-jdbc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Elytron Security JDBC Realm"
+name: "Elytron Security JDBC"
 metadata:
   keywords:
   - "security"

--- a/extensions/elytron-security-properties-file/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/elytron-security-properties-file/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Properties File based Security"
+name: "Elytron Security Properties File"
 metadata:
   keywords:
   - "security"

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-elytron-security</artifactId>
     <name>Quarkus - Elytron Security - Runtime</name>
-    <description>Secure your services</description>
+    <description>Secure your services via Elytron</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-hibernate-validator</artifactId>
     <name>Quarkus - Hibernate Validator - Runtime</name>
-    <description>Validate data coming to your REST endpoints</description>
+    <description>Validate object properties (field, getter) and method parameters for your beans (REST, CDI, JPA)</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-derby/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-derby/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-jdbc-derby</artifactId>
     <name>Quarkus - JDBC - Derby - Runtime</name>
-    <description>Derby database connector</description>
+    <description>Connect to the Derby database via JDBC</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-h2/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-h2/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-jdbc-h2</artifactId>
     <name>Quarkus - JDBC - H2 - Runtime</name>
-    <description>H2 database connector</description>
+    <description>Connect to the H2 database via JDBC</description>
     <dependencies>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-jdbc-mariadb</artifactId>
     <name>Quarkus - JDBC - MariaDB - Runtime</name>
-    <description>MariaDB database connector</description>
+    <description>Connect to the MariaDB database via JDBC</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-jdbc-mssql</artifactId>
     <name>Quarkus - JDBC - MSSQL - Runtime</name>
-    <description>Microsoft SQL Server database connector</description>
+    <description>Connect to the Microsoft SQL Server database via JDBC</description>
 
     <dependencies>
         <dependency>

--- a/extensions/jdbc/jdbc-mysql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-jdbc-mysql</artifactId>
     <name>Quarkus - JDBC - MySQL - Runtime</name>
-    <description>MySQL database connector</description>
+    <description>Connect to the MySQL database via JDBC</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-jdbc-postgresql</artifactId>
     <name>Quarkus - JDBC - PostgreSQL - Runtime</name>
-    <description>PostgreSQL database connector</description>
+    <description>Connect to the PostgreSQL database via JDBC</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-kafka-client</artifactId>
     <name>Quarkus - Kafka - Client - Runtime</name>
-    <description>A client for Apache Kafka</description>
+    <description>Connect to Apache Kafka with its native API</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/kubernetes/openshift/runtime/pom.xml
+++ b/extensions/kubernetes/openshift/runtime/pom.xml
@@ -11,8 +11,8 @@
     </parent>
 
     <artifactId>quarkus-openshift</artifactId>
-    <name>Quarkus - Kubernetes - Openshift - Runtime</name>
-    <description>Generate Openshift resources from annotations</description>
+    <name>Quarkus - Kubernetes - OpenShift - Runtime</name>
+    <description>Generate OpenShift resources from annotations</description>
 
     <dependencies>
         <!-- We need the config to be on the runtime classpath because it's referenced from the config generation -->

--- a/extensions/kubernetes/openshift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kubernetes/openshift/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,8 +1,9 @@
 ---
-name: "Kubernetes"
+name: "OpenShift"
 metadata:
   keywords:
   - "kubernetes"
+  - "openshift"
   guide: "https://quarkus.io/guides/openshift"
   categories:
   - "cloud"

--- a/extensions/kubernetes/vanilla/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kubernetes/vanilla/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,8 +1,8 @@
 ---
-name: "Openshift"
+name: "Kubernetes"
 metadata:
   keywords:
-  - "openshift"
+  - "kubernetes"
   guide: "https://quarkus.io/guides/kubernetes"
   categories:
   - "cloud"

--- a/extensions/mongodb-client/runtime/pom.xml
+++ b/extensions/mongodb-client/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-mongodb-client</artifactId>
     <name>Quarkus - MongoDB Client - Runtime</name>
-    <description>An imperative and reactive client for MongoDB</description>
+    <description>Connect to MongoDB in either imperative or reactive style</description>
 
     <dependencies>
 

--- a/extensions/mutiny/runtime/pom.xml
+++ b/extensions/mutiny/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-mutiny</artifactId>
     <name>Quarkus - Mutiny - Runtime</name>
-    <description>Mutiny is a Reactive Programming library</description>
+    <description>Write reactive applications with the modern Reactive Programming library Mutiny</description>
     <dependencies>
 
         <dependency>

--- a/extensions/mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: "Mutiny"
+metadata:
+  keywords:
+  - "reactive streams"
+  - "reactive programming"
+  - "reactive"
+  - "RXJava"
+  - "Reactor"
+  categories:
+  - "reactive"
+  status: "preview"

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-narayana-jta</artifactId>
     <name>Quarkus - Narayana JTA - Runtime</name>
-    <description>JTA transaction support (included in Hibernate ORM)</description>
+    <description>Offer JTA transaction support (included in Hibernate ORM)</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/narayana-stm/runtime/pom.xml
+++ b/extensions/narayana-stm/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-narayana-stm</artifactId>
     <name>Quarkus - Narayana STM - Runtime</name>
-    <description>Software Transactional Memory (stm) support</description>
+    <description>Offer Software Transactional Memory (stm) support</description>
     <dependencies>
         <dependency>
             <groupId>org.jboss.narayana.stm</groupId>

--- a/extensions/neo4j/runtime/pom.xml
+++ b/extensions/neo4j/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-neo4j</artifactId>
     <name>Quarkus - Neo4j - Runtime</name>
-    <description>A client for the Neo4j graph datastore</description>
+    <description>Connect to Neo4j graph datastore</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/optaplanner-jackson/runtime/src/main/resources/quarkus-extension.yaml
+++ b/extensions/optaplanner-jackson/runtime/src/main/resources/quarkus-extension.yaml
@@ -7,6 +7,5 @@ metadata:
     - "jackson"
   categories:
     - "business-automation"
-    - "web"
     - "serialization"
   status: "preview"

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-hibernate-orm-panache</artifactId>
     <name>Quarkus - Hibernate ORM with Panache - Runtime</name>
-    <description>Define your persistent model in Hibernate ORM with Panache</description>
+    <description>Simplify your persistence code for Hibernate ORM via the active record or the repository pattern</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/panache/mongodb-panache/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-mongodb-panache</artifactId>
     <name>Quarkus - MongoDB with Panache - Runtime</name>
-    <description>Use an active record or repository pattern with MongoDB</description>
+    <description>Simplify your persistence code for MongoDB via the active record or the repository pattern</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/qute/runtime/pom.xml
+++ b/extensions/qute/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-qute</artifactId>
     <name>Quarkus - Qute - Runtime</name>
-    <description>Qute is a templating engine designed specifically to meet the Quarkus needs</description>
+    <description>Offer templating support for web, email, etc in a build time, type-safe way</description>
 
     <dependencies>
         <dependency>

--- a/extensions/reactive-mysql-client/runtime/pom.xml
+++ b/extensions/reactive-mysql-client/runtime/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>quarkus-reactive-mysql-client</artifactId>
 
     <name>Quarkus - Reactive MySQL Client - Runtime</name>
-    <description>A reactive client for the MySQL database</description>
+    <description>Connect to the MySQL database using the reactive pattern</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>quarkus-reactive-pg-client</artifactId>
 
     <name>Quarkus - Reactive PostgreSQL Client - Runtime</name>
-    <description>A reactive client for the PostgreSQL database</description>
+    <description>Connect to the PostgreSQL database using the reactive pattern</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
     <name>Quarkus - SmallRye Reactive Streams Operators - Runtime</name>
-    <description>Operators for Reactive Streams programming</description>
+    <description>Operators to write Reactive Streams based applications (Mutiny recommended instead)</description>
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,7 +1,6 @@
 ---
 name: "SmallRye Reactive Streams Operators"
 metadata:
-  short-name: "reactive streams"
   keywords:
   - "smallrye-reactive-streams-operators"
   - "smallrye-reactive-streams"

--- a/extensions/resteasy-mutiny/runtime/pom.xml
+++ b/extensions/resteasy-mutiny/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-resteasy-mutiny</artifactId>
     <name>Quarkus - RESTEasy - Mutiny - Runtime</name>
-    <description>Mutiny integration for RESTEasy</description>
+    <description>Mutiny support for RESTEasy</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,4 +8,4 @@ metadata:
   categories:
     - "web"
     - "reactive"
-  status: "experimental"
+  status: "preview"

--- a/extensions/resteasy/runtime/pom.xml
+++ b/extensions/resteasy/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-resteasy</artifactId>
     <name>Quarkus - RESTEasy - Runtime</name>
-    <description>REST framework implementing JAX-RS and more</description>
+    <description>REST endpoint framework implementing JAX-RS and more</description>
 
     <dependencies>
         <dependency>

--- a/extensions/smallrye-context-propagation/runtime/pom.xml
+++ b/extensions/smallrye-context-propagation/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-smallrye-context-propagation</artifactId>
     <name>Quarkus - SmallRye Context Propagation - Runtime</name>
-    <description>SmallRye Context Propagation</description>
+    <description>Propagate contexts between managed threads in reactive applications</description>
     <dependencies>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/extensions/smallrye-metrics/runtime/pom.xml
+++ b/extensions/smallrye-metrics/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-smallrye-metrics</artifactId>
     <name>Quarkus - SmallRye Metrics - Runtime</name>
-    <description>Extract metrics out of your services</description>
+    <description>Expose metrics for your services</description>
     <dependencies>
 
         <dependency>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
     <name>Quarkus - SmallRye Reactive Messaging - AMQP 1.0 - Runtime</name>
-    <description>AMQP reactive messaging connector</description>
+    <description>Connect to AMQP with Reactive Messaging</description>
     <dependencies>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     <name>Quarkus - SmallRye Reactive Messaging - Kafka - Runtime</name>
-    <description>Kafka reactive messaging connector</description>
+    <description>Connect to Kafka with Reactive Messaging</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
     <name>Quarkus - SmallRye Reactive Messaging - MQTT - Runtime</name>
-    <description>MQTT reactive messaging connector</description>
+    <description>Connect to MQTT with Reactive Messaging</description>
     <dependencies>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
     <name>Quarkus - SmallRye Reactive Messaging - Runtime</name>
-    <description>Asynchronous messaging for Reactive Streams</description>
+    <description>Produce and consume messages and implement event driven and data streaming applications</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/undertow-websockets/runtime/pom.xml
+++ b/extensions/undertow-websockets/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-undertow-websockets</artifactId>
     <name>Quarkus - Undertow - WebSockets - Runtime</name>
-    <description>WebSocket support</description>
+    <description>WebSocket communication channel support</description>
 
     <dependencies>
         <dependency>

--- a/extensions/vertx-web/runtime/pom.xml
+++ b/extensions/vertx-web/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-vertx-web</artifactId>
     <name>Quarkus - Vert.x Web - Runtime</name>
-    <description>Vert.x Web</description>
+    <description>REST framework offering the route model to define non blocking endpoints</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx/runtime/pom.xml
+++ b/extensions/vertx/runtime/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-vertx</artifactId>
     <name>Quarkus - Vert.x - Runtime</name>
-    <description>Reactive application toolkit</description>
+    <description>Write reactive applications with the Vert.x API</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Here is my attempt at unifying extension definitions. Overall we were in a good shape.

No rules are absolute but the general pattern is to:
- describe the function over the technology
- use an action / verb to start the sentence
- connector JDBC / reactive etc tend to start with Connect
- do not mention Quarkus
- do not mention extension
- avoid repeating the extension name

I failed on rule 1+2 for RESTEasy, vert.x Web and the serialisation ones but they read well as is.
I also ignored the Camel ones. I did update the JMS QPid one.

Fixes https://github.com/quarkusio/quarkus/issues/7557