### PR TITLE
Add quarkusRemoteDev task in gradle plugin

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -27,6 +27,7 @@ import io.quarkus.gradle.tasks.QuarkusBuild;
 import io.quarkus.gradle.tasks.QuarkusDev;
 import io.quarkus.gradle.tasks.QuarkusGenerateConfig;
 import io.quarkus.gradle.tasks.QuarkusListExtensions;
+import io.quarkus.gradle.tasks.QuarkusRemoteDev;
 import io.quarkus.gradle.tasks.QuarkusTestConfig;
 import io.quarkus.gradle.tasks.QuarkusTestNative;
 
@@ -41,6 +42,7 @@ public class QuarkusPlugin implements Plugin<Project> {
     public static final String QUARKUS_BUILD_TASK_NAME = "quarkusBuild";
     public static final String GENERATE_CONFIG_TASK_NAME = "generateConfig";
     public static final String QUARKUS_DEV_TASK_NAME = "quarkusDev";
+    public static final String QUARKUS_REMOTE_DEV_TASK_NAME = "quarkusRemoteDev";
 
     @Deprecated
     public static final String BUILD_NATIVE_TASK_NAME = "buildNative";
@@ -73,6 +75,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
         Task quarkusBuild = tasks.create(QUARKUS_BUILD_TASK_NAME, QuarkusBuild.class);
         Task quarkusDev = tasks.create(QUARKUS_DEV_TASK_NAME, QuarkusDev.class);
+        Task quarkusRemoteDev = tasks.create(QUARKUS_REMOTE_DEV_TASK_NAME, QuarkusRemoteDev.class);
         tasks.create(QUARKUS_TEST_CONFIG_TASK_NAME, QuarkusTestConfig.class);
 
         Task buildNative = tasks.create(BUILD_NATIVE_TASK_NAME, DefaultTask.class);
@@ -101,6 +104,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
                     Task classesTask = tasks.getByName(JavaPlugin.CLASSES_TASK_NAME);
                     quarkusDev.dependsOn(classesTask);
+                    quarkusRemoteDev.dependsOn(classesTask);
                     quarkusBuild.dependsOn(classesTask, tasks.getByName(JavaPlugin.JAR_TASK_NAME));
 
                     SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class)

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusRemoteDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusRemoteDev.java
@@ -1,0 +1,104 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskAction;
+
+import io.quarkus.gradle.QuarkusPluginExtension;
+import io.quarkus.remotedev.AgentRunner;
+import io.quarkus.runtime.configuration.ConfigUtils;
+import io.quarkus.runtime.configuration.QuarkusConfigFactory;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+
+public class QuarkusRemoteDev extends QuarkusTask {
+
+    private static final String LIVE_RELOAD_URL = "quarkus.live-reload.url";
+    private static final String LIVE_RELOAD_PASSWORD = "quarkus.live-reload.password";
+
+    public QuarkusRemoteDev() {
+        super("Remote development mode: enables hot deployment on remote JVM with background compilation");
+    }
+
+    @TaskAction
+    public void startRemoteDev() {
+        Project project = getProject();
+        QuarkusPluginExtension extension = (QuarkusPluginExtension) project.getExtensions().findByName("quarkus");
+        if (!extension.sourceDir().isDirectory()) {
+            throw new GradleException("The `src/main/java` directory is required, please create it.");
+        }
+        if (extension.resourcesDir().isEmpty()) {
+            throw new GradleException("The `src/main/resources` directory is required, please create it");
+        }
+        if (!extension.outputDirectory().isDirectory()) {
+            throw new GradleException("The project has no output yet, " +
+                    "this should not happen as build should have been executed first. " +
+                    "Does the project have any source files?");
+        }
+
+        String classes = extension.outputDirectory().getAbsolutePath();
+        String sources = extension.sourceDir().getAbsolutePath();
+
+        String resources = null;
+        for (File resource : extension.resourcesDir()) {
+            resources = resource.getAbsolutePath();
+            break;
+        }
+
+        //first lets look for some config, as it is not on the current class path
+        //and we need to load it to run the build process
+        if (resources != null) {
+            Path config = Paths.get(resources).resolve("application.properties");
+            if (Files.exists(config)) {
+                try {
+                    SmallRyeConfig built = ConfigUtils.configBuilder(false)
+                            .withSources(new PropertiesConfigSource(config.toUri().toURL())).build();
+                    QuarkusConfigFactory.setConfig(built);
+                    final ConfigProviderResolver cpr = ConfigProviderResolver.instance();
+                    final Config existing = cpr.getConfig();
+                    if (existing != built) {
+                        cpr.releaseConfig(existing);
+                        // subsequent calls will get the new config
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        Optional<String> url = ConfigProvider.getConfig().getOptionalValue(LIVE_RELOAD_URL, String.class);
+        Optional<String> password = ConfigProvider.getConfig().getOptionalValue(LIVE_RELOAD_PASSWORD, String.class);
+        if (!url.isPresent()) {
+            throw new GradleException("To use remote-dev you must specify quarkus.live-reload.url");
+        }
+        if (!password.isPresent()) {
+            throw new GradleException("To use remote-dev you must specify quarkus.live-reload.password");
+        }
+
+        String remotePath = url.get();
+        if (remotePath.endsWith("/")) {
+            remotePath = remotePath.substring(0, remotePath.length() - 1);
+        }
+
+        AgentRunner runner = new AgentRunner(resources, sources, classes, remotePath + "/quarkus/live-reload",
+                password.get());
+        runner.run();
+
+        for (;;) {
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -192,6 +192,40 @@ quarkusDev {
 }
 ----
 
+=== Remote Development Mode
+
+It is possible to use development mode remotely, so that you can run Quarkus in a container environment (such as OpenShift)
+and have changes made to your local files become immediately visible.
+
+This allows you to develop in the same environment you will actually run your app in, and with access to the same services.
+
+WARNING: Do not use this in production. This should only be used in a development environment. You should not run production applications in dev mode.
+
+To do this you must have the `quarkus-undertow-websockets` extension installed:
+
+[source,shell]
+----
+./gradlew addExtension --extensions="undertow-websockets"
+----
+
+You must also have the following config properties set:
+
+- `quarkus.live-reload.password`
+- `quarkus.live-reload.url`
+
+These can be set via `application.properties`, or any other way (e.g. system properties, environment vars etc). The
+password must be set on both the local and remote processes, while the url only needs to be set on the local host.
+
+Start Quarkus in dev mode on the remote host. Now you need to connect your local agent to the remote host:
+
+[source,shell]
+----
+./gradlew quarkusRemoteDev -Dquarkus.live-reload.url=http://my-remote-host:8080
+----
+
+Now every time you refresh the browser you should see any changes you have made locally immediately visible in the remote
+app.
+
 == Debugging
 
 In development mode, Quarkus starts by default with debug mode enabled, listening to port `5005` without suspending the JVM.


### PR DESCRIPTION
This pull request adds `quarkusRemoteDev` task into gradle plugin. 
This works as `quarkus:remote-dev` maven goal. The code is highly inspired from `RemoteDevMojo` class, I don't know if we can put some of the code in a common place. 

To test this, I ran my application in a docker container in dev mode. Then, on my computer, I ran:

    ./gradlew quarkusRemoteDev -Dquarkus.live-reload.password=password -Dquarkus.live-reload.url=http://127.0.0.1:8080

`quarkus.live-reload.url` and `quarkus.live-reload.password` properties can be set as argument or directly in the `application.properties` file. 

`quarkus.live-reload.password` must be set on the remote application running in dev mode.

fix #5221 

