### PR TITLE
Bump to the latest dekorate version

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -142,7 +142,7 @@
         <awssdk.version>2.10.70</awssdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.61</kotlin.version>
-        <dekorate.version>0.11.2</dekorate.version>
+        <dekorate.version>0.11.3</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
         <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KnativeContainerImageTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KnativeContainerImageTest.java
@@ -12,7 +12,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.fabric8.knative.serving.v1alpha1.Service;
+import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -42,15 +42,11 @@ public class KnativeContainerImageTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, d -> {
 
                 assertThat(d.getSpec()).satisfies(serviceSpec -> {
-                    assertThat(serviceSpec.getRunLatest()).satisfies(revisionTemplate -> {
-                        assertThat(revisionTemplate.getConfiguration()).satisfies(configuration -> {
-                            assertThat(configuration.getRevisionTemplate()).satisfies(template -> {
-                                assertThat(template.getSpec()).satisfies(spec -> {
-                                    assertThat(spec.getContainer()).satisfies(c -> {
-                                        assertThat(c.getImage())
-                                                .isEqualTo("quay.io/grp/knative-with-container-image:0.1-SNAPSHOT");
-                                    });
-                                });
+                    assertThat(serviceSpec.getTemplate()).satisfies(revisionTemplate -> {
+                        assertThat(revisionTemplate.getSpec()).satisfies(spec -> {
+                            assertThat(spec.getContainers()).satisfies(containers -> {
+                                assertThat(containers.get(0)).satisfies(c -> assertThat(c.getImage())
+                                        .isEqualTo("quay.io/grp/knative-with-container-image:0.1-SNAPSHOT"));
                             });
                         });
                     });


### PR DESCRIPTION
This pull request updates to the latest dekorate version, that:

- Fixes the issue with long file names in S2i builds.
- Uses Knative v1.