### PR TITLE
Add commons-compress to kubernetes-client to avoid TypeNotPresentException for TarArchiveInputStream

### DIFF
--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -53,6 +53,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>


### PR DESCRIPTION
Add commons-compress to kubernetes-client to avoid TypeNotPresentException for TarArchiveInputStream. commons-compress already defined since https://github.com/quarkusio/quarkus/pull/8317

Regression comparing to 1.3.2.Final

Noticed via https://github.com/quarkus-qe/quarkus-openshift-test-suite/ on sql-db tests which can't be compiled with current master, running `mvn clean install -DskipTests -DskipITs` is enough to see the issue.

```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:build (default) on project sql-db-postgresql: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR] 	[error]: Build step io.quarkus.deployment.steps.ClassTransformingBuildStep#handleClassTransformation threw an exception: java.lang.IllegalStateException: java.util.concurrent.ExecutionException: java.lang.TypeNotPresentException: Type org/apache/commons/compress/archivers/tar/TarArchiveInputStream not present
[ERROR] 	at io.quarkus.deployment.ExtensionLoader$2.execute(ExtensionLoader.java:940)
[ERROR] 	at io.quarkus.builder.BuildContext.run(BuildContext.java:277)
[ERROR] 	at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2019)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1558)
[ERROR] 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1449)
[ERROR] 	at java.lang.Thread.run(Thread.java:748)
[ERROR] 	at org.jboss.threads.JBossThread.run(JBossThread.java:479)
[ERROR] Caused by: java.util.concurrent.ExecutionException: java.lang.TypeNotPresentException: Type org/apache/commons/compress/archivers/tar/TarArchiveInputStream not present
```