### PR TITLE
Output CloudWatch Logs for AWS Lambda invocation

### DIFF
--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
@@ -18,7 +18,10 @@ function cmd_invoke() {
   echo Invoking function
   aws lambda invoke response.txt \
     --function-name ${FUNCTION_NAME} \
-    --payload file://payload.json
+    --payload file://payload.json \
+    --log-type Tail \
+    --query 'LogResult' \
+    --output text |  base64 -d
 }
 
 function cmd_update() {


### PR DESCRIPTION
Template for Maven archetype on extension Amazon-Lambda for manage.sh updated to add parameters to extract the CloudWatch Logs for the invocation.  Without this you will not see a stack trace on failure.

Tested via:

mvn archetype:generate \
       -DarchetypeGroupId=io.quarkus \
       -DarchetypeArtifactId=quarkus-amazon-lambda-archetype \
       -DarchetypeVersion=999-SNAPSHOT

mvn package
sh manage.sh create
sh manage.sh invoke
