### PR TITLE
Test that CDI beans in SmallRye Health are present

### DIFF
--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/ExpectedBeansUnitTest.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/ExpectedBeansUnitTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.smallrye.health.test;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.health.HealthGroup;
+import io.smallrye.health.SmallRyeHealthReporter;
+
+public class ExpectedBeansUnitTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FailingHealthCheck.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+    @Inject
+    @Any
+    Instance<HealthCheck> checks;
+
+    @Inject
+    Instance<SmallRyeHealthReporter> reporters;
+
+    private boolean isUnique(Instance<?> instances) {
+        return !(instances.isAmbiguous() || instances.isUnsatisfied());
+    }
+
+    /**
+     * Test that SmallRye Health Reporter is registered and unique
+     */
+    @Test
+    public void testReporterIsUnique() {
+        Assertions.assertTrue(isUnique(reporters));
+    }
+
+    /**
+     * Test that HealthCheck procedure beans are registered once
+     */
+    @Test
+    public void testHealthCheckIsUnique() {
+        Assertions.assertTrue(isUnique(checks));
+    }
+
+    /**
+     * Test metadata on HealthCheck procedure beans
+     */
+    @Test
+    public void testHealthCheckMetadata() {
+        Instance<HealthCheck> selects;
+
+        selects = checks.select(Liveness.Literal.INSTANCE);
+        Assertions.assertTrue(isUnique(selects));
+
+        selects = checks.select(Readiness.Literal.INSTANCE);
+        Assertions.assertTrue(isUnique(selects));
+
+        selects = checks.select(HealthGroup.Literal.of("group1"));
+        Assertions.assertTrue(isUnique(selects));
+
+        selects = checks.select(HealthGroup.Literal.of("group2"));
+        Assertions.assertTrue(isUnique(selects));
+
+        selects = checks.select(Liveness.Literal.INSTANCE,
+                Readiness.Literal.INSTANCE,
+                HealthGroup.Literal.of("group1"),
+                HealthGroup.Literal.of("group2"));
+        Assertions.assertTrue(isUnique(selects));
+
+        Assertions.assertTrue(checks.select(HealthGroup.Literal.of("group3")).isUnsatisfied());
+
+    }
+
+}

--- a/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingHealthCheck.java
+++ b/extensions/smallrye-health/deployment/src/test/java/io/quarkus/smallrye/health/test/FailingHealthCheck.java
@@ -11,9 +11,13 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
 
+import io.smallrye.health.HealthGroup;
+
 @Dependent
 @Liveness
 @Readiness
+@HealthGroup("group1")
+@HealthGroup("group2")
 public class FailingHealthCheck implements HealthCheck {
 
     @Override


### PR DESCRIPTION
fixes #7030

Test that CDI beans in SmallRye Health are present and defined HealthCheck beans are registered once with the expected metadata