### PR TITLE
Update aws lambda

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -206,6 +206,8 @@ in the root directory of the project.
 
 The lambda can also be invoked locally with the SAM CLI like this:
 
+NOTE: If using Gradle, the path to the binaries in the `sam.jvm.yaml` must be changed from `target` to `build`
+
 [source]
 ----
 sam local invoke --template sam.jvm.yaml --event payload.json
@@ -307,7 +309,7 @@ Similarly for Gradle projects, if you want to adapt an existing project to use Q
 of things you need to do.  Take a look at the generated example project to get an example of what you need to adapt.
 
 1. Include the `quarkus-amazon-lambda`, and `quarkus-test-amazon-lambda` extensions as Gradle dependencies, as below
-2. Configure Quarkus to build an `uber-jar` (via appending --uber-jar to the Gradle build command)
+2. Configure Quarkus to build an `uber-jar` (via adding `quarkus.package.uber-jar=true` to `application.properties`)
 3. If you are doing a native image build, Amazon requires you to rename your executable to `bootstrap` and zip it up.
 
 

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/build.gradle
@@ -30,3 +30,26 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+buildNative {
+    enableHttpUrlHandler = true
+}
+
+task renameArtifacts (type: Copy) {
+    from "$buildDir"
+    include "${artifactId}-${version}-runner"
+    rename "${artifactId}-${version}-runner", "bootstrap"
+    into "$buildDir"
+}
+renameArtifacts.dependsOn build
+
+task createZip(type: Zip) {
+    from "$buildDir"
+    include 'bootstrap'
+    archiveName 'function.zip'
+    destinationDir(file("$buildDir"))
+}
+createZip.dependsOn renameArtifacts
+
+buildNative.finalizedBy createZip
+
+

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/gradle.properties
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/gradle.properties
@@ -4,4 +4,3 @@ quarkusPluginVersion=${project.version}
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformVersion=${project.version}
 quarkusPlatformGroupId=io.quarkus
-

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/sam.jvm.yaml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/sam.jvm.yaml
@@ -36,6 +36,6 @@ AWSTemplateFormatVersion: '2010-09-09'
         Handler: io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
         Runtime: java8
         CodeUri: target/${artifactId}-${version}-runner.jar
-        MemorySize: 128
+        MemorySize: 256
         Timeout: 15
         Policies: AWSLambdaBasicExecutionRole

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/sam.native.yaml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/sam.native.yaml
@@ -32,10 +32,10 @@ AWSTemplateFormatVersion: '2010-09-09'
     ${resourceName}NativeFunction:
       Type: AWS::Serverless::Function
       Properties:
-        Handler: not.used.in.provided.runtimei
+        Handler: not.used.in.provided.runtime
         Runtime: provided
         CodeUri: target/function.zip
-        MemorySize: 128
+        MemorySize: 256
         Policies: AWSLambdaBasicExecutionRole
         Timeout: 15
         Environment:

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.lambda.handler=test
+quarkus.package.uber-jar=true


### PR DESCRIPTION
Update amazon lambda extension and doc to also work for Gradle.

**New behavior**

- You can build a native image that will be renamed to `bootstrap` and zipped into `function.zip`.  Thereby behaving the same way as the `maven` workflow
- Updated quarkusBuild command to build an uber jar that you can use in amazon lambda
- Lambda memory to have working cold start