### PR TITLE
Drop OIDC code flow query params before the endpoint is called

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -497,7 +497,14 @@ public class OidcTenantConfig {
          * the authentication will be restored after the user has been redirected back to the application.
          */
         @ConfigItem(defaultValue = "true")
-        public boolean restorePathAfterRedirect;
+        public boolean restorePathAfterRedirect = true;
+
+        /**
+         * Remove the query parameters such as 'code' and 'state' set by the OIDC server on the redirect URI
+         * after the user has authenticated by redirecting a user to the same URI but without the query parameters.
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean removeRedirectParameters = true;
 
         /**
          * List of scopes

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -83,6 +83,8 @@ public class HttpSecurityRecorder {
                             AuthenticationRedirectException redirectEx = (AuthenticationRedirectException) throwable;
                             event.response().setStatusCode(redirectEx.getCode());
                             event.response().headers().set(HttpHeaders.LOCATION, redirectEx.getRedirectUri());
+                            event.response().headers().set(HttpHeaders.CACHE_CONTROL, "no-store");
+                            event.response().headers().set("Pragma", "no-cache");
                             event.response().end();
                         } else {
                             event.fail(throwable);


### PR DESCRIPTION
Fixes #8259.

@pedroigor, @stuartwdouglas I've made this feature optional, it is one more redirect, and in most cases neither the user nor JAX-RS code will see these extra query parameters created by the OIDC server.

Please review, I won't merge it before Pedro's logout PR goes in and will rebase