### PR TITLE
VertxHttpRecorder fix - startup gets stuck if insecure-requests=disabled

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithPemTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ssl/SslServerWithPemTest.java
@@ -21,6 +21,10 @@ import io.quarkus.test.common.http.TestHTTPResource;
 import io.restassured.RestAssured;
 import io.vertx.ext.web.Router;
 
+/**
+ * We also set quarkus.http.insecure-requests=disabled in order to test that server starts correctly - see
+ * https://github.com/quarkusio/quarkus/issues/8336.
+ */
 public class SslServerWithPemTest {
 
     @TestHTTPResource(value = "/ssl", ssl = true)

--- a/extensions/vertx-http/deployment/src/test/resources/conf/ssl-pem.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/ssl-pem.conf
@@ -1,3 +1,6 @@
 # Enable SSL, configure the key store
 quarkus.http.ssl.certificate.file=server-cert.pem
 quarkus.http.ssl.certificate.key-file=server-key.pem
+# Test that server starts with this option
+# See https://github.com/quarkusio/quarkus/issues/8336
+quarkus.http.insecure-requests=disabled


### PR DESCRIPTION
- resolves #8336
- also skip the http part in the "Listening on..." log message when
quarkus.http.insecure-requests=disabled