### PR TITLE
Initialize sun.nio.ch.Iocp at runtime on Windows with JDK 11

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/JdkSubstitutions.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/JdkSubstitutions.java
@@ -2,9 +2,11 @@ package io.quarkus.vertx.core.runtime.graal;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.channels.spi.AsynchronousChannelProvider;
 import java.util.function.Function;
 
 import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.InjectAccessors;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.jdk.JDK11OrLater;
@@ -85,6 +87,47 @@ final class Package_jdk_internal_loader implements Function<TargetClass, String>
         }
 
         return "jdk.internal.loader." + annotation.className();
+    }
+}
+
+@Substitute
+@TargetClass(className = "sun.nio.ch.WindowsAsynchronousFileChannelImpl", innerClass = "DefaultIocpHolder", onlyWith = JDK11OrLater.class)
+final class Target_sun_nio_ch_WindowsAsynchronousFileChannelImpl_DefaultIocpHolder {
+
+    @Alias
+    @InjectAccessors(DefaultIocpAccessor.class)
+    static Target_sun_nio_ch_Iocp defaultIocp;
+}
+
+@TargetClass(className = "sun.nio.ch.Iocp", onlyWith = JDK11OrLater.class)
+final class Target_sun_nio_ch_Iocp {
+
+    @Alias
+    Target_sun_nio_ch_Iocp(AsynchronousChannelProvider provider, Target_sun_nio_ch_ThreadPool pool) throws IOException {
+    }
+
+    @Alias
+    Target_sun_nio_ch_Iocp start() {
+        return null;
+    }
+}
+
+@TargetClass(className = "sun.nio.ch.ThreadPool", onlyWith = JDK11OrLater.class)
+final class Target_sun_nio_ch_ThreadPool {
+
+    @Alias
+    static Target_sun_nio_ch_ThreadPool createDefault() {
+        return null;
+    }
+}
+
+final class DefaultIocpAccessor {
+    static Target_sun_nio_ch_Iocp get() {
+        try {
+            return new Target_sun_nio_ch_Iocp(null, Target_sun_nio_ch_ThreadPool.createDefault()).start();
+        } catch (IOException ioe) {
+            throw new InternalError(ioe);
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes the following error from #7269:

```
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: No instances of sun.nio.ch.Iocp are allowed in the image heap as this class should be initialized at image runtime. Object has been initialized without the native-image initialization instrumentation and the stack trace can't be tracked.
Trace:
        at parsing sun.nio.ch.WindowsAsynchronousFileChannelImpl.open(WindowsAsynchronousFileChannelImpl.java:105)
Call path from entry point to sun.nio.ch.WindowsAsynchronousFileChannelImpl.open(FileDescriptor, boolean, boolean, ThreadPool):
        at sun.nio.ch.WindowsAsynchronousFileChannelImpl.open(WindowsAsynchronousFileChannelImpl.java:104)
        at sun.nio.fs.WindowsChannelFactory.newAsynchronousFileChannel(WindowsChannelFactory.java:215)
        at sun.nio.fs.WindowsFileSystemProvider.newAsynchronousFileChannel(WindowsFileSystemProvider.java:145)
        at java.nio.channels.AsynchronousFileChannel.open(AsynchronousFileChannel.java:253)
        at io.vertx.core.file.impl.AsyncFileImpl.<init>(AsyncFileImpl.java:97)
        at io.vertx.core.file.impl.FileSystemImpl.doOpen(FileSystemImpl.java:903)
        at io.vertx.core.file.impl.FileSystemImpl$18.perform(FileSystemImpl.java:897)
        at io.vertx.core.file.impl.FileSystemImpl$18.perform(FileSystemImpl.java:894)
        at io.vertx.core.file.impl.FileSystemImpl$BlockingAction.handle(FileSystemImpl.java:974)
        at io.vertx.core.file.impl.FileSystemImpl$BlockingAction.handle(FileSystemImpl.java:955)
        at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
        at io.vertx.core.impl.ContextImpl$$Lambda$771/0x00000007c1b7e840.run(Unknown Source)
        at com.oracle.svm.core.jdk.RuntimeSupport.executeHooks(RuntimeSupport.java:144)
        at com.oracle.svm.core.jdk.RuntimeSupport.executeStartupHooks(RuntimeSupport.java:89)
        at com.oracle.svm.core.JavaMainWrapper.runCore(JavaMainWrapper.java:143)
        at com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:186)
        at com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(generated:0)
```