### PR TITLE
Increase timeout for Data3 group of native tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -321,7 +321,7 @@ jobs:
               reactive-mysql-client
           - category: Data3
             postgres: "true"
-            timeout: 35
+            timeout: 40
             test-modules: >
               flyway
               hibernate-orm-panache


### PR DESCRIPTION
Done because I've seen this group exceeding the current time limit on some PRs