### PR TITLE
Hibernate ORM: further move some metadata validation and processing to Augmentation

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -14,7 +14,6 @@ import javax.sql.DataSource;
 
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
-import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
@@ -27,6 +26,7 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder;
 import io.quarkus.hibernate.orm.runtime.boot.registry.PreconfiguredServiceRegistryBuilder;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrations;
+import io.quarkus.hibernate.orm.runtime.recording.PrevalidatedQuarkusMetadata;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedState;
 
 /**
@@ -145,7 +145,7 @@ final class FastBootHibernatePersistenceProvider implements PersistenceProvider 
 
             RecordedState recordedState = PersistenceUnitsHolder.getRecordedState(persistenceUnitName);
 
-            final MetadataImplementor metadata = recordedState.getMetadata();
+            final PrevalidatedQuarkusMetadata metadata = recordedState.getMetadata();
             final BuildTimeSettings buildTimeSettings = recordedState.getBuildTimeSettings();
             final IntegrationSettings integrationSettings = recordedState.getIntegrationSettings();
             RuntimeSettings.Builder runtimeSettingsBuilder = new RuntimeSettings.Builder(buildTimeSettings,

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -66,7 +66,8 @@ public class PreconfiguredServiceRegistryBuilder {
     public PreconfiguredServiceRegistryBuilder(RecordedState rs) {
         this.initiators = buildQuarkusServiceInitiatorList(rs);
         this.integrators = rs.getIntegrators();
-        this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata().getMetadataBuildingOptions()
+        this.destroyedRegistry = (StandardServiceRegistryImpl) rs.getMetadata().getOriginalMetadata()
+                .getMetadataBuildingOptions()
                 .getServiceRegistry();
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
-import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.Metadata;
 import org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
@@ -49,7 +49,7 @@ public final class ProxyDefinitions {
         this.proxyDefinitionMap = proxyDefinitionMap;
     }
 
-    public static ProxyDefinitions createFromMetadata(MetadataImplementor storeableMetadata) {
+    public static ProxyDefinitions createFromMetadata(Metadata storeableMetadata) {
         //Check upfront for any need across all metadata: would be nice to avoid initializing the Bytecode provider.
         if (needAnyProxyDefinitions(storeableMetadata)) {
             final HashMap<Class<?>, ProxyClassDetailsHolder> proxyDefinitionMap = new HashMap<>();
@@ -83,7 +83,7 @@ public final class ProxyDefinitions {
         }
     }
 
-    private static boolean needAnyProxyDefinitions(MetadataImplementor storeableMetadata) {
+    private static boolean needAnyProxyDefinitions(Metadata storeableMetadata) {
         for (PersistentClass persistentClass : storeableMetadata.getEntityBindings()) {
             if (needsProxyGeneration(persistentClass))
                 return true;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -1,0 +1,226 @@
+package io.quarkus.hibernate.orm.runtime.recording;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+import org.hibernate.MappingException;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.internal.MetadataImpl;
+import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
+import org.hibernate.boot.model.IdentifierGeneratorDefinition;
+import org.hibernate.boot.model.TypeDefinition;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.annotations.NamedEntityGraphDefinition;
+import org.hibernate.cfg.annotations.NamedProcedureCallDefinition;
+import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.engine.ResultSetMappingDefinition;
+import org.hibernate.engine.spi.FilterDefinition;
+import org.hibernate.engine.spi.NamedQueryDefinition;
+import org.hibernate.engine.spi.NamedSQLQueryDefinition;
+import org.hibernate.id.factory.IdentifierGeneratorFactory;
+import org.hibernate.mapping.FetchProfile;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.type.Type;
+
+/**
+ * This is a Quarkus custom implementation of Metadata wrapping the original
+ * implementation from Hibernate ORM.
+ * The goal is to run the {@link MetadataImpl#validate()} method
+ * earlier than when it is normally performed, for two main reasons: further reduce
+ * the work that is still necessary when performing a runtime boot, and to be
+ * able to still use reflection as it's neccessary e.g. to validate enum fields.
+ *
+ * We also make sure that methods {@link #getSessionFactoryBuilder()} and {@link #buildSessionFactory()}
+ * are unavailable, as these would normally trigger an additional validation phase:
+ * we can actually boot Quarkus in a simpler way.
+ */
+public final class PrevalidatedQuarkusMetadata implements Metadata {
+
+    private final MetadataImpl metadata;
+
+    private PrevalidatedQuarkusMetadata(final MetadataImpl metadata) {
+        this.metadata = metadata;
+    }
+
+    public static PrevalidatedQuarkusMetadata validateAndWrap(final MetadataImpl original) {
+        original.validate();
+        return new PrevalidatedQuarkusMetadata(original);
+    }
+
+    // New helpers on this Quarkus specific metadata; these are useful to boot and manage the recorded state:
+
+    public SessionFactoryOptionsBuilder buildSessionFactoryOptionsBuilder() {
+        return new SessionFactoryOptionsBuilder(
+                metadata.getMetadataBuildingOptions().getServiceRegistry(),
+                metadata.getBootstrapContext());
+    }
+
+    public MetadataImplementor getOriginalMetadata() {
+        return metadata;
+    }
+
+    //Relevant overrides:
+
+    @Override
+    public SessionFactoryBuilder getSessionFactoryBuilder() {
+        //Ensure we don't boot Hibernate using this, but rather use the #buildSessionFactoryOptionsBuilder above.
+        throw new IllegalStateException("This method is not supposed to be used in Quarkus");
+    }
+
+    @Override
+    public SessionFactory buildSessionFactory() {
+        //Ensure we don't boot Hibernate using this, but rather use the #buildSessionFactoryOptionsBuilder above.
+        throw new IllegalStateException("This method is not supposed to be used in Quarkus");
+    }
+
+    //All other contracts from Metadata delegating:
+
+    @Override
+    public UUID getUUID() {
+        return metadata.getUUID();
+    }
+
+    @Override
+    public Database getDatabase() {
+        return metadata.getDatabase();
+    }
+
+    @Override
+    public Collection<PersistentClass> getEntityBindings() {
+        return metadata.getEntityBindings();
+    }
+
+    @Override
+    public PersistentClass getEntityBinding(final String entityName) {
+        return metadata.getEntityBinding(entityName);
+    }
+
+    @Override
+    public Collection<org.hibernate.mapping.Collection> getCollectionBindings() {
+        return metadata.getCollectionBindings();
+    }
+
+    @Override
+    public org.hibernate.mapping.Collection getCollectionBinding(final String role) {
+        return metadata.getCollectionBinding(role);
+    }
+
+    @Override
+    public Map<String, String> getImports() {
+        return metadata.getImports();
+    }
+
+    @Override
+    public NamedQueryDefinition getNamedQueryDefinition(final String name) {
+        return metadata.getNamedQueryDefinition(name);
+    }
+
+    @Override
+    public Collection<NamedQueryDefinition> getNamedQueryDefinitions() {
+        return metadata.getNamedQueryDefinitions();
+    }
+
+    @Override
+    public NamedSQLQueryDefinition getNamedNativeQueryDefinition(final String name) {
+        return metadata.getNamedNativeQueryDefinition(name);
+    }
+
+    @Override
+    public Collection<NamedSQLQueryDefinition> getNamedNativeQueryDefinitions() {
+        return metadata.getNamedNativeQueryDefinitions();
+    }
+
+    @Override
+    public Collection<NamedProcedureCallDefinition> getNamedProcedureCallDefinitions() {
+        return metadata.getNamedProcedureCallDefinitions();
+    }
+
+    @Override
+    public ResultSetMappingDefinition getResultSetMapping(final String name) {
+        return metadata.getResultSetMapping(name);
+    }
+
+    @Override
+    public Map<String, ResultSetMappingDefinition> getResultSetMappingDefinitions() {
+        return metadata.getResultSetMappingDefinitions();
+    }
+
+    @Override
+    public TypeDefinition getTypeDefinition(final String typeName) {
+        return metadata.getTypeDefinition(typeName);
+    }
+
+    @Override
+    public Map<String, FilterDefinition> getFilterDefinitions() {
+        return metadata.getFilterDefinitions();
+    }
+
+    @Override
+    public FilterDefinition getFilterDefinition(final String name) {
+        return metadata.getFilterDefinition(name);
+    }
+
+    @Override
+    public FetchProfile getFetchProfile(final String name) {
+        return metadata.getFetchProfile(name);
+    }
+
+    @Override
+    public Collection<FetchProfile> getFetchProfiles() {
+        return metadata.getFetchProfiles();
+    }
+
+    @Override
+    public NamedEntityGraphDefinition getNamedEntityGraph(final String name) {
+        return metadata.getNamedEntityGraph(name);
+    }
+
+    @Override
+    public Map<String, NamedEntityGraphDefinition> getNamedEntityGraphs() {
+        return metadata.getNamedEntityGraphs();
+    }
+
+    @Override
+    public IdentifierGeneratorDefinition getIdentifierGenerator(final String name) {
+        return metadata.getIdentifierGenerator(name);
+    }
+
+    @Override
+    public Collection<Table> collectTableMappings() {
+        return metadata.collectTableMappings();
+    }
+
+    @Override
+    public Map<String, SQLFunction> getSqlFunctionMap() {
+        return metadata.getSqlFunctionMap();
+    }
+
+    //All methods from org.hibernate.engine.spi.Mapping, the parent of Metadata:
+
+    @Override
+    @Deprecated
+    public IdentifierGeneratorFactory getIdentifierGeneratorFactory() {
+        return metadata.getIdentifierGeneratorFactory();
+    }
+
+    @Override
+    public Type getIdentifierType(final String className) throws MappingException {
+        return metadata.getIdentifierType(className);
+    }
+
+    @Override
+    public String getIdentifierPropertyName(final String className) throws MappingException {
+        return metadata.getIdentifierPropertyName(className);
+    }
+
+    @Override
+    public Type getReferencedPropertyType(final String className, final String propertyName) throws MappingException {
+        return metadata.getReferencedPropertyType(className, propertyName);
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedState.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedState.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.orm.runtime.recording;
 
 import java.util.Collection;
 
-import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.integrator.spi.Integrator;
@@ -15,7 +14,7 @@ import io.quarkus.hibernate.orm.runtime.proxies.ProxyDefinitions;
 public final class RecordedState {
 
     private final Dialect dialect;
-    private final MetadataImplementor metadata;
+    private final PrevalidatedQuarkusMetadata metadata;
     private final JtaPlatform jtaPlatform;
     private final BuildTimeSettings settings;
     private final Collection<Integrator> integrators;
@@ -23,7 +22,7 @@ public final class RecordedState {
     private final IntegrationSettings integrationSettings;
     private final ProxyDefinitions proxyClassDefinitions;
 
-    public RecordedState(Dialect dialect, JtaPlatform jtaPlatform, MetadataImplementor metadata,
+    public RecordedState(Dialect dialect, JtaPlatform jtaPlatform, PrevalidatedQuarkusMetadata metadata,
             BuildTimeSettings settings, Collection<Integrator> integrators,
             Collection<ProvidedService> providedServices, IntegrationSettings integrationSettings,
             ProxyDefinitions classDefinitions) {
@@ -41,7 +40,7 @@ public final class RecordedState {
         return dialect;
     }
 
-    public MetadataImplementor getMetadata() {
+    public PrevalidatedQuarkusMetadata getMetadata() {
         return metadata;
     }
 

--- a/integration-tests/jpa-h2/src/main/java/io/quarkus/it/jpa/h2/Timeslot.java
+++ b/integration-tests/jpa-h2/src/main/java/io/quarkus/it/jpa/h2/Timeslot.java
@@ -1,0 +1,57 @@
+package io.quarkus.it.jpa.h2;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/**
+ * This entity is using a DynamicParameterizedType as it's using Enum fields.
+ * Merely including this model in the bootstrap so to cover for our ability
+ * to actually map such types: see https://github.com/quarkusio/quarkus/issues/7653
+ */
+@Entity
+public class Timeslot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private DayOfWeek dayOfWeek;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    public Timeslot() {
+    }
+
+    public Timeslot(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public DayOfWeek getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    @Override
+    public String toString() {
+        return dayOfWeek + " " + startTime.toString();
+    }
+
+}


### PR DESCRIPTION
Fixes #7653

But also simplifies the bootstrap process, and further moves some bootstrap work into the augmentation phase.

This should also make the feedback loop better, as Quarkus would fail at buildtime (rather than runtime) on a larger cathegory of fatal mapping issues.