### PR TITLE
Apply sun.nio.ch.Iocp substitutions only against Windows

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/JdkSubstitutions.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/JdkSubstitutions.java
@@ -5,6 +5,9 @@ import java.net.URL;
 import java.nio.channels.spi.AsynchronousChannelProvider;
 import java.util.function.Function;
 
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.InjectAccessors;
 import com.oracle.svm.core.annotate.Substitute;
@@ -92,6 +95,7 @@ final class Package_jdk_internal_loader implements Function<TargetClass, String>
 
 @Substitute
 @TargetClass(className = "sun.nio.ch.WindowsAsynchronousFileChannelImpl", innerClass = "DefaultIocpHolder", onlyWith = JDK11OrLater.class)
+@Platforms({ Platform.WINDOWS.class })
 final class Target_sun_nio_ch_WindowsAsynchronousFileChannelImpl_DefaultIocpHolder {
 
     @Alias
@@ -100,6 +104,7 @@ final class Target_sun_nio_ch_WindowsAsynchronousFileChannelImpl_DefaultIocpHold
 }
 
 @TargetClass(className = "sun.nio.ch.Iocp", onlyWith = JDK11OrLater.class)
+@Platforms({ Platform.WINDOWS.class })
 final class Target_sun_nio_ch_Iocp {
 
     @Alias
@@ -113,6 +118,7 @@ final class Target_sun_nio_ch_Iocp {
 }
 
 @TargetClass(className = "sun.nio.ch.ThreadPool", onlyWith = JDK11OrLater.class)
+@Platforms({ Platform.WINDOWS.class })
 final class Target_sun_nio_ch_ThreadPool {
 
     @Alias


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/7632

The commit here applies the `sun.nio.ch.Iocp` `@Substitution` only on Windows to prevent issues noted in that linked bug.
With this change, the failure that I could reproduce from the original issue, on a non-Windows OS, no longer occurs and the project works fine.

I need one additional input from @gwenneg - in the original PR which introduced this `Substitution`, there's also a `@Alias` applied to `sun.nio.ch.ThreadPool` https://github.com/quarkusio/quarkus/pull/7587/files#diff-90406b62b00ac17517dec4fcf98458daR115. Now that class resides across different platforms, but do we want it enabled only when Windows in detected or is it fine to have it enabled on other OS, even when the other 2 `Substitution`/`Alias` now only apply for Windows?