### PR TITLE
Don't include optional deps for the deployment CP

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
@@ -136,7 +136,10 @@ public class BuildDependencyGraphVisitor {
         if (deploymentNode != null) {
             if (runtimeNode == null && !appDeps.contains(new AppArtifactKey(artifact.getGroupId(),
                     artifact.getArtifactId(), artifact.getClassifier(), artifact.getExtension()))) {
-                deploymentDepNodes.add(node);
+                //we never want optional deps on the deployment CP
+                if (!node.getDependency().isOptional()) {
+                    deploymentDepNodes.add(node);
+                }
             } else if (runtimeNode == node) {
                 runtimeNode = null;
                 runtimeArtifact = null;


### PR DESCRIPTION
As these are resolved indivisually Maven is including
top level optional deps for each -deployment artifact.

This is not desired behaviour, as only optional deps
in the users project should be included.