### PR TITLE
Set higher timeout for Security2 native image job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -365,7 +365,7 @@ jobs:
               elytron-undertow
               elytron-security-ldap
           - category: Security2
-            timeout: 50
+            timeout: 60
             keycloak: "true"
             test-modules: >
               elytron-resteasy


### PR DESCRIPTION
I sent an email to the list regarding this but let's set it higher for now.