### PR TITLE
Add config to override chunk sizes

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.configuration.MemorySize;
 @ConfigGroup
 public class ServerLimitsConfig {
     /**
-     * The the maximum length of all headers.
+     * The maximum length of all headers.
      */
     @ConfigItem(defaultValue = "20K")
     public MemorySize maxHeaderSize;
@@ -20,4 +20,10 @@ public class ServerLimitsConfig {
      */
     @ConfigItem
     public Optional<MemorySize> maxBodySize;
+
+    /**
+     * The max HTTP chunk size
+     */
+    @ConfigItem
+    public Optional<MemorySize> maxChunkSize;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -425,6 +425,10 @@ public class VertxHttpRecorder {
             }
         }
         serverOptions.setMaxHeaderSize(httpConfiguration.limits.maxHeaderSize.asBigInteger().intValueExact());
+        Optional<MemorySize> maxChunkSize = httpConfiguration.limits.maxChunkSize;
+        if (maxChunkSize.isPresent()) {
+            serverOptions.setMaxChunkSize(maxChunkSize.get().asBigInteger().intValueExact());
+        }
         setIdleTimeout(httpConfiguration, serverOptions);
 
         if (certFile.isPresent() && keyFile.isPresent()) {
@@ -581,6 +585,10 @@ public class VertxHttpRecorder {
         options.setPort(httpConfiguration.determinePort(launchMode));
         setIdleTimeout(httpConfiguration, options);
         options.setMaxHeaderSize(httpConfiguration.limits.maxHeaderSize.asBigInteger().intValueExact());
+        Optional<MemorySize> maxChunkSize = httpConfiguration.limits.maxChunkSize;
+        if (maxChunkSize.isPresent()) {
+            options.setMaxChunkSize(maxChunkSize.get().asBigInteger().intValueExact());
+        }
         options.setWebsocketSubProtocols(websocketSubProtocols);
         options.setReusePort(httpConfiguration.soReusePort);
         options.setTcpQuickAck(httpConfiguration.tcpQuickAck);
@@ -598,6 +606,10 @@ public class VertxHttpRecorder {
         options.setHost(httpConfiguration.domainSocket);
         setIdleTimeout(httpConfiguration, options);
         options.setMaxHeaderSize(httpConfiguration.limits.maxHeaderSize.asBigInteger().intValueExact());
+        Optional<MemorySize> maxChunkSize = httpConfiguration.limits.maxChunkSize;
+        if (maxChunkSize.isPresent()) {
+            options.setMaxChunkSize(maxChunkSize.get().asBigInteger().intValueExact());
+        }
         options.setWebsocketSubProtocols(websocketSubProtocols);
         return options;
     }


### PR DESCRIPTION
This commit introduces a new config property `quarkus.http.limits.max-chunk-size`

Fixes #8379