### PR TITLE
Undeploy verticles backed by contextual instances

### DIFF
--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/verticles/MyUndeployedVerticle.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/verticles/MyUndeployedVerticle.java
@@ -1,0 +1,17 @@
+package io.quarkus.vertx.verticles;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+
+@ApplicationScoped
+public class MyUndeployedVerticle extends AbstractVerticle {
+
+    @Override
+    public Uni<Void> asyncStart() {
+        return vertx.eventBus().consumer("bravo")
+                .handler(m -> m.replyAndForget("hello from bravo"))
+                .completionHandler();
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/verticles/NotDeployedVerticle.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/verticles/NotDeployedVerticle.java
@@ -1,0 +1,17 @@
+package io.quarkus.vertx.verticles;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+
+@ApplicationScoped
+public class NotDeployedVerticle extends AbstractVerticle {
+
+    @Override
+    public Uni<Void> asyncStart() {
+        return vertx.eventBus().consumer("alpha")
+                .handler(m -> m.replyAndForget("hello from alpha"))
+                .completionHandler();
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/verticles/VerticleDeployer.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/verticles/VerticleDeployer.java
@@ -2,6 +2,7 @@ package io.quarkus.vertx.verticles;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.mutiny.core.Vertx;
@@ -9,8 +10,18 @@ import io.vertx.mutiny.core.Vertx;
 @ApplicationScoped
 public class VerticleDeployer {
 
-    void deploy(@Observes StartupEvent event, Vertx vertx, MyBeanVerticle verticle) {
+    @Inject
+    Vertx vertx;
+
+    private volatile String deploymentId;
+
+    void deploy(@Observes StartupEvent event, MyBeanVerticle verticle, MyUndeployedVerticle undeployedVerticle) {
         vertx.deployVerticle(verticle).await().indefinitely();
+        deploymentId = vertx.deployVerticle(undeployedVerticle).await().indefinitely();
+    }
+
+    void undeploy() {
+        vertx.undeploy(deploymentId).await().indefinitely();
     }
 
 }


### PR DESCRIPTION
...of ApplicationScoped beans before the application context is destroyed