### PR TITLE
Remove MS SQL Server JDBC driver from Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -62,8 +62,6 @@ update_configs:
           dependency_name: "mysql:mysql-connector-java"
       - match:
           dependency_name: "org.apache.derby:derbyclient"
-      - match:
-          dependency_name: "com.microsoft.sqlserver:mssql-jdbc"
       # Kafka
       - match:
           dependency_name: "org.apache.kafka:kafka-clients"


### PR DESCRIPTION
Dependabot always suggests the JDK13 driver, which is always incompatible.
Revert this commit when Dependabot supports Regular expression patterns in the dependency gavs