### PR TITLE
Fix elytron-security performance issue due to missing bean scope

### DIFF
--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/DefaultRoleDecoder.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/DefaultRoleDecoder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -20,6 +21,7 @@ import org.wildfly.security.authz.Roles;
  * an application specific implementation of {@link RoleDecoder}, if provided.
  * 
  */
+@ApplicationScoped
 public class DefaultRoleDecoder {
 
     @ConfigProperty(name = "quarkus.security.roles-claim-name", defaultValue = "groups")


### PR DESCRIPTION
The DefaultRoleDecoder has no CDI scope so it is insantiated for each request.
As it reads a propety at initialization time, this is very costly.

Adding `@ApplicationScoped` annotation to it lower the cost of security in one of my profile from 5.7% of frames to 1.3%

All other elytron security related beans are `@ApplicationScoped` and reading the code this should be safe.