### PR TITLE
Don't attempt to load classes from the java package

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -35,6 +35,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     private static final Logger log = Logger.getLogger(QuarkusClassLoader.class);
     protected static final String META_INF_SERVICES = "META-INF/services/";
+    protected static final String JAVA = "java.";
 
     static {
         registerAsParallelCapable();
@@ -276,6 +277,9 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.startsWith(JAVA)) {
+            return parent.loadClass(name);
+        }
         //even if the thread is interrupted we still want to be able to load classes
         //if the interrupt bit is set then we clear it and restore it at the end
         boolean interrupted = Thread.interrupted();


### PR DESCRIPTION
If a dependency has packaged java. classes for some reason
this could cause problems.

Fixes #8260