### PR TITLE
Liquibase - Record service classes implementation instead of  generating a native resource file for each service interface

### DIFF
--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseRecorder.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseRecorder.java
@@ -1,6 +1,8 @@
 package io.quarkus.liquibase.runtime;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.enterprise.inject.Default;
@@ -10,6 +12,7 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.liquibase.LiquibaseDataSource;
 import io.quarkus.liquibase.LiquibaseFactory;
+import io.quarkus.liquibase.runtime.graal.LiquibaseServiceLoader;
 import io.quarkus.runtime.annotations.Recorder;
 import liquibase.Liquibase;
 import liquibase.exception.LiquibaseException;
@@ -19,6 +22,10 @@ import liquibase.exception.LiquibaseException;
  */
 @Recorder
 public class LiquibaseRecorder {
+
+    public void setServicesImplementations(Map<String, List<String>> serviceLoader) {
+        LiquibaseServiceLoader.setServicesImplementations(serviceLoader);
+    }
 
     /**
      * Sets the liquibase build configuration

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/graal/SubstituteServiceLocator.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/graal/SubstituteServiceLocator.java
@@ -8,13 +8,13 @@ import com.oracle.svm.core.annotate.TargetClass;
 /**
  * The liquibase service locator substitute replaces liquibase classpath scanner method
  * {@link liquibase.servicelocator.ServiceLocator#findClasses(Class)} with a custom implementation
- * {@link LiquibaseServiceLoader#findClassesImpl(Class)} which used the prebuilt txt file.
+ * {@link LiquibaseServiceLoader#findClassesImpl(Class)}.
  */
 @TargetClass(className = "liquibase.servicelocator.ServiceLocator")
 final class SubstituteServiceLocator {
 
     @Substitute
-    private List<Class<?>> findClassesImpl(Class<?> requiredInterface) throws Exception {
+    private List<Class<?>> findClassesImpl(Class<?> requiredInterface) {
         return LiquibaseServiceLoader.findClassesImpl(requiredInterface);
     }
 


### PR DESCRIPTION
This cleans up the extension processing part a little bit as we can record these info in a registry
and do a map lookup during runtime instead of reading the generated resource file for each service
class

Follows up this https://github.com/quarkusio/quarkus/pull/8065#issuecomment-603217470 comment. 
