### PR TITLE
Make deploying to Minikube effortless when not using a registry 

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerImageUtil.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerImageUtil.java
@@ -1,0 +1,26 @@
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.container.image.deployment.util.ImageUtil.hasRegistry;
+
+import java.util.Optional;
+
+import io.quarkus.container.image.deployment.ContainerImageCapabilitiesUtil;
+import io.quarkus.container.spi.ContainerImageInfoBuildItem;
+import io.quarkus.deployment.Capabilities;
+
+final class ContainerImageUtil {
+
+    private ContainerImageUtil() {
+    }
+
+    static boolean isRegistryMissingAndNotS2I(Capabilities capabilities, ContainerImageInfoBuildItem containerImageInfo) {
+        Optional<String> activeContainerImageCapability = ContainerImageCapabilitiesUtil
+                .getActiveContainerImageCapability(capabilities);
+        if (!activeContainerImageCapability.isPresent()) { // shouldn't ever happen when this method is called
+            return false;
+        }
+
+        return !hasRegistry(containerImageInfo.getImage())
+                && !Capabilities.CONTAINER_IMAGE_S2I.equals(activeContainerImageCapability.get());
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -1,7 +1,6 @@
 
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.container.image.deployment.util.ImageUtil.hasRegistry;
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT;
 import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
 import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT;
@@ -67,11 +66,11 @@ public class KubernetesDeployer {
         }
 
         boolean isContainerImageS2IPresent = Capabilities.CONTAINER_IMAGE_S2I.equals(activeContainerImageCapability.get());
-        if (!hasRegistry(containerImageInfo.getImage()) && !isContainerImageS2IPresent) {
+        if (ContainerImageUtil.isRegistryMissingAndNotS2I(capabilities, containerImageInfo)) {
             log.warn(
                     "A Kubernetes deployment was requested, but the container image to be built will not be pushed to any registry"
                             + " because \"quarkus.container-image.registry\" has not been set. The Kubernetes deployment will only work properly"
-                            + " if the cluster is using the local Docker daemon.");
+                            + " if the cluster is using the local Docker daemon. For that reason 'ImagePullPolicy' is being force-set to 'IfNotPresent'");
         }
 
         //Get any build item but if the build was s2i, use openshift

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -33,6 +33,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.DeploymentResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.kubernetes.client.deployment.KubernetesClientErrorHanlder;
@@ -52,7 +53,9 @@ public class KubernetesDeployer {
             List<KubernetesDeploymentTargetBuildItem> kubernetesDeploymentTargets,
             OutputTargetBuildItem outputTarget,
             Capabilities capabilities,
-            BuildProducer<DeploymentResultBuildItem> deploymentResult) {
+            BuildProducer<DeploymentResultBuildItem> deploymentResult,
+            // needed to ensure that this step runs after the container image has been built
+            @SuppressWarnings("unused") List<ArtifactResultBuildItem> artifactResults) {
 
         Optional<String> activeContainerImageCapability = ContainerImageCapabilitiesUtil
                 .getActiveContainerImageCapability(capabilities);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
@@ -70,6 +70,7 @@ public class BasicKubernetesTest {
                 assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getImagePullPolicy()).isEqualTo("Always"); // expect the default value
                             assertThat(container.getPorts()).hasOnlyOneElementSatisfying(p -> {
                                 assertThat(p.getContainerPort()).isEqualTo(8080);
                             });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthAndJibTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthAndJibTest.java
@@ -62,6 +62,8 @@ public class KubernetesWithHealthAndJibTest {
                             assertThat(container.getLivenessProbe()).isNotNull().satisfies(p -> {
                                 assertProbePath(p, "/health/live");
                             });
+                            // since no registry was set and a container-image extension exists, we force-set 'IfNotPresent'
+                            assertThat(container.getImagePullPolicy()).isEqualTo("IfNotPresent");
                         });
                     });
                 });


### PR DESCRIPTION
The idea here to force-set `IfNotPresent` to `ImagePullPolicy` when no registry is being used (and therefore only local docker daemon can work).

Based on the observation of @davsclaus and done after talking with @maxandersen 