### PR TITLE
Project root should not initialized to the current dir if the test class is from a JAR

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
@@ -126,7 +126,6 @@ public class DeploymentInjectingDependencyVisitor {
         node.setData(QUARKUS_DEPLOYMENT_ARTIFACT, deploymentArtifact);
         runtimeNodes.add(node);
         Dependency dependency = new Dependency(node.getArtifact(), JavaScopes.COMPILE);
-        managedDeps.add(dependency);
         runtimeExtensionDeps.add(dependency);
         managedDeps.add(new Dependency(deploymentArtifact, JavaScopes.COMPILE));
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,7 +107,7 @@ public class QuarkusTestExtension
             }
             CuratedApplication curatedApplication = runnerBuilder
                     .setTest(true)
-                    .setProjectRoot(new File("").toPath())
+                    .setProjectRoot(Files.isDirectory(appClassLocation) ? new File("").toPath() : null)
                     .build()
                     .bootstrap();
 


### PR DESCRIPTION
Fixes #8452 

There is a bit of a mess around `appClasses` and `projectRoot` in the bootstrap and the resolver. I'm cleaning it up in a different PR.
The other issue is that the output of `build-tree` isn't really working for an external test JAR.