### PR TITLE
Ensure that @QuarkusTest plays nicely with @TestFactory

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DynamicTestsTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DynamicTestsTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import io.quarkus.it.arc.UnusedBean;
+import io.quarkus.test.junit.QuarkusDynamicTest;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DynamicTestsTestCase {
+
+    @Inject
+    UnusedBean bean;
+
+    @Test
+    public void testInjection() {
+        assertNotNull(bean);
+    }
+
+    @TestFactory
+    public List<?> dynamicTests() {
+        return Arrays.asList(
+                QuarkusDynamicTest.dynamicTest("test 1", () -> {
+                    assertNotNull(bean);
+                }),
+                QuarkusDynamicTest.dynamicTest("test 2", () -> {
+                    assertEquals(1, 1);
+                }));
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusDynamicTest.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusDynamicTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.test.junit;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * This class needs to be used when users want to use JUnit 5's {@link org.junit.jupiter.api.DynamicTest} along with
+ * {@link org.junit.jupiter.api.TestFactory} in a {@link QuarkusTest}.
+ *
+ *
+ * An example usage in a test is:
+ *
+ * <code><pre>
+ * &#64;TestFactory
+ * public List<?> dynamicTests() {
+ *   return Arrays.asList(
+ *     QuarkusDynamicTest.dynamicTest("test 1", () -> {
+ *       assertEquals(1, 1);
+ *       // of course more complex things can be done here, like accessing a field injected with @Inject
+ *     }),
+ *     QuarkusDynamicTest.dynamicTest("test 2", () -> {
+ *       assertEquals(2, 2);
+ *     })
+ *   );
+ * }
+ * </pre></code>
+ */
+public class QuarkusDynamicTest {
+
+    private static ClassLoader cl;
+    private static Method dynamicTestMethod;
+    private static Constructor<?> quarkusExecutableClassConstructor;
+
+    public static Object dynamicTest(String displayName, Executable executable) {
+        try {
+            Object executableInstance = getQuarkusExecutableClassConstructor().newInstance(executable);
+            return getDynamicTestMethod().invoke(null, displayName, executableInstance);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void setClassLoader(ClassLoader classLoader) {
+        cl = classLoader;
+    }
+
+    private static Method getDynamicTestMethod() throws ClassNotFoundException, NoSuchMethodException {
+        if (dynamicTestMethod == null) {
+            dynamicTestMethod = Class.forName("org.junit.jupiter.api.DynamicTest", false, cl)
+                    .getMethod("dynamicTest", String.class, Class
+                            .forName("org.junit.jupiter.api.function.Executable", false, cl));
+        }
+        return dynamicTestMethod;
+    }
+
+    private static Constructor<?> getQuarkusExecutableClassConstructor() throws ClassNotFoundException, NoSuchMethodException {
+        if (quarkusExecutableClassConstructor == null) {
+            quarkusExecutableClassConstructor = Class.forName("io.quarkus.test.junit.QuarkusExecutable", false, cl)
+                    .getConstructor(Object.class);
+        }
+        return quarkusExecutableClassConstructor;
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusExecutable.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusExecutable.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.junit;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.function.Executable;
+
+public class QuarkusExecutable implements Executable {
+
+    private final Object executable;
+    private final Method executeMethod;
+
+    public QuarkusExecutable(Object executable) {
+        this.executable = executable;
+        try {
+            this.executeMethod = executable.getClass().getMethod("execute");
+            this.executeMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public void execute() throws Throwable {
+        executeMethod.invoke(executable);
+    }
+}


### PR DESCRIPTION
Currently `TestFactory` can't be used with `DynamicTest` for 2 reasons:

* The methods are not intercepted
* The is no handling for the different CLs

This PR introduces the necessary interception and ClassLoader handling to get `DynamicTest` to work. However this **requires** user code to use `QuarkusDynamicTest` instead of JUnit's `DynamicTest` and to **not** return specify `DynamicTest` as the method signature (due to JUnit 5 expecting `DynamicTest` to be loaded from the regular CL). 

Fixes: #8004