### PR TITLE
Document how to use a random test port

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -150,6 +150,7 @@ You can configure the port used by tests by configuring `quarkus.http.test-port`
 ----
 quarkus.http.test-port=8083
 ----
+`0` will result in the use of a random port (assigned by the operating system).
 ====
 
 Quarkus also provides RestAssured integration that updates the default port used by RestAssured before the tests are run,


### PR DESCRIPTION
Support was added in #4140 but no documentaion seems to exist to this day.