### PR TITLE
Support for mocking CDI beans

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -302,7 +302,11 @@ public class TestStereotypeTestCase {
 
 == Mock Support
 
-Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism.
+Quarkus supports the use of mock objects using two different approaches. You can either use CDI alternatives to
+mock out a bean for all test classes, or use `QuarkusMock` to mock out beans on a per test basis.
+
+=== CDI `@Alternative` mechanism.
+
 To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean. 
 Alternatively, a convenient `io.quarkus.test.Mock` stereotype annotation could be used.
 This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`. 
@@ -341,6 +345,64 @@ it will take effect all the time, not just when testing.
 
 Note that at present this approach does not work with native image testing, as this would required the test alternatives
 to be baked into the native image.
+
+=== Mocking using QuarkusMock
+
+The `io.quarkus.test.junit.QuarkusMock` class can be used to temporarily mock out any normal scoped
+bean. If you use this method in a `@BeforeAll` method the mock will take effect for all tests on the current class,
+while if you use this in a test method the mock will only take effect for the duration of the current test.
+
+This method can be used for any normal scoped CDI bean (e.g. `@ApplicationScoped`, `@RequestScoped` etc, basically
+every scope except `@Singleton` and `@Dependent`).
+
+An example usage could look like:
+
+[source,java]
+----
+@QuarkusTest
+public class MockTestCase {
+
+    @Inject
+    MockableBean1 mockableBean1;
+
+    @Inject
+    MockableBean2 mockableBean2;
+
+    @BeforeAll
+    public static void setup() {
+        MockableBean1 mock = Mockito.mock(MockableBean1.class);
+        Mockito.when(mock.greet("Stuart")).thenReturn("A mock for Stuart");
+        QuarkusMock.installMockForType(mock, MockableBean1.class);  <1>
+    }
+
+    @Test
+    public void testBeforeAll() {
+        Assertions.assertEquals("A mock for Stuart", mockableBean1.greet("Stuart"));
+        Assertions.assertEquals("Hello Stuart", mockableBean2.greet("Stuart"));
+    }
+
+    @Test
+    public void testPerTestMock() {
+        QuarkusMock.installMockForInstance(new BonourGreeter(), mockableBean2); <2>
+        Assertions.assertEquals("A mock for Stuart", mockableBean1.greet("Stuart"));
+        Assertions.assertEquals("Bonjour Stuart", mockableBean2.greet("Stuart"));
+    }
+
+    public static class BonourGreeter extends MockableBean2 {
+        @Override
+        public String greet(String name) {
+            return "Bonjour " + name;
+        }
+    }
+
+}
+----
+<1> As the injected instance is not available here we use `installMockForType`, this mock is used for both test methods
+<2> We use `installMockForInstance` to replace the injected bean, this takes effect for the duration of the test method.
+
+Note that there is no dependency on Mockito, you can use any mocking library you like, or even manually override the
+objects to provide the behaviour you require.
+
 
 == Test Bootstrap Configuration Options
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -60,12 +60,14 @@ import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.TestClassPredicateBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.runner.bootstrap.BootstrapDebug;
+import io.quarkus.runtime.LaunchMode;
 
 /**
  * This class contains build steps that trigger various phases of the bean processing.
@@ -115,7 +117,8 @@ public class ArcProcessor {
             Optional<TestClassPredicateBuildItem> testClassPredicate,
             Capabilities capabilities,
             BuildProducer<FeatureBuildItem> feature,
-            CustomScopeAnnotationsBuildItem scopes) {
+            CustomScopeAnnotationsBuildItem scopes,
+            LaunchModeBuildItem launchModeBuildItem) {
 
         if (!arcConfig.isRemoveUnusedBeansFieldValid()) {
             throw new IllegalArgumentException("Invalid configuration value set for 'quarkus.arc.remove-unused-beans'." +
@@ -243,6 +246,7 @@ public class ArcProcessor {
         builder.setTransformUnproxyableClasses(arcConfig.transformUnproxyableClasses);
         builder.setJtaCapabilities(capabilities.isCapabilityPresent(Capabilities.TRANSACTIONS));
         builder.setGenerateSources(BootstrapDebug.DEBUG_SOURCES_DIR != null);
+        builder.setAllowMocking(launchModeBuildItem.getLaunchMode() == LaunchMode.TEST);
 
         BeanProcessor beanProcessor = builder.build();
         ContextRegistrar.RegistrationContext context = beanProcessor.registerCustomContexts();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -58,6 +58,7 @@ public class BeanProcessor {
     private final Predicate<DotName> applicationClassPredicate;
     private final BeanDeployment beanDeployment;
     private final boolean generateSources;
+    private final boolean allowMocking;
 
     private BeanProcessor(String name, IndexView index, Collection<BeanDefiningAnnotation> additionalBeanDefiningAnnotations,
             ResourceOutput output,
@@ -78,13 +79,14 @@ public class BeanProcessor {
             List<InterceptorBindingRegistrar> interceptorBindingRegistrars,
             boolean transformUnproxyableClasses,
             boolean jtaCapabilities,
-            boolean generateSources) {
+            boolean generateSources, boolean allowMocking) {
         this.reflectionRegistration = reflectionRegistration;
         this.applicationClassPredicate = applicationClassPredicate;
         this.name = name;
         this.output = output;
         this.sharedAnnotationLiterals = sharedAnnotationLiterals;
         this.generateSources = generateSources;
+        this.allowMocking = allowMocking;
 
         // Initialize all build processors
         buildContext = new BuildContextImpl();
@@ -152,7 +154,8 @@ public class BeanProcessor {
                 applicationClassPredicate);
         BeanGenerator beanGenerator = new BeanGenerator(annotationLiterals, applicationClassPredicate, privateMembers,
                 generateSources);
-        ClientProxyGenerator clientProxyGenerator = new ClientProxyGenerator(applicationClassPredicate, generateSources);
+        ClientProxyGenerator clientProxyGenerator = new ClientProxyGenerator(applicationClassPredicate, generateSources,
+                allowMocking);
         InterceptorGenerator interceptorGenerator = new InterceptorGenerator(annotationLiterals, applicationClassPredicate,
                 privateMembers, generateSources);
         SubclassGenerator subclassGenerator = new SubclassGenerator(annotationLiterals, applicationClassPredicate,
@@ -279,6 +282,7 @@ public class BeanProcessor {
         private boolean generateSources = false;
         private boolean jtaCapabilities = false;
         private boolean transformUnproxyableClasses = false;
+        private boolean allowMocking = false;
 
         private Predicate<DotName> applicationClassPredicate = new Predicate<DotName>() {
             @Override
@@ -380,6 +384,10 @@ public class BeanProcessor {
             return this;
         }
 
+        public void setAllowMocking(boolean allowMocking) {
+            this.allowMocking = allowMocking;
+        }
+
         /**
          * If set to true the container will attempt to remove all unused beans.
          * <p>
@@ -454,7 +462,8 @@ public class BeanProcessor {
                     reflectionRegistration, annotationTransformers, injectionPointTransformers, observerTransformers,
                     resourceAnnotations, beanRegistrars, observerRegistrars, contextRegistrars, beanDeploymentValidators,
                     applicationClassPredicate, removeUnusedBeans, removalExclusions, additionalStereotypes,
-                    additionalInterceptorBindingRegistrars, transformUnproxyableClasses, jtaCapabilities, generateSources);
+                    additionalInterceptorBindingRegistrars, transformUnproxyableClasses, jtaCapabilities, generateSources,
+                    allowMocking);
         }
 
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/MockableProxy.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/MockableProxy.java
@@ -1,0 +1,13 @@
+package io.quarkus.arc;
+
+/**
+ * An interface that client proxies will implement when running in test mode.
+ *
+ * This allows normal scoped beans to be easily mocked for tests.
+ */
+public interface MockableProxy {
+
+    void quarkus$$setMock(Object instance);
+
+    void quarkus$$clearMock();
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/mock/MockableBean1.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/mock/MockableBean1.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.mock;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MockableBean1 {
+
+    public String greet(String name) {
+        return "Hello " + name;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/mock/MockableBean2.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/mock/MockableBean2.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.mock;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MockableBean2 {
+
+    public String greet(String name) {
+        return "Hello " + name;
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MockTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MockTestCase.java
@@ -1,0 +1,53 @@
+package io.quarkus.it.main;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.it.mock.MockableBean1;
+import io.quarkus.it.mock.MockableBean2;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class MockTestCase {
+
+    protected static final String BONJOUR = "Bonjour ";
+
+    @Inject
+    MockableBean1 mockableBean1;
+
+    @Inject
+    MockableBean2 mockableBean2;
+
+    @BeforeAll
+    public static void setup() {
+        MockableBean1 mock = Mockito.mock(MockableBean1.class);
+        Mockito.when(mock.greet("Stuart")).thenReturn("A mock for Stuart");
+        QuarkusMock.installMockForType(mock, MockableBean1.class);
+    }
+
+    @Test
+    public void testBeforeAll() {
+        Assertions.assertEquals("A mock for Stuart", mockableBean1.greet("Stuart"));
+        Assertions.assertEquals("Hello Stuart", mockableBean2.greet("Stuart"));
+    }
+
+    @Test
+    public void testPerTestMock() {
+        QuarkusMock.installMockForInstance(new BonourGreeter(), mockableBean2);
+        Assertions.assertEquals("A mock for Stuart", mockableBean1.greet("Stuart"));
+        Assertions.assertEquals("Bonjour Stuart", mockableBean2.greet("Stuart"));
+    }
+
+    public static class BonourGreeter extends MockableBean2 {
+        @Override
+        public String greet(String name) {
+            return BONJOUR + name;
+        }
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/MockSupport.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/MockSupport.java
@@ -1,0 +1,47 @@
+package io.quarkus.test.junit;
+
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+class MockSupport {
+
+    private static final Deque<List<Object>> contexts = new ArrayDeque<>();
+
+    @SuppressWarnings("unused")
+    static void pushContext() {
+        contexts.push(new ArrayList<>());
+    }
+
+    @SuppressWarnings("unused")
+    static void popContext() {
+        List<Object> val = contexts.pop();
+        for (Object i : val) {
+            try {
+                i.getClass().getDeclaredMethod("quarkus$$clearMock").invoke(i);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    static <T> void installMock(T instance, T mock) {
+        //due to class loading issues we can't access the interface directly
+        List<Object> inst = contexts.peek();
+        if (inst == null) {
+            throw new IllegalStateException("No test in progress");
+        }
+        try {
+            Method setMethod = instance.getClass().getDeclaredMethod("quarkus$$setMock", Object.class);
+            setMethod.invoke(instance, mock);
+            inst.add(instance);
+
+        } catch (Exception e) {
+            throw new RuntimeException(instance
+                    + " is not a normal scoped CDI bean, make sure the bean is a normal scope like @ApplicationScoped or @RequestScoped");
+
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMock.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMock.java
@@ -1,0 +1,53 @@
+package io.quarkus.test.junit;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Utility class that can be used to mock CDI normal scoped beans.
+ * 
+ * This includes beans that are {@link javax.enterprise.context.ApplicationScoped} and
+ * {@link javax.enterprise.context.RequestScoped}.
+ * 
+ * To use this inject the bean into a test, and then invoke the mock
+ * method with your mock.
+ *
+ * Mocks installed in {@link org.junit.jupiter.api.BeforeAll} will be present for every test,
+ * while mocks installed within a test are cleared after the test has run. Note that you will
+ * likely need to use {@link TestInstance.Lifecycle#PER_CLASS} to have a non-static before all method
+ * that can access injected beans.
+ *
+ * Note that as the bean is replaced globally you cannot use parallel test execution, as this will
+ * result in race conditions where mocks from one test are active in another.
+ *
+ */
+public class QuarkusMock {
+
+    /**
+     * Installs a mock for a CDI normal scoped bean
+     *
+     * @param mock The mock object
+     * @param instance The CDI normal scoped bean that was injected into your test
+     * @param <T> The bean type
+     */
+    public static <T> void installMockForInstance(T mock, T instance) {
+        //mock support does the actual work, but exposes other methods that are not part of the user API
+        MockSupport.installMock(instance, mock);
+    }
+
+    /**
+     * Installs a mock for a CDI normal scoped bean
+     *
+     * @param mock The mock object
+     * @param instance The type of the CDI normal scoped bean to replace
+     * @param qualifiers The CDI qualifiers of the bean to mock
+     * @param <T> The bean type
+     */
+    public static <T> void installMockForType(T mock, Class<? super T> instance, Annotation... qualifiers) {
+        //mock support does the actual work, but exposes other methods that are not part of the user API
+        MockSupport.installMock(CDI.current().select(instance, qualifiers).get(), mock);
+    }
+}


### PR DESCRIPTION
This allows all CDI normal scoped beans to be mocked at
test time by adding a form of redirection into the client
proxy.