### PR TITLE
Ensure that generated Kotlin - Maven projects target Java 8

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/pom.xml-template.ftl
@@ -107,6 +107,7 @@
                 </executions>
                 <configuration>
                     <javaParameters>true</javaParameters>
+                    <jvmTarget>1.8</jvmTarget>
                     <!-- Soon to be replaced by plugin that will pre-configure all necessary annotations -->
                     <compilerPlugins>
                         <plugin>all-open</plugin>


### PR DESCRIPTION
Fixes: #8104

FWIW, we already do this for generated Gradle projects: https://github.com/quarkusio/quarkus/blob/master/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/build.gradle-template.ftl#L44 