### PR TITLE
Bump jboss-threads from 3.0.1.Final to 3.1.0.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -100,7 +100,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.11.3.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
-        <jboss-threads.version>3.0.1.Final</jboss-threads.version>
+        <jboss-threads.version>3.1.0.Final</jboss-threads.version>
         <vertx.version>3.8.5</vertx.version>
         <httpclient.version>4.5.12</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>


### PR DESCRIPTION
JBoss-Threads 3.1.0.Final includes improvement to the EnhancedQueueExecutor that improves throughput performance;


Worker Pool - 16 HW threads | 1.3.1.Final | PR
-- | -- | --
Max Throughput (req/sec) | 79,919.2 | 139,835.9
Mean CPU % | 46.85% | 89.86%

