### PR TITLE
Check parent for null to avoid NPE on the "/"

### DIFF
--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
@@ -173,8 +173,9 @@ public class FunctionZipProcessor {
             if (toCheck.toFile().exists()) {
                 return toCheck;
             }
-            if (Files.exists(currentPath.getParent())) {
-                currentPath = currentPath.getParent();
+            Path parent = currentPath.getParent();
+            if (parent != null && Files.exists(parent)) {
+                currentPath = parent;
             } else {
                 return null;
             }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/issues/8838
Check parent for null to avoid NPE during MainSourcesRoot lookup