### PR TITLE
XStream substitutions to avoid @Delete paths #7422

### DIFF
--- a/extensions/optaplanner/runtime/src/main/java/io/quarkus/optaplanner/runtime/graal/XStreamSubstitutions.java
+++ b/extensions/optaplanner/runtime/src/main/java/io/quarkus/optaplanner/runtime/graal/XStreamSubstitutions.java
@@ -1,0 +1,52 @@
+package io.quarkus.optaplanner.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "com.thoughtworks.xstream.converters.reflection.SerializableConverter")
+final class Target_SerializableConverter {
+
+    @Substitute
+    public Object doUnmarshal(final Object result, final Target_HierarchicalStreamReader reader,
+            final Target_UnmarshallingContext context) {
+        return null;
+    }
+
+    @Substitute
+    public void doMarshal(final Object source, final Target_HierarchicalStreamWriter writer,
+            final Target_MarshallingContext context) {
+    }
+}
+
+@TargetClass(className = "com.thoughtworks.xstream.io.HierarchicalStreamReader")
+final class Target_HierarchicalStreamReader {
+
+}
+
+@TargetClass(className = "com.thoughtworks.xstream.converters.UnmarshallingContext")
+final class Target_UnmarshallingContext {
+
+}
+
+@TargetClass(className = "com.thoughtworks.xstream.io.HierarchicalStreamWriter")
+final class Target_HierarchicalStreamWriter {
+
+}
+
+@TargetClass(className = "com.thoughtworks.xstream.converters.MarshallingContext")
+final class Target_MarshallingContext {
+
+}
+
+@TargetClass(className = "com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider")
+final class Target_PureJavaReflectionProvider {
+
+    @Substitute
+    private Object instantiateUsingSerialization(final Class type) {
+        return null;
+    }
+}
+
+class XStreamSubstitutions {
+
+}


### PR DESCRIPTION
Fixes: https://github.com/quarkusio/quarkus/issues/7422

Essentially cutting off paths that could lead to new classes being created on the fly during Serializable object serialization/deserialization using xstream (see [path](https://gist.github.com/galderz/34cbc3df6709e90233dfd2309fd7367b)). 

Recent graalvm master changes made paths leading to `jdk.internal.reflect.ReflectionFactory` forbidden (see discussion in [graalvm issue](https://github.com/quarkusio/quarkus/issues/7422)).

Reached this fix through chats with @ge0ffrey (thx!!). Kogito (@mariofusco) also has a dependency on xstream, and hence it should also be validated/approved by that component owner (@mariofusco?).