### PR TITLE
Honor the environment variable for verifying the host at which the server is listening

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
@@ -11,6 +11,7 @@ import java.util.zip.GZIPOutputStream;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.rest.TestResource;
@@ -33,7 +34,8 @@ public class JaxRSTestCase {
 
     @Test
     public void testConfigInjectionOfPort() {
-        RestAssured.when().get("/test/config/host").then().body(is("0.0.0.0"));
+        String host = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class).orElse("0.0.0.0");
+        RestAssured.when().get("/test/config/host").then().body(is(host));
     }
 
     @Test


### PR DESCRIPTION
Sometimes, when running on a VPN, `0.0.0.0` is inaccessible and it forces me to set the `QUARKUS_HTTP_HOST` environment variable to `localhost`. There is one test case that does not honor the explicit environment variable setting. This PR fixes that problem.

I don't know if there is a better way of doing it, but I'm open to suggestions.