### PR TITLE
Enlist reactive entity for reflection

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -240,7 +240,7 @@ List<String> namesButEmmanuels = persons
 
 NOTE: A `persistOrUpdate()` method exist that persist or update an entity in the database, it uses the __upsert__ capability of MongoDB to do it in a single query.
 
-== Adding entity methods
+=== Adding entity methods
 
 Add custom queries on your entities inside the entities themselves.
 That way, you and your co-workers can find them easily, and queries are co-located with the object they operate on.
@@ -724,7 +724,7 @@ data class Person (
 ): PanacheMongoEntity()
 ----
 
-[[reactive]]]]
+[[reactive]]
 == Reactive Entities and Repositories
 
 MongoDB with Panache allows using reactive style implementation for both entities and repositories.


### PR DESCRIPTION
MongoDB with panache enlist for reflection entities (and repository parameterized types) automatically.

This PR adds the same facility for the reactive implementation.

This has been discuss on Zuilip: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Bson.20codec.20error.20when.20using.20reactive.20mongo.20panache.20in.20native