### PR TITLE
fix sns event deserialize issue

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -136,7 +136,7 @@
         <scala.version>2.12.9</scala.version>
         <tika.version>1.22</tika.version>
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>
-        <aws-lambda-java-events.version>2.2.5</aws-lambda-java-events.version>
+        <aws-lambda-java-events.version>2.2.7</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <aws-xray.version>2.4.0</aws-xray.version>
         <awssdk.version>2.10.70</awssdk.version>

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -16,6 +16,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
+import org.joda.time.DateTime;
 
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 
@@ -141,6 +142,8 @@ public final class AmazonLambdaProcessor {
                         .produce(new ReflectiveClassBuildItem(true, true, true, method.getParameterTypes()[0].getName()));
                 reflectiveClassBuildItemBuildProducer
                         .produce(new ReflectiveClassBuildItem(true, true, true, method.getReturnType().getName()));
+                reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, true, true,
+                        DateTime.class));
                 break;
             }
         }

--- a/extensions/amazon-lambda/runtime/pom.xml
+++ b/extensions/amazon-lambda/runtime/pom.xml
@@ -23,6 +23,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
+            <version>2.2.7</version>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -35,6 +42,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/amazon-lambda/runtime/pom.xml
+++ b/extensions/amazon-lambda/runtime/pom.xml
@@ -23,9 +23,8 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>2.2.7</version>
             <exclusions>
-                <exclusion>  <!-- declare the exclusion here -->
+                <exclusion>
                     <groupId>joda-time</groupId>
                     <artifactId>joda-time</artifactId>
                 </exclusion>

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -49,7 +50,8 @@ public class AmazonLambdaRecorder {
         beanContainer = container;
         AmazonLambdaRecorder.objectMapper = getObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+                .registerModule(new JodaModule());
         Method handlerMethod = discoverHandlerMethod(handlerClass);
         objectReader = objectMapper.readerFor(handlerMethod.getParameterTypes()[0]);
         objectWriter = objectMapper.writerFor(handlerMethod.getReturnType());


### PR DESCRIPTION
SNSEvent, CodeCommitEvent and ScheduledEvent used Joda DateTime. Added JodaModule to Jackson, so that these events can be properly deserialized. 

aws-lambda-java-events uses old Joda-time v2.6, which conflict with JodaModule. I excluded joda-time from aws-lambda-java-events and used the latest version from JodaModule. 

Solves issue #6491

