### PR TITLE
Enable epic maker workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -13,5 +13,10 @@ assignees: ''
 ### Analysis
 (links to analysis docs containing architecture design work, requirements gathering, etc)
 
-### Tasks
-- [ ] _Checklist of sub tasks goes here, represented as links to GitHub issues_
+<!-- task list will be automatically generated from below. 
+     Just add issue references, i.e. #23, #458 and it will
+     be picked up.
+ >
+<!-- EPIC:DATA
+     
+-->

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -8,8 +8,8 @@ jobs:
       runs-on: ubuntu-latest
       name: auto label
       steps:
-      - name: Debug Action
-        uses: hmarr/debug-action@v1.0.0
+#      - name: Debug Action
+#        uses: hmarr/debug-action@v1.0.0
       - name: issuelabeler
         continue-on-error: true
         uses: docker://maxandersen/jbang-issuelabeler

--- a/.github/workflows/epicissues.yml
+++ b/.github/workflows/epicissues.yml
@@ -1,0 +1,18 @@
+name: "Epic issue lists"
+on:
+    issues:
+      types: [opened, edited, labeled]
+
+jobs:
+    autolabel:
+      runs-on: ubuntu-latest
+      name: auto label
+      steps:
+#      - name: Debug Action
+#        uses: hmarr/debug-action@v1.0.0
+      - name: epicmaker
+        uses: docker://maxandersen/jbang-epic-maker
+        env:
+          GITHUB_TOKEN: ${{ secrets.ISSUE_GITHUB_TOKEN }}
+          BOTNAME: quarkusbot
+          EPICLABEL: kind/epic


### PR DESCRIPTION
when committed then issues with label `kind/epic` will on
open/edit/labeling have
a section like:

```
<!-- EPIC:DATA
       #23 #445 #44
-->
```

Expanded to a task list with link to issue + title header.

the checkbox will reflect wether open or closed at the time of
edit of the issue.
(we can potentially improve that in future)

Includes update to epic template and disables debug printing as
to speed things up a bit.