### PR TITLE
WIP: fix(#7900): Adds Cubbyhole Response Wrapping

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
@@ -3,8 +3,6 @@ package io.quarkus.vault.runtime.client;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static io.quarkus.vault.runtime.client.OkHttpClientFactory.createHttpClient;
 
-import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapData;
-import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapResult;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -40,6 +38,8 @@ import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
 import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapData;
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPGenerateCodeResult;

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
@@ -3,6 +3,8 @@ package io.quarkus.vault.runtime.client;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static io.quarkus.vault.runtime.client.OkHttpClientFactory.createHttpClient;
 
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapData;
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapResult;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -231,7 +233,6 @@ public class OkHttpVaultClient implements VaultClient {
     @Override
     public int systemHealth(boolean isStandByOk, boolean isPerfStandByOk) {
         Map<String, String> queryParams = getHealthParams(isStandByOk, isPerfStandByOk);
-
         return head("sys/health", queryParams);
     }
 
@@ -244,6 +245,12 @@ public class OkHttpVaultClient implements VaultClient {
     @Override
     public VaultSealStatusResult systemSealStatus() {
         return get("sys/seal-status", Collections.emptyMap(), VaultSealStatusResult.class);
+    }
+
+    @Override
+    public VaultUnwrapResult unwrap(String token) {
+        VaultUnwrapData body = new VaultUnwrapData(token);
+        return post("sys/wrapping/unwrap", token, body, VaultUnwrapResult.class);
     }
 
     @Override

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
@@ -1,5 +1,6 @@
 package io.quarkus.vault.runtime.client;
 
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapResult;
 import java.util.Map;
 
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
@@ -94,6 +95,8 @@ public interface VaultClient {
     VaultHealthResult systemHealthStatus(boolean isStandByOk, boolean isPerfStandByOk);
 
     VaultSealStatusResult systemSealStatus();
+
+    VaultUnwrapResult unwrap(String token);
 
     VaultInitResponse init(int secretShares, int secretThreshold);
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
@@ -1,6 +1,5 @@
 package io.quarkus.vault.runtime.client;
 
-import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapResult;
 import java.util.Map;
 
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
@@ -17,6 +16,7 @@ import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
 import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPGenerateCodeResult;

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapAuth.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapAuth.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.auth.AbstractVaultAuthAuth;
+
+public class VaultUnwrapAuth extends AbstractVaultAuthAuth<Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapData.java
@@ -1,0 +1,16 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultUnwrapData implements VaultModel {
+
+    private String token;
+
+    public VaultUnwrapData(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapResult.java
@@ -1,0 +1,34 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+/**
+ * {
+ *   "request_id": "5f654232-b0de-c27f-1fae-70c9d323c458",
+ *   "lease_id": "",
+ *   "lease_duration": 0,
+ *   "renewable": false,
+ *   "data": null,
+ *   "warnings": null,
+ *   "auth": {
+ *     "client_token": "s.6tyZnRgG7TpDMPg135CEVMHk",
+ *     "accessor": "Z00Qd1lU9apbt8eBIm1XUQHE",
+ *     "policies": [
+ *       "apps",
+ *       "default"
+ *     ],
+ *     "token_policies": [
+ *       "apps",
+ *       "default"
+ *     ],
+ *     "identity_policies": null,
+ *     "metadata": null,
+ *     "orphan": false,
+ *     "entity_id": "",
+ *     "lease_duration": 2764800,
+ *     "renewable": true
+ *   }
+ * }
+ */
+public class VaultUnwrapResult extends AbstractVaultDTO<Object, VaultUnwrapAuth> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapResult.java
@@ -4,30 +4,30 @@ import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
 
 /**
  * {
- *   "request_id": "5f654232-b0de-c27f-1fae-70c9d323c458",
- *   "lease_id": "",
- *   "lease_duration": 0,
- *   "renewable": false,
- *   "data": null,
- *   "warnings": null,
- *   "auth": {
- *     "client_token": "s.6tyZnRgG7TpDMPg135CEVMHk",
- *     "accessor": "Z00Qd1lU9apbt8eBIm1XUQHE",
- *     "policies": [
- *       "apps",
- *       "default"
- *     ],
- *     "token_policies": [
- *       "apps",
- *       "default"
- *     ],
- *     "identity_policies": null,
- *     "metadata": null,
- *     "orphan": false,
- *     "entity_id": "",
- *     "lease_duration": 2764800,
- *     "renewable": true
- *   }
+ * "request_id": "5f654232-b0de-c27f-1fae-70c9d323c458",
+ * "lease_id": "",
+ * "lease_duration": 0,
+ * "renewable": false,
+ * "data": null,
+ * "warnings": null,
+ * "auth": {
+ * "client_token": "s.6tyZnRgG7TpDMPg135CEVMHk",
+ * "accessor": "Z00Qd1lU9apbt8eBIm1XUQHE",
+ * "policies": [
+ * "apps",
+ * "default"
+ * ],
+ * "token_policies": [
+ * "apps",
+ * "default"
+ * ],
+ * "identity_policies": null,
+ * "metadata": null,
+ * "orphan": false,
+ * "entity_id": "",
+ * "lease_duration": 2764800,
+ * "renewable": true
+ * }
  * }
  */
 public class VaultUnwrapResult extends AbstractVaultDTO<Object, VaultUnwrapAuth> {

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAppRoleAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAppRoleAuthenticationConfig.java
@@ -15,9 +15,17 @@ public class VaultAppRoleAuthenticationConfig {
     public Optional<String> roleId;
 
     /**
-     * Secret Id for AppRole auth method. This property is required when selecting the app-role authentication type.
+     * Secret Id for AppRole auth method. This property is required when selecting the app-role authentication type and not setting the secret id as wrapped.
+     *
+     * {@link VaultAppRoleAuthenticationConfig#secretIdWrapped}
      */
     @ConfigItem
     public Optional<String> secretId;
+
+    /**
+     * Wrapped token containing the secret Id for AppRole auth method. This flag is not mandatory, only required if secret id is wrapped.
+     */
+    @ConfigItem
+    public Optional<String> secretIdWrapped;
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -18,15 +18,6 @@ public class VaultAuthenticationConfig {
     public Optional<String> clientToken;
 
     /**
-     * Vault inserts the generated token into the cubbyhole of a single-use token,
-     * returning that single-use wrapping token.
-     *
-     * Retrieving the secret requires an unwrap operation against this wrapping token.
-     */
-    @ConfigItem
-    public Optional<String> wrapToken;
-
-    /**
      * AppRole authentication method
      * <p>
      * See https://www.vaultproject.io/api/auth/approle/index.html

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -18,6 +18,15 @@ public class VaultAuthenticationConfig {
     public Optional<String> clientToken;
 
     /**
+     * Vault inserts the generated token into the cubbyhole of a single-use token,
+     * returning that single-use wrapping token.
+     *
+     * Retrieving the secret requires an unwrap operation against this wrapping token.
+     */
+    @ConfigItem
+    public Optional<String> wrapToken;
+
+    /**
      * AppRole authentication method
      * <p>
      * See https://www.vaultproject.io/api/auth/approle/index.html

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -215,9 +215,10 @@ public class VaultConfigSource implements ConfigSource {
                 DEFAULT_KUBERNETES_JWT_TOKEN_PATH);
         serverConfig.authentication.userpass.username = getOptionalVaultProperty("authentication.userpass.username");
         serverConfig.authentication.userpass.password = getOptionalVaultProperty("authentication.userpass.password");
+        serverConfig.authentication.userpass.passwordWrapped = getOptionalVaultProperty("authentication.userpass.password-wrapped");
         serverConfig.authentication.appRole.roleId = getOptionalVaultProperty("authentication.app-role.role-id");
         serverConfig.authentication.appRole.secretId = getOptionalVaultProperty("authentication.app-role.secret-id");
-        serverConfig.authentication.wrapToken = getOptionalVaultProperty("authentication.wrap-token");
+        serverConfig.authentication.appRole.secretIdWrapped = getOptionalVaultProperty("authentication.app-role.secret-id-wrapped");
         serverConfig.renewGracePeriod = getVaultDuration("renew-grace-period", DEFAULT_RENEW_GRACE_PERIOD);
         serverConfig.secretConfigCachePeriod = getVaultDuration("secret-config-cache-period",
                 DEFAULT_SECRET_CONFIG_CACHE_PERIOD);

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -217,6 +217,7 @@ public class VaultConfigSource implements ConfigSource {
         serverConfig.authentication.userpass.password = getOptionalVaultProperty("authentication.userpass.password");
         serverConfig.authentication.appRole.roleId = getOptionalVaultProperty("authentication.app-role.role-id");
         serverConfig.authentication.appRole.secretId = getOptionalVaultProperty("authentication.app-role.secret-id");
+        serverConfig.authentication.wrapToken = getOptionalVaultProperty("authentication.wrap-token");
         serverConfig.renewGracePeriod = getVaultDuration("renew-grace-period", DEFAULT_RENEW_GRACE_PERIOD);
         serverConfig.secretConfigCachePeriod = getVaultDuration("secret-config-cache-period",
                 DEFAULT_SECRET_CONFIG_CACHE_PERIOD);

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultUserpassAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultUserpassAuthenticationConfig.java
@@ -15,9 +15,17 @@ public class VaultUserpassAuthenticationConfig {
     public Optional<String> username;
 
     /**
-     * Password for userpass auth method. This property is required when selecting the userpass authentication type.
+     * Password for userpass auth method. This property is required when selecting the userpass authentication type and not setting the password as wrapped.
+     *
+     * {@link VaultUserpassAuthenticationConfig#passwordWrapped}
      */
     @ConfigItem
     public Optional<String> password;
+
+    /**
+     * Wrapped token containing the password for userpass auth method. This flag is not mandatory, only required if password is wrapped.
+     */
+    @ConfigItem
+    public Optional<String> passwordWrapped;
 
 }


### PR DESCRIPTION
The PR is not ready to be merged, need tests, docs, ... but it is the first iteration. As I said in the issue, I have used this method in the past and this is how I used it. But basically this method implements the next part: https://learn.hashicorp.com/vault/secrets-management/sm-cubbyhole#step-2-unwrap-the-secret which is how Vault creators shows that this should be used.

Things I want you to note:

1) It is really simple solution ad the code looks easy to follow.
2) It is not invasive at all, we are not changing the authentication method at all, what was working before should work now without any problem, this PR just add a new logic after this.
3) To access to unwrap token, the user can use any auth method supported.
4) an `application.properties` that implements the steps showed at https://learn.hashicorp.com/vault/secrets-management/sm-cubbyhole#step-2-unwrap-the-secret  would look like (notice that the token with `default` role is something that the Vault operator must create we cannot do this as an operator might decide to use another role):

```
quarkus.vault.authentication.client-token=s.VR3mwdk9miJ6VRLFbQe0Duwq
quarkus.vault.authentication.unwrap-token=s.3Kf3Xfn58Asr3bSDkRXATHrw
```

What is happening here is that we are logging to Vault using the `client-token` (notice that could be any other auth method), when logged unwraps the `unwrap-token` and use the returned token as logged token all the time.

So if you read the link these are the two steps implemented here:

1. Authenticate with Vault using this default token (less privileged token)
2. Unwrap the secret to obtain more privileged token (apps persona token)
3. Read secret/dev using the appstoken (unwrapped)

If you read the link I provided they say as a note:

`If a client has been expecting delivery of a response-wrapping token and none arrives, this may be due to an attacker intercepting the token and then preventing it from traveling further. This should cause an alert to trigger an immediate investigation.`

This is something I plan to implement when we agree with this first iteration.

Also they say:

`Verify that this token has apps policy attached.`

This is something that I'll add after this first iteration, if user for example adds a property with the roles this unwrapped token should contain, then I can automatically check them as well.

And that's all, I have no much time to spend on this so let's try to make things easy, and at the end the only thing I am implementing here is the lessons provided by Vault team.

cc/ @vsevel @sberyozkin @machi1990 