### PR TITLE
Load wagon providers from the classloader that loaded the bootstrap classes

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapWagonProvider.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapWagonProvider.java
@@ -47,7 +47,7 @@ public class BootstrapWagonProvider implements WagonProvider {
 
     private static Class<?> loadClass(String name, String protocol) {
         try {
-            return Thread.currentThread().getContextClassLoader().loadClass(name);
+            return BootstrapWagonProvider.class.getClassLoader().loadClass(name);
         } catch (ClassNotFoundException e) {
             final StringBuilder buf = new StringBuilder();
             buf.append("Failed to locate Wagon implementation ")


### PR DESCRIPTION
...instead of the current classloader which may already be an application Quarkus classloader