### PR TITLE
Disable the AMQP IT tests on Windows

### DIFF
--- a/integration-tests/reactive-messaging-amqp/src/test/java/io/quarkus/it/amqp/AmqpConnectorTest.java
+++ b/integration-tests/reactive-messaging-amqp/src/test/java/io/quarkus/it/amqp/AmqpConnectorTest.java
@@ -6,6 +6,8 @@ import static org.awaitility.Awaitility.await;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -13,6 +15,7 @@ import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
 @QuarkusTestResource(AmqpBroker.class)
+@DisabledOnOs(OS.WINDOWS)
 public class AmqpConnectorTest {
 
     protected static final TypeRef<List<Person>> TYPE_REF = new TypeRef<List<Person>>() {


### PR DESCRIPTION
We are hitting a disk space issue on Windows (on CI) making the test unreliable. 