### PR TITLE
changed tarLongFileMode to posix to mitigate problem with long group id

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -200,7 +200,7 @@
                             <appendAssemblyId>false</appendAssemblyId>
                             <outputDirectory>target/</outputDirectory>
                             <workDirectory>target/assembly/work</workDirectory>
-                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
I ran into an issue building Quarkus on my Mac at work which is bound to Active Directory. The assembly plugin failed in the doc project because my group ID was too long ([related post on stack overflow](https://stackoverflow.com/questions/33819438/maven-assembly-plugin-group-id-1377585961-is-too-big-error)).

Switching  `<tarLongFileMode>` from `gnu` to `posix` solves the issue and doesn't break the build. I'm not sure if it has implications on other platforms, though.