### PR TITLE
config doc generator should skip scanning and generation of config docs when `-DskipDocs` in use

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -47,11 +48,13 @@ final public class Constants {
 
     public static final Set<String> SUPPORTED_ANNOTATIONS_TYPES = new HashSet<>();
     public static final Map<String, String> ALIASED_TYPES = new HashMap<>();
-    public static final String DOCS_SRC_MAIN_ASCIIDOC_GENERATED = "/target/asciidoc/generated/config/";
-    public static final Path GENERATED_DOCS_PATH = Paths
-            .get(System.getProperties().getProperty("maven.multiModuleProjectDirectory")
-                    + Constants.DOCS_SRC_MAIN_ASCIIDOC_GENERATED);
+    private static final Properties SYSTEM_PROPERTIES = System.getProperties();
+
+    private static final String DOCS_SRC_MAIN_ASCIIDOC_GENERATED = "/target/asciidoc/generated/config/";
+    public static final Path GENERATED_DOCS_PATH = Paths.get(SYSTEM_PROPERTIES.getProperty("maven.multiModuleProjectDirectory")
+            + Constants.DOCS_SRC_MAIN_ASCIIDOC_GENERATED).toAbsolutePath();
     public static final File GENERATED_DOCS_DIR = GENERATED_DOCS_PATH.toFile();
+    public static final Boolean SKIP_DOCS_GENERATION = Boolean.valueOf(SYSTEM_PROPERTIES.getProperty("skipDocs", "false"));
 
     /**
      * Holds the list of configuration items / configuration sections of each configuration roots.

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -236,15 +236,18 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         }
 
         try {
-            final Set<ConfigDocGeneratedOutput> outputs = configDocItemScanner
-                    .scanExtensionsConfigurationItems(javaDocProperties);
-            for (ConfigDocGeneratedOutput output : outputs) {
-                DocGeneratorUtil.sort(output.getConfigDocItems()); // sort before writing
-                configDocWriter.writeAllExtensionConfigDocumentation(output);
+            if (!Constants.SKIP_DOCS_GENERATION) {
+                final Set<ConfigDocGeneratedOutput> outputs = configDocItemScanner
+                        .scanExtensionsConfigurationItems(javaDocProperties);
+                for (ConfigDocGeneratedOutput output : outputs) {
+                    DocGeneratorUtil.sort(output.getConfigDocItems()); // sort before writing
+                    configDocWriter.writeAllExtensionConfigDocumentation(output);
+                }
             }
         } catch (IOException e) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to generate extension doc: " + e);
             return;
+
         }
     }
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemScanner.java
@@ -51,6 +51,10 @@ final public class ConfigDocItemScanner {
      * Record configuration group. It will later be visited to find configuration items.
      */
     public void addConfigGroups(TypeElement configGroup) {
+        if (Constants.SKIP_DOCS_GENERATION) {
+            return;
+        }
+
         String configGroupName = configGroup.getQualifiedName().toString();
         final Matcher pkgMatcher = Constants.PKG_PATTERN.matcher(configGroupName);
         if (!pkgMatcher.find() || configGroupName.startsWith(IO_QUARKUS_TEST_EXTENSION_PACKAGE)) {
@@ -64,6 +68,10 @@ final public class ConfigDocItemScanner {
      * Record a configuration root class. It will later be visited to find configuration items.
      */
     public void addConfigRoot(final PackageElement pkg, TypeElement clazz) {
+        if (Constants.SKIP_DOCS_GENERATION) {
+            return;
+        }
+
         final Matcher pkgMatcher = Constants.PKG_PATTERN.matcher(pkg.toString());
         if (!pkgMatcher.find() || pkg.toString().startsWith(IO_QUARKUS_TEST_EXTENSION_PACKAGE)) {
             return;


### PR DESCRIPTION
Follows up 1f88015179bcde6085c40a734dd9b140d975275b

/cc @stuartwdouglas 