### PR TITLE
Revert maven-toolchain.version to 3.0-alpha-2

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -69,7 +69,7 @@
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
         <maven-core.version>3.6.3</maven-core.version>
         <maven-resolver.version>1.4.1</maven-resolver.version>
-        <maven-toolchain.version>3.0.0</maven-toolchain.version>
+        <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <guava.version>27.0.1-jre</guava.version>
         <plexus-utils.version>3.2.1</plexus-utils.version>
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>


### PR DESCRIPTION
3.0.0 does not actually exist. It was upgraded to 3.0.0 in #7459. I don't remember where I got it from.