### PR TITLE
Fix anchor ssl configuration plus small fixes

### DIFF
--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -1,2 +1,3 @@
 :idprefix:
 :idseparator: -
+:icons: font

--- a/docs/src/main/asciidoc/jgit.adoc
+++ b/docs/src/main/asciidoc/jgit.adoc
@@ -52,5 +52,5 @@ Here is an example using it in a JAX-RS endpoint:
 
 [WARNING]
 ====
-When running in native mode, make sure that the link:native-and-ssl#the-sunec-library-and-friends[SSL access is configured correctly].
+When running in native mode, make sure that the link:native-and-ssl#the-truststore-path[SSL access is configured correctly].
 ====

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -158,6 +158,7 @@ And let's build the native executable again:
 ./mvnw clean install -Pnative
 ```
 
+[#the-truststore-path]
 == The TrustStore path
 
 You haven't noticed anything but, while building the image,
@@ -230,8 +231,5 @@ CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Djavax.net.ssl.trustStore
 
 We make building native executable easy and, even if the SSL support in GraalVM is still requiring some serious thinking,
 it should be mostly transparent when using Quarkus.
-
-Hopefully, the situation will improve in the future:
-the native executables size overhead will be reduced and the SunCE library might not be needed anymore.
 
 We track GraalVM progress on a regular basis so we will promptly integrate in Quarkus any improvement with respect to SSL support.

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -165,7 +165,7 @@ In order to set-up the `tenant-a` configuration to use Google OpenID Provider, y
 Once you create the project and have your project's `client_id` and `client_secret`, you can try to configure a tenant as follows:
 
 [source, properties]
----
+----
 # Tenant configuration using Google OpenID Provider
 quarkus.oidc.tenant-b.auth-server-url=https://accounts.google.com
 quarkus.oidc.tenant-b.application-type=web-app
@@ -173,7 +173,7 @@ quarkus.oidc.tenant-b.client-id={GOOGLE_CLIENT_ID}
 quarkus.oidc.tenant-b.credentials.secret={GOOGLE_CLIENT_SECRET}
 quarkus.oidc.tenant-b.token.issuer=https://accounts.google.com
 quarkus.oidc.tenant-b.authentication.scopes=email,profile,openid
----
+----
 
 == Starting and Configuring the Keycloak Server
 


### PR DESCRIPTION
The anchor for the SSL configuration broken in 1bfaeed30e8f139e4c8a0584b89dfefa48e15fdd. I replaced it with the new auto-generated link to the same section. 

I wonder if this (maybe all referenced sections) should have explicit ID to avoid breaking anchors accidentally.

Adding the fourth "-" prevents the site to show the three dashes on the published site (in this case AsciiDoc recognizes it as a block without delimiters)

(Some background: While developing the link-checker functionality for the latest version of the [AsciiDoc plugin for IntelliJ](https://github.com/asciidoctor/asciidoctor-intellij-plugin), I gave it a test run on the Antora docs and it found this broken anchor.)