### PR TITLE
Ignore subclasses if bean is ambiguous

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotationServletTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotationServletTestCase.java
@@ -15,7 +15,7 @@ public class AnnotationServletTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestServlet.class));
+                    .addClasses(TestServlet.class, TestServletSubclass.class, TestGreeter.class));
 
     @Test
     public void testServlet() {
@@ -24,4 +24,10 @@ public class AnnotationServletTestCase {
                 .body(is("test servlet"));
     }
 
+    @Test
+    public void testServletSubclass() {
+        RestAssured.when().get("/test-sub").then()
+                .statusCode(200)
+                .body(is("test servlet"));
+    }
 }

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotationWithWebXmlTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotationWithWebXmlTestCase.java
@@ -50,7 +50,7 @@ public class AnnotationWithWebXmlTestCase {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(WebXmlServlet.class, TestServlet.class,
                             WebXmlFilter.class, AnnotatedFilter.class,
-                            WebXmlListener.class, AnnotatedListener.class)
+                            WebXmlListener.class, AnnotatedListener.class, TestGreeter.class)
                     .addAsManifestResource(new StringAsset(WEB_XML), "web.xml"));
 
     @Test

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ContextPathTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ContextPathTestCase.java
@@ -18,7 +18,7 @@ public class ContextPathTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestServlet.class)
+                    .addClasses(TestServlet.class, TestGreeter.class)
                     .addAsResource(new StringAsset("quarkus.servlet.context-path=" + CONTEXT_PATH), "application.properties"));
 
     @Test

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestGreeter.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestGreeter.java
@@ -1,0 +1,11 @@
+package io.quarkus.undertow.test;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class TestGreeter {
+
+    public String message() {
+        return "test servlet";
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestServlet.java
@@ -2,6 +2,7 @@ package io.quarkus.undertow.test;
 
 import java.io.IOException;
 
+import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -10,8 +11,11 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet(urlPatterns = "/test")
 public class TestServlet extends HttpServlet {
 
+    @Inject
+    TestGreeter testGreeter;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        resp.getWriter().write("test servlet");
+        resp.getWriter().write(testGreeter.message());
     }
 }

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestServletSubclass.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/TestServletSubclass.java
@@ -1,0 +1,8 @@
+package io.quarkus.undertow.test;
+
+import javax.servlet.annotation.WebServlet;
+
+@WebServlet(urlPatterns = "/test-sub")
+public class TestServletSubclass extends TestServlet {
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -75,6 +75,11 @@ public interface ArcContainer {
     /**
      * Returns a supplier that can be used to create new instances, or null if no matching bean can be found.
      *
+     * Note that if there are multiple sub classes of the given type this will return the exact match. This means
+     * that this can be used to directly instantiate superclasses of other beans without causing problems.
+     *
+     * see https://github.com/quarkusio/quarkus/issues/3369
+     *
      * @param type
      * @param qualifiers
      * @param <T>


### PR DESCRIPTION
This fixes a whole class of bugs where adding
a subclass will prevent injection into the parent.

Fixes #3369