### PR TITLE
Remove unnecessary open modifier for Kotlin tests

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/native-test-resource-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/native-test-resource-template.ftl
@@ -3,4 +3,4 @@ package ${package_name}
 import io.quarkus.test.junit.NativeImageTest
 
 @NativeImageTest
-open class Native${class_name}IT : ${class_name}Test()
+class Native${class_name}IT : ${class_name}Test()

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/test-resource-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/test-resource-template.ftl
@@ -6,7 +6,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-open class ${class_name}Test {
+class ${class_name}Test {
 
     @Test
     fun testHelloEndpoint() {

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -100,7 +100,7 @@ To make the test pass, we also need to update `GreetingResourceTest.kt` like so:
 [source,kotlin]
 ----
 @QuarkusTest
-open class GreetingResourceTest {
+class GreetingResourceTest {
 
     @Test
     fun testHelloEndpoint() {

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/native-test-resource-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/native-test-resource-template.ftl
@@ -3,4 +3,4 @@ package ${package_name}
 import io.quarkus.test.junit.NativeImageTest
 
 @NativeImageTest
-open class Native${class_name}IT : ${class_name}Test()
+class Native${class_name}IT : ${class_name}Test()

--- a/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/test-resource-template.ftl
+++ b/independent-projects/tools/common/src/test/resources/templates/basic-rest/kotlin/test-resource-template.ftl
@@ -6,7 +6,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-open class ${class_name}Test {
+class ${class_name}Test {
 
     @Test
     fun testHelloEndpoint() {


### PR DESCRIPTION
These don't serve any purpose and even make IntelliJ
suggest to remove them