### PR TITLE
Update NativeImageBuildStep.java

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -371,11 +371,11 @@ public class NativeImageBuildStep {
 
     private void checkGraalVMVersion(String version) {
         log.info("Running Quarkus native-image plugin on " + version);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.", "19.3.0");
-        final boolean vmVersionIsObsolete = obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
-        if (vmVersionIsObsolete) {
-            throw new IllegalStateException("Out of date version of GraalVM detected: " + version + "."
-                    + " Quarkus currently supports GraalVM 19.3.1 and 20.0.0. Please upgrade GraalVM to one of these versions.");
+        final List<String> supportedGraalVmVersions = Arrays.asList("19.3.1", "20.0.0");
+        final boolean vmVersionIsUnsupported = supportedGraalVmVersions.stream().noneMatch(v -> version.contains(" " + v));
+        if (vmVersionIsUnsupported) {
+            throw new IllegalStateException("Unsupported version of GraalVM detected: " + version + "."
+                    + " Quarkus currently supports GraalVM 19.3.1 and 20.0.0. Please change GraalVM to one of these versions.");
         }
     }
 


### PR DESCRIPTION
This way also newer versions of GraalVM get's a fitting error.