### PR TITLE
Only enable Hibernate Validator built-in constraints that are used

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -83,7 +83,7 @@
         <commons-codec.version>1.13</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.14.Final</hibernate-orm.version>
-        <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.1.4.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta6</hibernate-search.version>
         <narayana.version>5.10.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -35,6 +35,7 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String CONTAINER_IMAGE_JIB = "io.quarkus.container-image-jib";
     public static final String CONTAINER_IMAGE_DOCKER = "io.quarkus.container-image-docker";
     public static final String CONTAINER_IMAGE_S2I = "io.quarkus.container-image-s2i";
+    public static final String HIBERNATE_ORM = "io.quarkus.hibernate-orm";
 
     private final Set<String> capabilities;
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -59,7 +59,6 @@ import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
-import org.jboss.logging.Logger;
 import org.jboss.logmanager.Level;
 
 import io.quarkus.agroal.deployment.JdbcDataSourceBuildItem;
@@ -76,6 +75,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
@@ -121,7 +121,6 @@ import net.bytebuddy.dynamic.DynamicType;
  */
 public final class HibernateOrmProcessor {
 
-    private static final Logger LOG = Logger.getLogger(HibernateOrmProcessor.class);
     private static final String HIBERNATE_ORM_CONFIG_PREFIX = "quarkus.hibernate-orm.";
     private static final String NO_SQL_LOAD_SCRIPT_FILE = "no-file";
 
@@ -136,6 +135,11 @@ public final class HibernateOrmProcessor {
      * Hibernate ORM configuration
      */
     HibernateOrmConfig hibernateConfig;
+
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.HIBERNATE_ORM);
+    }
 
     // We do our own enhancement during the compilation phase, so disable any
     // automatic entity enhancement by Hibernate ORM

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -29,6 +29,7 @@ import io.quarkus.runtime.annotations.Recorder;
 public class HibernateValidatorRecorder {
 
     public BeanContainerListener initializeValidatorFactory(Set<Class<?>> classesToBeValidated,
+            Set<String> detectedBuiltinConstraints,
             ShutdownContext shutdownContext, LocalesBuildTimeConfig localesBuildTimeConfig) {
         BeanContainerListener beanContainerListener = new BeanContainerListener() {
 
@@ -46,6 +47,7 @@ public class HibernateValidatorRecorder {
                 }
 
                 configuration
+                        .builtinConstraints(detectedBuiltinConstraints)
                         .initializeBeanMetaData(classesToBeValidated)
                         .locales(localesBuildTimeConfig.locales)
                         .defaultLocale(localesBuildTimeConfig.defaultLocale)

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/TraverseAllTraversableResolver.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/TraverseAllTraversableResolver.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.validator.runtime;
+
+import java.lang.annotation.ElementType;
+
+import javax.validation.Path;
+import javax.validation.Path.Node;
+import javax.validation.TraversableResolver;
+
+class TraverseAllTraversableResolver implements TraversableResolver {
+
+    TraverseAllTraversableResolver() {
+    }
+
+    @Override
+    public boolean isReachable(Object traversableObject, Node traversableProperty, Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType) {
+        return true;
+    }
+
+    @Override
+    public boolean isCascadable(Object traversableObject, Node traversableProperty, Class<?> rootBeanType,
+            Path pathToTraversableObject,
+            ElementType elementType) {
+        return true;
+    }
+}


### PR DESCRIPTION
@loicmathieu can you try this PR in conjunction with this HV PR: https://github.com/hibernate/hibernate-validator/pull/1080 ?

Just deploy HV with a `mvn clean install -DskipTests -DskipITs` then build Quarkus with `mvn clean install -DskipTests -DskipITs` and bump your project to `999-SNAPSHOT`.

It should hopefully improve the situation for #8586 .