### PR TITLE
Gradle added to Amazon Lambda archetype

### DIFF
--- a/extensions/amazon-lambda/maven-archetype/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/pom.xml
@@ -30,6 +30,13 @@
                     <exclude>archetype-resources/pom.xml</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>archetype-resources/gradle.properties</include>
+                </includes>
+            </resource>
         </resources>
         <extensions>
             <extension>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -41,11 +41,19 @@ under the License.
         <include>*</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>src/test/resources</directory>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true">
       <directory></directory>
       <includes>
         <include>*.sh</include>
         <include>*.json</include>
+        <include>*.gradle</include>
+        <include>gradle.*</include>
         <include>sam.jvm.yaml</include>
         <include>sam.native.yaml</include>
       </includes>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-amazon-lambda'
+
+    testImplementation  "io.quarkus:quarkus-test-amazon-lambda"
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group '${groupId}'
+version '${version}'
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/gradle.properties
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/gradle.properties
@@ -1,0 +1,7 @@
+#Gradle properties
+#Tue Mar 17 10:20:48 UTC 2020
+quarkusPluginVersion=${project.version}
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformVersion=${project.version}
+quarkusPlatformGroupId=io.quarkus
+

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/settings.gradle
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='${artifactId}'

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 quarkus.lambda.handler=test
-
-quarkus.lambda.enable-polling-jvm-mode=true


### PR DESCRIPTION
Added Gradle support to the generic archetype project, to simplify the use of Gradle for new starters.  They have the option now to use Maven or Gradle and use the archetype project as a base for creating AWS Lambda projects.

**code.quarkus.io** only generates a sample HTTP project, it doesn't generate an AWS Lambda sample project, if someone is wanting to use Gradle.

** Tested by: **

mvn archetype:generate -DarchetypeGroupId=io.quarkus -DarchetypeArtifactId=quarkus-amazon-lambda-archetype -DarchetypeVersion=999-SNAPSHOT
mvn package
gradle assemble
(Unit test for Gradle fails per #7909 

/cc @patriot1burke 
/cc @Nxtra