### PR TITLE
Amazon lambda archetype manage.sh add timeout and output response.txt

### DIFF
--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
@@ -9,7 +9,11 @@ function cmd_create() {
     --handler ${HANDLER} \
     --runtime ${RUNTIME} \
     --role ${LAMBDA_ROLE_ARN} \
+    --timeout 15 \
+    --memory-size 256 \
     ${LAMBDA_META}
+# Enable and move this param above ${LAMBDA_META}, if using AWS X-Ray
+#    --tracing-config Mode=Active \
 }
 
 function cmd_delete() {
@@ -27,6 +31,8 @@ function cmd_invoke() {
     --log-type Tail \
     --query 'LogResult' \
     --output text |  base64 -d
+  { set +x; } 2>/dev/null
+  cat response.txt && rm -f response.txt
 }
 
 function cmd_update() {


### PR DESCRIPTION
**Summary of changes:**

1. Output the response when calling invoke (from response.txt):

`{"result":"hello Bill","requestId":"94b677ee-b9f0-49ad-878c-f147b3c1ca02"}
`

2. Increase timeout to 15s, on create, to align with the sam templates, from AWS default of 3s when not specified.

`    --timeout 15 
`

3. Memory size increased to 256MB from default.  When using X-Ray (or a bit more code), you'll hit Out of Memory on startup with the default of 128MB.  Be nice to newbies and have this set automatically.
`   --memory-size 256 \
`

3. Also, add commented lines as part of the create, to assist the use of x-ray, merely uncomment the lines.  Save time on determining the correct options to use.

```
# Enable and move this param above ${LAMBDA_META}, if using AWS X-Ray
#    --tracing-config Mode=Active \

```

**Tested via:**

1. mvn archetype:generate -DarchetypeGroupId=io.quarkus -DarchetypeArtifactId=quarkus-amazon-lambda-archetype -DarchetypeVersion=999-SNAPSHOT
2. mvn package
3. sh manage.sh create
4. sh manage.sh invoke


(and repeated with x-ray configuration enabled)

