### PR TITLE
fix: container-image integration with knative

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddMissingContainerNameDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddMissingContainerNameDecorator.java
@@ -1,0 +1,37 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.deps.kubernetes.api.model.ContainerFluent;
+import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
+import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
+import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
+import io.dekorate.kubernetes.decorator.ApplyImageDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+
+public class AddMissingContainerNameDecorator extends ApplicationContainerDecorator<ContainerFluent> {
+
+    private final String name;
+
+    public AddMissingContainerNameDecorator(String deploymentName, String name) {
+        super(deploymentName, null);
+        this.name = name;
+    }
+
+    public void andThenVisit(ContainerFluent container) {
+        if (container.getName() == null || container.getName().isEmpty()) {
+            container.withName(this.name);
+        }
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class, AddSidecarDecorator.class, AddInitContainerDecorator.class,
+                ApplyImageDecorator.class };
+    }
+
+    @Override
+    public Class<? extends Decorator>[] before() {
+        return new Class[] { ApplyContainerImageDecorator.class };
+    }
+
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -374,14 +374,13 @@ class KubernetesProcessor {
         String openshiftName = openshiftConfig.name.orElse(name);
         String knativeName = knativeConfig.name.orElse(name);
 
-        containerImageBuildItem.ifPresent(
-                c -> session.resources().decorate(KUBERNETES, new ApplyContainerImageDecorator(kubernetesName, c.getImage())));
-        containerImageBuildItem
-                .ifPresent(c -> session.resources().decorate(OPENSHIFT,
-                        new ApplyContainerImageDecorator(openshiftName, c.getImage())));
-        containerImageBuildItem
-                .ifPresent(c -> session.resources().decorate(KNATIVE,
-                        new ApplyContainerImageDecorator(knativeName, c.getImage())));
+        session.resources().decorate(KNATIVE, new AddMissingContainerNameDecorator(knativeName, knativeName));
+
+        containerImageBuildItem.ifPresent(c -> {
+            session.resources().decorate(OPENSHIFT, new ApplyContainerImageDecorator(openshiftName, c.getImage()));
+            session.resources().decorate(KUBERNETES, new ApplyContainerImageDecorator(kubernetesName, c.getImage()));
+            session.resources().decorate(KNATIVE, new ApplyContainerImageDecorator(knativeName, c.getImage()));
+        });
 
         //Handle Command and arguments
         commandBuildItem.ifPresent(c -> {

--- a/integration-tests/kubernetes/standard/pom.xml
+++ b/integration-tests/kubernetes/standard/pom.xml
@@ -48,6 +48,21 @@
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>
             </exclusions>
+         </dependency>
+         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>knative-model</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KnativeContainerImageTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KnativeContainerImageTest.java
@@ -1,0 +1,61 @@
+
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.knative.serving.v1alpha1.Service;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KnativeContainerImageTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("knative-with-container-image").setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("knative-with-container-image.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("knative.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("knative.yml"));
+
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("knative.yml"));
+
+        assertThat(kubernetesList).filteredOn(i -> "Service".equals(i.getKind())).hasOnlyOneElementSatisfying(i -> {
+            assertThat(i).isInstanceOfSatisfying(Service.class, d -> {
+
+                assertThat(d.getSpec()).satisfies(serviceSpec -> {
+                    assertThat(serviceSpec.getRunLatest()).satisfies(revisionTemplate -> {
+                        assertThat(revisionTemplate.getConfiguration()).satisfies(configuration -> {
+                            assertThat(configuration.getRevisionTemplate()).satisfies(template -> {
+                                assertThat(template.getSpec()).satisfies(spec -> {
+                                    assertThat(spec.getContainer()).satisfies(c -> {
+                                        assertThat(c.getImage())
+                                                .isEqualTo("quay.io/grp/knative-with-container-image:0.1-SNAPSHOT");
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/standard/src/test/resources/knative-with-container-image.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/knative-with-container-image.properties
@@ -1,0 +1,4 @@
+# Configuration file
+quarkus.kubernetes.deployment-target=knative
+quarkus.container-image.group=grp
+quarkus.container-image.registry=quay.io


### PR DESCRIPTION
Fixes: #7736 

The generated resources for knative are lacking container names.
This means that all container specific decorators are broken.
Until, this is addressed in Dekorate itself, this pull request adds the missing name.

The pr also includes integration test for the issue as described in #7736.