### PR TITLE
Add quarkus.oidc.proxy config

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTenantConfig.java
@@ -82,6 +82,11 @@ public class OidcTenantConfig {
     @ConfigItem
     Credentials credentials = new Credentials();
     /**
+     * Options to configure a proxy that OIDC adapter will use for talking with OIDC server.
+     */
+    @ConfigItem
+    Proxy proxy = new Proxy();
+    /**
      * Different options to configure authorization requests
      */
     Authentication authentication = new Authentication();
@@ -172,6 +177,14 @@ public class OidcTenantConfig {
 
     public void setTenantId(String tenantId) {
         this.tenantId = Optional.of(tenantId);
+    }
+
+    public Proxy getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
     }
 
     @ConfigGroup
@@ -465,6 +478,37 @@ public class OidcTenantConfig {
         public void setPrincipalClaim(String principalClaim) {
             this.principalClaim = Optional.of(principalClaim);
         }
+    }
+
+    @ConfigGroup
+    public static class Proxy {
+
+        /**
+         * The host (name or IP address) of the Proxy.<br/>
+         * Note: If OIDC adapter needs to use a Proxy to talk with OIDC server (Provider),
+         * then at least the "host" config item must be configured to enable the usage of a Proxy.
+         */
+        @ConfigItem
+        public Optional<String> host = Optional.empty();
+
+        /**
+         * The port number of the Proxy. Default value is 80.
+         */
+        @ConfigItem(defaultValue = "80")
+        public int port = 80;
+
+        /**
+         * The username, if Proxy needs authentication.
+         */
+        @ConfigItem
+        public Optional<String> username = Optional.empty();
+
+        /**
+         * The password, if Proxy needs authentication.
+         */
+        @ConfigItem
+        public Optional<String> password = Optional.empty();
+
     }
 
     public static enum ApplicationType {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcRecorderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcRecorderTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class OidcRecorderTest {
+
+    @Test
+    public void testtoProxyOptionsWithHostCheckPresent() {
+        OidcTenantConfig.Proxy proxy = new OidcTenantConfig.Proxy();
+        proxy.host = Optional.of("server.example.com");
+        assertTrue(OidcRecorder.toProxyOptions(proxy).isPresent());
+    }
+
+    @Test
+    public void testtoProxyOptionsWithoutHostCheckNonPresent() {
+        OidcTenantConfig.Proxy proxy = new OidcTenantConfig.Proxy();
+        assertFalse(OidcRecorder.toProxyOptions(proxy).isPresent());
+    }
+
+}


### PR DESCRIPTION
One addition to `oidc` extension: ability to use a proxy for talking with OIDC provider.
The following configuration items were added and can be used for this purpose:
- `quarkus.oidc.proxy.host`
- `quarkus.oidc.proxy.port`
- `quarkus.oidc.proxy.username`
- `quarkus.oidc.proxy.password`
- ~`quarkus.oidc.proxy.type`~ (update: ignored for now)

This refers to [issue 8088](https://github.com/quarkusio/quarkus/issues/8088).

Waiting for Quarkus team review and feedback.
Thanks.