### PR TITLE
fix: allow Flyway and Liquibase to play together by making JdbcDataSourceSchemaReadyBuildItem a multiple build item

### DIFF
--- a/extensions/agroal/spi/src/main/java/io/quarkus/agroal/deployment/JdbcDataSourceSchemaReadyBuildItem.java
+++ b/extensions/agroal/spi/src/main/java/io/quarkus/agroal/deployment/JdbcDataSourceSchemaReadyBuildItem.java
@@ -2,14 +2,14 @@ package io.quarkus.agroal.deployment;
 
 import java.util.Collection;
 
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * A build item which can be used to order build processors which need a datasource's
  * schema to be ready (which really means that the tables have been created and
  * any migration run on them) for processing.
  */
-public final class JdbcDataSourceSchemaReadyBuildItem extends SimpleBuildItem {
+public final class JdbcDataSourceSchemaReadyBuildItem extends MultiBuildItem {
 
     private final Collection<String> datasourceNames;
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -357,7 +357,7 @@ public final class HibernateOrmProcessor {
             List<JdbcDataSourceBuildItem> dataSourcesConfigured,
             JpaEntitiesBuildItem jpaEntities, List<NonJpaModelBuildItem> nonJpaModels,
             List<HibernateOrmIntegrationRuntimeConfiguredBuildItem> integrationsRuntimeConfigured,
-            Optional<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem) throws Exception {
+            List<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem) throws Exception {
         if (!hasEntities(jpaEntities, nonJpaModels)) {
             return;
         }

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -174,7 +174,7 @@ public class QuartzProcessor {
     public void build(QuartzRuntimeConfig runtimeConfig, QuartzBuildTimeConfig buildTimeConfig, QuartzRecorder recorder,
             BeanContainerBuildItem beanContainer,
             BuildProducer<ServiceStartBuildItem> serviceStart, QuartzJDBCDriverDialectBuildItem driverDialect,
-            Optional<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem) {
+            List<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem) {
         recorder.initialize(runtimeConfig, buildTimeConfig, beanContainer.getValue(), driverDialect.getDriver());
         // Make sure that StartupEvent is fired after the init
         serviceStart.produce(new ServiceStartBuildItem("quartz"));

--- a/integration-tests/liquibase/src/main/java/io/quarkus/it/liquibase/LiquibaseFunctionalityResource.java
+++ b/integration-tests/liquibase/src/main/java/io/quarkus/it/liquibase/LiquibaseFunctionalityResource.java
@@ -5,7 +5,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
 import io.quarkus.liquibase.LiquibaseFactory;


### PR DESCRIPTION

The liquibase extension was merged in #6334 which means that we have multiple possibilities of making a DB schema ready.
This makes the build item that controls whether DB schemas are ready a mutliple build item so that it can be produced by several extensions.

Without this we have the following extensions when we try to cohabite Flyway and Liquibase
```
io.quarkus.builder.ChainBuildException: Multiple producers of item class
io.quarkus.agroal.deployment.JdbcDataSourceSchemaReadyBuildItem(io.quarkus.flyway.FlywayProcessor#configureRuntimeProperties)
```

Also avoid the usage of star imports in liquibase integration tests