### PR TITLE
Have the Agroal datasources initialized eagerly

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -11,9 +11,9 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
 import javax.sql.XADataSource;
 
 import org.eclipse.microprofile.metrics.Metadata;
@@ -358,7 +358,7 @@ class AgroalProcessor {
                 .className(dataSourceProducerClassName)
                 .superClass(AbstractDataSourceProducer.class)
                 .build();
-        classCreator.addAnnotation(ApplicationScoped.class);
+        classCreator.addAnnotation(Singleton.class);
 
         for (AggregatedDataSourceBuildTimeConfigBuildItem aggregatedDataSourceBuildTimeConfig : aggregatedDataSourceBuildTimeConfigs) {
             String dataSourceName = aggregatedDataSourceBuildTimeConfig.getName();
@@ -366,7 +366,7 @@ class AgroalProcessor {
             MethodCreator dataSourceMethodCreator = classCreator.getMethodCreator(
                     "createDataSource_" + HashUtil.sha1(dataSourceName),
                     AgroalDataSource.class);
-            dataSourceMethodCreator.addAnnotation(ApplicationScoped.class);
+            dataSourceMethodCreator.addAnnotation(Singleton.class);
             dataSourceMethodCreator.addAnnotation(Produces.class);
             if (aggregatedDataSourceBuildTimeConfig.isDefault()) {
                 dataSourceMethodCreator.addAnnotation(Default.class);


### PR DESCRIPTION
Originally, this was done by @Sanne in https://github.com/quarkusio/quarkus/pull/4504/commits/5209e40b9b40d1bc8a740e9f2d2247c4cc5b7396
But I have no Idea how to cherry pick from a deleted branch..
Created a new commit with the same changes because of this.

Main difference is, that this time around all ITs are passing.

closes #4507