### PR TITLE
Gradle: Search for build script dependencies in the parent projects as well

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -431,8 +431,14 @@ public class QuarkusDev extends QuarkusTask {
     }
 
     private void addGradlePluginDeps(StringBuilder classPathManifest, DevModeContext context) {
-        Configuration conf = getProject().getBuildscript().getConfigurations().getByName("classpath");
-        ResolvedDependency quarkusDep = conf.getResolvedConfiguration().getFirstLevelModuleDependencies().stream()
+        List<ResolvedDependency> buildScriptDeps = new ArrayList<>();
+        Project prj = getProject();
+        while (prj != null) {
+            buildScriptDeps.addAll(prj.getBuildscript().getConfigurations().getByName("classpath")
+                    .getResolvedConfiguration().getFirstLevelModuleDependencies());
+            prj = prj.getParent();
+        }
+        ResolvedDependency quarkusDep = buildScriptDeps.stream()
                 .filter(rd -> "io.quarkus.gradle.plugin".equals(rd.getModuleName()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Unable to find quarkus-gradle-plugin dependency"));


### PR DESCRIPTION
It is possible to construct a multi-module project where the build script dependencies are defined in a parent project. This avoids having to include them in every project explicitly.

This is applicable when you are applying plugin via the legacy methodology.

Not sure how many teams run in to this problem, but I found this to be the reason why I wasn't able to use `startQuarkusDev`.