### PR TITLE
getting-started guide - small fix in TestHTTPResource related info

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -411,7 +411,7 @@ You can also run the test from your IDE directly (be sure you stopped the applic
 
 By default, tests will run on port `8081` so as not to conflict with the running application. We automatically
 configure RestAssured to use this port. If you want to use a different client you should use the `@TestHTTPResource`
-annotation to directly inject the URL of the test into a field on the test class. This field can be of the type
+annotation to directly inject the URL of the tested application into a field on the test class. This field can be of the type
 `String`, `URL` or `URI`. This annotation can also be given a value for the test path. For example, if I want to test
 a Servlet mapped to `/myservlet` I would just add the following to my test:
 


### PR DESCRIPTION
Small fix in TestHTTPResource related info

`inject the URL of the test into a field` doesn't sound right

It's URL of the tested application or resource, depending on the value of the annotation
