### PR TITLE
Add support for @InjectMock

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -720,6 +720,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-junit5</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-integration-test-class-transformer</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -904,6 +904,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-junit5-mockito</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-arquillian</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -388,13 +388,28 @@ public class MockTestCase {
         Assertions.assertEquals("Bonjour Stuart", mockableBean2.greet("Stuart"));
     }
 
+    @ApplicationScoped
+    public static class MockableBean1 {
+
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MockableBean2 {
+
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
     public static class BonourGreeter extends MockableBean2 {
         @Override
         public String greet(String name) {
             return "Bonjour " + name;
         }
     }
-
 }
 ----
 <1> As the injected instance is not available here we use `installMockForType`, this mock is used for both test methods
@@ -403,6 +418,111 @@ public class MockTestCase {
 Note that there is no dependency on Mockito, you can use any mocking library you like, or even manually override the
 objects to provide the behaviour you require.
 
+==== Further simplification with `@InjectMock`
+
+Building on the features provided by `QuarkusMock`, Quarkus also allows users to effortlessly take advantage of link:https://site.mockito.org/[Mockito] for mocking the beans supported by `QuarkusMock`.
+This functionality is available via the `@io.quarkus.test.junit.mockito.InjectMock` annotation which is available in the `quarkus-junit5-mockito` dependency.
+
+Using `@InjectMock`, the previous example could be written as follows:
+
+[source,java]
+----
+@QuarkusTest
+public class MockTestCase {
+
+    @InjectMock
+    MockableBean1 mockableBean1; <1>
+
+    @InjectMock
+    MockableBean2 mockableBean2;
+
+    @BeforeEach
+    public void setup() {
+        Mockito.when(mockableBean1.greet("Stuart")).thenReturn("A mock for Stuart"); <2>
+    }
+
+    @Test
+    public void firstTest() {
+        Assertions.assertEquals("A mock for Stuart", mockableBean1.greet("Stuart"));
+        Assertions.assertEquals(null, mockableBean2.greet("Stuart")); <3>
+    }
+
+    @Test
+    public void secondTest() {
+        Mockito.when(mockableBean2.greet("Stuart")).thenReturn("Bonjour Stuart"); <4>
+        Assertions.assertEquals("A mock for Stuart", mockableBean1.greet("Stuart"));
+        Assertions.assertEquals("Bonjour Stuart", mockableBean2.greet("Stuart"));
+    }
+
+    @ApplicationScoped
+    public static class MockableBean1 {
+
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MockableBean2 {
+
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+}
+----
+<1> `@InjectMock` results in a mock being and is available in test methods of the test class (other test classes are *not* affected by this)
+<2> The `mockableBean1` is configured here for every test method of the class
+<3> Since the `mockableBean2` mock has not been configured, it will return the default Mockito response.
+<4> In this test the `mockableBean2` is configured, so it returns the configured response.
+
+Although the test above is good for showing the capabilities of `@InjectMock`, it is not a good representation of a real test. In a real test
+we would most likely configure a mock, but then test a bean that uses the mocked bean.
+Here is an example:
+
+[source,java]
+----
+@QuarkusTest
+public class MockGreetingServiceTest {
+
+    @InjectMock
+    GreetingService greetingService;
+
+    @Test
+    public void testGreeting() {
+        when(greetingService.greet()).thenReturn("hi");
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("hi")); <1>
+    }
+
+    @Path("greeting")
+    public static class GreetingResource {
+
+        final GreetingService greetingService;
+
+        public GreetingResource(GreetingService greetingService) {
+            this.greetingService = greetingService;
+        }
+
+        @GET
+        @Produces("text/plain")
+        public String greet() {
+            return greetingService.greet();
+        }
+    }
+
+    @ApplicationScoped
+    public static class GreetingService {
+        public String greet(){
+            return "hello";
+        }
+    }
+}
+----
+<1> Since we configured `greetingService` as a mock, the `GreetingResource` which uses the `GreetingService` bean, we get the mocked response instead of the response of the regular `GreetingService` bean
 
 == Test Bootstrap Configuration Options
 

--- a/integration-tests/injectmock/pom.xml
+++ b/integration-tests/injectmock/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-injectmock</artifactId>
+    <name>Quarkus - Integration Tests - InjectMock</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/CapitalizerService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/CapitalizerService.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CapitalizerService {
+
+    public String capitalize(String input) {
+        return input.toUpperCase();
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyResource.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.mockbean;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/dummy")
+public class DummyResource {
+
+    @Inject
+    @Named("first")
+    DummyService firstDummyService;
+
+    @Inject
+    @Named("second")
+    DummyService secondDummyService;
+
+    @GET
+    public String firstPlusSecond() {
+        return firstDummyService.returnDummyValue() + "/" + secondDummyService.returnDummyValue();
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyService.java
@@ -1,0 +1,6 @@
+package io.quarkus.it.mockbean;
+
+public interface DummyService {
+
+    String returnDummyValue();
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyService1.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyService1.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mockbean;
+
+public class DummyService1 implements DummyService {
+
+    @Override
+    public String returnDummyValue() {
+        return "first";
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyService2.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyService2.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+@Named("second")
+@ApplicationScoped
+public class DummyService2 implements DummyService {
+
+    @Override
+    public String returnDummyValue() {
+        return "second";
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyServiceProducer.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/DummyServiceProducer.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+public class DummyServiceProducer {
+
+    @Produces
+    @ApplicationScoped
+    @Named("first")
+    public DummyService dummyService() {
+        return new DummyService1();
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/GreetingResource.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/GreetingResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.mockbean;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("greeting")
+public class GreetingResource {
+
+    final MessageService messageService;
+    final SuffixService suffixService;
+    final CapitalizerService capitalizerService;
+
+    public GreetingResource(MessageService messageService, SuffixService suffixService, CapitalizerService capitalizerService) {
+        this.messageService = messageService;
+        this.suffixService = suffixService;
+        this.capitalizerService = capitalizerService;
+    }
+
+    @GET
+    @Produces("text/plain")
+    public String greet() {
+        return capitalizerService.capitalize(messageService.getMessage() + suffixService.getSuffix());
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/MessageService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/MessageService.java
@@ -1,0 +1,6 @@
+package io.quarkus.it.mockbean;
+
+public interface MessageService {
+
+    String getMessage();
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/MessageServiceImpl.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/MessageServiceImpl.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MessageServiceImpl implements MessageService {
+
+    @Override
+    public String getMessage() {
+        return "hello";
+    }
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/SuffixService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/SuffixService.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SuffixService {
+
+    public String getSuffix() {
+        return "";
+    }
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/DummyResourceTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/DummyResourceTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.mockbean;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+@QuarkusTest
+class DummyResourceTest {
+
+    @InjectMock
+    @Named("first")
+    DummyService firstDummyService;
+
+    @BeforeEach
+    void setUp() {
+        when(firstDummyService.returnDummyValue()).thenReturn("1");
+    }
+
+    @Test
+    void testDummy() {
+        given()
+                .when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .body(is("1/second"));
+    }
+
+    @Test
+    void testDummyAgain() {
+        given()
+                .when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .body(is("1/second"));
+    }
+
+    @Test
+    void testWithOverrideInMethod() {
+        when(firstDummyService.returnDummyValue()).thenReturn("fst");
+        given()
+                .when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .body(is("fst/second"));
+    }
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/GreetingResourceTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/GreetingResourceTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.it.mockbean;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+@QuarkusTest
+class GreetingResourceTest {
+
+    @InjectMock
+    MessageService messageService;
+
+    @InjectMock
+    SuffixService suffixService;
+
+    @Test
+    public void testGreet() {
+        Mockito.when(messageService.getMessage()).thenReturn("hi");
+        Mockito.when(suffixService.getSuffix()).thenReturn("!");
+
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("HI!"));
+    }
+
+    @Test
+    public void testGreetAgain() {
+        Mockito.when(messageService.getMessage()).thenReturn("yolo");
+        Mockito.when(suffixService.getSuffix()).thenReturn("!!!");
+
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("YOLO!!!"));
+    }
+
+    @Test
+    public void testMocksNotSet() {
+        // when mocks are not configured, they return the Mockito default response
+        Assertions.assertNull(messageService.getMessage());
+        Assertions.assertNull(suffixService.getSuffix());
+
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("NULLNULL"));
+    }
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithoutMocksTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithoutMocksTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.mockbean;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class WithoutMocksTest {
+
+    @Test
+    public void testGreet() {
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("HELLO"));
+    }
+
+    @Test
+    public void testDummy() {
+        given()
+                .when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .body(is("first/second"));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -99,6 +99,7 @@
         <module>cache</module>
         <module>qute</module>
         <module>bootstrap-config</module>
+        <module>injectmock</module>
     </modules>
 
     <build>

--- a/test-framework/junit5-mockito/pom.xml
+++ b/test-framework/junit5-mockito/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-junit5-mockito</artifactId>
+    <name>Quarkus - Test framework - JUnit 5 - Mockito</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectMock.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectMock.java
@@ -1,0 +1,15 @@
+package io.quarkus.test.junit.mockito;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When used on a field of a test class, the field becomes a Mockito mock,
+ * that is then used to mock the normal scoped bean which the field represents
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectMock {
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoMocksCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoMocksCallback.java
@@ -1,0 +1,70 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Qualifier;
+
+import org.mockito.Mockito;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeAllCallback;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+public class CreateMockitoMocksCallback implements QuarkusTestBeforeAllCallback {
+
+    @Override
+    public void beforeAll(Object testInstance) {
+        Class<?> current = testInstance.getClass();
+        while (current.getSuperclass() != null) {
+            for (Field field : current.getDeclaredFields()) {
+                InjectMock injectMockAnnotation = field.getAnnotation(InjectMock.class);
+                if (injectMockAnnotation != null) {
+                    Object beanInstance = getBeanInstance(testInstance, field);
+                    Object mock = createMockAndSetTestField(testInstance, field, beanInstance);
+                    MockitoMocksTracker.track(testInstance, mock, beanInstance);
+                }
+            }
+            current = current.getSuperclass();
+        }
+    }
+
+    private Object createMockAndSetTestField(Object testInstance, Field field, Object beanInstance) {
+        Object mock = Mockito.mock(beanInstance.getClass());
+        field.setAccessible(true);
+        try {
+            field.set(testInstance, mock);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return mock;
+    }
+
+    private Object getBeanInstance(Object testInstance, Field field) {
+        Class<?> fieldClass = field.getType();
+        InstanceHandle<?> instance = Arc.container().instance(fieldClass, getQualifiers(field));
+        if (!instance.isAvailable()) {
+            throw new IllegalStateException("Invalid use of @InjectMock - could not determine bean of type: "
+                    + fieldClass + ". Offending field is " + field.getName() + " of test class "
+                    + testInstance.getClass());
+        }
+        return instance.get();
+    }
+
+    private Annotation[] getQualifiers(Field fieldToMock) {
+        List<Annotation> qualifiers = new ArrayList<>();
+        Annotation[] fieldAnnotations = fieldToMock.getDeclaredAnnotations();
+        for (Annotation fieldAnnotation : fieldAnnotations) {
+            for (Annotation annotationOfFieldAnnotation : fieldAnnotation.annotationType().getAnnotations()) {
+                if (annotationOfFieldAnnotation.annotationType().equals(Qualifier.class)) {
+                    qualifiers.add(fieldAnnotation);
+                    break;
+                }
+            }
+        }
+        return qualifiers.toArray(new Annotation[0]);
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
@@ -1,0 +1,40 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.mockito.Mockito;
+
+final class MockitoMocksTracker {
+
+    final static Map<Object, Set<Mocked>> TEST_TO_USED_MOCKS = new ConcurrentHashMap<>();
+
+    private MockitoMocksTracker() {
+    }
+
+    static void track(Object testInstance, Object mock, Object beanInstance) {
+        TEST_TO_USED_MOCKS.computeIfAbsent(testInstance, (k) -> new HashSet<>());
+        TEST_TO_USED_MOCKS.get(testInstance).add(new Mocked(mock, beanInstance));
+    }
+
+    static Set<Mocked> getMocks(Object testInstance) {
+        return TEST_TO_USED_MOCKS.getOrDefault(testInstance, Collections.emptySet());
+    }
+
+    static void reset(Object testInstance) {
+        Mockito.reset(getMocks(testInstance).stream().map(o -> o.mock).toArray());
+    }
+
+    static class Mocked {
+        final Object mock;
+        final Object beanInstance;
+
+        public Mocked(Object mock, Object beanInstance) {
+            this.mock = mock;
+            this.beanInstance = beanInstance;
+        }
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetMockitoMocksCallback.java
@@ -1,0 +1,11 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+
+public class ResetMockitoMocksCallback implements QuarkusTestAfterEachCallback {
+
+    @Override
+    public void afterEach(Object testInstance) {
+        MockitoMocksTracker.reset(testInstance);
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
@@ -1,0 +1,32 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import java.lang.reflect.Method;
+
+import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
+
+public class SetMockitoMockAsBeanMockCallback implements QuarkusTestBeforeEachCallback {
+
+    private volatile Method installMocksMethod;
+
+    @Override
+    public void beforeEach(Object testInstance) {
+        MockitoMocksTracker.getMocks(testInstance).forEach(m -> {
+            installMocks(m, m.beanInstance);
+        });
+    }
+
+    // call MockSupport.installMock using reflection since it is not public
+    private void installMocks(MockitoMocksTracker.Mocked m, Object beanInstance) {
+        try {
+            if (installMocksMethod == null) {
+                installMocksMethod = Class.forName("io.quarkus.test.junit.MockSupport").getDeclaredMethod("installMock",
+                        Object.class,
+                        Object.class);
+                installMocksMethod.setAccessible(true);
+            }
+            installMocksMethod.invoke(null, beanInstance, m.mock);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.mockito.internal.ResetMockitoMocksCallback

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeAllCallback
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeAllCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.mockito.internal.CreateMockitoMocksCallback

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.mockito.internal.SetMockitoMockAsBeanMockCallback

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestAfterEachCallback.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestAfterEachCallback.java
@@ -1,0 +1,6 @@
+package io.quarkus.test.junit.callback;
+
+public interface QuarkusTestAfterEachCallback {
+
+    void afterEach(Object testInstance);
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestBeforeAllCallback.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestBeforeAllCallback.java
@@ -1,0 +1,6 @@
+package io.quarkus.test.junit.callback;
+
+public interface QuarkusTestBeforeAllCallback {
+
+    void beforeAll(Object testInstance);
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestBeforeEachCallback.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestBeforeEachCallback.java
@@ -1,0 +1,6 @@
+package io.quarkus.test.junit.callback;
+
+public interface QuarkusTestBeforeEachCallback {
+
+    void beforeEach(Object testInstance);
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -21,6 +21,7 @@
         <module>kubernetes-client</module>
         <module>junit5-internal</module>
         <module>junit5</module>
+        <module>junit5-mockito</module>
         <module>amazon-lambda</module>
         <module>arquillian</module>
         <module>maven</module>


### PR DESCRIPTION
This PR builds on #8175 and allows users to easily 
combine Mockito with Quarkus mocks without having 
to use anything more than the `@MockBean` annotation