### PR TITLE
fix: Service type is no longer ignored

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyServiceTypeDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyServiceTypeDecorator.java
@@ -1,0 +1,31 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.deps.kubernetes.api.model.ObjectMeta;
+import io.dekorate.deps.kubernetes.api.model.ServiceSpecFluent;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+
+/**
+ * A decorator for applying a serviceType to the container
+ */
+public class ApplyServiceTypeDecorator extends NamedResourceDecorator<ServiceSpecFluent> {
+
+    private final String type;
+
+    public ApplyServiceTypeDecorator(String name, String type) {
+        super(name);
+        this.type = type;
+    }
+
+    @Override
+    public void andThenVisit(ServiceSpecFluent service, ObjectMeta resourceMeta) {
+        service.withType(type);
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ResourceProvidingDecorator.class };
+    }
+
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -413,6 +413,13 @@ class KubernetesProcessor {
                     .forEach(r -> session.resources().decorate(new AddRoleBindingResourceDecorator(r.getRole())));
         }
 
+        session.resources().decorate(KUBERNETES,
+                new ApplyServiceTypeDecorator(kubernetesName, kubernetesConfig.getServiceType().name()));
+        session.resources().decorate(OPENSHIFT,
+                new ApplyServiceTypeDecorator(openshiftName, openshiftConfig.getServiceType().name()));
+        session.resources().decorate(KNATIVE,
+                new ApplyServiceTypeDecorator(knativeName, knativeConfig.getServiceType().name()));
+
         //Handle custom s2i builder images
         if (deploymentTargets.contains(OPENSHIFT)) {
             baseImageBuildItem.map(BaseImageInfoBuildItem::getImage).ifPresent(builderImage -> {

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
@@ -3,6 +3,7 @@ package io.quarkus.it.kubernetes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -73,6 +74,7 @@ public class KubernetesWithApplicationPropertiesTest {
         assertThat(kubernetesList).filteredOn(i -> "Service".equals(i.getKind())).hasOnlyOneElementSatisfying(i -> {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
+                    assertEquals("NodePort", spec.getType());
                     assertThat(spec.getPorts()).hasSize(1).hasOnlyOneElementSatisfying(p -> {
                         assertThat(p.getPort()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithDefaultsTest.java
+++ b/integration-tests/kubernetes/standard/src/test/java/io/quarkus/it/kubernetes/KubernetesWithDefaultsTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithDefaultsTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("kubernetes-with-defaults")
+            .setApplicationVersion("0.1-SNAPSHOT");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList).filteredOn(i -> "Service".equals(i.getKind())).hasOnlyOneElementSatisfying(i -> {
+            assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
+                assertThat(s.getSpec()).satisfies(spec -> {
+                    assertEquals("ClusterIP", spec.getType());
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-application.properties
+++ b/integration-tests/kubernetes/standard/src/test/resources/kubernetes-with-application.properties
@@ -5,3 +5,4 @@ quarkus.kubernetes.env-vars.my-env-var.value=SOMEVALUE
 quarkus.container-image.group=grp
 quarkus.container-image.registry=quay.io
 quarkus.kubernetes.expose=true
+quarkus.kubernetes.service-type=NodePort


### PR DESCRIPTION
This pull request deals with the kubernetes extension completely ignoring the service type, when provided using `quarkus.kubernetes.service-type`.

