### PR TITLE
Mailer and JTA extensions had some Reactive Streams Ops leftovers

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -126,7 +126,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <test-containers.version>1.12.4</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <mutiny.version>0.4.4</mutiny.version>
+        <mutiny.version>0.5.0</mutiny.version>
         <axle-client.version>0.0.15</axle-client.version>
         <mutiny-client.version>0.0.15</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Attachment.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/Attachment.java
@@ -4,8 +4,9 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
 
 /**
  * Defines an attachment.
@@ -198,7 +199,7 @@ public class Attachment {
 
     public Attachment setData(byte[] data) {
         if (data == null || data.length == 0) {
-            this.data = ReactiveStreams.<Byte> empty().buildRs();
+            this.data = Multi.createFrom().empty();
             return this;
         }
 
@@ -223,13 +224,13 @@ public class Attachment {
             }
         };
 
-        this.data = ReactiveStreams.fromIterable(iterable).buildRs();
+        this.data = Multi.createFrom().iterable(iterable);
         return this;
     }
 
     public Attachment setData(Publisher<Byte> data) {
         if (data == null) {
-            this.data = ReactiveStreams.<Byte> empty().buildRs();
+            this.data = Multi.createFrom().empty();
         }
         this.data = data;
         return this;

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/AttachmentTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/AttachmentTest.java
@@ -8,7 +8,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
 import io.quarkus.mailer.runtime.MutinyMailerImpl;
+import io.smallrye.mutiny.Multi;
 import io.vertx.core.file.FileSystemException;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.mutiny.core.Vertx;
@@ -195,14 +195,11 @@ class AttachmentTest {
     void testCreationWithEmptyContent() {
         Attachment attachment1 = new Attachment("attachment-1", (byte[]) null, "text/plain");
         Attachment attachment2 = new Attachment("attachment-2", new byte[0], "text/plain");
-        Attachment attachment3 = new Attachment("attachment-3", ReactiveStreams.<Byte> empty().buildRs(), "text/plain");
+        Attachment attachment3 = new Attachment("attachment-3", Multi.createFrom().empty(), "text/plain");
 
-        assertThat(ReactiveStreams.fromPublisher(attachment1.getData()).findFirst().run().toCompletableFuture().join())
-                .isEmpty();
-        assertThat(ReactiveStreams.fromPublisher(attachment2.getData()).findFirst().run().toCompletableFuture().join())
-                .isEmpty();
-        assertThat(ReactiveStreams.fromPublisher(attachment3.getData()).findFirst().run().toCompletableFuture().join())
-                .isEmpty();
+        assertThat(Multi.createFrom().publisher(attachment1.getData()).collectItems().first().await().indefinitely()).isNull();
+        assertThat(Multi.createFrom().publisher(attachment2.getData()).collectItems().first().await().indefinitely()).isNull();
+        assertThat(Multi.createFrom().publisher(attachment3.getData()).collectItems().first().await().indefinitely()).isNull();
     }
 
     @Test

--- a/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/MailTest.java
+++ b/extensions/mailer/runtime/src/test/java/io/quarkus/mailer/MailTest.java
@@ -5,13 +5,16 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Multi;
 import io.vertx.axle.core.Vertx;
 
 class MailTest {
@@ -110,7 +113,7 @@ class MailTest {
         assertThat(mail2.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
 
         Mail mail3 = new Mail().addAttachment("some-name-3",
-                ReactiveStreams.of(0, 1, 2).map(Integer::byteValue).buildRs(), TEXT_PLAIN);
+                Multi.createFrom().items(0, 1, 2).map(Integer::byteValue), TEXT_PLAIN);
         assertThat(mail3.getAttachments()).hasSize(1);
         assertThat(mail3.getAttachments().get(0).getName()).isEqualTo("some-name-3");
         assertThat(mail3.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);
@@ -118,7 +121,7 @@ class MailTest {
         assertThat(mail3.getAttachments().get(0).getDisposition()).isEqualTo(Attachment.DISPOSITION_ATTACHMENT);
 
         Mail mail4 = new Mail().addAttachment("some-name-4",
-                ReactiveStreams.of(0, 1, 2).map(Integer::byteValue).buildRs(), TEXT_PLAIN,
+                Multi.createFrom().items(0, 1, 2).map(Integer::byteValue), TEXT_PLAIN,
                 DESCRIPTION, Attachment.DISPOSITION_ATTACHMENT);
         assertThat(mail4.getAttachments()).hasSize(1);
         assertThat(mail4.getAttachments().get(0).getName()).isEqualTo("some-name-4");
@@ -155,7 +158,7 @@ class MailTest {
         assertThat(mail2.getAttachments().get(0).getContentId()).isEqualTo("<cid-2>");
 
         Mail mail3 = new Mail().addInlineAttachment("name-3",
-                ReactiveStreams.of(0, 1, 2).map(Integer::byteValue).buildRs(), TEXT_PLAIN, "cid-3");
+                Multi.createFrom().items(0, 1, 2).map(Integer::byteValue), TEXT_PLAIN, "cid-3");
         assertThat(mail3.getAttachments()).hasSize(1);
         assertThat(mail3.getAttachments().get(0).getName()).isEqualTo("name-3");
         assertThat(mail3.getAttachments().get(0).getContentType()).isEqualTo(TEXT_PLAIN);

--- a/extensions/narayana-jta/deployment/pom.xml
+++ b/extensions/narayana-jta/deployment/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-narayana-jta</artifactId>
         </dependency>
         <dependency>

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-streams-operators</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/ContextEndpoint.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/ContextEndpoint.java
@@ -23,7 +23,6 @@ import javax.ws.rs.core.UriInfo;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.jboss.resteasy.annotations.Stream;
 import org.jboss.resteasy.annotations.Stream.MODE;
 import org.junit.jupiter.api.Assertions;
@@ -33,6 +32,7 @@ import org.wildfly.common.Assert;
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.panache.Panache;
 import io.reactivex.Single;
+import io.smallrye.mutiny.Multi;
 
 @Path("/context")
 @Produces(MediaType.TEXT_PLAIN)
@@ -335,8 +335,8 @@ public class ContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-publisher2")
-    public Publisher<String> transactionPublisher2() throws SystemException {
-        Publisher<String> ret = ReactiveStreams.of("OK").buildRs();
+    public Publisher<String> transactionPublisher2() {
+        Publisher<String> ret = Multi.createFrom().item("OK");
         // now delete both entities
         Assertions.assertEquals(2, ContextEntity.deleteAll());
         return ret;

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
@@ -101,7 +101,7 @@ public class SimpleContextPropagationTest {
 
     private void awaitState(ThrowingRunnable task) {
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
                 .untilAsserted(task);
     }
 


### PR DESCRIPTION
This PR is just doing some cleanup (it's spring right?).

The JTA and Mailer extensions were using internally reactive streams operators. I replace these usages with Mutiny. Fortunately, soon, it would let us remove the (transitive) dependency on Reactive Streams Operators completely. 