### PR TITLE
Prevent any side-effect NPE while closing a failed devmode launch

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -112,6 +112,8 @@ public class DevModeMain implements Closeable {
 
     @Override
     public void close() throws IOException {
-        realCloseable.close();
+        if (realCloseable != null) {
+            realCloseable.close();
+        }
     }
 }


### PR DESCRIPTION
The commit here prevents any NPE that can occur while closing `DevModeMain`, in cases where the dev mode launch itself might have failed.
One such case has been reported in the Quarkus mailing list:
```
Failed to create the application model for com.xxx.historyservice:historyservice-web::jar:1.0.0-SNAPSHOT
        at io.quarkus.dev.DevModeMain.start(DevModeMain.java:108)
        at io.quarkus.dev.DevModeMain.main(DevModeMain.java:46)
        Suppressed: java.lang.NullPointerException
                at io.quarkus.dev.DevModeMain.close(DevModeMain.java:115)
                at io.quarkus.dev.DevModeMain.main(DevModeMain.java:49)
```