### PR TITLE
Type-safe message bundles powered by Qute

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmoAdaptor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/GeneratedClassGizmoAdaptor.java
@@ -4,6 +4,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 
 import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -12,13 +13,23 @@ import io.quarkus.gizmo.ClassOutput;
 
 public class GeneratedClassGizmoAdaptor implements ClassOutput {
 
-    private final BuildProducer<GeneratedClassBuildItem> classOutput;
-    private final boolean applicationClass;
+    private final BuildProducer<GeneratedClassBuildItem> generatedClasses;
+    private final Predicate<String> applicationClassPredicate;
     private final Map<String, StringWriter> sources;
 
-    public GeneratedClassGizmoAdaptor(BuildProducer<GeneratedClassBuildItem> classOutput, boolean applicationClass) {
-        this.classOutput = classOutput;
-        this.applicationClass = applicationClass;
+    public GeneratedClassGizmoAdaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses, boolean applicationClass) {
+        this(generatedClasses, new Predicate<String>() {
+            @Override
+            public boolean test(String t) {
+                return applicationClass;
+            }
+        });
+    }
+
+    public GeneratedClassGizmoAdaptor(BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            Predicate<String> applicationClassPredicate) {
+        this.generatedClasses = generatedClasses;
+        this.applicationClassPredicate = applicationClassPredicate;
         this.sources = BootstrapDebug.DEBUG_SOURCES_DIR != null ? new ConcurrentHashMap<>() : null;
     }
 
@@ -31,8 +42,8 @@ public class GeneratedClassGizmoAdaptor implements ClassOutput {
                 source = sw.toString();
             }
         }
-        classOutput.produce(
-                new GeneratedClassBuildItem(applicationClass, className, bytes, source));
+        generatedClasses.produce(
+                new GeneratedClassBuildItem(applicationClassPredicate.test(className), className, bytes, source));
     }
 
     @Override

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -986,10 +986,101 @@ class DetailResource {
 
 In the development mode, all files located in `src/main/resources/templates` are watched for changes and modifications are immediately visible.
 
+=== Type-safe Message Bundles
+
+==== Basic Concepts
+
+The basic idea is that every message is potentially a very simple template.
+In order to prevent type errors a message is defined as an annotated method of a *message bundle interface*.
+Quarkus generates the *message bundle implementation* at build time.
+Subsequently, the bundles can be used at runtime:
+
+1. Directly in your code via `io.quarkus.qute.i18n.MessageBundles#get()`; e.g. `MessageBundles.get(AppMessages.class).hello_name("Lucie")`
+2. Injected in your beans via `@Inject`; e.g. `@Inject AppMessages`
+3. Referenced in the templates via the message bundle name; e.g. `{msg:hello_name('Lucie')}`
+
+.Message Bundle Interface Example
+[source,java]
+----
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle <1>
+public interface AppMessages {
+
+    @Message("Hello {name}!") <2>
+    String hello_name(String name); <3>
+}
+----
+<1> Denotes a message bundle interface. The bundle name is defaulted to `msg` and is used as a namespace in templates expressions, e.g. `{msg:hello_name}`.
+<2> Each method must be annotated with `@Message`. The value is a qute template.
+<3> The method parameters can be used in the template.
+
+==== Bundle Name and Message Keys
+
+Keys are used directly in templates.
+The bundle name is used as a namespace in template expressions. 
+The `@MessageBundle` can be used to define the default strategy used to generate message keys from method names. 
+However, the `@Message` can override this strategy and even define a custom key.
+By default, the annotated element's name is used as-is. 
+Other possibilities are:
+
+1. De-camel-cased and hyphenated; e.g. `helloName()` -> `hello-name`
+2. De-camel-cased and parts separated by underscores; e.g. `helloName()` -> `hello_name`. 
+
+==== Validation
+
+* All message bundle templates are validated:
+** All expressions without a namespace must map to a parameter; e.g. `Hello {foo}` -> the method must have a param of name `foo`
+** All expressions are validated against the types of the parameters; e.g. `Hello {foo.bar}` where the parameter `foo` is of type `org.acme.Foo` -> `org.acme.Foo` must have a property of name `bar`
++
+NOTE: A warning message is logged for each _unused_ parameter.
+* Expressions that reference a message bundle method, such as `{msg:hello(item.name)}`, are validated too.
+
+==== Localization
+
+The default locale of the Java Virtual Machine used to *build the application* is used for the `@MessageBundle` interface by default.
+However, the `io.quarkus.qute.i18n.MessageBundle#locale()` can be used to specify a custom locale.
+Additionaly, there are two ways to define a localized bundle:
+
+1. Create an interface that extends the default interface that is annotated with `@Localized`
+2. Create an UTF-8 encoded file located in `src/main/resources/messages`; e.g. `msg_de.properties`.
+
+TIP: A localized interface is the preferred solution mainly due to the possibility of easy refactoring.
+
+.Localized Interface Example
+[source,java]
+----
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+
+@Localized("de") <1>
+public interface GermanAppMessages {
+
+    @Override
+    @Message("Hallo {name}!") <2>
+    String hello_name(String name);
+}
+----
+<1> The value is the locale tag string (IETF).
+<2> The value is the localized template.
+
+Message bundle files must be encoded in UTF-8.
+The file name consists of the relevant bundle name (e.g. `msg`) and underscore followed by the locate tag (IETF).
+The file format is very simple: each line represents either a key/value pair with the equals sign used as a separator or a comment (line starts with `#`).
+Keys are mapped to method names from the corresponding message bundle interface.
+Values represent the templates normally defined by `io.quarkus.qute.i18n.Message#value()`.
+We use `.properties` suffix in our example because most IDEs and text editors support syntax highlighting of `.properties` files.
+But in fact, the suffix could be anything.
+
+.Localized File Example - `msg_de.properties`
+[source,properties]
+----
+hello_name=Hallo {name}! <1> <2>
+----
+<1> Each line in a localized file represents a message template. 
+<2> Keys and values are separated by the equals sign.
+
 === Configuration Reference
 
 include::{generated-dir}/config/quarkus-qute.adoc[leveloffset=+1, opts=optional]
-
-== Extension Points
-
-TODO

--- a/extensions/qute/deployment/pom.xml
+++ b/extensions/qute/deployment/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-qute-deployment</artifactId>
     <name>Quarkus - Qute - Deployment</name>
 
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/IncorrectExpressionBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/IncorrectExpressionBuildItem.java
@@ -9,13 +9,24 @@ public final class IncorrectExpressionBuildItem extends MultiBuildItem {
     public final String clazz;
     public final int line;
     public final String templateId;
+    public final String reason;
 
     public IncorrectExpressionBuildItem(String expression, String property, String clazz, int line, String templateId) {
+        this(expression, property, clazz, line, templateId, null);
+    }
+
+    public IncorrectExpressionBuildItem(String expression, String reason, int line, String templateId) {
+        this(expression, null, null, line, templateId, reason);
+    }
+
+    public IncorrectExpressionBuildItem(String expression, String property, String clazz, int line, String templateId,
+            String reason) {
         this.expression = expression;
         this.property = property;
         this.clazz = clazz;
         this.line = line;
         this.templateId = templateId;
+        this.reason = reason;
     }
 
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleBuildItem.java
@@ -1,0 +1,41 @@
+package io.quarkus.qute.deployment;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class MessageBundleBuildItem extends MultiBuildItem {
+
+    private final String name;
+    private final ClassInfo defaultBundleInterface;
+    private final Map<String, ClassInfo> localizedInterfaces;
+    private final Map<String, Path> localizedFiles;
+
+    public MessageBundleBuildItem(String name, ClassInfo defaultBundleInterface, Map<String, ClassInfo> localizedInterfaces,
+            Map<String, Path> localizedFiles) {
+        this.name = name;
+        this.defaultBundleInterface = defaultBundleInterface;
+        this.localizedInterfaces = localizedInterfaces;
+        this.localizedFiles = localizedFiles;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ClassInfo getDefaultBundleInterface() {
+        return defaultBundleInterface;
+    }
+
+    public Map<String, ClassInfo> getLocalizedInterfaces() {
+        return localizedInterfaces;
+    }
+
+    public Map<String, Path> getLocalizedFiles() {
+        return localizedFiles;
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleException.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleException.java
@@ -1,0 +1,11 @@
+package io.quarkus.qute.deployment;
+
+public class MessageBundleException extends RuntimeException {
+
+    private static final long serialVersionUID = -829022359988581607L;
+
+    public MessageBundleException(String message) {
+        super(message);
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleMethodBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleMethodBuildItem.java
@@ -1,0 +1,48 @@
+package io.quarkus.qute.deployment;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Represents a message bundle method that has a template that needs to be validated.
+ * <p>
+ * Note that templates that contain no expressions don't need to be validated.
+ */
+public final class MessageBundleMethodBuildItem extends MultiBuildItem {
+
+    private final String bundleName;
+    private final String key;
+    private final String templateId;
+    private final MethodInfo method;
+    private final String template;
+
+    public MessageBundleMethodBuildItem(String bundleName, String key, String templateId, MethodInfo method, String template) {
+        this.bundleName = bundleName;
+        this.key = key;
+        this.templateId = templateId;
+        this.method = method;
+        this.template = template;
+    }
+
+    public String getBundleName() {
+        return bundleName;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public MethodInfo getMethod() {
+        return method;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -1,0 +1,788 @@
+package io.quarkus.qute.deployment;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import javax.inject.Singleton;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.ApplicationArchive;
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.recording.RecorderContext;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassCreator.Builder;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.DescriptorUtils;
+import io.quarkus.gizmo.FunctionCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.qute.EvalContext;
+import io.quarkus.qute.Expression;
+import io.quarkus.qute.Expression.Part;
+import io.quarkus.qute.Resolver;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.deployment.QuteProcessor.Match;
+import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
+import io.quarkus.qute.generator.Descriptors;
+import io.quarkus.qute.generator.ValueResolverGenerator;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.qute.i18n.MessageBundles;
+import io.quarkus.qute.runtime.MessageBundleRecorder;
+import io.quarkus.runtime.util.StringUtil;
+
+public class MessageBundleProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(MessageBundleProcessor.class);
+
+    private static final String SUFFIX = "_Bundle";
+    private static final String BUNDLE_DEFAULT_KEY = "defaultKey";
+    private static final String BUNDLE_LOCALE = "locale";
+
+    static final DotName BUNDLE = DotName.createSimple(MessageBundle.class.getName());
+    static final DotName MESSAGE = DotName.createSimple(Message.class.getName());
+    static final DotName LOCALIZED = DotName.createSimple(Localized.class.getName());
+
+    static final MethodDescriptor TEMPLATE_INSTANCE = MethodDescriptor.ofMethod(Template.class, "instance",
+            TemplateInstance.class);
+    static final MethodDescriptor TEMPLATE_INSTANCE_DATA = MethodDescriptor.ofMethod(TemplateInstance.class, "data",
+            TemplateInstance.class, String.class, Object.class);
+    static final MethodDescriptor TEMPLATE_INSTANCE_RENDER = MethodDescriptor.ofMethod(TemplateInstance.class, "render",
+            String.class);
+    static final MethodDescriptor BUNDLES_GET_TEMPLATE = MethodDescriptor.ofMethod(MessageBundles.class, "getTemplate",
+            Template.class, String.class);
+
+    @BuildStep
+    AdditionalBeanBuildItem beans() {
+        return new AdditionalBeanBuildItem(MessageBundles.class, MessageBundle.class, Message.class, Localized.class);
+    }
+
+    @BuildStep
+    List<MessageBundleBuildItem> processBundles(BeanArchiveIndexBuildItem beanArchiveIndex,
+            ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses, BeanRegistrationPhaseBuildItem beanRegistration,
+            BuildProducer<BeanConfiguratorBuildItem> configurators,
+            BuildProducer<MessageBundleMethodBuildItem> messageTemplateMethods) throws IOException {
+
+        IndexView index = beanArchiveIndex.getIndex();
+        Map<String, ClassInfo> found = new HashMap<>();
+        List<MessageBundleBuildItem> bundles = new ArrayList<>();
+        Set<Path> messageFiles = findMessageFiles(applicationArchivesBuildItem);
+
+        // First collect all interfaces annotated with @MessageBundle
+        for (AnnotationInstance bundleAnnotation : index.getAnnotations(BUNDLE)) {
+            if (bundleAnnotation.target().kind() == Kind.CLASS) {
+                ClassInfo bundleClass = bundleAnnotation.target().asClass();
+                if (Modifier.isInterface(bundleClass.flags())) {
+                    AnnotationValue nameValue = bundleAnnotation.value();
+                    String name = nameValue != null ? nameValue.asString() : MessageBundle.DEFAULT_NAME;
+
+                    if (found.containsKey(name)) {
+                        throw new MessageBundleException(
+                                String.format("Message bundle interface name conflict - [%s] is used for both [%s] and [%s]",
+                                        name, bundleClass, found.get(name)));
+                    }
+                    found.put(name, bundleClass);
+
+                    // Find localizations for each interface
+                    String defaultLocale = getDefaultLocale(bundleAnnotation);
+                    List<ClassInfo> localized = new ArrayList<>();
+                    for (ClassInfo implementor : index.getKnownDirectImplementors(bundleClass.name())) {
+                        if (Modifier.isInterface(implementor.flags())) {
+                            localized.add(implementor);
+                        }
+                    }
+                    Map<String, ClassInfo> localeToInterface = new HashMap<>();
+                    for (ClassInfo localizedInterface : localized) {
+                        String locale = localizedInterface.classAnnotation(LOCALIZED).value().asString();
+                        ClassInfo previous = localeToInterface.put(locale, localizedInterface);
+                        if (defaultLocale.equals(locale) || previous != null) {
+                            throw new MessageBundleException(String.format(
+                                    "A localized message bundle interface [%s] already exists for locale %s: [%s]",
+                                    previous != null ? previous : bundleClass, localizedInterface));
+                        }
+                    }
+
+                    // Find localized files
+                    Map<String, Path> localeToFile = new HashMap<>();
+                    for (Path messageFile : messageFiles) {
+                        String fileName = messageFile.getFileName().toString();
+                        if (fileName.startsWith(name)) {
+                            // msg_en.txt -> en
+                            String locale = fileName.substring(fileName.indexOf('_') + 1, fileName.indexOf('.'));
+                            ClassInfo localizedInterface = localeToInterface.get(locale);
+                            if (localizedInterface != null) {
+                                throw new MessageBundleException(
+                                        String.format(
+                                                "A localized message bundle interface [%s] already exists for locale %s: [%s]",
+                                                localizedInterface, locale, fileName));
+                            }
+                            localeToFile.put(locale, messageFile);
+                        }
+                    }
+
+                    bundles.add(new MessageBundleBuildItem(name, bundleClass, localeToInterface, localeToFile));
+                } else {
+                    throw new MessageBundleException("@MessageBundle must be declared on an interface: " + bundleClass);
+                }
+            }
+        }
+
+        // Generate implementations
+        // name -> impl class
+        Map<String, String> generatedImplementations = generateImplementations(bundles,
+                applicationArchivesBuildItem, generatedClasses, messageTemplateMethods);
+
+        // Register synthetic beans
+        for (MessageBundleBuildItem bundle : bundles) {
+            ClassInfo bundleInterface = bundle.getDefaultBundleInterface();
+            beanRegistration.getContext().configure(bundleInterface.name()).addType(bundle.getDefaultBundleInterface().name())
+                    // The default message bundle - add both @Default and @Localized
+                    .addQualifier(DotNames.DEFAULT).addQualifier().annotation(LOCALIZED)
+                    .addValue("value", getDefaultLocale(bundleInterface.classAnnotation(BUNDLE))).done().unremovable()
+                    .scope(Singleton.class).creator(mc -> {
+                        // Just create a new instance of the generated class
+                        mc.returnValue(
+                                mc.newInstance(MethodDescriptor
+                                        .ofConstructor(generatedImplementations.get(bundleInterface.name().toString()))));
+                    }).done();
+
+            // Localized interfaces
+            for (ClassInfo localizedInterface : bundle.getLocalizedInterfaces().values()) {
+                beanRegistration.getContext().configure(localizedInterface.name())
+                        .addType(bundle.getDefaultBundleInterface().name())
+                        .addQualifier(localizedInterface.classAnnotation(LOCALIZED))
+                        .unremovable()
+                        .scope(Singleton.class).creator(mc -> {
+                            // Just create a new instance of the generated class
+                            mc.returnValue(
+                                    mc.newInstance(MethodDescriptor.ofConstructor(
+                                            generatedImplementations.get(localizedInterface.name().toString()))));
+                        }).done();
+            }
+            // Localized files
+            for (Entry<String, Path> entry : bundle.getLocalizedFiles().entrySet()) {
+                beanRegistration.getContext().configure(bundle.getDefaultBundleInterface().name())
+                        .addType(bundle.getDefaultBundleInterface().name())
+                        .addQualifier().annotation(LOCALIZED)
+                        .addValue("value", entry.getKey()).done()
+                        .unremovable()
+                        .scope(Singleton.class).creator(mc -> {
+                            // Just create a new instance of the generated class
+                            mc.returnValue(
+                                    mc.newInstance(MethodDescriptor
+                                            .ofConstructor(generatedImplementations.get(entry.getValue().toString()))));
+                        }).done();
+            }
+        }
+
+        return bundles;
+    }
+
+    @Record(value = STATIC_INIT)
+    @BuildStep
+    void initBundleContext(RecorderContext context, MessageBundleRecorder recorder,
+            List<MessageBundleMethodBuildItem> messageBundleMethods,
+            List<MessageBundleBuildItem> bundles,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+
+        Map<String, Map<String, Class<?>>> bundleInterfaces = new HashMap<>();
+        for (MessageBundleBuildItem bundle : bundles) {
+            Class<?> bundleClass = context.classProxy(bundle.getDefaultBundleInterface().toString());
+            Map<String, Class<?>> localeToInterface = new HashMap<>();
+            localeToInterface.put(MessageBundles.DEFAULT_LOCALE,
+                    bundleClass);
+
+            for (String locale : bundle.getLocalizedInterfaces().keySet()) {
+                localeToInterface.put(locale, bundleClass);
+            }
+            for (String locale : bundle.getLocalizedFiles().keySet()) {
+                localeToInterface.put(locale, bundleClass);
+            }
+            bundleInterfaces.put(bundle.getName(), localeToInterface);
+        }
+
+        Map<String, String> templateIdToContent = messageBundleMethods.stream().collect(
+                Collectors.toMap(MessageBundleMethodBuildItem::getTemplateId, MessageBundleMethodBuildItem::getTemplate));
+
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(MessageBundleRecorder.BundleContext.class)
+                .supplier(recorder.createContext(templateIdToContent, bundleInterfaces)).done());
+    }
+
+    @BuildStep
+    void validateMessageBundleMethods(TemplatesAnalysisBuildItem templatesAnalysis,
+            List<MessageBundleMethodBuildItem> messageBundleMethods,
+            BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions) {
+
+        Map<String, MessageBundleMethodBuildItem> bundleMethods = messageBundleMethods.stream()
+                .collect(Collectors.toMap(MessageBundleMethodBuildItem::getTemplateId, Function.identity()));
+
+        for (TemplateAnalysis analysis : templatesAnalysis.getAnalysis()) {
+            MessageBundleMethodBuildItem messageBundleMethod = bundleMethods.get(analysis.id);
+            if (messageBundleMethod != null) {
+                Set<String> usedParamNames = new HashSet<>();
+                // All top-level expressions without namespace map to a param
+                Set<String> paramNames = IntStream.range(0, messageBundleMethod.getMethod().parameters().size())
+                        .mapToObj(idx -> messageBundleMethod.getMethod().parameterName(idx)).collect(Collectors.toSet());
+                for (Expression expression : analysis.expressions) {
+                    if (expression.isLiteral() || expression.hasNamespace()) {
+                        continue;
+                    }
+                    String name = expression.getParts().get(0).getName();
+                    if (!paramNames.contains(name)) {
+                        incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
+                                name + " is not a parameter of the message bundle method "
+                                        + messageBundleMethod.getMethod().declaringClass().name() + "#"
+                                        + messageBundleMethod.getMethod().name() + "()",
+                                expression.getOrigin().getLine(),
+                                expression.getOrigin().getTemplateGeneratedId()));
+                    } else {
+                        usedParamNames.add(name);
+                    }
+                }
+
+                // Log a warning if a parameter is not used in the template
+                for (String paramName : paramNames) {
+                    if (!usedParamNames.contains(paramName)) {
+                        LOGGER.warnf("Unused parameter found [%s] in the message template of: %s", paramName,
+                                messageBundleMethod.getMethod().declaringClass().name() + "#"
+                                        + messageBundleMethod.getMethod().name() + "()");
+                    }
+                }
+            }
+        }
+    }
+
+    @BuildStep
+    void validateMessageBundleMethodsInTemplates(TemplatesAnalysisBuildItem analysis,
+            BeanArchiveIndexBuildItem beanArchiveIndex,
+            List<TemplateExtensionMethodBuildItem> templateExtensionMethods,
+            List<TypeCheckExcludeBuildItem> excludes,
+            List<MessageBundleBuildItem> messageBundles,
+            List<MessageBundleMethodBuildItem> messageBundleMethods,
+            BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
+            BuildProducer<ImplicitValueResolverBuildItem> implicitClasses) {
+
+        IndexView index = beanArchiveIndex.getIndex();
+        Function<String, String> templateIdToPathFun = new Function<String, String>() {
+            @Override
+            public String apply(String id) {
+                return QuteProcessor.findTemplatePath(analysis, id);
+            }
+        };
+
+        // bundle name -> (key -> method)
+        Map<String, Map<String, MethodInfo>> bundleMethodsMap = new HashMap<>();
+        for (MessageBundleMethodBuildItem messageBundleMethod : messageBundleMethods) {
+            Map<String, MethodInfo> bundleMethods = bundleMethodsMap.get(messageBundleMethod.getBundleName());
+            if (bundleMethods == null) {
+                bundleMethods = new HashMap<>();
+                bundleMethodsMap.put(messageBundleMethod.getBundleName(), bundleMethods);
+            }
+            bundleMethods.put(messageBundleMethod.getKey(), messageBundleMethod.getMethod());
+        }
+        // bundle name -> bundle interface
+        Map<String, ClassInfo> bundlesMap = new HashMap<>();
+        for (MessageBundleBuildItem messageBundle : messageBundles) {
+            bundlesMap.put(messageBundle.getName(), messageBundle.getDefaultBundleInterface());
+        }
+
+        for (Entry<String, Map<String, MethodInfo>> entry : bundleMethodsMap.entrySet()) {
+
+            Set<Expression> expressions = QuteProcessor.collectNamespaceExpressions(analysis, entry.getKey());
+            Map<String, MethodInfo> methods = entry.getValue();
+            ClassInfo defaultBundleInterface = bundlesMap.get(entry.getKey());
+
+            if (!expressions.isEmpty()) {
+
+                // Map implicit class -> true if methods were used
+                Map<ClassInfo, Boolean> implicitClassToMethodUsed = new HashMap<>();
+
+                for (Expression expression : expressions) {
+
+                    // msg:hello_world(foo.name)
+                    Part methodPart = expression.getParts().get(0);
+                    MethodInfo method = methods.get(methodPart.getName());
+
+                    if (method == null) {
+                        if (!methodPart.isVirtualMethod() || methodPart.asVirtualMethod().getParameters().isEmpty()) {
+                            // The method template may contain no expressions
+                            method = defaultBundleInterface.method(methodPart.getName());
+                        }
+                        if (method == null) {
+                            // User is referencing a non-existent message
+                            incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
+                                    "Message bundle [name=" + entry.getKey() + ", interface="
+                                            + defaultBundleInterface
+                                            + "] does not define a method for key: " + methodPart.getName(),
+                                    expression.getOrigin().getLine(),
+                                    expression.getOrigin().getTemplateGeneratedId()));
+                            continue;
+                        }
+                    }
+
+                    if (methodPart.isVirtualMethod()) {
+                        // For virtual method validate the number of params first  
+                        List<Expression> params = methodPart.asVirtualMethod().getParameters();
+                        List<Type> methodParams = method.parameters();
+
+                        if (methodParams.size() != params.size()) {
+                            incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
+                                    "Message bundle [name=" + entry.getKey() + ", interface="
+                                            + defaultBundleInterface
+                                            + "] - wrong number of parameters for method: " + method.toString(),
+                                    expression.getOrigin().getLine(),
+                                    expression.getOrigin().getTemplateGeneratedId()));
+                            continue;
+                        }
+
+                        // Then attempt to validate the parameter types
+                        int idx = 0;
+                        for (Expression param : params) {
+                            if (param.hasTypeInfo()) {
+                                Map<String, Match> results = new HashMap<>();
+                                QuteProcessor.validateNestedExpressions(defaultBundleInterface, results,
+                                        templateExtensionMethods, excludes,
+                                        incorrectExpressions, expression, index, implicitClassToMethodUsed,
+                                        templateIdToPathFun);
+                                Match match = results.get(param.toOriginalString());
+                                if (match != null && !Types.isAssignableFrom(match.type,
+                                        methodParams.get(idx), index)) {
+                                    incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
+                                            "Message bundle method " + method.declaringClass().name() + "#" +
+                                                    method.name() + "() parameter [" + method.parameterName(idx)
+                                                    + "] does not match the type: " + match.type,
+                                            expression.getOrigin().getLine(),
+                                            expression.getOrigin().getTemplateGeneratedId()));
+                                }
+                            }
+                            idx++;
+                        }
+                    }
+                }
+
+                for (Entry<ClassInfo, Boolean> implicit : implicitClassToMethodUsed.entrySet()) {
+                    implicitClasses.produce(implicit.getValue()
+                            ? new ImplicitValueResolverBuildItem(implicit.getKey(),
+                                    new TemplateDataBuilder().properties(false).build())
+                            : new ImplicitValueResolverBuildItem(implicit.getKey()));
+                }
+            }
+        }
+    }
+
+    private Map<String, String> generateImplementations(List<MessageBundleBuildItem> bundles,
+            ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            BuildProducer<MessageBundleMethodBuildItem> messageTemplateMethods) throws IOException {
+
+        Map<String, String> generatedTypes = new HashMap<>();
+
+        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, new Predicate<String>() {
+            @Override
+            public boolean test(String name) {
+                int idx = name.lastIndexOf(SUFFIX);
+                String className = name.substring(0, idx).replace("/", ".");
+                if (className.contains(ValueResolverGenerator.NESTED_SEPARATOR)) {
+                    className = className.replace(ValueResolverGenerator.NESTED_SEPARATOR, "$");
+                }
+                if (applicationArchivesBuildItem.getRootArchive().getIndex()
+                        .getClassByName(DotName.createSimple(className)) != null) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        for (MessageBundleBuildItem bundle : bundles) {
+            ClassInfo bundleInterface = bundle.getDefaultBundleInterface();
+            String bundleImpl = generateImplementation(null, null, bundleInterface, classOutput, messageTemplateMethods,
+                    Collections.emptyMap(), null);
+            generatedTypes.put(bundleInterface.name().toString(), bundleImpl);
+            for (ClassInfo localizedInterface : bundle.getLocalizedInterfaces().values()) {
+                generatedTypes.put(localizedInterface.name().toString(),
+                        generateImplementation(bundle.getDefaultBundleInterface(), bundleImpl, localizedInterface, classOutput,
+                                messageTemplateMethods, Collections.emptyMap(), null));
+            }
+
+            for (Entry<String, Path> entry : bundle.getLocalizedFiles().entrySet()) {
+                Path localizedFile = entry.getValue();
+                Map<String, String> keyToTemplate = new HashMap<>();
+                int linesProcessed = 0;
+                for (String line : Files.readAllLines(localizedFile)) {
+                    linesProcessed++;
+                    if (!line.startsWith("#")) {
+                        int eqIndex = line.indexOf('=');
+                        if (eqIndex == -1) {
+                            throw new MessageBundleException(
+                                    "Missing key/value separator\n\t- file: " + localizedFile + "\n\t- line " + linesProcessed);
+                        }
+                        String key = line.substring(0, eqIndex).trim();
+                        if (!hasMessageBundleMethod(bundleInterface, key)) {
+                            throw new MessageBundleException(
+                                    "Message bundle method " + key + "() not found on: " + bundleInterface + "\n\t- file: "
+                                            + localizedFile + "\n\t- line " + linesProcessed);
+                        }
+                        String value = line.substring(eqIndex + 1, line.length()).trim();
+                        keyToTemplate.put(key, value);
+                    }
+                }
+                generatedTypes.put(localizedFile.toString(),
+                        generateImplementation(bundle.getDefaultBundleInterface(), bundleImpl, bundleInterface, classOutput,
+                                messageTemplateMethods, keyToTemplate, entry.getKey()));
+            }
+        }
+        return generatedTypes;
+    }
+
+    private boolean hasMessageBundleMethod(ClassInfo bundleInterface, String name) {
+        for (MethodInfo method : bundleInterface.methods()) {
+            if (method.name().equals(name) && method.hasAnnotation(MESSAGE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String generateImplementation(ClassInfo defaultBundleInterface, String defaultBundleImpl, ClassInfo bundleInterface,
+            ClassOutput classOutput, BuildProducer<MessageBundleMethodBuildItem> messageTemplateMethods,
+            Map<String, String> messageTemplates, String locale) {
+
+        LOGGER.debugf("Generate bundle implementation for %s", bundleInterface);
+        AnnotationInstance bundleAnnotation = defaultBundleInterface != null ? defaultBundleInterface.classAnnotation(BUNDLE)
+                : bundleInterface.classAnnotation(BUNDLE);
+        AnnotationValue nameValue = bundleAnnotation.value();
+        String bundleName = nameValue != null ? nameValue.asString() : MessageBundle.DEFAULT_NAME;
+        AnnotationValue defaultKeyValue = bundleAnnotation.value(BUNDLE_DEFAULT_KEY);
+
+        String baseName;
+        if (bundleInterface.enclosingClass() != null) {
+            baseName = DotNames.simpleName(bundleInterface.enclosingClass()) + "_"
+                    + DotNames.simpleName(bundleInterface.name());
+        } else {
+            baseName = DotNames.simpleName(bundleInterface.name());
+        }
+        if (locale != null) {
+            baseName = baseName + "_" + locale;
+        }
+
+        String targetPackage = DotNames.packageName(bundleInterface.name());
+        String generatedName = targetPackage.replace('.', '/') + "/" + baseName + SUFFIX;
+
+        // MyMessages_Bundle implements MyMessages, Resolver
+        Builder builder = ClassCreator.builder().classOutput(classOutput).className(generatedName)
+                .interfaces(bundleInterface.name().toString(), Resolver.class.getName());
+        if (defaultBundleImpl != null) {
+            builder.superClass(defaultBundleImpl);
+        }
+        ClassCreator bundleCreator = builder.build();
+
+        // key -> method
+        Map<String, MethodInfo> keyMap = new HashMap<>();
+
+        for (MethodInfo method : bundleInterface.methods()) {
+            LOGGER.debugf("Found message bundle method %s on %s", method, bundleInterface);
+
+            MethodCreator bundleMethod = bundleCreator.getMethodCreator(MethodDescriptor.of(method));
+
+            AnnotationInstance messageAnnotation;
+            if (defaultBundleInterface != null) {
+                MethodInfo defaultBundleMethod = bundleInterface.method(method.name(),
+                        method.parameters().toArray(new Type[] {}));
+                if (defaultBundleMethod == null) {
+                    throw new MessageBundleException(
+                            String.format("Default bundle method not found on %s: %s", bundleInterface, method));
+                }
+                messageAnnotation = defaultBundleMethod.annotation(MESSAGE);
+            } else {
+                messageAnnotation = method.annotation(MESSAGE);
+            }
+
+            if (messageAnnotation == null) {
+                throw new MessageBundleException(
+                        "A message bundle interface method must be annotated with @Message: " + method);
+            }
+
+            String key = getKey(method, messageAnnotation, defaultKeyValue);
+            if (keyMap.containsKey(key)) {
+                throw new MessageBundleException(String.format("Duplicate key [%s] found on %s", key, bundleInterface));
+            }
+            keyMap.put(key, method);
+
+            String messageTemplate = messageTemplates.get(method.name());
+            if (messageTemplate == null) {
+                messageTemplate = messageAnnotation.value().asString();
+            }
+            if (!messageTemplate.contains("}")) {
+                // No expression/tag - no need to use qute
+                bundleMethod.returnValue(bundleMethod.load(messageTemplate));
+            } else {
+                // Obtain the template, e.g. msg_hello_name
+                String templateId;
+
+                if (defaultBundleInterface != null) {
+                    if (locale == null) {
+                        AnnotationInstance localizedAnnotation = bundleInterface.classAnnotation(LOCALIZED);
+                        locale = localizedAnnotation.value().asString();
+                    }
+                    templateId = bundleName + "_" + locale + "_" + key;
+                } else {
+                    templateId = bundleName + "_" + key;
+                }
+
+                messageTemplateMethods
+                        .produce(new MessageBundleMethodBuildItem(bundleName, key, templateId, method, messageTemplate));
+
+                ResultHandle template = bundleMethod.invokeStaticMethod(BUNDLES_GET_TEMPLATE,
+                        bundleMethod.load(templateId));
+                // Create a template instance
+                ResultHandle templateInstance = bundleMethod.invokeInterfaceMethod(TEMPLATE_INSTANCE, template);
+                List<Type> paramTypes = method.parameters();
+                if (!paramTypes.isEmpty()) {
+                    // Set data
+                    int i = 0;
+                    Iterator<Type> it = paramTypes.iterator();
+                    while (it.hasNext()) {
+                        String name = method.parameterName(i);
+                        if (name == null) {
+                            // TODO should we just log a warning and use arg0 etc.?
+                            throw new MessageBundleException("Null param name for index " + i + ": " + method);
+                        }
+                        bundleMethod.invokeInterfaceMethod(TEMPLATE_INSTANCE_DATA, templateInstance,
+                                bundleMethod.load(name), bundleMethod.getMethodParam(i));
+                        i++;
+                        it.next();
+                    }
+                }
+                // Render the template
+                // At this point it's already validated that the method returns String
+                bundleMethod.returnValue(bundleMethod.invokeInterfaceMethod(TEMPLATE_INSTANCE_RENDER, templateInstance));
+            }
+        }
+
+        implementResolve(defaultBundleImpl, bundleCreator, keyMap);
+
+        bundleCreator.close();
+        return generatedName.replace('/', '.');
+    }
+
+    private void implementResolve(String defaultBundleImpl, ClassCreator bundleCreator, Map<String, MethodInfo> keyMap) {
+        MethodCreator resolve = bundleCreator.getMethodCreator("resolve", CompletionStage.class, EvalContext.class);
+
+        ResultHandle evalContext = resolve.getMethodParam(0);
+        ResultHandle name = resolve.invokeInterfaceMethod(Descriptors.GET_NAME, evalContext);
+        ResultHandle ret = resolve.newInstance(MethodDescriptor.ofConstructor(CompletableFuture.class));
+
+        // Group messages to workaround limits of a java method body 
+        final int groupLimit = 300;
+        int groupIndex = 0;
+        int resolveIndex = 0;
+        MethodCreator resolveGroup = null;
+
+        for (Entry<String, MethodInfo> entry : keyMap.entrySet()) {
+            if (resolveGroup == null || groupIndex++ >= groupLimit) {
+                if (resolveGroup != null) {
+                    resolveGroup.returnValue(resolveGroup.loadNull());
+                }
+                groupIndex = 0;
+                String resolveMethodName = "resolve_" + resolveIndex++;
+                resolveGroup = bundleCreator.getMethodCreator(resolveMethodName, CompletableFuture.class, String.class,
+                        EvalContext.class, CompletableFuture.class).setModifiers(ACC_PRIVATE | ACC_FINAL);
+                ResultHandle resRet = resolve.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(bundleCreator.getClassName(), resolveMethodName, CompletableFuture.class,
+                                String.class, EvalContext.class, CompletableFuture.class),
+                        resolve.getThis(), name, evalContext, ret);
+                resolve.ifNotNull(resRet).trueBranch().returnValue(resRet);
+            }
+            addMessageMethod(resolveGroup, entry.getKey(), entry.getValue(), resolveGroup.getMethodParam(0),
+                    resolveGroup.getMethodParam(1), resolveGroup.getMethodParam(2), bundleCreator.getClassName());
+        }
+
+        if (resolveGroup != null) {
+            resolveGroup.returnValue(resolveGroup.loadNull());
+        }
+
+        if (defaultBundleImpl != null) {
+            resolve.returnValue(resolve.invokeSpecialMethod(
+                    MethodDescriptor.ofMethod(defaultBundleImpl, "resolve", CompletionStage.class, EvalContext.class),
+                    resolve.getThis(), evalContext));
+        } else {
+            resolve.returnValue(resolve.readStaticField(Descriptors.RESULTS_NOT_FOUND));
+        }
+    }
+
+    private void addMessageMethod(MethodCreator resolve, String key, MethodInfo method, ResultHandle name,
+            ResultHandle evalContext,
+            ResultHandle ret, String bundleClass) {
+        List<Type> methodParams = method.parameters();
+
+        BytecodeCreator matched = resolve.ifNonZero(resolve.invokeVirtualMethod(Descriptors.EQUALS,
+                resolve.load(key), name))
+                .trueBranch();
+        if (method.parameters().isEmpty()) {
+            matched.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, ret,
+                    matched.invokeInterfaceMethod(method, matched.getThis()));
+            matched.returnValue(ret);
+        } else {
+            // The CompletionStage upon which we invoke whenComplete()
+            ResultHandle evaluatedParams = matched.invokeStaticMethod(Descriptors.EVALUATED_PARAMS_EVALUATE,
+                    evalContext);
+            ResultHandle paramsReady = matched.readInstanceField(Descriptors.EVALUATED_PARAMS_STAGE,
+                    evaluatedParams);
+
+            FunctionCreator whenCompleteFun = matched.createFunction(BiConsumer.class);
+            matched.invokeInterfaceMethod(Descriptors.CF_WHEN_COMPLETE, paramsReady, whenCompleteFun.getInstance());
+
+            BytecodeCreator whenComplete = whenCompleteFun.getBytecode();
+
+            AssignableResultHandle whenThis = whenComplete
+                    .createVariable(DescriptorUtils.extToInt(bundleClass));
+            whenComplete.assign(whenThis, matched.getThis());
+            AssignableResultHandle whenRet = whenComplete.createVariable(CompletableFuture.class);
+            whenComplete.assign(whenRet, ret);
+
+            BranchResult throwableIsNull = whenComplete.ifNull(whenComplete.getMethodParam(1));
+
+            // complete
+            BytecodeCreator success = throwableIsNull.trueBranch();
+
+            ResultHandle[] paramsHandle = new ResultHandle[methodParams.size()];
+            if (methodParams.size() == 1) {
+                paramsHandle[0] = whenComplete.getMethodParam(0);
+            } else {
+                for (int i = 0; i < methodParams.size(); i++) {
+                    paramsHandle[i] = success.invokeVirtualMethod(Descriptors.EVALUATED_PARAMS_GET_RESULT,
+                            evaluatedParams,
+                            success.load(i));
+                }
+            }
+
+            AssignableResultHandle invokeRet = success.createVariable(Object.class);
+            // try
+            TryBlock tryCatch = success.tryBlock();
+            // catch (Throwable e)
+            CatchBlockCreator exception = tryCatch.addCatch(Throwable.class);
+            // CompletableFuture.completeExceptionally(Throwable)
+            exception.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE_EXCEPTIONALLY, whenRet,
+                    exception.getCaughtException());
+
+            tryCatch.assign(invokeRet,
+                    tryCatch.invokeInterfaceMethod(MethodDescriptor.of(method), whenThis, paramsHandle));
+
+            tryCatch.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE, whenRet, invokeRet);
+            // CompletableFuture.completeExceptionally(Throwable)
+            BytecodeCreator failure = throwableIsNull.falseBranch();
+            failure.invokeVirtualMethod(Descriptors.COMPLETABLE_FUTURE_COMPLETE_EXCEPTIONALLY, whenRet,
+                    whenComplete.getMethodParam(1));
+            whenComplete.returnValue(null);
+
+            matched.returnValue(ret);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private String getKey(MethodInfo method, AnnotationInstance messageAnnotation, AnnotationValue defaultKeyValue) {
+        AnnotationValue keyValue = messageAnnotation.value("key");
+        String key;
+        if (keyValue == null) {
+            // Use the strategy from @MessageBundle
+            key = defaultKeyValue != null ? defaultKeyValue.asString() : Message.ELEMENT_NAME;
+        } else {
+            key = keyValue.asString();
+        }
+        switch (key) {
+            case Message.ELEMENT_NAME:
+                return method.name();
+            case Message.HYPHENATED_ELEMENT_NAME:
+                return StringUtil.hyphenate(method.name());
+            case Message.UNDERSCORED_ELEMENT_NAME:
+                return StringUtil.join("_", StringUtil.lowerCase(StringUtil.camelHumpsIterator(method.name())));
+            default:
+                return keyValue.asString();
+        }
+    }
+
+    private String getDefaultLocale(AnnotationInstance bundleAnnotation) {
+        AnnotationValue localeValue = bundleAnnotation.value(BUNDLE_LOCALE);
+        String defaultLocale;
+        if (localeValue == null || localeValue.asString().equals(MessageBundle.DEFAULT_LOCALE)) {
+            defaultLocale = Locale.getDefault().toLanguageTag();
+        } else {
+            defaultLocale = localeValue.asString();
+        }
+        return defaultLocale;
+    }
+
+    private Set<Path> findMessageFiles(ApplicationArchivesBuildItem applicationArchivesBuildItem) throws IOException {
+        ApplicationArchive applicationArchive = applicationArchivesBuildItem.getRootArchive();
+        String basePath = "messages";
+        Path messagesPath = applicationArchive.getChildPath(basePath);
+        if (messagesPath == null) {
+            return Collections.emptySet();
+        }
+        Set<Path> messageFiles = new HashSet<>();
+        try (Stream<Path> files = Files.list(messagesPath)) {
+            Iterator<Path> iter = files.iterator();
+            while (iter.hasNext()) {
+                Path filePath = iter.next();
+                if (Files.isRegularFile(filePath)) {
+                    messageFiles.add(filePath);
+                }
+            }
+        }
+        return messageFiles;
+    }
+
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplatesAnalysisBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplatesAnalysisBuildItem.java
@@ -23,12 +23,15 @@ public final class TemplatesAnalysisBuildItem extends SimpleBuildItem {
 
     static class TemplateAnalysis {
 
+        // Path or other user-defined id; may be null
         public final String id;
+        public final String generatedId;
         public final Set<Expression> expressions;
-        public final TemplatePathBuildItem path;
+        public final String path;
 
-        public TemplateAnalysis(String id, Set<Expression> expressions, TemplatePathBuildItem path) {
+        public TemplateAnalysis(String id, String generatedId, Set<Expression> expressions, String path) {
             this.id = id;
+            this.generatedId = generatedId;
             this.expressions = expressions;
             this.path = path;
         }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/AlphaMessages.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/AlphaMessages.java
@@ -1,0 +1,15 @@
+package io.quarkus.qute.deployment.i18n;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle(value = "alpha", defaultKey = Message.HYPHENATED_ELEMENT_NAME)
+public interface AlphaMessages {
+
+    @Message("Hello alpha!")
+    String helloAlpha();
+
+    @Message(value = "Hello!", key = "hello_alpha")
+    String hello();
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/AppMessages.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/AppMessages.java
@@ -1,0 +1,28 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static io.quarkus.qute.i18n.Message.UNDERSCORED_ELEMENT_NAME;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle
+public interface AppMessages {
+
+    @Message("Hello world!")
+    String hello();
+
+    @Message("Hello {name}!")
+    String hello_name(String name);
+
+    // key=hello_with_if_section
+    @Message(key = UNDERSCORED_ELEMENT_NAME, value = "{#if count eq 1}"
+            + "{msg:hello_name('you guy')}"
+            + "{#else}"
+            + "{msg:hello_name('you guys')}"
+            + "{/if}")
+    String helloWithIfSection(int count);
+
+    @Message("Item name: {item.name}, age: {item.age}")
+    String itemDetail(Item item);
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/BravoMessages.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/BravoMessages.java
@@ -1,0 +1,12 @@
+package io.quarkus.qute.deployment.i18n;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle
+public interface BravoMessages {
+
+    @Message("Hello bravo!")
+    String hello();
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/Item.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/Item.java
@@ -1,0 +1,22 @@
+package io.quarkus.qute.deployment.i18n;
+
+public class Item {
+
+    private String name;
+
+    private Integer age;
+
+    public Item(String name, Integer age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleExpressionValidationTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleExpressionValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(WrongBundle.class, Item.class)
+                    .addAsResource(new StringAsset(
+                            "hello=Hallo {foo}!"),
+                            "messages/msg_de.properties"))
+            .assertException(t -> {
+                Throwable e = t;
+                TemplateException te = null;
+                while (e != null) {
+                    if (e instanceof TemplateException) {
+                        te = (TemplateException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                if (te == null) {
+                    fail("No template exception thrown: " + t);
+                }
+                assertTrue(te.getMessage().contains("Found template problems (3)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Incorrect expression: item.foo"), te.getMessage());
+                assertTrue(te.getMessage().contains("Incorrect expression: bar"), te.getMessage());
+                assertTrue(te.getMessage().contains("Incorrect expression: foo"), te.getMessage());
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface WrongBundle {
+
+        @Message("Hello {item.foo} {bar}") // -> there is no foo property and bar is not a parameter 
+        String hello(Item item);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLocaleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLocaleTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.qute.i18n.MessageBundles;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleLocaleTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Messages.class)
+                    .addAsResource(new StringAsset(
+                            "{msg:helloWorld}"),
+                            "templates/foo.html"));
+
+    @Inject
+    Template foo;
+
+    @Test
+    public void testResolvers() {
+        assertEquals("Ahoj svete!",
+                foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
+    }
+
+    @MessageBundle(locale = "cs")
+    public interface Messages {
+
+        @Message("Ahoj svete!")
+        String helloWorld();
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleNameConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleNameConflictTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.deployment.MessageBundleException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleNameConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AppMessages.class, BravoMessages.class))
+            .setExpectedException(MessageBundleException.class);
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleTemplateExpressionValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyBundle.class, Item.class)
+                    .addAsResource(new StringAsset("{msg:hello('foo')} {msg:hello_and_bye} {msg:hello(1,2)}"),
+                            "templates/hello.html"))
+            .assertException(t -> {
+                Throwable e = t;
+                TemplateException te = null;
+                while (e != null) {
+                    if (e instanceof TemplateException) {
+                        te = (TemplateException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                if (te == null) {
+                    fail("No template exception thrown: " + t);
+                }
+                assertTrue(te.getMessage().contains("Found template problems (3)"), te.getMessage());
+                assertTrue(te.getMessage().contains("msg:hello('foo')"), te.getMessage());
+                assertTrue(te.getMessage().contains("msg:hello_and_bye"), te.getMessage());
+                assertTrue(te.getMessage().contains("msg:hello(1,2)"), te.getMessage());
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface MyBundle {
+
+        @Message("Hello {item.name}")
+        String hello(Item item);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.MessageBundles;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AppMessages.class, OtherMessages.class, AlphaMessages.class, Item.class)
+                    .addAsResource(new StringAsset(
+                            "{msg:hello} {msg:hello_name('Jachym')} {msg:hello_with_if_section(3)} {alpha:hello-alpha} {alpha:hello_alpha}"),
+                            "templates/foo.html")
+                    .addAsResource(new StringAsset(
+                            "hello=Hallo Welt!\nhello_name=Hallo {name}!"),
+                            "messages/msg_de.properties"));
+
+    @Inject
+    AppMessages messages;
+
+    @Localized("cs")
+    AppMessages czechMessages;
+
+    // This one is backed by a file
+    @Localized("de")
+    AppMessages germanMessages;
+
+    @Inject
+    Template foo;
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testMessages() {
+        assertEquals("Hello Jachym!", MessageBundles.get(AppMessages.class).hello_name("Jachym"));
+        assertEquals("Hello you guy!", MessageBundles.get(AppMessages.class, Localized.Literal.of("cs")).helloWithIfSection(1));
+    }
+
+    @Test
+    public void testBeans() {
+        assertEquals("Hello Jachym!", messages.hello_name("Jachym"));
+        assertEquals("Item name: axe, age: 2", messages.itemDetail(new Item("axe", 2)));
+        assertEquals("Ahoj Jachym!", czechMessages.hello_name("Jachym"));
+        assertEquals("Hello you guy!", czechMessages.helloWithIfSection(1));
+        assertEquals("Hallo Welt!", germanMessages.hello());
+    }
+
+    @Test
+    public void testResolvers() {
+        assertEquals("Hello world! Hello Jachym! Hello you guys! Hello alpha! Hello!", foo.instance().render());
+        assertEquals("Hello world! Ahoj Jachym! Hello you guys! Hello alpha! Hello!",
+                foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
+        assertEquals("Hallo Welt! Hallo Jachym! Hello you guys! Hello alpha! Hello!",
+                foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.GERMAN).render());
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleValidationTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.deployment.MessageBundleException;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Hellos.class)
+                    .addAsResource(new StringAsset(
+                            "hello=Hallo {foo}!\nhello_never=Ball!"),
+                            "messages/msg_de.properties"))
+            .assertException(t -> {
+                Throwable e = t;
+                MessageBundleException me = null;
+                while (e != null) {
+                    if (e instanceof MessageBundleException) {
+                        me = (MessageBundleException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                if (me == null) {
+                    fail("No message bundle exception thrown: " + t);
+                }
+                assertTrue(me.getMessage().contains(
+                        "Message bundle method hello_never() not found on: io.quarkus.qute.deployment.i18n.MessageBundleValidationTest$Hellos"),
+                        me.getMessage());
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface Hellos {
+
+        @Message("Hello {foo}")
+        String hello(String foo);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/OtherMessages.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/OtherMessages.java
@@ -1,0 +1,13 @@
+package io.quarkus.qute.deployment.i18n;
+
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+
+@Localized("cs")
+public interface OtherMessages extends AppMessages {
+
+    @Message("Ahoj {name}!")
+    @Override
+    String hello_name(String name);
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Localized.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Localized.java
@@ -1,0 +1,53 @@
+package io.quarkus.qute.i18n;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Locale;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+/**
+ * Marks a localized message bundle interface.
+ * 
+ * @see MessageBundle
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD, FIELD, PARAMETER })
+public @interface Localized {
+
+    /**
+     * @return the locale tag string (IETF)
+     * @see Locale#forLanguageTag(String)
+     */
+    String value();
+
+    public static final class Literal extends AnnotationLiteral<Localized> implements Localized {
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Message.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Message.java
@@ -1,0 +1,52 @@
+package io.quarkus.qute.i18n;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * 
+ * @see MessageBundle
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Message {
+
+    /**
+     * Constant value for {@link #key()} indicating that the default strategy specified by {@link MessageBundle#defaultKey()}
+     * should be used.
+     */
+    String DEFAULT_NAME = "<<default>>";
+
+    /**
+     * Constant value for {@link #key()} indicating that the annotated element's name should be used as-is.
+     */
+    String ELEMENT_NAME = "<<element name>>";
+
+    /**
+     * Constant value for {@link #key()} indicating that the annotated element's name should be de-camel-cased and
+     * hyphenated, and then used.
+     */
+    String HYPHENATED_ELEMENT_NAME = "<<hyphenated element name>>";
+
+    /**
+     * Constant value for{@link #key()} indicating that the annotated element's name should be de-camel-cased and parts
+     * separated by underscores, and then used.
+     */
+    String UNDERSCORED_ELEMENT_NAME = "<<underscored element name>>";
+
+    /**
+     * 
+     * @return the key
+     */
+    String key() default DEFAULT_NAME;
+
+    /**
+     * 
+     * @return the message template
+     */
+    String value();
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundle.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundle.java
@@ -1,0 +1,67 @@
+package io.quarkus.qute.i18n;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes a message bundle interface.
+ * <p>
+ * Each method represents a single message:
+ * 
+ * <pre>
+ * &#64;MessageBundle
+ * interface MyBundle {
+ * 
+ *     &#64;Message("Hello {name}!")
+ *     String hello_world(String name);
+ * }
+ * </pre>
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface MessageBundle {
+
+    /**
+     * Constant value for {@link #locale()} indicating that the default locale of the Java Virtual Machine used to build the
+     * application should be used.
+     */
+    String DEFAULT_LOCALE = "<<default locale>>";
+
+    /**
+     * Constant value for {@link #value()}.
+     */
+    String DEFAULT_NAME = "msg";
+
+    /**
+     * The name is used as a namespace in templates expressions.
+     * 
+     * By default, the namespace {@value #DEFAULT_NAME} is used:
+     * 
+     * <pre>
+     * {msg:hello_world}
+     * </pre>
+     * 
+     * If multiple bundles declare the same name the build fails.
+     * 
+     * @return the name
+     */
+    String value() default DEFAULT_NAME;
+
+    /**
+     * The value may be one of the following: {@link Message#ELEMENT_NAME}, {@link Message#HYPHENATED_ELEMENT_NAME} and
+     * {@link Message#UNDERSCORED_ELEMENT_NAME}.
+     * 
+     * @return the default key strategy
+     * @see Message#key()
+     */
+    String defaultKey() default Message.ELEMENT_NAME;
+
+    /**
+     * 
+     * @return the locale for the default message bundle
+     */
+    String locale() default DEFAULT_LOCALE;
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
@@ -1,0 +1,108 @@
+package io.quarkus.qute.i18n;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.EngineBuilder;
+import io.quarkus.qute.EvalContext;
+import io.quarkus.qute.NamespaceResolver;
+import io.quarkus.qute.Resolver;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.runtime.MessageBundleRecorder.BundleContext;
+
+public final class MessageBundles {
+
+    public static final String ATTRIBUTE_LOCALE = "locale";
+    public static final String DEFAULT_LOCALE = "<<default>>";
+
+    private static final Logger LOGGER = Logger.getLogger(MessageBundles.class);
+
+    private MessageBundles() {
+    }
+
+    public static <T> T get(Class<T> bundleInterface) {
+        return get(bundleInterface, null);
+    }
+
+    public static <T> T get(Class<T> bundleInterface, Localized localized) {
+        if (!bundleInterface.isInterface()) {
+            throw new IllegalArgumentException("Not a message bundle interface: " + bundleInterface);
+        }
+        if (!bundleInterface.isAnnotationPresent(MessageBundle.class)
+                && !bundleInterface.isAnnotationPresent(Localized.class)) {
+            throw new IllegalArgumentException(
+                    "Message bundle interface must be annotated either with @Bundle or with @Localized: " + bundleInterface);
+        }
+        InstanceHandle<T> handle = localized != null ? Arc.container().instance(bundleInterface, localized)
+                : Arc.container().instance(bundleInterface);
+        if (handle.isAvailable()) {
+            return handle.get();
+        }
+        throw new IllegalStateException("Unable to obtain a message bundle instance for: " + bundleInterface);
+    }
+
+    static void setupNamespaceResolvers(@Observes EngineBuilder builder, BundleContext context,
+            @Any Instance<Object> instance) {
+        // For every bundle register a new resolver
+        for (Entry<String, Map<String, Class<?>>> entry : context.getBundleInterfaces().entrySet()) {
+            final String bundle = entry.getKey();
+            final Map<String, Resolver> interfaces = new HashMap<>();
+            Resolver resolver = null;
+            for (Entry<String, Class<?>> locEntry : entry.getValue().entrySet()) {
+                if (locEntry.getKey().equals(DEFAULT_LOCALE)) {
+                    resolver = (Resolver) instance.select(locEntry.getValue(), Default.Literal.INSTANCE).get();
+                    continue;
+                }
+                Instance<?> found = instance.select(locEntry.getValue(), new Localized.Literal(locEntry.getKey()));
+                if (!found.isResolvable()) {
+                    throw new IllegalStateException("Bean instance for localized interface not found: " + locEntry.getValue());
+                }
+                interfaces.put(locEntry.getKey(), (Resolver) found.get());
+            }
+            final Resolver defaultResolver = resolver;
+
+            builder.addNamespaceResolver(new NamespaceResolver() {
+                @Override
+                public CompletionStage<Object> resolve(EvalContext context) {
+                    Object locale = context.getAttribute(ATTRIBUTE_LOCALE);
+                    if (locale == null) {
+                        return defaultResolver.resolve(context);
+                    }
+                    Resolver localeResolver = interfaces
+                            .get(locale instanceof Locale ? ((Locale) locale).toLanguageTag() : locale.toString());
+                    return localeResolver != null ? localeResolver.resolve(context) : defaultResolver.resolve(context);
+                }
+
+                @Override
+                public String getNamespace() {
+                    return bundle;
+                }
+            });
+        }
+    }
+
+    static void setupMessageTemplates(@Observes Engine engine, BundleContext context) {
+        for (Entry<String, String> entry : context.getMessageTemplates().entrySet()) {
+            LOGGER.debugf("Register template for message [%s]", entry.getKey());
+            engine.putTemplate(entry.getKey(), engine.parse(entry.getValue()));
+        }
+    }
+
+    public static Template getTemplate(String id) {
+        return Arc.container().instance(Engine.class).get().getTemplate(id);
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -47,7 +47,7 @@ public class EngineProducer {
     private final String basePath;
     private final String tagPath;
 
-    public EngineProducer(QuteContext context, Event<EngineBuilder> event) {
+    public EngineProducer(QuteContext context, Event<EngineBuilder> builderReady, Event<Engine> engineReady) {
         this.suffixes = context.getConfig().suffixes;
         this.basePath = "templates/";
         this.tagPath = basePath + TAGS;
@@ -77,7 +77,7 @@ public class EngineProducer {
         builder.addValueResolver(new ReflectionValueResolver());
 
         // Allow anyone to customize the builder
-        event.fire(builder);
+        builderReady.fire(builder);
 
         // Resolve @Named beans
         builder.addNamespaceResolver(NamespaceResolver.builder(INJECT_NAMESPACE).resolve(ctx -> {
@@ -106,6 +106,7 @@ public class EngineProducer {
         for (String path : context.getTemplatePaths()) {
             engine.getTemplate(path);
         }
+        engineReady.fire(engine);
     }
 
     @Produces

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/MessageBundleRecorder.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/MessageBundleRecorder.java
@@ -1,0 +1,42 @@
+package io.quarkus.qute.runtime;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class MessageBundleRecorder {
+
+    public Supplier<Object> createContext(Map<String, String> messageTemplates,
+            Map<String, Map<String, Class<?>>> bundleInterfaces) {
+        return new Supplier<Object>() {
+
+            @Override
+            public Object get() {
+                return new BundleContext() {
+
+                    @Override
+                    public Map<String, String> getMessageTemplates() {
+                        return messageTemplates;
+                    }
+
+                    @Override
+                    public Map<String, Map<String, Class<?>>> getBundleInterfaces() {
+                        return bundleInterfaces;
+                    }
+                };
+            }
+        };
+    }
+
+    public interface BundleContext {
+
+        // message id -> message template
+        Map<String, String> getMessageTemplates();
+
+        // bundle -> (locale -> interface class)
+        Map<String, Map<String, Class<?>>> getBundleInterfaces();
+
+    }
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
@@ -145,22 +145,33 @@ public class TemplateProducer {
 
         @Override
         public String render() {
-            return template().instance().data(data()).render();
+            return templateInstance().render();
         }
 
         @Override
         public CompletionStage<String> renderAsync() {
-            return template().instance().data(data()).renderAsync();
+            return templateInstance().renderAsync();
         }
 
         @Override
         public Publisher<String> publisher() {
-            return template().instance().data(data()).publisher();
+            return templateInstance().publisher();
         }
 
         @Override
         public CompletionStage<Void> consume(Consumer<String> consumer) {
-            return template().instance().data(data()).consume(consumer);
+            return templateInstance().consume(consumer);
+        }
+
+        private TemplateInstance templateInstance() {
+            TemplateInstance instance = template().instance();
+            instance.data(data());
+            if (!attributes.isEmpty()) {
+                for (Entry<String, Object> entry : attributes.entrySet()) {
+                    instance.setAttribute(entry.getKey(), entry.getValue());
+                }
+            }
+            return instance;
         }
 
         private Template template() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
@@ -25,7 +25,6 @@ public interface Engine {
      * 
      * @param content
      * @return the template
-     * @see Engine#getTemplate(String)
      */
     default Template parse(String content) {
         return parse(content, null);
@@ -39,9 +38,22 @@ public interface Engine {
      * @param content
      * @param variant
      * @return the template
-     * @see Engine#getTemplate(String)
      */
-    public Template parse(String content, Variant variant);
+    default Template parse(String content, Variant variant) {
+        return parse(content, null, null);
+    }
+
+    /**
+     * Parse the template contents with the specified variant and id.
+     * <p>
+     * Note that this method always returns a new {@link Template} instance.
+     * 
+     * @param content
+     * @param variant
+     * @param id
+     * @return the template
+     */
+    public Template parse(String content, Variant variant, String id);
 
     /**
      * 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
@@ -70,9 +70,9 @@ class EngineImpl implements Engine {
     }
 
     @Override
-    public Template parse(String content, Variant variant) {
+    public Template parse(String content, Variant variant, String id) {
         String generatedId = generateId();
-        return newParser(null).parse(new StringReader(content), Optional.ofNullable(variant), generatedId, generatedId);
+        return newParser(id).parse(new StringReader(content), Optional.ofNullable(variant), generatedId, generatedId);
     }
 
     private Parser newParser(String id) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvalContext.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvalContext.java
@@ -49,4 +49,12 @@ public interface EvalContext {
      */
     CompletionStage<Object> evaluate(Expression expression);
 
+    /**
+     * 
+     * @param key
+     * @return the attribute or null
+     * @see TemplateInstance#getAttribute(String)
+     */
+    Object getAttribute(String key);
+
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -160,6 +160,11 @@ class EvaluatorImpl implements Evaluator {
         }
 
         @Override
+        public Object getAttribute(String key) {
+            return resolutionContext.getAttribute(key);
+        }
+
+        @Override
         public String toString() {
             StringBuilder builder = new StringBuilder();
             builder.append("EvalContextImpl [tryParent=").append(tryParent).append(", base=").append(base).append(", name=")

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContext.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContext.java
@@ -67,4 +67,12 @@ public interface ResolutionContext {
      */
     SectionBlock getExtendingBlock(String name);
 
+    /**
+     * 
+     * @param key
+     * @return the attribute or null
+     * @see TemplateInstance#getAttribute(String)
+     */
+    Object getAttribute(String key);
+
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContextImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContextImpl.java
@@ -11,14 +11,16 @@ class ResolutionContextImpl implements ResolutionContext {
     private final List<NamespaceResolver> namespaceResolvers;
     private final Evaluator evaluator;
     private final Map<String, SectionBlock> extendingBlocks;
+    private final TemplateInstance templateInstance;
 
     ResolutionContextImpl(ResolutionContextImpl parent, Object data, List<NamespaceResolver> namespaceResolvers,
-            Evaluator evaluator, Map<String, SectionBlock> extendingBlocks) {
+            Evaluator evaluator, Map<String, SectionBlock> extendingBlocks, TemplateInstance templateInstance) {
         this.parent = parent;
         this.data = data;
         this.namespaceResolvers = namespaceResolvers;
         this.evaluator = evaluator;
         this.extendingBlocks = extendingBlocks;
+        this.templateInstance = templateInstance;
     }
 
     @Override
@@ -33,12 +35,12 @@ class ResolutionContextImpl implements ResolutionContext {
 
     @Override
     public ResolutionContext createChild(Object data, List<NamespaceResolver> namespaceResolvers) {
-        return new ResolutionContextImpl(this, data, namespaceResolvers, evaluator, null);
+        return new ResolutionContextImpl(this, data, namespaceResolvers, evaluator, null, templateInstance);
     }
 
     @Override
     public ResolutionContext createChild(Map<String, SectionBlock> extendingBlocks) {
-        return new ResolutionContextImpl(this, data, namespaceResolvers, evaluator, extendingBlocks);
+        return new ResolutionContextImpl(this, data, namespaceResolvers, evaluator, extendingBlocks, templateInstance);
     }
 
     @Override
@@ -68,6 +70,11 @@ class ResolutionContextImpl implements ResolutionContext {
             }
         }
         return null;
+    }
+
+    @Override
+    public Object getAttribute(String key) {
+        return templateInstance.getAttribute(key);
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -87,31 +87,31 @@ class TemplateImpl implements Template {
             return renderData(data(), resultConsumer);
         }
 
-    }
-
-    private CompletionStage<Void> renderData(Object data, Consumer<String> consumer) {
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        DataNamespaceResolver dataResolver = new DataNamespaceResolver();
-        List<NamespaceResolver> namespaceResolvers = ImmutableList.<NamespaceResolver> builder()
-                .addAll(engine.getNamespaceResolvers()).add(dataResolver).build();
-        ResolutionContext rootContext = new ResolutionContextImpl(null, data, namespaceResolvers,
-                engine.getEvaluator(), null);
-        dataResolver.rootContext = rootContext;
-        // Async resolution
-        root.resolve(rootContext).whenComplete((r, t) -> {
-            if (t != null) {
-                result.completeExceptionally(t);
-            } else {
-                // Sync processing of the result tree - build the output
-                try {
-                    r.process(consumer);
-                    result.complete(null);
-                } catch (Throwable e) {
-                    result.completeExceptionally(e);
+        private CompletionStage<Void> renderData(Object data, Consumer<String> consumer) {
+            CompletableFuture<Void> result = new CompletableFuture<>();
+            DataNamespaceResolver dataResolver = new DataNamespaceResolver();
+            List<NamespaceResolver> namespaceResolvers = ImmutableList.<NamespaceResolver> builder()
+                    .addAll(engine.getNamespaceResolvers()).add(dataResolver).build();
+            ResolutionContext rootContext = new ResolutionContextImpl(null, data, namespaceResolvers,
+                    engine.getEvaluator(), null, this);
+            dataResolver.rootContext = rootContext;
+            // Async resolution
+            root.resolve(rootContext).whenComplete((r, t) -> {
+                if (t != null) {
+                    result.completeExceptionally(t);
+                } else {
+                    // Sync processing of the result tree - build the output
+                    try {
+                        r.process(consumer);
+                        result.complete(null);
+                    } catch (Throwable e) {
+                        result.completeExceptionally(e);
+                    }
                 }
-            }
-        });
-        return result;
+            });
+            return result;
+        }
+
     }
 
     static class DataNamespaceResolver implements NamespaceResolver {

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/Descriptors.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/Descriptors.java
@@ -13,47 +13,52 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 
-class Descriptors {
+public final class Descriptors {
 
-    static final MethodDescriptor IS_ASSIGNABLE_FROM = MethodDescriptor.ofMethod(Class.class, "isAssignableFrom",
+    private Descriptors() {
+    }
+
+    public static final MethodDescriptor IS_ASSIGNABLE_FROM = MethodDescriptor.ofMethod(Class.class, "isAssignableFrom",
             boolean.class, Class.class);
-    static final MethodDescriptor GET_CLASS = MethodDescriptor.ofMethod(Object.class, "getClass", Class.class);
-    static final MethodDescriptor COLLECTION_SIZE = MethodDescriptor.ofMethod(Collection.class, "size", int.class);
-    static final MethodDescriptor EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
+    public static final MethodDescriptor GET_CLASS = MethodDescriptor.ofMethod(Object.class, "getClass", Class.class);
+    public static final MethodDescriptor COLLECTION_SIZE = MethodDescriptor.ofMethod(Collection.class, "size", int.class);
+    public static final MethodDescriptor EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
             Object.class);
-    static final MethodDescriptor GET_NAME = MethodDescriptor.ofMethod(EvalContext.class, "getName", String.class);
-    static final MethodDescriptor GET_BASE = MethodDescriptor.ofMethod(EvalContext.class, "getBase", Object.class);
-    static final MethodDescriptor GET_PARAMS = MethodDescriptor.ofMethod(EvalContext.class, "getParams", List.class);
-    static final MethodDescriptor EVALUATE = MethodDescriptor.ofMethod(EvalContext.class, "evaluate",
+    public static final MethodDescriptor GET_NAME = MethodDescriptor.ofMethod(EvalContext.class, "getName", String.class);
+    public static final MethodDescriptor GET_BASE = MethodDescriptor.ofMethod(EvalContext.class, "getBase", Object.class);
+    public static final MethodDescriptor GET_PARAMS = MethodDescriptor.ofMethod(EvalContext.class, "getParams", List.class);
+    public static final MethodDescriptor EVALUATE = MethodDescriptor.ofMethod(EvalContext.class, "evaluate",
             CompletionStage.class, Expression.class);
     static final MethodDescriptor LIST_GET = MethodDescriptor.ofMethod(List.class, "get", Object.class, int.class);
     static final MethodDescriptor COMPLETED_FUTURE = MethodDescriptor.ofMethod(CompletableFuture.class,
             "completedFuture", CompletableFuture.class, Object.class);
-    static final MethodDescriptor COMPLETABLE_FUTURE_ALL_OF = MethodDescriptor.ofMethod(CompletableFuture.class,
+    public static final MethodDescriptor COMPLETABLE_FUTURE_ALL_OF = MethodDescriptor.ofMethod(CompletableFuture.class,
             "allOf",
             CompletableFuture.class, CompletableFuture[].class);
-    static final MethodDescriptor COMPLETABLE_FUTURE_COMPLETE_EXCEPTIONALLY = MethodDescriptor.ofMethod(
+    public static final MethodDescriptor COMPLETABLE_FUTURE_COMPLETE_EXCEPTIONALLY = MethodDescriptor.ofMethod(
             CompletableFuture.class,
             "completeExceptionally",
             boolean.class, Throwable.class);
-    static final MethodDescriptor COMPLETABLE_FUTURE_COMPLETE = MethodDescriptor.ofMethod(CompletableFuture.class,
+    public static final MethodDescriptor COMPLETABLE_FUTURE_COMPLETE = MethodDescriptor.ofMethod(CompletableFuture.class,
             "complete",
             boolean.class, Object.class);
-    static final MethodDescriptor COMPLETABLE_FUTURE_GET = MethodDescriptor.ofMethod(CompletableFuture.class,
+    public static final MethodDescriptor COMPLETABLE_FUTURE_GET = MethodDescriptor.ofMethod(CompletableFuture.class,
             "get",
             Object.class);
-    static final MethodDescriptor CF_TO_COMPLETABLE_FUTURE = MethodDescriptor.ofMethod(CompletionStage.class,
+    public static final MethodDescriptor CF_TO_COMPLETABLE_FUTURE = MethodDescriptor.ofMethod(CompletionStage.class,
             "toCompletableFuture",
             CompletableFuture.class);
-    static final MethodDescriptor CF_WHEN_COMPLETE = MethodDescriptor.ofMethod(CompletionStage.class,
+    public static final MethodDescriptor CF_WHEN_COMPLETE = MethodDescriptor.ofMethod(CompletionStage.class,
             "whenComplete",
             CompletionStage.class, BiConsumer.class);
-    static final MethodDescriptor BOOLEAN_LOGICAL_OR = MethodDescriptor.ofMethod(Boolean.class, "logicalOr",
+    public static final MethodDescriptor BOOLEAN_LOGICAL_OR = MethodDescriptor.ofMethod(Boolean.class, "logicalOr",
             boolean.class, boolean.class, boolean.class);
-    static final MethodDescriptor EVALUATED_PARAMS_EVALUATE = MethodDescriptor.ofMethod(EvaluatedParams.class, "evaluate",
+    public static final MethodDescriptor EVALUATED_PARAMS_EVALUATE = MethodDescriptor.ofMethod(EvaluatedParams.class,
+            "evaluate",
             EvaluatedParams.class,
             EvalContext.class);
-    static final MethodDescriptor EVALUATED_PARAMS_GET_RESULT = MethodDescriptor.ofMethod(EvaluatedParams.class, "getResult",
+    public static final MethodDescriptor EVALUATED_PARAMS_GET_RESULT = MethodDescriptor.ofMethod(EvaluatedParams.class,
+            "getResult",
             Object.class,
             int.class);
     static final MethodDescriptor EVALUATED_PARAMS_PARAM_TYPES_MATCH = MethodDescriptor.ofMethod(EvaluatedParams.class,
@@ -62,11 +67,11 @@ class Descriptors {
             "getVarargsResults", Object.class, int.class,
             Class.class);
 
-    static final FieldDescriptor RESULTS_NOT_FOUND = FieldDescriptor.of(Results.class, "NOT_FOUND",
+    public static final FieldDescriptor RESULTS_NOT_FOUND = FieldDescriptor.of(Results.class, "NOT_FOUND",
             CompletionStage.class);
-    static final FieldDescriptor RESULT_NOT_FOUND = FieldDescriptor.of(Result.class, "NOT_FOUND",
+    public static final FieldDescriptor RESULT_NOT_FOUND = FieldDescriptor.of(Result.class, "NOT_FOUND",
             Result.class);
-    static final FieldDescriptor EVALUATED_PARAMS_STAGE = FieldDescriptor.of(EvaluatedParams.class, "stage",
+    public static final FieldDescriptor EVALUATED_PARAMS_STAGE = FieldDescriptor.of(EvaluatedParams.class, "stage",
             CompletionStage.class);
 
 }

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/TestEvalContext.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/TestEvalContext.java
@@ -47,4 +47,9 @@ public class TestEvalContext implements EvalContext {
         return evaluate.apply(expression);
     }
 
+    @Override
+    public Object getAttribute(String key) {
+        return null;
+    }
+
 }


### PR DESCRIPTION
NOTE: The docs are updated too: https://github.com/quarkusio/quarkus/pull/8516/files#diff-2cca36cb4d8997f164012dd9f0bd2d6c

...

The basic idea is that each message is potentially a very simple template.

### Example

First you need to define the default message bundle interface:

```java
@MessageBundle // the name is defaulted to "msg" and is used as a namespace in templates expressions
public interface Messages {

    @Message("Hello {name}!") // value is a qute template
    String hello_name(String name); // name is a param that can be used in the template
}
```
Quarkus generates the implementations during build and you can use the bundles:

1. directly in your code `MessageBundles.get(Messages.class).hello_name("Jachym")`
2. `@Inject Messages messages` and call the bundle methods
3. in the templates: `{msg:hello_name('Jachym')}`

### Message Keys

Keys are used in qute templates. The `@MessageBundle` can be used to define the default strategy used to generate message keys for methods. By default, the annotated element's name is used as-is. Other possibilities are (1) de-camel-cased and hyphenated; `helloName()` -> `hello-name`, (2) de-camel-cased and parts separated by underscores; `helloName()` -> `hello_name`. `@Message` can override this strategy and even define a custom key.

### Localization

You can define a localized bundle interface that extends the default interface:

```java
@Localized("cs")
public interface CzechMessages extends Messages {

    @Message("Ahoj {name}!") // localized template
    @Override
    String hello_name(String name);
}
```

Alternatively, you can create an UTF-8 encoded file located in `src/main/resources/messages`; e.g. `msg_de.properties`. The file name consists of the relevant bundle name (`msg`) and underscore followed by the locate tag (IETF).

```properties
hello_name=Hallo {name}!
```

### Validation

Message templates are validated:
1. all expressions without a namespace must map to a param; e.g. `Hello {foo}` -> the method must have a param of name `foo`
2. all expressions are validated against the types of the parameters; e.g. `Hello {foo.bar}` where the parem `foo` is of type `org.acme.Foo` -> `org.acme.Foo` must have a property of name `bar`
3. a warning is logged for each unused param

Expressions that reference a message bundle method, such as `{msg:hello(name)}`, are validated too.

### TODO

- [x] Finish working prototype + validation
- [x] Update docs
- [x] Support localized properties file
- [x] Generate qute resolvers for all parameter types
- [x] Verify the limits of the generated implementations (each impl is also a registered as a namespace resolver)
  - ~I've verified that the current impl is able to handle ~ 1000 messages; if we split the generated `resolve()` method and group messages (a strategy already used in `io.quarkus.arc.processor.ComponentsProviderGenerator`) we could handle much more~
  - after the split 5000 messages is not a problem (except that we generate a huge class of course)