### PR TITLE
Mongo Panache: avoid ClassInfo as keys in maps

### DIFF
--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheResourceProcessor.java
@@ -293,18 +293,17 @@ public class PanacheResourceProcessor {
             BuildProducer<PropertyMappingClassBuildStep> propertyMappingClass,
             BuildProducer<BytecodeTransformerBuildItem> transformers) {
         // manage @BsonProperty for the @ProjectionFor annotation
-        Map<ClassInfo, Map<String, String>> propertyMapping = new HashMap<>();
+        Map<DotName, Map<String, String>> propertyMapping = new HashMap<>();
         for (AnnotationInstance annotationInstance : index.getIndex().getAnnotations(DOTNAME_PROJECTION_FOR)) {
             Type targetClass = annotationInstance.value().asClass();
             ClassInfo target = index.getIndex().getClassByName(targetClass.name());
             Map<String, String> classPropertyMapping = new HashMap<>();
             extractMappings(classPropertyMapping, target, index);
-            propertyMapping.put(target, classPropertyMapping);
+            propertyMapping.put(targetClass.name(), classPropertyMapping);
         }
         for (AnnotationInstance annotationInstance : index.getIndex().getAnnotations(DOTNAME_PROJECTION_FOR)) {
             Type targetClass = annotationInstance.value().asClass();
-            ClassInfo target = index.getIndex().getClassByName(targetClass.name());
-            Map<String, String> targetPropertyMapping = propertyMapping.get(target);
+            Map<String, String> targetPropertyMapping = propertyMapping.get(targetClass.name());
             if (targetPropertyMapping != null && !targetPropertyMapping.isEmpty()) {
                 ClassInfo info = annotationInstance.target().asClass();
                 ProjectionForEnhancer fieldEnhancer = new ProjectionForEnhancer(targetPropertyMapping);
@@ -313,7 +312,7 @@ public class PanacheResourceProcessor {
 
             // Register for building the property mapping cache
             propertyMappingClass
-                    .produce(new PropertyMappingClassBuildStep(target.name().toString(),
+                    .produce(new PropertyMappingClassBuildStep(targetClass.name().toString(),
                             annotationInstance.target().asClass().name().toString()));
         }
     }


### PR DESCRIPTION
Since it implements neither equals nor hashCode.