### PR TITLE
Document the fact that Panache stream methods should be closed

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -204,14 +204,17 @@ All `list` methods have equivalent `stream` versions.
 
 [source,java]
 ----
-Stream<Person> persons = Person.streamAll();
-List<String> namesButEmmanuels = persons
-    .map(p -> p.name.toLowerCase() )
-    .filter( n -> ! "emmanuel".equals(n) )
-    .collect(Collectors.toList());
+try (Stream<Person> persons = Person.streamAll()) {
+    List<String> namesButEmmanuels = persons
+        .map(p -> p.name.toLowerCase() )
+        .filter( n -> ! "emmanuel".equals(n) )
+        .collect(Collectors.toList());
+}
 ----
 
-NOTE: The `stream` methods require a transaction to work.
+NOTE: The `stream` methods require a transaction to work. +
+As they perform I/O operations, they should be closed via the `close()` method or via a try-with-resource to close the underlying `ResultSet`.
+If not, you will see warnings from Agroal that will close the underlying `ResultSet` for you.
 
 === Adding entity methods
 


### PR DESCRIPTION
Fixes #7492

@Sanne I added a note on the Hibernate with Panache guide about the usage of the `stream()` method (it uses ResultSet.stream()), can you validate that it's correct ? As some people asking questionq about it I think it's a good addition to the existing guide.