### PR TITLE
Changes to get native build work on Windows with GraalVM Java 11

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -96,7 +96,7 @@
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
         <slf4j.version>1.7.29</slf4j.version>
         <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
-        <wildfly-common.version>1.5.3.Final-format-001</wildfly-common.version>
+        <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.11.2.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -335,6 +335,9 @@ public class NativeImageBuildStep {
             if (exitCode != 0) {
                 throw imageGenerationFailed(exitCode, command);
             }
+            if (IS_WINDOWS) { //once image is generated it gets added .exe on windows
+                executableName = executableName + ".exe";
+            }
             Path generatedImage = outputDir.resolve(executableName);
             Path finalPath = outputTargetBuildItem.getOutputDirectory().resolve(executableName);
             IoUtils.copy(generatedImage, finalPath);


### PR DESCRIPTION
With this changes I am able to build (few) quickstarts natively on Windows 10 with GraalVM-java11-20.0.0

wildfly-common upgrade fixes wrongly included `winsock.h`  when compiling on windows.
maven plugin fix is just to address final name which includes .exe

VS 2017 with some extras is needed for build to work.
For anyone looking what all tools are needed: (mostly got it from [here](https://github.com/borkdude/babashka/issues/138#issuecomment-562683439))

For building on JDK 8, you need [different ](https://github.com/borkdude/babashka/issues/138#issuecomment-562760614)set of build tools and properly set environment. 

To install via chocolatey
> choco install visualstudio2017community --version 15.9.17.0 --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.CMake.Project"

once installed environment can be set by running:

> call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"