### PR TITLE
Update Netty to 4.1.49

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -160,17 +160,8 @@ jobs:
       - name: Set up JDK ${{ matrix.java-version }}
         # Uses sha for added security since tags can be updated
         uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
-        if: matrix.java-version != '8'
         with:
           java-version: ${{ matrix.java-version }}
-
-      - name: Set up JDK ${{ matrix.java-version }}
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
-        if: matrix.java-version == '8'
-        with:
-          java-version: ${{ matrix.java-version }}
-          release: jdk8u242-b08
 
       - name: Download Maven Repo
         uses: actions/download-artifact@v1

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -122,7 +122,7 @@
         <infinispan.version>10.1.5.Final</infinispan.version>
         <infinispan.protostream.version>4.3.2.Final</infinispan.protostream.version>
         <caffeine.version>2.8.0</caffeine.version>
-        <netty.version>4.1.48.Final</netty.version>
+        <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <test-containers.version>1.12.4</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -97,7 +97,7 @@ final class Target_io_netty_handler_ssl_JdkAlpnApplicationProtocolNegotiator_Alp
     @Substitute
     public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
             JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
-        return (SSLEngine) (Object) new Target_io_netty_handler_ssl_Java9SslEngine(engine, applicationNegotiator, isServer);
+        return (SSLEngine) (Object) new Target_io_netty_handler_ssl_JdkAlpnSslEngine(engine, applicationNegotiator, isServer);
     }
 
 }
@@ -139,10 +139,10 @@ final class Target_io_netty_handler_ssl_JettyAlpnSslEngine {
     }
 }
 
-@TargetClass(className = "io.netty.handler.ssl.Java9SslEngine", onlyWith = JDK11OrLater.class)
-final class Target_io_netty_handler_ssl_Java9SslEngine {
+@TargetClass(className = "io.netty.handler.ssl.JdkAlpnSslEngine", onlyWith = JDK11OrLater.class)
+final class Target_io_netty_handler_ssl_JdkAlpnSslEngine {
     @Alias
-    Target_io_netty_handler_ssl_Java9SslEngine(final SSLEngine engine,
+    Target_io_netty_handler_ssl_JdkAlpnSslEngine(final SSLEngine engine,
             final JdkApplicationProtocolNegotiator applicationNegotiator, final boolean isServer) {
 
     }


### PR DESCRIPTION
Netty 4.1.49 contains the ALPN fix and would allow running Quarkus HTTP/2 application on JAva 8 (251+). 

This PR lose revert the selection of a specific Java 8 build as the backporting of ALPN in Java 8 251+ broke Netty and so Quarkus build on Java 8. 