### PR TITLE
Always use "all" distribution when upgrading the wrapper in the Gradle plugin

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -84,3 +84,7 @@ check {
     // Run the functional tests as part of `check`
     dependsOn(tasks.functionalTest)
 }
+
+wrapper {
+    distributionType = Wrapper.DistributionType.ALL
+}


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/gradle_wrapper.html#customizing_wrapper