### PR TITLE
Support static CDI observer methods

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -389,7 +389,7 @@ public class BeanDeployment {
                 return new ArrayList<>(Arrays.asList(annotation.value().asNestedArray()));
             } else {
                 // neither qualifier, nor container annotation, return empty collection
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
         }
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/staticmethods/StaticObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/staticmethods/StaticObserverTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.arc.test.observers.staticmethods;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class StaticObserverTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(StringObserver.class, Fool.class);
+
+    @Test
+    public void testObserver() {
+        assertEquals(0, StringObserver.EVENTS.size());
+        assertFalse(Fool.DESTROYED.get());
+        Arc.container().beanManager().fireEvent("hello");
+        assertEquals(1, StringObserver.EVENTS.size());
+        assertEquals("hello", StringObserver.EVENTS.get(0));
+        assertTrue(Fool.DESTROYED.get());
+    }
+
+    static class StringObserver {
+
+        static final List<String> EVENTS = new CopyOnWriteArrayList<>();
+
+        static void observeString(@Observes String value, Fool fool) {
+            assertNotNull(fool);
+            EVENTS.add(value);
+        }
+
+    }
+
+    @Dependent
+    static class Fool {
+
+        static final AtomicBoolean DESTROYED = new AtomicBoolean();
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+    }
+
+}


### PR DESCRIPTION
- resolves #7938
- also split the BeanGenerator#implementCreate() method for better
readability