### PR TITLE
Upgrade Gradle publish plugin to 0.11.0

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '0.11.0'
     id 'java-gradle-plugin'
 }
 if (JavaVersion.current().isJava9Compatible()) {


### PR DESCRIPTION
I had an error when publishing the plugin:
```
Execution failed for task ':publishPlugins'.
> Failed to post to server.
  Server responded with:
  This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability.
  Please update to the latest version of the com.gradle.plugin-publish plugin found here:
     https://plugins.gradle.org/plugin/com.gradle.plugin-publish
  You can read more about this vulnerability here:
     https://blog.gradle.org/plugin-portal-update
```

@gastaldi shouldn't dependabot take care of this now? Also should we define the version? Doesn't Gradle just use the latest if we don't define it?

Thanks!