### PR TITLE
Gradle: if a project does not contain sources, don't add it as a module to the devmode context

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -271,9 +271,6 @@ public class QuarkusDev extends QuarkusTask {
                     continue;
                 }
 
-                final AppArtifact appArtifact = AppModelGradleResolver.toAppArtifact(dependency);
-                final AppArtifactKey key = new AppArtifactKey(appArtifact.getGroupId(), appArtifact.getArtifactId());
-                projectDependencies.add(key);
                 Project dependencyProject = project.getRootProject()
                         .findProject(((ProjectComponentIdentifier) componentId).getProjectPath());
                 JavaPluginConvention javaConvention = dependencyProject.getConvention().findPlugin(JavaPluginConvention.class);
@@ -286,7 +283,12 @@ public class QuarkusDev extends QuarkusTask {
                 Set<String> sourcePaths = new HashSet<>();
 
                 for (File sourceDir : mainSourceSet.getAllJava().getSrcDirs()) {
-                    sourcePaths.add(sourceDir.getAbsolutePath());
+                    if (sourceDir.exists()) {
+                        sourcePaths.add(sourceDir.getAbsolutePath());
+                    }
+                }
+                if (sourcePaths.isEmpty()) {
+                    continue;
                 }
 
                 String resourcePaths = mainSourceSet.getResources().getSourceDirectories().getSingleFile().getAbsolutePath(); //TODO: multiple resource directories
@@ -299,6 +301,10 @@ public class QuarkusDev extends QuarkusTask {
                         resourcePaths);
 
                 context.getModules().add(wsModuleInfo);
+
+                final AppArtifact appArtifact = AppModelGradleResolver.toAppArtifact(dependency);
+                final AppArtifactKey key = new AppArtifactKey(appArtifact.getGroupId(), appArtifact.getArtifactId());
+                projectDependencies.add(key);
             }
 
             for (AppDependency appDependency : appModel.getFullDeploymentDeps()) {


### PR DESCRIPTION
Fixes #7832 