### PR TITLE
Don't use locale specific strings for error checks in test

### DIFF
--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LegacyReactivePgReloadTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LegacyReactivePgReloadTest.java
@@ -25,7 +25,7 @@ public class LegacyReactivePgReloadTest {
                 .get("/dev/error")
                 .then()
                 .statusCode(200)
-                .body(Matchers.allOf(Matchers.startsWith("Connection refused"), Matchers.endsWith(":2345")));
+                .body(Matchers.endsWith(":2345"));
 
         test.modifyResourceFile("application.properties", s -> s.replace(":2345", ":5234"));
 
@@ -33,6 +33,6 @@ public class LegacyReactivePgReloadTest {
                 .get("/dev/error")
                 .then()
                 .statusCode(200)
-                .body(Matchers.allOf(Matchers.startsWith("Connection refused"), Matchers.endsWith(":5234")));
+                .body(Matchers.endsWith(":5234"));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/7564

The commit in this PR does the same change to `LegacyReactivePgReloadTest` that we did for `ReactivePgReloadTest` in https://github.com/quarkusio/quarkus/pull/7573/files