### PR TITLE
QuarkusPlatformTask - addPlatform to builder

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPlatformTask.java
@@ -55,7 +55,7 @@ public abstract class QuarkusPlatformTask extends QuarkusTask {
 
         final CombinedQuarkusPlatformDescriptor.Builder builder = CombinedQuarkusPlatformDescriptor.builder();
         for (QuarkusPlatformDescriptor platform : platforms) {
-            platforms.add(platform);
+            builder.addPlatform(platform);
         }
         return builder.build();
     }


### PR DESCRIPTION
Bugfix for QuarkusPlatformTask - invoke addPlatform on builder instead of iterating and modifying on the same list

