### PR TITLE
Throw exception if using blocking mailer from IO thread

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/BlockingMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/BlockingMailerImpl.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.Mailer;
 import io.quarkus.mailer.ReactiveMailer;
+import io.quarkus.runtime.BlockingOperationControl;
 
 /**
  * Implementation of {@link Mailer} relying on the {@link ReactiveMailer} and waiting for completion.
@@ -18,6 +19,10 @@ public class BlockingMailerImpl implements Mailer {
 
     @Override
     public void send(Mail... mails) {
+        if (!BlockingOperationControl.isBlockingAllowed()) {
+            throw new RuntimeException(
+                    "Attempted a blocking operation from the IO thread. If you want to send mail from an IO thread please use ReactiveMailer instead, or dispatch to a worker thread to use the blocking mailer.");
+        }
         mailer.send(mails).toCompletableFuture().join();
     }
 }


### PR DESCRIPTION
This prevents a potential deadlock.

Fixes #3223