### PR TITLE
Fix issue with config beans in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LiveReloadBuildItem.java
@@ -38,6 +38,9 @@ public final class LiveReloadBuildItem extends SimpleBuildItem {
      * If this is a reload of an app in the same JVM then this will return true. If it is the first
      * time this app has started, or the app is not running in developer mode it will return false.
      *
+     * Note that unsuccessful attempts to start are not counted, if if the app initially failed to start
+     * the next attempt this will still return false.
+     *
      * @return <code>true</code> if this is a live reload
      */
     public boolean isLiveReload() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -98,6 +98,8 @@ public final class RunTimeConfigurationGenerator {
             "runTimeDefaultsConfigSource", ConfigSource.class);
     static final MethodDescriptor C_BOOTSTRAP_CONFIG = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME, "readBootstrapConfig",
             void.class);
+    public static final MethodDescriptor REINIT = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME, "reinit",
+            void.class);
     public static final MethodDescriptor C_READ_CONFIG = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME, "readConfig", void.class,
             List.class);
     static final FieldDescriptor C_SPECIFIED_RUN_TIME_CONFIG_SOURCE = FieldDescriptor.of(CONFIG_CLASS_NAME,
@@ -233,16 +235,19 @@ public final class RunTimeConfigurationGenerator {
     }
 
     public static void generate(BuildTimeConfigurationReader.ReadResult readResult, final ClassOutput classOutput,
+            boolean devMode,
             final Map<String, String> runTimeDefaults, List<Class<?>> additionalTypes) {
-        new GenerateOperation.Builder().setBuildTimeReadResult(readResult).setClassOutput(classOutput)
+        new GenerateOperation.Builder().setBuildTimeReadResult(readResult).setClassOutput(classOutput).setDevMode(devMode)
                 .setRunTimeDefaults(runTimeDefaults).setAdditionalTypes(additionalTypes).build().run();
     }
 
     static final class GenerateOperation implements AutoCloseable {
+        final boolean devMode;
         final AccessorFinder accessorFinder;
         final ClassOutput classOutput;
         final ClassCreator cc;
         final MethodCreator clinit;
+        final MethodCreator reinit;
         final BytecodeCreator converterSetup;
         final MethodCreator readBootstrapConfig;
         final ResultHandle readBootstrapConfigNameBuilder;
@@ -280,6 +285,7 @@ public final class RunTimeConfigurationGenerator {
         int converterIndex = 0;
 
         GenerateOperation(Builder builder) {
+            this.devMode = builder.devMode;
             final BuildTimeConfigurationReader.ReadResult buildTimeReadResult = builder.buildTimeReadResult;
             buildTimeConfigResult = Assert.checkNotNullParam("buildTimeReadResult", buildTimeReadResult);
             specifiedRunTimeDefaultValues = Assert.checkNotNullParam("specifiedRunTimeDefaultValues",
@@ -296,6 +302,12 @@ public final class RunTimeConfigurationGenerator {
                 mc.setModifiers(Opcodes.ACC_PRIVATE);
                 mc.invokeSpecialMethod(MethodDescriptor.ofConstructor(Object.class), mc.getThis());
                 mc.returnValue(null);
+            }
+            if (devMode) {
+                reinit = cc.getMethodCreator(REINIT);
+                reinit.setModifiers(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC);
+            } else {
+                reinit = null;
             }
 
             // create <clinit>
@@ -385,6 +397,30 @@ public final class RunTimeConfigurationGenerator {
             // make the build time config global until we read the run time config -
             // at run time (when we're ready) we update the factory and then release the build time config
             installConfiguration(clinitConfig, clinit);
+            if (devMode) {
+                final ResultHandle buildTimeRunTimeDefaultValuesConfigSource = reinit
+                        .readStaticField(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE);
+                // create the map for build time config source
+                final ResultHandle buildTimeValues = reinit.newInstance(HM_NEW);
+                for (Map.Entry<String, String> entry : buildTimeRunTimeVisibleValues.entrySet()) {
+                    reinit.invokeVirtualMethod(HM_PUT, buildTimeValues, reinit.load(entry.getKey()),
+                            reinit.load(entry.getValue()));
+                }
+                final ResultHandle buildTimeConfigSource = reinit.newInstance(PCS_NEW, buildTimeValues,
+                        reinit.load("Build time config = Reloaded"), reinit.load(100));
+                // the build time config, which is for user use only (not used by us other than for loading converters)
+                final ResultHandle buildTimeBuilder = reinit.invokeStaticMethod(CU_CONFIG_BUILDER, reinit.load(true));
+                final ResultHandle array = reinit.newArray(ConfigSource[].class, 2);
+                // build time values
+                reinit.writeArrayValue(array, 0, buildTimeConfigSource);
+                // build time defaults
+                reinit.writeArrayValue(array, 1, buildTimeRunTimeDefaultValuesConfigSource);
+                reinit.invokeVirtualMethod(SRCB_WITH_SOURCES, buildTimeBuilder, array);
+                ResultHandle clinitConfig = reinit.checkCast(reinit.invokeVirtualMethod(SRCB_BUILD, buildTimeBuilder),
+                        SmallRyeConfig.class);
+                installConfiguration(clinitConfig, reinit);
+                reinit.returnValue(null);
+            }
 
             // fill roots map
             for (RootDefinition root : roots) {
@@ -428,9 +464,14 @@ public final class RunTimeConfigurationGenerator {
 
             // create the map for run time specified values config source
             final ResultHandle specifiedRunTimeValues = clinit.newInstance(HM_NEW);
-            for (Map.Entry<String, String> entry : specifiedRunTimeDefaultValues.entrySet()) {
-                clinit.invokeVirtualMethod(HM_PUT, specifiedRunTimeValues, clinit.load(entry.getKey()),
-                        clinit.load(entry.getValue()));
+            if (!devMode) {
+                //we don't need these in devmode
+                //including it would just cache the first values
+                //but these can already just be read directly, as we are in the same JVM
+                for (Map.Entry<String, String> entry : specifiedRunTimeDefaultValues.entrySet()) {
+                    clinit.invokeVirtualMethod(HM_PUT, specifiedRunTimeValues, clinit.load(entry.getKey()),
+                            clinit.load(entry.getValue()));
+                }
             }
             for (Map.Entry<String, String> entry : runTimeDefaults.entrySet()) {
                 if (!specifiedRunTimeDefaultValues.containsKey(entry.getKey())) {
@@ -441,7 +482,8 @@ public final class RunTimeConfigurationGenerator {
             }
             final ResultHandle specifiedRunTimeSource = clinit.newInstance(PCS_NEW, specifiedRunTimeValues,
                     clinit.load("Specified default values"), clinit.load(Integer.MIN_VALUE + 100));
-            cc.getFieldCreator(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE).setModifiers(Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
+            cc.getFieldCreator(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE)
+                    .setModifiers(Opcodes.ACC_STATIC | (devMode ? Opcodes.ACC_VOLATILE : Opcodes.ACC_FINAL));
             clinit.writeStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE, specifiedRunTimeSource);
 
             // add in the custom sources that bootstrap config needs
@@ -557,11 +599,12 @@ public final class RunTimeConfigurationGenerator {
                 // specific actions based on config phase
                 String rootName = root.getRootName();
                 if (root.getConfigPhase() == ConfigPhase.BUILD_AND_RUN_TIME_FIXED) {
-                    // config root field is final; we initialize it from clinit
+                    // config root field is volatile in dev mode, final otherwise; we initialize it from clinit, and readConfig in dev mode
                     cc.getFieldCreator(rootFieldDescriptor)
-                            .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
+                            .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC
+                                    | (devMode ? Opcodes.ACC_VOLATILE : Opcodes.ACC_FINAL));
                     // construct instance in <clinit>
-                    final ResultHandle instance = clinit.invokeStaticMethod(ctor);
+                    ResultHandle instance = clinit.invokeStaticMethod(ctor);
                     // assign instance to field
                     clinit.writeStaticField(rootFieldDescriptor, instance);
                     instanceCache.put(rootFieldDescriptor, instance);
@@ -572,6 +615,19 @@ public final class RunTimeConfigurationGenerator {
                     }
                     clinit.invokeStaticMethod(initGroup, clinitConfig, clinitNameBuilder, instance);
                     clinit.invokeVirtualMethod(SB_SET_LENGTH, clinitNameBuilder, clInitOldLen);
+                    if (devMode) {
+                        //we don't regenerate this class in dev mode, but we do allow config to be reloaded
+                        instance = readConfig.invokeStaticMethod(ctor);
+                        // assign instance to field
+                        readConfig.writeStaticField(rootFieldDescriptor, instance);
+                        if (!rootName.isEmpty()) {
+                            readConfig.invokeVirtualMethod(SB_APPEND_CHAR, readConfigNameBuilder, readConfig.load('.'));
+                            readConfig.invokeVirtualMethod(SB_APPEND_STRING, readConfigNameBuilder,
+                                    readConfig.load(rootName));
+                        }
+                        readConfig.invokeStaticMethod(initGroup, runTimeConfig, readConfigNameBuilder, instance);
+                        readConfig.invokeVirtualMethod(SB_SET_LENGTH, readConfigNameBuilder, rcOldLen);
+                    }
                 } else if (root.getConfigPhase() == ConfigPhase.BOOTSTRAP) {
                     if (bootstrapConfigSetupNeeded()) {
                         // config root field is volatile; we initialize and read config from the readBootstrapConfig method
@@ -1362,6 +1418,7 @@ public final class RunTimeConfigurationGenerator {
         }
 
         static final class Builder {
+            private boolean devMode;
             private ClassOutput classOutput;
             private BuildTimeConfigurationReader.ReadResult buildTimeReadResult;
             private Map<String, String> runTimeDefaults;
@@ -1403,6 +1460,15 @@ public final class RunTimeConfigurationGenerator {
 
             Builder setAdditionalTypes(final List<Class<?>> additionalTypes) {
                 this.additionalTypes = additionalTypes;
+                return this;
+            }
+
+            public boolean isDevMode() {
+                return devMode;
+            }
+
+            public Builder setDevMode(boolean devMode) {
+                this.devMode = devMode;
                 return this;
             }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -52,6 +52,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
     private static volatile CuratedApplication curatedApplication;
     private static volatile AugmentAction augmentAction;
     private static volatile boolean restarting;
+    private static volatile boolean firstStartCompleted;
 
     private synchronized void firstStart() {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
@@ -85,6 +86,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                             }
                         });
                 runner = start.runMainClass(context.getArgs());
+                firstStartCompleted = true;
             } catch (Throwable t) {
                 deploymentProblem = t;
                 if (context.isAbortOnFailedStart()) {
@@ -127,8 +129,9 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
 
             //ok, we have resolved all the deps
             try {
-                StartupAction start = augmentAction.reloadExistingApplication(changedResources);
+                StartupAction start = augmentAction.reloadExistingApplication(firstStartCompleted, changedResources);
                 runner = start.runMainClass(context.getArgs());
+                firstStartCompleted = true;
             } catch (Throwable t) {
                 deploymentProblem = t;
                 log.error("Failed to start quarkus", t);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigBuildSteps.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigBuildSteps.java
@@ -16,6 +16,7 @@ import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationSourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -36,8 +37,12 @@ class ConfigBuildSteps {
 
     @BuildStep
     void generateConfigSources(List<RunTimeConfigurationSourceBuildItem> runTimeSources,
-            final BuildProducer<GeneratedClassBuildItem> generatedClass) {
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+            final BuildProducer<GeneratedClassBuildItem> generatedClass,
+            LiveReloadBuildItem liveReloadBuildItem) {
+        if (liveReloadBuildItem.isLiveReload()) {
+            return;
+        }
+        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, false);
 
         try (ClassCreator cc = ClassCreator.builder().interfaces(ConfigSourceProvider.class).setFinal(true)
                 .className(PROVIDER_CLASS_NAME)

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -11,10 +11,13 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.ConfigurationTypeBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
 import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.runtime.LaunchMode;
 
 public class ConfigGenerationBuildStep {
 
@@ -24,7 +27,12 @@ public class ConfigGenerationBuildStep {
     @BuildStep
     void generateConfigClass(ConfigurationBuildItem configItem, List<RunTimeConfigurationDefaultBuildItem> runTimeDefaults,
             List<ConfigurationTypeBuildItem> typeItems,
-            BuildProducer<GeneratedClassBuildItem> generatedClass) {
+            LaunchModeBuildItem launchModeBuildItem,
+            BuildProducer<GeneratedClassBuildItem> generatedClass,
+            LiveReloadBuildItem liveReloadBuildItem) {
+        if (liveReloadBuildItem.isLiveReload()) {
+            return;
+        }
         BuildTimeConfigurationReader.ReadResult readResult = configItem.getReadResult();
         Map<String, String> defaults = new HashMap<>();
         for (RunTimeConfigurationDefaultBuildItem item : runTimeDefaults) {
@@ -35,8 +43,9 @@ public class ConfigGenerationBuildStep {
         List<Class<?>> additionalConfigTypes = typeItems.stream().map(ConfigurationTypeBuildItem::getValueType)
                 .collect(Collectors.toList());
 
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
+        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, false);
 
-        RunTimeConfigurationGenerator.generate(readResult, classOutput, defaults, additionalConfigTypes);
+        RunTimeConfigurationGenerator.generate(readResult, classOutput,
+                launchModeBuildItem.getLaunchMode() == LaunchMode.DEVELOPMENT, defaults, additionalConfigTypes);
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -61,7 +61,7 @@ public class AugmentActionImpl implements AugmentAction {
     /**
      * A map that is shared between all re-runs of the same augment instance. This is
      * only really relevant in dev mode, however it is present in all modes for consistency.
-     * 
+     *
      */
     private final Map<Class<?>, Object> reloadContext = new ConcurrentHashMap<>();
 
@@ -134,12 +134,12 @@ public class AugmentActionImpl implements AugmentAction {
     }
 
     @Override
-    public StartupActionImpl reloadExistingApplication(Set<String> changedResources) {
+    public StartupActionImpl reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources) {
         if (launchMode != LaunchMode.DEVELOPMENT) {
             throw new IllegalStateException("Only application with launch mode DEVELOPMENT can restart");
         }
         ClassLoader classLoader = curatedApplication.createDeploymentClassLoader();
-        BuildResult result = runAugment(false, changedResources, classLoader, GeneratedClassBuildItem.class,
+        BuildResult result = runAugment(!hasStartedSuccessfully, changedResources, classLoader, GeneratedClassBuildItem.class,
                 GeneratedResourceBuildItem.class, BytecodeTransformerBuildItem.class, ApplicationClassNameBuildItem.class);
         return new StartupActionImpl(curatedApplication, result, classLoader);
     }

--- a/extensions/flyway/deployment/pom.xml
+++ b/extensions/flyway/deployment/pom.xml
@@ -44,6 +44,16 @@
             <artifactId>quarkus-jdbc-h2-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/DevModeTestEndpoint.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/DevModeTestEndpoint.java
@@ -1,0 +1,22 @@
+package io.quarkus.flyway.test;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.flywaydb.core.Flyway;
+
+@Path("/fly")
+public class DevModeTestEndpoint {
+
+    @Inject
+    Instance<Flyway> flyway;
+
+    @GET
+    public boolean present() {
+        flyway.get();
+        return true;
+    }
+
+}

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayDevModeTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.flyway.test;
+
+import java.util.function.Function;
+
+import org.flywaydb.core.Flyway;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Flyway needs a datasource to work.
+ * This tests assures, that an error occurs,
+ * as soon as the default flyway configuration points to an missing default datasource.
+ */
+public class FlywayDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DevModeTestEndpoint.class)
+                    .addAsResource("db/migration/V1.0.0__Quarkus.sql")
+                    .addAsResource("config-empty.properties", "application.properties"));
+
+    @Test
+    @DisplayName("Injecting (default) flyway should fail if there is no datasource configured")
+    public void testAddingFlyway() {
+        RestAssured.get("fly").then().statusCode(500);
+        config.modifyResourceFile("application.properties", new Function<String, String>() {
+            @Override
+            public String apply(String s) {
+                return "quarkus.datasource.db-kind=h2\n" +
+                        "quarkus.datasource.username=sa\n" +
+                        "quarkus.datasource.password=sa\n" +
+                        "quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test-quarkus-migrate-at-start;DB_CLOSE_DELAY=-1\n"
+                        +
+                        "quarkus.flyway.migrate-at-start=true";
+            }
+        });
+        RestAssured.get("/fly").then().statusCode(200);
+
+    }
+}

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AugmentAction.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AugmentAction.java
@@ -7,5 +7,5 @@ public interface AugmentAction {
 
     StartupAction createInitialRuntimeApplication();
 
-    StartupAction reloadExistingApplication(Set<String> changedResources);
+    StartupAction reloadExistingApplication(boolean hasStartedSuccessfully, Set<String> changedResources);
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -112,7 +112,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> bytecodeTransformers,
             ClassLoader transformerClassLoader) {
         if (resettableElement == null) {
-            throw new IllegalStateException("Classloader is no resettable");
+            throw new IllegalStateException("Classloader is not resettable");
         }
         this.transformerClassLoader = transformerClassLoader;
         synchronized (this) {


### PR DESCRIPTION
The config beans are generated into a different CL
to RuntimeConfig, and so did not have access to it.

This also provides a nice bump to dev mode hot reload speed, around 50ms on my machine.