### PR TITLE
JPA named query with Hibernate with Panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -518,6 +518,25 @@ Order.find("select distinct o from Order o left join fetch o.lineItems");
 Order.update("update from Person set name = 'Mortal' where status = ?", Status.Alive);
 ----
 
+=== Named queries
+
+You can reference a named query instead of a (simplified) HQL query by prefixing its name with the '#' character.
+
+[source,java]
+----
+@Entity
+@NamedQuery(name = "Person.getByName", query = "from Person where name = :name")
+public class Person extends PanacheEntity {
+    public String name;
+    public LocalDate birth;
+    public Status status;
+
+    public static Person findByName(String name){
+        return find("#Person.getByName", name).firstResult();
+    }
+}
+----
+
 === Query parameters
 
 You can pass query parameters by index (1-based) as shown below:

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -537,6 +537,12 @@ public class Person extends PanacheEntity {
 }
 ----
 
+[WARNING]
+====
+Named queries can only be defined inside your JPA entity classes (being the Panache entity class, or the repository parameterized type),
+or on one of its super classes.
+====
+
 === Query parameters
 
 You can pass query parameters by index (1-based) as shown below:

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/NamedQueryEntityClassBuildStep.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/NamedQueryEntityClassBuildStep.java
@@ -1,0 +1,23 @@
+package io.quarkus.hibernate.orm.panache.deployment;
+
+import java.util.Set;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+final class NamedQueryEntityClassBuildStep extends MultiBuildItem {
+    private String className;
+    private Set<String> namedQueries;
+
+    public NamedQueryEntityClassBuildStep(String className, Set<String> namedQueries) {
+        this.className = className;
+        this.namedQueries = namedQueries;
+    }
+
+    public String getClassName() {
+        return this.className;
+    }
+
+    public Set<String> getNamedQueries() {
+        return namedQueries;
+    }
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
@@ -1,25 +1,36 @@
 package io.quarkus.hibernate.orm.panache.deployment;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.hibernate.orm.deployment.AdditionalJpaModelBuildItem;
 import io.quarkus.hibernate.orm.deployment.HibernateEnhancersRegisteredBuildItem;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.hibernate.orm.panache.PanacheHibernateRecorder;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.deployment.EntityField;
@@ -37,6 +48,10 @@ public final class PanacheResourceProcessor {
     private static final DotName DOTNAME_PANACHE_ENTITY = DotName.createSimple(PanacheEntity.class.getName());
 
     private static final DotName DOTNAME_ENTITY_MANAGER = DotName.createSimple(EntityManager.class.getName());
+
+    private static final DotName DOTNAME_NAMED_QUERY = DotName.createSimple(NamedQuery.class.getName());
+    private static final DotName DOTNAME_NAMED_QUERIES = DotName.createSimple(NamedQueries.class.getName());
+    private static final DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
 
     @BuildStep
     FeatureBuildItem featureBuildItem() {
@@ -60,10 +75,12 @@ public final class PanacheResourceProcessor {
     void build(CombinedIndexBuildItem index,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
             HibernateEnhancersRegisteredBuildItem hibernateMarker,
-            BuildProducer<PanacheEntityClassesBuildItem> entityClasses) throws Exception {
+            BuildProducer<PanacheEntityClassesBuildItem> entityClasses,
+            BuildProducer<NamedQueryEntityClassBuildStep> namedQueries) throws Exception {
 
         PanacheJpaRepositoryEnhancer daoEnhancer = new PanacheJpaRepositoryEnhancer(index.getIndex());
         Set<String> daoClasses = new HashSet<>();
+        Set<Type> daoTypeParameters = new HashSet<>();
         for (ClassInfo classInfo : index.getIndex().getAllKnownImplementors(DOTNAME_PANACHE_REPOSITORY_BASE)) {
             // Skip PanacheRepository
             if (classInfo.name().equals(DOTNAME_PANACHE_REPOSITORY))
@@ -76,9 +93,18 @@ public final class PanacheResourceProcessor {
             if (PanacheRepositoryEnhancer.skipRepository(classInfo))
                 continue;
             daoClasses.add(classInfo.name().toString());
+            daoTypeParameters.addAll(
+                    JandexUtil.resolveTypeParameters(classInfo.name(), DOTNAME_PANACHE_REPOSITORY_BASE, index.getIndex()));
         }
         for (String daoClass : daoClasses) {
             transformers.produce(new BytecodeTransformerBuildItem(daoClass, daoEnhancer));
+        }
+
+        for (Type parameterType : daoTypeParameters) {
+            // lookup for `@NamedQuery` on the hierarchy and produce NamedQueryEntityClassBuildStep
+            Set<String> typeNamedQueries = new HashSet<>();
+            lookupNamedQueries(index, parameterType.name(), typeNamedQueries);
+            namedQueries.produce(new NamedQueryEntityClassBuildStep(parameterType.name().toString(), typeNamedQueries));
         }
 
         PanacheJpaEntityEnhancer modelEnhancer = new PanacheJpaEntityEnhancer(index.getIndex());
@@ -99,6 +125,11 @@ public final class PanacheResourceProcessor {
         }
         for (String modelClass : modelClasses) {
             transformers.produce(new BytecodeTransformerBuildItem(modelClass, modelEnhancer));
+
+            // lookup for `@NamedQuery` on the hierarchy and produce NamedQueryEntityClassBuildStep
+            Set<String> typeNamedQueries = new HashSet<>();
+            lookupNamedQueries(index, DotName.createSimple(modelClass), typeNamedQueries);
+            namedQueries.produce(new NamedQueryEntityClassBuildStep(modelClass, typeNamedQueries));
         }
         if (!modelClasses.isEmpty()) {
             entityClasses.produce(new PanacheEntityClassesBuildItem(modelClasses));
@@ -113,6 +144,50 @@ public final class PanacheResourceProcessor {
                     transformers.produce(new BytecodeTransformerBuildItem(className, panacheFieldAccessEnhancer));
                 }
             }
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void buildNamedQueryMap(List<NamedQueryEntityClassBuildStep> namedQueryEntityClasses,
+            PanacheHibernateRecorder panacheHibernateRecorder) {
+        Map<String, Set<String>> namedQueryMap = new HashMap<>();
+        for (NamedQueryEntityClassBuildStep entityNamedQueries : namedQueryEntityClasses) {
+            namedQueryMap.put(entityNamedQueries.getClassName(), entityNamedQueries.getNamedQueries());
+        }
+
+        panacheHibernateRecorder.setNamedQueryMap(namedQueryMap);
+    }
+
+    private void lookupNamedQueries(CombinedIndexBuildItem index, DotName name, Set<String> namedQueries) {
+        ClassInfo classInfo = index.getIndex().getClassByName(name);
+        if (classInfo == null) {
+            return;
+        }
+
+        List<AnnotationInstance> namedQueryInstances = classInfo.annotations().get(DOTNAME_NAMED_QUERY);
+        if (namedQueryInstances != null) {
+            for (AnnotationInstance namedQueryInstance : namedQueryInstances) {
+                namedQueries.add(namedQueryInstance.value("name").asString());
+            }
+        }
+
+        List<AnnotationInstance> namedQueriesInstances = classInfo.annotations().get(DOTNAME_NAMED_QUERIES);
+        if (namedQueriesInstances != null) {
+            for (AnnotationInstance namedQueriesInstance : namedQueriesInstances) {
+                AnnotationValue value = namedQueriesInstance.value();
+                AnnotationInstance[] nestedInstances = value.asNestedArray();
+                for (AnnotationInstance nested : nestedInstances) {
+                    namedQueries.add(nested.value("name").asString());
+                }
+            }
+        }
+
+        // climb up the hierarchy of types
+        if (!classInfo.superClassType().name().equals(DOTNAME_OBJECT)) {
+            Type superType = classInfo.superClassType();
+            ClassInfo superClass = index.getIndex().getClassByName(superType.name());
+            lookupNamedQueries(index, superClass.name(), namedQueries);
         }
     }
 }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheHibernateRecorder.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheHibernateRecorder.java
@@ -1,0 +1,14 @@
+package io.quarkus.hibernate.orm.panache;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.hibernate.orm.panache.runtime.NamedQueryUtil;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class PanacheHibernateRecorder {
+    public void setNamedQueryMap(Map<String, Set<String>> namedQueryMap) {
+        NamedQueryUtil.setNamedQueryMap(namedQueryMap);
+    }
+}

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/package-info.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/package-info.java
@@ -75,6 +75,9 @@
  * <li><code>set? &lt;update-query&gt;</code> will expand to
  * <code>update from EntityName set &lt;update-query&gt; = ?</code></li>
  * </ul>
+ *
+ * We also support named queries, for Panache to know that a query is a named query and not an HQL one, you need
+ * to prefix the name of the query with '#'.
  * 
  * @author Stéphane Épardaud
  */

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -265,7 +265,9 @@ public class JpaOperations {
         // FIXME: check for duplicate ORDER BY clause?
         Query jpaQuery;
         if (isNamedQuery(query)) {
-            jpaQuery = em.createNamedQuery(query.substring(1));
+            String namedQuery = query.substring(1);
+            NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
+            jpaQuery = em.createNamedQuery(namedQuery);
         } else {
             jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         }
@@ -284,7 +286,9 @@ public class JpaOperations {
         // FIXME: check for duplicate ORDER BY clause?
         Query jpaQuery;
         if (isNamedQuery(query)) {
-            jpaQuery = em.createNamedQuery(query.substring(1));
+            String namedQuery = query.substring(1);
+            NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
+            jpaQuery = em.createNamedQuery(namedQuery);
         } else {
             jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -115,12 +115,19 @@ public class JpaOperations {
     }
 
     static String createFindQuery(Class<?> entityClass, String query, int paramCount) {
-        if (query == null)
+        if (query == null) {
             return "FROM " + getEntityName(entityClass);
+        }
 
         String trimmed = query.trim();
-        if (trimmed.isEmpty())
+        if (trimmed.isEmpty()) {
             return "FROM " + getEntityName(entityClass);
+        }
+
+        if (isNamedQuery(query)) {
+            // we return named query as is
+            return query;
+        }
 
         String trimmedLc = trimmed.toLowerCase();
         if (trimmedLc.startsWith("from ") || trimmedLc.startsWith("select ")) {
@@ -133,6 +140,13 @@ public class JpaOperations {
             query += " = ?1";
         }
         return "FROM " + getEntityName(entityClass) + " WHERE " + query;
+    }
+
+    static boolean isNamedQuery(String query) {
+        if (query == null || query.isEmpty()) {
+            return false;
+        }
+        return query.charAt(0) == '#';
     }
 
     private static String createCountQuery(Class<?> entityClass, String query, int paramCount) {
@@ -249,7 +263,12 @@ public class JpaOperations {
         String findQuery = createFindQuery(entityClass, query, paramCount(params));
         EntityManager em = getEntityManager();
         // FIXME: check for duplicate ORDER BY clause?
-        Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        Query jpaQuery;
+        if (isNamedQuery(query)) {
+            jpaQuery = em.createNamedQuery(query.substring(1));
+        } else {
+            jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        }
         bindParameters(jpaQuery, params);
         return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
     }
@@ -263,7 +282,12 @@ public class JpaOperations {
         String findQuery = createFindQuery(entityClass, query, paramCount(params));
         EntityManager em = getEntityManager();
         // FIXME: check for duplicate ORDER BY clause?
-        Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        Query jpaQuery;
+        if (isNamedQuery(query)) {
+            jpaQuery = em.createNamedQuery(query.substring(1));
+        } else {
+            jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+        }
         bindParameters(jpaQuery, params);
         return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
     }

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/NamedQueryUtil.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/NamedQueryUtil.java
@@ -1,0 +1,29 @@
+package io.quarkus.hibernate.orm.panache.runtime;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.panache.common.exception.PanacheQueryException;
+
+public final class NamedQueryUtil {
+
+    // will be replaced at augmentation phase
+    private static volatile Map<String, Set<String>> namedQueryMap = Collections.emptyMap();
+
+    private NamedQueryUtil() {
+        // prevent initialization
+    }
+
+    public static void setNamedQueryMap(Map<String, Set<String>> newNamedQueryMap) {
+        namedQueryMap = newNamedQueryMap;
+    }
+
+    public static void checkNamedQuery(Class<?> entityClass, String namedQuery) {
+        Set<String> namedQueries = namedQueryMap.get(entityClass.getName());
+        if (namedQueries == null || !namedQueries.contains(namedQuery)) {
+            throw new PanacheQueryException("The named query '" + namedQuery +
+                    "' must be defined on your JPA entity or one of its super classes");
+        }
+    }
+}

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -15,6 +15,7 @@ import javax.persistence.Query;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Range;
+import io.quarkus.panache.common.exception.PanacheQueryException;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
@@ -141,6 +142,10 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     @SuppressWarnings("unchecked")
     public long count() {
+        if (JpaOperations.isNamedQuery(query)) {
+            throw new PanacheQueryException("Unable to perform a count operation on a named query");
+        }
+
         if (count == null) {
             // FIXME: this is crude but good enough for a first version
             String lcQuery = query.toLowerCase();

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryEntity.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryEntity.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+import javax.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "NamedQueryEntity.getAll", query = "from NamedQueryEntity")
+public class NamedQueryEntity extends NamedQueryMappedSuperClass {
+    public String test;
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryMappedSuperClass.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryMappedSuperClass.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.MappedSuperclass;
+import javax.persistence.NamedQuery;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@MappedSuperclass
+@NamedQuery(name = "NamedQueryMappedSuperClass.getAll", query = "from NamedQueryEntity")
+public class NamedQueryMappedSuperClass extends PanacheEntity {
+    public String superField;
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryRepository.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.panache;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+@ApplicationScoped
+public class NamedQueryRepository implements PanacheRepository<NamedQueryEntity> {
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryWith2QueriesEntity.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryWith2QueriesEntity.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+import javax.persistence.NamedQuery;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+@NamedQuery(name = "NamedQueryWith2QueriesEntity.getAll1", query = "from NamedQueryWith2QueriesEntity")
+@NamedQuery(name = "NamedQueryWith2QueriesEntity.getAll2", query = "from NamedQueryWith2QueriesEntity")
+public class NamedQueryWith2QueriesEntity extends PanacheEntity {
+    public String test;
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryWith2QueriesRepository.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NamedQueryWith2QueriesRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.panache;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+@ApplicationScoped
+public class NamedQueryWith2QueriesRepository implements PanacheRepository<NamedQueryWith2QueriesEntity> {
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Person.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Person.java
@@ -8,6 +8,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Transient;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -19,6 +20,7 @@ import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
 @XmlRootElement
 @Entity(name = "Person2")
+@NamedQuery(name = "Person.getByName", query = "from Person2 where name = :name")
 public class Person extends PanacheEntity {
 
     public String name;

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -31,7 +31,6 @@ import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.hibernate.jpa.QueryHints;
 import org.junit.jupiter.api.Assertions;
 
-import io.quarkus.hibernate.orm.panache.Panache;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Parameters;
@@ -156,6 +155,11 @@ public class TestEndpoint {
         persons = Person.find("#Person.getByName", Parameters.with("name", "stef")).list();
         Assertions.assertEquals(1, persons.size());
         Assertions.assertEquals(person, persons.get(0));
+        Assertions.assertThrows(PanacheQueryException.class, () -> Person.find("#Person.namedQueryNotFound").list());
+        NamedQueryEntity.find("#NamedQueryMappedSuperClass.getAll").list();
+        NamedQueryEntity.find("#NamedQueryEntity.getAll").list();
+        NamedQueryWith2QueriesEntity.find("#NamedQueryWith2QueriesEntity.getAll1").list();
+        NamedQueryWith2QueriesEntity.find("#NamedQueryWith2QueriesEntity.getAll2").list();
 
         //empty query
         persons = Person.find("").list();
@@ -510,6 +514,10 @@ public class TestEndpoint {
     DogDao dogDao;
     @Inject
     AddressDao addressDao;
+    @Inject
+    NamedQueryRepository namedQueryRepository;
+    @Inject
+    NamedQueryWith2QueriesRepository namedQueryWith2QueriesRepository;
 
     @GET
     @Path("model-dao")
@@ -618,6 +626,11 @@ public class TestEndpoint {
         persons = personDao.find("#Person.getByName", Parameters.with("name", "stef")).list();
         Assertions.assertEquals(1, persons.size());
         Assertions.assertEquals(person, persons.get(0));
+        Assertions.assertThrows(PanacheQueryException.class, () -> personDao.find("#Person.namedQueryNotFound").list());
+        namedQueryRepository.find("#NamedQueryMappedSuperClass.getAll").list();
+        namedQueryRepository.find("#NamedQueryEntity.getAll").list();
+        namedQueryWith2QueriesRepository.find("#NamedQueryWith2QueriesEntity.getAll1").list();
+        namedQueryWith2QueriesRepository.find("#NamedQueryWith2QueriesEntity.getAll2").list();
 
         //empty query
         persons = personDao.find("").list();

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -152,6 +152,19 @@ public class TestEndpoint {
         Assertions.assertEquals(person, Person.find("name", "stef").firstResult());
         Assertions.assertEquals(person, Person.find("name", "stef").singleResult());
 
+        //named query
+        persons = Person.find("#Person.getByName", Parameters.with("name", "stef")).list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+
+        //empty query
+        persons = Person.find("").list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+        persons = Person.find(null).list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+
         Person byId = Person.findById(person.id);
         Assertions.assertEquals(person, byId);
         Assertions.assertEquals("Person<" + person.id + ">", byId.toString());
@@ -600,6 +613,19 @@ public class TestEndpoint {
         Assertions.assertEquals(person, personDao.find("name", "stef").firstResult());
         Assertions.assertEquals(person, personDao.find("name", "stef").singleResult());
         Assertions.assertEquals(person, personDao.find("name", "stef").singleResultOptional().get());
+
+        // named query
+        persons = personDao.find("#Person.getByName", Parameters.with("name", "stef")).list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+
+        //empty query
+        persons = personDao.find("").list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+        persons = personDao.find(null).list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
 
         Person byId = personDao.findById(person.id);
         Assertions.assertEquals(person, byId);


### PR DESCRIPTION
This PR adds support for JPA named queries inside Hibernate with Panache.

Fixes #3483

I only added tests for the `find()` method but it should works for `count()`, `delete()` and `update()` as the code is common to all query constructions.