### PR TITLE
Avoid the usage of unrecommended private members in Naryana JTA integration tests application beans

### DIFF
--- a/integration-tests/narayana-jta/src/main/java/io/quarkus/narayana/jta/TransactionBeanWithEvents.java
+++ b/integration-tests/narayana-jta/src/main/java/io/quarkus/narayana/jta/TransactionBeanWithEvents.java
@@ -27,7 +27,7 @@ public class TransactionBeanWithEvents {
     private static int commitCount, rollbackCount;
 
     @Inject
-    private TransactionManager tm;
+    TransactionManager tm;
 
     static int getInitialized() {
         return initializedCount;
@@ -90,7 +90,7 @@ public class TransactionBeanWithEvents {
             log.error("@Initialized expects transaction is Status.STATUS_ACTIVE");
             throw new IllegalStateException("@Initialized expects transaction is Status.STATUS_ACTIVE");
         }
-        Context ctx = null;
+        Context ctx;
         try {
             ctx = beanManager.getContext(TransactionScoped.class);
         } catch (Exception e) {
@@ -116,7 +116,7 @@ public class TransactionBeanWithEvents {
             log.error("@BeforeDestroyed expects an active transaction");
             throw new IllegalStateException("@BeforeDestroyed expects an active transaction");
         }
-        Context ctx = null;
+        Context ctx;
         try {
             ctx = beanManager.getContext(TransactionScoped.class);
         } catch (Exception e) {

--- a/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopedTest.java
+++ b/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopedTest.java
@@ -16,16 +16,16 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 class TransactionScopedTest {
     @Inject
-    private UserTransaction tx;
+    UserTransaction tx;
 
     @Inject
-    private TransactionManager tm;
+    TransactionManager tm;
 
     @Inject
-    private TransactionScopedBean beanTransactional;
+    TransactionScopedBean beanTransactional;
 
     @Inject
-    private TransactionBeanWithEvents beanEvents;
+    TransactionBeanWithEvents beanEvents;
 
     @Test
     void transactionScopedInTransaction() throws Exception {


### PR DESCRIPTION
Otherwise log messages like the one below were printed when running tests, let's get rid of them.

```
2020-03-28 20:26:18,276 INFO  [io.qua.arc.pro.BeanProcessor] (build-11) Found unrecommended usage of private members (use package-private instead) in application beans:
	- @Inject field io.quarkus.narayana.jta.TransactionScopedTest#beanEvents,
	- @Inject field io.quarkus.narayana.jta.TransactionScopedTest#beanTransactional,
	- @Inject field io.quarkus.narayana.jta.TransactionScopedTest#tm,
	- @Inject field io.quarkus.narayana.jta.TransactionScopedTest#tx,
	- @Inject field io.quarkus.narayana.jta.TransactionBeanWithEvents#tm
```