### PR TITLE
Change Vault default KV secret engine from v1 to v2

### DIFF
--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -130,19 +130,6 @@ Cluster ID      55bd74b6-eaaf-3862-f7ce-3473ab86c57f
 HA Enabled      false
 ----
 
-For simplicity reasons, we are going to use a _kv secret engine version 1_ (which is the default) mounted at path
-`secret` instead of the pre-configured _kv version 2_ available in dev mode. So let's disable the current kv engine,
-and recreate a new one:
-
-[source, shell]
-----
-# this will disable the current kv version 2 secret engine mounted at path 'secret'
-vault secrets disable secret
-
-# this will enable a new kv engine version 1 at path 'secret'
-vault secrets enable -path=secret kv
-----
-
 Now let's add a secret configuration for our application:
 
 [source, shell]
@@ -157,7 +144,7 @@ Create a policy that gives read access to `secret/myapps/vault-quickstart` and s
 [source, shell]
 ----
 cat <<EOF | vault policy write vault-quickstart-policy -
-path "secret/myapps/vault-quickstart/*" {
+path "secret/data/myapps/vault-quickstart/*" {
   capabilities = ["read"]
 }
 EOF
@@ -169,7 +156,8 @@ When using a _kv secret engine version 2_, secrets are written and fetched at pa
 as opposed to `<mount>/<secret-path>` in a _kv secret engine version 1_.
 It does not change any of the CLI commands (i.e. you do not specify `data` in your path).
 However it does change the policies, since capabilities are applied to the real path. In the example above,
-the path should be `secret/*data*/myapps/vault-quickstart/*` if you were working with a _kv secret engine version 2_.
+the path is `secret/*data*/myapps/vault-quickstart/\*` since we are working with a _kv secret engine version 2_.
+It would be `secret/myapps/vault-quickstart/*` with a _kv secret engine version 1_.
 ====
 
 And finally, let's enable the _userpass auth secret engine_, and create user `bob` with access to the `vault-quickstart-policy`:

--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -96,6 +96,13 @@ in the following step)
 * TLS is disabled
 * a _kv secret engine v2_ is mounted at `secret/`
 
+[NOTE]
+====
+By default quarkus assumes that a _kv secret engine_ in version *2* mounted at path `secret/` will be used.
+If that is not the case, please use properties `quarkus.vault.kv-secret-engine-version`
+and `quarkus.vault.kv-secret-engine-mount-path` accordingly.
+====
+
 In the following step, we are going to add a `userpass` authentication that we will use from the Quarkus application,
 to access a secret stored in the _kv secret engine_.
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -11,7 +11,7 @@ import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_RENEW_G
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_SECRET_CONFIG_CACHE_PERIOD;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_TLS_SKIP_VERIFY;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_TLS_USE_KUBERNETES_CACERT;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.KV_SECRET_ENGINE_VERSION_V1;
+import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.KV_SECRET_ENGINE_VERSION_V2;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
 import static java.util.Collections.emptyMap;
@@ -195,7 +195,7 @@ public class VaultConfigSource implements ConfigSource {
         serverConfig.logConfidentialityLevel = LogConfidentialityLevel
                 .valueOf(getVaultProperty("log-confidentiality-level", MEDIUM.name()).toUpperCase());
         serverConfig.kvSecretEngineVersion = parseInt(
-                getVaultProperty("kv-secret-engine-version", KV_SECRET_ENGINE_VERSION_V1));
+                getVaultProperty("kv-secret-engine-version", KV_SECRET_ENGINE_VERSION_V2));
         serverConfig.kvSecretEngineMountPath = getVaultProperty("kv-secret-engine-mount-path",
                 DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH);
         serverConfig.secretConfigKvPath = getOptionalListProperty("secret-config-kv-path");

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -145,7 +145,7 @@ public class VaultRuntimeConfig {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = KV_SECRET_ENGINE_VERSION_V1)
+    @ConfigItem(defaultValue = KV_SECRET_ENGINE_VERSION_V2)
     public int kvSecretEngineVersion;
 
     /**

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultKv1ITCase.java
@@ -21,21 +21,21 @@ import io.quarkus.vault.test.VaultTestLifecycleManager;
 
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
-public class AgroalVaultKv2ITCase {
+public class AgroalVaultKv1ITCase {
 
-    private static final Logger log = Logger.getLogger(AgroalVaultKv2ITCase.class.getName());
+    private static final Logger log = Logger.getLogger(AgroalVaultKv1ITCase.class.getName());
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-vault-kv-version2-datasource.properties", "application.properties"));
+                    .addAsResource("application-vault-kv-version1-datasource.properties", "application.properties"));
 
     @Inject
-    AgroalDataSource staticDataSourceV2;
+    AgroalDataSource staticDataSourceV1;
 
     @Test
     public void staticKvVersion2() throws SQLException {
-        testDataSource(staticDataSourceV2);
+        testDataSource(staticDataSourceV1);
     }
 
 }

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
@@ -17,21 +17,21 @@ import io.quarkus.vault.test.VaultTestLifecycleManager;
 
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
-public class VaultKv2ITCase {
+public class VaultKv1ITCase {
 
-    private static final Logger log = Logger.getLogger(VaultKv2ITCase.class.getName());
+    private static final Logger log = Logger.getLogger(VaultKv1ITCase.class.getName());
 
     public static final String CRUD_PATH = "crud";
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("application-vault-kv-version2-datasource.properties", "application.properties"));
+                    .addAsResource("application-vault-kv-version1-datasource.properties", "application.properties"));
     @Inject
     VaultKVSecretEngine kvSecretEngine;
 
     @Test
-    public void crudSecretV2() {
+    public void crudSecretV1() {
         VaultTestExtension.assertCrudSecret(kvSecretEngine);
     }
 }

--- a/integration-tests/vault-agroal/src/test/resources/application-vault-kv-version1-datasource.properties
+++ b/integration-tests/vault-agroal/src/test/resources/application-vault-kv-version1-datasource.properties
@@ -4,8 +4,8 @@ quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.log-confidentiality-level=low
 quarkus.vault.tls.skip-verify=true
-quarkus.vault.kv-secret-engine-version=2
-quarkus.vault.kv-secret-engine-mount-path=secret-v2
+quarkus.vault.kv-secret-engine-version=1
+quarkus.vault.kv-secret-engine-mount-path=secret-v1
 
 quarkus.vault.credentials-provider.default-ds.kv-path=config
 

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleITCase.java
@@ -33,7 +33,7 @@ public class VaultAppRoleITCase {
     VaultKVSecretEngine kvSecretEngine;
 
     @Test
-    public void secretV1() {
+    public void secretV2() {
         Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
         assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
     }

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -58,8 +58,8 @@ public class VaultTestExtension {
     public static final String VAULT_AUTH_USERPASS_USER = "bob";
     public static final String VAULT_AUTH_USERPASS_PASSWORD = "sinclair";
     public static final String VAULT_AUTH_APPROLE = "myapprole";
-    public static final String SECRET_PATH_V1 = "secret";
-    public static final String SECRET_PATH_V2 = "secret-v2";
+    public static final String SECRET_PATH_V1 = "secret-v1";
+    public static final String SECRET_PATH_V2 = "secret";
     public static final String VAULT_DBROLE = "mydbrole";
     public static final String APP_SECRET_PATH = "foo";
     static final String APP_CONFIG_PATH = "config";
@@ -250,16 +250,16 @@ public class VaultTestExtension {
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
 
-        // multi config
-        execVault(format("vault kv put %s/multi/default1 color=blue size=XL", SECRET_PATH_V1));
-        execVault(format("vault kv put %s/multi/default2 color=red weight=3", SECRET_PATH_V1));
-        execVault(format("vault kv put %s/multi/singer1 firstname=paul lastname=shaffer", SECRET_PATH_V1));
-        execVault(format("vault kv put %s/multi/singer2 lastname=simon age=78 color=green", SECRET_PATH_V1));
-
         // static secrets kv v2
         execVault(format("vault secrets enable -path=%s -version=2 kv", SECRET_PATH_V2));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
+
+        // multi config
+        execVault(format("vault kv put %s/multi/default1 color=blue size=XL", SECRET_PATH_V2));
+        execVault(format("vault kv put %s/multi/default2 color=red weight=3", SECRET_PATH_V2));
+        execVault(format("vault kv put %s/multi/singer1 firstname=paul lastname=shaffer", SECRET_PATH_V2));
+        execVault(format("vault kv put %s/multi/singer2 lastname=simon age=78 color=green", SECRET_PATH_V2));
 
         // dynamic secrets
 

--- a/test-framework/vault/src/main/resources/vault.policy
+++ b/test-framework/vault/src/main/resources/vault.policy
@@ -1,25 +1,25 @@
-# kv engine default (v1 in non dev mode)
-path "secret/foo" {
-  capabilities = ["read"]
-}
-
-# vault config source kv engine v1
-path "secret/config" {
-  capabilities = ["read"]
-}
-
-# vault config source kv engine v1 with multi paths
-path "secret/multi/*" {
-  capabilities = ["read"]
-}
-
-# kv engine v2
-path "secret-v2/data/foo" {
+# kv engine default (v2)
+path "secret/data/foo" {
   capabilities = ["read"]
 }
 
 # vault config source kv engine v2
-path "secret-v2/data/config" {
+path "secret/data/config" {
+  capabilities = ["read"]
+}
+
+# vault config source kv engine v2 with multi paths
+path "secret/data/multi/*" {
+  capabilities = ["read"]
+}
+
+# kv engine v1
+path "secret-v1/foo" {
+  capabilities = ["read"]
+}
+
+# vault config source kv engine v1
+path "secret-v1/config" {
   capabilities = ["read"]
 }
 
@@ -42,11 +42,11 @@ path "transit/*" {
 #  capabilities = [ "read", "update" ]
 #}
 
-path "secret/crud" {
+path "secret/data/crud" {
   capabilities = ["read", "create", "update", "delete"]
 }
 
-path "secret-v2/data/crud" {
+path "secret-v1/crud" {
   capabilities = ["read", "create", "update", "delete"]
 }
 


### PR DESCRIPTION
Fixes Fetching credentials from Vault KV v2 fails https://github.com/quarkusio/quarkus/issues/6739
The change involves moving the kv secret engine default version to be v2 instead of v1, as discussed in https://github.com/quarkusio/quarkus/issues/6739#issuecomment-577778616 and https://github.com/quarkusio/quarkus/issues/6739#issuecomment-577869497