### PR TITLE
Add OIDC tenant-enabled property

### DIFF
--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -1,4 +1,5 @@
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/devmode
+quarkus.oidc.tenant-enabled=false
 # This is a wrong client-id, will be updated to 'client-dev-mode' in the dev mode test
 quarkus.oidc.client-id=client-dev
 quarkus.oidc.application-type=web-app

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -104,7 +104,11 @@ public class DefaultTenantConfigResolver {
             if (context.get(CURRENT_TENANT_CONFIG) != null) {
                 tenantConfig = context.get(CURRENT_TENANT_CONFIG);
             } else {
-                tenantConfig = this.tenantConfigResolver.get().resolve(context);
+                OidcTenantConfig newTenantConfig = this.tenantConfigResolver.get().resolve(context);
+                if (newTenantConfig != null && !newTenantConfig.tenantEnabled) {
+                    newTenantConfig = null;
+                }
+                tenantConfig = newTenantConfig;
                 context.put(CURRENT_TENANT_CONFIG, tenantConfig);
             }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletionStage;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.quarkus.oidc.OIDCException;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
@@ -33,7 +34,11 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     }
 
     private boolean isWebApp(RoutingContext context) {
-        return OidcTenantConfig.ApplicationType.WEB_APP == resolver.resolve(context, false).oidcConfig.applicationType;
+        TenantConfigContext tenantContext = resolver.resolve(context, false);
+        if (tenantContext == null) {
+            throw new OIDCException("Tenant configuration context has not been resolved");
+        }
+        return OidcTenantConfig.ApplicationType.WEB_APP == tenantContext.oidcConfig.applicationType;
     }
 
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -20,6 +20,12 @@ public class OidcTenantConfig {
     Optional<String> tenantId = Optional.empty();
 
     /**
+     * If this tenant configuration is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean tenantEnabled = true;
+
+    /**
      * The application type, which can be one of the following values from enum {@link ApplicationType}.
      */
     @ConfigItem(defaultValue = "service")


### PR DESCRIPTION
Fixes #7561. 
This PR:
- adds a `tenant-enabled` property to avoid using a null `auth-server-url` as an indicator that a given configuration is effectively disabled which we did initially for the multi-tenancy case.
- has a default config value for `tenant-enabled` and sets it to `true`: the latter is for `TenantConfigResolver` not to have explicitly enable `OidcTenantConfig` though the default config property is still needed otherwise it is reset to `false` for `OidcTenantConfig`s set in `application.properties`.
- Adding few NPE guards, check for the `auth-server-url` and `client-id`, updated the dev mode test
- `tenant-enabled` avoids a clash with an `enabled` property which is used for all of `quarkus-oidc` when a default configuration needs to be disabled, for example, when only tenant-specific configurations are used. Otherwise we would still get NPE in case of #7561. It duplicates the build time `enabled` property when no multi-tenancy is used but it is a small cost.

IMHO it will not have to be set in 90-99% of `quarkus-oidc` and `quarkus-keycloak-authorization` cases.
It gives us an opportunity to report that `auth-server-url`, `client-id` must not be null; lets the users see a useful debug message when no tenant configuration has been resolved, and control, when really needed per a tenant specific basis, which configuration is active...

CC @rsvoboda  
