### PR TITLE
[WIP] Load Quarkus HTTP first

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -89,7 +89,7 @@ public class DevModeMain implements Closeable {
             if (context.getProjectDir() != null) {
                 bootstrapBuilder.setProjectRoot(context.getProjectDir().toPath());
             } else {
-                bootstrapBuilder.setProjectRoot(new File(".").toPath());
+                bootstrapBuilder.setProjectRoot(Paths.get("").toAbsolutePath().normalize());
             }
             for (int i = 1; i < context.getClassesRoots().size(); ++i) {
                 bootstrapBuilder.addAdditionalApplicationArchive(

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -106,6 +106,9 @@
                     <parentFirstArtifacts>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-core</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-development-mode-spi</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus.http:quarkus-http-core</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus.http:quarkus-http-servlet</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus.http:quarkus-http-websockets-jsr</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logmanager:jboss-logmanager-embedded</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logging:jboss-logging</parentFirstArtifact>
                         <parentFirstArtifact>org.ow2.asm:asm</parentFirstArtifact>


### PR DESCRIPTION
QuarkusDev depends on quarkus-devtools-common which requires Quarkus HTTP (including Websockets)

Fixes #7996