### PR TITLE
MongoDB documentation improvements

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -637,6 +637,17 @@ TIP: Using `@BsonProperty` is not needed to define custom column mappings, as th
 
 TIP: You can have your projection class extends from another class. In this case, the parent class also needs to have use `@ProjectionFor` annotation.
 
+== Query debugging
+
+As MongoDB with Panache allows writing simplified queries, it is sometimes handy to log the generated native queries for debugging purpose.
+
+This can be achieved by setting to DEBUG the following log category inside your `application.properties`:
+
+[source,properties]
+----
+quarkus.log.category."io.quarkus.mongodb.panache.runtime".level=DEBUG
+----
+
 == Transactions
 
 WARNING: MongoDB offers ACID transactions since version 4.0. MongoDB with Panache doesn't provide support for them.
@@ -855,7 +866,6 @@ public Multi<ReactivePerson> streamPersons() {
 ----
 
 TIP: `@SseElementType(MediaType.APPLICATION_JSON)` tells RESTEasy to serialize the object in JSON.
-
 
 == How and why we simplify MongoDB API
 

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -236,6 +236,14 @@ Notice there's an extra bit in the key (the `users` and `inventory` segments).
 The syntax is as follows: `quarkus.mongodb.[optional name.][mongo connection property]`.
 If the name is omitted, it configures the default client.
 
+[NOTE]
+====
+The use of multiple MongoDB clients enables multi-tenancy for MongoDB by allowing to connect to multiple MongoDB clusters. +
+If you want to connect to multiple databases inside the same cluster,
+multiple clients are **not** necessary as a single client is able to access all databases in the same cluster
+(like a JDBC connection is able to access to multiple schemas inside the same database).
+====
+
 === Named Mongo client Injection
 
 When using multiple clients, each `MongoClient`, you can select the client to inject using the `io.quarkus.mongodb.runtime.MongoClientName` qualifier.
@@ -596,6 +604,13 @@ You can then point your browser to `http://localhost:8080/fruits.html` and use y
 Currently, Quarkus doesn't support the `mongodb+srv` protocol in native mode.
 
 link:https://docs.mongodb.com/manual/core/security-client-side-encryption/[Client-Side Field Level Encryption] is also not supported in native mode.
+====
+
+[TIP]
+====
+If you encounter the following error when running your application in native mode: +
+`Failed to encode 'MyObject'. Encoding 'myVariable' errored with: Can't find a codec for class org.acme.MyVariable.` +
+This means that the `org.acme.MyVariable` class is not known to GraalVM, the remedy is to add the `@RegisterForReflection` annotation to your `MyVariable class`.
 ====
 
 == Conclusion


### PR DESCRIPTION
Some improvements to the MongoDB documentation:

- Clarify multi-tenancy (see discussions https://github.com/quarkusio/quarkus/pull/7431#issuecomment-595826130)
- Add a note on the cryptic `Can't find a codec for class` error that should be fixed via `@RegisterForReflection`. Maybe this note needs to be on MongoDB with Panache as it was reported with the usage of MongoDB with Panache (all now normally fixed).
- Add some debugging tips