### PR TITLE
Upgrade to Hibernate Search 6.0.0.Beta6

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -84,12 +84,12 @@
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.13.Final</hibernate-orm.version>
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.Beta5</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Beta6</hibernate-search.version>
         <narayana.version>5.10.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.7</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.6.0</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.6.1</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.19</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Maven plugin versions -->
         <elasticsearch-maven-plugin.version>6.15</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.6.0</elasticsearch-server.version>
+        <elasticsearch-server.version>7.6.1</elasticsearch-server.version>
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->

--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -537,8 +537,8 @@ quarkus.hibernate-orm.sql-load-script=import.sql <4>
 
 quarkus.hibernate-search.elasticsearch.version=7 <5>
 quarkus.hibernate-search.elasticsearch.analysis.configurer=org.acme.hibernate.search.elasticsearch.config.AnalysisConfigurer <6>
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create <7>
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=yellow <8>
+quarkus.hibernate-search.schema-management.strategy=drop-and-create <7>
+quarkus.hibernate-search.elasticsearch.index-defaults.schema-management.required-status=yellow <8>
 quarkus.hibernate-search.automatic-indexing.synchronization.strategy=sync <9>
 ----
 <1> We won't use SSL so we disable it to have a more compact native executable.
@@ -550,7 +550,7 @@ It is important because there are significant differences between Elasticsearch 
 Since the mapping is created at build time to reduce startup time, Hibernate Search cannot connect to the cluster to automatically detect the version.
 <6> We point to the custom `AnalysisConfigurer` which defines the configuration of our analyzers and normalizers.
 <7> Obviously, this is not for production: we drop and recreate the index every time we start the application.
-<8> We consider the `yellow` status is sufficient to connect to the Elasticsearch cluster.
+<8> We consider the `yellow` status is sufficient to proceed after an index is created.
 This is for testing purposes with the Elasticsearch Docker container.
 It should not be used in production.
 <9> This means that we wait for the entities to be searchable before considering a write complete.
@@ -601,7 +601,7 @@ Let's use Docker to start one of each:
 
 [source, shell]
 ----
-docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.5.0
+docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.1
 ----
 
 [source, shell]

--- a/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/IndexedNonEntity.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/IndexedNonEntity.java
@@ -3,11 +3,11 @@ package io.quarkus.hibernate.search.elasticsearch.test;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 /**
- * This particular entity is not a valid entity as it is not marked with @Entity.
+ * This particular class is not a valid entity as it is not marked with @Entity.
  * <p>
  * It is done this way just for the sake of testing the extension bootstrap.
  */
 @Indexed
-public class IndexedEntity {
+public class IndexedNonEntity {
 
 }

--- a/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/NoConfigIndexedNonEntityTest.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/NoConfigIndexedNonEntityTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.deployment.configuration.ConfigurationError;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class NoConfigIndexedEntityTest {
+public class NoConfigIndexedNonEntityTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class).addClass(IndexedEntity.class))
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(IndexedNonEntity.class))
             .setExpectedException(ConfigurationError.class);
 
     @Test

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -139,6 +139,8 @@ public class HibernateSearchElasticsearchRecorder {
                     elasticsearchBackendConfig.maxConnections);
             addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.MAX_CONNECTIONS_PER_ROUTE,
                     elasticsearchBackendConfig.maxConnectionsPerRoute);
+            addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.THREAD_POOL_SIZE,
+                    elasticsearchBackendConfig.threadPool.size);
 
             addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.DISCOVERY_ENABLED,
                     elasticsearchBackendConfig.discovery.enabled);

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -156,6 +156,15 @@ public class HibernateSearchElasticsearchRecorder {
                     ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
                     elasticsearchBackendConfig.indexDefaults.schemaManagement.requiredStatusWaitTimeout, Optional::isPresent,
                     d -> d.get().toMillis());
+            addBackendDefaultIndexConfig(propertyCollector, backendName,
+                    ElasticsearchIndexSettings.INDEXING_QUEUE_COUNT,
+                    elasticsearchBackendConfig.indexDefaults.indexing.queueCount);
+            addBackendDefaultIndexConfig(propertyCollector, backendName,
+                    ElasticsearchIndexSettings.INDEXING_QUEUE_SIZE,
+                    elasticsearchBackendConfig.indexDefaults.indexing.queueSize);
+            addBackendDefaultIndexConfig(propertyCollector, backendName,
+                    ElasticsearchIndexSettings.INDEXING_MAX_BULK_SIZE,
+                    elasticsearchBackendConfig.indexDefaults.indexing.maxBulkSize);
 
             for (Entry<String, ElasticsearchIndexConfig> indexConfigEntry : runtimeConfig.defaultBackend.indexes.entrySet()) {
                 String indexName = indexConfigEntry.getKey();
@@ -168,6 +177,15 @@ public class HibernateSearchElasticsearchRecorder {
                         ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
                         indexConfig.schemaManagement.requiredStatusWaitTimeout, Optional::isPresent,
                         d -> d.get().toMillis());
+                addBackendIndexConfig(propertyCollector, backendName, indexName,
+                        ElasticsearchIndexSettings.INDEXING_QUEUE_COUNT,
+                        indexConfig.indexing.queueCount);
+                addBackendIndexConfig(propertyCollector, backendName, indexName,
+                        ElasticsearchIndexSettings.INDEXING_QUEUE_SIZE,
+                        indexConfig.indexing.queueSize);
+                addBackendIndexConfig(propertyCollector, backendName, indexName,
+                        ElasticsearchIndexSettings.INDEXING_MAX_BULK_SIZE,
+                        indexConfig.indexing.maxBulkSize);
             }
         }
     }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -88,6 +88,9 @@ public class HibernateSearchElasticsearchRecorder {
         @Override
         public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
             addConfig(propertyCollector,
+                    HibernateOrmMapperSettings.SCHEMA_MANAGEMENT_STRATEGY,
+                    runtimeConfig.schemaManagement.strategy);
+            addConfig(propertyCollector,
                     HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
                     runtimeConfig.automaticIndexing.synchronization.strategy);
             addConfig(propertyCollector,
@@ -144,28 +147,24 @@ public class HibernateSearchElasticsearchRecorder {
                         elasticsearchBackendConfig.discovery.refreshInterval.getSeconds());
             }
 
-            addBackendDefaultIndexConfig(propertyCollector, backendName, ElasticsearchIndexSettings.LIFECYCLE_STRATEGY,
-                    elasticsearchBackendConfig.indexDefaults.lifecycle.strategy);
             addBackendDefaultIndexConfig(propertyCollector, backendName,
-                    ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS,
-                    elasticsearchBackendConfig.indexDefaults.lifecycle.requiredStatus);
+                    ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS,
+                    elasticsearchBackendConfig.indexDefaults.schemaManagement.requiredStatus);
             addBackendDefaultIndexConfig(propertyCollector, backendName,
-                    ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
-                    elasticsearchBackendConfig.indexDefaults.lifecycle.requiredStatusWaitTimeout, Optional::isPresent,
+                    ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
+                    elasticsearchBackendConfig.indexDefaults.schemaManagement.requiredStatusWaitTimeout, Optional::isPresent,
                     d -> d.get().toMillis());
 
             for (Entry<String, ElasticsearchIndexConfig> indexConfigEntry : runtimeConfig.defaultBackend.indexes.entrySet()) {
                 String indexName = indexConfigEntry.getKey();
                 ElasticsearchIndexConfig indexConfig = indexConfigEntry.getValue();
 
-                addBackendIndexConfig(propertyCollector, backendName, indexName, ElasticsearchIndexSettings.LIFECYCLE_STRATEGY,
-                        indexConfig.lifecycle.strategy);
                 addBackendIndexConfig(propertyCollector, backendName, indexName,
-                        ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS,
-                        indexConfig.lifecycle.requiredStatus);
+                        ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS,
+                        indexConfig.schemaManagement.requiredStatus);
                 addBackendIndexConfig(propertyCollector, backendName, indexName,
-                        ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
-                        indexConfig.lifecycle.requiredStatusWaitTimeout, Optional::isPresent,
+                        ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT,
+                        indexConfig.schemaManagement.requiredStatusWaitTimeout, Optional::isPresent,
                         d -> d.get().toMillis());
             }
         }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -479,6 +479,13 @@ public class HibernateSearchElasticsearchRuntimeConfig {
     public static class ElasticsearchIndexIndexingConfig {
         /**
          * The number of indexing queues assigned to each index.
+         * <p>
+         * Higher values will lead to more connections being used in parallel,
+         * which may lead to higher indexing throughput,
+         * but incurs a risk of overloading Elasticsearch,
+         * i.e. of overflowing its HTTP request buffers and tripping
+         * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.6/circuit-breaker.html">circuit breakers</a>,
+         * leading to Elasticsearch giving up on some request and resulting in indexing failures.
          */
         // We can't set an actual default value here: see comment on this class.
         @ConfigItem(defaultValueDocumentation = "10")
@@ -486,6 +493,11 @@ public class HibernateSearchElasticsearchRuntimeConfig {
 
         /**
          * The size of indexing queues.
+         * <p>
+         * Lower values may lead to lower memory usage, especially if there are many queues,
+         * but values that are too low will reduce the likeliness of reaching the max bulk size
+         * and increase the likeliness of application threads blocking because the queue is full,
+         * which may lead to lower indexing throughput.
          */
         // We can't set an actual default value here: see comment on this class.
         @ConfigItem(defaultValueDocumentation = "1000")
@@ -493,6 +505,16 @@ public class HibernateSearchElasticsearchRuntimeConfig {
 
         /**
          * The maximum size of bulk requests created when processing indexing queues.
+         * <p>
+         * Higher values will lead to more documents being sent in each HTTP request sent to Elasticsearch,
+         * which may lead to higher indexing throughput,
+         * but incurs a risk of overloading Elasticsearch,
+         * i.e. of overflowing its HTTP request buffers and tripping
+         * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.6/circuit-breaker.html">circuit breakers</a>,
+         * leading to Elasticsearch giving up on some request and resulting in indexing failures.
+         * <p>
+         * Note that raising this number above the queue size has no effect,
+         * as bulks cannot include more requests than are contained in the queue.
          */
         // We can't set an actual default value here: see comment on this class.
         @ConfigItem(defaultValueDocumentation = "100")

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -180,6 +180,12 @@ public class HibernateSearchElasticsearchRuntimeConfig {
          */
         @ConfigItem
         ElasticsearchIndexSchemaManagementConfig schemaManagement;
+
+        /**
+         * Configuration for the indexing process that creates, updates and deletes documents.
+         */
+        @ConfigItem
+        ElasticsearchIndexIndexingConfig indexing;
     }
 
     @ConfigGroup
@@ -454,5 +460,31 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         // We can't set an actual default value here: see comment on this class.
         @ConfigItem(defaultValueDocumentation = "10S")
         Optional<Duration> requiredStatusWaitTimeout;
+    }
+
+    // We can't set actual default values in this section,
+    // otherwise "quarkus.hibernate-search.elasticsearch.index-defaults" will be ignored.
+    @ConfigGroup
+    public static class ElasticsearchIndexIndexingConfig {
+        /**
+         * The number of indexing queues assigned to each index.
+         */
+        // We can't set an actual default value here: see comment on this class.
+        @ConfigItem(defaultValueDocumentation = "10")
+        OptionalInt queueCount;
+
+        /**
+         * The size of indexing queues.
+         */
+        // We can't set an actual default value here: see comment on this class.
+        @ConfigItem(defaultValueDocumentation = "1000")
+        OptionalInt queueSize;
+
+        /**
+         * The maximum size of bulk requests created when processing indexing queues.
+         */
+        // We can't set an actual default value here: see comment on this class.
+        @ConfigItem(defaultValueDocumentation = "100")
+        OptionalInt maxBulkSize;
     }
 }

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyNames;
@@ -117,6 +118,12 @@ public class HibernateSearchElasticsearchRuntimeConfig {
          */
         @ConfigItem
         DiscoveryConfig discovery;
+
+        /**
+         * Configuration for the thread pool assigned to the backend.
+         */
+        @ConfigItem
+        ThreadPoolConfig threadPool;
 
         /**
          * The default configuration for the Elasticsearch indexes.
@@ -416,6 +423,18 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         @ConfigItem(defaultValue = "create-or-validate")
         SchemaManagementStrategyName strategy;
 
+    }
+
+    @ConfigGroup
+    public static class ThreadPoolConfig {
+        /**
+         * The size of the thread pool assigned to the backend.
+         * <p>
+         * Defaults to the number of processor cores available to the JVM on startup.
+         */
+        // We can't set an actual default value here: see comment on this class.
+        @ConfigItem
+        OptionalInt size;
     }
 
     // We can't set actual default values in this section,

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -436,6 +436,17 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         /**
          * The size of the thread pool assigned to the backend.
          * <p>
+         * Note that number is <em>per backend</em>, not per index.
+         * Adding more indexes will not add more threads.
+         * <p>
+         * As all operations happening in this thread-pool are non-blocking,
+         * raising its size above the number of processor cores available to the JVM will not bring noticeable performance
+         * benefit.
+         * The only reason to alter this setting would be to reduce the number of threads;
+         * for example, in an application with a single index with a single indexing queue,
+         * running on a machine with 64 processor cores,
+         * you might want to bring down the number of threads.
+         * <p>
          * Defaults to the number of processor cores available to the JVM on startup.
          */
         // We can't set an actual default value here: see comment on this class.

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -6,9 +6,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import org.hibernate.search.backend.elasticsearch.index.IndexLifecycleStrategyName;
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyNames;
+import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.impl.StringHelper;
@@ -36,6 +36,13 @@ public class HibernateSearchElasticsearchRuntimeConfig {
     @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
     public ElasticsearchAdditionalBackendsRuntimeConfig additionalBackends;
+
+    /**
+     * Configuration for automatic creation and validation of the Elasticsearch schema:
+     * indexes, their mapping, their settings.
+     */
+    @ConfigItem
+    SchemaManagementConfig schemaManagement;
 
     /**
      * Configuration for how entities are loaded by a search query.
@@ -162,10 +169,10 @@ public class HibernateSearchElasticsearchRuntimeConfig {
     @ConfigGroup
     public static class ElasticsearchIndexConfig {
         /**
-         * Configuration for the lifecyle of the indexes.
+         * Configuration for the schema management of the indexes.
          */
         @ConfigItem
-        LifecycleConfig lifecycle;
+        ElasticsearchIndexSchemaManagementConfig schemaManagement;
     }
 
     @ConfigGroup
@@ -399,18 +406,22 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         EntityLoadingCacheLookupStrategy strategy;
     }
 
-    // We can't set actual default values in this section,
-    // otherwise "quarkus.hibernate-search.elasticsearch.index-defaults" will be ignored.
     @ConfigGroup
-    public static class LifecycleConfig {
+    public static class SchemaManagementConfig {
 
         /**
          * The strategy used for index lifecycle.
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "create")
-        Optional<IndexLifecycleStrategyName> strategy;
+        @ConfigItem(defaultValue = "create-or-validate")
+        SchemaManagementStrategyName strategy;
 
+    }
+
+    // We can't set actual default values in this section,
+    // otherwise "quarkus.hibernate-search.elasticsearch.index-defaults" will be ignored.
+    @ConfigGroup
+    public static class ElasticsearchIndexSchemaManagementConfig {
         /**
          * The minimal cluster status required.
          */

--- a/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-elasticsearch/src/main/resources/application.properties
@@ -10,6 +10,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search.elasticsearch.version=7
 quarkus.hibernate-search.elasticsearch.analysis.configurer=io.quarkus.it.hibernate.search.elasticsearch.search.DefaultITAnalysisConfigurer
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.strategy=drop-and-create-and-drop
-quarkus.hibernate-search.elasticsearch.index-defaults.lifecycle.required-status=yellow
+quarkus.hibernate-search.elasticsearch.index-defaults.schema-management.required-status=yellow
+quarkus.hibernate-search.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search.automatic-indexing.synchronization.strategy=sync


### PR DESCRIPTION
The last commit is not really necessary, but I made this change as I was working on adding more unit tests related to configuration properties... and I then gave up on that.