### PR TITLE
make security policy explicit

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report potential issues and vulnerabilities in Quarkus with details (e.g. steps to reproduce) to:
+
+    security@quarkus.io
+
+More information on Red Hat's [Security Contacts and Procedures page](https://access.redhat.com/security/team/contact/).


### PR DESCRIPTION

don't merge until `security@quarkus.io` email (or similar) is in place.

@emmanuelbernard @n1hility wdyt ? realized we didn't seem to have security policy documented anywhere so thought we should add it.

Can we create `security@quarkus.io` or do we have some existing alias users should use ? 