### PR TITLE
Bump SmallRye Config to 1.7.0

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -32,7 +32,7 @@
         <microprofile-opentracing-api.version>1.3.3</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
-        <smallrye-config.version>1.6.2</smallrye-config.version>
+        <smallrye-config.version>1.7.0</smallrye-config.version>
         <smallrye-health.version>2.2.0</smallrye-health.version>
         <smallrye-metrics.version>2.4.1</smallrye-metrics.version>
         <smallrye-open-api.version>1.2.1</smallrye-open-api.version>


### PR DESCRIPTION
This fixes a Stackoverflow issue in the YamlConfigSource and injection of specialized Optional types.