### PR TITLE
Document RequestStreamHandler, JUnit tests, Gradle, AWS SDK Java v2, and AWS ASK SDK

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -8,7 +8,7 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-The `quarkus-amazon-lambda` extension allows you to use Quarkus to build your Amazon Lambdas.
+The `quarkus-amazon-lambda` extension allows you to use Quarkus to build your AWS Lambdas.
 Your lambdas can use injection annotations from CDI or Spring and other Quarkus facilities as you need them.
 
 Quarkus lambdas can be deployed using the Amazon Java Runtime, or you can build a native executable and use
@@ -26,6 +26,8 @@ To complete this guide, you need:
 * https://aws.amazon.com[An Amazon AWS account]
 * https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html[AWS CLI]
 * https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html[AWS SAM CLI], for local testing
+
+NOTE: For Gradle projects please <<gradle,see below>>, or for further reference consult the guide in the link:gradle-tooling[Gradle setup page].
 
 == Getting Started
 
@@ -49,9 +51,24 @@ mvn archetype:generate \
        -DarchetypeVersion={quarkus-version}
 ----
 
+[NOTE]
+====
+If you prefer to use Gradle, you can quickly and easily generate a Gradle project via https://code.quarkus.io/[code.quarkus.io]
+adding the `quarkus-amazon-lambda` extension as a dependency.
+
+Copy the build.gradle, gradle.properties and settings.gradle into the above generated Maven archetype project, to follow along with this guide.
+
+Execute: gradle wrapper to setup the gradle wrapper (recommended).
+
+The dependency for `quarkus-test-amazon-lambda` will also need to be added to your build.gradle.
+
+For full Gradle details <<gradle, see below>>.
+====
+
+[[choose]]
 == Choose Your Lambda
 
-The `quarkus-amazon-lambda` extension scans your project for a class that implements the Amazon `RequestHandler` interface.
+The `quarkus-amazon-lambda` extension scans your project for a class that directly implements the Amazon `RequestHandler<?, ?>` or `RequestStreamHandler` interface.
 It must find a class in your project that implements this interface or it will throw a build time failure.
 If it finds more than one handler class, a build time exception will also be thrown.
 
@@ -59,7 +76,7 @@ Sometimes, though, you might have a few related lambdas that share code and crea
 an overhead you don't want to do.  The `quarkus-amazon-lambda` extension allows you to bundle multiple lambdas in one
 project and use configuration or an environment variable to pick the handler you want to deploy.
 
-The generated project has two lambdas within it.  One that is used and one that is unused.  If you open up
+The generated project has three lambdas within it.  Two that implement the `RequestHandler<?, ?>` interface, and one that implements the `RequestStreamHandler` interface. One that is used and two that are unused.  If you open up
 `src/main/resources/application.properties` you'll see this:
 
 [source, subs=attributes+]
@@ -70,7 +87,7 @@ quarkus.lambda.handler=test
 The `quarkus.lambda.handler` property tells Quarkus which lambda handler to deploy. This can be overridden
 with an environment variable too.
 
-If you look at the two generated handler classes in the project, you'll see that they are `@Named` differently.
+If you look at the three generated handler classes in the project, you'll see that they are `@Named` differently.
 
 [source, subs=attributes+]
 ----
@@ -80,6 +97,10 @@ public class TestLambda implements RequestHandler<InputObject, OutputObject> {
 
 @Named("unused")
 public class UnusedLambda implements RequestHandler<InputObject, OutputObject> {
+}
+
+@Named("stream")
+public class StreamLambda implements RequestStreamHandler {
 }
 ----
 
@@ -97,7 +118,12 @@ Build the project using maven.
 
 [source, subs=attributes+]
 ----
-./mvnw clean install
+./mvnw clean package
+----
+
+or, if using Gradle:
+----
+./gradlew clean assemble
 ----
 
 This will compile and package your code.
@@ -121,7 +147,21 @@ The `manage.sh` script is for managing your lambda using the AWS Lambda Java run
 your convenience. Examine the output of the `manage.sh` script if you want to learn what aws commands are executed
 to create, delete, and update your lambdas.
 
-`manage.sh` supports four operation:  `create`, `delete`, `update`, and `invoke`.  You can create your function using the following command:
+`manage.sh` supports four operation:  `create`, `delete`, `update`, and `invoke`.
+
+NOTE: To verify your setup, that you have the AWS CLI installed, executed aws configure for the AWS access keys,
+and setup the `LAMBDA_ROLE_ARN` environment variable (as described above), please execute `manage.sh` without any parameters.
+A usage statement will be printed to guide you accordingly.
+
+NOTE: If using Gradle, the path to the binaries in the `manage.sh` must be changed from `target` to `build`
+
+To see the `usage` statement, and validate AWS configuration:
+[source, subs=attributes+]
+----
+sh manage.sh
+----
+
+You can `create` your function using the following command:
 
 [source, subs=attributes+]
 ----
@@ -162,15 +202,21 @@ sh manage.sh invoke
 ----
 
 The example lambda takes input passed in via the `--payload` switch which points to a json file
-in the root directory of the project.  If you want to see the output of the lambda, open the `response.txt` file.
-The lambda can also be invoked locally like this:
+in the root directory of the project.
+
+The lambda can also be invoked locally with the SAM CLI like this:
 
 [source]
 ----
 sam local invoke --template sam.jvm.yaml --event payload.json
 ----
 
-If you are working with your native image build, simply replace the template name above with the native version.
+If you are working with your native image build, simply replace the template name with the native version:
+
+[source]
+----
+sam local invoke --template sam.native.yaml --event payload.json
+----
 
 == Update the Lambda
 
@@ -187,23 +233,37 @@ sh manage.sh update
 If you want a lower memory footprint and faster initialization times for your lambda, you can compile your Java
 code to a native executable.  Just make sure to rebuild your project with the `-Pnative` switch.
 
+For Linux hosts execute:
+
 [source, subs=attributes+]
 ----
-mvn clean install -Pnative
+mvn package -Pnative
 ----
 
-If you are building on a non-linux system, you will need to also pass in a property instructing quarkus to use a docker build as Amazon
-Lambda requires linux binaries.  You can do this by passing this property to your maven build:
-`-Dnative-image.docker-build=true`.  This requires you to have docker installed locally, however.
+or, if using Gradle:
+[source, subs=attributes+]
+----
+./gradlew buildNative
+----
+
+NOTE: If you are building on a non-Linux system, you will need to also pass in a property instructing quarkus to use a docker build as Amazon
+Lambda requires linux binaries.  You can do this by passing this property to your Maven build:
+`-Dnative-image.docker-build=true`, or for Gradle: `--docker-build=true`.  This requires you to have docker installed locally, however.
 
 [source, subs=attributes+]
 ----
 ./mvnw clean install -Pnative -Dnative-image.docker-build=true
 ----
 
+or, if using Gradle:
+[source, subs=attributes+]
+----
+./gradlew buildNative --docker-build=true
+----
+
 Either of these commands will compile and create a native executable image.  It also generates a zip file `target/function.zip`.
-This zip file contains your native executable image renamed to `bootstrap`.  This is a requirement of Amazon Lambda
-Custom Runtime.
+This zip file contains your native executable image renamed to `bootstrap`.  This is a requirement of the AWS Lambda
+Custom (Provided) Runtime.
 
 
 
@@ -240,29 +300,137 @@ of things you need to do.  Take a look at the generated example project to get a
 3. If you are doing a native image build, Amazon requires you to rename your executable to `bootstrap` and zip it up.
 Notice that the `pom.xml` uses the `maven-assembly-plugin` to perform this requirement.
 
-NB: With gradle, to build the uber-jar execute: ./gradlew quarkusBuild --uber-jar
+[[gradle]]
+== Gradle build
+
+Similarly for Gradle projects, if you want to adapt an existing project to use Quarkus's Amazon Lambda extension, there are a couple
+of things you need to do.  Take a look at the generated example project to get an example of what you need to adapt.
+
+1. Include the `quarkus-amazon-lambda`, and `quarkus-test-amazon-lambda` extensions as Gradle dependencies, as below
+2. Configure Quarkus to build an `uber-jar` (via appending --uber-jar to the Gradle build command)
+3. If you are doing a native image build, Amazon requires you to rename your executable to `bootstrap` and zip it up.
+
+
+Example Gradle dependencies:
+
+[source, groovy]
+----
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-amazon-lambda'
+
+    testimplementation  "io.quarkus:quarkus-test-amazon-lambda"
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+----
+
+
+== Integration Testing
+The Quarkus Amazon Lambda extension has a matching test framework that provides functionality to execute standard JUnit tests on your AWS Lambda function,
+via the integration layer that Quarkus provides.  This is true for both JVM and native modes.
+It provides similar functionality to the SAM CLI, without the overhead of Docker.
+
+To illustrate, the project generated by the Maven archetype, generates a JUnit test for the `RequestHandler<?, ?>` implementation, which is shown below.
+The test replicates the execution environment, for the function that is selected for invocation, as described <<choose, above>>.
+
+[source,java]
+----
+@QuarkusTest
+public class LambdaHandlerTest {
+
+    @Test
+    public void testSimpleLambdaSuccess() throws Exception {
+        InputObject in = new InputObject();
+        in.setGreeting("Hello");
+        in.setName("Stu");
+
+        OutputObject out = LambdaClient.invoke(OutputObject.class, in);
+
+        Assertions.assertEquals("Hello Stu", out.getResult());
+        Assertions.assertTrue(out.getRequestId().matches("aws-request-\\d"), "Expected requestId as 'aws-request-<number>'");
+    }
+}
+----
+
+Similarly, if you are using a `RequestStreamHandler` implementation, you can add a matching JUnit test, like below,
+which aligns to the generated `StreamLambda` class in the generated project.
+
+Obviously, these two types of tests are mutually exclusive.  You must have a test that corresponds to the implemented AWS Lambda interfaces,
+whether `RequestHandler<?, ?>` or `RequestStreamHandler`.
+
+Two versions of the Test for `RequestStreamHandler` are presented below.  You can use either, depending on
+the needs of your Unit test.  The first is obviously simpler and quicker.  Using Java streams can require more coding.
+
+[source,java]
+----
+@QuarkusTest
+public class LambdaStreamHandlerTest {
+
+    private static Logger LOG = Logger.getLogger(LambdaStreamHandlerTest.class);
+
+    @Test
+    public void testSimpleLambdaSuccess() throws Exception {
+        String out = LambdaClient.invoke(String.class, "lowercase");
+        Assertions.assertEquals("LOWERCASE", out);
+    }
+
+    @Test
+    public void testInputStreamSuccess() {
+        try {
+            String input = "{ \"name\": \"Bill\", \"greeting\": \"hello\"}";
+            InputStream inputStream = new ByteArrayInputStream(input.getBytes());
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            LambdaClient.invoke(inputStream, outputStream);
+
+            ByteArrayInputStream out = new ByteArrayInputStream(outputStream.toByteArray());
+            StringBuilder response = new StringBuilder();
+            int i = 0;
+            while ((i = out.read()) != -1) {
+                response.append((char)i);
+            }
+
+            Assertions.assertTrue(response.toString().contains("BILL"));
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+    }
+
+}
+----
+
+If your code uses CDI injection, this too will be executed, along with mocking functionality, see the link:getting-started-testing[Test Guide] for more details.
+
+To add JUnit functionality for native tests, add the `@NativeImageTest` annotation to a subclass of your test class, which will execute against your native image, and can be leveraged in an IDE.
+
 
 == Testing with the SAM CLI
 
 The https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html[AWS SAM CLI]
 allows you to run your lambdas locally on your laptop in a simulated Lambda environment.  This requires
 https://www.docker.com/products/docker-desktop[docker] to be installed.  This is an optional approach should you choose
-to take advantage of it.  Otherwise, dev mode should be sufficient for most of your needs.
+to take advantage of it.  Otherwise, the Quarkus JUnit integration should be sufficient for most of your needs.
 
 A starter template has been generated for both JVM and native execution modes.
 
-Run the following SAM CLI command to locally test your lambda function:
+Run the following SAM CLI command to locally test your lambda function, passing the appropriate SAM `template`.
+The `event` parameter takes any JSON file, in this case the sample `payload.json`.
+
+NOTE: If using Gradle, the path to the binaries in the YAML templates must be changed from `target` to `build`
 
 [source]
 ----
-sam local invoke --template sam.jvm.yaml --event {json test file}
+sam local invoke --template sam.jvm.yaml --event payload.json
 ----
 
 The native image can also be locally tested using the `sam.native.yaml` template:
 
 [source]
 ----
-sam local invoke --template sam.native.yaml --event {json test file}
+sam local invoke --template sam.native.yaml --event payload.json
 ----
 
 == Tracing with AWS XRay and GraalVM
@@ -270,3 +438,258 @@ sam local invoke --template sam.native.yaml --event {json test file}
 If you are building native images, and want to use https://aws.amazon.com/xray[AWS X-Ray Tracing] with your lambda
 you will need to include `quarkus-amazon-lambda-xray` as a dependency in your pom.  The AWS X-Ray
 library is not fully compatible with GraalVM so we had to do some integration work to make this work.
+
+In addition, remember to enable the AWS X-Ray tracing parameter in `manage.sh`, in the `cmd_create()` function.  This can also be set in the AWS Management Console.
+[source]
+----
+    --tracing-config Mode=Active
+----
+
+For the sam template files, add the following to the YAML function Properties.
+[source]
+----
+    Tracing: Active
+----
+
+AWS X-Ray does add many classes to your distribution, do ensure you are using at least the 256MB AWS Lambda memory size.
+This is explicitly set in `manage.sh` `cmd_create()`. Whilst the native image potentially can always use a lower memory setting, it would be recommended to keep the setting the same, especially to help compare performance.
+
+[[https]]
+== Using HTTPS or SSL/TLS
+
+If your code makes HTTPS calls, such as to a micro-service (or AWS service), you will need to add configuration to the native image,
+as GraalVM will only include the dependencies when explictly declared.  Quarkus, by default enables this functionality on extensions that implicitly require it.
+For further information, please consult the link:native-and-ssl[Quarkus SSL guide]
+
+Open src/main/resources/application.properties and add the following line to enable SSL in your native image.
+
+[source]
+----
+quarkus.ssl.native=true
+----
+
+[[aws-sdk-v2]]
+== Using the AWS Java SDK v2
+
+With minimal integration, it is possible to leverage the AWS Java SDK v2,
+which can be used to invoke services such as SQS, SNS, S3 and DynamoDB.
+
+For native image, however the URL Connection client must be preferred over the Apache HTTP Client
+when using synchronous mode, due to issues in the GraalVM compilation (at present).
+
+Add `quarkus-jaxb` as a dependency in your Maven `pom.xml`, or Gradle `build.gradle` file.
+
+You must also force your AWS service client for SQS, SNS, S3 et al, to use the URL Connection client,
+which connects to AWS services over HTTPS, hence the inclusion of the SSL enabled property, as described in the <<Using HTTPS>> section above.
+
+[source,java]
+----
+// select the appropriate client, in this case SQS, and
+// insert your region, instead of XXXX, which also improves startup time over the default client
+  client = SqsClient.builder().region(Region.XXXX).httpClient(software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.builder().build()).build();
+----
+
+For Maven, add the following to your `pom.xml`.
+
+[source,xml]
+----
+
+    <properties>
+        <aws.sdk2.version>2.10.69</aws.sdk2.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk2.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <!-- sqs/sns/s3 etc -->
+            <artifactId>sqs</artifactId>
+            <exclusions>
+                <!-- exclude the apache-client and netty client -->
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
+    </dependencies>
+----
+
+NOTE: if you are using GraalVM earlier than 19.3, or see `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty` or similar SSL error, due to the current status of GraalVM,
+there is some additional work to bundle the function.zip, as below.  For more information, please see the link:native-and-ssl[Quarkus Native SSL Guide].
+
+NOTE: If you have a Linux installation of GraalVM, you can reference the artifacts directly; if not, you will need to use Docker.
+
+To bundle the missing artifacts, we need to first extract them from the Docker image used to build the native image.
+
+We do this by starting up a Docker container, in the background, and attaching to that container to copy the artifacts.
+
+First, let's start the GraalVM container, noting the container id output.
+[source, shell]
+----
+docker run -it -d --entrypoint bash quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8
+
+# This will output a container id, like 6304eea6179522aff69acb38eca90bedfd4b970a5475aa37ccda3585bc2abdde
+# Note this value as we will need it for the commands below
+----
+
+First, libsunec.so, the C library used for the SSL implementation:
+
+[source]
+----
+docker cp {container-id-from-above}:/opt/graalvm/jre/lib/amd64/libsunec.so src/main/resources/
+----
+
+Second, cacerts, the certificate store.  You may need to periodically obtain an updated copy, also.
+[source]
+----
+docker cp {container-id-from-above}:/opt/graalvm/jre/lib/security/cacerts src/main/resources/
+----
+
+We then create a new function.zip that adds these artifacts.  As we now need to execute a bootstrap script,
+we have to rename the Quarkus image to a new name, here `boostrap.bin`, and use the below script as `bootstrap`.
+
+[source, shell]
+----
+./bootstrap.bin \
+    -Djava.library.path=${LAMBDA_TASK_ROOT}/ssl \
+    -Djavax.net.ssl.trustStore=${LAMBDA_TASK_ROOT}/ssl/cacerts \
+    -Djavax.net.ssl.trustAnchors=${LAMBDA_TASK_ROOT}/ssl/cacerts \
+    -Djavax.net.ssl.trustStorePassword=changeit
+----
+
+Your final archive will look like this:
+[source, shell]
+----
+jar tvf target/function.zip
+
+    bootstrap
+    bootstrap.bin
+    ssl/
+    ssl/cacerts
+    ssl/libsunec.so
+----
+
+This can be automated with a new Maven assembly zip.xml, for a new profile, such as the `function-zip.xml` below:
+
+[source, xml]
+----
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>function-package</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <files>
+        <file>
+            <source>${project.build.directory}${file.separator}${artifactId}-${version}-runner</source>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <destName>bootstrap.bin</destName>
+            <fileMode>755</fileMode>
+        </file>
+        <file>
+            <source>${project.basedir}${file.separator}src${file.separator}main${file.separator}resources${file.separator}cacerts</source>
+            <outputDirectory>${file.separator}ssl</outputDirectory>
+            <destName>cacerts</destName>
+            <fileMode>644</fileMode>
+        </file>
+        <file>
+            <source>${project.basedir}${file.separator}src${file.separator}main${file.separator}resources${file.separator}bootstrap</source>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <destName>bootstrap</destName>
+            <fileMode>755</fileMode>
+        </file>
+        <file>
+            <source>${project.basedir}${file.separator}src${file.separator}main${file.separator}resources${file.separator}libsunec.so</source>
+            <outputDirectory>${file.separator}ssl</outputDirectory>
+            <destName>libsunec.so</destName>
+            <fileMode>755</fileMode>
+        </file>
+    </files>
+</assembly>
+----
+
+Maven profile to execute the new function.zip:
+
+[source, xml]
+----
+        <profile>
+            <id>zip</id>
+            <activation>
+                <property>
+                    <name>zip</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>zip-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>function</finalName>
+                                    <descriptors>
+                                        <descriptor>src/assembly/function-zip.xml</descriptor>
+                                    </descriptors>
+                                    <attach>false</attach>
+                                    <appendAssemblyId>false</appendAssemblyId>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+----


### PR DESCRIPTION
Enhancement to the Amazon Lambda extension documentation, primarily driven by the addition of the RequestSteamHandler.

I have also added some of the more difficult topics around AWS Lambda with native image, such as using the AWS Java SDK v2 SSL client, and Amazon Alexa with the ASK SDK v2.

Gradle support was added also for those looking for a simpler view on how to use Gradle with the Amazon Lambda extension (as opposed to having to stitch it all together themselves).  Indeed that's the theme with all these additions, I've spent months fiddling with all this stuff in Java & Kotlin, Gradle and Maven, JVM and Native Image, trying to get it all to work.  I do plan to write a few blogs, however I wanted to capture as much of those learnings into the Quarkus docs directly for better re-use.

Yes, some of the additions for AWS Java SDK v2 and Alexa ASK SDK v2, could be a guide on their own, as there is a lot more to add.  I plan to write my own Quarkus extensions to automate all of this, so arguably the documentation will reduce in the future, and perhaps could remain in one place.  

/cc @patriot1burke 
/cc @evanchooly 
/cc @bnusunny 