### PR TITLE
Add example for the configuration of the logging manager in gradle projects

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -239,6 +239,15 @@ In particular, you need to set the appropriate `LogManager` using the `java.util
 <1> Make sure the `org.jboss.logmanager.LogManager` is used.
 <2> Enable debug logging for all logging categories.
 
+If you are using Gradle, add this to your `build.gradle`:
+
+[source, groovy]
+----
+test {
+	systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}
+----
+
 [[loggingConfigurationReference]]
 == Logging configuration reference
 


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/pull/8594
I added the example for the configuration of the logging manager in gradle projects