### PR TITLE
Disallow beans with split packages

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SplitPackageTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SplitPackageTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.arc.test;
+
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SplitPackageTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setAllowTestClassOutsideDeployment(true)
+            .assertException(new Consumer<Throwable>() {
+                @Override
+                public void accept(Throwable throwable) {
+                    Assertions.assertTrue(throwable.toString().contains("Split package"));
+                }
+            })
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SubclassBean.class)
+                    .addAsResource(new StringAsset("quarkus.arc.remove-unused-beans=none"), "application.properties"));
+
+    @Test
+    public void testSimpleBean() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SubclassBean.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SubclassBean.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SubclassBean extends SuperclassBean {
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SuperclassBean.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/SuperclassBean.java
@@ -1,0 +1,4 @@
+package io.quarkus.arc.test;
+
+public class SuperclassBean {
+}


### PR DESCRIPTION
If the superclass of a bean is in the same package
but a different archive throw an exception. This just
causes problems, so this error message makes it obvious
what the problem is.

Fixes #7284