### PR TITLE
refactor: remove initialization of unused variable in `HibernateOrmIntegrations`

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/LightPersistenceXmlDescriptor.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/LightPersistenceXmlDescriptor.java
@@ -11,11 +11,8 @@ import javax.persistence.spi.PersistenceUnitTransactionType;
 
 import org.hibernate.bytecode.enhance.spi.EnhancementContext;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
-import org.jboss.logging.Logger;
 
 public final class LightPersistenceXmlDescriptor implements PersistenceUnitDescriptor {
-
-    private static final Logger log = Logger.getLogger(LightPersistenceXmlDescriptor.class);
 
     private final String name;
     private final String providerClassName;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/integration/HibernateOrmIntegrations.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/integration/HibernateOrmIntegrations.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.BootstrapContext;
 
 public class HibernateOrmIntegrations {
@@ -25,7 +24,6 @@ public class HibernateOrmIntegrations {
     public static void onMetadataInitialized(Metadata metadata, BootstrapContext bootstrapContext,
             BiConsumer<String, Object> propertyCollector) {
         for (HibernateOrmIntegrationListener listener : LISTENERS) {
-            ClassLoaderService cls = bootstrapContext.getServiceRegistry().getService(ClassLoaderService.class);
             listener.onMetadataInitialized(metadata, bootstrapContext, propertyCollector);
         }
     }


### PR DESCRIPTION
I stumbled upon this class while trying to understand the cause of an "unrelated" issue in this
comment https://github.com/quarkusio/quarkus/issues/7936#issuecomment-601217372. After running some
tests in my dev machine, I think the line of code can be removed.