### PR TITLE
Increase timeout for security2 native image tests group

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -363,7 +363,7 @@ jobs:
               elytron-security-jdbc
               elytron-undertow 
           - category: Security2
-            timeout: 45
+            timeout: 50
             keycloak: "true"
             test-modules: >
               elytron-resteasy


### PR DESCRIPTION
I've seen a few PRs fail with this group timing out