### PR TITLE
Run QuarkusTestResource in the runtime ClassLoader

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -36,17 +36,11 @@ public class StartupActionImpl implements StartupAction {
 
     private final CuratedApplication curatedApplication;
     private final BuildResult buildResult;
+    private final QuarkusClassLoader runtimeClassLoader;
 
     public StartupActionImpl(CuratedApplication curatedApplication, BuildResult buildResult) {
         this.curatedApplication = curatedApplication;
         this.buildResult = buildResult;
-    }
-
-    /**
-     * Runs the application, and returns a handle that can be used to shut it down.
-     */
-    public RunningQuarkusApplication run(String... args) throws Exception {
-        //first
         Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> bytecodeTransformers = extractTransformers();
         QuarkusClassLoader baseClassLoader = curatedApplication.getBaseRuntimeClassLoader();
         ClassLoader transformerClassLoader = buildResult.consume(DeploymentClassLoaderBuildItem.class).getClassLoader();
@@ -67,6 +61,15 @@ public class StartupActionImpl implements StartupAction {
             baseClassLoader.reset(resources, bytecodeTransformers, transformerClassLoader);
             runtimeClassLoader = baseClassLoader;
         }
+        this.runtimeClassLoader = runtimeClassLoader;
+    }
+
+    /**
+     * Runs the application, and returns a handle that can be used to shut it down.
+     */
+    public RunningQuarkusApplication run(String... args) throws Exception {
+        //first
+
         ForkJoinClassLoading.setForkJoinClassLoader(runtimeClassLoader);
 
         //we have our class loaders
@@ -128,6 +131,11 @@ public class StartupActionImpl implements StartupAction {
             Thread.currentThread().setContextClassLoader(old);
         }
 
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return runtimeClassLoader;
     }
 
     private Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> extractTransformers() {

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -231,6 +231,7 @@ This will log every request using the standard Quarkus logging infrastructure un
 
 You can customize the category like this:
 
+
 [source]
 ----
 access-log(format='common', category='my.own.category')

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -67,13 +67,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                <configuration>
-                    <parentFirstArtifacts>
-                        <parentFirstArtifact>io.fabric8:kubernetes-server-mock</parentFirstArtifact>
-                        <parentFirstArtifact>io.fabric8:mockwebserver</parentFirstArtifact>
-                        <parentFirstArtifact>io.quarkus:quarkus-test-kubernetes-client</parentFirstArtifact>
-                    </parentFirstArtifacts>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/StartupAction.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.app;
 
 public interface StartupAction {
-    public RunningQuarkusApplication run(String... args) throws Exception;
+    RunningQuarkusApplication run(String... args) throws Exception;
+
+    ClassLoader getClassLoader();
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
@@ -11,7 +11,11 @@ import java.util.Map;
  *
  * These can also be loaded via a service loader mechanism, however if a service
  * loader is used it should not also be annotated as this will result in it being executed
- * twice
+ * twice.
+ *
+ * Note that when using these with QuarkusUnitTest (rather than @QuarkusTest) they run
+ * before the ClassLoader has been setup. This means injection may not work
+ * as expected.
  */
 public interface QuarkusTestResourceLifecycleManager {
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -123,7 +123,7 @@ public class QuarkusDevModeTest
 
                 @Override
                 public void close() throws Throwable {
-                    manager.stop();
+                    manager.close();
                 }
             });
         }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -324,7 +324,7 @@ public class QuarkusUnitTest
 
                 @Override
                 public void close() throws Throwable {
-                    manager.stop();
+                    manager.close();
                 }
             });
         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -113,7 +113,7 @@ public class NativeTestExtension
 
         @Override
         public void close() throws Throwable {
-            testResourceManager.stop();
+            testResourceManager.close();
             resource.close();
         }
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -37,6 +37,7 @@ import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
+import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
@@ -65,8 +66,8 @@ public class QuarkusTestExtension
     private static Path testClassLocation;
     private static Throwable firstException; //if this is set then it will be thrown from the very first test that is run, the rest are aborted
 
-    private ExtensionState doJavaStart(ExtensionContext context, TestResourceManager testResourceManager) {
-
+    private ExtensionState doJavaStart(ExtensionContext context) throws Throwable {
+        Closeable testResourceManager = null;
         try {
             final LinkedBlockingDeque<Runnable> shutdownTasks = new LinkedBlockingDeque<>();
 
@@ -87,17 +88,26 @@ public class QuarkusTestExtension
                     .setProjectRoot(new File("").toPath())
                     .build()
                     .bootstrap();
+
             Timing.staticInitStarted(curatedApplication.getBaseRuntimeClassLoader());
             AugmentAction augmentAction = curatedApplication.createAugmentor(TestBuildChainFunction.class.getName(),
                     Collections.singletonMap(TEST_LOCATION, testClassLocation));
-            runningQuarkusApplication = augmentAction.createInitialRuntimeApplication().run();
+            StartupAction startupAction = augmentAction.createInitialRuntimeApplication();
+            Thread.currentThread().setContextClassLoader(startupAction.getClassLoader());
+
+            //must be done after the TCCL has been set
+            testResourceManager = (Closeable) startupAction.getClassLoader().loadClass(TestResourceManager.class.getName())
+                    .getConstructor(Class.class)
+                    .newInstance(context.getRequiredTestClass());
+            testResourceManager.getClass().getMethod("start").invoke(testResourceManager);
+
+            runningQuarkusApplication = startupAction.run();
 
             ConfigProviderResolver.setInstance(new RunningAppConfigResolver(runningQuarkusApplication));
 
-            Thread.currentThread().setContextClassLoader(runningQuarkusApplication.getClassLoader());
-
             System.setProperty("test.url", TestHTTPResourceManager.getUri(runningQuarkusApplication));
 
+            Closeable tm = testResourceManager;
             Closeable shutdownTask = new Closeable() {
                 @Override
                 public void close() throws IOException {
@@ -106,8 +116,12 @@ public class QuarkusTestExtension
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     } finally {
-                        while (!shutdownTasks.isEmpty()) {
-                            shutdownTasks.pop().run();
+                        try {
+                            while (!shutdownTasks.isEmpty()) {
+                                shutdownTasks.pop().run();
+                            }
+                        } finally {
+                            tm.close();
                         }
                     }
                 }
@@ -125,8 +139,16 @@ public class QuarkusTestExtension
                 }
             }, "Quarkus Test Cleanup Shutdown task"));
             return new ExtensionState(testResourceManager, shutdownTask);
-        } catch (java.util.ServiceConfigurationError | Exception e) {
-            throw new RuntimeException(e);
+        } catch (Throwable e) {
+
+            try {
+                if (testResourceManager != null) {
+                    testResourceManager.close();
+                }
+            } catch (Exception ex) {
+                e.addSuppressed(ex);
+            }
+            throw e;
         }
     }
 
@@ -178,18 +200,11 @@ public class QuarkusTestExtension
         ExtensionState state = store.get(ExtensionState.class.getName(), ExtensionState.class);
         if (state == null && !failedBoot) {
             PropertyTestUtil.setLogFileProperty();
-            TestResourceManager testResourceManager = new TestResourceManager(extensionContext.getRequiredTestClass());
             try {
-                testResourceManager.start();
-                state = doJavaStart(extensionContext, testResourceManager);
+                state = doJavaStart(extensionContext);
                 store.put(ExtensionState.class.getName(), state);
 
             } catch (Throwable e) {
-                try {
-                    testResourceManager.stop();
-                } catch (Exception ex) {
-                    e.addSuppressed(ex);
-                }
                 failedBoot = true;
                 firstException = e;
             }
@@ -264,7 +279,8 @@ public class QuarkusTestExtension
 
             Class<?> resM = Thread.currentThread().getContextClassLoader().loadClass(TestHTTPResourceManager.class.getName());
             resM.getDeclaredMethod("inject", Object.class).invoke(null, actualTestInstance);
-            state.testResourceManager.inject(actualTestInstance);
+            state.testResourceManager.getClass().getMethod("inject", Object.class).invoke(state.testResourceManager,
+                    actualTestInstance);
         } catch (Exception e) {
             throw new TestInstantiationException("Failed to create test instance", e);
         }
@@ -405,10 +421,10 @@ public class QuarkusTestExtension
 
     class ExtensionState implements ExtensionContext.Store.CloseableResource {
 
-        private final TestResourceManager testResourceManager;
+        private final Closeable testResourceManager;
         private final Closeable resource;
 
-        ExtensionState(TestResourceManager testResourceManager, Closeable resource) {
+        ExtensionState(Closeable testResourceManager, Closeable resource) {
             this.testResourceManager = testResourceManager;
             this.resource = resource;
         }
@@ -421,7 +437,7 @@ public class QuarkusTestExtension
                 if (QuarkusTestExtension.this.originalCl != null) {
                     setCCL(QuarkusTestExtension.this.originalCl);
                 }
-                testResourceManager.stop();
+                testResourceManager.close();
             }
         }
     }


### PR DESCRIPTION
This is only for QuarkusTest, QuarkusUnitTest will need
a slightly different solution if we decide it is a problem, as
the lifecycles don't match.

Fixes #7880