### PR TITLE
ObserverGenerator - rework the way a declaring bean instance is obtained

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -174,7 +174,7 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     /**
      * 
-     * @return the class of the declaring bean or
+     * @return the class of the declaring bean or the class provided by the configurator for synthetic observers
      */
     public DotName getBeanClass() {
         return beanClass;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/notification/ObserverNotificationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/notification/ObserverNotificationTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.arc.test.observers.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ObserverNotificationTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(StringObserver.class);
+
+    @Test
+    public void testContextualInstanceIsUsed() {
+        assertEquals(0, StringObserver.CONSTRUCTED.get());
+        assertEquals(0, StringObserver.NOTIFIED.get());
+        Arc.container().beanManager().fireEvent("hello");
+        assertEquals(1, StringObserver.CONSTRUCTED.get());
+        assertEquals(1, StringObserver.NOTIFIED.get());
+    }
+
+    @ApplicationScoped
+    static class StringObserver {
+
+        private static final AtomicInteger CONSTRUCTED = new AtomicInteger();
+        private static final AtomicInteger NOTIFIED = new AtomicInteger();
+
+        StringObserver() {
+            CONSTRUCTED.incrementAndGet();
+        }
+
+        void observeString(@Observes String value) {
+            NOTIFIED.incrementAndGet();
+        }
+
+    }
+
+}


### PR DESCRIPTION
- also create client proxy instances lazily
- resolves #8062