### PR TITLE
Use proper substitutions for Netty ALPN in Java 8

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -122,18 +122,18 @@ final class Target_io_netty_handler_ssl_JdkAlpnApplicationProtocolNegotiator_Alp
 
 @TargetClass(className = "io.netty.handler.ssl.JettyAlpnSslEngine", onlyWith = JDK8OrEarlier.class)
 final class Target_io_netty_handler_ssl_JettyAlpnSslEngine {
-    @Alias
+    @Substitute
     static boolean isAvailable() {
         return false;
     }
 
-    @Alias
+    @Substitute
     static Target_io_netty_handler_ssl_JettyAlpnSslEngine newClientEngine(SSLEngine engine,
             JdkApplicationProtocolNegotiator applicationNegotiator) {
         return null;
     }
 
-    @Alias
+    @Substitute
     static Target_io_netty_handler_ssl_JettyAlpnSslEngine newServerEngine(SSLEngine engine,
             JdkApplicationProtocolNegotiator applicationNegotiator) {
         return null;


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/8156

P.S: Although this does fix the issue at hand, this change will need proper testing against Native test cases and/or an explanation from someone who understands more about code reachability analytics semantics in native-image (see my comment in the linked issue for reasons https://github.com/quarkusio/quarkus/issues/8156#issuecomment-604246369).