### PR TITLE
Test Quarkus with OpenJDK 14 instead of 13

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [8, 11, 13]
+        java-version: [8, 11, 14]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Waiting for CI running in my fork.