### PR TITLE
Adjust the script syncing the website

### DIFF
--- a/docs/sync-web-site.sh
+++ b/docs/sync-web-site.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-git clone git@github.com:quarkusio/quarkusio.github.io.git target/web-site
+git clone -b develop --single-branch git@github.com:quarkusio/quarkusio.github.io.git target/web-site
 
 rsync -vr \
     --exclude='**/*.html' \
@@ -9,12 +9,12 @@ rsync -vr \
     src/main/asciidoc/* \
     target/web-site/_guides
 
-rsync -vr \
+rsync -vr --delete \
     --exclude='**/*.html' \
     --exclude='**/index.adoc' \
     --exclude='**/attributes.adoc' \
-    ../target/asciidoc/generated \
-    target/web-site/_guides/
+    ../target/asciidoc/generated/ \
+    target/web-site/_generated-config
 
 echo "Sync done!"
 echo "=========="


### PR DESCRIPTION
We had to move the generated config outside of the _guides collection.
Otherwise Jekyll generates pages for these files and it does that at the
root of /guides/.