### PR TITLE
Load Graal SDK Parent first

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -104,6 +104,8 @@
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
                 <configuration>
                     <parentFirstArtifacts>
+                        <parentFirstArtifact>org.graalvm.sdk:graal-sdk</parentFirstArtifact>
+                        <parentFirstArtifact>org.graalvm.nativeimage:svm</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-core</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-development-mode-spi</parentFirstArtifact>
                         <parentFirstArtifact>org.jboss.logmanager:jboss-logmanager-embedded</parentFirstArtifact>


### PR DESCRIPTION
We always want to load this from the actual
GraalVM installation if present, this will only
be loaded from the artifact if running on a
normal JVM.

Fixes #8035