### PR TITLE
Amazon Alexa extension for Quarkus Native integration with AWS Lambda

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -498,6 +498,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-alexa-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-amazon-lambda-xray-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -141,6 +141,7 @@
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <aws-xray.version>2.4.0</aws-xray.version>
         <awssdk.version>2.10.70</awssdk.version>
+        <aws-alexa-sdk.version>2.30.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.71</kotlin.version>
         <dekorate.version>0.11.4</dekorate.version>
@@ -763,6 +764,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-amazon-dynamodb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-alexa</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -2707,6 +2713,44 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>url-connection-client</artifactId>
                 <version>${awssdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazon.alexa</groupId>
+                <artifactId>ask-sdk</artifactId>
+                <version>${aws-alexa-sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.amazon.alexa</groupId>
+                        <artifactId>ask-sdk-apache-client</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.amazon.alexa</groupId>
+                <artifactId>ask-sdk-apache-client</artifactId>
+                <version>${aws-alexa-sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.amazon.alexa</groupId>
+                        <artifactId>ask-sdk-model-runtime</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/extensions/amazon-alexa/deployment/pom.xml
+++ b/extensions/amazon-alexa/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-alexa-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-alexa-deployment</artifactId>
+    <name>Quarkus - Amazon Alexa - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/amazon-alexa/deployment/src/main/java/io/quarkus/amazon/lambda/alexa/AlexaProcessor.java
+++ b/extensions/amazon-alexa/deployment/src/main/java/io/quarkus/amazon/lambda/alexa/AlexaProcessor.java
@@ -1,0 +1,28 @@
+package io.quarkus.amazon.lambda.alexa;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
+
+public class AlexaProcessor {
+
+    @BuildStep
+    void addDependencies(BuildProducer<IndexDependencyBuildItem> indexDependency) {
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-runtime"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-model"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-lambda-support"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-servlet-support"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-dynamodb-persistence-adapter"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-apache-client"));
+        indexDependency.produce(new IndexDependencyBuildItem("com.amazon.alexa", "ask-sdk-model-runtime"));
+    }
+
+    @BuildStep
+    NativeImageProxyDefinitionBuildItem httpProxies() {
+        return new NativeImageProxyDefinitionBuildItem("org.apache.http.conn.HttpClientConnectionManager",
+                "org.apache.http.pool.ConnPoolControl", "com.amazonaws.http.conn.Wrapped");
+    }
+
+}

--- a/extensions/amazon-alexa/pom.xml
+++ b/extensions/amazon-alexa/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-alexa-parent</artifactId>
+    <name>Quarkus - Amazon Alexa</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/extensions/amazon-alexa/runtime/pom.xml
+++ b/extensions/amazon-alexa/runtime/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-alexa-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-alexa</artifactId>
+    <name>Quarkus - Amazon Alexa - Runtime</name>
+    <description>Write Amazon Alexa Skills with AWS Lambda or HTTPS endpoints</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazon.alexa</groupId>
+            <artifactId>ask-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.amazon.alexa</groupId>
+                    <artifactId>ask-sdk-apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.alexa</groupId>
+            <artifactId>ask-sdk-apache-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazon.alexa</groupId>
+                    <artifactId>ask-sdk-model-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/amazon-alexa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/amazon-alexa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,10 @@
+---
+name: "Amazon Alexa"
+metadata:
+  keywords:
+  - "lambda"
+  - "alexa"
+  categories:
+  - "cloud"
+  guide: "https://quarkus.io/guides/amazon-lambda"
+  status: "preview"

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -128,6 +128,7 @@
         <module>amazon-lambda-xray</module>
         <module>amazon-lambda-http</module>
         <module>amazon-dynamodb</module>
+        <module>amazon-alexa</module>
         <module>azure-functions-http</module>
 
         <!-- New Frameworks -->


### PR DESCRIPTION
**Summary:**

Introduce a new extension, to assist the native image compilation of Amazon Alexa AWS Lambda functions.  Alexa can also be hosted by any HTTPS endpoint.

The Amazon Alexa ASK Java SDK v2 uses the RequestStreamHandler interface, via subclassing the SkillStreamHandler classes.  With the merge of commits to enable Amazon Alexa to be integrated with Quarkus, the remaining piece was support for Quarkus native.

Commits that added the functionality required for Alexa were #7866, #7985 and documentation #7927

The AWS ASK SDK v2 uses a builder pattern for the Jackson deserialisation, which needs to be added as reflective classes to the native build.  I've created a simple scanner to do this dynamically via identifying all classes annotated with JsonDeserialize.class. As common with all AWS clients, a dynamic proxy is required also.  It is quite tedious to do all this manually if a Quarkus extension was not used.

FYI, I'll update documentation in a subsequent PR if this one is accepted.

**Tested by**:

**Install new extension:**
1. git clone -b ext/alexa https://github.com/oztimpower/quarkus.git
2. cd quarkus
3. cd extensions/amazon-alexa
4. mvn install

**Alexa Test Project:**
1. git clone https://github.com/oztimpower/alexa-quarkus.git
2. cd alexa-quarkus
3. mvn -Pnative package -Dquarkus.native.container-build=true

The output of the native image will show the number of classes included for build time.

`Printing 20792 classes of type BUILD_TIME to /project/reports/build_time_classes_20200330_052538.txt
`

4. sam local invoke --template sam.native.yaml --event payload.json

A positive outcome is expected, where Quarkus Native is able to produce a valid response to the Lambda test payload.json.

```
END RequestId: d9815e18-3c7c-1881-120e-af6ebed0bb81
REPORT RequestId: d9815e18-3c7c-1881-120e-af6ebed0bb81	Init Duration: 235.37 ms	Duration: 103.46 ms	Billed Duration: 200 ms	Memory Size: 256 MB	Max Memory Used: 51 MB	

{"version":"1.0","userAgent":"ask-java/2.28.0 Java/11.0.6 templateResolver","response":{"outputSpeech":{"type":"SSML","ssml":"\u003cspeak\u003eHi \u003calexa:name type=\"first\" personId=\"amzn1.ask.account.AA274FLEVWIWU6CTPZQ25XW6P7XGAJJ4YB7OPEFKULHJRUQDIO5AFS2UNPLBPG6BZKTGRTH6BDQZJ3SNAC6ELTPWT4DALVM5WZGC59JHXBZQRZ4V646JEF2EKO3DVMWW65E67NPBTLIGV4HUDK45JFAQWAY5C7OGWQNIOLWNS4M6WNLIMQWU5HUEHDXAT7QTONKHS7ILR2V5EOY\"/\u003e\u003c/speak\u003e"}}}

```

**Negative Test:**

1. Comment out the new extension in the project POM

```
<!--
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-amazon-alexa</artifactId>
            <version>${quarkus.version}</version>
        </dependency>
-->

```

2. Recompile
mvn  -Pnative package -Dquarkus.native.container-build=true

The number of classes included at build time drops significantly.

`Printing 11212 classes of type BUILD_TIME to /project/reports/build_time_classes_20200330_055547.txt
`

3. sam local invoke --template sam.native.yaml --event payload.json

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Builder class com.amazon.ask.model.RequestEnvelope$Builder does not have build method (name: 'build')

END RequestId: 411c18ec-af00-1623-1ff3-795de76f32ed
REPORT RequestId: 411c18ec-af00-1623-1ff3-795de76f32ed	Init Duration: 143.56 ms	Duration: 49.91 ms	Billed Duration: 100 ms	Memory Size: 256 MB	Max Memory Used: 35 MB	

{"errorType":"com.amazon.ask.exception.AskSdkException","errorMessage":"Deserialization error"}

```

/cc @patriot1burke 
/cc @gsmet 
/cc @geoand 
