### PR TITLE
Usage statement added to Amazon Lambda archetype manage.sh script

### DIFF
--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 function cmd_create() {
   echo Creating function
   aws lambda create-function \
@@ -35,6 +37,20 @@ FUNCTION_NAME=${resourceName}Function
 HANDLER=io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
 RUNTIME=java8
 ZIP_FILE=fileb://target/${artifactId}-${version}-runner.jar
+
+function usage() {
+  [ "_$1" == "_" ] && echo "\nUsage (JVM): \n$0 [create|delete|invoke]\ne.g.: $0 invoke"
+  [ "_$1" == "_" ] && echo "\nUsage (Native): \n$0 native [create|delete|invoke]\ne.g.: $0 native invoke"
+
+  [ "_" == "_`which aws 2>/dev/null`" ] && echo "\naws CLI not installed. Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+  [ ! -e $HOME/.aws/credentials ] && [ "_$AWS_ACCESS_KEY_ID" == "_" ] && echo "\naws configure not setup.  Please execute: aws configure"
+  [ "_$LAMBDA_ROLE_ARN" == "_" ] && echo "\nEnvironment variable must be set: LAMBDA_ROLE_ARN\ne.g.: export LAMBDA_ROLE_ARN=arn:aws:iam::123456789012:role/my-example-role"
+}
+
+if [ "_$1" == "_" ] || [ "$1" == "help" ]
+ then
+  usage
+fi
 
 if [ "$1" == "native" ]
 then


### PR DESCRIPTION
Add a **usage** statement to simplify manage.sh for a better user experience, without having to read the docs in detail.  
i.e.:

```
Usage (JVM): 
manage.sh [create|delete|invoke]
e.g.: manage.sh invoke

Usage (Native): 
manage.sh native [create|delete|invoke]
e.g.: manage.sh native invoke

```
Usage statement also validates whether the was-cli is installed, and configured with credentials.  The required LAMBDA_ROLE_ARN environment variable also checked.


Tested via:
mvn archetype:generate -DarchetypeGroupId=io.quarkus -DarchetypeArtifactId=quarkus-amazon-lambda-archetype -DarchetypeVersion=999-SNAPSHOT

mvn package

sh manage.sh
sh manage.sh help

Validate existing functionality:
sh manage.sh create
sh manage.sh invoke

Tested the presence and lack-thereof of the aws-cli and envs by appending a 1 to the test, 
i.e.:

`  [ "_$LAMBDA_ROLE_ARN1" == "_" ] && echo "\nEnvironment variable must be set: LAMBDA_ROLE_ARN\ne.g.: export LAMBDA_ROLE_ARN=arn:aws:iam::123456789012:role/my-example-role"
`

@patriot1burke 
@evanchooly 