### PR TITLE
Exclude protobuf-java from mysql-connector-jdbc

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2180,6 +2180,12 @@
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql-jdbc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
It seems probuf-java is needed only for Protocol X

See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-installing-maven.html