### PR TITLE
fix: duplicate envFrom in k8s manifests

### DIFF
--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithEnvFromSecretTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithEnvFromSecretTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithEnvFromSecretTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("env-from-secret")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-env-from-secret.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("env-from-secret");
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getEnvFrom()).hasOnlyOneElementSatisfying(env -> {
+                                assertThat(env.getSecretRef()).satisfies(secretRef -> {
+                                    assertThat(secretRef.getName()).isEqualTo("my-secret");
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-env-from-secret.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-env-from-secret.properties
@@ -1,0 +1,1 @@
+quarkus.kubernetes.env-vars.ignored.secret=my-secret


### PR DESCRIPTION
This pull request fixes the presence of duplicate envFrom entries appearing in the manifests.

We recently fixes duplicate env variables, but mised this case.

Fixes: #7740 