### PR TITLE
Test Uni<Response> support

### DIFF
--- a/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/MutinyResource.java
+++ b/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/MutinyResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.annotations.Stream;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import io.quarkus.resteasy.mutiny.test.annotations.Async;
 import io.smallrye.mutiny.Multi;
@@ -57,5 +58,31 @@ public class MutinyResource {
                 .onItem().apply(s -> {
                     throw new IllegalStateException("BOOM!");
                 });
+    }
+
+    @Path("response/tea-pot")
+    @GET
+    public Uni<Response> teapot() {
+        return Uni.createFrom().item(() -> Response.status(418).build());
+    }
+
+    @Path("response/no-content")
+    @GET
+    public Uni<Response> noContent() {
+        return Uni.createFrom().item(() -> Response.noContent().build());
+    }
+
+    @Path("response/accepted")
+    @GET
+    public Uni<Response> accepted() {
+        return Uni.createFrom().item(() -> Response.accepted("Hello").build());
+    }
+
+    @Path("response/conditional/{test}")
+    @GET
+    public Uni<Response> conditional(@PathParam("test") boolean test) {
+        return Uni.createFrom().item(test)
+                .map(b -> b ? Response.accepted() : Response.noContent())
+                .map(Response.ResponseBuilder::build);
     }
 }

--- a/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/RestEasyMutinyTest.java
+++ b/extensions/resteasy-mutiny/deployment/src/test/java/io/quarkus/resteasy/mutiny/test/RestEasyMutinyTest.java
@@ -71,4 +71,31 @@ public class RestEasyMutinyTest {
         Assertions.assertEquals(response.getStatus(), 500);
     }
 
+    @Test
+    public void testHttpResponseTeaPot() {
+        Response response = client.target(url.toExternalForm() + "/response/tea-pot").request().get();
+        Assertions.assertEquals(418, response.getStatus());
+    }
+
+    @Test
+    public void testHttpResponseNoContent() {
+        Response response = client.target(url.toExternalForm() + "/response/no-content").request().get();
+        Assertions.assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    public void testHttpResponseAcceptedWithBody() {
+        Response response = client.target(url.toExternalForm() + "/response/accepted").request().get();
+        Assertions.assertEquals(202, response.getStatus());
+        Assertions.assertEquals("Hello", response.readEntity(String.class));
+    }
+
+    @Test
+    public void testHttpResponseConditional() {
+        Response response = client.target(url.toExternalForm() + "/response/conditional/true").request().get();
+        Assertions.assertEquals(202, response.getStatus());
+        response = client.target(url.toExternalForm() + "/response/conditional/false").request().get();
+        Assertions.assertEquals(204, response.getStatus());
+    }
+
 }


### PR DESCRIPTION
Add a few more tests checking the behavior of Resteasy Mutiny when returning `Uni<Response>` objects.

Related to: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Resteasy.20Mutiny