### PR TITLE
[oidc] Add config to trust all certs and skip hostname verification

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -110,6 +110,7 @@ jobs:
           JAVA_OPTS: "-server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dkeycloak.profile.feature.upload_scripts=enabled"
         ports:
           - 127.0.0.1:8180:8080
+          - 127.0.0.1:8543:8443
       postgres:
         image: postgres:10.5
         env:
@@ -459,7 +460,7 @@ jobs:
         if: matrix.neo4j
       - name: Keycloak Service
         run: |
-          docker run --rm --publish 8180:8080 --name build-keycloak \
+          docker run --rm --publish 8180:8080 --publish 8543:8443 --name build-keycloak \
             -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e JAVA_OPTS=" \
               -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M \
               -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true \

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -15,6 +15,7 @@ import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.runtime.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Credentials;
 import io.quarkus.oidc.runtime.OidcTenantConfig.Credentials.Secret;
+import io.quarkus.oidc.runtime.OidcTenantConfig.Tls.Verification;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.vertx.core.AsyncResult;
@@ -138,6 +139,11 @@ public class OidcRecorder {
         Optional<ProxyOptions> proxyOpt = toProxyOptions(oidcConfig.getProxy());
         if (proxyOpt.isPresent()) {
             options.setProxyOptions(proxyOpt.get());
+        }
+
+        if (oidcConfig.tls.verification == Verification.NONE) {
+            options.setTrustAll(true);
+            options.setVerifyHost(false);
         }
 
         final long connectionDelayInSecs = oidcConfig.getConnectionDelay().isPresent()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -91,6 +91,34 @@ public class OidcTenantConfig {
      */
     Authentication authentication = new Authentication();
 
+    /**
+     * TLS configurations
+     */
+    @ConfigItem
+    Tls tls = new Tls();
+
+    @ConfigGroup
+    public static class Tls {
+        public enum Verification {
+            /**
+             * Certificates are validated and hostname verification is enabled. This is the default value.
+             */
+            REQUIRED,
+            /**
+             * All certificated are trusted and hostname verification is disabled.
+             */
+            NONE
+        }
+
+        /**
+         * Certificate validation and hostname verification, which can be one of the following values from enum
+         * {@link Verification}. Default is required.
+         */
+        @ConfigItem(defaultValue = "REQUIRED")
+        Verification verification;
+
+    }
+
     public Optional<Duration> getConnectionDelay() {
         return connectionDelay;
     }

--- a/integration-tests/oidc/README.md
+++ b/integration-tests/oidc/README.md
@@ -16,7 +16,7 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn clean install -Dtest-keycloak -Ddocker -Dnative
 ```
 
-If you don't want to run Keycloak Server as a Docker container, you can start your own Keycloak server. It needs to listen on the default port `8180`.
+If you don't want to run Keycloak Server as a Docker container, you can start your own Keycloak server. It needs to listen on the default https port `8543`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
@@ -24,4 +24,4 @@ You can then run the tests as follows (either with `-Dnative` or not):
 mvn clean install -Dtest-keycloak
 ```
 
-If you have specific requirements, you can define a specific connection URL with `-Dkeycloak.url=http://keycloak.server.domain:8180/auth`.
+If you have specific requirements, you can define a specific connection URL with `-Dkeycloak.url=https://keycloak.server.domain:8543/auth`.

--- a/integration-tests/oidc/pom.xml
+++ b/integration-tests/oidc/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <keycloak.ssl.url>https://localhost:8543/auth</keycloak.ssl.url>
     </properties>
 
     <dependencies>
@@ -104,7 +105,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
+                                <keycloak.url>${keycloak.ssl.url}</keycloak.url>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -113,7 +114,7 @@
                         <configuration>
                             <skip>false</skip>
                             <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
+                                <keycloak.url>${keycloak.ssl.url}</keycloak.url>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -173,6 +174,7 @@
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableHttpsUrlHandler>true</enableHttpsUrlHandler>
                                     <enableServer>false</enableServer>
                                     <dumpProxies>false</dumpProxies>
                                     <graalvmHome>${graalvmHome}</graalvmHome>
@@ -194,6 +196,7 @@
             </activation>
             <properties>
                 <keycloak.url>http://localhost:8180/auth</keycloak.url>
+                <keycloak.ssl.url>https://localhost:8543/auth</keycloak.ssl.url>
             </properties>
             <build>
                 <plugins>
@@ -208,6 +211,7 @@
                                     <run>
                                         <ports>
                                             <port>8180:8080</port>
+                                            <port>8543:8443</port>
                                         </ports>
                                         <env>
                                             <KEYCLOAK_USER>admin</KEYCLOAK_USER>

--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Configuration file
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.auth-server-url=${keycloak.ssl.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.token.principal-claim=email
 quarkus.http.cors=true
+quarkus.oidc.tls.verification=none

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -21,8 +21,12 @@ import io.restassured.RestAssured;
 
 public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
+    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.ssl.url", "https://localhost:8543/auth");
     private static final String KEYCLOAK_REALM = "quarkus";
+
+    static {
+        RestAssured.useRelaxedHTTPSValidation();
+    }
 
     @Override
     public Map<String, String> start() {


### PR DESCRIPTION
Add 2 new config to trust all server certificates and turn off hostname verification.

Fixes #5640