### PR TITLE
Pass args for command-mode application to dev-mode.

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
@@ -38,6 +38,8 @@ public class DevModeContext implements Serializable {
     // the jar file which is used to launch the DevModeMain
     private File devModeRunnerJarFile;
     private boolean localProjectDiscovery = true;
+    // args of the main-method
+    private String[] args;
 
     private List<String> compilerOptions;
     private String sourceJavaVersion;
@@ -174,6 +176,14 @@ public class DevModeContext implements Serializable {
     public DevModeContext setProjectDir(File projectDir) {
         this.projectDir = projectDir;
         return this;
+    }
+
+    public String[] getArgs() {
+        return args;
+    }
+
+    public void setArgs(String[] args) {
+        this.args = args;
     }
 
     public static class ModuleInfo implements Serializable {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeMain.java
@@ -42,7 +42,6 @@ public class DevModeMain implements Closeable {
     }
 
     public static void main(String... args) throws Exception {
-
         try (InputStream devModeCp = DevModeMain.class.getClassLoader().getResourceAsStream(DEV_MODE_CONTEXT)) {
             DevModeContext context;
             try {
@@ -52,6 +51,7 @@ public class DevModeMain implements Closeable {
                         "Unable to deserialize the dev mode context. Does the Quarkus plugin version match the version of Quarkus that is in use?",
                         e);
             }
+            context.setArgs(args);
             try (DevModeMain devModeMain = new DevModeMain(context)) {
                 devModeMain.start();
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -83,7 +83,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                                 }
                             }
                         });
-                runner = start.runMainClass();
+                runner = start.runMainClass(context.getArgs());
             } catch (Throwable t) {
                 deploymentProblem = t;
                 if (context.isAbortOnFailedStart()) {
@@ -128,7 +128,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
             //ok, we have resolved all the deps
             try {
                 StartupAction start = augmentAction.reloadExistingApplication(changedResources);
-                runner = start.runMainClass();
+                runner = start.runMainClass(context.getArgs());
             } catch (Throwable t) {
                 deploymentProblem = t;
                 log.error("Failed to start quarkus", t);

--- a/core/runtime/src/main/java/io/quarkus/runtime/CommandLineRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/CommandLineRuntimeConfig.java
@@ -1,0 +1,23 @@
+package io.quarkus.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * This configuration class is here to avoid warnings when using {@code -Dquarkus.args=...}.
+ */
+@ConfigRoot(name = ConfigItem.PARENT, phase = ConfigPhase.RUN_TIME)
+public class CommandLineRuntimeConfig {
+
+    /**
+     * The arguments passed to the command line.
+     * <p>
+     * We don't make it a list as the args are separated by a space, not a comma.
+     */
+    @ConfigItem
+    public Optional<String> args;
+
+}

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -13,8 +13,10 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -23,6 +25,7 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -69,6 +72,8 @@ public class QuarkusDev extends QuarkusTask {
     private List<String> jvmArgs;
 
     private boolean preventnoverify = false;
+
+    private List<String> args = new LinkedList<String>();
 
     public QuarkusDev() {
         super("Development mode: enables hot deployment with background compilation");
@@ -126,6 +131,21 @@ public class QuarkusDev extends QuarkusTask {
     @Option(description = "Set JVM arguments", option = "jvm-args")
     public void setJvmArgs(List<String> jvmArgs) {
         this.jvmArgs = jvmArgs;
+    }
+
+    @Optional
+    @Input
+    public List<String> getArgs() {
+        return args;
+    }
+
+    public void setArgs(List<String> args) {
+        this.args = args;
+    }
+
+    @Option(description = "Set application arguments", option = "quarkus-args")
+    public void setArgsString(String argsString) {
+        this.setArgs(Arrays.asList(Commandline.translateCommandline(argsString)));
     }
 
     @Input
@@ -363,6 +383,7 @@ public class QuarkusDev extends QuarkusTask {
 
             args.add("-jar");
             args.add(tempFile.getAbsolutePath());
+            args.addAll(this.getArgs());
             if (getLogger().isDebugEnabled()) {
                 getLogger().debug("Launching JVM with command line: {}", String.join(" ", args));
             }

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -49,6 +49,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -183,6 +184,9 @@ public class DevMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${jvm.args}")
     private String jvmArgs;
+
+    @Parameter(defaultValue = "${quarkus.args}")
+    private String argsString;
 
     @Parameter(defaultValue = "${session}")
     private MavenSession session;
@@ -640,7 +644,9 @@ public class DevMojo extends AbstractMojo {
             }
             args.add("-jar");
             args.add(tempFile.getAbsolutePath());
-
+            if (argsString != null) {
+                args.addAll(Arrays.asList(CommandLineUtils.translateCommandline(argsString)));
+            }
         }
 
         private void addQuarkusDevModeDeps(StringBuilder classPathManifest, final DevModeContext devModeContext)

--- a/docs/src/main/asciidoc/command-mode-reference.adoc
+++ b/docs/src/main/asciidoc/command-mode-reference.adoc
@@ -93,3 +93,21 @@ thread (A non-command mode application is essentially just running an applicatio
 
 If you want to shut down a running application and you are not in the main thread then you should call `Quarkus.asyncExit`
 in order to unblock the main thread and initiate the shutdown process.
+
+=== Dev mode
+
+Also for command mode applications the dev mode is supported. When running `mvn compile quarkus:dev`, the command mode application is executed and on press of the Enter key, is restarted.
+
+As command mode applications will often require arguments to be passed on the commandline, this is also possible in dev mode via:
+
+----
+mvn compile quarkus:dev -Dquarkus.args='--help'
+----
+
+The same can be achived with Gradle:
+
+----
+./gradlew quarkusDev --quarkus-args='--help'
+----
+
+


### PR DESCRIPTION
Fixes #8428
For Maven and Gradle.

Usage:
gardle quarkusDev --quarkus-args='arg1=1 arg2=2'
mvn quarkus:dev -Dquarkus.args='arg1=1 arg2=2'