### PR TITLE
fix(#7712): S2i build no longer renames artifacts

### DIFF
--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBaseJavaImage.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBaseJavaImage.java
@@ -1,0 +1,71 @@
+
+package io.quarkus.container.image.s2i.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.container.image.deployment.util.ImageUtil;
+
+public enum S2iBaseJavaImage {
+
+    //We only compare `repositories` so registries and tags are stripped
+    FABRIC8("fabric8/s2i-java:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJDK_8_RHEL7("redhat-openjdk-18/openjdk18-openshift:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR",
+            "JAVA_CLASSPATH", "JAVA_OPTIONS"),
+    OPENJDK_8_RHEL8("openjdk/openjdk-8-rhel8:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
+            "JAVA_OPTIONS"),
+    OPENJDK_11_RHEL7("openjdk/openjdk-11-rhel7:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
+            "JAVA_OPTIONS"),
+    OPENJDK_11_RHEL8("openjdk/openjdk-11-rhel8:latest", "JAVA_MAIN_CLASS", "JAVA_APP_JAR", "JAVA_LIB_DIR", "JAVA_CLASSPATH",
+            "JAVA_OPTIONS");
+
+    private final String image;
+    private final String javaMainClassEnvVar;
+    private final String jarEnvVar;
+    private final String jarLibEnvVar;
+    private final String classpathEnvVar;
+    private final String jvmOptionsEnvVar;
+
+    public static Optional<S2iBaseJavaImage> findMatching(String image) {
+        for (S2iBaseJavaImage candidate : S2iBaseJavaImage.values()) {
+            if (ImageUtil.getRepository(candidate.getImage()).equals(ImageUtil.getRepository(image))) {
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private S2iBaseJavaImage(String image, String javaMainClassEnvVar, String jarEnvVar, String jarLibEnvVar,
+            String classpathEnvVar, String jvmOptionsEnvVar) {
+        this.image = image;
+        this.javaMainClassEnvVar = javaMainClassEnvVar;
+        this.jarEnvVar = jarEnvVar;
+        this.jarLibEnvVar = jarLibEnvVar;
+        this.classpathEnvVar = classpathEnvVar;
+        this.jvmOptionsEnvVar = jvmOptionsEnvVar;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public String getJavaMainClassEnvVar() {
+        return javaMainClassEnvVar;
+    }
+
+    public String getJvmOptionsEnvVar() {
+        return jvmOptionsEnvVar;
+    }
+
+    public String getClasspathEnvVar() {
+        return classpathEnvVar;
+    }
+
+    public String getJarLibEnvVar() {
+        return jarLibEnvVar;
+    }
+
+    public String getJarEnvVar() {
+        return jarEnvVar;
+    }
+
+}

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBaseNativeImage.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBaseNativeImage.java
@@ -1,0 +1,49 @@
+
+package io.quarkus.container.image.s2i.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.container.image.deployment.util.ImageUtil;
+
+public enum S2iBaseNativeImage {
+
+    //We only compare `repositories` so registries and tags are stripped
+    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:latest", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
+
+    private final String image;
+    private final String fixedNativeBinaryName;
+    private final String homeDirEnvVar;
+    private final String optsEnvVar;
+
+    public static Optional<S2iBaseNativeImage> findMatching(String image) {
+        for (S2iBaseNativeImage candidate : S2iBaseNativeImage.values()) {
+            if (ImageUtil.getRepository(candidate.getImage()).equals(ImageUtil.getRepository(image))) {
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private S2iBaseNativeImage(String image, String fixedNativeBinaryName, String homeDirEnvVar, String optsEnvVar) {
+        this.image = image;
+        this.fixedNativeBinaryName = fixedNativeBinaryName;
+        this.homeDirEnvVar = homeDirEnvVar;
+        this.optsEnvVar = optsEnvVar;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public String getFixedNativeNinaryName() {
+        return this.fixedNativeBinaryName;
+    }
+
+    public String getHomeDirEnvVar() {
+        return homeDirEnvVar;
+    }
+
+    public String getOptsEnvVar() {
+        return optsEnvVar;
+    }
+}

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.container.image.s2i.deployment;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -12,6 +13,7 @@ public class S2iConfig {
 
     public static final String DEFAULT_BASE_JVM_IMAGE = "fabric8/s2i-java:2.3";
     public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:19.3.0";
+    public static final String DEFAULT_NATIVE_TARGET_FILENAME = "application";
 
     /**
      * The base image to be used when a container image is being produced for the jar build
@@ -38,18 +40,32 @@ public class S2iConfig {
     public List<String> nativeArguments;
 
     /**
-     * The path to where the jar is added during the assemble phase.
+     * The directory where the jar is added during the assemble phase.
      * This is dependant on the s2i image and should be supplied if a non default image is used.
      */
-    @ConfigItem(defaultValue = "/deployments/application${quarkus.package.runner-suffix}.jar")
-    public String jarPath;
+    @ConfigItem(defaultValue = "/deployments/")
+    public String jarDirectory;
 
     /**
-     * The path to where the native binary is added during the assemble phase.
-     * This is dependant on the s2i image and should be supplied if a non default image is used.
+     * The resulting filename of the jar in the s2i image.
+     * This option may be used if the selected s2i image uses a fixed name for the jar.
      */
-    @ConfigItem(defaultValue = "/home/quarkus/application")
-    public String nativeBinaryPath;
+    @ConfigItem
+    public Optional<String> jarFileName;
+
+    /**
+     * The directory where the native binary is added during the assemble phase.
+     * This is dependant on the s2i image and should be supplied if a non-default image is used.
+     */
+    @ConfigItem(defaultValue = "/home/quarkus/")
+    public String nativeBinaryDirectory;
+
+    /**
+     * The resulting filename of the native binary in the s2i image.
+     * This option may be used if the selected s2i image uses a fixed name for the native binary.
+     */
+    @ConfigItem
+    public Optional<String> nativeBinaryFileName;
 
     /**
      * The build timeout.

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -65,8 +65,6 @@ import io.quarkus.kubernetes.spi.KubernetesCommandBuildItem;
 public class S2iProcessor {
 
     private static final String S2I = "s2i";
-    private static final String JAR_ARTIFACT_FORMAT = "%s%s.jar";
-    private static final String NATIVE_ARTIFACT_FORMAT = "%s%s";
     private static final String BUILD_CONFIG_NAME = "openshift.io/build-config.name";
     private static final String RUNNING = "Running";
 
@@ -77,18 +75,27 @@ public class S2iProcessor {
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             OutputTargetBuildItem out,
             PackageConfig packageConfig,
+            JarBuildItem jarBuildItem,
             BuildProducer<BaseImageInfoBuildItem> builderImageProducer,
             BuildProducer<KubernetesCommandBuildItem> commandProducer) {
 
         final List<AppDependency> appDeps = curateOutcomeBuildItem.getEffectiveModel().getUserDependencies();
+
+        String outputJarFileName = jarBuildItem.getPath().getFileName().toString();
+
         String classpath = appDeps.stream()
-                .map(d -> Paths.get(s2iConfig.jarPath).getParent().resolve("lib")
-                        .resolve(d.getArtifact().getGroupId() + "." + d.getArtifact().getPath().getFileName()).toAbsolutePath()
+                .map(d -> String.valueOf(d.getArtifact().getGroupId() + "." + d.getArtifact().getPath().getFileName()))
+                .map(s -> Paths.get(s2iConfig.jarDirectory).resolve("lib").resolve(s).toAbsolutePath()
                         .toString())
                 .collect(Collectors.joining(File.pathSeparator));
 
+        String jarFileName = s2iConfig.jarFileName.orElse(outputJarFileName);
+        String pathToJar = Paths.get(s2iConfig.jarDirectory).resolve(jarFileName)
+                .toAbsolutePath()
+                .toString();
+
         List<String> args = new ArrayList<>();
-        args.addAll(Arrays.asList("-jar", s2iConfig.jarPath, "-cp", classpath));
+        args.addAll(Arrays.asList("-jar", pathToJar, "-cp", classpath));
         args.addAll(s2iConfig.jvmArguments);
 
         if (!s2iConfig.hasDefaultBaseJvmImage()) {
@@ -102,11 +109,30 @@ public class S2iProcessor {
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             OutputTargetBuildItem out,
             PackageConfig packageConfig,
+            NativeImageBuildItem nativeImage,
             BuildProducer<BaseImageInfoBuildItem> builderImageProducer,
             BuildProducer<KubernetesCommandBuildItem> commandProducer) {
 
+        boolean usingDefaultBuilder = ImageUtil.getRepository(S2iConfig.DEFAULT_BASE_NATIVE_IMAGE)
+                .equals(ImageUtil.getRepository(s2iConfig.baseNativeImage));
+        String outputNativeBinaryFileName = nativeImage.getPath().getFileName().toString();
+
+        String nativeBinaryFileName = null;
+
+        //The default s2i builder for native builds, renames the native binary.
+        //To make things easier for the user, we need to handle it.
+        if (usingDefaultBuilder && !s2iConfig.nativeBinaryFileName.isPresent()) {
+            nativeBinaryFileName = S2iConfig.DEFAULT_NATIVE_TARGET_FILENAME;
+        } else {
+            nativeBinaryFileName = s2iConfig.nativeBinaryFileName.orElse(outputNativeBinaryFileName);
+        }
+
+        String pathToNativeBinary = Paths.get(s2iConfig.nativeBinaryDirectory).resolve(nativeBinaryFileName)
+                .toAbsolutePath()
+                .toString();
+
         builderImageProducer.produce(new BaseImageInfoBuildItem(s2iConfig.baseNativeImage));
-        commandProducer.produce(new KubernetesCommandBuildItem(s2iConfig.nativeBinaryPath,
+        commandProducer.produce(new KubernetesCommandBuildItem(pathToNativeBinary,
                 s2iConfig.nativeArguments.toArray(new String[s2iConfig.nativeArguments.size()])));
     }
 
@@ -138,18 +164,7 @@ public class S2iProcessor {
                 .filter(r -> r.getName().endsWith("kubernetes/openshift.yml"))
                 .findFirst().orElseThrow(() -> new IllegalStateException("Could not find kubernetes/openshift.yml"));
 
-        Path artifactPath = out.getOutputDirectory()
-                .resolve(String.format(JAR_ARTIFACT_FORMAT, out.getBaseName(), packageConfig.runnerSuffix));
-        Path applicationJarPath = out.getOutputDirectory()
-                .resolve(String.format(JAR_ARTIFACT_FORMAT, "application", packageConfig.runnerSuffix));
-
-        try {
-            Files.copy(artifactPath, applicationJarPath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
-            throw new RuntimeException("Error preparing the s2i build archive.", e);
-        }
-
-        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), applicationJarPath,
+        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), jar.getPath(),
                 out.getOutputDirectory().resolve("lib"));
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "jar-container", Collections.emptyMap()));
         containerImageResultProducer.produce(
@@ -166,7 +181,7 @@ public class S2iProcessor {
             Optional<ContainerImagePushRequestBuildItem> pushRequest,
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,
             BuildProducer<ContainerImageResultBuildItem> containerImageResultProducer,
-            NativeImageBuildItem nativeImageBuildItem) {
+            NativeImageBuildItem nativeImage) {
 
         if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
                 && !pushRequest.isPresent()) {
@@ -184,21 +199,10 @@ public class S2iProcessor {
                 .filter(r -> r.getName().endsWith("kubernetes/openshift.yml"))
                 .findFirst().orElseThrow(() -> new IllegalStateException("Could not find kubernetes/openshift.yml"));
 
-        Path artifactPath = out.getOutputDirectory()
-                .resolve(String.format(NATIVE_ARTIFACT_FORMAT, out.getBaseName(), packageConfig.runnerSuffix));
-        Path applicationImagePath = out.getOutputDirectory()
-                .resolve(String.format(NATIVE_ARTIFACT_FORMAT, "application", packageConfig.runnerSuffix));
-
-        try {
-            Files.copy(artifactPath, applicationImagePath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
-            throw new RuntimeException("Error preparing the s2i build archive.", e);
-        }
-
-        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), applicationImagePath);
+        createContainerImage(kubernetesClient, openshiftYml, s2iConfig, out.getOutputDirectory(), nativeImage.getPath());
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container", Collections.emptyMap()));
-        containerImageResultProducer.produce(
-                new ContainerImageResultBuildItem(S2I, null, ImageUtil.getRepository(image), ImageUtil.getTag(image)));
+        containerImageResultProducer
+                .produce(new ContainerImageResultBuildItem(S2I, null, ImageUtil.getRepository(image), ImageUtil.getTag(image)));
     }
 
     public static void createContainerImage(KubernetesClientBuildItem kubernetesClient,

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesEnvBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesEnvBuildItem.java
@@ -1,0 +1,30 @@
+
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class KubernetesEnvBuildItem extends MultiBuildItem {
+
+    private final String target;
+
+    private final String key;
+    private final String value;
+
+    public KubernetesEnvBuildItem(String target, String key, String value) {
+        this.target = target;
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getTarget() {
+        return this.target;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyEnvVarDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyEnvVarDecorator.java
@@ -1,0 +1,95 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Objects;
+
+import io.dekorate.deps.kubernetes.api.builder.Predicate;
+import io.dekorate.deps.kubernetes.api.model.ContainerBuilder;
+import io.dekorate.deps.kubernetes.api.model.ContainerFluent.EnvFromNested;
+import io.dekorate.deps.kubernetes.api.model.ContainerFluent.EnvNested;
+import io.dekorate.deps.kubernetes.api.model.EnvVarBuilder;
+import io.dekorate.deps.kubernetes.api.model.EnvVarFluent.ValueFromNested;
+import io.dekorate.doc.Description;
+import io.dekorate.kubernetes.config.Env;
+import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
+import io.dekorate.utils.Strings;
+
+@Description("Add a environment variable to the container.")
+public class ApplyEnvVarDecorator extends ApplicationContainerDecorator<ContainerBuilder> {
+
+    private final Env env;
+
+    public ApplyEnvVarDecorator(Env env) {
+        this(ANY, ANY, env);
+    }
+
+    public ApplyEnvVarDecorator(String deployment, String container, Env env) {
+        super(deployment, container);
+        this.env = env;
+    }
+
+    public void andThenVisit(ContainerBuilder builder) {
+        Predicate<EnvVarBuilder> p = new Predicate<EnvVarBuilder>() {
+            public Boolean apply(EnvVarBuilder e) {
+                if (e.getName() != null) {
+                    return e.getName().equals(env.getName());
+                } else if (e.getValueFrom() != null && e.getValueFrom().getSecretKeyRef() != null
+                        && e.getValueFrom().getSecretKeyRef().getName() != null) {
+                    return e.getValueFrom().getSecretKeyRef().getName().equals(env.getSecret());
+                } else if (e.getValueFrom() != null && e.getValueFrom().getConfigMapKeyRef() != null
+                        && e.getValueFrom().getConfigMapKeyRef().getName() != null) {
+                    return e.getValueFrom().getConfigMapKeyRef().getName().equals(env.getConfigmap());
+                }
+                return false;
+            }
+        };
+        builder.removeMatchingFromEnv(p);
+
+        if (Strings.isNotNullOrEmpty(this.env.getSecret())) {
+            this.populateFromSecret(builder);
+        } else if (Strings.isNotNullOrEmpty(this.env.getConfigmap())) {
+            this.populateFromConfigMap(builder);
+        } else if (Strings.isNotNullOrEmpty(this.env.getField())) {
+            ((ValueFromNested) ((EnvNested) builder.addNewEnv().withName(this.env.getName())).withNewValueFrom()
+                    .withNewFieldRef((String) null, this.env.getField())).endValueFrom();
+        } else if (Strings.isNotNullOrEmpty(this.env.getName())) {
+            ((EnvNested) ((EnvNested) builder.addNewEnv().withName(this.env.getName())).withValue(this.env.getValue()))
+                    .endEnv();
+        }
+    }
+
+    private void populateFromSecret(ContainerBuilder builder) {
+        if (Strings.isNotNullOrEmpty(this.env.getName()) && Strings.isNotNullOrEmpty(this.env.getValue())) {
+            ((EnvNested) ((ValueFromNested) ((EnvNested) builder.addNewEnv().withName(this.env.getName())).withNewValueFrom()
+                    .withNewSecretKeyRef(this.env.getValue(), this.env.getSecret(), false)).endValueFrom()).endEnv();
+        } else {
+            ((EnvFromNested) builder.addNewEnvFrom().withNewSecretRef(this.env.getSecret(), false)).endEnvFrom();
+        }
+
+    }
+
+    private void populateFromConfigMap(ContainerBuilder builder) {
+        if (Strings.isNotNullOrEmpty(this.env.getName()) && Strings.isNotNullOrEmpty(this.env.getValue())) {
+            ((EnvNested) ((ValueFromNested) ((EnvNested) builder.addNewEnv().withName(this.env.getName())).withNewValueFrom()
+                    .withNewConfigMapKeyRef(this.env.getValue(), this.env.getConfigmap(), false)).endValueFrom()).endEnv();
+        } else {
+            ((EnvFromNested) builder.addNewEnvFrom().withNewConfigMapRef(this.env.getConfigmap(), false)).endEnvFrom();
+        }
+
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o != null && this.getClass() == o.getClass()) {
+            ApplyEnvVarDecorator addEnvVarDecorator = (ApplyEnvVarDecorator) o;
+            return Objects.equals(this.env, addEnvVarDecorator.env);
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        return Objects.hash(new Object[] { this.env });
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -10,7 +10,7 @@ public class Constants {
     static final String OPENSHIFT_APP_RUNTIME = "app.openshift.io/runtime";
     static final String DEPLOYMENT_CONFIG = "DeploymentConfig";
     static final String S2I = "s2i";
-    static final String DEFAULT_S2I_IMAGE_NAME = "s2i-java";
+    static final String DEFAULT_S2I_IMAGE_NAME = "s2i-java"; //refers to the Dekorate default image.
 
     static final String KNATIVE = "knative";
     static final String SERVICE = "Service";

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkus.kubernetes.deployment;
 
 import static io.quarkus.kubernetes.deployment.Constants.DEFAULT_S2I_IMAGE_NAME;
-import static io.quarkus.kubernetes.deployment.Constants.DEPLOY;
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT;
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_CONFIG;
 import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -135,8 +135,7 @@ class KubernetesProcessor {
             Optional<KubernetesCommandBuildItem> commandBuildItem,
             Optional<KubernetesHealthLivenessPathBuildItem> kubernetesHealthLivenessPathBuildItem,
             Optional<KubernetesHealthReadinessPathBuildItem> kubernetesHealthReadinessPathBuildItem,
-            BuildProducer<GeneratedFileSystemResourceBuildItem> generatedResourceProducer,
-            BuildProducer<FeatureBuildItem> featureProducer) {
+            BuildProducer<GeneratedFileSystemResourceBuildItem> generatedResourceProducer) {
 
         if (kubernetesPortBuildItems.isEmpty()) {
             log.debug("The service is not an HTTP service so no Kubernetes manifests will be generated");
@@ -223,7 +222,11 @@ class KubernetesProcessor {
         } catch (IOException e) {
             log.debug("Unable to delete temporary directory " + root, e);
         }
-        featureProducer.produce(new FeatureBuildItem(FeatureBuildItem.KUBERNETES));
+    }
+
+    @BuildStep
+    FeatureBuildItem produceFeature() {
+        return new FeatureBuildItem(FeatureBuildItem.KUBERNETES);
     }
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -288,7 +288,7 @@ class KubernetesProcessor {
         });
 
         config.getWorkingDir().ifPresent(w -> {
-            session.resources().decorate(target, new ApplyWorkingDirDecorator(name, DEPLOY));
+            session.resources().decorate(target, new ApplyWorkingDirDecorator(name, w));
         });
 
         config.getCommand().ifPresent(c -> {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -284,7 +284,7 @@ class KubernetesProcessor {
 
         //EnvVars
         config.getEnvVars().entrySet().forEach(e -> {
-            session.resources().decorate(target, new AddEnvVarDecorator(EnvConverter.convert(e)));
+            session.resources().decorate(target, new ApplyEnvVarDecorator(EnvConverter.convert(e)));
         });
 
         config.getWorkingDir().ifPresent(w -> {


### PR DESCRIPTION
Fixes: #7712 #7766 #7740

This pull request changes the way that the artifact is handled during the s2i build process.

- **The artifact is no longer renamed**.
- The user is able to specify the target directory and or the target filename (if the s2i builder image changes the name).
- The artifact name that is used in the manifests comes from `JarBuildItem` / `NativeBuildItem` unless the user specifies something else (see above).
