### PR TITLE
Gradle: init AppModel resolver with LaunchMode.DEVELOPMENT in QuarkusDev task

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -62,6 +62,7 @@ import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.dev.DevModeContext;
 import io.quarkus.dev.DevModeMain;
 import io.quarkus.gradle.QuarkusPluginExtension;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.utilities.JavaBinFinder;
 
 public class QuarkusDev extends QuarkusTask {
@@ -235,7 +236,7 @@ public class QuarkusDev extends QuarkusTask {
             StringBuilder classPathManifest = new StringBuilder();
 
             final AppModel appModel;
-            final AppModelResolver modelResolver = extension().getAppModelResolver();
+            final AppModelResolver modelResolver = extension().getAppModelResolver(LaunchMode.DEVELOPMENT);
             try {
                 final AppArtifact appArtifact = extension.getAppArtifact();
                 appArtifact.setPath(extension.outputDirectory().toPath());


### PR DESCRIPTION
Fixes #7758 

We didn't need this before. But now it's necessary.