### PR TITLE
Alexa SkillStreamHandler subclass check for RequestStreamHandler in AmazonLambdaProcessor

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -50,6 +50,7 @@ public final class AmazonLambdaProcessor {
 
     private static final DotName REQUEST_HANDLER = DotName.createSimple(RequestHandler.class.getName());
     private static final DotName REQUEST_STREAM_HANDLER = DotName.createSimple(RequestStreamHandler.class.getName());
+    private static final DotName SKILL_STREAM_HANDLER = DotName.createSimple("com.amazon.ask.SkillStreamHandler");
 
     private static final DotName NAMED = DotName.createSimple(Named.class.getName());
     private static final Logger log = Logger.getLogger(AmazonLambdaProcessor.class);
@@ -70,11 +71,13 @@ public final class AmazonLambdaProcessor {
             BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemBuildProducer,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer) throws BuildException {
-        Collection<ClassInfo> allKnownImplementors = combinedIndexBuildItem.getIndex().getAllKnownImplementors(REQUEST_HANDLER);
-        Collection<ClassInfo> allKnownStreamImplementors = combinedIndexBuildItem.getIndex()
-                .getAllKnownImplementors(REQUEST_STREAM_HANDLER);
 
-        allKnownImplementors.addAll(allKnownStreamImplementors);
+        Collection<ClassInfo> allKnownImplementors = combinedIndexBuildItem.getIndex().getAllKnownImplementors(REQUEST_HANDLER);
+        allKnownImplementors.addAll(combinedIndexBuildItem.getIndex()
+                .getAllKnownImplementors(REQUEST_STREAM_HANDLER));
+        allKnownImplementors.addAll(combinedIndexBuildItem.getIndex()
+                .getAllKnownImplementors(SKILL_STREAM_HANDLER));
+
         if (allKnownImplementors.size() > 0 && providedLambda.isPresent()) {
             throw new BuildException(
                     "Multiple handler classes.  You have a custom handler class and the " + providedLambda.get().getProvider()


### PR DESCRIPTION
Per suggestion of @gsmet on #7955, I have added a simple 2 line check for subclasses of the Alexa SkillStreamHandler in the Amazon Lambda extension deployment module, AmazonLambdaProcessor.  

It worked with my sample project.

runtime bom updated with the relevant Alexa SDK dependency, which also excludes conflicting dependencies of sl4j.  Checked via mvn dependency:tree

/cc @gsmet 
/cc @geoand 
/cc @patriot1burke 