### PR TITLE
Don't expect a .exe suffix to the native image generated in a container

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -338,7 +338,8 @@ public class NativeImageBuildStep {
             if (exitCode != 0) {
                 throw imageGenerationFailed(exitCode, command);
             }
-            if (IS_WINDOWS) { //once image is generated it gets added .exe on windows
+            if (IS_WINDOWS && !(nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild)) {
+                //once image is generated it gets added .exe on Windows
                 executableName = executableName + ".exe";
             }
             Path generatedImage = outputDir.resolve(executableName);


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/7990

The commit here checks to see if the native image was generated within a *nix based container runtime to prevent it from expecting a `.exe` suffix to the generated native image.