### PR TITLE
RequestStreamHandler functionality added to Amazon Lambda

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaBuildItem.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaBuildItem.java
@@ -6,10 +6,12 @@ public final class AmazonLambdaBuildItem extends MultiBuildItem {
 
     private final String handlerClass;
     private final String name;
+    private final boolean streamHandler;
 
-    public AmazonLambdaBuildItem(String handlerClass, String name) {
+    public AmazonLambdaBuildItem(String handlerClass, String name, boolean streamHandler) {
         this.handlerClass = handlerClass;
         this.name = name;
+        this.streamHandler = streamHandler;
     }
 
     public String getHandlerClass() {
@@ -18,5 +20,9 @@ public final class AmazonLambdaBuildItem extends MultiBuildItem {
 
     public String getName() {
         return name;
+    }
+
+    public boolean isStreamHandler() {
+        return streamHandler;
     }
 }

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/manage.sh
@@ -9,7 +9,11 @@ function cmd_create() {
     --handler ${HANDLER} \
     --runtime ${RUNTIME} \
     --role ${LAMBDA_ROLE_ARN} \
+    --timeout 15 \
+    --memory-size 256 \
     ${LAMBDA_META}
+# Enable and move this param above ${LAMBDA_META}, if using AWS X-Ray
+#    --tracing-config Mode=Active \
 }
 
 function cmd_delete() {
@@ -27,6 +31,8 @@ function cmd_invoke() {
     --log-type Tail \
     --query 'LogResult' \
     --output text |  base64 -d
+  { set +x; } 2>/dev/null
+  cat response.txt && rm -f response.txt
 }
 
 function cmd_update() {

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -32,6 +32,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-amazon-lambda</artifactId>
+            <version>${quarkus.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/java/StreamLambda.java
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/java/StreamLambda.java
@@ -1,0 +1,25 @@
+package ${package};
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+
+@Named("stream")
+public class StreamLambda implements RequestStreamHandler {
+
+    @Override
+    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
+        int letter;
+        while ((letter = inputStream.read()) != -1) {
+            int character = Character.toUpperCase(letter);
+            outputStream.write(character);
+        }
+    }
+}

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerTest.java
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerTest.java
@@ -1,0 +1,22 @@
+package ${package};
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.amazon.lambda.test.LambdaClient;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class LambdaHandlerTest {
+
+    @Test
+    public void testSimpleLambdaSuccess() throws Exception {
+        InputObject in = new InputObject();
+        in.setGreeting("Hello");
+        in.setName("Stu");
+        OutputObject out = LambdaClient.invoke(OutputObject.class, in);
+        Assertions.assertEquals("Hello Stu", out.getResult());
+        Assertions.assertTrue(out.getRequestId().matches("aws-request-\\d"), "Expected requestId as 'aws-request-<number>'");
+    }
+
+}

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/resources/application.properties
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/resources/application.properties
@@ -1,3 +1,5 @@
 quarkus.lambda.handler=test
 
 quarkus.lambda.enable-polling-jvm-mode=true
+
+

--- a/test-framework/amazon-lambda/src/main/java/io/quarkus/amazon/lambda/test/LambdaClient.java
+++ b/test-framework/amazon-lambda/src/main/java/io/quarkus/amazon/lambda/test/LambdaClient.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.lambda.test;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +45,50 @@ public class LambdaClient {
         REQUESTS = requests;
         REQUEST_QUEUE = requestQueue;
 
+    }
+
+    public static void invoke(InputStream inputStream, OutputStream outputStream) {
+        if (problem != null) {
+            throw new RuntimeException(problem);
+        }
+        try {
+            String id = "aws-request-" + REQUEST_ID_GENERATOR.incrementAndGet();
+            CompletableFuture<String> result = new CompletableFuture<>();
+            REQUESTS.put(id, result);
+            StringBuilder requestBody = new StringBuilder();
+            int i = 0;
+            while ((i = inputStream.read()) != -1) {
+                requestBody.append((char) i);
+            }
+            REQUEST_QUEUE.add(new Map.Entry<String, String>() {
+
+                @Override
+                public String getKey() {
+                    return id;
+                }
+
+                @Override
+                public String getValue() {
+                    return requestBody.toString();
+                }
+
+                @Override
+                public String setValue(String value) {
+                    return null;
+                }
+            });
+            String output = result.get();
+            outputStream.write(output.getBytes());
+        } catch (Exception e) {
+            if (e instanceof ExecutionException) {
+                Throwable ex = e.getCause();
+                if (ex instanceof RuntimeException) {
+                    throw (RuntimeException) ex;
+                }
+                throw new RuntimeException(ex);
+            }
+            throw new RuntimeException(e);
+        }
     }
 
     public static <T> T invoke(Class<T> returnType, Object input) {


### PR DESCRIPTION
**Summary:**

Amazon Lambda extension currently only supports the interface RequestHandler<?, ?>.  

Enhance the extension, to enable the use of the interface RequestStreamHandler, so that both AWS Lambda interfaces are supported.

#6707 requests this functionality.

The RequestStreamHandler can co-exist in a project with RequestHandler<?, ?>, and the active function toggled via the property quarkus.lambda.handler, as normal.  The requestHandler signature for the former has 3 params, the latter 2.

Validated as working for NativeImage, via SAM and AWS.

**Specifics:**

**Deployment:**

AmazonLambdaBuildItem adds a flag to indicate whether the scanned requestHandler is of type RequestStreamHandler, since it was the only way I could determine this (tried lots of options not to modify this BuildItem class).

`
    public AmazonLambdaBuildItem(String handlerClass, String name, boolean streamHandler) {
`

Various changes to AmazonLambdaProcessesor to recognise and process the RequestStreamHandler::requestHandler implementation.


**Runtime:**

AmazonLambdaRecorder has similar changes to accept the co-existance of the RequestStreamHandler::requestHandler implementation.

Only one lambda handler can be active, per the existing validation in chooseHandlerClass, thus the code is checking which one is present to determine how to branch. 

Added a compatible integration test for the AmazonClient.invoke in the test-framework for Amazon Lambda.  I used this to test both.

**Archetype:**

Added a StreamHandler to the archetype, to demonstrate you can have both in your project, and that you must use the @Named annotation along with the application.properties to select the active lambda function, per existing functionality.

In addition, I added test functionality to include the integration test for Amazon Lambda into the archetype, as that is an easy way for people to test their functions, and wasn't previously in the archetype.  For JVM, there is no need to use SAM when you have the integration test available (see issues with SAM for JVM #6701) which I continue to experience.

**Tested by**:

1. mvn archetype:generate -DarchetypeGroupId=io.quarkus -DarchetypeArtifactId=quarkus-amazon-lambda-archetype -DarchetypeVersion=999-SNAPSHOT
2. mvn package
3. sh manage.sh create
4. sh manage.sh invoke
5. mvn package -Dnative -Dquarkus.native.container-build=true'
6. sam local invoke --template sam.native.yaml --event payload.json
7. sh manage.sh native create invoke
(repeated toggling the application.property to swap handler type quarkus.lambda.handler)

/cc @patriot1burke 
/cc @evanchooly 
/cc @bnusunny  
