### PR TITLE
Add ReflectionValueResolver to DefaultValueResolvers.

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -85,7 +85,7 @@ public final class EngineBuilder {
      */
     public EngineBuilder addDefaultValueResolvers() {
         return addValueResolvers(mapResolver(), mapperResolver(), mapEntryResolver(), collectionResolver(),
-                thisResolver(), orResolver(), trueResolver());
+                thisResolver(), orResolver(), trueResolver(), new ReflectionValueResolver());
     }
 
     public EngineBuilder addDefaults() {


### PR DESCRIPTION
The issue I run into was like this:

```
public class SimpleTest {
    public static void main(String[] args) {
        final Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
        final Template template =
            engine.parse("{single} -> {single.name}");
        final String result = template
            .data("single", new Single("some name"))
            .render();
        System.out.println(result);
    }

    public static class Single {
        public String name;

        public Single(final String name) {
            this.name = name;
        }

        @Override
        public String toString() {
            return "Single{" +
                "name='" + name + '\'' +
                '}';
        }
    }
}
```

Without `.addValueResolver(new ReflectionValueResolver())`, the result
would be `Single{name='some name'} -> NOT_FOUND`.

Or we could change the documentation, mentioning that when a Java bean is
used, one needs to add `.addValueResolver(new ReflectionValueResolver())`.

Please let me know how I could continue with this. Thanks.