### PR TITLE
Update setup-jdk in the GH actions workflow

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -62,9 +62,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@7134ae95986e4e0a4f9f0b51345c93fcebfc4ea9
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk11
+          java-version: 11
       - name: Compute cache restore key
         # Always recompute on a push so that the maven repo doesnt grow indefinitely with old versions
         run: |
@@ -157,9 +157,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@7134ae95986e4e0a4f9f0b51345c93fcebfc4ea9
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk${{ matrix.java-version }}
+          java-version: ${{ matrix.java-version }}
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -193,9 +193,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@7134ae95986e4e0a4f9f0b51345c93fcebfc4ea9
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk11
+          java-version: 11
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -257,9 +257,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@7134ae95986e4e0a4f9f0b51345c93fcebfc4ea9
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk11
+          java-version: 11
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -470,9 +470,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@7134ae95986e4e0a4f9f0b51345c93fcebfc4ea9
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk11
+          java-version: 11
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
Hopefully, this will fix the issues downloading JDK 13