### PR TITLE
Revert how readers and writers are registered for REST clients

### DIFF
--- a/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
+++ b/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
@@ -68,6 +68,7 @@ import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.restclient.runtime.RestClientBase;
 import io.quarkus.restclient.runtime.RestClientRecorder;
 import io.quarkus.resteasy.common.deployment.JaxrsProvidersToRegisterBuildItem;
+import io.quarkus.resteasy.common.deployment.RestClientBuildItem;
 import io.quarkus.resteasy.common.deployment.ResteasyDotNames;
 import io.quarkus.resteasy.common.deployment.ResteasyInjectionReadyBuildItem;
 
@@ -145,6 +146,7 @@ class RestClientProcessor {
             BuildProducer<BeanRegistrarBuildItem> beanRegistrars,
             BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             BuildProducer<ServiceProviderBuildItem> serviceProvider,
+            BuildProducer<RestClientBuildItem> restClient,
             RestClientRecorder restClientRecorder) {
 
         // According to the spec only rest client interfaces annotated with RegisterRestClient are registered as beans
@@ -158,6 +160,10 @@ class RestClientProcessor {
 
         if (interfaces.isEmpty()) {
             return;
+        }
+
+        for (DotName interfaze : interfaces.keySet()) {
+            restClient.produce(new RestClientBuildItem(interfaze.toString()));
         }
 
         for (Map.Entry<DotName, ClassInfo> entry : interfaces.entrySet()) {

--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/RestClientBuildItem.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/RestClientBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.common.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Used to mark a class as a potential REST client interface consumed by the MicroProfile REST client.
+ * <p>
+ * Useful when you want to apply different behaviors to REST resources and REST clients.
+ */
+public final class RestClientBuildItem extends MultiBuildItem {
+
+    private String interfaceName;
+
+    public RestClientBuildItem(String interfaceName) {
+        this.interfaceName = interfaceName;
+    }
+
+    public String getInterfaceName() {
+        return interfaceName;
+    }
+}


### PR DESCRIPTION
They used to be registered as for the JAX-RS resources but they should
be registered the opposite way.

Fixes #8223