### PR TITLE
fix(docs): make sure that mapped properties are sorted properly

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocElement.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocElement.java
@@ -1,5 +1,7 @@
 package io.quarkus.annotation.processor.generate_doc;
 
+import static io.quarkus.annotation.processor.generate_doc.ConfigPhase.COMPARATOR;
+
 import java.io.IOException;
 import java.io.Writer;
 
@@ -19,18 +21,13 @@ public interface ConfigDocElement {
     default int compare(ConfigDocElement item) {
         if (isWithinAMap()) {
             if (item.isWithinAMap()) {
-                return 0;
+                return COMPARATOR.compare(getConfigPhase(), item.getConfigPhase());
             }
             return 1;
         } else if (item.isWithinAMap()) {
             return -1;
         }
 
-        int phaseComparison = ConfigPhase.COMPARATOR.compare(getConfigPhase(), item.getConfigPhase());
-        if (phaseComparison == 0) {
-            return 0;
-        }
-
-        return phaseComparison;
+        return COMPARATOR.compare(getConfigPhase(), item.getConfigPhase());
     }
 }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigPhase.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigPhase.java
@@ -41,14 +41,8 @@ public enum ConfigPhase implements Comparable<ConfigPhase> {
                 }
                 case BOOTSTRAP: {
                     switch (secondPhase) {
-                        case BUILD_TIME:
-                            return 1;
-                        case BUILD_AND_RUN_TIME_FIXED:
-                            return 1;
                         case BOOTSTRAP:
                             return 0;
-                        case RUN_TIME:
-                            return 1;
                         default:
                             return 1;
                     }


### PR DESCRIPTION
Use the config phase comparator even for mapped properties to make sure that config items in a Map
are sorted in correct ordering - build time items first and runtime items at the end

Fixes https://github.com/quarkusio/quarkus/issues/7781