### PR TITLE
Add healthcheck for reactive datasources

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -400,7 +400,7 @@ AgroalDataSource inventoryDataSource;
 
 == Datasource Health Check
 
-If you are using the `quarkus-smallrye-health` extension, `quarkus-agroal` will automatically add a readiness health check
+If you are using the `quarkus-smallrye-health` extension, `quarkus-agroal`, `quarkus-reactive-pg-client` and `quarkus-reactive-mysql-client` extensions will automatically add a readiness health check
 to validate the datasource.
 
 So when you access the `/health/ready` endpoint of your application you will have information about the datasource validation status.

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -44,6 +44,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-mysql-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-spi</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -19,6 +19,7 @@ import io.quarkus.reactive.mysql.client.runtime.DataSourceReactiveMySQLConfig;
 import io.quarkus.reactive.mysql.client.runtime.LegacyDataSourceReactiveMySQLConfig;
 import io.quarkus.reactive.mysql.client.runtime.MySQLPoolProducer;
 import io.quarkus.reactive.mysql.client.runtime.MySQLPoolRecorder;
+import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 
 @SuppressWarnings("deprecation")
@@ -62,5 +63,11 @@ class ReactiveMySQLClientProcessor {
                 shutdown)));
 
         return serviceStart;
+    }
+
+    @BuildStep
+    HealthBuildItem addHealthCheck(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
+        return new HealthBuildItem("io.quarkus.reactive.mysql.client.runtime.health.ReactiveMySQLDataSourceHealthCheck",
+                dataSourcesBuildTimeConfig.healthEnabled, "datasource");
     }
 }

--- a/extensions/reactive-mysql-client/runtime/pom.xml
+++ b/extensions/reactive-mysql-client/runtime/pom.xml
@@ -52,6 +52,12 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-mysql-client</artifactId>
         </dependency>
+        <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/health/ReactiveMySQLDataSourceHealthCheck.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/health/ReactiveMySQLDataSourceHealthCheck.java
@@ -1,0 +1,48 @@
+package io.quarkus.reactive.mysql.client.runtime.health;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+import io.quarkus.arc.Arc;
+import io.vertx.mysqlclient.MySQLPool;
+
+@Readiness
+@ApplicationScoped
+public class ReactiveMySQLDataSourceHealthCheck implements HealthCheck {
+
+    private MySQLPool mySQLPool;
+
+    @PostConstruct
+    protected void init() {
+        mySQLPool = Arc.container().instance(MySQLPool.class).get();
+    }
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.named("Reactive MySQL connection health check").up();
+
+        try {
+            CompletableFuture<Void> databaseConnectionAttempt = new CompletableFuture<>();
+            mySQLPool.query("SELECT 1")
+                    .execute(ar -> {
+                        if (ar.failed()) {
+                            builder.down();
+                        }
+                        databaseConnectionAttempt.complete(null);
+                    });
+            databaseConnectionAttempt.get(10, TimeUnit.SECONDS);
+        } catch (Exception exception) {
+            builder.down();
+        }
+
+        return builder.build();
+    }
+}

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -28,6 +28,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-spi</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.reactive.pg.client.runtime.DataSourceReactivePostgreSQLConfig;
 import io.quarkus.reactive.pg.client.runtime.LegacyDataSourceReactivePostgreSQLConfig;
 import io.quarkus.reactive.pg.client.runtime.PgPoolProducer;
 import io.quarkus.reactive.pg.client.runtime.PgPoolRecorder;
+import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 
 @SuppressWarnings("deprecation")
@@ -68,5 +69,11 @@ class ReactivePgClientProcessor {
                 shutdown)));
 
         return serviceStart;
+    }
+
+    @BuildStep
+    HealthBuildItem addHealthCheck(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
+        return new HealthBuildItem("io.quarkus.reactive.pg.client.runtime.health.ReactivePgDataSourceHealthCheck",
+                dataSourcesBuildTimeConfig.healthEnabled, "datasource");
     }
 }

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -40,6 +40,13 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-pg-client</artifactId>
         </dependency>
+
+        <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/health/ReactivePgDataSourceHealthCheck.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/health/ReactivePgDataSourceHealthCheck.java
@@ -1,0 +1,47 @@
+package io.quarkus.reactive.pg.client.runtime.health;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+import io.quarkus.arc.Arc;
+import io.vertx.pgclient.PgPool;
+
+@Readiness
+@ApplicationScoped
+public class ReactivePgDataSourceHealthCheck implements HealthCheck {
+    private PgPool pgPool;
+
+    @PostConstruct
+    protected void init() {
+        pgPool = Arc.container().instance(PgPool.class).get();
+    }
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.named("Reactive PostgreSQL connection health check").up();
+
+        try {
+            CompletableFuture<Void> databaseConnectionAttempt = new CompletableFuture<>();
+            pgPool.query("SELECT 1")
+                    .execute(ar -> {
+                        if (ar.failed()) {
+                            builder.down();
+                        }
+                        databaseConnectionAttempt.complete(null);
+                    });
+            databaseConnectionAttempt.get(10, TimeUnit.SECONDS);
+        } catch (Exception exception) {
+            builder.down();
+        }
+
+        return builder.build();
+    }
+}

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -44,6 +44,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-mysql-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/HealthCheckIT.java
+++ b/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/HealthCheckIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.reactive.mysql.client;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class HealthCheckIT extends HealthCheckTest {
+}

--- a/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/HealthCheckTest.java
+++ b/integration-tests/reactive-mysql-client/src/test/java/io/quarkus/it/reactive/mysql/client/HealthCheckTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.reactive.mysql.client;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class HealthCheckTest {
+    @Test
+    public void testHealthCheck() {
+        RestAssured.when().get("/health").then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("charset=UTF-8"))
+                .body("status", is("UP"),
+                        "checks.status", containsInAnyOrder("UP"),
+                        "checks.name", containsInAnyOrder("Reactive MySQL connection health check"));
+    }
+}

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -28,6 +28,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HealthCheckIT.java
+++ b/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HealthCheckIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.reactive.pg.client;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class HealthCheckIT extends HealthCheckTest {
+}

--- a/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HealthCheckTest.java
+++ b/integration-tests/reactive-pg-client/src/test/java/io/quarkus/it/reactive/pg/client/HealthCheckTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.reactive.pg.client;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+public class HealthCheckTest {
+    @Test
+    public void testHealthCheck() {
+        RestAssured.when().get("/health").then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("charset=UTF-8"))
+                .body("status", is("UP"),
+                        "checks.status", containsInAnyOrder("UP"),
+                        "checks.name", containsInAnyOrder("Reactive PostgreSQL connection health check"));
+    }
+}


### PR DESCRIPTION
the datasource config had a health check enabled option which was only consumed by Agroal Datasource
and not the reactive ones. Let's use this option for reactive datasource too and send appropriate
check status when database is down.