### PR TITLE
Gradle: Refining the fix for #7996

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -149,7 +149,14 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
                 if (c.getClassLoader() == this) {
                     //if the service class is defined by this class loader then any resources that could be loaded
                     //by the parent would have a different copy of the service class
-                    banned = true;
+                    ClassLoader parent = getParent();
+                    if (parent != null) {
+                        try {
+                            getParent().loadClass(name.substring(META_INF_SERVICES.length()));
+                            banned = true;
+                        } catch (ClassNotFoundException ignored) {
+                        }
+                    }
                 }
             } catch (ClassNotFoundException ignored) {
                 //ignore
@@ -256,7 +263,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     /**
      * This method is needed to make packages work correctly on JDK9+, as it will be called
      * to load the package-info class.
-     * 
+     *
      * @param moduleName
      * @param name
      * @return
@@ -491,7 +498,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
          *
          * Banned elements have the highest priority, a banned element will never be loaded,
          * and resources will never appear to be present.
-         * 
+         *
          * @param element The element to add
          * @return This builder
          */
@@ -502,7 +509,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
         /**
          * Sets any bytecode transformers that should be applied to this Class Loader
-         * 
+         *
          * @param bytecodeTransformers
          */
         public void setBytecodeTransformers(
@@ -533,7 +540,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
         /**
          * Builds the class loader
-         * 
+         *
          * @return The class loader
          */
         public QuarkusClassLoader build() {


### PR DESCRIPTION
The original fix for #7996 skipped a service provider if it showed up as part of the current classloader. This was done on the assumption that the parent classloader would contain the resource. But what happens if the parent classloader does not contain the reference? This commit attempts to refine the fix further by checking with the parent classloader, before banning the service provider implementation.