### PR TITLE
Add quarkus-test-amazon-lambda to BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -909,6 +909,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-amazon-lambda</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-qute</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-amazon-lambda</artifactId>
-            <version>${quarkus.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Add the **quarkus-test-amazon-lambda** test-framework module version to the BOM.  This is useful as the integration test has been added to the Maven archetype for the Amazon Lambda extension.

I can now remove the version from the POM for the Maven archetype, as tested below.

Tested by:

1. mvn archetype:generate -DarchetypeGroupId=io.quarkus -DarchetypeArtifactId=quarkus-amazon-lambda-archetype -DarchetypeVersion=999-SNAPSHOT
2. mvn package

/cc @patriot1burke 
/cc @geoand 