### PR TITLE
Add more test to MongoDB with Panache

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
@@ -207,11 +207,11 @@ public abstract class PanacheMongoEntityBase {
      *
      * @param query a {@link org.bson.Document} query
      * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends PanacheMongoEntityBase> PanacheQuery<T> find(Document query) {
@@ -224,11 +224,11 @@ public abstract class PanacheMongoEntityBase {
      * @param query a {@link org.bson.Document} query
      * @param sort the {@link org.bson.Document} sort
      * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends PanacheMongoEntityBase> PanacheQuery<T> find(Document query, Document sort) {
@@ -378,12 +378,12 @@ public abstract class PanacheMongoEntityBase {
      * This method is a shortcut for <code>find(query).list()</code>.
      *
      * @param query a {@link org.bson.Document} query
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends PanacheMongoEntityBase> List<T> list(Document query) {
@@ -396,12 +396,12 @@ public abstract class PanacheMongoEntityBase {
      *
      * @param query a {@link org.bson.Document} query
      * @param sort the {@link org.bson.Document} sort
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends PanacheMongoEntityBase> List<T> list(Document query, Document sort) {
@@ -553,12 +553,12 @@ public abstract class PanacheMongoEntityBase {
      * This method is a shortcut for <code>find(query).stream()</code>.
      *
      * @param query a {@link org.bson.Document} query
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link Stream} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends PanacheMongoEntityBase> Stream<T> stream(Document query) {
@@ -571,12 +571,12 @@ public abstract class PanacheMongoEntityBase {
      *
      * @param query a {@link org.bson.Document} query
      * @param sort the {@link org.bson.Document} sort
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link Stream} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends PanacheMongoEntityBase> Stream<T> stream(Document query, Document sort) {

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheMongoRepositoryBase.java
@@ -213,11 +213,11 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link org.bson.Document} query
      * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public default PanacheQuery<Entity> find(Document query) {
@@ -230,11 +230,11 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      * @param query a {@link org.bson.Document} query
      * @param sort the {@link org.bson.Document} sort
      * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public default PanacheQuery<Entity> find(Document query, Document sort) {
@@ -384,15 +384,15 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      * This method is a shortcut for <code>find(query).list()</code>.
      *
      * @param query a {@link org.bson.Document} query
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
-    public default PanacheQuery<Entity> list(Document query) {
+    public default List<Entity> list(Document query) {
         throw MongoOperations.implementationInjectionMissing();
     }
 
@@ -402,15 +402,15 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link org.bson.Document} query
      * @param sort the {@link org.bson.Document} sort
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
-    public default PanacheQuery<Entity> list(Document query, Document sort) {
+    public default List<Entity> list(Document query, Document sort) {
         throw MongoOperations.implementationInjectionMissing();
     }
 
@@ -559,15 +559,15 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      * This method is a shortcut for <code>find(query).stream()</code>.
      *
      * @param query a {@link org.bson.Document} query
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link Stream} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
-    public default PanacheQuery<Entity> stream(Document query) {
+    public default Stream<Entity> stream(Document query) {
         throw MongoOperations.implementationInjectionMissing();
     }
 
@@ -577,15 +577,15 @@ public interface PanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link org.bson.Document} query
      * @param sort the {@link org.bson.Document} sort
-     * @return a new {@link PanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link Stream} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
      */
     @GenerateBridge
-    public default PanacheQuery<Entity> stream(Document query, Document sort) {
+    public default Stream<Entity> stream(Document query, Document sort) {
         throw MongoOperations.implementationInjectionMissing();
     }
 

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoEntityBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoEntityBase.java
@@ -213,11 +213,11 @@ public abstract class ReactivePanacheMongoEntityBase {
      *
      * @param query a {@link Document} query
      * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends ReactivePanacheMongoEntityBase> ReactivePanacheQuery<T> find(Document query) {
@@ -230,11 +230,11 @@ public abstract class ReactivePanacheMongoEntityBase {
      * @param query a {@link Document} query
      * @param sort the {@link Document} sort
      * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends ReactivePanacheMongoEntityBase> ReactivePanacheQuery<T> find(Document query, Document sort) {
@@ -388,12 +388,12 @@ public abstract class ReactivePanacheMongoEntityBase {
      * This method is a shortcut for <code>find(query).list()</code>.
      *
      * @param query a {@link Document} query
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends ReactivePanacheMongoEntityBase> Uni<List<T>> list(Document query) {
@@ -406,12 +406,12 @@ public abstract class ReactivePanacheMongoEntityBase {
      *
      * @param query a {@link Document} query
      * @param sort the {@link Document} sort
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public static <T extends ReactivePanacheMongoEntityBase> Uni<List<T>> list(Document query, Document sort) {
@@ -453,7 +453,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param params optional sequence of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Sort, Object...)
      * @see #stream(String, Map)
      * @see #stream(String, Parameters)
@@ -472,7 +472,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Object...)
      * @see #stream(String, Sort, Map)
      * @see #stream(String, Sort, Parameters)
@@ -490,7 +490,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param params {@link Map} of named parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Sort, Map)
      * @see #stream(String, Object...)
      * @see #stream(String, Parameters)
@@ -509,7 +509,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param sort the sort strategy to use
      * @param params {@link Map} of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Map)
      * @see #stream(String, Sort, Object...)
      * @see #stream(String, Sort, Parameters)
@@ -528,7 +528,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param params {@link Parameters} of named parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Sort, Parameters)
      * @see #stream(String, Object...)
      * @see #stream(String, Map)
@@ -547,7 +547,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param sort the sort strategy to use
      * @param params {@link Parameters} of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Parameters)
      * @see #stream(String, Sort, Object...)
      * @see #stream(String, Sort, Map)
@@ -564,7 +564,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      * This method is a shortcut for <code>find(query).stream()</code>.
      *
      * @param query a {@link Document} query
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
+     * @return a {@link Multi} containing all results, without paging
      * @see #find(String, Parameters)
      * @see #find(String, Sort, Map)
      * @see #find(String, Sort, Parameters)
@@ -582,7 +582,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      *
      * @param query a {@link Document} query
      * @param sort the {@link Document} sort
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
+     * @return a {@link Multi} containing all results, without paging
      * @see #find(String, Parameters)
      * @see #find(String, Sort, Map)
      * @see #find(String, Sort, Parameters)
@@ -598,7 +598,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      * Find all entities of this type.
      * This method is a shortcut for <code>findAll().stream()</code>.
      *
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #streamAll(Sort)
      * @see #findAll()
      * @see #listAll()
@@ -613,7 +613,7 @@ public abstract class ReactivePanacheMongoEntityBase {
      * This method is a shortcut for <code>findAll(sort).stream()</code>.
      *
      * @param sort the sort order to use
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #streamAll()
      * @see #findAll(Sort)
      * @see #listAll(Sort)

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoRepositoryBase.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheMongoRepositoryBase.java
@@ -215,11 +215,11 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link Document} query
      * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public default ReactivePanacheQuery<Entity> find(Document query) {
@@ -232,11 +232,11 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * @param query a {@link Document} query
      * @param sort the {@link Document} sort
      * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @see #find(Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public default ReactivePanacheQuery<Entity> find(Document query, Document sort) {
@@ -386,15 +386,15 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * This method is a shortcut for <code>find(query).list()</code>.
      *
      * @param query a {@link Document} query
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
-    public default ReactivePanacheQuery<Entity> list(Document query) {
+    public default Uni<List<Entity>> list(Document query) {
         throw ReactiveMongoOperations.implementationInjectionMissing();
     }
 
@@ -404,15 +404,15 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link Document} query
      * @param sort the {@link Document} sort
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link List} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
-    public default ReactivePanacheQuery<Entity> list(Document query, Document sort) {
+    public default Uni<List<Entity>> list(Document query, Document sort) {
         throw ReactiveMongoOperations.implementationInjectionMissing();
     }
 
@@ -451,7 +451,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param params optional sequence of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Sort, Object...)
      * @see #stream(String, Map)
      * @see #stream(String, Parameters)
@@ -470,7 +470,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Object...)
      * @see #stream(String, Sort, Map)
      * @see #stream(String, Sort, Parameters)
@@ -488,7 +488,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param params {@link Map} of named parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Sort, Map)
      * @see #stream(String, Object...)
      * @see #stream(String, Parameters)
@@ -507,7 +507,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param sort the sort strategy to use
      * @param params {@link Map} of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Map)
      * @see #stream(String, Sort, Object...)
      * @see #stream(String, Sort, Parameters)
@@ -525,7 +525,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param params {@link Parameters} of named parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Sort, Parameters)
      * @see #stream(String, Object...)
      * @see #stream(String, Map)
@@ -544,7 +544,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * @param query a {@link io.quarkus.mongodb.panache query string}
      * @param sort the sort strategy to use
      * @param params {@link Parameters} of indexed parameters
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #stream(String, Parameters)
      * @see #stream(String, Sort, Object...)
      * @see #stream(String, Sort, Map)
@@ -561,12 +561,13 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * This method is a shortcut for <code>find(query).stream()</code>.
      *
      * @param query a {@link Document} query
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link Multi} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public default Multi<Entity> stream(Document query) {
@@ -579,12 +580,13 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      *
      * @param query a {@link Document} query
      * @param sort the {@link Document} sort
-     * @return a new {@link ReactivePanacheQuery} instance for the given query
-     * @see #find(String, Parameters)
-     * @see #find(String, Sort, Map)
-     * @see #find(String, Sort, Parameters)
-     * @see #list(String, Sort, Parameters)
-     * @see #stream(String, Sort, Parameters)
+     * @return a {@link Multi} containing all results, without paging
+     * @see #find(Document)
+     * @see #find(Document, Document)
+     * @see #list(Document)
+     * @see #list(Document, Document)
+     * @see #stream(Document)
+     * @see #stream(Document, Document)
      */
     @GenerateBridge
     public default Multi<Entity> stream(Document query, Document sort) {
@@ -595,7 +597,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * Find all entities of this type.
      * This method is a shortcut for <code>findAll().stream()</code>.
      *
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #streamAll(Sort)
      * @see #findAll()
      * @see #listAll()
@@ -609,7 +611,7 @@ public interface ReactivePanacheMongoRepositoryBase<Entity, Id> {
      * Find all entities of this type, in the given order.
      * This method is a shortcut for <code>findAll(sort).stream()</code>.
      *
-     * @return a {@link Stream} containing all results, without paging
+     * @return a {@link Multi} containing all results, without paging
      * @see #streamAll()
      * @see #findAll(Sort)
      * @see #listAll(Sort)

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactiveMongoOperations.java
@@ -238,11 +238,8 @@ public class ReactiveMongoOperations {
     }
 
     private static Uni<Void> update(ReactiveMongoCollection collection, List<Object> entities) {
-        Uni<Void> ret = nullUni();
-        for (Object entity : entities) {
-            ret.and(update(collection, entity));
-        }
-        return ret.onItem().ignore().andContinueWithNull();
+        List<Uni<Void>> unis = entities.stream().map(entity -> update(collection, entity)).collect(Collectors.toList());
+        return Uni.combine().all().unis(unis).combinedWith(u -> null);
     }
 
     private static Uni<Void> persistOrUpdate(ReactiveMongoCollection collection, Object entity) {

--- a/integration-tests/mongodb-panache/pom.xml
+++ b/integration-tests/mongodb-panache/pom.xml
@@ -32,6 +32,13 @@
             <artifactId>quarkus-rest-client</artifactId>
         </dependency>
 
+        <!-- Force the scope to compile as we make assertions inside the resources -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestImperativeEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestImperativeEntity.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.mongodb.panache.test;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class TestImperativeEntity extends PanacheMongoEntity {
+    public String title;
+    public String category;
+    public String description;
+
+    public TestImperativeEntity() {
+    }
+
+    public TestImperativeEntity(String title, String category, String description) {
+        this.title = title;
+        this.category = category;
+        this.description = description;
+    }
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestImperativeRepository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestImperativeRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.test;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+
+@ApplicationScoped
+public class TestImperativeRepository implements PanacheMongoRepository<TestImperativeEntity> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestReactiveEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestReactiveEntity.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.mongodb.panache.test;
+
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class TestReactiveEntity extends ReactivePanacheMongoEntity {
+    public String title;
+    public String category;
+    public String description;
+
+    public TestReactiveEntity() {
+    }
+
+    public TestReactiveEntity(String title, String category, String description) {
+        this.title = title;
+        this.category = category;
+        this.description = description;
+    }
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestReactiveRepository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestReactiveRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.test;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoRepository;
+
+@ApplicationScoped
+public class TestReactiveRepository implements ReactivePanacheMongoRepository<TestReactiveEntity> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestResource.java
@@ -1,0 +1,562 @@
+package io.quarkus.it.mongodb.panache.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.mongodb.panache.PanacheQuery;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Parameters;
+import io.quarkus.panache.common.Sort;
+
+@Path("/test")
+public class TestResource {
+
+    @Inject
+    TestImperativeRepository testImperativeRepository;
+    @Inject
+    TestReactiveRepository testReactiveRepository;
+
+    @GET
+    @Path("imperative/entity")
+    public Response testImperativeEntity() {
+        List<TestImperativeEntity> entities = getTestImperativeEntities();
+
+        // insert all
+        Assertions.assertEquals(0, TestImperativeEntity.count());
+        TestImperativeEntity.persist(entities);
+        Assertions.assertEquals(10, TestImperativeEntity.count());
+
+        // varargs
+        TestImperativeEntity entity11 = new TestImperativeEntity("title11", "category", "desc");
+        TestImperativeEntity entity12 = new TestImperativeEntity("title11", "category", "desc");
+        TestImperativeEntity.persist(entity11, entity12);
+        Assertions.assertEquals(12, TestImperativeEntity.count());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        TestImperativeEntity.update(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        TestImperativeEntity.persistOrUpdate(entity11, entity12);
+        Assertions.assertEquals(12, TestImperativeEntity.count());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        TestImperativeEntity.persistOrUpdate(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        Assertions.assertEquals(10, TestImperativeEntity.count());
+
+        // paginate
+        testImperativePagination(TestImperativeEntity.findAll());
+
+        // range
+        testImperativeRange(TestImperativeEntity.findAll());
+
+        // query
+        Assertions.assertEquals(5, TestImperativeEntity.list("category", "category0").size());
+        Assertions.assertEquals(5, TestImperativeEntity.list("category = ?1", "category0").size());
+        Assertions.assertEquals(5, TestImperativeEntity.list("category = :category",
+                Parameters.with("category", "category1")).size());
+        Assertions.assertEquals(5, TestImperativeEntity.list("{'category' : ?1}", "category0").size());
+        Assertions.assertEquals(5, TestImperativeEntity.list("{'category' : :category}",
+                Parameters.with("category", "category1")).size());
+        Document listQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, TestImperativeEntity.list(listQuery).size());
+
+        // sort
+        TestImperativeEntity entityA = new TestImperativeEntity("aaa", "aaa", "aaa");
+        entityA.persist();
+        TestImperativeEntity entityZ = new TestImperativeEntity("zzz", "zzz", "zzz");
+        entityZ.persistOrUpdate();
+        TestImperativeEntity result = TestImperativeEntity.<TestImperativeEntity> listAll(Sort.ascending("title")).get(0);
+        Assertions.assertEquals("aaa", result.title);
+        result = TestImperativeEntity.<TestImperativeEntity> listAll(Sort.descending("title")).get(0);
+        Assertions.assertEquals("zzz", result.title);
+        entityA.delete();
+        entityZ.delete();
+
+        // count
+        Assertions.assertEquals(5, TestImperativeEntity.count("category", "category0"));
+        Assertions.assertEquals(5, TestImperativeEntity.count("category = ?1", "category0"));
+        Assertions.assertEquals(5, TestImperativeEntity.count("category = :category",
+                Parameters.with("category", "category1")));
+        Assertions.assertEquals(5, TestImperativeEntity.count("{'category' : ?1}", "category0"));
+        Assertions.assertEquals(5, TestImperativeEntity.count("{'category' : :category}",
+                Parameters.with("category", "category1")));
+        Document countQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, TestImperativeEntity.count(countQuery));
+
+        // update
+        List<TestImperativeEntity> list = TestImperativeEntity.list("category = ?1", "category0");
+        Assertions.assertEquals(5, list.size());
+        for (TestImperativeEntity entity : list) {
+            entity.category = "newCategory";
+        }
+        TestImperativeEntity.update(list);
+        TestImperativeEntity.update(list.stream());
+        TestImperativeEntity.persistOrUpdate(list);
+        Assertions.assertEquals(5, TestImperativeEntity.count("category = ?1", "newCategory"));
+
+        // delete
+        TestImperativeEntity.delete("category = ?1", "newCategory");
+        TestImperativeEntity.delete("{'category' : ?1}", "category1");
+        Assertions.assertEquals(0, TestImperativeEntity.count());
+        TestImperativeEntity.persist(entities.stream());
+        TestImperativeEntity.delete("category = :category", Parameters.with("category", "category0"));
+        TestImperativeEntity.delete("{'category' : :category}", Parameters.with("category", "category1"));
+        Assertions.assertEquals(0, TestImperativeEntity.count());
+        TestImperativeEntity.persistOrUpdate(entities.stream());
+        TestImperativeEntity.delete("category", "category0");
+        TestImperativeEntity.delete("category", "category1");
+        Assertions.assertEquals(0, TestImperativeEntity.count());
+
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("imperative/repository")
+    public Response testImperativeRepository() {
+        List<TestImperativeEntity> entities = getTestImperativeEntities();
+
+        // insert all
+        Assertions.assertEquals(0, testImperativeRepository.count());
+        testImperativeRepository.persist(entities);
+        Assertions.assertEquals(10, testImperativeRepository.count());
+
+        // varargs
+        TestImperativeEntity entity11 = new TestImperativeEntity("title11", "category", "desc");
+        TestImperativeEntity entity12 = new TestImperativeEntity("title11", "category", "desc");
+        testImperativeRepository.persist(entity11, entity12);
+        Assertions.assertEquals(12, testImperativeRepository.count());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        testImperativeRepository.update(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        testImperativeRepository.persistOrUpdate(entity11, entity12);
+        Assertions.assertEquals(12, testImperativeRepository.count());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        testImperativeRepository.persistOrUpdate(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        Assertions.assertEquals(10, testImperativeRepository.count());
+
+        // paginate
+        testImperativePagination(testImperativeRepository.findAll());
+
+        // range
+        testImperativeRange(testImperativeRepository.findAll());
+
+        // query
+        Assertions.assertEquals(5, testImperativeRepository.list("category", "category0").size());
+        Assertions.assertEquals(5, testImperativeRepository.list("category = ?1", "category0").size());
+        Assertions.assertEquals(5, testImperativeRepository.list("category = :category",
+                Parameters.with("category", "category1")).size());
+        Assertions.assertEquals(5, testImperativeRepository.list("{'category' : ?1}", "category0").size());
+        Assertions.assertEquals(5, testImperativeRepository.list("{'category' : :category}",
+                Parameters.with("category", "category1")).size());
+        Document listQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, testImperativeRepository.list(listQuery).size());
+
+        // sort
+        TestImperativeEntity entityA = new TestImperativeEntity("aaa", "aaa", "aaa");
+        testImperativeRepository.persist(entityA);
+        TestImperativeEntity entityZ = new TestImperativeEntity("zzz", "zzz", "zzz");
+        testImperativeRepository.persistOrUpdate(entityZ);
+        TestImperativeEntity result = testImperativeRepository.listAll(Sort.ascending("title")).get(0);
+        Assertions.assertEquals("aaa", result.title);
+        result = testImperativeRepository.listAll(Sort.descending("title")).get(0);
+        Assertions.assertEquals("zzz", result.title);
+        testImperativeRepository.delete(entityA);
+        testImperativeRepository.delete(entityZ);
+
+        // count
+        Assertions.assertEquals(5, testImperativeRepository.count("category", "category0"));
+        Assertions.assertEquals(5, testImperativeRepository.count("category = ?1", "category0"));
+        Assertions.assertEquals(5, testImperativeRepository.count("category = :category",
+                Parameters.with("category", "category1")));
+        Assertions.assertEquals(5, testImperativeRepository.count("{'category' : ?1}", "category0"));
+        Assertions.assertEquals(5, testImperativeRepository.count("{'category' : :category}",
+                Parameters.with("category", "category1")));
+        Document countQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, testImperativeRepository.count(countQuery));
+
+        // update
+        List<TestImperativeEntity> list = testImperativeRepository.list("category = ?1", "category0");
+        Assertions.assertEquals(5, list.size());
+        for (TestImperativeEntity entity : list) {
+            entity.category = "newCategory";
+        }
+        testImperativeRepository.update(list);
+        testImperativeRepository.update(list.stream());
+        Assertions.assertEquals(5, testImperativeRepository.count("category = ?1", "newCategory"));
+
+        // delete
+        testImperativeRepository.delete("category = ?1", "newCategory");
+        testImperativeRepository.delete("{'category' : ?1}", "category1");
+        Assertions.assertEquals(0, testImperativeRepository.count());
+        testImperativeRepository.persist(entities.stream());
+        testImperativeRepository.delete("category = :category", Parameters.with("category", "category0"));
+        testImperativeRepository.delete("{'category' : :category}", Parameters.with("category", "category1"));
+        Assertions.assertEquals(0, testImperativeRepository.count());
+        testImperativeRepository.persistOrUpdate(entities.stream());
+        testImperativeRepository.delete("category", "category0");
+        testImperativeRepository.delete("category", "category1");
+        Assertions.assertEquals(0, testImperativeRepository.count());
+
+        return Response.ok().build();
+    }
+
+    private List<TestImperativeEntity> getTestImperativeEntities() {
+        List<TestImperativeEntity> entities = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            entities.add(new TestImperativeEntity("title" + i,
+                    "category" + i % 2,
+                    "description" + i));
+        }
+        return entities;
+    }
+
+    private void testImperativePagination(PanacheQuery<TestImperativeEntity> query) {
+        query.page(0, 4);
+        Assertions.assertEquals(3, query.pageCount());
+        List<TestImperativeEntity> page = query.list();
+        Assertions.assertEquals(4, page.size());
+        Assertions.assertTrue(query.hasNextPage());
+        Assertions.assertFalse(query.hasPreviousPage());
+        query.nextPage();
+        page = query.list();
+        Assertions.assertEquals(4, page.size());
+        Assertions.assertTrue(query.hasNextPage());
+        Assertions.assertTrue(query.hasPreviousPage());
+        query.lastPage();
+        page = query.list();
+        Assertions.assertEquals(2, page.size());
+        Assertions.assertFalse(query.hasNextPage());
+        Assertions.assertTrue(query.hasPreviousPage());
+        query.firstPage();
+        page = query.list();
+        Assertions.assertEquals(4, page.size());
+        Assertions.assertTrue(query.hasNextPage());
+        Assertions.assertFalse(query.hasPreviousPage());
+        query.page(Page.of(1, 5));
+        Assertions.assertEquals(2, query.pageCount());
+        page = query.list();
+        Assertions.assertEquals(5, page.size());
+        Assertions.assertFalse(query.hasNextPage());
+        Assertions.assertTrue(query.hasPreviousPage());
+
+        // mix page with range
+        page = query.page(0, 3).range(0, 1).list();
+        Assertions.assertEquals(2, page.size());
+    }
+
+    private void testImperativeRange(PanacheQuery<TestImperativeEntity> query) {
+        query.range(0, 3);
+        List<TestImperativeEntity> range = query.list();
+        Assertions.assertEquals(4, range.size());
+        range = query.range(4, 7).list();
+        Assertions.assertEquals(4, range.size());
+        range = query.range(8, 12).list();
+        Assertions.assertEquals(2, range.size());
+        range = query.range(10, 12).list();
+        Assertions.assertEquals(0, range.size());
+
+        // when using range, we cannot use any of the page related operations
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).nextPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).previousPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).pageCount());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).lastPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).firstPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).hasPreviousPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).hasNextPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).page());
+
+        // but this is valid to switch from range to page
+        range = query.range(0, 2).page(0, 3).list();
+        Assertions.assertEquals(3, range.size());
+    }
+
+    @GET
+    @Path("reactive/entity")
+    public Response testReactiveEntity() {
+        List<TestReactiveEntity> entities = getTestReactiveEntities();
+
+        // insert all
+        Assertions.assertEquals(0, TestReactiveEntity.count().await().indefinitely());
+        TestReactiveEntity.persist(entities).await().indefinitely();
+        Assertions.assertEquals(10, TestReactiveEntity.count().await().indefinitely());
+
+        // varargs
+        TestReactiveEntity entity11 = new TestReactiveEntity("title11", "category", "desc");
+        TestReactiveEntity entity12 = new TestReactiveEntity("title11", "category", "desc");
+        TestReactiveEntity.persist(entity11, entity12).await().indefinitely();
+        Assertions.assertEquals(12, TestReactiveEntity.count().await().indefinitely());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        TestReactiveEntity.update(entity11, entity12).await().indefinitely();
+        entity11.delete().await().indefinitely();
+        entity12.delete().await().indefinitely();
+        TestReactiveEntity.persistOrUpdate(entity11, entity12).await().indefinitely();
+        Assertions.assertEquals(12, TestReactiveEntity.count().await().indefinitely());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        TestReactiveEntity.persistOrUpdate(entity11, entity12).await().indefinitely();
+        entity11.delete().await().indefinitely();
+        entity12.delete().await().indefinitely();
+        Assertions.assertEquals(10, TestReactiveEntity.count().await().indefinitely());
+
+        // paginate
+        testReactivePagination(TestReactiveEntity.findAll());
+
+        // range
+        testReactiveRange(TestReactiveEntity.findAll());
+
+        // query
+        Assertions.assertEquals(5,
+                TestReactiveEntity.list("category", "category0").await().indefinitely().size());
+        Assertions.assertEquals(5,
+                TestReactiveEntity.list("category = ?1", "category0").await().indefinitely().size());
+        Assertions.assertEquals(5, TestReactiveEntity.list("category = :category",
+                Parameters.with("category", "category1")).await().indefinitely().size());
+        Assertions.assertEquals(5,
+                TestReactiveEntity.list("{'category' : ?1}", "category0").await().indefinitely().size());
+        Assertions.assertEquals(5, TestReactiveEntity.list("{'category' : :category}",
+                Parameters.with("category", "category1")).await().indefinitely().size());
+        Document listQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, TestReactiveEntity.list(listQuery).await().indefinitely().size());
+
+        // sort
+        TestReactiveEntity entityA = new TestReactiveEntity("aaa", "aaa", "aaa");
+        entityA.persist().await().indefinitely();
+        TestReactiveEntity entityZ = new TestReactiveEntity("zzz", "zzz", "zzz");
+        entityZ.persistOrUpdate().await().indefinitely();
+        TestReactiveEntity result = TestReactiveEntity.<TestReactiveEntity> listAll(Sort.ascending("title")).await()
+                .indefinitely().get(0);
+        Assertions.assertEquals("aaa", result.title);
+        result = TestReactiveEntity.<TestReactiveEntity> listAll(Sort.descending("title")).await().indefinitely().get(0);
+        Assertions.assertEquals("zzz", result.title);
+        entityA.delete().await().indefinitely();
+        entityZ.delete().await().indefinitely();
+
+        // count
+        Assertions.assertEquals(5, TestReactiveEntity.count("category", "category0").await().indefinitely());
+        Assertions.assertEquals(5, TestReactiveEntity.count("category = ?1", "category0").await().indefinitely());
+        Assertions.assertEquals(5, TestReactiveEntity.count("category = :category",
+                Parameters.with("category", "category1")).await().indefinitely());
+        Assertions.assertEquals(5, TestReactiveEntity.count("{'category' : ?1}", "category0").await().indefinitely());
+        Assertions.assertEquals(5, TestReactiveEntity.count("{'category' : :category}",
+                Parameters.with("category", "category1")).await().indefinitely());
+        Document countQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, TestReactiveEntity.count(countQuery).await().indefinitely());
+
+        // update
+        List<TestReactiveEntity> list = TestReactiveEntity.<TestReactiveEntity> list("category = ?1", "category0").await()
+                .indefinitely();
+        Assertions.assertEquals(5, list.size());
+        for (TestReactiveEntity entity : list) {
+            entity.category = "newCategory";
+        }
+        TestReactiveEntity.update(list).await().indefinitely();
+        TestReactiveEntity.update(list.stream()).await().indefinitely();
+        Assertions.assertEquals(5, TestReactiveEntity.count("category = ?1", "newCategory").await().indefinitely());
+
+        // delete
+        TestReactiveEntity.delete("category = ?1", "newCategory").await().indefinitely();
+        TestReactiveEntity.delete("{'category' : ?1}", "category1").await().indefinitely();
+        Assertions.assertEquals(0, TestReactiveEntity.count().await().indefinitely());
+        TestReactiveEntity.persist(entities.stream()).await().indefinitely();
+        TestReactiveEntity.delete("category = :category", Parameters.with("category", "category0")).await().indefinitely();
+        TestReactiveEntity.delete("{'category' : :category}", Parameters.with("category", "category1")).await().indefinitely();
+        Assertions.assertEquals(0, TestReactiveEntity.count().await().indefinitely());
+        TestReactiveEntity.persistOrUpdate(entities.stream()).await().indefinitely();
+        TestReactiveEntity.delete("category", "category0").await().indefinitely();
+        TestReactiveEntity.delete("category", "category1").await().indefinitely();
+        Assertions.assertEquals(0, TestReactiveEntity.count().await().indefinitely());
+
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("reactive/repository")
+    public Response testReactiveRepository() {
+        List<TestReactiveEntity> entities = getTestReactiveEntities();
+
+        // insert all
+        Assertions.assertEquals(0, testReactiveRepository.count().await().indefinitely());
+        testReactiveRepository.persist(entities).await().indefinitely();
+        Assertions.assertEquals(10, testReactiveRepository.count().await().indefinitely());
+
+        // varargs
+        TestReactiveEntity entity11 = new TestReactiveEntity("title11", "category", "desc");
+        TestReactiveEntity entity12 = new TestReactiveEntity("title11", "category", "desc");
+        testReactiveRepository.persist(entity11, entity12).await().indefinitely();
+        Assertions.assertEquals(12, testReactiveRepository.count().await().indefinitely());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        testReactiveRepository.update(entity11, entity12).await().indefinitely();
+        entity11.delete().await().indefinitely();
+        entity12.delete().await().indefinitely();
+        testReactiveRepository.persistOrUpdate(entity11, entity12).await().indefinitely();
+        Assertions.assertEquals(12, testReactiveRepository.count().await().indefinitely());
+        entity11.category = "categoryUpdated";
+        entity12.category = "categoryUpdated";
+        testReactiveRepository.persistOrUpdate(entity11, entity12).await().indefinitely();
+        entity11.delete().await().indefinitely();
+        entity12.delete().await().indefinitely();
+        Assertions.assertEquals(10, testReactiveRepository.count().await().indefinitely());
+
+        // paginate
+        testReactivePagination(testReactiveRepository.findAll());
+
+        // range
+        testReactiveRange(testReactiveRepository.findAll());
+
+        // query
+        Assertions.assertEquals(5,
+                testReactiveRepository.list("category", "category0").await().indefinitely().size());
+        Assertions.assertEquals(5,
+                testReactiveRepository.list("category = ?1", "category0").await().indefinitely().size());
+        Assertions.assertEquals(5, testReactiveRepository.list("category = :category",
+                Parameters.with("category", "category1")).await().indefinitely().size());
+        Assertions.assertEquals(5,
+                testReactiveRepository.list("{'category' : ?1}", "category0").await().indefinitely().size());
+        Assertions.assertEquals(5, testReactiveRepository.list("{'category' : :category}",
+                Parameters.with("category", "category1")).await().indefinitely().size());
+        Document listQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, testReactiveRepository.list(listQuery).await().indefinitely().size());
+
+        // sort
+        TestReactiveEntity entityA = new TestReactiveEntity("aaa", "aaa", "aaa");
+        testReactiveRepository.persist(entityA).await().indefinitely();
+        TestReactiveEntity entityZ = new TestReactiveEntity("zzz", "zzz", "zzz");
+        testReactiveRepository.persistOrUpdate(entityZ).await().indefinitely();
+        TestReactiveEntity result = testReactiveRepository.listAll(Sort.ascending("title")).await().indefinitely().get(0);
+        Assertions.assertEquals("aaa", result.title);
+        result = testReactiveRepository.listAll(Sort.descending("title")).await().indefinitely().get(0);
+        Assertions.assertEquals("zzz", result.title);
+        testReactiveRepository.delete(entityA).await().indefinitely();
+        testReactiveRepository.delete(entityZ).await().indefinitely();
+
+        // count
+        Assertions.assertEquals(5,
+                testReactiveRepository.count("category", "category0").await().indefinitely());
+        Assertions.assertEquals(5,
+                testReactiveRepository.count("category = ?1", "category0").await().indefinitely());
+        Assertions.assertEquals(5, testReactiveRepository.count("category = :category",
+                Parameters.with("category", "category1")).await().indefinitely());
+        Assertions.assertEquals(5,
+                testReactiveRepository.count("{'category' : ?1}", "category0").await().indefinitely());
+        Assertions.assertEquals(5, testReactiveRepository.count("{'category' : :category}",
+                Parameters.with("category", "category1")).await().indefinitely());
+        Document countQuery = new Document().append("category", "category1");
+        Assertions.assertEquals(5, testReactiveRepository.count(countQuery).await().indefinitely());
+
+        // update
+        List<TestReactiveEntity> list = testReactiveRepository.list("category = ?1", "category0").await().indefinitely();
+        Assertions.assertEquals(5, list.size());
+        for (TestReactiveEntity entity : list) {
+            entity.category = "newCategory";
+        }
+        testReactiveRepository.update(list).await().indefinitely();
+        testReactiveRepository.update(list.stream()).await().indefinitely();
+        Assertions.assertEquals(5, testReactiveRepository.count("category = ?1", "newCategory").await().indefinitely());
+
+        // delete
+        testReactiveRepository.delete("category = ?1", "newCategory").await().indefinitely();
+        testReactiveRepository.delete("{'category' : ?1}", "category1").await().indefinitely();
+        Assertions.assertEquals(0, testReactiveRepository.count().await().indefinitely());
+        testReactiveRepository.persist(entities.stream()).await().indefinitely();
+        testReactiveRepository.delete("category = :category", Parameters.with("category", "category0")).await().indefinitely();
+        testReactiveRepository.delete("{'category' : :category}", Parameters.with("category", "category1")).await()
+                .indefinitely();
+        Assertions.assertEquals(0, testReactiveRepository.count().await().indefinitely());
+        testReactiveRepository.persistOrUpdate(entities.stream()).await().indefinitely();
+        testReactiveRepository.delete("category", "category0").await().indefinitely();
+        testReactiveRepository.delete("category", "category1").await().indefinitely();
+        Assertions.assertEquals(0, testReactiveRepository.count().await().indefinitely());
+
+        return Response.ok().build();
+    }
+
+    private List<TestReactiveEntity> getTestReactiveEntities() {
+        List<TestReactiveEntity> entities = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            entities.add(new TestReactiveEntity("title" + i,
+                    "category" + i % 2,
+                    "description" + i));
+        }
+        return entities;
+    }
+
+    private void testReactivePagination(ReactivePanacheQuery<TestReactiveEntity> query) {
+        query.page(0, 4);
+        Assertions.assertEquals(3, query.pageCount().await().indefinitely());
+        List<TestReactiveEntity> page = query.list().await().indefinitely();
+        Assertions.assertEquals(4, page.size());
+        Assertions.assertTrue(query.hasNextPage().await().indefinitely());
+        Assertions.assertFalse(query.hasPreviousPage());
+        query.nextPage();
+        page = query.list().await().indefinitely();
+
+        Assertions.assertEquals(4, page.size());
+        Assertions.assertTrue(query.hasNextPage().await().indefinitely());
+        Assertions.assertTrue(query.hasPreviousPage());
+        query.lastPage().await().indefinitely();
+        page = query.list().await().indefinitely();
+
+        Assertions.assertEquals(2, page.size());
+        Assertions.assertFalse(query.hasNextPage().await().indefinitely());
+        Assertions.assertTrue(query.hasPreviousPage());
+        query.firstPage();
+        page = query.list().await().indefinitely();
+        Assertions.assertEquals(4, page.size());
+        Assertions.assertTrue(query.hasNextPage().await().indefinitely());
+        Assertions.assertFalse(query.hasPreviousPage());
+        query.page(Page.of(1, 5));
+        Assertions.assertEquals(2, query.pageCount().await().indefinitely());
+        page = query.list().await().indefinitely();
+        Assertions.assertEquals(5, page.size());
+        Assertions.assertFalse(query.hasNextPage().await().indefinitely());
+        Assertions.assertTrue(query.hasPreviousPage());
+
+        // mix page with range
+        page = query.page(0, 3).range(0, 1).list().await().indefinitely();
+        Assertions.assertEquals(2, page.size());
+    }
+
+    private void testReactiveRange(ReactivePanacheQuery<TestReactiveEntity> query) {
+        query.range(0, 3);
+        List<TestReactiveEntity> range = query.list().await().indefinitely();
+        Assertions.assertEquals(4, range.size());
+        range = query.range(4, 7).list().await().indefinitely();
+        Assertions.assertEquals(4, range.size());
+        range = query.range(8, 12).list().await().indefinitely();
+        Assertions.assertEquals(2, range.size());
+        range = query.range(10, 12).list().await().indefinitely();
+        Assertions.assertEquals(0, range.size());
+
+        // when using range, we cannot use any of the page related operations
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).nextPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).previousPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).pageCount());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).lastPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).firstPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).hasPreviousPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).hasNextPage());
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.range(0, 2).page());
+
+        // but this is valid to switch from range to page
+        range = query.range(0, 2).page(0, 3).list().await().indefinitely();
+        Assertions.assertEquals(3, range.size());
+    }
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -334,4 +334,14 @@ class MongodbPanacheResourceTest {
     public void testBug7415() {
         get("/bugs/7415").then().statusCode(200);
     }
+
+    @Test
+    public void testMoreEntityFunctionalities() {
+        get("/test/imperative/entity").then().statusCode(200);
+    }
+
+    @Test
+    public void testMoreRepositoryFunctionalities() {
+        get("/test/imperative/repository").then().statusCode(200);
+    }
 }

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
@@ -334,4 +334,14 @@ class ReactiveMongodbPanacheResourceTest {
             return cpt;
         }
     }
+
+    @Test
+    public void testMoreEntityFunctionalities() {
+        get("/test/reactive/entity").then().statusCode(200);
+    }
+
+    @Test
+    public void testMoreRepositoryFunctionalities() {
+        get("/test/reactive/repository").then().statusCode(200);
+    }
 }


### PR DESCRIPTION
This PR adds a bunch of tests to MongoDB with Panache.

Fixes #7698

I don't know if it's easily possible to have the test coverage of a specific extension before and after a PR but this could be a good way to spot missing tests.

I found two bugs (so worth it to add the tests) and fix them in the same PR.