### PR TITLE
fix OpenTracing trace context propagation with Fault Tolerance @Asynchronous methods

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -37,7 +37,7 @@
         <smallrye-metrics.version>2.4.1</smallrye-metrics.version>
         <smallrye-open-api.version>1.2.1</smallrye-open-api.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
-        <smallrye-fault-tolerance.version>4.1.1</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>4.2.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.1.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.11</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.10</smallrye-reactive-streams-operators.version>
@@ -1445,6 +1445,11 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
+                <version>${smallrye-fault-tolerance.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>
                 <version>${smallrye-fault-tolerance.version}</version>
             </dependency>
             <dependency>

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.jaeger.deployment;
 
 import javax.inject.Inject;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -21,13 +22,15 @@ public class JaegerProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupTracer(JaegerDeploymentRecorder jdr, JaegerBuildTimeConfig buildTimeConfig, JaegerConfig jaeger,
-            ApplicationConfig appConfig) {
+            ApplicationConfig appConfig, Capabilities capabilities) {
 
         // Indicates that this extension would like the SSL support to be enabled
         extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.JAEGER));
 
         if (buildTimeConfig.enabled) {
-            jdr.registerTracer(jaeger, appConfig);
+            boolean metricsEnabled = capabilities.isCapabilityPresent(Capabilities.METRICS);
+
+            jdr.registerTracer(jaeger, appConfig, metricsEnabled);
         }
     }
 

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -18,7 +18,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
-       <dependency>
+        <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-core</artifactId>
         </dependency>
@@ -31,12 +31,9 @@
             <artifactId>svm</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.metrics</groupId>
-            <artifactId>microprofile-metrics-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-metrics</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
@@ -15,7 +15,7 @@ public class JaegerDeploymentRecorder {
     private static final Optional UNKNOWN_SERVICE_NAME = Optional.of("quarkus/unknown");
     private static final QuarkusJaegerTracer quarkusTracer = new QuarkusJaegerTracer();
 
-    synchronized public void registerTracer(JaegerConfig jaeger, ApplicationConfig appConfig) {
+    synchronized public void registerTracer(JaegerConfig jaeger, ApplicationConfig appConfig, boolean metricsEnabled) {
         if (!jaeger.serviceName.isPresent()) {
             if (appConfig.name.isPresent()) {
                 jaeger.serviceName = appConfig.name;
@@ -24,6 +24,7 @@ public class JaegerDeploymentRecorder {
             }
         }
         initTracerConfig(jaeger);
+        quarkusTracer.setMetricsEnabled(metricsEnabled);
         quarkusTracer.reset();
         // register Quarkus tracer to GlobalTracer.
         // Usually the tracer will be registered only here, although consumers

--- a/extensions/smallrye-opentracing/deployment/pom.xml
+++ b/extensions/smallrye-opentracing/deployment/pom.xml
@@ -41,6 +41,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/RestService.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/RestService.java
@@ -1,10 +1,13 @@
 package io.quarkus.smallrye.opentracing.deployment;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.eclipse.microprofile.opentracing.Traced;
 
 @Path("/")
 public interface RestService {
@@ -22,7 +25,11 @@ public interface RestService {
     Response restClient();
 
     @GET
-    @Traced(false)
     @Path("/faultTolerance")
-    Response faultTolerance();
+    CompletionStage<String> faultTolerance();
+
+    @GET
+    @Path("/jpa")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<Fruit> jpa();
 }

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Service.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Service.java
@@ -1,10 +1,15 @@
 package io.quarkus.smallrye.opentracing.deployment;
 
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.persistence.EntityManager;
 
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
@@ -12,25 +17,37 @@ import org.eclipse.microprofile.opentracing.Traced;
 
 import io.opentracing.Tracer;
 
-@Traced
 @ApplicationScoped
 public class Service {
 
     @Inject
     Tracer tracer;
 
+    @Inject
+    EntityManager em;
+
+    @Traced
     public void foo() {
     }
 
+    // @Asynchronous methods (and their fallback methods) shouldn't be @Traced
+    // because https://github.com/eclipse/microprofile-opentracing/issues/189
+    @Asynchronous
     @Fallback(fallbackMethod = "fallback")
     @Timeout(value = 20L, unit = ChronoUnit.MILLIS)
     @Retry(delay = 10L, maxRetries = 2)
-    public String faultTolerance() {
+    public CompletionStage<String> faultTolerance() {
         tracer.buildSpan("ft").start().finish();
         throw new RuntimeException();
     }
 
-    public String fallback() {
-        return "fallback";
+    public CompletionStage<String> fallback() {
+        tracer.buildSpan("fallback").start().finish();
+        return CompletableFuture.completedFuture("fallback");
+    }
+
+    @Traced
+    public List<Fruit> getFruits() {
+        return em.createNamedQuery("Fruits.findAll", Fruit.class).getResultList();
     }
 }

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/TestResource.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/TestResource.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.opentracing.deployment;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
 import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
@@ -38,8 +41,11 @@ public class TestResource implements RestService {
     }
 
     @Override
-    public Response faultTolerance() {
-        String ret = service.faultTolerance();
-        return Response.ok(ret).build();
+    public CompletionStage<String> faultTolerance() {
+        return service.faultTolerance();
+    }
+
+    public List<Fruit> jpa() {
+        return service.getFruits();
     }
 }

--- a/extensions/smallrye-opentracing/runtime/pom.xml
+++ b/extensions/smallrye-opentracing/runtime/pom.xml
@@ -33,6 +33,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>


### PR DESCRIPTION
There used to be a test for that, but didn't involve `@Asynchronous`
methods, so was in fact useless. This commit changes the test to
actually call an `@Asynchronous` method, which revealed an issue.
The `smallrye-fault-tolerance-tracing-propagation` dependency was
missing, so trace context propagation didn't actually work.

Then, the test also uncovered an issue in SmallRye Fault Tolerance
(see https://github.com/smallrye/smallrye-fault-tolerance/pull/208),
which is why this commit also brings a new version of it.

In addition to that, this commit also fixes a devmode issue where
on hot reload, the Jaeger extension tried to register a gauge
that was already present. That ended up with an exception.

And finally, this commit also adds a test for tracing JDBC.

Resolves #7981.
Resolves #7982.
Resolves #7984.