### PR TITLE
fix Jaeger metrics initialization

### DIFF
--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -30,7 +30,11 @@ public class JaegerProcessor {
         if (buildTimeConfig.enabled) {
             boolean metricsEnabled = capabilities.isCapabilityPresent(Capabilities.METRICS);
 
-            jdr.registerTracer(jaeger, appConfig, metricsEnabled);
+            if (metricsEnabled) {
+                jdr.registerTracerWithMetrics(jaeger, appConfig);
+            } else {
+                jdr.registerTracerWithoutMetrics(jaeger, appConfig);
+            }
         }
     }
 

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
@@ -5,6 +5,8 @@ import java.util.function.Function;
 
 import org.jboss.logging.Logger;
 
+import io.jaegertracing.internal.metrics.NoopMetricsFactory;
+import io.jaegertracing.spi.MetricsFactory;
 import io.opentracing.util.GlobalTracer;
 import io.quarkus.runtime.ApplicationConfig;
 import io.quarkus.runtime.annotations.Recorder;
@@ -15,7 +17,15 @@ public class JaegerDeploymentRecorder {
     private static final Optional UNKNOWN_SERVICE_NAME = Optional.of("quarkus/unknown");
     private static final QuarkusJaegerTracer quarkusTracer = new QuarkusJaegerTracer();
 
-    synchronized public void registerTracer(JaegerConfig jaeger, ApplicationConfig appConfig, boolean metricsEnabled) {
+    synchronized public void registerTracerWithoutMetrics(JaegerConfig jaeger, ApplicationConfig appConfig) {
+        registerTracer(jaeger, appConfig, new NoopMetricsFactory());
+    }
+
+    synchronized public void registerTracerWithMetrics(JaegerConfig jaeger, ApplicationConfig appConfig) {
+        registerTracer(jaeger, appConfig, new QuarkusJaegerMetricsFactory());
+    }
+
+    private void registerTracer(JaegerConfig jaeger, ApplicationConfig appConfig, MetricsFactory metricsFactory) {
         if (!jaeger.serviceName.isPresent()) {
             if (appConfig.name.isPresent()) {
                 jaeger.serviceName = appConfig.name;
@@ -24,7 +34,7 @@ public class JaegerDeploymentRecorder {
             }
         }
         initTracerConfig(jaeger);
-        quarkusTracer.setMetricsEnabled(metricsEnabled);
+        quarkusTracer.setMetricsFactory(metricsFactory);
         quarkusTracer.reset();
         // register Quarkus tracer to GlobalTracer.
         // Usually the tracer will be registered only here, although consumers

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/QuarkusJaegerTracer.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/QuarkusJaegerTracer.java
@@ -2,7 +2,6 @@ package io.quarkus.jaeger.runtime;
 
 import io.jaegertracing.Configuration;
 import io.jaegertracing.internal.JaegerTracer;
-import io.jaegertracing.internal.metrics.NoopMetricsFactory;
 import io.jaegertracing.spi.MetricsFactory;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
@@ -16,14 +15,14 @@ public class QuarkusJaegerTracer implements Tracer {
     private volatile JaegerTracer tracer;
 
     private boolean logTraceContext;
-    private boolean metricsEnabled;
+    private MetricsFactory metricsFactory;
 
     void setLogTraceContext(boolean logTraceContext) {
         this.logTraceContext = logTraceContext;
     }
 
-    void setMetricsEnabled(boolean metricsEnabled) {
-        this.metricsEnabled = metricsEnabled;
+    void setMetricsFactory(MetricsFactory metricsFactory) {
+        this.metricsFactory = metricsFactory;
     }
 
     @Override
@@ -42,9 +41,6 @@ public class QuarkusJaegerTracer implements Tracer {
         if (tracer == null) {
             synchronized (this) {
                 if (tracer == null) {
-                    MetricsFactory metricsFactory = metricsEnabled
-                            ? new QuarkusJaegerMetricsFactory()
-                            : new NoopMetricsFactory();
                     tracer = Configuration.fromEnv()
                             .withMetricsFactory(metricsFactory)
                             .getTracerBuilder()


### PR DESCRIPTION
Creation of the correct `MetricsFactory` was moved from runtime
to build time, which also means that it's created during native
image compilation. Therefore, the MicroProfile Metrics API and
SmallRye Metrics are not required to be present at runtime.
Which, in the end, means that native image compilation no longer
fails when the `quarkus-smallrye-opentracing` extension is present
but `quarkus-smallrye-metrics` is not.

Resolves #8578.