### PR TITLE
Make Jaeger metrics more consistent with other extensions

### DIFF
--- a/extensions/jaeger/deployment/pom.xml
+++ b/extensions/jaeger/deployment/pom.xml
@@ -30,6 +30,22 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jaeger/deployment/pom.xml
+++ b/extensions/jaeger/deployment/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>quarkus-jaeger</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-metrics-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -2,6 +2,10 @@ package io.quarkus.jaeger.deployment;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.Tag;
+
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -12,7 +16,9 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.jaeger.runtime.JaegerBuildTimeConfig;
 import io.quarkus.jaeger.runtime.JaegerConfig;
 import io.quarkus.jaeger.runtime.JaegerDeploymentRecorder;
+import io.quarkus.jaeger.runtime.QuarkusJaegerMetricsFactory;
 import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.smallrye.metrics.deployment.spi.MetricBuildItem;
 
 public class JaegerProcessor {
 
@@ -22,7 +28,7 @@ public class JaegerProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupTracer(JaegerDeploymentRecorder jdr, JaegerBuildTimeConfig buildTimeConfig, JaegerConfig jaeger,
-            ApplicationConfig appConfig, Capabilities capabilities) {
+            ApplicationConfig appConfig, Capabilities capabilities, BuildProducer<MetricBuildItem> metricProducer) {
 
         // Indicates that this extension would like the SSL support to be enabled
         extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.JAEGER));
@@ -30,8 +36,8 @@ public class JaegerProcessor {
         if (buildTimeConfig.enabled) {
             boolean metricsEnabled = capabilities.isCapabilityPresent(Capabilities.METRICS)
                     && buildTimeConfig.metricsEnabled;
-
             if (metricsEnabled) {
+                produceMetrics(metricProducer);
                 jdr.registerTracerWithMetrics(jaeger, appConfig);
             } else {
                 jdr.registerTracerWithoutMetrics(jaeger, appConfig);
@@ -42,6 +48,53 @@ public class JaegerProcessor {
     @BuildStep
     public void build(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(FeatureBuildItem.JAEGER));
+    }
+
+    private void produceMetrics(BuildProducer<MetricBuildItem> producer) {
+        producer.produce(
+                metric("jaeger_tracer_baggage_restrictions_updates", MetricType.COUNTER, null, new Tag("result", "err")));
+        producer.produce(
+                metric("jaeger_tracer_baggage_restrictions_updates", MetricType.COUNTER, null, new Tag("result", "ok")));
+        producer.produce(metric("jaeger_tracer_baggage_truncations", MetricType.COUNTER, null));
+        producer.produce(metric("jaeger_tracer_baggage_updates", MetricType.COUNTER, null, new Tag("result", "err")));
+        producer.produce(metric("jaeger_tracer_baggage_updates", MetricType.COUNTER, null, new Tag("result", "ok")));
+        producer.produce(metric("jaeger_tracer_finished_spans", MetricType.COUNTER, null));
+        producer.produce(metric("jaeger_tracer_reporter_spans", MetricType.COUNTER, null, new Tag("result", "dropped")));
+        producer.produce(metric("jaeger_tracer_reporter_spans", MetricType.COUNTER, null, new Tag("result", "err")));
+        producer.produce(metric("jaeger_tracer_reporter_spans", MetricType.COUNTER, null, new Tag("result", "ok")));
+        producer.produce(metric("jaeger_tracer_sampler_queries", MetricType.COUNTER, null, new Tag("result", "err")));
+        producer.produce(metric("jaeger_tracer_sampler_queries", MetricType.COUNTER, null, new Tag("result", "ok")));
+        producer.produce(metric("jaeger_tracer_sampler_updates", MetricType.COUNTER, null, new Tag("result", "ok")));
+        producer.produce(metric("jaeger_tracer_sampler_updates", MetricType.COUNTER, null, new Tag("result", "err")));
+        producer.produce(metric("jaeger_tracer_span_context_decoding_errors", MetricType.COUNTER, null));
+        producer.produce(metric("jaeger_tracer_started_spans", MetricType.COUNTER, null, new Tag("sampled", "n")));
+        producer.produce(metric("jaeger_tracer_started_spans", MetricType.COUNTER, null, new Tag("sampled", "y")));
+        producer.produce(metric("jaeger_tracer_traces", MetricType.COUNTER, null,
+                new Tag("sampled", "y"), new Tag("state", "joined")));
+        producer.produce(metric("jaeger_tracer_traces", MetricType.COUNTER, null,
+                new Tag("sampled", "y"), new Tag("state", "started")));
+        producer.produce(metric("jaeger_tracer_traces", MetricType.COUNTER, null,
+                new Tag("sampled", "n"), new Tag("state", "joined")));
+        producer.produce(metric("jaeger_tracer_traces", MetricType.COUNTER, null,
+                new Tag("sampled", "n"), new Tag("state", "started")));
+        producer.produce(
+                metric("jaeger_tracer_reporter_queue_length", MetricType.GAUGE, new QuarkusJaegerMetricsFactory.JaegerGauge()));
+    }
+
+    private MetricBuildItem metric(String name, MetricType type, Object implementor, Tag... tags) {
+        Metadata metadata = Metadata.builder()
+                .withName(name)
+                .withDisplayName(name)
+                .withType(type)
+                .withUnit("none")
+                .withDescription(name)
+                .reusable()
+                .build();
+        if (implementor == null) {
+            return new MetricBuildItem(metadata, true, "jaeger", tags);
+        } else {
+            return new MetricBuildItem(metadata, implementor, true, "jaeger", tags);
+        }
     }
 
 }

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -28,7 +28,8 @@ public class JaegerProcessor {
         extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(FeatureBuildItem.JAEGER));
 
         if (buildTimeConfig.enabled) {
-            boolean metricsEnabled = capabilities.isCapabilityPresent(Capabilities.METRICS);
+            boolean metricsEnabled = capabilities.isCapabilityPresent(Capabilities.METRICS)
+                    && buildTimeConfig.metricsEnabled;
 
             if (metricsEnabled) {
                 jdr.registerTracerWithMetrics(jaeger, appConfig);

--- a/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/JaegerMetricsTestCase.java
+++ b/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/JaegerMetricsTestCase.java
@@ -1,0 +1,52 @@
+package io.quarkus.jaeger.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JaegerMetricsTestCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .withConfigurationResource("application-metrics-enabled.properties");
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    MetricRegistry registry;
+
+    /**
+     * We're not running a Jaeger instance to be able to test anything thoroughly,
+     * so just check that the metrics are registered after start.
+     */
+    @Test
+    public void test() {
+        Set<String> registeredMetrics = registry.getMetrics().keySet().stream().map(MetricID::getName)
+                .collect(Collectors.toSet());
+        assertTrue(registeredMetrics.contains("jaeger_tracer_baggage_restrictions_updates"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_baggage_updates"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_baggage_truncations"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_finished_spans"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_reporter_queue_length"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_reporter_spans"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_sampler_queries"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_sampler_updates"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_span_context_decoding_errors"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_started_spans"));
+        assertTrue(registeredMetrics.contains("jaeger_tracer_traces"));
+    }
+
+}

--- a/extensions/jaeger/deployment/src/test/resources/application-metrics-enabled.properties
+++ b/extensions/jaeger/deployment/src/test/resources/application-metrics-enabled.properties
@@ -1,0 +1,1 @@
+quarkus.jaeger.metrics.enabled=true

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerBuildTimeConfig.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerBuildTimeConfig.java
@@ -14,4 +14,10 @@ public class JaegerBuildTimeConfig {
     @ConfigItem(defaultValue = "true")
     public boolean enabled;
 
+    /**
+     * Whether or not metrics are published in case the smallrye-metrics extension is present.
+     */
+    @ConfigItem(name = "metrics.enabled", defaultValue = "false")
+    public boolean metricsEnabled;
+
 }

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/QuarkusJaegerMetricsFactory.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/QuarkusJaegerMetricsFactory.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Tag;
@@ -21,7 +22,7 @@ public class QuarkusJaegerMetricsFactory implements MetricsFactory {
 
     @Override
     public Counter createCounter(final String name, final Map<String, String> tags) {
-        org.eclipse.microprofile.metrics.Counter counter = registry.counter(meta(name, MetricType.COUNTER), toTagArray(tags));
+        org.eclipse.microprofile.metrics.Counter counter = registry.counter(name, toTagArray(tags));
 
         return new Counter() {
             @Override
@@ -33,7 +34,7 @@ public class QuarkusJaegerMetricsFactory implements MetricsFactory {
 
     @Override
     public Timer createTimer(final String name, final Map<String, String> tags) {
-        org.eclipse.microprofile.metrics.Timer timer = registry.timer(meta(name, MetricType.TIMER), toTagArray(tags));
+        org.eclipse.microprofile.metrics.Timer timer = registry.timer(name, toTagArray(tags));
 
         return new Timer() {
             @Override
@@ -45,7 +46,7 @@ public class QuarkusJaegerMetricsFactory implements MetricsFactory {
 
     @Override
     public Gauge createGauge(final String name, final Map<String, String> tags) {
-        JaegerGauge gauge = registry.register(meta(name, MetricType.GAUGE), new JaegerGauge(), toTagArray(tags));
+        JaegerGauge gauge = (JaegerGauge) registry.getGauges().get(new MetricID(name, toTagArray(tags)));
 
         return new Gauge() {
             @Override
@@ -72,7 +73,7 @@ public class QuarkusJaegerMetricsFactory implements MetricsFactory {
                 .build();
     }
 
-    static class JaegerGauge implements org.eclipse.microprofile.metrics.Gauge<Long> {
+    public static class JaegerGauge implements org.eclipse.microprofile.metrics.Gauge<Long> {
         private AtomicLong value = new AtomicLong();
 
         public void update(long value) {


### PR DESCRIPTION
- Eager registration of Jaeger metrics during build
- Ability to turn Jaeger metrics on/off using `quarkus.jaeger.metrics.enabled` property
- Plus a very dummy test for metrics. If you guys feel that it's not worth it I will remove it.

Fixes #8502