### PR TITLE
Set fail-fast to false for the JVM builds

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -99,7 +99,7 @@ jobs:
     needs: build-jdk8
     timeout-minutes: 120
     strategy:
-      fail-fast: ${{ github.repository == 'quarkusio/quarkus' }}
+      fail-fast: false
       matrix:
         java-version: [8, 11, 12]
 


### PR DESCRIPTION
We sometimes have flaky tests and having all the builds failing really
doesn't help with that.

Already discussed with Jason.