### PR TITLE
Make beans injected with @InjectMock unremoveable.

### DIFF
--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/OtherUnusedService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/OtherUnusedService.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This gets removed removed by Arc since it's not being used in the application,
+ * nor is it injected anywhere in tests
+ */
+@ApplicationScoped
+public class OtherUnusedService {
+}

--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/UnusedService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/UnusedService.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.mockbean;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This would normally have been removed by Arc since it's not being used in the application,
+ * but the fact that it's used with {@code @InjectMock} in a test prevents that from happening
+ */
+@ApplicationScoped
+public class UnusedService {
+
+    public String doSomething(String input) {
+        return null;
+    }
+}

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/UnusedServiceTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/UnusedServiceTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.mockbean;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+@QuarkusTest
+public class UnusedServiceTest {
+
+    @InjectMock
+    UnusedService unusedService;
+
+    @Test
+    public void testInjectedUnusedBeanIsNotRemoved() {
+        Assertions.assertNotNull(unusedService);
+
+        Assertions.assertTrue(Arc.container().instance(UnusedService.class).isAvailable());
+    }
+
+    @Test
+    public void testNonInjectedUnusedBeanIsNotRemoved() {
+        Assertions.assertFalse(Arc.container().instance(OtherUnusedService.class).isAvailable());
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/UnremoveableMockTestBuildChainCustomizerProducer.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/UnremoveableMockTestBuildChainCustomizerProducer.java
@@ -1,0 +1,45 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+public class UnremoveableMockTestBuildChainCustomizerProducer implements TestBuildChainCustomizerProducer {
+
+    private static final DotName INJECT_MOCK = DotName.createSimple(InjectMock.class.getName());
+
+    @Override
+    public Consumer<BuildChainBuilder> produce(Index testClassesIndex) {
+        return new Consumer<BuildChainBuilder>() {
+
+            @Override
+            public void accept(BuildChainBuilder buildChainBuilder) {
+                buildChainBuilder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        Set<String> mockTypes = new HashSet<>();
+                        List<AnnotationInstance> instances = testClassesIndex.getAnnotations(INJECT_MOCK);
+                        for (AnnotationInstance instance : instances) {
+                            mockTypes.add(instance.target().asField().type().name().toString());
+                        }
+                        context.produce(
+                                new UnremovableBeanBuildItem(new UnremovableBeanBuildItem.BeanClassNamesExclusion(mockTypes)));
+                    }
+                }).produces(UnremovableBeanBuildItem.class)
+                        .build();
+            }
+        };
+    }
+}

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.mockito.internal.UnremoveableMockTestBuildChainCustomizerProducer

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/buildchain/TestBuildChainCustomizerProducer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/buildchain/TestBuildChainCustomizerProducer.java
@@ -1,0 +1,15 @@
+package io.quarkus.test.junit.buildchain;
+
+import java.util.function.Consumer;
+
+import org.jboss.jandex.Index;
+
+import io.quarkus.builder.BuildChainBuilder;
+
+/**
+ * Implementation of this class have the ability to add build items
+ */
+public interface TestBuildChainCustomizerProducer {
+
+    Consumer<BuildChainBuilder> produce(Index testClassesIndex);
+}


### PR DESCRIPTION
Based on a chat conversation that took place here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/quarkus.20Mockito/near/193297711.

It was also mentioned in the original PR that introduced `@InjectMock`.