### PR TITLE
Avoid unresolved bean issue when retrieving the ShutdownReadinessCheck

### DIFF
--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/ShutdownReadinessListener.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/ShutdownReadinessListener.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.health.runtime;
 
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.enterprise.util.AnnotationLiteral;
 
@@ -20,8 +21,12 @@ public class ShutdownReadinessListener implements ShutdownListener {
 
     @Override
     public void preShutdown(ShutdownNotification notification) {
-        CDI.current().select(ShutdownReadinessCheck.class, new AnnotationLiteral<Readiness>() {
-        }).get().shutdown();
+        Instance<ShutdownReadinessCheck> instance = CDI.current()
+                .select(ShutdownReadinessCheck.class, new AnnotationLiteral<Readiness>() {
+                });
+        if (!instance.isUnsatisfied()) {
+            instance.get().shutdown();
+        }
         notification.done();
     }
 }


### PR DESCRIPTION
Fixes: #7631

Without, you get:


```
Mar 06, 2020 10:46:58 AM io.quarkus.runtime.shutdown.ShutdownRecorder runShutdown
ERROR: Graceful shutdown failed
javax.enterprise.inject.UnsatisfiedResolutionException: No bean found for required type [class io.quarkus.smallrye.health.runtime.ShutdownReadinessCheck] and qualifiers [[@org.eclipse.microprofile.health.Readiness()]]
	at io.quarkus.arc.impl.InstanceImpl.bean(InstanceImpl.java:151)
	at io.quarkus.arc.impl.InstanceImpl.get(InstanceImpl.java:81)
	at io.quarkus.smallrye.health.runtime.ShutdownReadinessListener.preShutdown(ShutdownReadinessListener.java:24)
	at io.quarkus.runtime.shutdown.ShutdownRecorder.runShutdown(ShutdownRecorder.java:30)
	at io.quarkus.runtime.Application.stop(Application.java:171)
	at io.quarkus.runtime.Application.close(Application.java:114)
	at io.quarkus.runner.bootstrap.StartupActionImpl$1.close(StartupActionImpl.java:107)
	at io.quarkus.runner.bootstrap.RunningQuarkusApplicationImpl.close(RunningQuarkusApplicationImpl.java:29)
	at io.quarkus.test.junit.QuarkusTestExtension$1.close(QuarkusTestExtension.java:101)
	at io.quarkus.test.junit.QuarkusTestExtension$ExtensionState.close(QuarkusTestExtension.java:372)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.execution.ExtensionValuesStore.closeAllStoredCloseableValues(ExtensionValuesStore.java:61)
	at org.junit.jupiter.engine.descriptor.AbstractExtensionContext.close(AbstractExtensionContext.java:73)
	at org.junit.jupiter.engine.execution.JupiterEngineExecutionContext.close(JupiterEngineExecutionContext.java:53)
	at org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor.cleanUp(JupiterEngineDescriptor.java:67)
	at org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor.cleanUp(JupiterEngineDescriptor.java:29)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$cleanUp$9(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.cleanUp(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:83)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
```