### PR TITLE
Rename OIDC expiration-grace property to lifespan-grace

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -589,11 +589,14 @@ public class OidcTenantConfig {
         public Optional<List<String>> audience = Optional.empty();
 
         /**
-         * Expiration grace period in seconds. A token expiration time will be reduced by
-         * the value of this property before being compared to the current time.
+         * Life span grace period in seconds.
+         * When checking token expiry, current time is allowed to be later than token expiration time by at most the configured
+         * number of seconds.
+         * When checking token issuance, current time is allowed to be sooner than token issue time by at most the configured
+         * number of seconds.
          */
         @ConfigItem
-        public Optional<Integer> expirationGrace = Optional.empty();
+        public Optional<Integer> lifespanGrace = Optional.empty();
 
         /**
          * Name of the claim which contains a principal name. By default, the 'upn', 'preferred_username' and `sub` claims are
@@ -629,12 +632,12 @@ public class OidcTenantConfig {
             this.audience = Optional.of(audience);
         }
 
-        public Optional<Integer> getExpirationGrace() {
-            return expirationGrace;
+        public Optional<Integer> getLifespanGrace() {
+            return lifespanGrace;
         }
 
-        public void setExpirationGrace(int expirationGrace) {
-            this.expirationGrace = Optional.of(expirationGrace);
+        public void setLifespanGrace(int lifespanGrace) {
+            this.lifespanGrace = Optional.of(lifespanGrace);
         }
 
         public Optional<String> getPrincipalClaim() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -303,8 +303,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 .append(COOKIE_DELIM)
                 .append(result.opaqueRefreshToken()).toString());
         long maxAge = result.idToken().getLong("exp") - result.idToken().getLong("iat");
-        if (configContext.oidcConfig.token.expirationGrace.isPresent()) {
-            maxAge += configContext.oidcConfig.token.expirationGrace.get();
+        if (configContext.oidcConfig.token.lifespanGrace.isPresent()) {
+            maxAge += configContext.oidcConfig.token.lifespanGrace.get();
         }
         LOG.debugf("Session cookie 'max-age' parameter is set to %d", maxAge);
         cookie.setMaxAge(maxAge);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -83,9 +83,9 @@ public class OidcRecorder {
             options.setValidateIssuer(false);
         }
 
-        if (oidcConfig.getToken().getExpirationGrace().isPresent()) {
+        if (oidcConfig.getToken().getLifespanGrace().isPresent()) {
             JWTOptions jwtOptions = new JWTOptions();
-            jwtOptions.setLeeway(oidcConfig.getToken().getExpirationGrace().get());
+            jwtOptions.setLeeway(oidcConfig.getToken().getLifespanGrace().get());
             options.setJWTOptions(jwtOptions);
         }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -71,7 +71,7 @@ quarkus.oidc.tenant-logout.authentication.cookie-path=/tenant-logout
 quarkus.oidc.tenant-logout.logout.path=/tenant-logout/logout
 quarkus.oidc.tenant-logout.logout.post-logout-path=/tenant-logout/post-logout
 quarkus.oidc.tenant-logout.token.refresh-expired=true
-quarkus.oidc.tenant-logout.token.expiration-grace=120
+quarkus.oidc.tenant-logout.token.lifespan-grace=120
 
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated


### PR DESCRIPTION
Fixes #8627

I'm renaming it to `lifespan-grace` as somehow I'm not keen on `leeway` :-), it sounds a bit too generic. It is a minor issue though (can rename to `leeway` if preferred). Note we already use `jwt.lifespan` property for the `client_secret_jwt` so `lifespan-grace` seems not too bad.
Pedro's logout PR uses the `expiration-grace` property so I'll rebase once his PR is in and there will be a test too, we already have a few timeout tests so I'd rather not add another one yet.
It's better to fix this property name now as it is misleading.

I'm not sure it is worth keeping the `expiration-grace` as deprecated, the users are quite likely not aware that `iat` is affected by this property, so it feels the best action is to rename it and send a message.

@Ladicek, hi.

I'd rather not assign it some default value > 0, as we'll open a potential CVE, some user's app will be invoked by the stolen token few secs after the exp (which can happen with the leeway), they will start investigating and find out that it is our fault etc. I agree in many cases no one will probably care but I'd rather them set this property themselves :-)