### PR TITLE
Fix issue 8254 - PanacheQuery.count() throws "unexpected token: SELECT"

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/PanacheQueryImpl.java
@@ -3,6 +3,8 @@ package io.quarkus.hibernate.orm.panache.runtime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
@@ -15,6 +17,9 @@ import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Range;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
+
+    private static final Pattern SELECT_PATTERN = Pattern.compile("^\\s*SELECT\\s+((?:DISTINCT\\s+)?[^\\s]+)\\s+([^\\s]+.*)$",
+            Pattern.CASE_INSENSITIVE);
 
     private Query jpaQuery;
     private Object paramsArrayOrMap;
@@ -153,6 +158,10 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     }
 
     protected String countQuery() {
+        Matcher selectMatcher = SELECT_PATTERN.matcher(query);
+        if (selectMatcher.matches()) {
+            return "SELECT COUNT(" + selectMatcher.group(1) + ") " + selectMatcher.group(2);
+        }
         return "SELECT COUNT(*) " + query;
     }
 

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Cat.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Cat.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Cat extends PanacheEntity {
+
+    @ManyToOne
+    CatOwner owner;
+
+    public Cat(CatOwner owner) {
+        this.owner = owner;
+    }
+
+    public Cat() {
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/CatOwner.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/CatOwner.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class CatOwner extends PanacheEntity {
+
+    public String name;
+
+    public CatOwner(String name) {
+        this.name = name;
+    }
+
+    public CatOwner() {
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -158,4 +158,9 @@ public class PanacheFunctionalityTest {
     public void testBug7721() {
         RestAssured.when().get("/test/7721").then().body(is("OK"));
     }
+
+    @Test
+    public void testBug8254() {
+        RestAssured.when().get("/test/8254").then().body(is("OK"));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/8254

Queries like these
`select distinct o from Order o left join fetch o.lineItems`
are translated into
`SELECT COUNT(*) select distinct o from Order o left join fetch o.lineItems`
when `PanacheQuery.count()` is invoked which clearly is not valid syntax.

This change will result in a query that looks like this:
`SELECT COUNT(distinct o) from Order o left join fetch o.lineItems`

Works with SELECT and SELECT DISTINCT.