### PR TITLE
fix(flyway): multiple datasource migration does not work on native

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -52,9 +52,7 @@ class FlywayProcessor {
     private static final String FILE_APPLICATION_MIGRATIONS_PROTOCOL = "file";
 
     private static final Logger LOGGER = Logger.getLogger(FlywayProcessor.class);
-    /**
-     * Flyway build config
-     */
+
     FlywayBuildTimeConfig flywayBuildConfig;
 
     @BuildStep
@@ -90,15 +88,8 @@ class FlywayProcessor {
         containerListenerProducer.produce(new BeanContainerListenerBuildItem(recorder.setFlywayBuildConfig(flywayBuildConfig)));
     }
 
-    /**
-     * Handles all the operations that can be recorded in the RUNTIME_INIT execution time phase
-     *
-     * @param recorder Used to set the runtime config
-     * @param flywayRuntimeConfig The Flyway configuration
-     * @param jdbcDataSourceBuildItems Added this dependency to be sure that Agroal is initialized first
-     */
-    @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
     ServiceStartBuildItem configureRuntimeProperties(FlywayRecorder recorder,
             FlywayRuntimeConfig flywayRuntimeConfig,
             BeanContainerBuildItem beanContainer,
@@ -117,10 +108,6 @@ class FlywayProcessor {
 
     /**
      * Collects the configured migration locations for the default and all named DataSources.
-     * <p>
-     * A {@link LinkedHashSet} is used to avoid duplications.
-     *
-     * @return {@link Collection} of {@link String}
      */
     private Collection<String> getMigrationLocations(Collection<String> dataSourceNames) {
         Collection<String> migrationLocations = dataSourceNames.stream()

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayRecorder.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.flyway.runtime;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Map.Entry;
 
 import javax.enterprise.inject.Default;
@@ -11,10 +12,14 @@ import org.flywaydb.core.Flyway;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.flyway.FlywayDataSource;
+import io.quarkus.flyway.runtime.graal.QuarkusPathLocationScanner;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class FlywayRecorder {
+    public void setApplicationMigrationFiles(List<String> migrationFiles) {
+        QuarkusPathLocationScanner.setApplicationMigrationFiles(migrationFiles);
+    }
 
     public BeanContainerListener setFlywayBuildConfig(FlywayBuildTimeConfig flywayBuildConfig) {
         return beanContainer -> {

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/QuarkusPathLocationScanner.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/QuarkusPathLocationScanner.java
@@ -1,18 +1,12 @@
 package io.quarkus.flyway.runtime.graal;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
+import org.flywaydb.core.api.Location;
 import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.resource.LoadableResource;
@@ -21,32 +15,46 @@ import org.flywaydb.core.internal.scanner.classpath.ResourceAndClassScanner;
 
 public final class QuarkusPathLocationScanner implements ResourceAndClassScanner {
     private static final Log LOG = LogFactory.getLog(QuarkusPathLocationScanner.class);
-    /**
-     * File with the migrations list. It is generated dynamically in the Flyway Quarkus Processor
-     */
-    public final static String MIGRATIONS_LIST_FILE = "META-INF/flyway-migrations.txt";
+    private static final String LOCATION_SEPARATOR = "/";
+    private static List<String> applicationMigrationFiles;
+
+    private final Collection<LoadableResource> scannedResources;
+
+    public QuarkusPathLocationScanner(Collection<Location> locations) {
+        this.scannedResources = new ArrayList<>();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        for (String migrationFile : applicationMigrationFiles) {
+            if (canHandleMigrationFile(locations, migrationFile)) {
+                LOG.debug("Loading " + migrationFile);
+                scannedResources.add(new ClassPathResource(null, migrationFile, classLoader, StandardCharsets.UTF_8));
+            }
+        }
+
+    }
 
     /**
-     * Returns the migrations loaded into the {@see MIGRATIONS_LIST_FILE}
      *
      * @return The resources that were found.
      */
     @Override
     public Collection<LoadableResource> scanForResources() {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        try (InputStream resource = classLoader.getResourceAsStream(MIGRATIONS_LIST_FILE);
-                BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(Objects.requireNonNull(resource), StandardCharsets.UTF_8))) {
-            List<String> migrations = reader.lines().collect(Collectors.toList());
-            Set<LoadableResource> resources = new HashSet<>();
-            for (String file : migrations) {
-                LOG.debug("Loading " + file);
-                resources.add(new ClassPathResource(null, file, classLoader, StandardCharsets.UTF_8));
+        return scannedResources;
+    }
+
+    private boolean canHandleMigrationFile(Collection<Location> locations, String migrationFile) {
+        for (Location location : locations) {
+            String locationPath = location.getPath();
+            if (!locationPath.endsWith(LOCATION_SEPARATOR)) {
+                locationPath += "/";
             }
-            return resources;
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
+
+            if (migrationFile.startsWith(locationPath)) {
+                return true;
+            }
         }
+
+        return false;
     }
 
     /**
@@ -59,5 +67,9 @@ public final class QuarkusPathLocationScanner implements ResourceAndClassScanner
     public Collection<Class<?>> scanForClasses() {
         // Classes are not supported in native mode
         return Collections.emptyList();
+    }
+
+    public static void setApplicationMigrationFiles(List<String> applicationMigrationFiles) {
+        QuarkusPathLocationScanner.applicationMigrationFiles = applicationMigrationFiles;
     }
 }

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/QuarkusPathLocationScanner.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/QuarkusPathLocationScanner.java
@@ -7,14 +7,13 @@ import java.util.Collections;
 import java.util.List;
 
 import org.flywaydb.core.api.Location;
-import org.flywaydb.core.api.logging.Log;
-import org.flywaydb.core.api.logging.LogFactory;
 import org.flywaydb.core.internal.resource.LoadableResource;
 import org.flywaydb.core.internal.resource.classpath.ClassPathResource;
 import org.flywaydb.core.internal.scanner.classpath.ResourceAndClassScanner;
+import org.jboss.logging.Logger;
 
 public final class QuarkusPathLocationScanner implements ResourceAndClassScanner {
-    private static final Log LOG = LogFactory.getLog(QuarkusPathLocationScanner.class);
+    private static final Logger LOGGER = Logger.getLogger(QuarkusPathLocationScanner.class);
     private static final String LOCATION_SEPARATOR = "/";
     private static List<String> applicationMigrationFiles;
 
@@ -26,7 +25,7 @@ public final class QuarkusPathLocationScanner implements ResourceAndClassScanner
 
         for (String migrationFile : applicationMigrationFiles) {
             if (canHandleMigrationFile(locations, migrationFile)) {
-                LOG.debug("Loading " + migrationFile);
+                LOGGER.debugf("Loading %s", migrationFile);
                 scannedResources.add(new ClassPathResource(null, migrationFile, classLoader, StandardCharsets.UTF_8));
             }
         }

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/ScannerSubstitutions.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/ScannerSubstitutions.java
@@ -36,7 +36,7 @@ public final class ScannerSubstitutions {
     @Substitute
     public ScannerSubstitutions(Class<?> implementedInterface, Collection<Location> locations, ClassLoader classLoader,
             Charset encoding, ResourceNameCache resourceNameCache) {
-        ResourceAndClassScanner quarkusScanner = new QuarkusPathLocationScanner();
+        ResourceAndClassScanner quarkusScanner = new QuarkusPathLocationScanner(locations);
         resources.addAll(quarkusScanner.scanForResources());
         classes.addAll(quarkusScanner.scanForClasses());
     }

--- a/integration-tests/flyway/src/main/java/io/quarkus/it/flyway/FlywayFunctionalityResource.java
+++ b/integration-tests/flyway/src/main/java/io/quarkus/it/flyway/FlywayFunctionalityResource.java
@@ -13,6 +13,8 @@ import javax.ws.rs.core.MediaType;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 
+import io.quarkus.flyway.FlywayDataSource;
+
 @Path("/")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -20,12 +22,25 @@ public class FlywayFunctionalityResource {
     @Inject
     Flyway flyway;
 
+    @Inject
+    @FlywayDataSource("second-datasource")
+    Flyway flyway2;
+
     @GET
     @Path("migrate")
     public String doMigrateAuto() {
         flyway.migrate();
         MigrationVersion version = Objects.requireNonNull(flyway.info().current().getVersion(),
                 "Version is null! Migration was not applied");
+        return version.toString();
+    }
+
+    @GET
+    @Path("multiple-flyway-migratation")
+    public String doMigratationOfSecondDataSource() {
+        flyway2.migrate();
+        MigrationVersion version = Objects.requireNonNull(flyway2.info().current().getVersion(),
+                "Version is null! Migration was not applied for second datasource");
         return version.toString();
     }
 

--- a/integration-tests/flyway/src/main/resources/application.properties
+++ b/integration-tests/flyway/src/main/resources/application.properties
@@ -5,8 +5,9 @@ quarkus.log.category."io.quarkus.flyway".level=DEBUG
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
+
+# default flyway configuration properties
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test_quarkus;DB_CLOSE_DELAY=-1
-# Flyway config properties
 quarkus.flyway.connect-retries=10
 quarkus.flyway.schemas=TEST_SCHEMA
 quarkus.flyway.table=flyway_quarkus_history
@@ -16,3 +17,13 @@ quarkus.flyway.migrate-at-start=true
 quarkus.flyway.placeholders.foo=bar
 
 quarkus.hibernate-orm.database.generation=validate
+
+# second Agroal config
+quarkus.datasource.second-datasource.db-kind=h2
+quarkus.datasource.second-datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test_multiple_flyway_datasource;DB_CLOSE_DELAY=-1
+
+# configuration to test multiple flyway datasources
+quarkus.flyway.second-datasource.locations=db/location3
+quarkus.flyway.second-datasource.sql-migration-prefix=V
+quarkus.flyway.second-datasource.migrate-at-start=true
+quarkus.flyway.second-datasource.placeholders.mambo=poa

--- a/integration-tests/flyway/src/main/resources/db/location3/V1.0.0__Quarkus.sql
+++ b/integration-tests/flyway/src/main/resources/db/location3/V1.0.0__Quarkus.sql
@@ -1,0 +1,7 @@
+CREATE TABLE multiple_flyway_test
+(
+    id   INT,
+    name VARCHAR(255)
+);
+INSERT INTO multiple_flyway_test(id, name)
+VALUES (1, 'Multiple flyway datasources should work seamlessly in JVM and native mode');

--- a/integration-tests/flyway/src/test/java/io/quarkus/it/flyway/FlywayFunctionalityTest.java
+++ b/integration-tests/flyway/src/test/java/io/quarkus/it/flyway/FlywayFunctionalityTest.java
@@ -19,6 +19,12 @@ public class FlywayFunctionalityTest {
     }
 
     @Test
+    @DisplayName("Migrates a schema correctly using second instance of Flyway")
+    public void testMultipleFlywayQuarkusFunctionality() {
+        when().get("/flyway/multiple-flyway-migratation").then().body(is("1.0.0"));
+    }
+
+    @Test
     @DisplayName("Returns current placeholders")
     public void testPlaceholders() {
         when().get("/flyway/placeholders").then().body("foo", is("bar"));


### PR DESCRIPTION
The QuarkusPathLocationScanner returned all migrations locations by default, this risked to cause
collision when we have a same filename for a migration script which is handled by different
datasources - a behaviour encountered on the issue #7685. Let's avoid this case by making sure that
the scanner only returns migration that it can recognize.

Fixes #7685

/cc @yanxuehe this should fix the issue for you. 