### PR TITLE
Properly apply MongoClientConfig.socketTimeout

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/AbstractMongoClientProducer.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/AbstractMongoClientProducer.java
@@ -207,6 +207,9 @@ public abstract class AbstractMongoClientProducer {
             if (config.connectTimeout.isPresent()) {
                 builder.connectTimeout((int) config.connectTimeout.get().toMillis(), TimeUnit.MILLISECONDS);
             }
+            if (config.socketTimeout.isPresent()) {
+                builder.readTimeout((int) config.socketTimeout.get().toMillis(), TimeUnit.MILLISECONDS);
+            }
         }
     }
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/AbstractMongoClientProducer.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/AbstractMongoClientProducer.java
@@ -207,8 +207,8 @@ public abstract class AbstractMongoClientProducer {
             if (config.connectTimeout.isPresent()) {
                 builder.connectTimeout((int) config.connectTimeout.get().toMillis(), TimeUnit.MILLISECONDS);
             }
-            if (config.socketTimeout.isPresent()) {
-                builder.readTimeout((int) config.socketTimeout.get().toMillis(), TimeUnit.MILLISECONDS);
+            if (config.readTimeout.isPresent()) {
+                builder.readTimeout((int) config.readTimeout.get().toMillis(), TimeUnit.MILLISECONDS);
             }
         }
     }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -137,7 +137,7 @@ public class MongoClientConfig {
     public Optional<Duration> connectTimeout;
 
     /**
-     * How long a send or receive on a socket can take before timing out.
+     * How long a socket read can take before timing out.
      */
     @ConfigItem
     public Optional<Duration> socketTimeout;

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -140,7 +140,7 @@ public class MongoClientConfig {
      * How long a socket read can take before timing out.
      */
     @ConfigItem
-    public Optional<Duration> socketTimeout;
+    public Optional<Duration> readTimeout;
 
     /**
      * If connecting with TLS, this option enables insecure TLS connections.


### PR DESCRIPTION
Fixes: #8026

The property should probably be renamed to `readTimeout` in a later version