### PR TITLE
Fix reference to Vert.x API used in examples

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -480,7 +480,7 @@ Depending on the API model you want to use you need to add the right dependency 
 
 NOTE: The `vertx-rx-java2` provides the RX Java 2 API for the whole Vert.x stack, not only the web client.
 
-In this guide, we are going to use the Axle API, so:
+In this guide, we are going to use the Mutiny API, so:
 
 [source, xml, subs=attributes+]
 ----


### PR DESCRIPTION
The text said that examples in this guide are using the Axle API, while this seems to be not the case; Mutiny classes are used across all code snippets, with the exception of a single part that shows how the four APIs differ.