### PR TITLE
Qute type-safe templates - fix inconsitency in "raw" validation

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -718,7 +718,7 @@ public class QuteProcessor {
             @Override
             public boolean test(Check check) {
                 // RawString
-                if (check.isProperty() && check.classNameEquals(STRING) && check.nameIn("raw", "safe")) {
+                if (check.isProperty() && check.nameIn("raw", "safe")) {
                     return true;
                 }
                 // Elvis and ternary operators

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ObjectValidationSuccessTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ObjectValidationSuccessTest.java
@@ -20,7 +20,8 @@ public class ObjectValidationSuccessTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(Movie.class, MovieExtensions.class)
                     .addAsResource(new StringAsset("{@java.lang.Object obj}"
-                            + "{obj.toString}"),
+                            + "{@java.lang.Object anotherObj}"
+                            + "{obj.toString}:{anotherObj.raw}"),
                             "templates/object.html"));
 
     @Inject
@@ -28,7 +29,7 @@ public class ObjectValidationSuccessTest {
 
     @Test
     public void testResult() {
-        assertEquals("hello", object.data("obj", "hello").render());
+        assertEquals("hello:<strong>", object.data("obj", "hello").data("anotherObj", "<strong>").render());
     }
 
 }


### PR DESCRIPTION
- "{@java.lang.Object obj}{obj.raw}" should not result in an incorrect expression
- follows up on #7771