### PR TITLE
Qute enhancements

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
@@ -542,4 +542,17 @@ public class AsmUtil {
         return 1;
     }
 
+    /**
+     * Prints the value pushed on the stack (must be an Object) by the given <tt>valuePusher</tt>
+     * to STDERR.
+     * 
+     * @param mv The MethodVisitor to forward printing to.
+     * @param valuePusher The function to invoke to push an Object to print on the stack.
+     */
+    public static void printValueOnStderr(MethodVisitor mv, Runnable valuePusher) {
+        mv.visitFieldInsn(Opcodes.GETSTATIC, "java/lang/System", "err", "Ljava/io/PrintStream;");
+        valuePusher.run();
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println",
+                "(Ljava/lang/Object;)V", false);
+    }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
@@ -318,4 +318,30 @@ public final class JandexUtil {
         }
         return isSubclassOf(index, superClass, parentName);
     }
+
+    @SuppressWarnings("incomplete-switch")
+    public static String getBoxedTypeName(Type type) {
+        switch (type.kind()) {
+            case PRIMITIVE:
+                switch (type.asPrimitiveType().primitive()) {
+                    case BOOLEAN:
+                        return "java.lang.Boolean";
+                    case BYTE:
+                        return "java.lang.Byte";
+                    case CHAR:
+                        return "java.lang.Character";
+                    case DOUBLE:
+                        return "java.lang.Double";
+                    case FLOAT:
+                        return "java.lang.Float";
+                    case INT:
+                        return "java.lang.Integer";
+                    case LONG:
+                        return "java.lang.Long";
+                    case SHORT:
+                        return "java.lang.Short";
+                }
+        }
+        return type.toString();
+    }
 }

--- a/docs/src/main/asciidoc/mailer.adoc
+++ b/docs/src/main/asciidoc/mailer.adoc
@@ -232,6 +232,39 @@ It's also possible to inject a mail template, where the message body is created 
 
 [source, java]
 ----
+@Path("")
+public class MailingResource {
+
+    @CheckedTemplate
+    class Templates {
+        public static native MailTemplateInstance hello(String name); <1>
+    }
+    
+    @GET
+    @Path("/mail")
+    public CompletionStage<Response> send() {
+        // the template looks like: Hello {name}! <2>
+        return Templates.hello("John")
+           .to("to@acme.org") <3>
+           .subject("Hello from Qute template")
+           .send() <4>
+           .subscribeAsCompletionStage()
+           .thenApply(x -> Response.accepted().build());
+    }
+}
+----
+<1> By convention, the enclosing class name and method names are used to locate the template. In this particular case, 
+we will use the `MailingResource/hello.html` and `MailingResource/hello.txt` templates to create the message body.
+<2> Set the data used in the template.
+<3> Create a mail template instance and set the recipient.
+<4> `MailTemplate.send()` triggers the rendering and, once finished, sends the e-mail via a `Mailer` instance. 
+
+TIP: Injected mail templates are validated during build. If there is no matching template in `src/main/resources/templates` the build fails.
+
+You can also do this without type-safe templates:
+
+[source, java]
+----
 @Inject
 MailTemplate hello; <1>
 

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -81,12 +81,115 @@ $ curl -w "\n" http://localhost:8080/hello?name=Martin
 Hello Martin!
 ----
 
-== Parameter Declarations and Template Extension Methods
+== Type-safe templates
 
-Qute has many useful features.
-In this example, we'll demonstrate two of them.
+There's an alternate way to declare your templates in your Java code, which relies on the following convention:
+
+- Organise your template files in the `/src/main/resources/templates` directory, by grouping them into one directory per resource class. So, if
+  your `ItemResource` class references two templates `hello` and `goodbye`, place them at `/src/main/resources/templates/ItemResource/hello.txt`
+  and `/src/main/resources/templates/ItemResource/goodbye.txt`. Grouping templates per resource class makes it easier to navigate to them.
+- In each of your resource class, declare a `@CheckedTemplate static class Template {}` class within your resource class.
+- Declare one `public static native TemplateInstance method();` per template file for your resource.
+- Use those static methods to build your template instances.
+
+Here's the previous example, rewritten using this style:
+
+We'll start with a very simple template:
+
+.HelloResource/hello.txt
+[source]
+----
+Hello {name}! <1>
+----
+<1> `{name}` is a value expression that is evaluated when the template is rendered.
+
+Now let's declare and use those templates in the resource class.
+
+.HelloResource.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+
+@Path("hello")
+public class HelloResource {
+
+    @CheckedTemplate
+    class Templates {
+        public static native TemplateInstance hello(); <1>
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public TemplateInstance get(@QueryParam("name") String name) {
+        return Templates.hello().data("name", name); <2> <3>
+    }
+}
+----
+<1> This declares a template with path `templates/HelloResource/hello.txt`.
+<2> `Templates.hello()` returns a new template instance that can be customized before the actual rendering is triggered. In this case, we put the name value under the key `name`. The data map is accessible during rendering. 
+<3> Note that we don't trigger the rendering - this is done automatically by a special `ContainerResponseFilter` implementation.
+ 
+NOTE: Once you have declared a `@CheckedTemplate` class, we will check that all its methods point to existing templates, so if you try to use a template
+from your Java code and you forgot to add it, we will let you know at build time :)
+
+Keep in mind this style of declaration allows you to reference templates declared in other resources too:
+
+.HelloResource.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import io.quarkus.qute.TemplateInstance;
+
+@Path("goodbye")
+public class GoodbyeResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public TemplateInstance get(@QueryParam("name") String name) {
+        return HelloResource.Templates.hello().data("name", name);
+    }
+}
+----
+
+=== Toplevel type-safe templates
+
+Naturally, if you want to declare templates at the toplevel, directly in `/src/main/resources/templates/hello.txt`, for example,
+you can declare them in a toplevel (non-nested) `Templates` class:
+
+.HelloResource.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.api.CheckedTemplate;
+
+@CheckedTemplate
+public class Templates {
+    public static native TemplateInstance hello(); <1>
+}
+----
+<1> This declares a template with path `templates/hello.txt`.
+
+
+== Template Parameter Declarations 
+
 If you declare a *parameter declaration* in a template then Qute attempts to validate all expressions that reference this parameter and if an incorrect expression is found the build fails.
-*Template extension methods* are used to extend the set of accessible properties of data objects.
 
 Let's suppose we have a simple class like this:
 
@@ -99,9 +202,69 @@ public class Item {
 }
 ----
 
-And we'd like to render a simple HTML page that contains the item name, price and also a discounted price.
-The discounted price is sometimes called a "computed property".
-We will implement a template extension method to render this property easily.
+And we'd like to render a simple HTML page that contains the item name and price.
+
+Let's start again with the template:
+
+.ItemResource/item.html
+[source,html]
+----
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>{item.name}</title> <1>
+</head>
+<body>
+    <h1>{item.name}</h1>
+    <div>Price: {item.price}</div> <2> 
+</body>
+</html>
+----
+<1> This expression is validated. Try to change the expression to `{item.nonSense}` and the build should fail.
+<2> This is also validated.
+
+Finally, let's create a resource class with type-safe templates:
+
+.ItemResource.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.api.CheckedTemplate;
+
+@Path("item")
+public class ItemResource {
+
+    @CheckedTemplate
+    class Templates {
+        public static native TemplateInstance item(Item item); <1>
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance get(@PathParam("id") Integer id) {
+        return Templates.item(service.findItem(id)); <2>
+    }
+}
+----
+<1> Declare a method that gives us a `TemplateInstance` for `templates/ItemResource/item.html` and declare its `Item item` parameter so we can validate the template.
+<2> Make the `Item` object accessible in the template.
+
+=== Template parameter declaration inside the template itself
+
+Alternatively, you can declare your template parameters in the template file itself.
+
 Let's start again with the template:
 
 .item.html
@@ -117,16 +280,11 @@ Let's start again with the template:
 <body>
     <h1>{item.name}</h1>
     <div>Price: {item.price}</div> 
-    {#if item.price > 100} <3>
-    <div>Discounted Price: {item.discountedPrice}</div> <4>
-    {/if}
 </body>
 </html>
 ----
 <1> Optional parameter declaration. Qute attempts to validate all expressions that reference the parameter `item`.
 <2> This expression is validated. Try to change the expression to `{item.nonSense}` and the build should fail.
-<3> `if` is a basic control flow section.
-<4> This expression is also validated against the `Item` class and obviously there is no such property declared. However, there is a template extension method declared on the `ItemResource` class - see below.
 
 Finally, let's create a resource class.
 
@@ -160,16 +318,66 @@ public class ItemResource {
     public TemplateInstance get(@PathParam("id") Integer id) {
         return item.data("item", service.findItem(id)); <2>
     }
-
-    @TemplateExtension <3>
-    static BigDecimal discountedPrice(Item item) {
-        return item.price.multiply(new BigDecimal("0.9"));
-    }
 }
 ----
 <1> Inject the template with path `templates/item.html`.
 <2> Make the `Item` object accessible in the template.
-<3> A static template extension method can be used to add "computed properties" to a data class. The class of the first parameter is used to match the base object and the method name is used to match the property name.
+
+== Template Extension Methods
+
+*Template extension methods* are used to extend the set of accessible properties of data objects.
+
+Sometimes, you're not in control of the classes that you want to use in your template, and you cannot add methods
+to them. Template extension methods allows you to declare new method for those classes that will be available
+from your templates just as if they belonged to the target class.
+
+Let's keep extending on our simple HTML page that contains the item name, price and add a discounted price.
+The discounted price is sometimes called a "computed property".
+We will implement a template extension method to render this property easily.
+Let's update our template:
+
+.HelloResource/item.html
+[source,html]
+----
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>{item.name}</title>
+</head>
+<body>
+    <h1>{item.name}</h1>
+    <div>Price: {item.price}</div> 
+    {#if item.price > 100} <1>
+    <div>Discounted Price: {item.discountedPrice}</div> <2>
+    {/if}
+</body>
+</html>
+----
+<1> `if` is a basic control flow section.
+<2> This expression is also validated against the `Item` class and obviously there is no such property declared. However, there is a template extension method declared on the `TemplateExtensions` class - see below.
+
+Finally, let's create a class where we put all our extension methods:
+
+.TemplateExtensions.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import io.quarkus.qute.TemplateExtension;
+
+@TemplateExtension
+public class TemplateExtensions {
+
+    public static BigDecimal discountedPrice(Item item) { <1>
+        return item.price.multiply(new BigDecimal("0.9"));
+    }
+}
+----
+<1> A static template extension method can be used to add "computed properties" to a data class. The class of the first parameter is used to match the base object and the method name is used to match the property name.
+
+NOTE: you can place template extension methods in every class if you annotate them with `@TemplateExtension` but we advise to keep them either
+grouped by target type, or in a single `TemplateExtensions` class by convention.
 
 == Rendering Periodic Reports
 

--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -46,6 +46,7 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <parameters>true</parameters>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.quarkus</groupId>

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailTemplateInstanceAdaptor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailTemplateInstanceAdaptor.java
@@ -1,0 +1,28 @@
+package io.quarkus.mailer.deployment;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
+import io.quarkus.mailer.runtime.MailTemplateProducer;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.deployment.CheckedTemplateAdapter;
+
+public class MailTemplateInstanceAdaptor implements CheckedTemplateAdapter {
+
+    @Override
+    public String templateInstanceBinaryName() {
+        return MailTemplateInstance.class.getName().replace('.', '/');
+    }
+
+    @Override
+    public void convertTemplateInstance(MethodVisitor mv) {
+        // we have a TemplateInstance on the stack, we need to turn it into a MailTemplateInstance
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, MailTemplateProducer.class.getName().replace('.', '/'),
+                "getMailTemplateInstance",
+                "(L" + TemplateInstance.class.getName().replace('.', '/') + ";)L"
+                        + MailTemplateInstance.class.getName().replace('.', '/') + ";",
+                false);
+    }
+
+}

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.mailer.runtime.MailerSupportProducer;
 import io.quarkus.mailer.runtime.MockMailboxImpl;
 import io.quarkus.mailer.runtime.MutinyMailerImpl;
 import io.quarkus.mailer.runtime.ReactiveMailerImpl;
+import io.quarkus.qute.deployment.CheckedTemplateAdapterBuildItem;
 import io.quarkus.qute.deployment.QuteProcessor;
 import io.quarkus.qute.deployment.TemplatePathBuildItem;
 
@@ -46,6 +47,11 @@ public class MailerProcessor {
                 .addBeanClasses(ReactiveMailerImpl.class, MutinyMailerImpl.class, BlockingMailerImpl.class,
                         MockMailboxImpl.class, MailTemplateProducer.class)
                 .build();
+    }
+
+    @BuildStep
+    CheckedTemplateAdapterBuildItem registerCheckedTemplateAdaptor() {
+        return new CheckedTemplateAdapterBuildItem(new MailTemplateInstanceAdaptor());
     }
 
     @BuildStep

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateProducer.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateProducer.java
@@ -13,8 +13,10 @@ import javax.inject.Singleton;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.mailer.MailTemplate;
 import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.api.ResourcePath;
 
 @Singleton
@@ -74,5 +76,13 @@ public class MailTemplateProducer {
                 return new MailTemplateInstanceImpl(mailer, template.select(new ResourcePath.Literal(name)).get().instance());
             }
         };
+    }
+
+    /**
+     * Called by MailTemplateInstanceAdaptor
+     */
+    public static MailTemplate.MailTemplateInstance getMailTemplateInstance(TemplateInstance instance) {
+        MutinyMailerImpl mailerImpl = Arc.container().instance(MutinyMailerImpl.class).get();
+        return new MailTemplateInstanceImpl(mailerImpl, instance);
     }
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateAdapter.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateAdapter.java
@@ -1,0 +1,11 @@
+package io.quarkus.qute.deployment;
+
+import org.objectweb.asm.MethodVisitor;
+
+public interface CheckedTemplateAdapter {
+
+    String templateInstanceBinaryName();
+
+    void convertTemplateInstance(MethodVisitor nativeMethodVisitor);
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateAdapterBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateAdapterBuildItem.java
@@ -1,0 +1,13 @@
+package io.quarkus.qute.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class CheckedTemplateAdapterBuildItem extends MultiBuildItem {
+
+    public final CheckedTemplateAdapter adapter;
+
+    public CheckedTemplateAdapterBuildItem(CheckedTemplateAdapter adapter) {
+        this.adapter = adapter;
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.qute.deployment;
+
+import java.util.Map;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class CheckedTemplateBuildItem extends MultiBuildItem {
+
+    public final String templateId;
+    public final Map<String, String> bindings;
+
+    public CheckedTemplateBuildItem(String templateId, Map<String, String> bindings) {
+        this.templateId = templateId;
+        this.bindings = bindings;
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/NativeCheckedTemplateEnhancer.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/NativeCheckedTemplateEnhancer.java
@@ -1,0 +1,143 @@
+package io.quarkus.qute.deployment;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.util.AsmUtil;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.qute.runtime.TemplateProducer;
+
+public class NativeCheckedTemplateEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    private static class NativeMethod {
+        private final MethodInfo methodInfo;
+        private final String templateId;
+        private final List<String> parameterNames;
+        private final CheckedTemplateAdapter adaptor;
+
+        public NativeMethod(MethodInfo methodInfo, String templatePath, List<String> parameterNames,
+                CheckedTemplateAdapter adaptor) {
+            this.methodInfo = methodInfo;
+            this.templateId = templatePath;
+            this.parameterNames = parameterNames;
+            this.adaptor = adaptor;
+        }
+    }
+
+    private final Map<String, NativeMethod> methods = new HashMap<>();
+
+    public void implement(MethodInfo methodInfo, String templatePath, List<String> parameterNames,
+            CheckedTemplateAdapter adaptor) {
+        // FIXME: this should support overloading by using the method signature as key, but requires moving JandexUtil stuff around
+        methods.put(methodInfo.name(), new NativeMethod(methodInfo, templatePath, parameterNames, adaptor));
+    }
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        return new DynamicTemplateClassVisitor(className, methods, outputClassVisitor);
+    }
+
+    public static class DynamicTemplateClassVisitor extends ClassVisitor {
+
+        private final Map<String, NativeMethod> methods;
+
+        public DynamicTemplateClassVisitor(String className, Map<String, NativeMethod> methods,
+                ClassVisitor outputClassVisitor) {
+            super(Gizmo.ASM_API_VERSION, outputClassVisitor);
+            this.methods = methods;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            NativeMethod nativeMethod = methods.get(name);
+            if (nativeMethod != null) {
+                // remove the native bit
+                access = access & ~Modifier.NATIVE;
+            }
+            MethodVisitor ret = super.visitMethod(access, name, descriptor, signature, exceptions);
+            if (nativeMethod != null) {
+                return new NativeMethodVisitor(nativeMethod, ret);
+            }
+            return ret;
+        }
+
+        public static class NativeMethodVisitor extends MethodVisitor {
+
+            private NativeMethod nativeMethod;
+
+            public NativeMethodVisitor(NativeMethod nativeMethod, MethodVisitor outputVisitor) {
+                super(Gizmo.ASM_API_VERSION, outputVisitor);
+                this.nativeMethod = nativeMethod;
+            }
+
+            @Override
+            public void visitEnd() {
+                visitCode();
+                /*
+                 * Template template =
+                 * Arc.container().instance(TemplateProducer.class).get().getInjectableTemplate("HelloResource/typedTemplate");
+                 */
+                visitMethodInsn(Opcodes.INVOKESTATIC, "io/quarkus/arc/Arc", "container", "()Lio/quarkus/arc/ArcContainer;",
+                        false);
+                visitLdcInsn(org.objectweb.asm.Type.getType(TemplateProducer.class));
+                visitLdcInsn(0);
+                visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/annotation/Annotation");
+                visitMethodInsn(Opcodes.INVOKEINTERFACE, "io/quarkus/arc/ArcContainer", "instance",
+                        "(Ljava/lang/Class;[Ljava/lang/annotation/Annotation;)Lio/quarkus/arc/InstanceHandle;", true);
+                visitMethodInsn(Opcodes.INVOKEINTERFACE, "io/quarkus/arc/InstanceHandle", "get",
+                        "()Ljava/lang/Object;", true);
+                visitTypeInsn(Opcodes.CHECKCAST, "io/quarkus/qute/runtime/TemplateProducer");
+                visitLdcInsn(nativeMethod.templateId);
+                visitMethodInsn(Opcodes.INVOKEVIRTUAL, "io/quarkus/qute/runtime/TemplateProducer", "getInjectableTemplate",
+                        "(Ljava/lang/String;)Lio/quarkus/qute/Template;", false);
+
+                /*
+                 * TemplateInstance instance = template.instance();
+                 */
+                // we store it on the stack because local vars are too much trouble
+                visitMethodInsn(Opcodes.INVOKEINTERFACE, "io/quarkus/qute/Template", "instance",
+                        "()Lio/quarkus/qute/TemplateInstance;", true);
+
+                String templateInstanceBinaryName = "io/quarkus/qute/TemplateInstance";
+                // some adaptors are required to return a different type such as MailTemplateInstance
+                if (nativeMethod.adaptor != null) {
+                    nativeMethod.adaptor.convertTemplateInstance(this);
+                    templateInstanceBinaryName = nativeMethod.adaptor.templateInstanceBinaryName();
+                }
+
+                int slot = 0; // arg slots start at 0 for static methods
+                List<Type> parameters = nativeMethod.methodInfo.parameters();
+                for (int i = 0; i < nativeMethod.parameterNames.size(); i++) {
+                    Type parameterType = parameters.get(i);
+                    /*
+                     * instance = instance.data("name", name);
+                     */
+                    visitLdcInsn(nativeMethod.parameterNames.get(i)); // first arg name
+                    visitVarInsn(AsmUtil.getLoadOpcode(parameterType), slot); // slot-th arg value
+                    AsmUtil.boxIfRequired(this, parameterType);
+
+                    visitMethodInsn(Opcodes.INVOKEINTERFACE, templateInstanceBinaryName, "data",
+                            "(Ljava/lang/String;Ljava/lang/Object;)L" + templateInstanceBinaryName + ";", true);
+
+                    slot += AsmUtil.getParameterSize(parameterType);
+                }
+                /*
+                 * return instance;
+                 */
+                visitInsn(Opcodes.ARETURN);
+
+                visitMaxs(0, 0);
+                super.visitEnd();
+            }
+        }
+    }
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/api/CheckedTemplate.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/api/CheckedTemplate.java
@@ -1,0 +1,59 @@
+package io.quarkus.qute.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.qute.TemplateInstance;
+
+/**
+ * <p>
+ * If you place this annotation on a class, all its <code>native static</code> methods will be used to declare
+ * templates and the list of parameters they require.
+ * <p>
+ * If this is placed on an inner class of the class <code>X</code>, a <code>native static</code> method of the name
+ * <code>foo</code> will refer to a template at the path <code>X/foo</code> (template file extensions are
+ * not part of the method name) relative to your templates root.
+ * <p>
+ * If this is placed on a toplevel class, a <code>native static</code> method of the name
+ * <code>foo</code> will refer to a template at the path <code>foo</code> (template file extensions are
+ * not part of the method name) at the toplevel of your templates root.
+ * <p>
+ * Each parameter of the <code>native static</code> will be used to validate the template at build time, to
+ * make sure that those parameters are used properly in a type-safe manner. The return type of each
+ * <code>native static</code> method should be {@link TemplateInstance}.
+ * <p>
+ * Example:
+ * <p>
+ * 
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;Path("item")
+ *     public class ItemResource {
+ * 
+ *         &#64;CheckedTemplate
+ *         class Templates {
+ *             // defines a template at ItemResource/item, taking an Item parameter named item
+ *             public static native TemplateInstance item(Item item);
+ *         }
+ * 
+ *         &#64;GET
+ *         &#64;Path("{id}")
+ *         &#64;Produces(MediaType.TEXT_HTML)
+ *         public TemplateInstance get(@PathParam("id") Integer id) {
+ *             // instantiate that template and pass it the required template parameter
+ *             return Templates.item(service.findItem(id));
+ *         }
+ *     }
+ * }
+ * </pre>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface CheckedTemplate {
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
@@ -87,6 +87,13 @@ public class TemplateProducer {
         return new InjectableTemplate(path.value(), templateVariants, engine);
     }
 
+    /**
+     * Used by NativeCheckedTemplateEnhancer to inject calls to this method in the native type-safe methods.
+     */
+    public Template getInjectableTemplate(String path) {
+        return new InjectableTemplate(path, templateVariants, engine);
+    }
+
     static class InjectableTemplate implements Template {
 
         private final String path;
@@ -182,6 +189,10 @@ public class TemplateProducer {
             this.defaultTemplate = defaultTemplate;
         }
 
+        @Override
+        public String toString() {
+            return "TemplateVariants{default=" + defaultTemplate + ", variants=" + variantToTemplate + "}";
+        }
     }
 
     static String parseMediaType(String suffix) {

--- a/extensions/resteasy-qute/deployment/pom.xml
+++ b/extensions/resteasy-qute/deployment/pom.xml
@@ -51,6 +51,7 @@
                             <version>${project.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/HelloResource.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/HelloResource.java
@@ -1,25 +1,84 @@
 package io.quarkus.qute.resteasy.deployment;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
+
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+import io.quarkus.resteasy.qute.RestTemplate;
 
 @Path("hello")
 public class HelloResource {
+
+    @CheckedTemplate
+    public static class Templates {
+        // GENERATED    
+        //        {
+        //            Template template = Arc.container().instance(Engine.class).get().getTemplate("HelloResource/typedTemplate");
+        //            TemplateInstance instance = template.instance();
+        //            instance.data("name", name);
+        //            return instance;
+        //        }
+
+        public static native TemplateInstance typedTemplate(String name, Map<String, Object> other);
+
+        public static native TemplateInstance typedTemplatePrimitives(boolean bool, byte b, short s, int i, long l, char c,
+                float f, double d);
+    }
 
     @Inject
     Template hello;
 
     @GET
-    public TemplateInstance get(@QueryParam("name") String name) {
+    public TemplateInstance get(@QueryParam String name) {
         if (name == null) {
             name = "world";
         }
         return hello.data("name", name);
     }
 
+    @Path("no-injection")
+    @GET
+    public TemplateInstance hello(@QueryParam String name) {
+        if (name == null) {
+            name = "world";
+        }
+        return RestTemplate.data("name", name);
+    }
+
+    @Path("type-error")
+    @GET
+    public TemplateInstance typeError() {
+        return RestTemplate.data("name", "world");
+    }
+
+    @Path("native/typed-template-primitives")
+    @GET
+    public TemplateInstance typedTemplatePrimitives() {
+        return Templates.typedTemplatePrimitives(true, (byte) 0, (short) 1, 2, 3, 'a', 4.0f, 5.0);
+    }
+
+    @Path("native/typed-template")
+    @GET
+    public TemplateInstance nativeTypedTemplate(@QueryParam String name) {
+        if (name == null) {
+            name = "world";
+        }
+        return Templates.typedTemplate(name, null);
+    }
+
+    @Path("native/toplevel")
+    @GET
+    public TemplateInstance nativeToplevelTypedTemplate(@QueryParam String name) {
+        if (name == null) {
+            name = "world";
+        }
+        return io.quarkus.qute.resteasy.deployment.Templates.toplevel(name);
+    }
 }

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/MissingTemplateResource.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/MissingTemplateResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import java.util.Map;
+
+import javax.ws.rs.Path;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+
+@Path("missing-template")
+public class MissingTemplateResource {
+
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance hello(String name, Map<String, Object> other);
+
+        public static native TemplateInstance missingTemplate();
+    }
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/MissingTemplateTest.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/MissingTemplateTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.common.Assert;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MissingTemplateTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest configError = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MissingTemplateResource.class)
+                    .addAsResource("templates/MissingTemplateResource/hello.txt"))
+            .assertException(t -> {
+                t.printStackTrace();
+                Assert.assertTrue(t.getMessage().contains(
+                        "Declared template MissingTemplateResource/missingTemplate could not be found. Either add it or delete its declaration in io.quarkus.qute.resteasy.deployment.MissingTemplateResource$Templates.missingTemplate"));
+            });
+
+    @Test
+    public void emptyTest() {
+    }
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TemplateResponseFilterTest.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TemplateResponseFilterTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 public class TemplateResponseFilterTest {
 
@@ -17,12 +19,29 @@ public class TemplateResponseFilterTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(HelloResource.class)
+                    .addClass(Templates.class)
+                    .addAsResource("templates/toplevel.txt")
+                    .addAsResource("templates/HelloResource/hello.txt")
+                    .addAsResource("templates/HelloResource/typedTemplate.txt")
+                    .addAsResource("templates/HelloResource/typedTemplate.html")
+                    .addAsResource("templates/HelloResource/typedTemplatePrimitives.txt")
                     .addAsResource(new StringAsset("Hello {name}!"), "templates/hello.txt"));
 
     @Test
     public void testFilter() {
         when().get("/hello").then().body(Matchers.is("Hello world!"));
         when().get("/hello?name=Joe").then().body(Matchers.is("Hello Joe!"));
+        when().get("/hello/no-injection").then().body(Matchers.is("Salut world!"));
+        when().get("/hello/no-injection?name=Joe").then().body(Matchers.is("Salut Joe!"));
+        RestAssured.given().accept(ContentType.TEXT).get("/hello/native/typed-template").then()
+                .body(Matchers.is("Salut world!"));
+        RestAssured.given().accept(ContentType.TEXT).get("/hello/native/typed-template?name=Joe").then()
+                .body(Matchers.is("Salut Joe!"));
+        RestAssured.given().accept(ContentType.HTML).get("/hello/native/typed-template?name=Joe").then()
+                .body(Matchers.is("<html>Salut Joe!</html>"));
+        when().get("/hello/native/typed-template-primitives").then()
+                .body(Matchers.is("Byte: 0 Short: 1 Int: 2 Long: 3 Char: a Boolean: true Float: 4.0 Double: 5.0"));
+        when().get("/hello/native/toplevel?name=Joe").then().body(Matchers.is("Salut Joe!"));
     }
 
 }

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/Templates.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/Templates.java
@@ -1,0 +1,9 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+
+@CheckedTemplate
+public class Templates {
+    public static native TemplateInstance toplevel(String name);
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorResource.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.api.CheckedTemplate;
+
+@Path("type-error")
+public class TypeErrorResource {
+
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance typeError3(String name);
+    }
+
+    @Path("native/type-error3")
+    @GET
+    public TemplateInstance nativeTypeError3() {
+        return Templates.typeError3("world");
+    }
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorTest.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.common.Assert;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TypeErrorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest configError = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(HelloResource.class)
+                    .addAsResource("templates/HelloResource/hello.txt")
+                    .addAsResource("templates/HelloResource/typeError.txt")
+                    .addAsResource("templates/HelloResource/typedTemplate.txt")
+                    .addAsResource("templates/HelloResource/typedTemplatePrimitives.txt")
+                    .addAsResource(new StringAsset("Hello {name}!"), "templates/hello.txt"))
+            .assertException(t -> {
+                Assert.assertTrue(t.getMessage().contains("Incorrect expression: name.foo()"));
+            });
+
+    @Test
+    public void emptyTest() {
+    }
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorTest3.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorTest3.java
@@ -1,0 +1,26 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.common.Assert;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TypeErrorTest3 {
+
+    @RegisterExtension
+    static final QuarkusUnitTest configError = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TypeErrorResource.class)
+                    .addAsResource("templates/TypeErrorResource/typeError3.txt"))
+            .assertException(t -> {
+                t.printStackTrace();
+                Assert.assertTrue(t.getMessage().contains("Incorrect expression: name.foo()"));
+            });
+
+    @Test
+    public void emptyTest() {
+    }
+}

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/hello.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/hello.txt
@@ -1,0 +1,1 @@
+Salut {name}!

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typeError.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typeError.txt
@@ -1,0 +1,1 @@
+{@java.lang.String name}Salut {name.foo()}!

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typeError2.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typeError2.txt
@@ -1,0 +1,1 @@
+Salut {name.foo()}!

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typedTemplate.html
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typedTemplate.html
@@ -1,0 +1,1 @@
+<html>Salut {name}!</html>

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typedTemplate.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typedTemplate.txt
@@ -1,0 +1,1 @@
+Salut {name}!

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typedTemplatePrimitives.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/HelloResource/typedTemplatePrimitives.txt
@@ -1,0 +1,1 @@
+Byte: {b} Short: {s} Int: {i} Long: {l} Char: {c} Boolean: {bool} Float: {f} Double: {d}

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/MissingTemplateResource/hello.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/MissingTemplateResource/hello.txt
@@ -1,0 +1,1 @@
+Salut {name}!

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/TypeErrorResource/typeError3.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/TypeErrorResource/typeError3.txt
@@ -1,0 +1,1 @@
+Salut {name.foo()}!

--- a/extensions/resteasy-qute/deployment/src/test/resources/templates/toplevel.txt
+++ b/extensions/resteasy-qute/deployment/src/test/resources/templates/toplevel.txt
@@ -1,0 +1,1 @@
+Salut {name}!

--- a/extensions/resteasy-qute/runtime/src/main/java/io/quarkus/resteasy/qute/RestTemplate.java
+++ b/extensions/resteasy-qute/runtime/src/main/java/io/quarkus/resteasy/qute/RestTemplate.java
@@ -1,0 +1,31 @@
+package io.quarkus.resteasy.qute;
+
+import javax.ws.rs.container.ResourceInfo;
+
+import org.jboss.resteasy.core.ResteasyContext;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+
+public final class RestTemplate {
+
+    private RestTemplate() {
+    }
+
+    private static String getActionName() {
+        ResourceInfo resourceMethod = ResteasyContext.getContextData(ResourceInfo.class);
+        return resourceMethod.getResourceClass().getSimpleName() + "/" + resourceMethod.getResourceMethod().getName();
+    }
+
+    public static TemplateInstance data(String name, Object value) {
+        Template template = Arc.container().instance(Engine.class).get().getTemplate(getActionName());
+        return template.data(name, value);
+    }
+
+    public static TemplateInstance data(Object data) {
+        Template template = Arc.container().instance(Engine.class).get().getTemplate(getActionName());
+        return template.data(data);
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -27,6 +27,7 @@ public final class EngineBuilder {
     private final List<TemplateLocator> locators;
     private final List<ResultMapper> resultMappers;
     private Function<String, SectionHelperFactory<?>> sectionHelperFunc;
+    private final List<ParserHook> parserHooks;
 
     EngineBuilder() {
         this.sectionHelperFactories = new HashMap<>();
@@ -34,6 +35,7 @@ public final class EngineBuilder {
         this.namespaceResolvers = new ArrayList<>();
         this.locators = new ArrayList<>();
         this.resultMappers = new ArrayList<>();
+        this.parserHooks = new ArrayList<>();
     }
 
     public EngineBuilder addSectionHelper(SectionHelperFactory<?> factory) {
@@ -115,6 +117,11 @@ public final class EngineBuilder {
         return this;
     }
 
+    public EngineBuilder addParserHook(ParserHook parserHook) {
+        this.parserHooks.add(parserHook);
+        return this;
+    }
+
     /**
      * 
      * @param resultMapper
@@ -132,7 +139,7 @@ public final class EngineBuilder {
 
     public Engine build() {
         return new EngineImpl(sectionHelperFactories, valueResolvers, namespaceResolvers, locators, resultMappers,
-                sectionHelperFunc);
+                sectionHelperFunc, parserHooks);
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -138,7 +138,7 @@ final class ExpressionImpl implements Expression {
         if (value == null || value.isEmpty()) {
             return EMPTY;
         }
-        return Parser.parseExpression(value, Collections.emptyMap(), Parser.SYNTHETIC_ORIGIN);
+        return Parser.parseExpression(value, Scope.EMPTY, Parser.SYNTHETIC_ORIGIN);
     }
 
     static ExpressionImpl literalFrom(String literal) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -100,7 +99,7 @@ public class IfSectionHelper implements SectionHelper {
         }
 
         @Override
-        public Map<String, String> initializeBlock(Map<String, String> outerNameTypeInfos, BlockInfo block) {
+        public Scope initializeBlock(Scope previousScope, BlockInfo block) {
             List<Object> params = null;
             if (MAIN_BLOCK_NAME.equals(block.getLabel())) {
                 params = parseParams(new ArrayList<>(block.getParameters().values()), block);
@@ -113,7 +112,7 @@ public class IfSectionHelper implements SectionHelper {
             }
             addExpressions(params, block);
             // {#if} never changes the scope
-            return Collections.emptyMap();
+            return previousScope;
         }
 
         @SuppressWarnings("unchecked")

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -5,8 +5,6 @@ import static io.quarkus.qute.Parameter.EMPTY;
 import io.quarkus.qute.Results.Result;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +124,7 @@ public class LoopSectionHelper implements SectionHelper {
         }
 
         @Override
-        public Map<String, String> initializeBlock(Map<String, String> outerNameTypeInfos, BlockInfo block) {
+        public Scope initializeBlock(Scope previousScope, BlockInfo block) {
             if (block.getLabel().equals(MAIN_BLOCK_NAME)) {
                 String iterable = block.getParameters().get(ITERABLE);
                 if (iterable == null) {
@@ -136,17 +134,17 @@ public class LoopSectionHelper implements SectionHelper {
                 String alias = block.getParameters().get(ALIAS);
                 if (iterableExpr.getParts().get(0).getTypeInfo() != null) {
                     alias = alias.equals(Parameter.EMPTY) ? DEFAULT_ALIAS : alias;
-                    Map<String, String> typeInfos = new HashMap<String, String>(outerNameTypeInfos);
-                    typeInfos.put(alias, iterableExpr.collectTypeInfo() + HINT);
-                    return typeInfos;
+                    Scope newScope = new Scope(previousScope);
+                    newScope.put(alias, iterableExpr.collectTypeInfo() + HINT);
+                    return newScope;
                 } else {
-                    Map<String, String> typeInfos = new HashMap<String, String>(outerNameTypeInfos);
                     // Make sure we do not try to validate against the parent context
-                    typeInfos.put(alias, null);
-                    return typeInfos;
+                    Scope newScope = new Scope(previousScope);
+                    newScope.put(alias, null);
+                    return newScope;
                 }
             } else {
-                return Collections.emptyMap();
+                return previousScope;
             }
         }
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHelper.java
@@ -1,0 +1,5 @@
+package io.quarkus.qute;
+
+public interface ParserHelper {
+    public void addParameter(String name, String type);
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHook.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHook.java
@@ -1,0 +1,7 @@
+package io.quarkus.qute;
+
+public interface ParserHook {
+
+    void beforeParsing(ParserHelper parser, String id);
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Scope.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Scope.java
@@ -1,0 +1,41 @@
+package io.quarkus.qute;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Scope {
+
+    public static final Scope EMPTY = new Scope(null) {
+        @Override
+        public void put(String binding, String type) {
+            throw new UnsupportedOperationException("Immutable empty scope");
+        }
+    };
+
+    private Scope parentScope;
+    private Map<String, String> bindings;
+
+    public Scope(Scope parentScope) {
+        this.parentScope = parentScope;
+    }
+
+    public void put(String binding, String type) {
+        if (bindings == null)
+            bindings = new HashMap<>();
+        bindings.put(binding, type);
+    }
+
+    public String getBindingType(String binding) {
+        // we can contain null types to override outer scopes
+        if (bindings != null
+                && bindings.containsKey(binding))
+            return bindings.get(binding);
+        return parentScope != null ? parentScope.getBindingType(binding) : null;
+    }
+
+    public String getBindingTypeOrDefault(String binding, String defaultValue) {
+        String type = getBindingType(binding);
+        return type != null ? type : defaultValue;
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -62,11 +62,11 @@ public interface SectionHelperFactory<T extends SectionHelper> {
     /**
      * Initialize a section block.
      * 
-     * @return a map of name to type infos
+     * @return a new scope if this section introduces a new scope, or the outer scope
      * @see BlockInfo#addExpression(String, String)
      */
-    default Map<String, String> initializeBlock(Map<String, String> outerNameTypeInfos, BlockInfo block) {
-        return Collections.emptyMap();
+    default Scope initializeBlock(Scope outerScope, BlockInfo block) {
+        return outerScope;
     }
 
     interface ParserDelegate {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SetSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SetSectionHelper.java
@@ -2,8 +2,6 @@ package io.quarkus.qute;
 
 import static io.quarkus.qute.Futures.evaluateParams;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -65,16 +63,16 @@ public class SetSectionHelper implements SectionHelper {
         }
 
         @Override
-        public Map<String, String> initializeBlock(Map<String, String> outerNameTypeInfos, BlockInfo block) {
+        public Scope initializeBlock(Scope previousScope, BlockInfo block) {
             if (block.getLabel().equals(MAIN_BLOCK_NAME)) {
-                Map<String, String> typeInfos = new HashMap<String, String>(outerNameTypeInfos);
+                Scope newScope = new Scope(previousScope);
                 for (Entry<String, String> entry : block.getParameters().entrySet()) {
                     Expression expr = block.addExpression(entry.getKey(), entry.getValue());
-                    typeInfos.put(entry.getKey(), expr.collectTypeInfo());
+                    newScope.put(entry.getKey(), expr.collectTypeInfo());
                 }
-                return typeInfos;
+                return newScope;
             } else {
-                return Collections.emptyMap();
+                return previousScope;
             }
         }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/WithSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/WithSectionHelper.java
@@ -1,9 +1,7 @@
 package io.quarkus.qute;
 
 import io.quarkus.qute.SectionHelperFactory.SectionInitContext;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -48,16 +46,16 @@ public class WithSectionHelper implements SectionHelper {
         }
 
         @Override
-        public Map<String, String> initializeBlock(Map<String, String> outerNameTypeInfos, BlockInfo block) {
+        public Scope initializeBlock(Scope previousScope, BlockInfo block) {
             if (block.getLabel().equals(MAIN_BLOCK_NAME)) {
                 String object = block.getParameters().get(OBJECT);
                 if (object == null) {
                     throw new IllegalStateException("Object param not present");
                 }
                 block.addExpression(OBJECT, object);
-                return outerNameTypeInfos;
+                return previousScope;
             } else {
-                return Collections.emptyMap();
+                return previousScope;
             }
         }
 

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/TestEvalContext.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/TestEvalContext.java
@@ -1,7 +1,6 @@
 package io.quarkus.qute;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -18,7 +17,7 @@ public class TestEvalContext implements EvalContext {
             Function<Expression, CompletionStage<Object>> evaluate, String... params) {
         this.base = base;
         this.name = name;
-        this.params = Arrays.stream(params).map(p -> Parser.parseExpression(p, Collections.emptyMap(), null))
+        this.params = Arrays.stream(params).map(p -> Parser.parseExpression(p, Scope.EMPTY, null))
                 .collect(Collectors.toList());
         this.evaluate = evaluate;
     }
@@ -40,7 +39,7 @@ public class TestEvalContext implements EvalContext {
 
     @Override
     public CompletionStage<Object> evaluate(String expression) {
-        return evaluate(Parser.parseExpression(expression, Collections.emptyMap(), null));
+        return evaluate(Parser.parseExpression(expression, Scope.EMPTY, null));
     }
 
     @Override


### PR DESCRIPTION
Finally found the time to follow up on the discussions we had at the last f2f, here's my proposal for improving UX for templating.

ATM, in order to do a non-type-safe template you need this template in `templates/hello.txt`:

```
Salut {name}!
```

And this controller:

```java
@Path("hello")
public class HelloResource {
    @Inject
    Template hello;

    @GET
    public TemplateInstance get(@QueryParam String name) {
        return hello.data("name", name);
    }
}
```

My proposal for non-type-safe templates is to move the template to `templates/HelloResource/hello.txt` and write the following code:

```java
@Path("hello")
public class HelloResource {
    @GET
    public TemplateInstance hello(@QueryParam String name) {
// we can change the class/method name, add a static import, or move it to a superinterface to get it in scope easier
        return ResteasyTemplate.data("name", name);
    }
}
```

This will default to using a template under `{className}/{methodName}`, and will (this is still missing) take an optional template name as parameter if you want to override it.

## Type-safe templates

On the other hand (and orthogonally), ATM if you want type-safe templates you need to write this template:

```
{@java.lang.String name}
Salut {name.toLowerCase()}!
```

While the invocation (in any style: old or new) is not ever type-safe, letting you do this:

```java
@Path("hello")
public class HelloResource {
    @GET
    public TemplateInstance hello(@QueryParam String name) {
        return ResteasyTemplate.data("name", 23); // will fail at run-time
    }
}
```

I propose the following variant, guaranteeing type-safety as discussed at the f2f:

The template doesn't have types in there:

```
Salut {name.toLowerCase()}!
```

And the template declares a constructor for the template instance:

```java
@Path("hello")
public class HelloResource {
    public static class hello extends CheckedTemplateInstance {
        public hello(String name) {
        }
    }

    @GET
    public TemplateInstance hello(@QueryParam String name) {
        return new hello(name); // this is type-safe
    }
}
```

This is implemented in this branch and a little bit tested.

Opinions @mkouba @maxandersen @emmanuelbernard @cescoffier @nicmarti ?