### PR TITLE
Register BUILD_AND_RUN_TIME_FIXED and RUN_TIME config roots as beans

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.enterprise.context.Dependent;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -22,6 +24,7 @@ import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem;
+import io.quarkus.arc.processor.BeanRegistrar;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InjectionPointInfo;
@@ -30,7 +33,10 @@ import io.quarkus.arc.runtime.ConfigRecorder;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.configuration.definition.RootDefinition;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.smallrye.config.inject.ConfigProducer;
 
 /**
@@ -135,6 +141,25 @@ public class ConfigBuildStep {
                 groupingBy(ConfigPropertyBuildItem::getPropertyName,
                         mapping(c -> c.getPropertyType().name().toString(), toSet())));
         recorder.validateConfigProperties(propNamesToClasses);
+    }
+
+    @BuildStep
+    BeanRegistrarBuildItem registerConfigRootsAsBeans(ConfigurationBuildItem configItem) {
+        return new BeanRegistrarBuildItem(new BeanRegistrar() {
+            @Override
+            public void register(RegistrationContext context) {
+                for (RootDefinition rootDefinition : configItem.getReadResult().getAllRoots()) {
+                    if (rootDefinition.getConfigPhase() == ConfigPhase.BUILD_AND_RUN_TIME_FIXED
+                            || rootDefinition.getConfigPhase() == ConfigPhase.RUN_TIME) {
+                        context.configure(rootDefinition.getConfigurationClass()).types(rootDefinition.getConfigurationClass())
+                                .scope(Dependent.class).creator(mc -> {
+                                    // e.g. return Config.ApplicationConfig
+                                    mc.returnValue(mc.readStaticField(rootDefinition.getDescriptor()));
+                                }).done();
+                    }
+                }
+            }
+        });
     }
 
     private String getPropertyName(String name, ClassInfo declaringClass) {

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configroot/ConfigRootInjectionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configroot/ConfigRootInjectionTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.arc.test.configroot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.runtime.ThreadPoolConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigRootInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfigRootInjectionTest.class, Client.class));
+
+    @Inject
+    Client client;
+
+    @Test
+    public void testInjectionWorks() {
+        assertNotNull(client.applicationConfig);
+        assertNotNull(client.applicationConfig.name);
+        assertEquals(1, client.threadPoolConfig.coreThreads);
+    }
+
+    @Singleton
+    static class Client {
+
+        @Inject
+        ApplicationConfig applicationConfig;
+
+        @Inject
+        ThreadPoolConfig threadPoolConfig;
+
+    }
+
+}


### PR DESCRIPTION
- i.e. make them injectable

Motivation
-------------
Very often extensions register beans that need to access the runtime configuration (and BUILD_AND_RUN_TIME_FIXED). Currently, the only way how to accomplish this is to pass a root config through a recorder method. This has several disadvantages. First of all, you need to write more code. Morever, a bean instance is initialized after it's created. As a result, the bean state must be synchronized (volatile fields etc.). This may lead to errors where a bean client reads an uninitialized state.

Implementation note
---------------------------
For each BUILD_AND_RUN_TIME_FIXED and RUN_TIME config root a synthetic bean is registered. The bean has the `@Default` qualifier and the contextual instance is the value of a static field stored in the generated `Config` class, i.e. `return Config.ApplicationConfig`. This should be safe because bean instances are always created after the CDI container is started.