### PR TITLE
Add ThrowableDescription to XrayBuildStep reflectiveClass

### DIFF
--- a/extensions/amazon-lambda-xray/deployment/src/main/java/io/quarkus/amazon/lambda/xray/XrayBuildStep.java
+++ b/extensions/amazon-lambda-xray/deployment/src/main/java/io/quarkus/amazon/lambda/xray/XrayBuildStep.java
@@ -34,6 +34,7 @@ public class XrayBuildStep {
                 "com.amazonaws.xray.handlers.config.AWSOperationHandler",
                 "com.amazonaws.xray.handlers.config.AWSOperationHandlerRequestDescriptor",
                 "com.amazonaws.xray.handlers.config.AWSOperationHandlerResponseDescriptor",
+                "com.amazonaws.xray.entities.ThrowableDescription",
                 "com.amazonaws.xray.entities.SubsegmentImpl",
                 "com.amazonaws.xray.entities.EntityImpl",
                 "com.amazonaws.xray.entities.TraceID",


### PR DESCRIPTION
This is a follow up PR to my team consuming #7165 via Quarkus 1.3.1.Final. Everything works well except for Jackson serialization of exceptions to an AWS SDK client when the app is built with native mode. The below screenshot is verification that tracing works for both successful and unsuccessful responses to AWS SDK requests

![Screen Shot 2020-04-07 at 12 03 18 PM](https://user-images.githubusercontent.com/1335137/78710387-82bb4e00-78d2-11ea-8fe5-c4c44924d867.png)
