### PR TITLE
Add note about class reading in class loading guide

### DIFF
--- a/docs/src/main/asciidoc/class-loading-reference.adoc
+++ b/docs/src/main/asciidoc/class-loading-reference.adoc
@@ -19,6 +19,28 @@ a normal production Quarkus application.
 For all other use cases (e.g. tests, dev mode, and building the application) Quarkus
 uses the class loading architecture outlined here.
 
+== Reading Class Bytecode
+
+Whenever class bytecode needs to be read, a `@BuildStep` where class reading is done must have the `loadsApplicationClasses` parameter set to `true`. Otherwise the class will not be found.
+
+It's also important to use the correct `ClassLoader`. The recommended approach is to get it by calling the
+`Thread.currentThread().getContextClassLoader()` method.
+
+Example:
+
+
+[source,java,subs=attributes+]
+----
+@BuildStep(loadsApplicationClasses = true)
+GeneratedClassBuildItem instrument(final CombinedIndexBuildItem index) {
+    final String classname = "com.example.SomeClass";
+    final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    final byte[] originalBytecode = IoUtil.readClassAsBytes(cl, classname);
+    final byte[] enhancedBytecode = ... // class instrumentation from originalBytecode
+    return new GeneratedClassBuildItem(true, classname, enhancedBytecode));
+}
+----
+
 == Bootstrapping Quarkus
 
 All Quarkus applications are created by the QuarkusBootstrap class in the `independent-projects/bootstrap` module. This


### PR DESCRIPTION
Hello Quarkus Team!

I'm sending this PR due to the problem with class reading I experienced when migrating from 1.2.1.Final to 1.3.0.Final. After some digging I found this document, i.e. the [Class Loading Reference guide](https://quarkus.io/guides/class-loading-reference), but it didn't help much. I went back to the code to check how other extensions are doing class reading. I nailed my problem down to the following points:

- A `@BuildStep` which reads classes needs to have `loadsApplicationClasses` set to `true`.
- A `ClassLoader` should be taken from `Thread.currentThread().getContextClassLoader()`.

Adding parameter itself did not help. Using appropriate class loader was also important.

Before I migrated to 1.3.0 I haven't had these issues. My build step did not use `loadsApplicationClasses` parameter, I got `ClassLoader` from `getClass().getClassLoader()`, and everything worked just fine. 

I hope the change I made in the guide will help extension writers in the future.

This concludes this PR.