### PR TITLE
Add gradle wrapper into platform-descriptor

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -15,6 +15,8 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -47,6 +49,7 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.cli.commands.AddExtensions;
 import io.quarkus.cli.commands.CreateProject;
 import io.quarkus.cli.commands.writer.FileProjectWriter;
+import io.quarkus.cli.commands.writer.ProjectWriter;
 import io.quarkus.generators.BuildTool;
 import io.quarkus.generators.SourceType;
 import io.quarkus.maven.components.MavenVersionEnforcer;
@@ -221,7 +224,7 @@ public class CreateProjectMojo extends AbstractMojo {
             if (BuildTool.MAVEN.equals(buildToolEnum)) {
                 createMavenWrapper(createdDependenciesBuildFile, ToolsUtils.readQuarkusProperties(platform));
             } else if (BuildTool.GRADLE.equals(buildToolEnum)) {
-                createGradleWrapper(buildFile.getParentFile(), ToolsUtils.readQuarkusProperties(platform));
+                createGradleWrapper(platform, projectWriter);
             }
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to generate Quarkus project", e);
@@ -234,27 +237,27 @@ public class CreateProjectMojo extends AbstractMojo {
         }
     }
 
-    private void createGradleWrapper(File projectDirectory, Properties props) {
+    private void createGradleWrapper(QuarkusPlatformDescriptor platform,
+            ProjectWriter writer) {
         try {
-            String gradleName = IS_WINDOWS ? "gradle.bat" : "gradle";
-            ProcessBuilder pb = new ProcessBuilder(gradleName, "wrapper",
-                    "--gradle-version=" + ToolsUtils.getGradleWrapperVersion(props)).directory(projectDirectory)
-                            .inheritIO();
-            Process x = pb.start();
+            writer.mkdirs("gradle/wrapper");
 
-            x.waitFor();
-
-            if (x.exitValue() != 0) {
-                getLog().warn("Unable to install the Gradle wrapper (./gradlew) in project. See log for details.");
+            for (String filename : CreateUtils.GRADLE_WRAPPER_FILES) {
+                byte[] fileContent = platform.loadResource(Paths.get(CreateUtils.GRADLE_WRAPPER_PATH, filename).toString(),
+                        is -> {
+                            byte[] buffer = new byte[is.available()];
+                            is.read(buffer);
+                            return buffer;
+                        });
+                final Path destination = writer.getProjectFolder().toPath().resolve(filename);
+                Files.write(destination, fileContent);
             }
 
-        } catch (InterruptedException | IOException e) {
-            // no reason to fail if the wrapper could not be created
-            getLog().error(
-                    "Unable to install the Gradle wrapper (./gradlew) in the project. You need to have gradle installed to generate the wrapper files.",
-                    e);
+            new File(writer.getProjectFolder(), "gradlew").setExecutable(true);
+            new File(writer.getProjectFolder(), "gradlew.bat").setExecutable(true);
+        } catch (IOException e) {
+            getLog().error("Unable to copy Gradle wrapper from platform descriptor", e);
         }
-
     }
 
     private void createMavenWrapper(File createdPomFile, Properties props) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -31,6 +31,14 @@ public final class CreateUtils {
     public static final String QUARKUS_CORE_BOM_ARTIFACT_ID = "quarkus-bom";
     public static final String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = QUARKUS_CORE_BOM_ARTIFACT_ID;
 
+    public static final String GRADLE_WRAPPER_PATH = "gradle-wrapper";
+    public static final String[] GRADLE_WRAPPER_FILES = new String[] {
+            "gradlew",
+            "gradlew.bat",
+            "gradle/wrapper/gradle-wrapper.properties",
+            "gradle/wrapper/gradle-wrapper.jar"
+    };
+
     private CreateUtils() {
         //Not to be constructed
     }

--- a/devtools/platform-descriptor-json/pom.xml
+++ b/devtools/platform-descriptor-json/pom.xml
@@ -13,6 +13,11 @@
     <artifactId>quarkus-platform-descriptor-json</artifactId>
     <name>Quarkus - Dev tools - Platform Descriptor - JSON</name>
 
+    <properties>
+        <gradle-wrapper.path>${project.basedir}/../gradle</gradle-wrapper.path>
+        <gradle.executable>gradlew</gradle.executable>
+    </properties>
+
     <build>
         <resources>
             <resource>
@@ -65,6 +70,29 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-gradle-wrapper</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <executable>${gradle-wrapper.path}/${gradle.executable}</executable>
+                            <arguments>
+                                <argument>wrapper</argument>
+                                <argument>--gradle-version</argument>
+                                <argument>${gradle-wrapper.version}</argument>
+                            </arguments>
+                            <workingDirectory>target/classes/gradle-wrapper</workingDirectory>
+                            <addOutputToClasspath>true</addOutputToClasspath>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -88,11 +116,24 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-            <dependency>
-      	      <groupId>org.junit.jupiter</groupId>
-              <artifactId>junit-jupiter</artifactId>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <gradle.executable>gradlew.bat</gradle.executable>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
When generating a project with gradle as build tool, the wrapper is generated using the `gradle wrapper` command. If gradle is not installed on the machine, the project creation will fail.

This branch adds a fallback such as, in case of failure, gradle wrapper's files are copied from `platform-descriptor-json` artifact. 

Gradle wrapper's file are embedded in the `platform-descriptor-json` artifact at build time. 

This branch can be tested using a docker container: 

    docker run --rm -v ~/.m2:/root/.m2 maven:3.6.3-jdk-11 mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create \
                -DprojectGroupId=org.acme \
                -DprojectArtifactId=my-gradle-project \        
                -DclassName="org.acme.quickstart.GreetingResource" \
                -DplatformArtifactId=quarkus-bom \
                -Dpath="/hello" \
                -DbuildTool=gradle

close #4982 
