### PR TITLE
Panache check

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdEntity.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdEntity.java
@@ -1,0 +1,10 @@
+package io.quarkus.hibernate.orm.panache.test;
+
+import javax.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+public class DuplicateIdEntity extends PanacheEntity {
+    @Id
+    public String customId;
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdEntityTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdEntityTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.panache.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdEntityTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(BuildException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdEntity.class));
+
+    @Test
+    void shouldThrow() {
+        fail("A BuildException should have been thrown due to duplicate entity ID");
+    }
+
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdParentEntity.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdParentEntity.java
@@ -1,0 +1,6 @@
+package io.quarkus.hibernate.orm.panache.test;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+public class DuplicateIdParentEntity extends PanacheEntity {
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdWithParentEntity.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdWithParentEntity.java
@@ -1,0 +1,8 @@
+package io.quarkus.hibernate.orm.panache.test;
+
+import javax.persistence.Id;
+
+public class DuplicateIdWithParentEntity extends DuplicateIdParentEntity {
+    @Id
+    public String customId;
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdWithParentTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/test/DuplicateIdWithParentTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.orm.panache.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdWithParentTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(BuildException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdWithParentEntity.class, DuplicateIdParentEntity.class));
+
+    @Test
+    void shouldThrow() {
+        fail("A BuildException should have been thrown due to duplicate entity ID");
+    }
+}

--- a/extensions/panache/mongodb-panache/deployment/pom.xml
+++ b/extensions/panache/mongodb-panache/deployment/pom.xml
@@ -32,15 +32,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-common-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mongodb-client-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mongodb-panache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -139,7 +139,7 @@ public class PanacheResourceProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
             BuildProducer<PanacheEntityClassesBuildItem> entityClasses,
-            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) throws BuildException {
+            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) {
 
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
                 .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());
@@ -224,7 +224,7 @@ public class PanacheResourceProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
-            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) throws BuildException {
+            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) {
 
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
                 .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
 import org.jboss.jandex.AnnotationInstance;
@@ -22,6 +23,8 @@ import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
+import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -65,6 +68,7 @@ public class PanacheResourceProcessor {
 
     private static final DotName DOTNAME_PROJECTION_FOR = DotName.createSimple(ProjectionFor.class.getName());
     private static final DotName DOTNAME_BSON_PROPERTY = DotName.createSimple(BsonProperty.class.getName());
+    private static final DotName DOTNAME_BSON_ID = DotName.createSimple(BsonId.class.getName());
 
     // reactive types (Mutiny)
     static final DotName DOTNAME_MUTINY_PANACHE_REPOSITORY_BASE = DotName
@@ -77,8 +81,6 @@ public class PanacheResourceProcessor {
             .createSimple(ReactivePanacheMongoEntity.class.getName());
 
     private static final DotName DOTNAME_OBJECT_ID = DotName.createSimple(ObjectId.class.getName());
-
-    private static final DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
 
     @BuildStep
     CapabilityBuildItem capability() {
@@ -137,7 +139,7 @@ public class PanacheResourceProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
             BuildProducer<PanacheEntityClassesBuildItem> entityClasses,
-            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) {
+            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) throws BuildException {
 
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
                 .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());
@@ -222,11 +224,10 @@ public class PanacheResourceProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
-            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) {
+            List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) throws BuildException {
 
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
                 .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());
-
         ReactivePanacheMongoRepositoryEnhancer daoEnhancer = new ReactivePanacheMongoRepositoryEnhancer(index.getIndex());
         Set<String> daoClasses = new HashSet<>();
         Set<Type> daoTypeParameters = new HashSet<>();
@@ -301,6 +302,31 @@ public class PanacheResourceProcessor {
     }
 
     @BuildStep
+    ValidationPhaseBuildItem.ValidationErrorBuildItem validate(ValidationPhaseBuildItem validationPhase,
+            CombinedIndexBuildItem index) throws BuildException {
+        // we verify that no ID fields are defined (via @BsonId) when extending PanacheMongoEntity or ReactivePanacheMongoEntity
+        for (AnnotationInstance annotationInstance : index.getIndex().getAnnotations(DOTNAME_BSON_ID)) {
+            ClassInfo info = io.quarkus.panache.common.deployment.JandexUtil.getEnclosingClass(annotationInstance);
+            if (io.quarkus.panache.common.deployment.JandexUtil.isSubclassOf(index.getIndex(), info,
+                    DOTNAME_PANACHE_ENTITY)) {
+                BuildException be = new BuildException("You provide a MongoDB identifier via @BsonId inside '" + info.name() +
+                        "' but one is already provided by PanacheMongoEntity, " +
+                        "your class should extend PanacheMongoEntityBase instead, or use the id provided by PanacheMongoEntity",
+                        Collections.emptyList());
+                return new ValidationPhaseBuildItem.ValidationErrorBuildItem(be);
+            } else if (io.quarkus.panache.common.deployment.JandexUtil.isSubclassOf(index.getIndex(), info,
+                    DOTNAME_MUTINY_PANACHE_ENTITY)) {
+                BuildException be = new BuildException("You provide a MongoDB identifier via @BsonId inside '" + info.name() +
+                        "' but one is already provided by ReactivePanacheMongoEntity, " +
+                        "your class should extend ReactivePanacheMongoEntityBase instead, or use the id provided by ReactivePanacheMongoEntity",
+                        Collections.emptyList());
+                return new ValidationPhaseBuildItem.ValidationErrorBuildItem(be);
+            }
+        }
+        return null;
+    }
+
+    @BuildStep
     void handleProjectionFor(CombinedIndexBuildItem index,
             BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
             BuildProducer<BytecodeTransformerBuildItem> transformers) {
@@ -344,7 +370,7 @@ public class PanacheResourceProcessor {
         }
 
         // climb up the hierarchy of types
-        if (!target.superClassType().name().equals(DOTNAME_OBJECT)) {
+        if (!target.superClassType().name().equals(io.quarkus.panache.common.deployment.JandexUtil.DOTNAME_OBJECT)) {
             Type superType = target.superClassType();
             ClassInfo superClass = index.getIndex().getClassByName(superType.name());
             extractMappings(classPropertyMapping, superClass, index);

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdMongoEntity.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdMongoEntity.java
@@ -1,0 +1,8 @@
+package io.quarkus.mongodb.panache;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+public class DuplicateIdMongoEntity extends PanacheMongoEntity {
+    @BsonId
+    public String customId;
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdMongoEntityTest.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdMongoEntityTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.mongodb.panache;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdMongoEntityTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(BuildException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdMongoEntity.class));
+
+    @Test
+    void shouldThrow() {
+        fail("A BuildException should have been thrown due to duplicate entity ID");
+    }
+
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdParentEntity.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdParentEntity.java
@@ -1,0 +1,4 @@
+package io.quarkus.mongodb.panache;
+
+public class DuplicateIdParentEntity extends PanacheMongoEntity {
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdReactiveMongoEntity.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdReactiveMongoEntity.java
@@ -1,0 +1,10 @@
+package io.quarkus.mongodb.panache;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+
+public class DuplicateIdReactiveMongoEntity extends ReactivePanacheMongoEntity {
+    @BsonId
+    public String customId;
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdReactiveMongoEntityTest.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdReactiveMongoEntityTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.mongodb.panache;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdReactiveMongoEntityTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(BuildException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdReactiveMongoEntity.class));
+
+    @Test
+    void shouldThrow() {
+        fail("A BuildException should have been thrown due to duplicate entity ID");
+    }
+
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdWithParentEntity.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdWithParentEntity.java
@@ -1,0 +1,8 @@
+package io.quarkus.mongodb.panache;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+public class DuplicateIdWithParentEntity extends DuplicateIdParentEntity {
+    @BsonId
+    public String customId;
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdWithParentTest.java
+++ b/extensions/panache/mongodb-panache/deployment/src/test/java/io/quarkus/mongodb/panache/DuplicateIdWithParentTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.mongodb.panache;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateIdWithParentTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(BuildException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DuplicateIdWithParentEntity.class, DuplicateIdParentEntity.class));
+
+    @Test
+    void shouldThrow() {
+        fail("A BuildException should have been thrown due to duplicate entity ID");
+    }
+}

--- a/extensions/panache/mongodb-panache/deployment/src/test/resources/application.properties
+++ b/extensions/panache/mongodb-panache/deployment/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.mongodb.database=test

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JandexUtil.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JandexUtil.java
@@ -327,7 +327,7 @@ public class JandexUtil {
             case TYPE:
                 return annotationInstance.target().asType().asClass(); // TODO is it legal here or should I throw ?
             default:
-                throw new RuntimeException(); // this should not occurs
+                throw new RuntimeException(); // this should not occur
         }
     }
 
@@ -343,7 +343,7 @@ public class JandexUtil {
         Type superType = info.superClassType();
         ClassInfo superClass = index.getClassByName(superType.name());
         if (superClass == null) {
-            // this can happens if the parent is not inside the Yandex index
+            // this can happens if the parent is not inside the Jandex index
             throw new BuildException("The class " + superType.name() + " is not inside the Jandex index",
                     Collections.emptyList());
         }

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JandexUtil.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/JandexUtil.java
@@ -1,11 +1,15 @@
 package io.quarkus.panache.common.deployment;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.PrimitiveType.Primitive;
@@ -15,10 +19,12 @@ import org.jboss.jandex.TypeVariable;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.quarkus.builder.BuildException;
 import io.quarkus.panache.common.impl.GenerateBridge;
 
 public class JandexUtil {
     public static final DotName DOTNAME_GENERATE_BRIDGE = DotName.createSimple(GenerateBridge.class.getName());
+    public static final DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
 
     public static String getSignature(MethodInfo method, Function<String, String> typeArgMapper) {
         List<Type> parameters = method.parameters();
@@ -306,6 +312,42 @@ public class JandexUtil {
             }
         }
         return Opcodes.ALOAD;
+    }
+
+    public static ClassInfo getEnclosingClass(AnnotationInstance annotationInstance) {
+        switch (annotationInstance.target().kind()) {
+            case FIELD:
+                return annotationInstance.target().asField().declaringClass();
+            case METHOD:
+                return annotationInstance.target().asMethod().declaringClass();
+            case METHOD_PARAMETER:
+                return annotationInstance.target().asMethodParameter().method().declaringClass();
+            case CLASS:
+                return annotationInstance.target().asClass();
+            case TYPE:
+                return annotationInstance.target().asType().asClass(); // TODO is it legal here or should I throw ?
+            default:
+                throw new RuntimeException(); // this should not occurs
+        }
+    }
+
+    public static boolean isSubclassOf(IndexView index, ClassInfo info, DotName parentName) throws BuildException {
+        if (info.superName().equals(DOTNAME_OBJECT)) {
+            return false;
+        }
+        if (info.superName().equals(parentName)) {
+            return true;
+        }
+
+        // climb up the hierarchy of classes
+        Type superType = info.superClassType();
+        ClassInfo superClass = index.getClassByName(superType.name());
+        if (superClass == null) {
+            // this can happens if the parent is not inside the Yandex index
+            throw new BuildException("The class " + superType.name() + " is not inside the Jandex index",
+                    Collections.emptyList());
+        }
+        return isSubclassOf(index, superClass, parentName);
     }
 
     public static void unboxIfRequired(MethodVisitor mv, Type jandexType) {


### PR DESCRIPTION
Fixes #5433

This PR adds a check to crash the build if an ID field is defined when using PanacheEntity or PanacheMongoEntity.

I check the performance impact on the build and it's less than 5ms for the integration test.