### PR TITLE
Show hostname to be added to /etc/hosts

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
@@ -25,7 +25,9 @@ public class NettyRecorder {
                 DefaultChannelId.newInstance();
                 if (System.currentTimeMillis() - start > 1000) {
                     log.warn(
-                            "Localhost lookup took more than one second, you need to add a /etc/hosts entry to improve Quarkus startup time. See https://thoeni.io/post/macos-sierra-java/ for details.");
+                            "Localhost lookup took more than one second, you need to add your hostname ("
+                                    + System.getenv("HOSTNAME")
+                                    + ") to the /etc/hosts entry to improve Quarkus startup time. See https://thoeni.io/post/macos-sierra-java/ for details.");
                 }
             }
         }).start();


### PR DESCRIPTION
This helps to fix warnings like

```
2020-03-05 09:19:15,953 WARNING [io.ver.cor.imp.BlockedThreadChecker] (vertx-blocked-thread-checker) Thread Thread[vert.x-eventloop-thread-1,5,main]=Thread[vert.x-eventloop-thread-1,5,main] has been blocked for 3866 ms, time limit is 2000 ms: io.vertx.core.VertxException: Thread blocked
```