### PR TITLE
Add skip parameter to ValidateExtensionsJsonMojo

### DIFF
--- a/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
+++ b/devtools/platform-descriptor-json-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
@@ -53,6 +53,14 @@ public class ValidateExtensionsJsonMojo extends AbstractMojo {
     @Parameter(property = "jsonVersion", required = true)
     private String jsonVersion;
 
+    /**
+     * Skip the execution of this mojo.
+     *
+     * @since 1.4.0
+     */
+    @Parameter(defaultValue = "false", property = "quarkus.validate-extensions-json.skip")
+    private boolean skip;
+
     @Component
     private RepositorySystem repoSystem;
 
@@ -64,6 +72,10 @@ public class ValidateExtensionsJsonMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping as required by the mojo configuration");
+            return;
+        }
 
         MavenArtifactResolver mvn;
         try {

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -79,6 +79,7 @@
                             <goal>validate-extensions-json</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <jsonGroupId>io.quarkus</jsonGroupId>
                             <jsonArtifactId>quarkus-bom-descriptor-json</jsonArtifactId>
                             <jsonVersion>${project.version}</jsonVersion>


### PR DESCRIPTION
This PR makes it possible to build the whole source tree with `mvnd` [1] in using

```
mvnd clean install -DskipTests -DskipITs -Dquarkus.build.skip -DskipDocs -Denforcer.skip
```

It takes ~28 sec on my machine (vs. ~135s with plain mvn).

I am not 100% sure binding the mojo's skip with `skipTests` is a good idea. I am ready to remove that part if somebody finds it better. I'd be OK with passing `-Dquarkus.validate-extensions-json.skip` via CLI.

[1] https://github.com/gnodet/mvnd

cc @aloubyansky