### PR TITLE
Make duration in Kubernetes extension config proper durations

### DIFF
--- a/docs/src/main/asciidoc/kubernetes.adoc
+++ b/docs/src/main/asciidoc/kubernetes.adoc
@@ -326,8 +326,8 @@ To set the initial delay of the probe to 20 seconds and the period to 45:
 
 [source]
 ----
-quarkus.kubernetes.readiness-probe.initial-delay-seconds=20
-quarkus.kubernetes.readiness-probe.period-seconds=45
+quarkus.kubernetes.readiness-probe.initial-delay=20s
+quarkus.kubernetes.readiness-probe.period=45s
 ----
 
 === Using the Kubernetes client
@@ -395,11 +395,11 @@ For example to define a `kubernetes-readiness-probe` which is of type `Probe`:
 
 [source]
 ----
-quarkus.kubernetes.readiness-probe.initial-delay-seconds=20
-quarkus.kubernetes.readiness-probe.period-seconds=45
+quarkus.kubernetes.readiness-probe.initial-delay=20s
+quarkus.kubernetes.readiness-probe.period=45s
 ----
 
-In this example `initial-delay` and `period-seconds` are fields of the type `Probe`.
+In this example `initial-delay` and `period` are fields of the type `Probe`.
 Below you will find tables describing all available types.
 
 
@@ -416,13 +416,13 @@ Below you will find tables describing all available types.
 
 .Probe
 |====
-| Property              | Type   | Description | Default Value
-| http-action-path      | String |             |
-| exec-action           | String |             |
-| tcp-socket-action     | String |             |               
-| initial-delay-seconds | int    |             |             0 
-| period-seconds        | int    |             |            30
-| timeout-seconds       | int    |             |            10
+| Property              | Type     | Description | Default Value
+| http-action-path      | String   |             |
+| exec-action           | String   |             |
+| tcp-socket-action     | String   |             |              
+| initial-delay         | Duration |             |             0
+| period                | Duration |             |           30s
+| timeout               | Duration |             |           10s
 |====
 
 .Port
@@ -511,6 +511,7 @@ Below you will find tables describing all available types.
 | claim-name  | String  |             |
 | read-only   | boolean |             | false        
 |====
+
 .AzureFileVolume
 |====
 | Property    | Type    | Description | Default Value

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -117,13 +117,13 @@ public class KnativeConfig implements PlatformConfiguration {
      * The liveness probe
      */
     @ConfigItem
-    Optional<ProbeConfig> livenessProbe;
+    ProbeConfig livenessProbe;
 
     /**
      * The readiness probe
      */
     @ConfigItem
-    Optional<ProbeConfig> readinessProbe;
+    ProbeConfig readinessProbe;
 
     /**
      * Volume mounts
@@ -250,11 +250,11 @@ public class KnativeConfig implements PlatformConfiguration {
         return imagePullSecrets;
     }
 
-    public Optional<ProbeConfig> getLivenessProbe() {
+    public ProbeConfig getLivenessProbe() {
         return livenessProbe;
     }
 
-    public Optional<ProbeConfig> getReadinessProbe() {
+    public ProbeConfig getReadinessProbe() {
         return readinessProbe;
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -117,13 +117,13 @@ public class KubernetesConfig implements PlatformConfiguration {
      * The liveness probe
      */
     @ConfigItem
-    Optional<ProbeConfig> livenessProbe;
+    ProbeConfig livenessProbe;
 
     /**
      * The readiness probe
      */
     @ConfigItem
-    Optional<ProbeConfig> readinessProbe;
+    ProbeConfig readinessProbe;
 
     /**
      * Volume mounts
@@ -264,11 +264,11 @@ public class KubernetesConfig implements PlatformConfiguration {
         return imagePullSecrets;
     }
 
-    public Optional<ProbeConfig> getLivenessProbe() {
+    public ProbeConfig getLivenessProbe() {
         return livenessProbe;
     }
 
-    public Optional<ProbeConfig> getReadinessProbe() {
+    public ProbeConfig getReadinessProbe() {
         return readinessProbe;
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -118,13 +118,13 @@ public class OpenshiftConfig implements PlatformConfiguration {
      * The liveness probe
      */
     @ConfigItem
-    Optional<ProbeConfig> livenessProbe;
+    ProbeConfig livenessProbe;
 
     /**
      * The readiness probe
      */
     @ConfigItem
-    Optional<ProbeConfig> readinessProbe;
+    ProbeConfig readinessProbe;
 
     /**
      * Volume mounts
@@ -257,11 +257,11 @@ public class OpenshiftConfig implements PlatformConfiguration {
         return imagePullSecrets;
     }
 
-    public Optional<ProbeConfig> getLivenessProbe() {
+    public ProbeConfig getLivenessProbe() {
         return livenessProbe;
     }
 
-    public Optional<ProbeConfig> getReadinessProbe() {
+    public ProbeConfig getReadinessProbe() {
         return readinessProbe;
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -42,9 +42,9 @@ public interface PlatformConfiguration {
 
     Optional<List<String>> getImagePullSecrets();
 
-    Optional<ProbeConfig> getLivenessProbe();
+    ProbeConfig getLivenessProbe();
 
-    Optional<ProbeConfig> getReadinessProbe();
+    ProbeConfig getReadinessProbe();
 
     Map<String, MountConfig> getMounts();
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
@@ -64,4 +64,7 @@ public class ProbeConfig {
     @ConfigItem(defaultValue = "3")
     Integer failureThreshold;
 
+    public boolean hasUserSuppliedAction() {
+        return httpActionPath.isPresent() || tcpSocketAction.isPresent() || execAction.isPresent();
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
@@ -1,6 +1,7 @@
 
 package io.quarkus.kubernetes.deployment;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -34,22 +35,22 @@ public class ProbeConfig {
     Optional<String> tcpSocketAction;
 
     /**
-     * The amount of time to wait in seconds before starting to probe.
+     * The amount of time to wait before starting to probe.
      */
     @ConfigItem(defaultValue = "0")
-    Integer initialDelaySeconds;
+    Duration initialDelay;
 
     /**
      * The period in which the action should be called.
      */
-    @ConfigItem(defaultValue = "30")
-    Integer periodSeconds;
+    @ConfigItem(defaultValue = "30s")
+    Duration period;
 
     /**
      * The amount of time to wait for each action.
      */
-    @ConfigItem(defaultValue = "10")
-    Integer timeoutSeconds;
+    @ConfigItem(defaultValue = "10s")
+    Duration timeout;
 
     /**
      * The success threshold to use.

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
@@ -11,9 +11,9 @@ public class ProbeConverter {
         probe.httpActionPath.ifPresent(v -> b.withHttpActionPath(v));
         probe.execAction.ifPresent(v -> b.withExecAction(v));
         probe.tcpSocketAction.ifPresent(v -> b.withTcpSocketAction(v));
-        b.withInitialDelaySeconds(probe.initialDelaySeconds);
-        b.withPeriodSeconds(probe.periodSeconds);
-        b.withTimeoutSeconds(probe.timeoutSeconds);
+        b.withInitialDelaySeconds((int) probe.initialDelay.getSeconds());
+        b.withPeriodSeconds((int) probe.period.getSeconds());
+        b.withTimeoutSeconds((int) probe.timeout.getSeconds());
         b.withSuccessThreshold(probe.successThreshold);
         b.withFailureThreshold(probe.failureThreshold);
         return b.build();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConverter.java
@@ -7,6 +7,10 @@ import io.dekorate.kubernetes.config.ProbeBuilder;
 public class ProbeConverter {
 
     public static Probe convert(ProbeConfig probe) {
+        return builder(probe).build();
+    }
+
+    public static ProbeBuilder builder(ProbeConfig probe) {
         ProbeBuilder b = new ProbeBuilder();
         probe.httpActionPath.ifPresent(v -> b.withHttpActionPath(v));
         probe.execAction.ifPresent(v -> b.withExecAction(v));
@@ -16,6 +20,6 @@ public class ProbeConverter {
         b.withTimeoutSeconds((int) probe.timeout.getSeconds());
         b.withSuccessThreshold(probe.successThreshold);
         b.withFailureThreshold(probe.failureThreshold);
-        return b.build();
+        return b;
     }
 }

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-health.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-health.properties
@@ -1,0 +1,1 @@
+quarkus.kubernetes.liveness-probe.initial-delay=20s

--- a/integration-tests/kubernetes/standard/src/test/resources/openshift-with-health.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/openshift-with-health.properties
@@ -1,0 +1,3 @@
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.readiness-probe.period=10s
+quarkus.openshift.liveness-probe.exec-action=kill


### PR DESCRIPTION
/cc @geoand @iocanel 

I didn't have the time to think about using the generated doc, considering there are a lot of additional info in there. We might need some doc generation tweaks.

We can do that in 1.3.1 but we need to fix the config properties to be consistent with the Quarkus way of doing things.