### PR TITLE
fix security checks to make @RolesAllowed("**") work

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -78,7 +78,7 @@ Quarkus comes with built-in security to allow for Role-Based Access Control (lin
 based on the common security annotations `@RolesAllowed`, `@DenyAll`, `@PermitAll` on REST endpoints and CDI beans.
 An example of an endpoint that makes use of both JAX-RS and Common Security annotations to describe and secure its endpoints is given in <<subject-example>>. Quarkus also provides
 the `io.quarkus.security.Authenticated` annotation that will permit any authenticated user to access the resource
-(equivalent to `@RolesAllowed("*")`).
+(equivalent to `@RolesAllowed("**")`).
 
 [#subject-example]
 .SubjectExposingResource Example

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/RolesAllowedCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/RolesAllowedCheck.java
@@ -54,7 +54,7 @@ public class RolesAllowedCheck implements SecurityCheck {
         Set<String> roles = identity.getRoles();
         if (roles != null) {
             for (String role : allowedRoles) {
-                if (roles.contains(role)) {
+                if (roles.contains(role) || ("**".equals(role) && !identity.isAnonymous())) {
                     return;
                 }
             }

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/RBACBean.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/RBACBean.java
@@ -18,6 +18,11 @@ public class RBACBean {
         return "callingAuthenticated";
     }
 
+    @RolesAllowed("**")
+    public String allRoles() {
+        return "callingAllRoles";
+    }
+
     @PermitAll
     public String permitted() {
         return "callingPermitted";

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/RBACSecuredResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/RBACSecuredResource.java
@@ -59,9 +59,22 @@ public class RBACSecuredResource {
     }
 
     @GET
+    @RolesAllowed("**")
+    @Path("allRoles")
+    public String allRoles() {
+        return "allRoles";
+    }
+
+    @GET
     @Path("callingAuthenticated")
     public String callingAuthenticated() {
         return bean.authenticated();
+    }
+
+    @GET
+    @Path("callingAllRoles")
+    public String callingAllRoles() {
+        return bean.allRoles();
     }
 
     @GET

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RBACAccessTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RBACAccessTest.java
@@ -53,6 +53,12 @@ public class RBACAccessTest {
     }
 
     @Test
+    public void shouldRestrictAllRoles() {
+        assertForAnonymous("/rbac-secured/allRoles", 401, Optional.empty());
+        assertForUsers("/rbac-secured/allRoles", 200, Optional.of("allRoles"));
+    }
+
+    @Test
     public void shouldRestrictAccessToSpecificRoleOnBean() {
         String path = "/rbac-secured/callingTesterOnly";
         assertForAnonymous(path, 401, Optional.empty());
@@ -77,6 +83,12 @@ public class RBACAccessTest {
     public void shouldRestrictAuthenticatedOnBean() {
         assertForAnonymous("/rbac-secured/callingAuthenticated", 401, Optional.empty());
         assertForUsers("/rbac-secured/callingAuthenticated", 200, Optional.of("callingAuthenticated"));
+    }
+
+    @Test
+    public void shouldRestrictAllRolesOnBean() {
+        assertForAnonymous("/rbac-secured/callingAllRoles", 401, Optional.empty());
+        assertForUsers("/rbac-secured/callingAllRoles", 200, Optional.of("callingAllRoles"));
     }
 
     private void assertForAnonymous(String path, int status, Optional<String> content) {


### PR DESCRIPTION
The correct wildcard to use seems to be `**`, because that's what
the Jakarta EE specifications use. More specifically:

- the EJB spec says that `**` means all roles
  (chapter 12.2.5.2 in EJB 3.2 Core spec)
- the Servlet spec says that `**` means all roles and `*` should
  never be used (chapter 13.3 in Servlet 4.0 spec)
- the JAX-RS specification doesn't seem to define this, but
  `QuarkusResteasySecurityContext.isUserInRole` already uses `**`

Resolves #7994.