### PR TITLE
Remove unneeded paging when using PanacheQuery

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
@@ -52,6 +52,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the next page
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #previousPage()
      */
     public <T extends Entity> PanacheQuery<T> nextPage();
@@ -60,6 +61,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the previous page (or the first page if there is no previous page)
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #nextPage()
      */
     public <T extends Entity> PanacheQuery<T> previousPage();
@@ -68,6 +70,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the first page
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #lastPage()
      */
     public <T extends Entity> PanacheQuery<T> firstPage();
@@ -76,6 +79,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the last page. This will cause reading of the entity count.
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #firstPage()
      * @see #count()
      */
@@ -86,6 +90,7 @@ public interface PanacheQuery<Entity> {
      * This will cause reading of the entity count.
      * 
      * @return true if there is another page to read
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #hasPreviousPage()
      * @see #count()
      */
@@ -95,6 +100,7 @@ public interface PanacheQuery<Entity> {
      * Returns true if there is a page to read before the current one.
      * 
      * @return true if there is a previous page to read
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #hasNextPage()
      */
     public boolean hasPreviousPage();
@@ -104,6 +110,7 @@ public interface PanacheQuery<Entity> {
      * This will cause reading of the entity count.
      * 
      * @return the total number of pages to be read using the current page size.
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      */
     public int pageCount();
 
@@ -111,6 +118,7 @@ public interface PanacheQuery<Entity> {
      * Returns the current page.
      * 
      * @return the current page
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #page(Page)
      * @see #page(int,int)
      */

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/PanacheQuery.java
@@ -52,6 +52,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the next page
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #previousPage()
      */
     public <T extends Entity> PanacheQuery<T> nextPage();
@@ -60,6 +61,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the previous page (or the first page if there is no previous page)
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #nextPage()
      */
     public <T extends Entity> PanacheQuery<T> previousPage();
@@ -68,6 +70,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the first page
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #lastPage()
      */
     public <T extends Entity> PanacheQuery<T> firstPage();
@@ -76,6 +79,7 @@ public interface PanacheQuery<Entity> {
      * Sets the current page to the last page. This will cause reading of the entity count.
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #firstPage()
      * @see #count()
      */
@@ -86,6 +90,7 @@ public interface PanacheQuery<Entity> {
      * This will cause reading of the entity count.
      * 
      * @return true if there is another page to read
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #hasPreviousPage()
      * @see #count()
      */
@@ -95,6 +100,7 @@ public interface PanacheQuery<Entity> {
      * Returns true if there is a page to read before the current one.
      * 
      * @return true if there is a previous page to read
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #hasNextPage()
      */
     public boolean hasPreviousPage();
@@ -104,6 +110,7 @@ public interface PanacheQuery<Entity> {
      * This will cause reading of the entity count.
      * 
      * @return the total number of pages to be read using the current page size.
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      */
     public int pageCount();
 
@@ -111,6 +118,7 @@ public interface PanacheQuery<Entity> {
      * Returns the current page.
      * 
      * @return the current page
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #page(Page)
      * @see #page(int,int)
      */

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheQuery.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/ReactivePanacheQuery.java
@@ -54,6 +54,7 @@ public interface ReactivePanacheQuery<Entity> {
      * Sets the current page to the next page
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #previousPage()
      */
     public <T extends Entity> ReactivePanacheQuery<T> nextPage();
@@ -62,6 +63,7 @@ public interface ReactivePanacheQuery<Entity> {
      * Sets the current page to the previous page (or the first page if there is no previous page)
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #nextPage()
      */
     public <T extends Entity> ReactivePanacheQuery<T> previousPage();
@@ -70,6 +72,7 @@ public interface ReactivePanacheQuery<Entity> {
      * Sets the current page to the first page
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #lastPage()
      */
     public <T extends Entity> ReactivePanacheQuery<T> firstPage();
@@ -78,6 +81,7 @@ public interface ReactivePanacheQuery<Entity> {
      * Sets the current page to the last page. This will cause reading of the entity count.
      * 
      * @return this query, modified
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #firstPage()
      * @see #count()
      */
@@ -88,6 +92,7 @@ public interface ReactivePanacheQuery<Entity> {
      * This will cause reading of the entity count.
      * 
      * @return true if there is another page to read
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #hasPreviousPage()
      * @see #count()
      */
@@ -97,6 +102,7 @@ public interface ReactivePanacheQuery<Entity> {
      * Returns true if there is a page to read before the current one.
      * 
      * @return true if there is a previous page to read
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #hasNextPage()
      */
     public boolean hasPreviousPage();
@@ -106,6 +112,7 @@ public interface ReactivePanacheQuery<Entity> {
      * This will cause reading of the entity count.
      * 
      * @return the total number of pages to be read using the current page size.
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      */
     public Uni<Integer> pageCount();
 
@@ -113,6 +120,7 @@ public interface ReactivePanacheQuery<Entity> {
      * Returns the current page.
      * 
      * @return the current page
+     * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
      * @see #page(Page)
      * @see #page(int,int)
      */

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
@@ -23,10 +23,6 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     private Document sort;
     private Document projections;
 
-    /*
-     * We store the pageSize and apply it for each request because getFirstResult()
-     * sets the page size to 1
-     */
     private Page page;
     private Long count;
 
@@ -36,7 +32,6 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
         this.collection = collection;
         this.mongoQuery = mongoQuery;
         this.sort = sort;
-        page = new Page(0, Integer.MAX_VALUE);
     }
 
     // Builder
@@ -70,43 +65,43 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public <T extends Entity> PanacheQuery<T> nextPage() {
-        checkNotInRange();
+        checkPagination();
         return page(page.next());
     }
 
     @Override
     public <T extends Entity> PanacheQuery<T> previousPage() {
-        checkNotInRange();
+        checkPagination();
         return page(page.previous());
     }
 
     @Override
     public <T extends Entity> PanacheQuery<T> firstPage() {
-        checkNotInRange();
+        checkPagination();
         return page(page.first());
     }
 
     @Override
     public <T extends Entity> PanacheQuery<T> lastPage() {
-        checkNotInRange();
+        checkPagination();
         return page(page.index(pageCount() - 1));
     }
 
     @Override
     public boolean hasNextPage() {
-        checkNotInRange();
+        checkPagination();
         return page.index < (pageCount() - 1);
     }
 
     @Override
     public boolean hasPreviousPage() {
-        checkNotInRange();
+        checkPagination();
         return page.index > 0;
     }
 
     @Override
     public int pageCount() {
-        checkNotInRange();
+        checkPagination();
         long count = count();
         if (count == 0)
             return 1; // a single page of zero results
@@ -115,11 +110,16 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public Page page() {
-        checkNotInRange();
+        checkPagination();
         return page;
     }
 
-    private void checkNotInRange() {
+    private void checkPagination() {
+        if (page == null) {
+            throw new UnsupportedOperationException(
+                    "Cannot call a page related method, "
+                            + "call page(Page) or page(int, int) to initiate pagination first");
+        }
         if (range != null) {
             throw new UnsupportedOperationException("Cannot call a page related method in a ranged query, " +
                     "call page(Page) or page(int, int) to initiate pagination first");
@@ -130,7 +130,7 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     public <T extends Entity> PanacheQuery<T> range(int startIndex, int lastIndex) {
         this.range = Range.of(startIndex, lastIndex);
         // reset the page to its default to be able to switch from page to range
-        this.page = new Page(0, Integer.MAX_VALUE);
+        this.page = null;
         return (PanacheQuery<T>) this;
     }
 
@@ -146,14 +146,18 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends Entity> List<T> list() {
+        return list(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Entity> List<T> list(Integer limit) {
         List<T> list = new ArrayList<>();
         FindIterable find = mongoQuery == null ? collection.find() : collection.find(mongoQuery);
         if (this.projections != null) {
             find.projection(projections);
         }
-        manageOffsets(find);
+        manageOffsets(find, limit);
         MongoCursor<T> cursor = find.sort(sort).iterator();
 
         try {
@@ -175,7 +179,7 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public <T extends Entity> T firstResult() {
-        List<T> list = list();
+        List<T> list = list(1);
         return list.isEmpty() ? null : list.get(0);
     }
 
@@ -185,9 +189,8 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends Entity> T singleResult() {
-        List<T> list = list();
+        List<T> list = list(2);
         if (list.size() != 1) {
             throw new PanacheQueryException("There should be only one result");
         }
@@ -196,9 +199,8 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends Entity> Optional<T> singleResultOptional() {
-        List<T> list = list();
+        List<T> list = list(2);
         if (list.size() > 1) {
             throw new PanacheQueryException("There should be no more than one result");
         }
@@ -206,12 +208,21 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
         return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
     }
 
-    private void manageOffsets(FindIterable find) {
+    private void manageOffsets(FindIterable find, Integer limit) {
         if (range != null) {
-            // range is 0 based, so we add 1 to the limit
-            find.skip(range.getStartIndex()).limit(range.getLastIndex() - range.getStartIndex() + 1);
-        } else {
-            find.skip(page.index * page.size).limit(page.size);
+            find.skip(range.getStartIndex());
+            if (limit == null) {
+                // range is 0 based, so we add 1 to the limit
+                find.limit(range.getLastIndex() - range.getStartIndex() + 1);
+            }
+        } else if (page != null) {
+            find.skip(page.index * page.size);
+            if (limit == null) {
+                find.limit(page.size);
+            }
+        }
+        if (limit != null) {
+            find.limit(limit);
         }
     }
 }

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -64,6 +64,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
@@ -88,6 +93,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -106,6 +116,30 @@
                         <goals>
                             <goal>build</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <!--
+                    The prod mode tests need to be part of a different execution to ensure that they don't mess with the standard tests.
+                    By adding this configuration we ensure that the maven surefire plugin will execute twice, one for the regular **/*Test.java
+                    tests (using the 'default-test' execution), and one for the prod mode tests (this 'prod-mode' execution)
+                    -->
+                    <execution>
+                        <id>prod-mode</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemProperties>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            </systemProperties>
+                            <argLine>${jacoco.agent.argLine}</argLine>
+                            <includes>**/*PMT.java</includes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NoPagingTestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/NoPagingTestEndpoint.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.panache;
+
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Run a simple, no paged PanacheQueryTest in order to log the generated SQL.
+ *
+ * @see io.quarkus.it.panache.NoPagingPMT
+ */
+@Path("no-paging-test")
+public class NoPagingTestEndpoint {
+
+    @GET
+    @Transactional
+    public String test() {
+        PageItem.findAll().list();
+
+        return "OK";
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/PageItem.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/PageItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class PageItem extends PanacheEntity {
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -842,6 +842,24 @@ public class TestEndpoint {
     }
 
     private void testPaging(PanacheQuery<Person> query) {
+        // No paging allowed until a page is setup
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.firstPage(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.previousPage(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.nextPage(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.lastPage(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.hasNextPage(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.hasPreviousPage(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.page(),
+                "UnsupportedOperationException should have thrown");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> query.pageCount(),
+                "UnsupportedOperationException should have thrown");
+
         // ints
         List<Person> persons = query.page(0, 3).list();
         Assertions.assertEquals(3, persons.size());

--- a/integration-tests/hibernate-orm-panache/src/main/resources/nopaging.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/nopaging.properties
@@ -1,0 +1,9 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
+quarkus.datasource.jdbc.max-size=8
+quarkus.datasource.jdbc.min-size=2
+
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.log.category."org.hibernate.SQL".level=DEBUG

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/NoPagingPMT.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/NoPagingPMT.java
@@ -1,0 +1,81 @@
+package io.quarkus.it.panache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.test.LogFile;
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test if PanacheQuery is using unnecessary SQL for limiting the number of output rows, the log output is tested for the
+ * presence of <code>offset</code> or <code>limit</code> in the SQL.
+ */
+public class NoPagingPMT {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PageItem.class, TestResources.class, NoPagingTestEndpoint.class))
+            .setApplicationName("no-paging-test")
+            .setApplicationVersion(Version.getVersion())
+            .setRun(true)
+            .setLogFileName("no-paging-test.log")
+            .withConfigurationResource("nopaging.properties");
+
+    @LogFile
+    private Path logfile;
+
+    @Test
+    public void test() {
+        assertThat(logfile).isRegularFile().hasFileName("no-paging-test.log");
+
+        RestAssured.when().get("/no-paging-test").then().body(is("OK"));
+
+        // the logs might not be flushed to disk immediately, so wait a few seconds before giving up completely
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(this::checkLog);
+    }
+
+    private void checkLog() {
+        final List<String> lines;
+        try {
+            lines = Files.readAllLines(logfile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        /*
+         * Test the SQL was logged, this could fail if Hibernate decides to change how it logs the generated SQL, here in order
+         * to not silently skip the following test
+         */
+        final boolean sqlFound = lines.stream()
+                .filter(line -> line.matches(".*select .* from PageItem .*"))
+                .findAny()
+                .isPresent();
+        assertThat(sqlFound)
+                .as("Hibernate query wasn't logged")
+                .isTrue();
+
+        // Search for the presence of a SQL with a limit or offset
+        final boolean wrongSqlFound = lines.stream()
+                .filter(line -> line.matches(".*select .* limit .*") || line.matches(".*select .* offset .*"))
+                .findAny()
+                .isPresent();
+        assertThat(wrongSqlFound)
+                .as("PanacheQuery is generating SQL with limits and/or offsets when no paging has been requested")
+                .isFalse();
+    }
+}


### PR DESCRIPTION
Avoid setting paging information on the native query implementation when no paging has been set on PanacheQuery.
 
Closes #8098