### PR TITLE
Add missing ooxml-schemas dependency #8081

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -135,6 +135,7 @@
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.12.9</scala.version>
         <tika.version>1.22</tika.version>
+        <ooxml-schemas.version>1.4</ooxml-schemas.version>
         <aws-lambda-java.version>1.1.0</aws-lambda-java.version>
         <aws-lambda-java-events.version>2.2.7</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
@@ -1252,6 +1253,11 @@
                     </exclusion>
                 </exclusions>
                 <version>${tika.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>ooxml-schemas</artifactId>
+                <version>${ooxml-schemas.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus.http</groupId>

--- a/extensions/tika/runtime/pom.xml
+++ b/extensions/tika/runtime/pom.xml
@@ -44,6 +44,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>ooxml-schemas</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.xmlbeans</groupId>
+                    <artifactId>xmlbeans</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>


### PR DESCRIPTION
~This is a draft PR~.

Required to avoid [issue](https://github.com/quarkusio/quarkus/issues/8081#issuecomment-604014138).

Note that this change happens to be part of the bigger #7198 PR. I came to it separately following the advice [here](https://stackoverflow.com/questions/49483042/apache-poi-java-lang-noclassdeffounderror). Talking to @sberyozkin he pointed out it was part of the other PR.