### PR TITLE
Hibernate projection inside Hibernate with Panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -577,6 +577,46 @@ Person.find("name = :name and status = :status",
 
 Every query operation accepts passing parameters by index (`Object...`), or by name (`Map<String,Object>` or `Parameters`).
 
+=== Query projection
+
+Query projection can be done with the `project(Class)` method on the `PanacheQuery` object that is returned by the `find()` methods.
+
+You can use it to restrict which fields will be returned by the database.
+
+Hibernate will use **DTO projection** and generate a SELECT clause with the attributes from the projection class.
+This is also called **dynamic instantiation** or **constructor expression**, more info can be found on the Hibernate guide:
+link:https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql-select-clause[hql select clause]
+
+The projection class needs to be a valid Java Bean and have a constructor that contains all its attributes, this constructor will be used to
+instantiate the projection DTO instead of using the entity class. This must be the only constructor of the class.
+
+[source,java]
+----
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection // <1>
+public class PersonName {
+    public final String name; // <2>
+
+    public PersonName(String name){ // <3>
+        this.name = name;
+    }
+}
+
+// only 'name' will be loaded from the database
+PanacheQuery<PersonName> query = Person.find("status", Status.Alive).project(PersonName.class);
+----
+
+1. If you plan to deploy your application as a native executable, you must register manually the projection class for reflection.
+2. We use public fields here, but you can use private fields and getters/setters if you prefer.
+3. This constructor will be used by Hibernate, it must be the only constructor in your class and have all the class attributes as parameters.
+
+[WARNING]
+====
+The implementation of the `project(Class)` method uses the constructor's parameter names to build the select clause of the query,
+so the compiler must be configured to store parameter names inside the compiled class.
+This is enabled by default if you are using the Quarkus Maven archetype. If you are not using it, add the property `<maven.compiler.parameters>true</maven.compiler.parameters>` to your pom.xml.
+====
 
 == Transactions
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/PanacheQuery.java
@@ -28,6 +28,14 @@ public interface PanacheQuery<Entity> {
     // Builder
 
     /**
+     * Defines a projection class: the getters, and the public fields, will be used to restrict which fields should be
+     * retrieved from the database.
+     *
+     * @return a new query with the same state as the previous one (params, page, range, lockMode, hints, ...).
+     */
+    public <T> PanacheQuery<T> project(Class<T> type);
+
+    /**
      * Sets the current page.
      * 
      * @param page the new page

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/CustomCountPanacheQuery.java
@@ -11,7 +11,7 @@ public class CustomCountPanacheQuery<Entity> extends PanacheQueryImpl<Entity> {
 
     public CustomCountPanacheQuery(EntityManager em, Query jpaQuery, String query, String customCountQuery,
             Object paramsArrayOrMap) {
-        super(em, jpaQuery, query, paramsArrayOrMap);
+        super(em, query, null, paramsArrayOrMap);
         this.customCountQuery = customCountQuery;
     }
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/JpaOperations.java
@@ -220,6 +220,9 @@ public class JpaOperations {
     }
 
     public static String toOrderBy(Sort sort) {
+        if (sort == null) {
+            return null;
+        }
         if (sort.getColumns().size() == 0) {
             return "";
         }
@@ -263,16 +266,12 @@ public class JpaOperations {
         String findQuery = createFindQuery(entityClass, query, paramCount(params));
         EntityManager em = getEntityManager();
         // FIXME: check for duplicate ORDER BY clause?
-        Query jpaQuery;
         if (isNamedQuery(query)) {
             String namedQuery = query.substring(1);
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            jpaQuery = em.createNamedQuery(namedQuery);
-        } else {
-            jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+            return new PanacheQueryImpl(em, query, toOrderBy(sort), params);
         }
-        bindParameters(jpaQuery, params);
-        return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
+        return new PanacheQueryImpl(em, findQuery, toOrderBy(sort), params);
     }
 
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Map<String, Object> params) {
@@ -284,16 +283,12 @@ public class JpaOperations {
         String findQuery = createFindQuery(entityClass, query, paramCount(params));
         EntityManager em = getEntityManager();
         // FIXME: check for duplicate ORDER BY clause?
-        Query jpaQuery;
         if (isNamedQuery(query)) {
             String namedQuery = query.substring(1);
             NamedQueryUtil.checkNamedQuery(entityClass, namedQuery);
-            jpaQuery = em.createNamedQuery(namedQuery);
-        } else {
-            jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
+            return new PanacheQueryImpl(em, query, toOrderBy(sort), params);
         }
-        bindParameters(jpaQuery, params);
-        return new PanacheQueryImpl(em, jpaQuery, findQuery, params);
+        return new PanacheQueryImpl(em, findQuery, toOrderBy(sort), params);
     }
 
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Parameters params) {
@@ -356,7 +351,7 @@ public class JpaOperations {
     public static PanacheQuery<?> findAll(Class<?> entityClass) {
         String query = "FROM " + getEntityName(entityClass);
         EntityManager em = getEntityManager();
-        return new PanacheQueryImpl(em, em.createQuery(query), query, null);
+        return new PanacheQueryImpl(em, query, null, null);
     }
 
     @SuppressWarnings("rawtypes")
@@ -364,7 +359,7 @@ public class JpaOperations {
         String query = "FROM " + getEntityName(entityClass);
         String sortedQuery = query + toOrderBy(sort);
         EntityManager em = getEntityManager();
-        return new PanacheQueryImpl(em, em.createQuery(sortedQuery), query, null);
+        return new PanacheQueryImpl(em, query, toOrderBy(sort), null);
     }
 
     public static List<?> listAll(Class<?> entityClass) {

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -12,6 +12,15 @@
 
     <artifactId>quarkus-integration-test-hibernate-orm-panache</artifactId>
     <name>Quarkus - Integration Tests - Hibernate ORM with Panache</name>
+
+    <!--
+        This is enabled in the Quarkus Maven archetype but not on the integration tests.
+        PanacheQuery.project(Class) needs it.
+    -->
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/PersonName.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/PersonName.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.panache;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class PersonName {
+    public final String name;
+    public final String uniqueName;
+
+    public PersonName(String uniqueName, String name) {
+        this.name = name;
+        this.uniqueName = uniqueName;
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1082,6 +1082,34 @@ public class TestEndpoint {
     }
 
     @GET
+    @Path("projection")
+    @Transactional
+    public String testProjection() {
+        Assertions.assertEquals(1, Person.count());
+
+        PersonName person = Person.findAll().project(PersonName.class).firstResult();
+        Assertions.assertEquals("2", person.name);
+
+        person = Person.find("name", "2").project(PersonName.class).firstResult();
+        Assertions.assertEquals("2", person.name);
+
+        person = Person.find("name = ?1", "2").project(PersonName.class).firstResult();
+        Assertions.assertEquals("2", person.name);
+
+        person = Person.find("name = :name", Parameters.with("name", "2")).project(PersonName.class).firstResult();
+        Assertions.assertEquals("2", person.name);
+
+        PanacheQuery<PersonName> query = Person.findAll().project(PersonName.class).page(0, 2);
+        Assertions.assertEquals(1, query.list().size());
+        query.nextPage();
+        Assertions.assertEquals(0, query.list().size());
+
+        Assertions.assertEquals(1, Person.findAll().project(PersonName.class).count());
+
+        return "OK";
+    }
+
+    @GET
     @Path("model3")
     @Transactional
     public String testModel3() {

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -44,6 +44,7 @@ public class PanacheFunctionalityTest {
 
         RestAssured.when().get("/test/model1").then().body(is("OK"));
         RestAssured.when().get("/test/model2").then().body(is("OK"));
+        RestAssured.when().get("/test/projection").then().body(is("OK"));
         RestAssured.when().get("/test/model3").then().body(is("OK"));
     }
 


### PR DESCRIPTION
This implements the `PanacheQuery.project(Class)` method that allows doing a DTO projection on the query.

The projection class needs to be a Java Bean and have a constructor with all it's fields in it. In order to work in native it needs to be annotated with `@RegisterForReflection`.

It uses the **constructor expression** construct, to build it we need to have the compiler parameters attribute on (by default on our Quarkus Maven archetype but not on the IT).

It fixes #6261