### PR TITLE
Change the "reactive route" extension name

### DIFF
--- a/extensions/vertx-web/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/vertx-web/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Eclipse Vert.x - Web"
+name: "Reactive Routes"
 metadata:
   keywords:
   - "eclipse"


### PR DESCRIPTION
Change the extension name to "Reactive Routes". Not perfect but better than the current one.

Related to: https://groups.google.com/d/msgid/quarkus-dev/13d0d843-7015-04e0-3c31-4fd4a4fb17a3%40redhat.com