### PR TITLE
Avoid NPE in QuarkusProdModeTest when bootstrap fails

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -541,7 +541,9 @@ public class QuarkusProdModeTest
         }
 
         try {
-            curatedApplication.close();
+            if (curatedApplication != null) {
+                curatedApplication.close();
+            }
         } finally {
             timeoutTask.cancel();
             timeoutTask = null;


### PR DESCRIPTION
Alexey is tracking the bootstrap issue but in the meantime let's avoid a NPE when the bootstrap fails.