### PR TITLE
fix: do not hyphenate enum values all the times

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -42,6 +42,8 @@ final public class Constants {
     public static final String ANNOTATION_CONFIG_ITEM = "io.quarkus.runtime.annotations.ConfigItem";
     public static final String ANNOTATION_BUILD_STEP = "io.quarkus.deployment.annotations.BuildStep";
     public static final String ANNOTATION_CONFIG_ROOT = "io.quarkus.runtime.annotations.ConfigRoot";
+    public static final String ANNOTATION_DEFAULT_CONVERTER = "io.quarkus.runtime.annotations.DefaultConverter";
+    public static final String ANNOTATION_CONVERT_WITH = "io.quarkus.runtime.annotations.ConvertWith";
     public static final String ANNOTATION_CONFIG_GROUP = "io.quarkus.runtime.annotations.ConfigGroup";
     public static final String ANNOTATION_CONFIG_DOC_MAP_KEY = "io.quarkus.runtime.annotations.ConfigDocMapKey";
     public static final String ANNOTATION_CONFIG_DOC_SECTION = "io.quarkus.runtime.annotations.ConfigDocSection";


### PR DESCRIPTION
Following this comment https://github.com/quarkusio/quarkus/pull/8827#discussion_r414695398 where we realized the need to make sure that default values are also hyphenated with two exceptions:
1) for a config item annotated with `@DefaultConverter` where we could just display the enum name a.k.a use SmallRye config default converters
2) And when a config item is annotated with `@ConvertWith` where we are not sure of the converter type to use.