### PR TITLE
Remove RESTEasy exclusion

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2014,6 +2014,12 @@
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-rxjava2</artifactId>
                 <version>${resteasy.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.resteasy</groupId>
+                        <artifactId>resteasy-context-propagation</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -298,7 +298,7 @@
                                             <!-- We use our own impl here, including this one causes problems-->
                                             <exclude>org.jboss.resteasy:resteasy-context-propagation</exclude>
                                         </excludes>
-                                        <includes>a
+                                        <includes>
                                             <!-- this is for REST Assured -->
                                             <include>jakarta.xml.bind:jakarta.xml.bind-api:*:*:test</include>
                                         </includes>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -295,8 +295,10 @@
                                             <!-- Ban checker-qual, we don't use Checker Framework -->
                                             <exclude>org.checkerframework:checker-qual</exclude>
                                             <exclude>com.google.code.findbugs:jsr305</exclude>
+                                            <!-- We use our own impl here, including this one causes problems-->
+                                            <exclude>org.jboss.resteasy:resteasy-context-propagation</exclude>
                                         </excludes>
-                                        <includes>
+                                        <includes>a
                                             <!-- this is for REST Assured -->
                                             <include>jakarta.xml.bind:jakarta.xml.bind-api:*:*:test</include>
                                         </includes>

--- a/extensions/mutiny/runtime/pom.xml
+++ b/extensions/mutiny/runtime/pom.xml
@@ -26,12 +26,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-context-propagation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-context-propagation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -26,7 +26,6 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-core</artifactId>
         </dependency>
-        <!--
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-context-propagation</artifactId>
@@ -37,7 +36,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -57,6 +57,7 @@
                         <excludedArtifact>javax.activation:javax.activation-api</excludedArtifact>
                         <excludedArtifact>javax.activation:activation</excludedArtifact>
                         <excludedArtifact>jakarta.ws.rs:jakarta.ws.rs-api</excludedArtifact>
+                        <excludedArtifact>org.jboss.resteasy:resteasy-context-propagation</excludedArtifact>
                     </excludedArtifacts>
                 </configuration>
             </plugin>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -27,16 +27,6 @@
             <artifactId>resteasy-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-context-propagation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.smallrye</groupId>
-                    <artifactId>smallrye-context-propagation</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/ResteasyContextProvider.java
+++ b/extensions/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/ResteasyContextProvider.java
@@ -1,0 +1,40 @@
+package io.quarkus.resteasy.common.runtime;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+import org.jboss.resteasy.core.ResteasyContext;
+
+public class ResteasyContextProvider implements ThreadContextProvider {
+
+    private static final String JAXRS_CONTEXT = "JAX-RS";
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        Map<Class<?>, Object> context = ResteasyContext.getContextDataMap();
+        return () -> {
+            ResteasyContext.pushContextDataMap(context);
+            return () -> {
+                ResteasyContext.removeContextDataLevel();
+            };
+        };
+    }
+
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        Map<Class<?>, Object> context = Collections.emptyMap();
+        return () -> {
+            ResteasyContext.pushContextDataMap(context);
+            return () -> {
+                ResteasyContext.removeContextDataLevel();
+            };
+        };
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return JAXRS_CONTEXT;
+    }
+}

--- a/extensions/resteasy-common/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
+++ b/extensions/resteasy-common/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
@@ -1,0 +1,1 @@
+io.quarkus.resteasy.common.runtime.ResteasyContextProvider

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -40,14 +40,6 @@ class SmallRyeContextPropagationProcessor {
         List<ContextManagerExtension> discoveredExtensions = new ArrayList<>();
         for (Class<?> provider : ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
                 "META-INF/services/" + ThreadContextProvider.class.getName())) {
-            if (provider.getName().equals("org.jboss.resteasy.context.ResteasyContextProvider")) {
-                try {
-                    Class.forName("org.jboss.resteasy.core.ResteasyContext", false,
-                            Thread.currentThread().getContextClassLoader());
-                } catch (ClassNotFoundException e) {
-                    continue; // resteasy is not being used so ditch this context provider
-                }
-            }
             try {
                 discoveredProviders.add((ThreadContextProvider) provider.newInstance());
             } catch (InstantiationException | IllegalAccessException e) {

--- a/extensions/smallrye-context-propagation/runtime/pom.xml
+++ b/extensions/smallrye-context-propagation/runtime/pom.xml
@@ -29,16 +29,6 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-context-propagation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>


### PR DESCRIPTION
This instead adds the dependency in RESTEasy Common,
with an exclusion on the actual CP implementation.

This approach is much less problematic, as RESTEasy
has no knowledge of CP, so there is no chance these
classes can be accidently loaded unless CP is on the
classpath.

The current approach does not have this advatage so
problematic hacks have been used to try and stop it
being loaded, but this approach is much simpler.
Fixes #7809