### PR TITLE
Simplify kubernetes tests

### DIFF
--- a/integration-tests/kubernetes/standard/pom.xml
+++ b/integration-tests/kubernetes/standard/pom.xml
@@ -85,25 +85,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-                <includes>
-                    <include>**/*.txt</include>
-                </includes>
-                <filtering>true</filtering>
-            </testResource>
-            <testResource>
-                <directory>src/test/resources</directory>
-                <excludes>
-                    <exclude>**/*.txt</exclude>
-                </excludes>
-                <filtering>false</filtering>
-            </testResource>
-        </testResources>
-    </build>
     
     <profiles>
         <profile>

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -34,7 +35,7 @@ public class KubernetesWithHealthTest {
             .setLogFileName("k8s.log")
             .setForcedDependencies(
                     Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", TestUtil.getProjectVersion())));
+                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,7 +31,7 @@ public class KubernetesWithRootAndHealthTest {
             .withConfigurationResource("kubernetes-with-root-and-health.properties")
             .setForcedDependencies(
                     Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", TestUtil.getProjectVersion())));
+                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/TestUtil.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/TestUtil.java
@@ -3,11 +3,7 @@ package io.quarkus.it.kubernetes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -17,19 +13,6 @@ import java.util.concurrent.TimeUnit;
 final class TestUtil {
 
     private TestUtil() {
-    }
-
-    /**
-     * Gets the project version from a version.txt (that has been properly setup in maven to contain the version)
-     * This is needed in order to avoid hard-coding Quarkus dependency versions that could break the release process
-     */
-    public static String getProjectVersion() {
-        try (BufferedReader bufferedReader = new BufferedReader(
-                new InputStreamReader(TestUtil.class.getResourceAsStream("/version.txt"), StandardCharsets.UTF_8))) {
-            return bufferedReader.readLine();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     public static void assertLogFileContents(Path logfile, String... expectedOutput) {

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -32,7 +33,7 @@ public class WithKubernetesClientTest {
             .setLogFileName("k8s.log")
             .setForcedDependencies(
                     Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-client", TestUtil.getProjectVersion())));
+                            new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/standard/src/test/resources/version.txt
+++ b/integration-tests/kubernetes/standard/src/test/resources/version.txt
@@ -1,1 +1,0 @@
-${project.version}


### PR DESCRIPTION
Remove the unnecessary version retrieval method that was added
and use the Version of the quarkus-builder module class that
does the same thing