### PR TITLE
Fix AmazonLambdaProcessor SkillStreamHandler subclass check

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -76,7 +76,7 @@ public final class AmazonLambdaProcessor {
         allKnownImplementors.addAll(combinedIndexBuildItem.getIndex()
                 .getAllKnownImplementors(REQUEST_STREAM_HANDLER));
         allKnownImplementors.addAll(combinedIndexBuildItem.getIndex()
-                .getAllKnownImplementors(SKILL_STREAM_HANDLER));
+                .getAllKnownSubclasses(SKILL_STREAM_HANDLER));
 
         if (allKnownImplementors.size() > 0 && providedLambda.isPresent()) {
             throw new BuildException(
@@ -102,7 +102,7 @@ public final class AmazonLambdaProcessor {
 
             ClassInfo current = info;
             boolean done = false;
-            boolean streamHandler = false;
+            boolean streamHandler = info.superName().equals(SKILL_STREAM_HANDLER) ? true : false;
             while (current != null && !done) {
                 for (MethodInfo method : current.methods()) {
                     if (method.name().equals("handleRequest")) {


### PR DESCRIPTION
Apologies I have to re-do #7985 due to an error in the commit. 

SkillStreamHandler to check to for known subclasses of SkillStreamHandler (fix). 

Plus, the methods() check does not find the requestHandler(), only directly implemented methods, so I have to force this with an additional check.

Output from execution on AWS:
```
END RequestId: f7b66f2a-7951-4da9-9860-36b82c417a93
REPORT RequestId: f7b66f2a-7951-4da9-9860-36b82c417a93  Duration: 4380.92 ms    Billed Duration: 4400 ms        Memory Size: 256 MB     Max Memory Used: 125 MB Init Duration: 1341.26 ms       
XRAY TraceId: 1-5e74edf6-cbd07c56fb45500a5179c402       SegmentId: 0d6d366a14777dff     Sampled: true   
{"version":"1.0","userAgent":"ask-java/2.28.0 Java/11.0.6 templateResolver","response":{"outputSpeech":{"type":"SSML","ssml":"<speak>Hi <alexa:name type=\"first\" \"/></speak>"}}}%   

```
/cc @gsmet 
  