### PR TITLE
fix: Avoid logging a WARN message about having duplicates persistence-unit during testing

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -124,7 +125,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         //for resources banned means that we don't delegate to the parent, as there can be multiple resources
         //for single resources we still respect this
         boolean banned = state.bannedResources.contains(name);
-        List<URL> resources = new ArrayList<>();
+        Set<URL> resources = new LinkedHashSet<>();
         //ClassPathElement[] providers = loadableResources.get(name);
         //if (providers != null) {
         //    for (ClassPathElement element : providers) {


### PR DESCRIPTION
When running tests of an app with a `META-INF/persistence` file, I noticed the following
warning message:

```
2020-03-22 01:07:12,791 WARN  [org.hib.jpa.boo.int.PersistenceXmlParser] (build-22) HHH015018: Encountered multiple persistence-unit stanzas defining same name [templatePU]; persistence-unit names must be unique
```

The warning above is only observed in `test` profile and is deceiving since the app did not have mutliple persistence units.

Fix the issue by ensuring that no duplicates resources are loaded.

The error can be reproduced by simply running the tests (JVM mode) in the `ìntegration-tests/main` module.