### PR TITLE
Use the actual DynamicTest type in test

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DynamicTestsTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DynamicTestsTestCase.java
@@ -27,7 +27,7 @@ public class DynamicTestsTestCase {
     }
 
     @TestFactory
-    public List<?> dynamicTests() {
+    public List<DynamicTest> dynamicTests() {
         return Arrays.asList(
                 DynamicTest.dynamicTest("test 1", () -> {
                     assertNotNull(bean);


### PR DESCRIPTION
`?` was only used with the previous solution,
with the new solution, code can refer to the type
without any problem