### PR TITLE
Fix intermittent Kubernetes test failures on Windows

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -220,8 +220,8 @@ public class QuarkusProdModeTest
 
         try {
             outputDir = Files.createTempDirectory("quarkus-prod-mode-test");
-            Path deploymentDir = outputDir.resolve("deployment");
-            buildDir = outputDir.resolve("build");
+            Path deploymentDir = outputDir.resolve("deployment-result");
+            buildDir = outputDir.resolve("build-result");
 
             if (applicationName != null) {
                 overrideConfigKey("quarkus.application.name", applicationName);


### PR DESCRIPTION
We have been seeing various test failures on CI when running the Kubernetes tests on Windows. This seems to be caused by `Dekorate` looking for a `Bazel` directory that uses the same name (but different case) as the name of the directory we use as output of the `QuarkusProdModeTest`.

An example of the test failure is:

```
2020-03-16T21:36:56.4336489Z [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.524 s <<< FAILURE! - in io.quarkus.it.kubernetes.KnativeContainerImageTest
2020-03-16T21:36:56.7018324Z [ERROR] io.quarkus.it.kubernetes.KnativeContainerImageTest  Time elapsed: 2.524 s  <<< ERROR!
2020-03-16T21:36:56.9187148Z java.lang.RuntimeException: 
2020-03-16T21:36:57.0673021Z java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
2020-03-16T21:36:57.1454264Z 	[error]: Build step io.quarkus.kubernetes.deployment.KubernetesProcessor#build threw an exception: io.dekorate.DekorateException: D:\a\quarkus\quarkus\integration-tests\kubernetes\standard\target\quarkus-prod-mode-test3390733709830322240\BUILD
2020-03-16T21:36:57.4125019Z 	at io.dekorate.DekorateException.launderThrowable(DekorateException.java:42)
2020-03-16T21:36:57.4483429Z 	at io.dekorate.DekorateException.launderThrowable(DekorateException.java:32)
2020-03-16T21:36:57.4562169Z 	at io.dekorate.project.BazelInfoReader.readBuild(BazelInfoReader.java:134)
2020-03-16T21:36:57.4570366Z 	at io.dekorate.project.BazelInfoReader.getInfo(BazelInfoReader.java:69)
2020-03-16T21:36:57.4984098Z 	at io.dekorate.project.FileProjectFactory.lambda$getProjectInfo$2(FileProjectFactory.java:79)
2020-03-16T21:36:58.2223159Z 	at java.base/java.util.Optional.map(Optional.java:265)
2020-03-16T21:36:58.5418046Z 	at io.dekorate.project.FileProjectFactory.getProjectInfo(FileProjectFactory.java:79)
2020-03-16T21:36:58.5959041Z 	at io.dekorate.project.FileProjectFactory.createInternal(FileProjectFactory.java:54)
2020-03-16T21:36:58.5967513Z 	at io.dekorate.project.FileProjectFactory.create(FileProjectFactory.java:43)
2020-03-16T21:36:58.5971274Z 	at io.quarkus.kubernetes.deployment.KubernetesProcessor.createProject(KubernetesProcessor.java:519)
2020-03-16T21:36:58.5972015Z 	at io.quarkus.kubernetes.deployment.KubernetesProcessor.build(KubernetesProcessor.java:163)
2020-03-16T21:36:58.6240017Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2020-03-16T21:36:58.6269285Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2020-03-16T21:36:58.6275680Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2020-03-16T21:36:58.6278321Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2020-03-16T21:36:58.6282001Z 	at io.quarkus.deployment.ExtensionLoader$2.execute(ExtensionLoader.java:938)
2020-03-16T21:36:58.6300833Z 	at io.quarkus.builder.BuildContext.run(BuildContext.java:273)
2020-03-16T21:36:58.6303704Z 	at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
2020-03-16T21:36:58.6305562Z 	at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2027)
2020-03-16T21:36:58.6313639Z 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1551)
2020-03-16T21:36:58.6314478Z 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1442)
2020-03-16T21:36:58.6317624Z 	at java.base/java.lang.Thread.run(Thread.java:834)
2020-03-16T21:36:58.6321446Z 	at org.jboss.threads.JBossThread.run(JBossThread.java:479)
2020-03-16T21:36:58.6336411Z Caused by: java.nio.file.AccessDeniedException: D:\a\quarkus\quarkus\integration-tests\kubernetes\standard\target\quarkus-prod-mode-test3390733709830322240\BUILD
```