### PR TITLE
Fix issue with native cron build

### DIFF
--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -35,9 +35,9 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-native-cron-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-native-cron-
 
       - name: Build Quarkus
         run: mvn -B install -DskipTests -DskipITs -Dformat.skip


### PR DESCRIPTION
Attempt to get around:

```
No space left on device
```

error encountered during the `Quarkus CI - JDK 8 Native Build` run