### PR TITLE
Mongodb panache/cleanups

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheQueryImpl.java
@@ -1,10 +1,6 @@
 package io.quarkus.mongodb.panache.reactive.runtime;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -46,28 +42,8 @@ public class ReactivePanacheQueryImpl<Entity> implements ReactivePanacheQuery<En
 
     @Override
     public <T> ReactivePanacheQuery<T> project(Class<T> type) {
-        Set<String> fieldNames = new HashSet<>();
-        // gather field names from getters
-        for (Method method : type.getMethods()) {
-            if (method.getName().startsWith("get") && !method.getName().equals("getClass")) {
-                String fieldName = MongoPropertyUtil.decapitalize(method.getName().substring(3));
-                fieldNames.add(fieldName);
-            }
-        }
-
-        // gather field names from public fields
-        for (Field field : type.getFields()) {
-            fieldNames.add(field.getName());
-        }
-
-        // replace fields that have @BsonProperty mappings
-        Map<String, String> replacementMap = MongoPropertyUtil.getReplacementMap(type);
-        for (Map.Entry<String, String> entry : replacementMap.entrySet()) {
-            if (fieldNames.contains(entry.getKey())) {
-                fieldNames.remove(entry.getKey());
-                fieldNames.add(entry.getValue());
-            }
-        }
+        // collect field names from public fields and getters
+        Set<String> fieldNames = MongoPropertyUtil.collectFields(type);
 
         // create the projection document
         this.projections = new Document();

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
@@ -1,11 +1,7 @@
 package io.quarkus.mongodb.panache.runtime;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -47,28 +43,8 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @Override
     public <T> PanacheQuery<T> project(Class<T> type) {
-        Set<String> fieldNames = new HashSet<>();
-        // gather field names from getters
-        for (Method method : type.getMethods()) {
-            if (method.getName().startsWith("get") && !method.getName().equals("getClass")) {
-                String fieldName = MongoPropertyUtil.decapitalize(method.getName().substring(3));
-                fieldNames.add(fieldName);
-            }
-        }
-
-        // gather field names from public fields
-        for (Field field : type.getFields()) {
-            fieldNames.add(field.getName());
-        }
-
-        // replace fields that have @BsonProperty mappings
-        Map<String, String> replacementMap = MongoPropertyUtil.getReplacementMap(type);
-        for (Map.Entry<String, String> entry : replacementMap.entrySet()) {
-            if (fieldNames.contains(entry.getKey())) {
-                fieldNames.remove(entry.getKey());
-                fieldNames.add(entry.getValue());
-            }
-        }
+        // collect field names from public fields and getters
+        Set<String> fieldNames = MongoPropertyUtil.collectFields(type);
 
         // create the projection document
         this.projections = new Document();

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestImperativeEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestImperativeEntity.java
@@ -1,9 +1,7 @@
 package io.quarkus.it.mongodb.panache.test;
 
 import io.quarkus.mongodb.panache.PanacheMongoEntity;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 
-@RegisterForReflection
 public class TestImperativeEntity extends PanacheMongoEntity {
     public String title;
     public String category;

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestReactiveEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/test/TestReactiveEntity.java
@@ -1,9 +1,7 @@
 package io.quarkus.it.mongodb.panache.test;
 
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 
-@RegisterForReflection
 public class TestReactiveEntity extends ReactivePanacheMongoEntity {
     public String title;
     public String category;


### PR DESCRIPTION
These are some cleanups for MongoDB with Panache: 

- remove no more needed `@RegisterForReflection` inside the IT: /cc @FroMage 
- remove some code duplication between the reactive and the imperative implementation
- refactor the build step processor