### PR TITLE
fix unstable Vault ITs 

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkus.vault.runtime;
 
-import org.jboss.logging.Logger;
-
 import io.quarkus.arc.Arc;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
@@ -9,8 +7,6 @@ import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 
 @Recorder
 public class VaultRecorder {
-
-    private static final Logger log = Logger.getLogger(VaultRecorder.class);
 
     public void configureRuntimeProperties(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig vaultRuntimeConfig) {
 

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultITCase.java
@@ -6,7 +6,6 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -23,8 +22,6 @@ import io.quarkus.vault.test.VaultTestLifecycleManager;
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class AgroalVaultITCase {
-
-    private static final Logger log = Logger.getLogger(AgroalVaultITCase.class.getName());
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/AgroalVaultKv1ITCase.java
@@ -6,7 +6,6 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -22,8 +21,6 @@ import io.quarkus.vault.test.VaultTestLifecycleManager;
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class AgroalVaultKv1ITCase {
-
-    private static final Logger log = Logger.getLogger(AgroalVaultKv1ITCase.class.getName());
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(

--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
@@ -2,7 +2,6 @@ package io.quarkus.vault;
 
 import javax.inject.Inject;
 
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -18,10 +17,6 @@ import io.quarkus.vault.test.VaultTestLifecycleManager;
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultKv1ITCase {
-
-    private static final Logger log = Logger.getLogger(VaultKv1ITCase.class.getName());
-
-    public static final String CRUD_PATH = "crud";
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(

--- a/integration-tests/vault-agroal/src/test/resources/application-vault-datasource.properties
+++ b/integration-tests/vault-agroal/src/test/resources/application-vault-datasource.properties
@@ -1,5 +1,4 @@
 # vault server
-quarkus.vault.url=https://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=config
@@ -13,14 +12,14 @@ quarkus.vault.credentials-provider.dynamic-ds.database-credentials-role=mydbrole
 quarkus.datasource.staticDS.db-kind=postgresql
 quarkus.datasource.staticDS.username=postgres
 quarkus.datasource.staticDS.credentials-provider=static-ds
-quarkus.datasource.staticDS.jdbc.url=jdbc:postgresql://localhost:6543/mydb
+quarkus.datasource.staticDS.jdbc.url=${vault-postgres-url}
 
 # dynamic through named credentials provider
 quarkus.datasource.dynamicDS.db-kind=postgresql
 quarkus.datasource.dynamicDS.username=postgres
 quarkus.datasource.dynamicDS.credentials-provider=dynamic-ds
 quarkus.datasource.dynamicDS.credentials-provider-type=vault-credentials-provider
-quarkus.datasource.dynamicDS.jdbc.url=jdbc:postgresql://localhost:6543/mydb
+quarkus.datasource.dynamicDS.jdbc.url=${vault-postgres-url}
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 quarkus.log.category."io.quarkus.vault.runtime.vault".level=DEBUG

--- a/integration-tests/vault-agroal/src/test/resources/application-vault-kv-version1-datasource.properties
+++ b/integration-tests/vault-agroal/src/test/resources/application-vault-kv-version1-datasource.properties
@@ -1,5 +1,4 @@
 # vault server
-quarkus.vault.url=https://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.log-confidentiality-level=low
@@ -13,4 +12,4 @@ quarkus.vault.credentials-provider.default-ds.kv-path=config
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.credentials-provider=default-ds
-quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:6543/mydb
+quarkus.datasource.jdbc.url=${vault-postgres-url}

--- a/integration-tests/vault-app/src/main/resources/application.properties
+++ b/integration-tests/vault-app/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 # see TLS availability in native mode https://github.com/quarkusio/quarkus/issues/3797
-quarkus.vault.url=http://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.log-confidentiality-level=low
@@ -18,4 +17,4 @@ quarkus.log.category."io.quarkus.vault".level=DEBUG
 
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.credentials-provider=mydb
-quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:6543/mydb
+quarkus.datasource.jdbc.url=${vault-postgres-url}

--- a/integration-tests/vault-app/src/test/java/io/quarkus/it/vault/VaultTest.java
+++ b/integration-tests/vault-app/src/test/java/io/quarkus/it/vault/VaultTest.java
@@ -18,7 +18,7 @@ import io.restassured.RestAssured;
 public class VaultTest {
 
     @Test
-    public void test() throws Exception {
+    public void test() {
         RestAssured.when().get("/vault").then().body(is("OK"));
     }
 

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -85,8 +85,6 @@ public class VaultITCase {
 
     public static final String MY_PASSWORD = "my-password";
 
-    public static final String CRUD_PATH = "crud";
-
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
@@ -20,7 +20,6 @@ import java.util.stream.IntStream;
 
 import javax.inject.Inject;
 
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -40,8 +39,6 @@ import io.quarkus.vault.transit.VaultVerificationBatchException;
 import io.quarkus.vault.transit.VerificationRequest;
 
 public class VaultTransitITCase {
-
-    private static final Logger log = Logger.getLogger(VaultTransitITCase.class);
 
     public static final String COUCOU = "coucou";
     public static final String NEW_KEY = "new-key";

--- a/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
@@ -1,5 +1,3 @@
-quarkus.vault.url=https://localhost:8200
-
 # role-id & secret-id-wrapping-token provided by VaultTestLifecycleManager
 quarkus.vault.authentication.app-role.role-id=${vault-test.role-id}
 quarkus.vault.authentication.app-role.secret-id-wrapping-token=${vault-test.secret-id-wrapping-token}

--- a/integration-tests/vault/src/test/resources/application-vault-approle.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle.properties
@@ -1,5 +1,3 @@
-quarkus.vault.url=https://localhost:8200
-
 # role-id & secret-id provided by VaultTestLifecycleManager
 quarkus.vault.authentication.app-role.role-id=${vault-test.role-id}
 quarkus.vault.authentication.app-role.secret-id=${vault-test.secret-id}

--- a/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
@@ -1,5 +1,3 @@
-quarkus.vault.url=https://localhost:8200
-
 # vault-test.client-token-wrapping-token provided by VaultTestLifecycleManager
 quarkus.vault.authentication.client-token-wrapping-token=${vault-test.client-token-wrapping-token}
 

--- a/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
@@ -1,4 +1,3 @@
-quarkus.vault.url=https://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=multi/default1,multi/default2

--- a/integration-tests/vault/src/test/resources/application-vault-totp.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-totp.properties
@@ -1,4 +1,3 @@
-quarkus.vault.url=https://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
@@ -1,5 +1,3 @@
-quarkus.vault.url=https://localhost:8200
-
 quarkus.vault.kv-secret-engine-version=1
 quarkus.vault.kv-secret-engine-mount-path=secret-v1
 

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
@@ -1,5 +1,3 @@
-quarkus.vault.url=https://localhost:8200
-
 # password-kv-v2-wrapping-token provided by VaultTestLifecycleManager
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password-wrapping-token=${vault-test.password-kv-v2-wrapping-token}

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -1,4 +1,3 @@
-quarkus.vault.url=https://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=config

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -19,13 +19,12 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
     @Override
     public Map<String, String> start() {
 
-        Map<String, String> sysprops = new HashMap<>();
+        Map<String, String> testProperties = new HashMap<>();
 
         // see TLS availability in native mode https://github.com/quarkusio/quarkus/issues/3797
         if (VaultTestExtension.useTls()) {
-            sysprops.put("quarkus.vault.url", "https://localhost:8200");
-            sysprops.put("javax.net.ssl.trustStore", "src/test/resources/vaultTrustStore");
-            sysprops.put("java.library.path", GRAALVM_JRE_LIB_AMD_64);
+            testProperties.put("javax.net.ssl.trustStore", "src/test/resources/vaultTrustStore");
+            testProperties.put("java.library.path", GRAALVM_JRE_LIB_AMD_64);
         }
 
         try {
@@ -34,18 +33,23 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
             throw new RuntimeException(e);
         }
 
-        sysprops.put("vault-test.role-id", vaultTestExtension.appRoleRoleId);
-        sysprops.put("vault-test.secret-id", vaultTestExtension.appRoleSecretId);
+        testProperties.put("quarkus.vault.url", VaultTestExtension.getMappedVaultUrl());
 
-        sysprops.put("vault-test.secret-id-wrapping-token", vaultTestExtension.appRoleSecretIdWrappingToken);
-        sysprops.put("vault-test.client-token-wrapping-token", vaultTestExtension.clientTokenWrappingToken);
-        sysprops.put("vault-test.password-kv-v1-wrapping-token", vaultTestExtension.passwordKvv1WrappingToken);
-        sysprops.put("vault-test.password-kv-v2-wrapping-token", vaultTestExtension.passwordKvv2WrappingToken);
-        sysprops.put("vault-test.another-password-kv-v2-wrapping-token", vaultTestExtension.anotherPasswordKvv2WrappingToken);
+        testProperties.put("vault-test.role-id", vaultTestExtension.appRoleRoleId);
+        testProperties.put("vault-test.secret-id", vaultTestExtension.appRoleSecretId);
 
-        log.info("using system properties " + sysprops);
+        testProperties.put("vault-test.secret-id-wrapping-token", vaultTestExtension.appRoleSecretIdWrappingToken);
+        testProperties.put("vault-test.client-token-wrapping-token", vaultTestExtension.clientTokenWrappingToken);
+        testProperties.put("vault-test.password-kv-v1-wrapping-token", vaultTestExtension.passwordKvv1WrappingToken);
+        testProperties.put("vault-test.password-kv-v2-wrapping-token", vaultTestExtension.passwordKvv2WrappingToken);
+        testProperties.put("vault-test.another-password-kv-v2-wrapping-token",
+                vaultTestExtension.anotherPasswordKvv2WrappingToken);
 
-        return sysprops;
+        testProperties.put("vault-postgres-url",
+                "jdbc:postgresql://localhost:" + VaultTestExtension.getMappedPostgresqlPort() + "/mydb");
+        log.info("using system properties " + testProperties);
+
+        return testProperties;
     }
 
     @Override


### PR DESCRIPTION
Fixes #8836 

The test failed with:
```
Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:485)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:317)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	... 43 more
Caused by: com.github.dockerjava.api.exception.InternalServerErrorException: {"message":"driver failed programming external connectivity on endpoint focused_mayer (1936f0278456d8fcc931b7b9e48e9d902a8e84fb5b5a0aad4440e0cc70e0b4e3): Bind for 0.0.0.0:6543 failed: port is already allocated"}
```

seems like the vault test extension used a fixed port  binding, the fix I am proposing is to let testcontainer generate a random port for us for both the `vault` and `postgres` containers, from which the appropriate configuration properties will be initialised. 

Opening as draft to let a complete CI  run in my fork. 

WDYT? @vsevel @gsmet 