### PR TITLE
Add build items for Labels, Annotations

### DIFF
--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesAnnotationBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesAnnotationBuildItem.java
@@ -1,0 +1,29 @@
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class KubernetesAnnotationBuildItem extends MultiBuildItem {
+
+    private final String key;
+    private final String value;
+    private final String target;
+
+    public KubernetesAnnotationBuildItem(String key, String value, String target) {
+        this.key = key;
+        this.value = value;
+        this.target = target;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+}

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesEnvBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesEnvBuildItem.java
@@ -5,26 +5,48 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 public final class KubernetesEnvBuildItem extends MultiBuildItem {
 
+    private final String name;
+    private final String value;
+    private final String secret;
+    private final String configmap;
+    private final String field;
     private final String target;
 
-    private final String key;
-    private final String value;
+    public KubernetesEnvBuildItem(String name, String value, String target) {
+        this(name, value, null, null, null, target);
+    }
 
-    public KubernetesEnvBuildItem(String target, String key, String value) {
-        this.target = target;
-        this.key = key;
+    public KubernetesEnvBuildItem(String name, String value, String secret, String configmap, String field, String target) {
+        this.name = name;
         this.value = value;
+        this.secret = secret;
+        this.configmap = configmap;
+        this.field = field;
+        this.target = target;
     }
 
-    public String getTarget() {
-        return this.target;
-    }
-
-    public String getKey() {
-        return key;
+    public String getName() {
+        return name;
     }
 
     public String getValue() {
         return value;
     }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public String getConfigmap() {
+        return configmap;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
 }

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesLabelBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesLabelBuildItem.java
@@ -1,0 +1,28 @@
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class KubernetesLabelBuildItem extends MultiBuildItem {
+
+    private final String key;
+    private final String value;
+    private final String target;
+
+    public KubernetesLabelBuildItem(String key, String value, String target) {
+        this.key = key;
+        this.value = value;
+        this.target = target;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getTarget() {
+        return this.target;
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -52,7 +52,7 @@ public class KubernetesDeployer {
     public void deploy(KubernetesClientBuildItem kubernetesClient,
             ContainerImageInfoBuildItem containerImageInfo,
             List<ContainerImageResultBuildItem> containerImageResults,
-            List<KubernetesDeploymentTargetBuildItem> kubernetesDeploymentTargetBuildItems,
+            List<KubernetesDeploymentTargetBuildItem> kubernetesDeploymentTargets,
             OutputTargetBuildItem outputTarget,
             BuildProducer<DeploymentResultBuildItem> deploymentResult) {
 
@@ -76,7 +76,7 @@ public class KubernetesDeployer {
         }
 
         //Get any build item but if the build was s2i, use openshift
-        KubernetesDeploymentTargetBuildItem deploymentTarget = kubernetesDeploymentTargetBuildItems
+        KubernetesDeploymentTargetBuildItem deploymentTarget = kubernetesDeploymentTargets
                 .stream()
                 .filter(d -> !S2I.equals(containerImageResult.getProvider()) || OPENSHIFT.equals(d.getName()))
                 .findFirst()


### PR DESCRIPTION
Fixes #8295 

The pull request introduces two new build items:

- labels
- annotation

It also mofies the env build item so that it encapsulated all env var configuration parameters.

In addition to these changes it also modifies the KubernetesProcessor, so that labels, annotations and env vars are handled in a single place.