### PR TITLE
Follow up to #8474. Maven resolver init improvements

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenRepoInitializer.java
@@ -161,7 +161,12 @@ public class MavenRepoInitializer {
             locator.addService(TransporterFactory.class, WagonTransporterFactory.class);
             locator.setServices(WagonProvider.class, new BootstrapWagonProvider());
         }
-        locator.setServices(ModelBuilder.class, new MavenModelBuilder(wsModelResolver));
+        try {
+            locator.setServices(ModelBuilder.class, new MavenModelBuilder(wsModelResolver, mvnArgs,
+                    wsModelResolver == null ? Collections.emptyList() : getActiveSettingsProfiles()));
+        } catch (AppModelResolverException e) {
+            throw new IllegalStateException("Failed to resolve active settings profiles", e);
+        }
         locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
             @Override
             public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {


### PR DESCRIPTION
Follow up to #8474
1) avoid referencing now deprecated MavenRepoInitializer from MavenModelBuilder to avoid the initialization of the deprecated class;
2) perform proper and more efficient workspace loading when BootstrapMavenContext is available