### PR TITLE
Fix broken Kafka Quickstarts

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -105,6 +105,10 @@ public class KafkaProcessor {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, RangeAssignor.class.getName()));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, RoundRobinAssignor.class.getName()));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, StickyAssignor.class.getName()));
+
+        // classes needed to perform reflection on DirectByteBuffer - only really needed for Java 8
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "java.nio.DirectByteBuffer"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "sun.misc.Cleaner"));
     }
 
     private static void collectImplementors(Set<DotName> set, CombinedIndexBuildItem indexBuildItem, Class<?> cls) {

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/ByteBufferUnmapper.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/ByteBufferUnmapper.java
@@ -1,0 +1,32 @@
+package io.quarkus.kafka.client.runtime.graal;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.utils.ByteBufferUnmapper;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK8OrEarlier;
+
+@TargetClass(value = ByteBufferUnmapper.class, onlyWith = JDK8OrEarlier.class)
+final class Target_org_apache_kafka_common_utils_ByteBufferUnmapper {
+
+    @Substitute
+    public static void unmap(String resourceDescription, ByteBuffer buffer) throws IOException {
+        if (!buffer.isDirect())
+            throw new IllegalArgumentException("Unmapping only works with direct buffers");
+        try {
+            Method cleanerMethod = buffer.getClass().getMethod("cleaner");
+            cleanerMethod.setAccessible(true);
+            Object cleaner = cleanerMethod.invoke(buffer);
+            Method cleanMethod = cleaner.getClass().getMethod("clean");
+            cleanMethod.setAccessible(true);
+            cleanMethod.invoke(cleaner);
+        } catch (Throwable t) {
+            throw new IOException("Unable to unmap the mapped buffer: " + resourceDescription, t);
+        }
+
+    }
+}


### PR DESCRIPTION
Fix broken Kafka Quickstarts

This problem was introduced by our bump to Kafka 2.5.
The substitution uses simple reflection to invoke the cleaner
on a DirectByteBuffer