### PR TITLE
Properly support dependency on a java-library module

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/BasicJavaLibraryModuleTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/BasicJavaLibraryModuleTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class BasicJavaLibraryModuleTest extends QuarkusGradleTestBase {
+
+    @Test
+    public void testBasicMultiModuleBuild() throws Exception {
+
+        final File projectDir = getProjectDir("basic-java-library-module");
+        
+        BuildResult build = GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments(arguments(":application:quarkusBuild"))
+                .withProjectDir(projectDir)
+                .build();
+        
+        final Path commonLibs = projectDir.toPath().resolve("library").resolve("build").resolve("libs");
+        assertThat(commonLibs).exists();
+        assertThat(commonLibs.resolve("library-1.0.0-SNAPSHOT.jar")).exists();
+        
+        final Path applicationLib = projectDir.toPath().resolve("application").resolve("build").resolve("lib");
+        assertThat(applicationLib).exists();
+        assertThat(applicationLib.resolve("org.acme.library-1.0.0-SNAPSHOT.jar")).exists();
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    implementation project(':library')
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/docker/Dockerfile.jvm
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,47 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY build/lib/* /deployments/lib/
+COPY build/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/docker/Dockerfile.native
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/docker/Dockerfile.native
@@ -1,0 +1,30 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the docker image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/code-with-quarkus .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+WORKDIR /work/
+COPY build/*-runner /work/application
+
+# set up permissions for user `1001`
+RUN chmod 775 /work /work/application \
+  && chown -R 1001 /work \
+  && chmod -R "g+rwX" /work \
+  && chown -R 1001:root /work
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/java/org/acme/ExampleResource.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,26 @@
+package org.acme;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @Inject
+    BeanWithInjection beanWithInjection;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        KubernetesClient kubernetesClient = beanWithInjection.kubernetesClient;
+        System.out.println("KubernetesClient is: "+kubernetesClient);
+        kubernetesClient.pods(); // fails with NullPointerException
+
+        return "hello";
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>code-with-quarkus - 1.0.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme</li>
+                <li>ArtifactId: code-with-quarkus</li>
+                <li>Version: 1.0.0-SNAPSHOT</li>
+                <li>Quarkus Version: 1.2.1.Final</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/resources/application.properties
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/native-test/java/org/acme/NativeExampleResourceIT.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/native-test/java/org/acme/NativeExampleResourceIT.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeExampleResourceIT extends ExampleResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/test/java/org/acme/ExampleResourceTest.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/application/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class ExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello"));
+    }
+
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/build.gradle
@@ -1,0 +1,18 @@
+buildscript {
+     repositories {
+          mavenLocal()
+          mavenCentral()
+     }
+}
+
+allprojects {
+     group 'org.acme'
+     version '1.0.0-SNAPSHOT'
+}
+
+subprojects{
+     repositories {
+          mavenLocal()
+          mavenCentral()
+     }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/gradle.properties
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    api enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    api 'io.quarkus:quarkus-kubernetes-client'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/src/main/docker/Dockerfile.jvm
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,47 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus-jvm
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY build/lib/* /deployments/lib/
+COPY build/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/src/main/docker/Dockerfile.native
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/src/main/docker/Dockerfile.native
@@ -1,0 +1,30 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the docker image run:
+#
+# mvn package -Pnative -Dquarkus.native.container-build=true
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/code-with-quarkus .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+WORKDIR /work/
+COPY build/*-runner /work/application
+
+# set up permissions for user `1001`
+RUN chmod 775 /work /work/application \
+  && chown -R 1001 /work \
+  && chmod -R "g+rwX" /work \
+  && chown -R 1001:root /work
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/src/main/java/org/acme/BeanWithInjection.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/library/src/main/java/org/acme/BeanWithInjection.java
@@ -1,0 +1,12 @@
+package org.acme;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithInjection {
+    @Inject
+    KubernetesClient kubernetesClient;
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-library-module/settings.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-library-module/settings.gradle
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'
+include 'library'
+include 'application'
+

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -23,11 +23,11 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact;
@@ -140,13 +140,7 @@ public class AppModelGradleResolver implements AppModelResolver {
         Map<AppArtifactKey, AppDependency> versionMap = new HashMap<>();
         Map<ModuleIdentifier, ModuleVersionIdentifier> userModules = new HashMap<>();
 
-        collectDependencies(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, appBuilder, directExtensionDeps, userDeps,
-                versionMap,
-                userModules);
-        if (launchMode == LaunchMode.TEST) {
-            collectDependencies(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, appBuilder, directExtensionDeps, userDeps,
-                    versionMap, userModules);
-        }
+        collectDependencies(appBuilder, directExtensionDeps, userDeps, versionMap, userModules);
 
         final List<AppDependency> deploymentDeps = new ArrayList<>();
         final List<AppDependency> fullDeploymentDeps = new ArrayList<>();
@@ -205,15 +199,26 @@ public class AppModelGradleResolver implements AppModelResolver {
         return this.appModel = appBuilder.build();
     }
 
-    private void collectDependencies(String configName, AppModel.Builder appBuilder, final List<Dependency> directExtensionDeps,
+    private void collectDependencies(AppModel.Builder appBuilder, final List<Dependency> directExtensionDeps,
             final List<AppDependency> userDeps, Map<AppArtifactKey, AppDependency> versionMap,
             Map<ModuleIdentifier, ModuleVersionIdentifier> userModules) {
-        final Configuration config = project.getConfigurations().getByName(configName);
+        collectDependencies(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME),
+                appBuilder, directExtensionDeps, userDeps,
+                versionMap, userModules);
+        if (launchMode == LaunchMode.TEST) {
+            collectDependencies(project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME),
+                    appBuilder, directExtensionDeps, userDeps,
+                    versionMap, userModules);
+        }
+    }
 
-        final DependencySet incomingSet = config.getIncoming().getDependencies();
-        final Set<AppArtifactKey> directDeps = new HashSet<>(incomingSet.size());
-        incomingSet.forEach(d -> directDeps.add(new AppArtifactKey(d.getGroup(), d.getName())));
-        for (ResolvedArtifact a : config.getResolvedConfiguration().getResolvedArtifacts()) {
+    private void collectDependencies(Configuration config, AppModel.Builder appBuilder,
+            final List<Dependency> directExtensionDeps,
+            final List<AppDependency> userDeps, Map<AppArtifactKey, AppDependency> versionMap,
+            Map<ModuleIdentifier, ModuleVersionIdentifier> userModules) {
+
+        final ResolvedConfiguration resolvedConfig = config.getResolvedConfiguration();
+        for (ResolvedArtifact a : resolvedConfig.getResolvedArtifacts()) {
             if (!isDependency(a)) {
                 continue;
             }
@@ -244,23 +249,50 @@ public class AppModelGradleResolver implements AppModelResolver {
             }
 
             userDeps.add(dependency);
-            versionMap
-                    .put(new AppArtifactKey(dependency.getArtifact().getGroupId(), dependency.getArtifact().getArtifactId(),
-                            dependency.getArtifact().getClassifier()), dependency);
+            versionMap.put(artifactGa, dependency);
+        }
 
-            final Dependency dep;
-            final Path artifactPath = dependency.getArtifact().getPath();
+        collectExtensionDeps(resolvedConfig.getFirstLevelModuleDependencies(), versionMap, appBuilder, directExtensionDeps,
+                true, new HashSet<>());
+    }
+
+    private void collectExtensionDeps(Set<ResolvedDependency> resolvedDeps,
+            Map<AppArtifactKey, AppDependency> versionMap,
+            AppModel.Builder appBuilder,
+            List<Dependency> firstLevelExtensions,
+            boolean firstLevelExt,
+            Set<AppArtifactKey> visited) {
+        for (ResolvedDependency dep : resolvedDeps) {
+            final AppArtifactKey key = new AppArtifactKey(dep.getModuleGroup(), dep.getModuleName());
+            if (!visited.add(key)) {
+                continue;
+            }
+            final AppDependency appDep = versionMap.get(key);
+            if (appDep == null) {
+                // not a jar
+                continue;
+            }
+
+            final Dependency extDep;
+            final Path artifactPath = appDep.getArtifact().getPath();
             if (Files.isDirectory(artifactPath)) {
-                dep = processQuarkusDir(a, artifactPath.resolve(BootstrapConstants.META_INF), appBuilder);
+                extDep = processQuarkusDir(appDep.getArtifact(), artifactPath.resolve(BootstrapConstants.META_INF), appBuilder);
             } else {
                 try (FileSystem artifactFs = FileSystems.newFileSystem(artifactPath, null)) {
-                    dep = processQuarkusDir(a, artifactFs.getPath(BootstrapConstants.META_INF), appBuilder);
+                    extDep = processQuarkusDir(appDep.getArtifact(), artifactFs.getPath(BootstrapConstants.META_INF),
+                            appBuilder);
                 } catch (IOException e) {
                     throw new GradleException("Failed to process " + artifactPath, e);
                 }
             }
-            if (dep != null && directDeps.contains(artifactGa)) {
-                directExtensionDeps.add(dep);
+
+            if (extDep != null && firstLevelExt) {
+                firstLevelExt = false;
+                firstLevelExtensions.add(extDep);
+            }
+            final Set<ResolvedDependency> resolvedChildren = dep.getChildren();
+            if (!resolvedChildren.isEmpty()) {
+                collectExtensionDeps(resolvedChildren, versionMap, appBuilder, firstLevelExtensions, firstLevelExt, visited);
             }
         }
     }
@@ -275,8 +307,7 @@ public class AppModelGradleResolver implements AppModelResolver {
 
     private AppDependency alignVersion(AppDependency dependency, Map<AppArtifactKey, AppDependency> versionMap) {
         AppArtifactKey appKey = new AppArtifactKey(dependency.getArtifact().getGroupId(),
-                dependency.getArtifact().getArtifactId(),
-                dependency.getArtifact().getClassifier());
+                dependency.getArtifact().getArtifactId());
         if (versionMap.containsKey(appKey)) {
             return versionMap.get(appKey);
         }
@@ -306,7 +337,7 @@ public class AppModelGradleResolver implements AppModelResolver {
         return new AppDependency(appArtifact, "runtime");
     }
 
-    private Dependency processQuarkusDir(ResolvedArtifact a, Path quarkusDir, AppModel.Builder appBuilder) {
+    private Dependency processQuarkusDir(AppArtifact a, Path quarkusDir, AppModel.Builder appBuilder) {
         if (!Files.exists(quarkusDir)) {
             return null;
         }

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.gradle.api.GradleException;
@@ -142,16 +143,33 @@ public class QuarkusPlugin implements Plugin<Project> {
     }
 
     private void configProjectDependency(Project project, Project dep) {
+        dep.afterEvaluate(p -> {
+            setupTaskDependencies(project, p);
+            for (Map.Entry<String, Project> entry : dep.getChildProjects().entrySet()) {
+                configProjectDependency(project, entry.getValue());
+            }
+        });
+    }
+
+    private void setupTaskDependencies(Project project, Project dep) {
+        project.getLogger().debug("Configuring %s task dependencies on %s tasks", project, dep);
         try {
             final Task jarTask = dep.getTasks().getByName(JavaPlugin.JAR_TASK_NAME);
-            final Task quarkusBuild = project.getTasks().findByName(QUARKUS_BUILD_TASK_NAME);
-            project.getLogger().debug("Configuring %s task dependencies on %s tasks", project, dep);
+            final Task quarkusBuild = findTask(project.getTasks(), QUARKUS_BUILD_TASK_NAME);
             if (quarkusBuild != null) {
                 quarkusBuild.dependsOn(jarTask);
             }
             extension.addProjectDepJarTask(dep, jarTask);
         } catch (UnknownTaskException e) {
-            project.getLogger().debug("Expected tasks not present", e);
+            project.getLogger().debug("Project %s does not include %s task", dep, JavaPlugin.JAR_TASK_NAME, e);
+        }
+    }
+
+    private static Task findTask(TaskContainer tasks, String name) {
+        try {
+            return tasks.findByName(name);
+        } catch (UnknownTaskException e) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
And collect first-level extension dependencies in the complete dependency tree instead of project direct extension dependencies.

Fixes #7729