### PR TITLE
Include the original exception that caused .env file copy to fail

### DIFF
--- a/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
+++ b/core/devmode/src/main/java/io/quarkus/dev/DevModeMain.java
@@ -136,7 +136,7 @@ public class DevModeMain implements Closeable {
                 // create a symlink to ensure that user updates to the file have the expected effect in dev-mode
                 Files.createSymbolicLink(link, dotEnvPath);
             } catch (IOException e) {
-                log.warn("Unable to copy .env file");
+                log.warn("Unable to copy .env file", e);
             }
         }
     }


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/8297

I initially thought of having an additional `logger.debug` which would include the exception that caused this to fail. But thinking a bit more, I think this warn message itself should include the original exception since a failure to copy an application artifact (which this `.env` is) can cause issues in the application (like shown in that linked issue), so IMO, the root cause should be available easily instead of just the warn message.