### PR TITLE
Bump SLF4J to 1.7.30

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -94,7 +94,7 @@
         <rxjava.version>2.2.19</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
-        <slf4j.version>1.7.29</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>


### PR DESCRIPTION
Not adding to Dependabot because org.jboss.slf4j:slf4j-jboss-logging would need to be compatible with it