### PR TITLE
Properly identify and exclude project's modules from the classpath for Gradle's dev mode

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/AppModelGradleResolver.java
@@ -331,10 +331,14 @@ public class AppModelGradleResolver implements AppModelResolver {
     }
 
     static AppDependency toAppDependency(ResolvedArtifact a) {
+        return new AppDependency(toAppArtifact(a), "runtime");
+    }
+
+    public static AppArtifact toAppArtifact(ResolvedArtifact a) {
         final String[] split = a.getModuleVersion().toString().split(":");
         final AppArtifact appArtifact = new AppArtifact(split[0], split[1], split.length > 2 ? split[2] : null);
         appArtifact.setPath(a.getFile().toPath());
-        return new AppDependency(appArtifact, "runtime");
+        return appArtifact;
     }
 
     private Dependency processQuarkusDir(AppArtifact a, Path quarkusDir, AppModel.Builder appBuilder) {


### PR DESCRIPTION
We haven't been catching all the modules of a multimodule Gradle project and then we haven't properly filtered them out from the classpath (adding version to the key is a mistake because it may be unspecified).