### PR TITLE
Enhance slow lookup message to be explicit about macOS and to mention path for Windows

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
@@ -25,7 +25,8 @@ public class NettyRecorder {
                 DefaultChannelId.newInstance();
                 if (System.currentTimeMillis() - start > 1000) {
                     log.warn(
-                            "Localhost lookup took more than one second, you need to add a /etc/hosts entry to improve Quarkus startup time. See https://thoeni.io/post/macos-sierra-java/ for details.");
+                            "Localhost lookup took more than one second, you need to add a /etc/hosts entry to improve Quarkus startup time. "
+                                    + "On Windows the path is C:\\Windows\\System32\\Drivers\\etc\\hosts. See https://thoeni.io/post/macos-sierra-java/ for macOS details.");
                 }
             }
         }).start();


### PR DESCRIPTION
Enhance slow lookup message to be explicit about macOS and to mention path for Windows

Motivated by Windows user complaining in https://github.com/quarkusio/quarkus/issues/7699:
> I've got this warning message that you don't have :
2020-03-10 08:23:08,526 WARN [io.qua.net.run.NettyRecorder] (Thread-41) Localhost lookup took more than one second, you need to add a /etc/hosts entry to improve Quarkus startup time. See https://thoeni.io/post/macos-sierra-java/ for details.
Why is it showing on my system?