### PR TITLE
Make enum values generated for documentation consistent with converter

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
@@ -30,6 +30,8 @@ public class DocGeneratorUtil {
     private static final Map<String, String> PRIMITIVE_DEFAULT_VALUES = new HashMap<>();
     private static final Map<String, String> EXTENSION_JAVA_DOC_LINK = new HashMap<>();
     private static Pattern PACKAGE_PATTERN = Pattern.compile("^(\\w+)\\.(\\w+)\\..*$");
+    private static final String HYPHEN = "-";
+    private static final Pattern PATTERN = Pattern.compile("([-_]+)");
 
     static {
         PRIMITIVE_DEFAULT_VALUES.put("int", "0");
@@ -235,8 +237,18 @@ public class DocGeneratorUtil {
         return join(lowerCase(camelHumpsIterator(orig)));
     }
 
+    /**
+     * This needs to be consistent with io.quarkus.runtime.configuration.HyphenateEnumConverter.
+     */
     static String hyphenateEnumValue(String orig) {
-        return orig.replace('_', '-').toLowerCase(Locale.ROOT);
+        StringBuffer target = new StringBuffer();
+        String hyphenate = hyphenate(orig);
+        Matcher matcher = PATTERN.matcher(hyphenate);
+        while (matcher.find()) {
+            matcher.appendReplacement(target, HYPHEN);
+        }
+        matcher.appendTail(target);
+        return target.toString();
     }
 
     static String joinAcceptedValues(List<String> acceptedValues) {


### PR DESCRIPTION
At some point, we should probably share that code somehow but we need
something easy to backport for now.