### PR TITLE
Support for recognizing multiple Quarkus platforms in a project

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildFileMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildFileMojoBase.java
@@ -2,6 +2,7 @@ package io.quarkus.maven;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.model.Dependency;
@@ -22,6 +23,7 @@ import io.quarkus.cli.commands.file.BuildFile;
 import io.quarkus.cli.commands.file.GradleBuildFile;
 import io.quarkus.cli.commands.file.MavenBuildFile;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
+import io.quarkus.platform.descriptor.CombinedQuarkusPlatformDescriptor;
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import io.quarkus.platform.descriptor.resolver.json.QuarkusJsonPlatformDescriptorResolver;
 import io.quarkus.platform.tools.MessageWriter;
@@ -76,7 +78,7 @@ public abstract class BuildFileMojoBase extends AbstractMojo {
                 final MavenBuildFile mvnBuild = new MavenBuildFile(fileProjectWriter);
                 buildFile = mvnBuild;
 
-                Artifact descrArtifact = null;
+                final List<Artifact> descrArtifactList = new ArrayList<>(2);
                 for (Dependency dep : mvnBuild.getManagedDependencies()) {
                     if (!dep.getScope().equals("import") && !dep.getType().equals("pom")) {
                         continue;
@@ -89,29 +91,21 @@ public abstract class BuildFileMojoBase extends AbstractMojo {
                         continue;
                     }
 
-                    Artifact jsonArtifact = new DefaultArtifact(bomGroupId, bomArtifactId, null, "json", bomVersion);
-                    try {
-                        jsonArtifact = mvn.resolve(jsonArtifact).getArtifact();
-                    } catch (Exception e) {
-                        log.debug("Failed to resolve JSON descriptor as %s", jsonArtifact);
-                        jsonArtifact = new DefaultArtifact(bomGroupId, bomArtifactId + "-descriptor-json", null, "json",
-                                bomVersion);
-                        try {
-                            jsonArtifact = mvn.resolve(jsonArtifact).getArtifact();
-                        } catch (Exception e1) {
-                            getLog().debug("Failed to resolve JSON descriptor as " + jsonArtifact);
-                            continue;
-                        }
+                    final Artifact jsonArtifact = resolveJsonOrNull(mvn, bomGroupId, bomArtifactId, bomVersion);
+                    if (jsonArtifact != null) {
+                        descrArtifactList.add(jsonArtifact);
                     }
-                    descrArtifact = jsonArtifact;
-                    break;
                 }
-                if (descrArtifact != null) {
-                    log.debug("Quarkus platform JSON descriptor resolved from %s", descrArtifact);
-                    platformDescr = QuarkusJsonPlatformDescriptorResolver.newInstance()
-                            .setArtifactResolver(new BootstrapAppModelResolver(mvn))
-                            .setMessageWriter(log)
-                            .resolveFromJson(descrArtifact.getFile().toPath());
+                if (!descrArtifactList.isEmpty()) {
+                    if (descrArtifactList.size() == 1) {
+                        platformDescr = loadPlatformDescriptor(mvn, log, descrArtifactList.get(0));
+                    } else {
+                        final CombinedQuarkusPlatformDescriptor.Builder builder = CombinedQuarkusPlatformDescriptor.builder();
+                        for (Artifact descrArtifact : descrArtifactList) {
+                            builder.addPlatform(loadPlatformDescriptor(mvn, log, descrArtifact));
+                        }
+                        platformDescr = builder.build();
+                    }
                 }
             } else if (new File(project.getBasedir(), "build.gradle").exists()
                     || new File(project.getBasedir(), "build.gradle.kts").exists()) {
@@ -137,6 +131,39 @@ public abstract class BuildFileMojoBase extends AbstractMojo {
         }
     }
 
+    private QuarkusPlatformDescriptor loadPlatformDescriptor(final MavenArtifactResolver mvn, final MessageWriter log,
+            Artifact descrArtifact) {
+        return QuarkusJsonPlatformDescriptorResolver.newInstance()
+                .setArtifactResolver(new BootstrapAppModelResolver(mvn))
+                .setMessageWriter(log)
+                .resolveFromJson(descrArtifact.getFile().toPath());
+    }
+
+    private Artifact resolveJsonOrNull(MavenArtifactResolver mvn, String bomGroupId, String bomArtifactId, String bomVersion) {
+        Artifact jsonArtifact = new DefaultArtifact(bomGroupId, bomArtifactId, null, "json", bomVersion);
+        try {
+            jsonArtifact = mvn.resolve(jsonArtifact).getArtifact();
+        } catch (Exception e) {
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Failed to resolve JSON descriptor as " + jsonArtifact);
+            }
+            jsonArtifact = new DefaultArtifact(bomGroupId, bomArtifactId + "-descriptor-json", null, "json",
+                    bomVersion);
+            try {
+                jsonArtifact = mvn.resolve(jsonArtifact).getArtifact();
+            } catch (Exception e1) {
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug("Failed to resolve JSON descriptor as " + jsonArtifact);
+                }
+                return null;
+            }
+        }
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Resolve JSON descriptor " + jsonArtifact);
+        }
+        return jsonArtifact;
+    }
+
     protected void validateParameters() throws MojoExecutionException {
     }
 
@@ -145,9 +172,12 @@ public abstract class BuildFileMojoBase extends AbstractMojo {
 
     private String resolveValue(String expr, BuildFile buildFile) throws IOException {
         if (expr.startsWith("${") && expr.endsWith("}")) {
-            final String v = buildFile.getProperty(expr.substring(2, expr.length() - 1));
+            final String name = expr.substring(2, expr.length() - 1);
+            final String v = buildFile.getProperty(name);
             if (v == null) {
-                getLog().debug("Failed to resolve version of " + v);
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug("Failed to resolve property " + name);
+                }
             }
             return v;
         }

--- a/independent-projects/tools/common/src/test/java/io/quarkus/test/platform/descriptor/CombinedQuarkusPlatformDescriptorTest.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/test/platform/descriptor/CombinedQuarkusPlatformDescriptorTest.java
@@ -1,0 +1,117 @@
+package io.quarkus.test.platform.descriptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.quarkus.cli.commands.PlatformAwareTestBase;
+import io.quarkus.dependencies.Category;
+import io.quarkus.dependencies.Extension;
+import io.quarkus.platform.descriptor.CombinedQuarkusPlatformDescriptor;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CombinedQuarkusPlatformDescriptorTest extends PlatformAwareTestBase {
+
+    private static final String DOMINATING_VERSION = "dominating-version";
+
+    QuarkusPlatformDescriptor dominatingPlatform;
+    QuarkusPlatformDescriptor defaultPlatform;
+
+    @BeforeEach
+    public void setup() {
+        dominatingPlatform = new TestDominatingQuarkusPlatformDescriptor();
+        defaultPlatform = getPlatformDescriptor();
+    }
+
+    @Test
+    public void testDominance() throws Exception {
+
+        final QuarkusPlatformDescriptor combined = CombinedQuarkusPlatformDescriptor.builder()
+                .addPlatform(dominatingPlatform)
+                .addPlatform(defaultPlatform)
+                .build();
+
+        final Map<String, Extension> expectedExtensions = toMap(defaultPlatform.getExtensions());
+        expectedExtensions.putAll(toMap(dominatingPlatform.getExtensions()));
+
+        assertBom(combined);
+
+        assertEquals(dominatingPlatform.getQuarkusVersion(), combined.getQuarkusVersion());
+
+        assertCategories(combined);
+
+        assertExtensions(expectedExtensions, combined);
+
+        assertManagedDeps(combined);
+
+        assertEquals("dominating pom.xml template", combined.getTemplate("templates/basic-rest/java/pom.xml-template.ftl"));
+        assertEquals(defaultPlatform.getTemplate("templates/dockerfile-jvm.ftl"),
+                combined.getTemplate("templates/dockerfile-jvm.ftl"));
+    }
+
+    private void assertBom(QuarkusPlatformDescriptor descriptor) {
+        assertEquals(dominatingPlatform.getBomGroupId(), descriptor.getBomGroupId());
+        assertEquals(dominatingPlatform.getBomArtifactId(), descriptor.getBomArtifactId());
+        assertEquals(dominatingPlatform.getBomVersion(), descriptor.getBomVersion());
+    }
+
+    private void assertCategories(QuarkusPlatformDescriptor descriptor) {
+        final List<Category> categories = descriptor.getCategories();
+        assertFalse(categories.isEmpty());
+        final Map<String, Category> map = categories.stream().collect(Collectors.toMap(Category::getId, c -> c));
+        assertEquals("Dominating Web", map.get("web").getName());
+        assertEquals("Data", map.get("data").getName());
+        assertEquals("Other category", map.get("other").getName());
+    }
+
+    private void assertExtensions(Map<String, Extension> expectedExtensions, QuarkusPlatformDescriptor descriptor) {
+        final List<Extension> extensions = descriptor.getExtensions();
+        assertFalse(extensions.isEmpty());
+        for (Extension actual : extensions) {
+            final Extension expected = expectedExtensions.get(getGa(actual));
+            assertNotNull(expected);
+            assertEquals(expected.getVersion(), actual.getVersion());
+        }
+
+        final Map<String, Extension> actualMap = toMap(descriptor.getExtensions());
+        Extension ext = actualMap.get("io.quarkus:quarkus-jdbc-h2");
+        assertNotNull(ext);
+        assertEquals(defaultPlatform.getQuarkusVersion(), ext.getVersion());
+
+        ext = actualMap.get("io.quarkus:quarkus-resteasy");
+        assertNotNull(ext);
+        assertEquals(DOMINATING_VERSION, ext.getVersion());
+    }
+
+    private void assertManagedDeps(QuarkusPlatformDescriptor descriptor) {
+        final List<Dependency> deps = descriptor.getManagedDependencies();
+        assertFalse(deps.isEmpty());
+        final Map<String, Dependency> actualMap = deps.stream().collect(Collectors.toMap(d -> getGa(d), d -> d));
+
+        Dependency dep = actualMap.get("io.quarkus:quarkus-jdbc-h2");
+        assertNotNull(dep);
+        assertEquals(defaultPlatform.getQuarkusVersion(), dep.getVersion());
+
+        dep = actualMap.get("io.quarkus:quarkus-resteasy");
+        assertNotNull(dep);
+        assertEquals(DOMINATING_VERSION, dep.getVersion());
+    }
+
+    private static Map<String, Extension> toMap(final List<Extension> extensions) {
+        return extensions.stream().collect(Collectors.toMap(e -> getGa(e), e -> e));
+    }
+
+    private static String getGa(Extension e) {
+        return e.getGroupId() + ":" + e.getArtifactId();
+    }
+
+    private static String getGa(Dependency d) {
+        return d.getGroupId() + ":" + d.getArtifactId();
+    }
+}

--- a/independent-projects/tools/common/src/test/java/io/quarkus/test/platform/descriptor/TestDominatingQuarkusPlatformDescriptor.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/test/platform/descriptor/TestDominatingQuarkusPlatformDescriptor.java
@@ -1,0 +1,77 @@
+package io.quarkus.test.platform.descriptor;
+
+import static io.quarkus.test.platform.descriptor.loader.QuarkusTestPlatformDescriptorLoader.addCategory;
+import static io.quarkus.test.platform.descriptor.loader.QuarkusTestPlatformDescriptorLoader.addExtension;
+
+import io.quarkus.dependencies.Category;
+import io.quarkus.dependencies.Extension;
+import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
+import io.quarkus.platform.descriptor.ResourceInputStreamConsumer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.model.Dependency;
+
+public class TestDominatingQuarkusPlatformDescriptor implements QuarkusPlatformDescriptor {
+
+    private final List<Category> categories = new ArrayList<>();
+    private final List<Extension> extensions = new ArrayList<>();
+    private final List<Dependency> bomDeps = new ArrayList<>();
+
+    public TestDominatingQuarkusPlatformDescriptor() {
+
+        addCategory("other", "Other category", categories);
+        addCategory("web", "Dominating Web", categories);
+
+        addExtension("io.quarkus", "quarkus-resteasy", "dominating-version", "Dominating RESTEasy", "dominating/guide",
+                extensions, bomDeps);
+    }
+
+    @Override
+    public String getBomGroupId() {
+        return "dominating.bom.group.id";
+    }
+
+    @Override
+    public String getBomArtifactId() {
+        return "dominating.bom.artifact.id";
+    }
+
+    @Override
+    public String getBomVersion() {
+        return "dominating.bom.version";
+    }
+
+    @Override
+    public String getQuarkusVersion() {
+        return "dominating.quarkus.version";
+    }
+
+    @Override
+    public List<Dependency> getManagedDependencies() {
+        return bomDeps;
+    }
+
+    @Override
+    public List<Extension> getExtensions() {
+        return extensions;
+    }
+
+    @Override
+    public List<Category> getCategories() {
+        return categories;
+    }
+
+    @Override
+    public String getTemplate(String name) {
+        if ("templates/basic-rest/java/pom.xml-template.ftl".equals(name)) {
+            return "dominating pom.xml template";
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T loadResource(String name, ResourceInputStreamConsumer<T> consumer) throws IOException {
+        return null;
+    }
+}

--- a/independent-projects/tools/common/src/test/java/io/quarkus/test/platform/descriptor/loader/QuarkusTestPlatformDescriptorLoader.java
+++ b/independent-projects/tools/common/src/test/java/io/quarkus/test/platform/descriptor/loader/QuarkusTestPlatformDescriptorLoader.java
@@ -25,40 +25,18 @@ public class QuarkusTestPlatformDescriptorLoader
     private static final List<Dependency> bomDeps = new ArrayList<>();
     private static final Properties quarkusProps;
     private static final String quarkusVersion;
+    private static final List<Category> categories = new ArrayList<>();
 
-    private static void addExtension(String artifactId, String name) {
-        addExtension(artifactId, name, "url://" + name);
+    private static void addCategories() {
+        addCategory("web", "Web");
+        addCategory("data", "Data");
+        addCategory("messaging", "Messaging");
+        addCategory("core", "Core");
+        addCategory("reactive", "Reactive");
+        addCategory("cloud", "Cloud");
     }
 
-    private static void addExtension(String artifactId, String name, String guide) {
-        addExtension("io.quarkus", artifactId, quarkusVersion, name, guide);
-    }
-
-    private static void addExtension(String groupId, String artifactId, String version, String name, String guide) {
-        extensions.add(new Extension(groupId, artifactId, version).setName(name).setGuide(guide));
-
-        final Dependency d = new Dependency();
-        d.setGroupId(groupId);
-        d.setArtifactId(artifactId);
-        d.setVersion(version);
-        bomDeps.add(d);
-    }
-
-    static {
-        try {
-            quarkusProps = loadStaticResource("quarkus.properties", is -> {
-                final Properties props = new Properties();
-                props.load(is);
-                return props;
-            });
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to load quarkus.properties", e);
-        }
-        quarkusVersion = quarkusProps.getProperty("plugin-version");
-        if (quarkusVersion == null) {
-            throw new IllegalStateException("plugin-version property is missing from quarkus.properties");
-        }
-
+    private static void addExtensions() {
         addExtension("quarkus-agroal", "Agroal");
         addExtension("quarkus-arc", "Arc");
         addExtension("quarkus-hibernate-orm-panache", "Hibernate ORM Panache");
@@ -82,6 +60,59 @@ public class QuarkusTestPlatformDescriptorLoader
         addExtension("quarkus-smallrye-fault-tolerance", "SmallRye Fault Tolerance");
 
         addExtension("quarkus-vertx", "Vert.X");
+    }
+
+    private static void addExtension(String artifactId, String name) {
+        addExtension(artifactId, name, "url://" + name);
+    }
+
+    private static void addExtension(String artifactId, String name, String guide) {
+        addExtension("io.quarkus", artifactId, quarkusVersion, name, guide);
+    }
+
+    private static void addExtension(String groupId, String artifactId, String version, String name, String guide) {
+        addExtension(groupId, artifactId, version, name, guide, extensions, bomDeps);
+    }
+
+    public static void addExtension(String groupId, String artifactId, String version, String name, String guide,
+            List<Extension> extensions, List<Dependency> bomDeps) {
+        extensions.add(new Extension(groupId, artifactId, version).setName(name).setGuide(guide));
+
+        final Dependency d = new Dependency();
+        d.setGroupId(groupId);
+        d.setArtifactId(artifactId);
+        d.setVersion(version);
+        bomDeps.add(d);
+    }
+
+    private static void addCategory(String id, String name) {
+        addCategory(id, name, categories);
+    }
+
+    public static void addCategory(String id, String name, List<Category> categories) {
+        Category cat = new Category();
+        cat.setId(id);
+        cat.setName(name);
+        categories.add(cat);
+    }
+
+    static {
+        try {
+            quarkusProps = loadStaticResource("quarkus.properties", is -> {
+                final Properties props = new Properties();
+                props.load(is);
+                return props;
+            });
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load quarkus.properties", e);
+        }
+        quarkusVersion = quarkusProps.getProperty("plugin-version");
+        if (quarkusVersion == null) {
+            throw new IllegalStateException("plugin-version property is missing from quarkus.properties");
+        }
+
+        addCategories();
+        addExtensions();
     }
 
     @Override
@@ -145,7 +176,7 @@ public class QuarkusTestPlatformDescriptorLoader
 
             @Override
             public List<Category> getCategories() {
-                return new ArrayList<Category>();
+                return categories;
             }
         };
     }

--- a/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/descriptor/CombinedQuarkusPlatformDescriptor.java
+++ b/independent-projects/tools/platform-descriptor-api/src/main/java/io/quarkus/platform/descriptor/CombinedQuarkusPlatformDescriptor.java
@@ -1,0 +1,220 @@
+package io.quarkus.platform.descriptor;
+
+import io.quarkus.dependencies.Category;
+import io.quarkus.dependencies.Extension;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.model.Dependency;
+
+/**
+ * Platform descriptor that is composed of multiple platform descriptors.
+ * The order in which descriptors are added is significant. Platform descriptor
+ * added earlier dominate over those added later.
+ */
+public class CombinedQuarkusPlatformDescriptor implements QuarkusPlatformDescriptor {
+
+    public static class Builder {
+
+        private List<QuarkusPlatformDescriptor> platforms = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Adds a platform descriptor.
+         * The order in which descriptors are added is significant. Platform descriptor
+         * added earlier dominate over those added later.
+         *
+         * @param platform platform descriptor to add
+         * @return this builder instance
+         */
+        public Builder addPlatform(QuarkusPlatformDescriptor platform) {
+            platforms.add(platform);
+            return this;
+        }
+
+        public QuarkusPlatformDescriptor build() {
+            return new CombinedQuarkusPlatformDescriptor(this);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final QuarkusPlatformDescriptor master;
+    private final List<QuarkusPlatformDescriptor> platforms;
+    private List<Dependency> managedDeps;
+    private List<Extension> extensions;
+    private List<Category> categories;
+
+    private CombinedQuarkusPlatformDescriptor(Builder builder) {
+        if (builder.platforms.isEmpty()) {
+            throw new IllegalArgumentException("No platforms to combine");
+        }
+        master = builder.platforms.get(0);
+        platforms = new ArrayList<>(builder.platforms);
+    }
+
+    @Override
+    public String getBomGroupId() {
+        return master.getBomGroupId();
+    }
+
+    @Override
+    public String getBomArtifactId() {
+        return master.getBomArtifactId();
+    }
+
+    @Override
+    public String getBomVersion() {
+        return master.getBomVersion();
+    }
+
+    @Override
+    public String getQuarkusVersion() {
+        return master.getQuarkusVersion();
+    }
+
+    @Override
+    public List<Dependency> getManagedDependencies() {
+        if (managedDeps != null) {
+            return managedDeps;
+        }
+        final List<Dependency> deps = new ArrayList<>();
+        final Set<DepKey> depKeys = new HashSet<>();
+        for (QuarkusPlatformDescriptor platform : platforms) {
+            for (Dependency dep : platform.getManagedDependencies()) {
+                if (depKeys.add(new DepKey(dep))) {
+                    deps.add(dep);
+                }
+            }
+        }
+        return managedDeps = deps;
+    }
+
+    @Override
+    public List<Extension> getExtensions() {
+        if (extensions != null) {
+            return extensions;
+        }
+        final List<Extension> list = new ArrayList<>();
+        final Set<DepKey> depKeys = new HashSet<>();
+        for (QuarkusPlatformDescriptor platform : platforms) {
+            for (Extension ext : platform.getExtensions()) {
+                if (depKeys.add(new DepKey(ext.getGroupId(), ext.getArtifactId()))) {
+                    list.add(ext);
+                }
+            }
+        }
+        return extensions = list;
+    }
+
+    @Override
+    public List<Category> getCategories() {
+        if (categories != null) {
+            return categories;
+        }
+        final List<Category> list = new ArrayList<>();
+        final Set<String> ids = new HashSet<>();
+        for (QuarkusPlatformDescriptor platform : platforms) {
+            for (Category cat : platform.getCategories()) {
+                if (ids.add(cat.getId())) {
+                    list.add(cat);
+                }
+            }
+        }
+        return categories = list;
+    }
+
+    @Override
+    public String getTemplate(String name) {
+        for (QuarkusPlatformDescriptor platform : platforms) {
+            final String template = platform.getTemplate(name);
+            if (template != null) {
+                return template;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T loadResource(String name, ResourceInputStreamConsumer<T> consumer) throws IOException {
+        for (QuarkusPlatformDescriptor platform : platforms) {
+            try {
+                return platform.loadResource(name, consumer);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        throw new IOException("Failed to locate resource " + name);
+    }
+
+    private static class DepKey {
+        final String groupId;
+        final String artifactId;
+        final String classifier;
+        final String type;
+
+        DepKey(Dependency dep) {
+            this(dep.getGroupId(), dep.getArtifactId(), dep.getClassifier(), dep.getType());
+        }
+
+        DepKey(String groupId, String artifactId) {
+            this(groupId, artifactId, null, null);
+        }
+
+        DepKey(String groupId, String artifactId, String classifier, String type) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.classifier = classifier;
+            this.type = type;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((artifactId == null) ? 0 : artifactId.hashCode());
+            result = prime * result + ((classifier == null) ? 0 : classifier.hashCode());
+            result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
+            result = prime * result + ((type == null) ? 0 : type.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            DepKey other = (DepKey) obj;
+            if (artifactId == null) {
+                if (other.artifactId != null)
+                    return false;
+            } else if (!artifactId.equals(other.artifactId))
+                return false;
+            if (classifier == null) {
+                if (other.classifier != null)
+                    return false;
+            } else if (!classifier.equals(other.classifier))
+                return false;
+            if (groupId == null) {
+                if (other.groupId != null)
+                    return false;
+            } else if (!groupId.equals(other.groupId))
+                return false;
+            if (type == null) {
+                if (other.type != null)
+                    return false;
+            } else if (!type.equals(other.type))
+                return false;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
(both maven and gradle supported) and merging their descriptors into a single one (with the platforms imported earlier dominating over those imported later) for the tools to be able to list and add extensions.

@gastaldi if you have time, I'd appreciate if you could review this one. Thanks.