### PR TITLE
Add Environment and Release option to logging-sentry

### DIFF
--- a/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerEnvironmentOptionTests.java
+++ b/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerEnvironmentOptionTests.java
@@ -1,0 +1,35 @@
+package io.quarkus.logging.sentry;
+
+import static io.quarkus.logging.sentry.SentryLoggerTest.getSentryHandler;
+import static io.sentry.jvmti.ResetFrameCache.resetFrameCache;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.sentry.Sentry;
+import io.sentry.jul.SentryHandler;
+
+public class SentryLoggerEnvironmentOptionTests {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setAllowTestClassOutsideDeployment(true)
+            .withConfigurationResource("application-sentry-logger-environment-option.properties");
+
+    @Test
+    public void sentryLoggerEnvironmentOptionTest() {
+        final SentryHandler sentryHandler = getSentryHandler();
+        assertThat(sentryHandler).isNotNull();
+        assertThat(Sentry.getStoredClient()).isNotNull();
+        assertThat(Sentry.getStoredClient().getEnvironment()).isEqualTo("test-environment");
+        assertThat(Sentry.isInitialized()).isTrue();
+    }
+
+    @AfterAll
+    public static void reset() {
+        resetFrameCache();
+    }
+}

--- a/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerReleaseOptionTests.java
+++ b/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerReleaseOptionTests.java
@@ -1,0 +1,35 @@
+package io.quarkus.logging.sentry;
+
+import static io.quarkus.logging.sentry.SentryLoggerTest.getSentryHandler;
+import static io.sentry.jvmti.ResetFrameCache.resetFrameCache;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.sentry.Sentry;
+import io.sentry.jul.SentryHandler;
+
+public class SentryLoggerReleaseOptionTests {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setAllowTestClassOutsideDeployment(true)
+            .withConfigurationResource("application-sentry-logger-release-option.properties");
+
+    @Test
+    public void sentryLoggerEnvironmentOptionTest() {
+        final SentryHandler sentryHandler = getSentryHandler();
+        assertThat(sentryHandler).isNotNull();
+        assertThat(Sentry.getStoredClient()).isNotNull();
+        assertThat(Sentry.getStoredClient().getRelease()).isEqualTo("releaseABC");
+        assertThat(Sentry.isInitialized()).isTrue();
+    }
+
+    @AfterAll
+    public static void reset() {
+        resetFrameCache();
+    }
+}

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-environment-option.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-environment-option.properties
@@ -1,0 +1,5 @@
+quarkus.log.sentry=true
+quarkus.log.sentry.dsn=https://123@test.io/22222
+quarkus.log.sentry.level=TRACE
+quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
+quarkus.log.sentry.release=releaseABC

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-environment-option.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-environment-option.properties
@@ -2,4 +2,4 @@ quarkus.log.sentry=true
 quarkus.log.sentry.dsn=https://123@test.io/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
-quarkus.log.sentry.release=releaseABC
+quarkus.log.sentry.environment=test-environment

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-release-option.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-release-option.properties
@@ -2,4 +2,4 @@ quarkus.log.sentry=true
 quarkus.log.sentry.dsn=https://123@test.io/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
-quarkus.log.sentry.environment=test-environment
+quarkus.log.sentry.release=releaseABC

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-release-option.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-release-option.properties
@@ -1,0 +1,5 @@
+quarkus.log.sentry=true
+quarkus.log.sentry.dsn=https://123@test.io/22222
+quarkus.log.sentry.level=TRACE
+quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
+quarkus.log.sentry.environment=test-environment

--- a/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -51,7 +51,7 @@ public class SentryConfig {
     /**
      * Environment
      *
-     * As of Sentry 9, you can easily filter issues, releases, and user feedback by environment.
+     * With Sentry you can easily filter issues, releases, and user feedback by environment.
      * The environment filter on sentry affects all issue-related metrics like count of users affected, times series graphs,
      * and event count.
      * By setting the environment option, an environment tag will be added to each new issue sent to Sentry.
@@ -59,8 +59,6 @@ public class SentryConfig {
      * There are a few restrictions:
      * -> the environment name cannot contain newlines or spaces, cannot be the string “None” or exceed 64 characters.
      *
-     * For further detail, please refer to the sentry environment option documentation:
-     * https://docs.sentry.io/enriching-error-data/environments/
      */
     @ConfigItem
     public Optional<String> environment;
@@ -75,8 +73,6 @@ public class SentryConfig {
      * - Resolve issues by including the issue number in your commit message
      * - Receive email notifications when your code gets deployed
      *
-     * For further detail, please refer to the sentry release option documentation:
-     * https://docs.sentry.io/workflow/releases/
      */
     @ConfigItem
     public Optional<String> release;

--- a/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
+++ b/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfig.java
@@ -47,4 +47,37 @@ public class SentryConfig {
      */
     @ConfigItem
     public Optional<List<String>> inAppPackages;
+
+    /**
+     * Environment
+     *
+     * As of Sentry 9, you can easily filter issues, releases, and user feedback by environment.
+     * The environment filter on sentry affects all issue-related metrics like count of users affected, times series graphs,
+     * and event count.
+     * By setting the environment option, an environment tag will be added to each new issue sent to Sentry.
+     *
+     * There are a few restrictions:
+     * -> the environment name cannot contain newlines or spaces, cannot be the string “None” or exceed 64 characters.
+     *
+     * For further detail, please refer to the sentry environment option documentation:
+     * https://docs.sentry.io/enriching-error-data/environments/
+     */
+    @ConfigItem
+    public Optional<String> environment;
+
+    /**
+     * Release
+     *
+     * A release is a version of your code that is deployed to an environment.
+     * When you give Sentry information about your releases, you unlock a number of new features:
+     * - Determine the issues and regressions introduced in a new release
+     * - Predict which commit caused an issue and who is likely responsible
+     * - Resolve issues by including the issue number in your commit message
+     * - Receive email notifications when your code gets deployed
+     *
+     * For further detail, please refer to the sentry release option documentation:
+     * https://docs.sentry.io/workflow/releases/
+     */
+    @ConfigItem
+    public Optional<String> release;
 }

--- a/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfigProvider.java
+++ b/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfigProvider.java
@@ -25,6 +25,10 @@ class SentryConfigProvider implements ConfigurationProvider {
                 return config.inAppPackages.map(p -> join(",", p))
                         .filter(s -> !Objects.equals(s, "*"))
                         .orElse("");
+            case DefaultSentryClientFactory.ENVIRONMENT_OPTION:
+                return config.environment.orElse("");
+            case DefaultSentryClientFactory.RELEASE_OPTION:
+                return config.release.orElse("");
             // New SentryConfig options should be mapped here
             default:
                 return null;

--- a/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfigProvider.java
+++ b/extensions/logging-sentry/runtime/src/main/java/io/quarkus/logging/sentry/SentryConfigProvider.java
@@ -26,9 +26,9 @@ class SentryConfigProvider implements ConfigurationProvider {
                         .filter(s -> !Objects.equals(s, "*"))
                         .orElse("");
             case DefaultSentryClientFactory.ENVIRONMENT_OPTION:
-                return config.environment.orElse("");
+                return config.environment.orElse(null);
             case DefaultSentryClientFactory.RELEASE_OPTION:
-                return config.release.orElse("");
+                return config.release.orElse(null);
             // New SentryConfig options should be mapped here
             default:
                 return null;


### PR DESCRIPTION
Details:
- Add config fields for Environment and Release in `SentryConfig.java`
- Add provider functionality to return configured Environment and Release in `SentryConfigProvider`
- Add Tests to prove the configs are loaded into Sentry Client.

GitHub Issue: #7821