### PR TITLE
fix how defaultMode in Kubernetes volumes is parsed

### DIFF
--- a/docs/src/main/asciidoc/kubernetes.adoc
+++ b/docs/src/main/asciidoc/kubernetes.adoc
@@ -464,7 +464,7 @@ Below you will find tables describing all available types.
 |====
 | Property        | Type    | Description | Default Value
 | config-map-name | String  |             |
-| default-mode    | int     |             | 384
+| default-mode    | int     |             | 0600
 | optional        | boolean |             | false
 |====
 
@@ -472,7 +472,7 @@ Below you will find tables describing all available types.
 |====
 | Property     | Type    | Description | Default Value
 | secret-name  | String  |             |
-| default-mode | int     |             | 384           
+| default-mode | int     |             | 0600
 | optional     | boolean |             | false
 |====
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
@@ -14,11 +14,12 @@ public class ConfigMapVolumeConfig {
 
     /**
      * Default mode.
+     * When specifying an octal number, leading zero must be present.
      *
      * @return The default mode.
      */
     @ConfigItem(defaultValue = "0600")
-    Integer defaultMode;
+    String defaultMode;
 
     /**
      * Optional

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConverter.java
@@ -15,7 +15,7 @@ public class ConfigMapVolumeConverter {
     public static ConfigMapVolumeBuilder convert(ConfigMapVolumeConfig cm) {
         ConfigMapVolumeBuilder b = new ConfigMapVolumeBuilder();
         b.withConfigMapName(cm.configMapName);
-        b.withDefaultMode(cm.defaultMode);
+        b.withDefaultMode(FilePermissionUtil.parseInt(cm.defaultMode));
         b.withOptional(cm.optional);
         return b;
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/FilePermissionUtil.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/FilePermissionUtil.java
@@ -1,0 +1,14 @@
+package io.quarkus.kubernetes.deployment;
+
+final class FilePermissionUtil {
+    /**
+     * When {@code value} starts with {@code 0}, parses it as an octal integer, otherwise as decimal.
+     */
+    static int parseInt(String value) {
+        if (value.startsWith("0")) {
+            return Integer.parseInt(value, 8);
+        } else {
+            return Integer.parseInt(value);
+        }
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PvcVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PvcVolumeConfig.java
@@ -15,11 +15,12 @@ public class PvcVolumeConfig {
 
     /**
      * Default mode.
+     * When specifying an octal number, leading zero must be present.
      *
      * @return The default mode.
      */
     @ConfigItem(defaultValue = "0600")
-    Integer defaultMode;
+    String defaultMode;
 
     /**
      * Optional

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
@@ -1,21 +1,25 @@
 package io.quarkus.kubernetes.deployment;
 
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
+@ConfigGroup
 public class SecretVolumeConfig {
 
     /**
      * The name of the secret to mount.
      */
+    @ConfigItem
     String secretName;
 
     /**
      * Default mode.
+     * When specifying an octal number, leading zero must be present.
      *
      * @return The default mode.
      */
     @ConfigItem(defaultValue = "0600")
-    Integer defaultMode;
+    String defaultMode;
 
     /**
      * Optional

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConverter.java
@@ -14,7 +14,7 @@ public class SecretVolumeConverter {
     public static SecretVolumeBuilder convert(SecretVolumeConfig c) {
         SecretVolumeBuilder b = new SecretVolumeBuilder();
         b.withSecretName(c.secretName);
-        b.withDefaultMode(c.defaultMode);
+        b.withDefaultMode(FilePermissionUtil.parseInt(c.defaultMode));
         b.withOptional(c.optional);
         return b;
     }

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithConfigMapCustomModeTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithConfigMapCustomModeTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithConfigMapCustomModeTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("configmap-custom-mode")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-configmap-custom-mode.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("configmap-custom-mode");
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getVolumes()).hasOnlyOneElementSatisfying(volume -> {
+                            assertThat(volume.getName()).isEqualTo("app-config");
+                            assertThat(volume.getConfigMap().getName()).isEqualTo("app-config");
+                            assertThat(volume.getConfigMap().getDefaultMode()).isEqualTo(420);
+                        });
+
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getVolumeMounts()).hasOnlyOneElementSatisfying(volumeMount -> {
+                                assertThat(volumeMount.getName()).isEqualTo("app-config");
+                                assertThat(volumeMount.getMountPath()).isEqualTo("/deployments/config");
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithConfigMapTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithConfigMapTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithConfigMapTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("configmap")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-configmap.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("configmap");
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getVolumes()).hasOnlyOneElementSatisfying(volume -> {
+                            assertThat(volume.getName()).isEqualTo("app-config");
+                            assertThat(volume.getConfigMap().getName()).isEqualTo("app-config");
+                            assertThat(volume.getConfigMap().getDefaultMode()).isEqualTo(384);
+                        });
+
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getVolumeMounts()).hasOnlyOneElementSatisfying(volumeMount -> {
+                                assertThat(volumeMount.getName()).isEqualTo("app-config");
+                                assertThat(volumeMount.getMountPath()).isEqualTo("/deployments/config");
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-configmap-custom-mode.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-configmap-custom-mode.properties
@@ -1,0 +1,3 @@
+quarkus.kubernetes.config-map-volumes.app-config.config-map-name=app-config
+quarkus.kubernetes.config-map-volumes.app-config.default-mode=0644
+quarkus.kubernetes.mounts.app-config.path=/deployments/config

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-configmap.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-configmap.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.config-map-volumes.app-config.config-map-name=app-config
+quarkus.kubernetes.mounts.app-config.path=/deployments/config


### PR DESCRIPTION
Previously, the `defaultMode` config property of some Kubernetes
volumes (ConfigMap, secret) was always treated as a decimal number,
even though octal number is a common format (and we actually used
an octal number when specifying the default value!).

This commit changes the type of the config property to `String`,
which is later parsed to an `int` when calling the Dekorate API.
At that time, if the string begins with `0`, it's parsed as octal,
otherwise as decimal.

Fixes #7722.