### PR TITLE
Upgrade Hibernate Validator to 6.1.3.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -83,7 +83,7 @@
         <commons-codec.version>1.13</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.14.Final</hibernate-orm.version>
-        <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta6</hibernate-search.version>
         <narayana.version>5.10.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ArcProxyBeanMetaDataClassNormalizer.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ArcProxyBeanMetaDataClassNormalizer.java
@@ -10,12 +10,12 @@ import io.quarkus.arc.Subclass;
 public class ArcProxyBeanMetaDataClassNormalizer implements BeanMetaDataClassNormalizer {
 
     @Override
-    public Class<?> normalize(Class<?> clazz) {
-        if (Subclass.class.isAssignableFrom(clazz)) {
-            return clazz.getSuperclass();
+    public <T> Class<? super T> normalize(Class<T> beanClass) {
+        if (Subclass.class.isAssignableFrom(beanClass)) {
+            return beanClass.getSuperclass();
         }
 
-        return clazz;
+        return beanClass;
     }
 
 }


### PR DESCRIPTION
Should reduce the memory allocations when validating executables.