### PR TITLE
Replace obsolete OS-dependent compilation condition

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
@@ -9,7 +9,6 @@ import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.os.IsDefined;
 import com.oracle.svm.core.posix.headers.Pthread;
 
 /**
@@ -44,7 +43,8 @@ public final class DiagnosticPrinter {
             w.print("prio=");
             w.print(thread.getPriority());
             w.print(" tid=");
-            if ((IsDefined.isLinux() || IsDefined.isDarwin()) && Target_PosixJavaThreads.hasThreadIdentifier(thread)) {
+            if ((Platform.includedIn(Platform.LINUX.class) || Platform.includedIn(Platform.DARWIN.class))
+                    && Target_PosixJavaThreads.hasThreadIdentifier(thread)) {
                 final long nativeId = Target_PosixJavaThreads.getPthreadIdentifier(thread).rawValue();
                 w.print("0x");
                 w.println(Long.toHexString(nativeId));


### PR DESCRIPTION
As discussed in https://github.com/oracle/graal/pull/2236, we're currently using an obsolete OS-dependent compilation condition that will be removed soon from GraalVM.

This PR fixes that problem by using the OS-dependent compilation condition recommended by the GraalVM team.

It was successfully tested with Windows 10 and GraalVM 20.0.0 (the condition was introduced because of a Windows issue).