### PR TITLE
Include the original cause in AppModelResolverException

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -201,7 +201,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             deploymentInjector.injectDeploymentDependencies(resolvedDeps);
         } catch (BootstrapDependencyProcessingException e) {
             throw new AppModelResolverException(
-                    "Failed to inject extension deployment dependencies for " + resolvedDeps.getArtifact(), e.getCause());
+                    "Failed to inject extension deployment dependencies for " + resolvedDeps.getArtifact(), e);
         }
 
         List<AppDependency> deploymentDeps = Collections.emptyList();


### PR DESCRIPTION
The commit here includes the original `BootstrapDependencyProcessingException` when throwing an `AppModelResolverException`, instead of assuming the presence of a cause in `BootstrapDependencyProcessingException`. That way even in the absence of a nested cause in `BootstrapDependencyProcessingException`, the `AppModelResolverException` will atleast show up the real exception (message) that triggered the problem.

This should help in the case which is currently reported in Quarkus mailing list:

```
Caused by: io.quarkus.bootstrap.BootstrapException: Failed to create the application model for com.xxx.historyservice:historyservice-web::jar:1.0.0-SNAPSHOT
        at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModel(BootstrapAppModelFactory.java:297)
        at io.quarkus.bootstrap.app.QuarkusBootstrap.bootstrap(QuarkusBootstrap.java:137)
        at io.quarkus.dev.DevModeMain.start(DevModeMain.java:103)
        ... 1 more
Caused by: io.quarkus.bootstrap.resolver.AppModelResolverException: Failed to inject extension deployment dependencies for com.xxx.historyservice:historyservice-web:jar:1.0.0-SNAPSHOT
        at io.quarkus.bootstrap.resolver.BootstrapAppModelResolver.doResolveModel(BootstrapAppModelResolver.java:204)
        at io.quarkus.bootstrap.resolver.BootstrapAppModelResolver.resolveManagedModel(BootstrapAppModelResolver.java:143)
        at io.quarkus.bootstrap.BootstrapAppModelFactory.resolveAppModel(BootstrapAppModelFactory.java:283)
        ... 3 more
```