### PR TITLE
add explanations to expose the debug remote port into docker image

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-jvm.ftl
@@ -13,6 +13,13 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/${project_artifactId}-jvm
 #
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
+# 
+# Then run the container using : 
+#
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/${project_artifactId}-jvm
+#
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 


### PR DESCRIPTION
for now there is a issue in run-java-sh that doesn't produce the right syntax for the debug port,  the workaround is to use this for now

ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"

and don't pass the variable JAVA_ENABLE_DEBUG