### PR TITLE
[docker][jib] Bump baseJvmImage from JRE8 to JRE11

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
@@ -16,7 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
-ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -13,7 +13,7 @@ public class JibConfig {
     /**
      * The base image to be used when a container image is being produced for the jar build
      */
-    @ConfigItem(defaultValue = "fabric8/java-alpine-openjdk8-jre")
+    @ConfigItem(defaultValue = "fabric8/java-alpine-openjdk11-jre")
     public String baseJvmImage;
 
     /**


### PR DESCRIPTION
JDK11 has been around over a year. Time to upgrade