### PR TITLE
Remove Docker bridge mode for jpa-mssql and jpa-mariadb tests

### DIFF
--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -178,9 +178,6 @@
                                     <name>${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
                                     <run>
-                                        <network>
-                                            <mode>bridge</mode>
-                                        </network>
                                         <ports>
                                             <port>3308:3306</port>
                                         </ports>
@@ -198,15 +195,10 @@
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
-                                            <tcp>
-                                                <mode>direct</mode>
-                                                <ports>
-                                                    <port>3306</port>
-                                                </ports>
-                                            </tcp>
-                                            <!-- Unfortunately booting MariaDB is slow, needs to set a generous timeout: -->
-                                            <time>40000</time>
+                                            <time>20000</time>
+                                            <exec>
+                                                <postStart>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test</postStart>
+                                            </exec>
                                         </wait>
                                         <volumes>
                                             <bind>

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -189,9 +189,6 @@
                                     <name>${mssqldb.image}</name>
                                     <alias>quarkus-test-mssqldb</alias>
                                     <run>
-                                        <network>
-                                            <mode>bridge</mode>
-                                        </network>
                                         <ports>
                                             <port>1433:1433</port>
                                         </ports>
@@ -205,13 +202,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
-                                            <tcp>
-                                                <mode>direct</mode>
-                                                <ports>
-                                                    <port>1433</port>
-                                                </ports>
-                                            </tcp>
+                                            <log>SQL Server is now ready for client connections</log>
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>40000</time>
                                         </wait>


### PR DESCRIPTION
Remove Docker bridge mode for jpa-mssql and jpa-mariadb tests

Bridge mode is not available on non-linux systems

jpa-mysql and jpa-postgresql have it already solved
jpa-mariadb uses the same approach as jpa-mysql
jpa-mssql has log based check

Can be check via:
```
cd integration-tests
mvn clean install -fae -pl jpa-mariadb,jpa-mssql,jpa-mysql,jpa-postgresql -Ddocker \
  -Dtest-mariadb -Dtest-mssql -Dtest-mysql -Dtest-postgresql
```