### PR TITLE
Fix quarkus-quartz duplicating clustered jobs

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -56,7 +56,6 @@ public class QuartzScheduler implements Scheduler {
     private static final String INVOKER_KEY = "invoker";
 
     private final org.quartz.Scheduler scheduler;
-    private final AtomicInteger triggerNameSequence;
     private final Map<String, ScheduledInvoker> invokers;
 
     @Produces
@@ -68,12 +67,10 @@ public class QuartzScheduler implements Scheduler {
     public QuartzScheduler(SchedulerContext context, QuartzSupport quartzSupport, Config config) {
         if (!quartzSupport.getRuntimeConfig().forceStart && context.getScheduledMethods().isEmpty()) {
             LOGGER.infof("No scheduled business methods found - Quartz scheduler will not be started");
-            this.triggerNameSequence = null;
             this.scheduler = null;
             this.invokers = null;
 
         } else {
-            this.triggerNameSequence = new AtomicInteger();
             this.invokers = new HashMap<>();
 
             try {
@@ -92,6 +89,7 @@ public class QuartzScheduler implements Scheduler {
                 for (ScheduledMethodMetadata method : context.getScheduledMethods()) {
 
                     invokers.put(method.getInvokerClassName(), context.createInvoker(method.getInvokerClassName()));
+                    AtomicInteger triggerNameSequence = new AtomicInteger();
 
                     for (Scheduled scheduled : method.getSchedules()) {
                         String name = triggerNameSequence.getAndIncrement() + "_" + method.getInvokerClassName();

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -5,7 +5,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.Priority;
@@ -89,12 +88,15 @@ public class QuartzScheduler implements Scheduler {
                 for (ScheduledMethodMetadata method : context.getScheduledMethods()) {
 
                     invokers.put(method.getInvokerClassName(), context.createInvoker(method.getInvokerClassName()));
-                    AtomicInteger triggerNameSequence = new AtomicInteger();
+                    int nameSequence = 0;
 
                     for (Scheduled scheduled : method.getSchedules()) {
-                        String name = triggerNameSequence.getAndIncrement() + "_" + method.getInvokerClassName();
+                        String identity = scheduled.identity().trim();
+                        if (identity.isEmpty()) {
+                            identity = ++nameSequence + "_" + method.getInvokerClassName();
+                        }
                         JobBuilder jobBuilder = JobBuilder.newJob(InvokerJob.class)
-                                .withIdentity(name, Scheduler.class.getName())
+                                .withIdentity(identity, Scheduler.class.getName())
                                 .usingJobData(INVOKER_KEY, method.getInvokerClassName())
                                 .requestRecovery();
                         ScheduleBuilder<?> scheduleBuilder;
@@ -129,7 +131,7 @@ public class QuartzScheduler implements Scheduler {
                         }
 
                         TriggerBuilder<?> triggerBuilder = TriggerBuilder.newTrigger()
-                                .withIdentity(name + "_trigger", Scheduler.class.getName())
+                                .withIdentity(identity + "_trigger", Scheduler.class.getName())
                                 .withSchedule(scheduleBuilder);
 
                         Long millisToAdd = null;

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -6,7 +6,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Singleton;
 
@@ -165,6 +167,7 @@ public class SchedulerProcessor {
     void validateScheduledBusinessMethods(SchedulerConfig config, List<ScheduledBusinessMethodItem> scheduledMethods,
             ValidationPhaseBuildItem validationPhase, BuildProducer<ValidationErrorBuildItem> validationErrors) {
         List<Throwable> errors = new ArrayList<>();
+        Map<String, AnnotationInstance> encounteredIdentities = new HashMap<>();
 
         for (ScheduledBusinessMethodItem scheduledMethod : scheduledMethods) {
             MethodInfo method = scheduledMethod.getMethod();
@@ -185,7 +188,7 @@ public class SchedulerProcessor {
             // Validate cron() and every() expressions
             CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(config.cronType));
             for (AnnotationInstance scheduled : scheduledMethod.getSchedules()) {
-                Throwable error = validateScheduled(parser, scheduled);
+                Throwable error = validateScheduled(parser, scheduled, encounteredIdentities);
                 if (error != null) {
                     errors.add(error);
                 }
@@ -294,7 +297,8 @@ public class SchedulerProcessor {
         return generatedName.replace('/', '.');
     }
 
-    private Throwable validateScheduled(CronParser parser, AnnotationInstance schedule) {
+    private Throwable validateScheduled(CronParser parser, AnnotationInstance schedule,
+            Map<String, AnnotationInstance> encounteredIdentities) {
         AnnotationValue cronValue = schedule.value("cron");
         if (cronValue != null && !cronValue.asString().trim().isEmpty()) {
             String cron = cronValue.asString().trim();
@@ -342,6 +346,20 @@ public class SchedulerProcessor {
                     return new IllegalStateException("Invalid delayed() expression on: " + schedule, e);
                 }
             }
+        }
+
+        AnnotationValue identityValue = schedule.value("identity");
+        if (identityValue != null) {
+            String identity = identityValue.asString().trim();
+            AnnotationInstance previousInstanceWithSameIdentity = encounteredIdentities.get(identity);
+            if (previousInstanceWithSameIdentity != null) {
+                String message = String.format("The identity: \"%s\" on: %s is not unique and it has already bean used by : %s",
+                        identity, schedule, previousInstanceWithSameIdentity);
+                return new IllegalStateException(message);
+            } else {
+                encounteredIdentities.put(identity, schedule);
+            }
+
         }
         return null;
     }

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DuplicateJobIdentityTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DuplicateJobIdentityTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.scheduler.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateJobIdentityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(DeploymentException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Jobs.class));
+
+    @Test
+    public void test() {
+        fail("Should not reach here since job identity must be unique and a deployment exception should have been thrown");
+    }
+
+    static class Jobs {
+        @Scheduled(cron = "0/1 * * * * ?", identity = "identity")
+        void firstMethod() {
+        }
+
+        @Scheduled(cron = "0/1 * * * * ?", identity = "identity")
+        void secondMethod() {
+        }
+    }
+
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/Scheduled.java
@@ -40,6 +40,16 @@ import io.quarkus.scheduler.Scheduled.Schedules;
 public @interface Scheduled {
 
     /**
+     * Optionally defines a unique identifier for this job.
+     * <p>
+     * If the value is not given, Quarkus will generate a unique id.
+     * <p>
+     * 
+     * @return the unique identity of the schedule
+     */
+    String identity() default "";
+
+    /**
      * Defines a cron-like expression. For example "0 15 10 * * ?" fires at 10:15am every day.
      * <p>
      * If the value starts with "&#123;" and ends with "&#125;" the scheduler attempts to find a corresponding config property

--- a/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/Counter.java
+++ b/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/Counter.java
@@ -21,7 +21,7 @@ public class Counter {
         return counter.get();
     }
 
-    @Scheduled(cron = "0/1 * * * * ?")
+    @Scheduled(cron = "0/1 * * * * ?", identity = "counter")
     void increment() {
         counter.incrementAndGet();
     }


### PR DESCRIPTION
Fix #8661 

The first commit should fix the issue. Upon my attempt to reproduce it I came to a conclusion that this only occurs if you re-build the application but once the application is built, the name ("identity") is maintained across several runs as the list of triggers (methods) has already been recorded - during deployment time. 

/cc @mkouba @gsmet opening as draft to get feedback

/cc @brunobat & @joao-rafael-tdx this should address the issue.
