### PR TITLE
Add test closure and configure the logging manager so log levels are considered on tests

### DIFF
--- a/devtools/gradle/src/test/java/io/quarkus/gradle/GradleBuildFileTest.java
+++ b/devtools/gradle/src/test/java/io/quarkus/gradle/GradleBuildFileTest.java
@@ -58,6 +58,11 @@ class GradleBuildFileTest {
     }
 
     @Test
+    void testGetTestClosure() throws IOException {
+        assertNull(buildFile.getProperty("test"));
+    }
+
+    @Test
     void testFindInstalled() throws IOException {
         Map<String, Dependency> installed = buildFile.findInstalled();
         assertNotNull(installed);

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -102,6 +102,12 @@ public class GradleBuildFile extends BuildFile {
             res.append(System.lineSeparator()).append(versionLine)
                     .append(System.lineSeparator());
         }
+
+        res.append(System.lineSeparator())
+            .append("test {").append(System.lineSeparator())
+            .append("    systemProperty \"java.util.logging.manager\", \"org.jboss.logmanager.LogManager\"").append(System.lineSeparator())
+            .append("}");
+
         getModel().setBuildContent(res.toString());
     }
 

--- a/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
+++ b/independent-projects/tools/common/src/main/java/io/quarkus/cli/commands/file/GradleBuildFile.java
@@ -104,9 +104,10 @@ public class GradleBuildFile extends BuildFile {
         }
 
         res.append(System.lineSeparator())
-            .append("test {").append(System.lineSeparator())
-            .append("    systemProperty \"java.util.logging.manager\", \"org.jboss.logmanager.LogManager\"").append(System.lineSeparator())
-            .append("}");
+                .append("test {").append(System.lineSeparator())
+                .append("    systemProperty \"java.util.logging.manager\", \"org.jboss.logmanager.LogManager\"")
+                .append(System.lineSeparator())
+                .append("}");
 
         getModel().setBuildContent(res.toString());
     }


### PR DESCRIPTION
I found this issue where log levels were not being considered on tests https://github.com/quarkusio/quarkus/issues/8574
And I found this issue: https://github.com/quarkusio/quarkus/issues/2491 where a solution is shown.
It seems that this solution is already incorporated on the pom file generated in code.quarkus.io, but not on the build.gradle file.
This PR aims to add this entry to the build.gradle file so the defined log level is considered in tests, just like this is done in the maven file.

I am not aware of the process required to get this merged. I expect the tests to run when I open this PR, but if I forgot something, please let me know