### PR TITLE
Add Vault response wrapping support for client token auth and secret id in approle auth

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultAuthManager.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultAuthManager.java
@@ -9,15 +9,22 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultClientException;
 import io.quarkus.vault.runtime.client.dto.auth.AbstractVaultAuthAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleGenerateNewSecretID;
 import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelfAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultTokenCreate;
 import io.quarkus.vault.runtime.config.VaultAuthenticationType;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 
@@ -30,7 +37,9 @@ public class VaultAuthManager {
 
     private VaultRuntimeConfig serverConfig;
     private VaultClient vaultClient;
-    private AtomicReference<VaultToken> auth = new AtomicReference<>(null);
+    private AtomicReference<VaultToken> loginCache = new AtomicReference<>(null);
+    private Map<String, String> wrappedCache = new ConcurrentHashMap<>();
+    private Semaphore unwrapSem = new Semaphore(1);
 
     public VaultAuthManager(VaultClient vaultClient, VaultRuntimeConfig serverConfig) {
         this.vaultClient = vaultClient;
@@ -38,13 +47,24 @@ public class VaultAuthManager {
     }
 
     public String getClientToken() {
-        return serverConfig.authentication.clientToken.orElseGet(() -> login().clientToken);
+        return serverConfig.authentication.isDirectClientToken() ? getDirectClientToken() : login().clientToken;
+    }
+
+    private String getDirectClientToken() {
+
+        Optional<String> clientTokenOption = serverConfig.authentication.clientToken;
+        if (clientTokenOption.isPresent()) {
+            return clientTokenOption.get();
+        }
+
+        return unwrapWrappingTokenOnce("client token",
+                serverConfig.authentication.clientTokenWrappingToken.get(), unwrap -> unwrap.auth.clientToken,
+                VaultTokenCreate.class);
     }
 
     private VaultToken login() {
-        VaultAuthManager service = new VaultAuthManager(vaultClient, serverConfig);
-        VaultToken vaultToken = service.login(auth.get());
-        auth.set(vaultToken);
+        VaultToken vaultToken = login(loginCache.get());
+        loginCache.set(vaultToken);
         return vaultToken;
     }
 
@@ -109,13 +129,57 @@ public class VaultAuthManager {
             auth = vaultClient.loginUserPass(username, password).auth;
         } else if (type == APPROLE) {
             String roleId = serverConfig.authentication.appRole.roleId.get();
-            String secretId = serverConfig.authentication.appRole.secretId.get();
+            String secretId = getSecretId();
             auth = vaultClient.loginAppRole(roleId, secretId).auth;
         } else {
             throw new UnsupportedOperationException("unknown authType " + serverConfig.getAuthenticationType());
         }
 
         return new VaultToken(auth.clientToken, auth.renewable, auth.leaseDurationSecs);
+    }
+
+    private String getSecretId() {
+
+        Optional<String> secretIdOption = serverConfig.authentication.appRole.secretId;
+        if (secretIdOption.isPresent()) {
+            return secretIdOption.get();
+        }
+
+        return unwrapWrappingTokenOnce("secret id",
+                serverConfig.authentication.appRole.secretIdWrappingToken.get(), unwrap -> unwrap.data.secretId,
+                VaultAppRoleGenerateNewSecretID.class);
+    }
+
+    private <T> String unwrapWrappingTokenOnce(String type, String wrappingToken,
+            Function<T, String> f, Class<T> clazz) {
+
+        String wrappedValue = wrappedCache.get(wrappingToken);
+        if (wrappedValue != null) {
+            return wrappedValue;
+        }
+
+        try {
+            unwrapSem.acquire();
+            try {
+                // by the time we reach here, may be somebody has populated the cache
+                wrappedValue = wrappedCache.get(wrappingToken);
+                if (wrappedValue != null) {
+                    return wrappedValue;
+                }
+
+                T unwrap = vaultClient.unwrap(wrappingToken, clazz);
+                wrappedValue = f.apply(unwrap);
+                wrappedCache.put(wrappingToken, wrappedValue);
+                String displayValue = serverConfig.logConfidentialityLevel.maskWithTolerance(wrappedValue, LOW);
+                log.debug("unwrapped " + type + ": " + displayValue);
+                return wrappedValue;
+
+            } finally {
+                unwrapSem.release();
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("unable to unwrap " + type);
+        }
     }
 
     private VaultKubernetesAuthAuth loginKubernetes() {

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
@@ -262,8 +262,7 @@ public class OkHttpVaultClient implements VaultClient {
 
     @Override
     public <T> T unwrap(String wrappingToken, Class<T> resultClass) {
-        VaultUnwrapBody body = new VaultUnwrapBody(null);
-        return post("sys/wrapping/unwrap", wrappingToken, body, resultClass);
+        return post("sys/wrapping/unwrap", wrappingToken, VaultUnwrapBody.EMPTY, resultClass);
     }
 
     // ---

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
@@ -16,6 +16,7 @@ import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
 import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultWrapResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPGenerateCodeResult;
@@ -96,4 +97,8 @@ public interface VaultClient {
     VaultSealStatusResult systemSealStatus();
 
     VaultInitResponse init(int secretShares, int secretThreshold);
+
+    VaultWrapResult wrap(String token, long ttl, Object object);
+
+    <T> T unwrap(String wrappingToken, Class<T> resultClass);
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/AbstractVaultDTO.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/AbstractVaultDTO.java
@@ -13,7 +13,7 @@ public class AbstractVaultDTO<DATA, AUTH> implements VaultModel {
     public int leaseDurationSecs;
     public DATA data;
     @JsonProperty("wrap_info")
-    public Object wrapInfo;
+    public WrapInfo wrapInfo;
     public Object warnings;
     public AUTH auth;
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/WrapInfo.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/WrapInfo.java
@@ -1,0 +1,16 @@
+package io.quarkus.vault.runtime.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WrapInfo implements VaultModel {
+
+    public String token;
+    public long ttl;
+
+    @JsonProperty("creation_time")
+    public String creationTime;
+
+    @JsonProperty("creation_path")
+    public String creationPath;
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAppRoleGenerateNewSecretID.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAppRoleGenerateNewSecretID.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultAppRoleGenerateNewSecretID extends AbstractVaultDTO<VaultAppRoleGenerateNewSecretIDData, Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAppRoleGenerateNewSecretIDData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAppRoleGenerateNewSecretIDData.java
@@ -1,0 +1,15 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultAppRoleGenerateNewSecretIDData implements VaultModel {
+
+    @JsonProperty("secret_id")
+    public String secretId;
+
+    @JsonProperty("secret_id_accessor")
+    public String secretIdAccessor;
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultTokenCreate.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultTokenCreate.java
@@ -1,0 +1,36 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+/*
+
+{
+  "request_id": "f00341c1-fad5-f6e6-13fd-235617f858a1",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": null,
+  "wrap_info": null,
+  "warnings": [
+    "Policy \"stage\" does not exist",
+    "Policy \"web\" does not exist"
+  ],
+  "auth": {
+    "client_token": "s.wOrq9dO9kzOcuvB06CMviJhZ",
+    "accessor": "B6oixijqmeR4bsLOJH88Ska9",
+    "policies": ["default", "stage", "web"],
+    "token_policies": ["default", "stage", "web"],
+    "metadata": {
+      "user": "armon"
+    },
+    "lease_duration": 3600,
+    "renewable": true,
+    "entity_id": "",
+    "token_type": "service",
+    "orphan": false
+  }
+}
+
+ */
+public class VaultTokenCreate extends AbstractVaultDTO<Object, VaultTokenCreateAuth> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultTokenCreateAuth.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultTokenCreateAuth.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import java.util.Map;
+
+public class VaultTokenCreateAuth extends AbstractVaultAuthAuth<Map<String, String>> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapBody.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapBody.java
@@ -1,0 +1,17 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultUnwrapBody implements VaultModel {
+
+    private String token;
+
+    public VaultUnwrapBody(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapBody.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultUnwrapBody.java
@@ -4,7 +4,13 @@ import io.quarkus.vault.runtime.client.dto.VaultModel;
 
 public class VaultUnwrapBody implements VaultModel {
 
+    public static final VaultUnwrapBody EMPTY = new VaultUnwrapBody();
+
     private String token;
+
+    private VaultUnwrapBody() {
+        this(null);
+    }
 
     public VaultUnwrapBody(String token) {
         this.token = token;

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultWrapResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultWrapResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultWrapResult extends AbstractVaultDTO<Object, Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAppRoleAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAppRoleAuthenticationConfig.java
@@ -20,4 +20,13 @@ public class VaultAppRoleAuthenticationConfig {
     @ConfigItem
     public Optional<String> secretId;
 
+    /**
+     * Wrapping token containing a Secret Id, obtained from:
+     * <p>
+     * vault write -wrap-ttl=60s -f auth/approle/role/myapp/secret-id
+     * <p>
+     * secret-id and secret-id-wrapping-token are exclusive
+     */
+    @ConfigItem
+    public Optional<String> secretIdWrappingToken;
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -60,7 +60,7 @@ public class VaultAuthenticationConfig {
     }
 
     public boolean isUserpass() {
-        return userpass.username.isPresent() && userpass.password.isPresent();
+        return userpass.username.isPresent() && (userpass.password.isPresent() || userpass.passwordWrappingToken.isPresent());
     }
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -12,10 +12,20 @@ public class VaultAuthenticationConfig {
      * Vault token, bypassing Vault authentication (kubernetes, userpass or approle). This is useful in development
      * where an authentication mode might not have been set up. In production we will usually prefer some
      * authentication such as userpass, or preferably kubernetes, where Vault tokens get generated with a TTL
-     * and some ability to revoke them.
+     * and some ability to revoke them. Lease renewal does not apply.
      */
     @ConfigItem
     public Optional<String> clientToken;
+
+    /**
+     * Client token wrapped in a wrapping token, such as what is returned by:
+     * <p>
+     * vault token create -wrap-ttl=60s -policy=myapp
+     * <p>
+     * client-token and client-token-wrapping-token are exclusive. Lease renewal does not apply.
+     */
+    @ConfigItem
+    public Optional<String> clientTokenWrappingToken;
 
     /**
      * AppRole authentication method
@@ -40,5 +50,17 @@ public class VaultAuthenticationConfig {
      */
     @ConfigItem
     public VaultKubernetesAuthenticationConfig kubernetes;
+
+    public boolean isDirectClientToken() {
+        return clientToken.isPresent() || clientTokenWrappingToken.isPresent();
+    }
+
+    public boolean isAppRole() {
+        return appRole.roleId.isPresent() && (appRole.secretId.isPresent() || appRole.secretIdWrappingToken.isPresent());
+    }
+
+    public boolean isUserpass() {
+        return userpass.username.isPresent() && userpass.password.isPresent();
+    }
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -210,6 +210,8 @@ public class VaultConfigSource implements ConfigSource {
         serverConfig.authentication.kubernetes = new VaultKubernetesAuthenticationConfig();
         serverConfig.url = newURL(getOptionalVaultProperty("url"));
         serverConfig.authentication.clientToken = getOptionalVaultProperty("authentication.client-token");
+        serverConfig.authentication.clientTokenWrappingToken = getOptionalVaultProperty(
+                "authentication.client-token-wrapping-token");
         serverConfig.authentication.kubernetes.role = getOptionalVaultProperty("authentication.kubernetes.role");
         serverConfig.authentication.kubernetes.jwtTokenPath = getVaultProperty("authentication.kubernetes.jwt-token-path",
                 DEFAULT_KUBERNETES_JWT_TOKEN_PATH);
@@ -217,6 +219,8 @@ public class VaultConfigSource implements ConfigSource {
         serverConfig.authentication.userpass.password = getOptionalVaultProperty("authentication.userpass.password");
         serverConfig.authentication.appRole.roleId = getOptionalVaultProperty("authentication.app-role.role-id");
         serverConfig.authentication.appRole.secretId = getOptionalVaultProperty("authentication.app-role.secret-id");
+        serverConfig.authentication.appRole.secretIdWrappingToken = getOptionalVaultProperty(
+                "authentication.app-role.secret-id-wrapping-token");
         serverConfig.renewGracePeriod = getVaultDuration("renew-grace-period", DEFAULT_RENEW_GRACE_PERIOD);
         serverConfig.secretConfigCachePeriod = getVaultDuration("secret-config-cache-period",
                 DEFAULT_SECRET_CONFIG_CACHE_PERIOD);

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -217,6 +217,8 @@ public class VaultConfigSource implements ConfigSource {
                 DEFAULT_KUBERNETES_JWT_TOKEN_PATH);
         serverConfig.authentication.userpass.username = getOptionalVaultProperty("authentication.userpass.username");
         serverConfig.authentication.userpass.password = getOptionalVaultProperty("authentication.userpass.password");
+        serverConfig.authentication.userpass.passwordWrappingToken = getOptionalVaultProperty(
+                "authentication.userpass.password-wrapping-token");
         serverConfig.authentication.appRole.roleId = getOptionalVaultProperty("authentication.app-role.role-id");
         serverConfig.authentication.appRole.secretId = getOptionalVaultProperty("authentication.app-role.secret-id");
         serverConfig.authentication.appRole.secretIdWrappingToken = getOptionalVaultProperty(

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultUserpassAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultUserpassAuthenticationConfig.java
@@ -20,4 +20,18 @@ public class VaultUserpassAuthenticationConfig {
     @ConfigItem
     public Optional<String> password;
 
+    /**
+     * Wrapping token containing a Password, obtained from:
+     * <p>
+     * vault kv get -wrap-ttl=60s secret/<path>
+     * <p>
+     * The key has to be 'password', meaning the password has initially been provisioned with:
+     * <p>
+     * vault kv put secret/<path> password=<password value>
+     * <p>
+     * password and password-wrapping-token are exclusive
+     */
+    @ConfigItem
+    public Optional<String> passwordWrappingToken;
+
 }

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultAuthManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultAuthManagerTest.java
@@ -104,6 +104,7 @@ public class VaultAuthManagerTest {
             config.authentication.appRole.secretIdWrappingToken = Optional.empty();
             config.authentication.userpass.username = Optional.of("bob");
             config.authentication.userpass.password = Optional.of("sinclair");
+            config.authentication.userpass.passwordWrappingToken = Optional.empty();
             config.connectTimeout = Duration.ofSeconds(1);
             config.readTimeout = Duration.ofSeconds(1);
             config.tls.skipVerify = true;

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultAuthManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultAuthManagerTest.java
@@ -97,9 +97,11 @@ public class VaultAuthManagerTest {
             config.authentication.userpass = new VaultUserpassAuthenticationConfig();
             config.url = Optional.of(new URL("http://localhost:8200"));
             config.authentication.clientToken = Optional.empty();
+            config.authentication.clientTokenWrappingToken = Optional.empty();
             config.authentication.kubernetes.role = Optional.empty();
             config.authentication.appRole.roleId = Optional.empty();
             config.authentication.appRole.secretId = Optional.empty();
+            config.authentication.appRole.secretIdWrappingToken = Optional.empty();
             config.authentication.userpass.username = Optional.of("bob");
             config.authentication.userpass.password = Optional.of("sinclair");
             config.connectTimeout = Duration.ofSeconds(1);

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
@@ -110,6 +110,7 @@ public class VaultDbManagerTest {
             config.authentication.appRole.secretIdWrappingToken = Optional.empty();
             config.authentication.userpass.username = Optional.empty();
             config.authentication.userpass.password = Optional.empty();
+            config.authentication.userpass.passwordWrappingToken = Optional.empty();
             config.connectTimeout = Duration.ofSeconds(1);
             config.readTimeout = Duration.ofSeconds(1);
             config.tls.skipVerify = true;

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
@@ -103,9 +103,11 @@ public class VaultDbManagerTest {
             config.authentication.userpass = new VaultUserpassAuthenticationConfig();
             config.url = Optional.of(new URL("http://localhost:8200"));
             config.authentication.clientToken = Optional.of("123");
+            config.authentication.clientTokenWrappingToken = Optional.empty();
             config.authentication.kubernetes.role = Optional.empty();
             config.authentication.appRole.roleId = Optional.empty();
             config.authentication.appRole.secretId = Optional.empty();
+            config.authentication.appRole.secretIdWrappingToken = Optional.empty();
             config.authentication.userpass.username = Optional.empty();
             config.authentication.userpass.password = Optional.empty();
             config.connectTimeout = Duration.ofSeconds(1);

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleWrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAppRoleWrapITCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_KEY;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultAppRoleWrapITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault-approle-wrap.properties", "application.properties"));
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void secretV2() {
+        Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
+        assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
+    }
+
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultClientTokenWrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultClientTokenWrapITCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_KEY;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultClientTokenWrapITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault-client-token-wrap.properties", "application.properties"));
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void secretV2() {
+        Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
+        assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
+    }
+
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -2,6 +2,7 @@ package io.quarkus.vault;
 
 import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.vault.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.vault.runtime.VaultAuthManager.USERPASS_WRAPPING_TOKEN_PASSWORD_KEY;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.APPROLE;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
 import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
@@ -152,10 +153,14 @@ public class VaultITCase {
 
         VaultClient vaultClient = VaultManager.getInstance().getVaultClient();
 
+        String anotherWrappingToken = System.getProperty("vault-test.another-password-kv-v2-wrapping-token");
+        VaultKvSecretV2 unwrap = vaultClient.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
+        assertEquals(VAULT_AUTH_USERPASS_PASSWORD, unwrap.data.data.get(USERPASS_WRAPPING_TOKEN_PASSWORD_KEY));
         try {
-            vaultClient.unwrap("toto", Object.class);
+            vaultClient.unwrap(anotherWrappingToken, VaultKvSecretV2.class);
             fail("expected error 400: wrapping token is not valid or does not exist");
         } catch (VaultClientException e) {
+            // fails on second unwrap attempt
             assertEquals(400, e.getStatus());
         }
 

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv1WrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv1WrapITCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_KEY;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultUserpassKvv1WrapITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault-userpass-kvv1-wrap.properties", "application.properties"));
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void secretV2() {
+        Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
+        assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
+    }
+
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv2WrapITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultUserpassKvv2WrapITCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_KEY;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultUserpassKvv2WrapITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault-userpass-kvv2-wrap.properties", "application.properties"));
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void secretV2() {
+        Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
+        assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
+    }
+
+}

--- a/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
@@ -1,8 +1,8 @@
 quarkus.vault.url=https://localhost:8200
 
-# role-id & secret-id provided by VaultTestLifecycleManager
+# role-id & secret-id-wrapping-token provided by VaultTestLifecycleManager
 quarkus.vault.authentication.app-role.role-id=${vault-test.role-id}
-quarkus.vault.authentication.app-role.secret-id=${vault-test.secret-id}
+quarkus.vault.authentication.app-role.secret-id-wrapping-token=${vault-test.secret-id-wrapping-token}
 
 #quarkus.vault.tls.skip-verify=true
 quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt

--- a/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
@@ -1,8 +1,7 @@
 quarkus.vault.url=https://localhost:8200
 
-# role-id & secret-id provided by VaultTestLifecycleManager
-quarkus.vault.authentication.app-role.role-id=${vault-test.role-id}
-quarkus.vault.authentication.app-role.secret-id=${vault-test.secret-id}
+# vault-test.client-token-wrapping-token provided by VaultTestLifecycleManager
+quarkus.vault.authentication.client-token-wrapping-token=${vault-test.client-token-wrapping-token}
 
 #quarkus.vault.tls.skip-verify=true
 quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
@@ -15,3 +14,5 @@ quarkus.log.category."io.quarkus.vault".level=DEBUG
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG
+
+

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
@@ -1,0 +1,20 @@
+quarkus.vault.url=https://localhost:8200
+
+quarkus.vault.kv-secret-engine-version=1
+quarkus.vault.kv-secret-engine-mount-path=secret-v1
+
+# password-kv-v1-wrapping-token provided by VaultTestLifecycleManager
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password-wrapping-token=${vault-test.password-kv-v1-wrapping-token}
+
+#quarkus.vault.tls.skip-verify=true
+quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
+
+quarkus.vault.log-confidentiality-level=low
+quarkus.vault.renew-grace-period=10
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG
+
+#quarkus.log.min-level=DEBUG
+#quarkus.log.level=DEBUG
+#quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
@@ -1,0 +1,17 @@
+quarkus.vault.url=https://localhost:8200
+
+# password-kv-v2-wrapping-token provided by VaultTestLifecycleManager
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password-wrapping-token=${vault-test.password-kv-v2-wrapping-token}
+
+#quarkus.vault.tls.skip-verify=true
+quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
+
+quarkus.vault.log-confidentiality-level=low
+quarkus.vault.renew-grace-period=10
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG
+
+#quarkus.log.min-level=DEBUG
+#quarkus.log.level=DEBUG
+#quarkus.log.console.level=DEBUG

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -34,8 +34,11 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
             throw new RuntimeException(e);
         }
 
-        sysprops.put("quarkus.vault.authentication.app-role.role-id", vaultTestExtension.appRoleRoleId);
-        sysprops.put("quarkus.vault.authentication.app-role.secret-id", vaultTestExtension.appRoleSecretId);
+        sysprops.put("vault-test.role-id", vaultTestExtension.appRoleRoleId);
+        sysprops.put("vault-test.secret-id", vaultTestExtension.appRoleSecretId);
+
+        sysprops.put("vault-test.secret-id-wrapping-token", vaultTestExtension.appRoleSecretIdWrappingToken);
+        sysprops.put("vault-test.client-token-wrapping-token", vaultTestExtension.clientTokenWrappingToken);
 
         log.info("using system properties " + sysprops);
 

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -39,6 +39,9 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
 
         sysprops.put("vault-test.secret-id-wrapping-token", vaultTestExtension.appRoleSecretIdWrappingToken);
         sysprops.put("vault-test.client-token-wrapping-token", vaultTestExtension.clientTokenWrappingToken);
+        sysprops.put("vault-test.password-kv-v1-wrapping-token", vaultTestExtension.passwordKvv1WrappingToken);
+        sysprops.put("vault-test.password-kv-v2-wrapping-token", vaultTestExtension.passwordKvv2WrappingToken);
+        sysprops.put("vault-test.another-password-kv-v2-wrapping-token", vaultTestExtension.anotherPasswordKvv2WrappingToken);
 
         log.info("using system properties " + sysprops);
 


### PR DESCRIPTION
This PR provides the ability to use wrapping tokens instead of plain sensitive data in configuration for vault authentication: client token (the token itself), approle (the secret id)

typically instead of providing:
```
quarkus.vault.authentication.client-token=s.XYZ
```
you could provide:
```
quarkus.vault.authentication.client-token-wrapping-token=s.xSr3IHx9RXxpSSwCctTd6n02
```
Where `s.xSr3IHx9RXxpSSwCctTd6n02` is obtained from:
```
/ # vault token create -wrap-ttl=60s -policy=myapp
Key                              Value
---                              -----
wrapping_token:                  s.xSr3IHx9RXxpSSwCctTd6n02
wrapping_accessor:               8H0BUXHPFv6LVIrXa9H9XNWb
wrapping_token_ttl:              1m
wrapping_token_creation_time:    2020-03-31 16:26:49.0405113 +0000 UTC
wrapping_token_creation_path:    auth/token/create
wrapped_accessor:                xoFYP9EgPi9I3xa7cDB3bm5v
```

Similarly for approle, instead of providing:
```
quarkus.vault.authentication.app-role.secret-id=ef8e1ebc-3be1-7bb7-3166-8b63b6289449
```
You could provide:
```
quarkus.vault.authentication.app-role.secret-id-wrapping-token=s.QdjujN8PGGN8EICldXpFnSYO
```
Where `s.QdjujN8PGGN8EICldXpFnSYO `is obtained from:
```
/ # vault write -wrap-ttl=60s -f auth/approle/role/myapp/secret-id
Key                              Value
---                              -----
wrapping_token:                  s.QdjujN8PGGN8EICldXpFnSYO
wrapping_accessor:               NCk8gkK90xLNzFMcnTq68nY8
wrapping_token_ttl:              1m
wrapping_token_creation_time:    2020-03-31 16:29:05.5958584 +0000 UTC
wrapping_token_creation_path:    auth/approle/role/myapp/secret-id
```

A wrapping token is a token that gives access to a secret information just once and has a small ttl. After the token has been unwrapped, the token is destroyed.

This approach is interesting when you want to start an application that needs to connect to vault, but you want to protect the sensitive data used to authenticate (e.g. secret id for approle). Instead of providing the sensitive data, you wrap it and include the wrapping token in the configuration of the application you are about to launch, then launch the application. This is done by a _trusted entity_ that can connect to vault and generate wrapping tokens.

If the application cannot unwrap the wrapping token, it means it was either too slow, or most likely the wrapping token has been stolen, which can trigger an alarm.

This mechanism adds some security around not exposing sensitive auth information in application configuration. It comes with a major drawback where the application cannot be restarted after it has consumed the wrapping token. The _trusted entity_ will have to re-provision a new wrapping token in the application configuration.

This is, in essence, what k8s is doing for free through the `jwt` token located in `/var/run/secrets/kubernetes.io/serviceaccount`.

There are several pieces of relevant documentation:
 - https://www.vaultproject.io/docs/concepts/response-wrapping/
 - https://learn.hashicorp.com/vault/secrets-management/sm-cubbyhole

Please see also https://github.com/quarkusio/quarkus/issues/7900 and https://github.com/quarkusio/quarkus/pull/8248 and for initial discussions.
