### PR TITLE
Use addresses instead of deprecated queues

### DIFF
--- a/integration-tests/artemis-core/src/test/resources/broker.xml
+++ b/integration-tests/artemis-core/src/test/resources/broker.xml
@@ -12,6 +12,7 @@
             <acceptor name="activemq">tcp://localhost:61616</acceptor>
         </acceptors>
 
+        <max-disk-usage>-1</max-disk-usage>
         <security-enabled>false</security-enabled>
 
         <addresses>
@@ -21,6 +22,5 @@
                 </anycast>
             </address>
         </addresses>
-        <max-disk-usage>100</max-disk-usage>
     </core>
 </configuration>

--- a/integration-tests/artemis-jms/src/test/resources/broker.xml
+++ b/integration-tests/artemis-jms/src/test/resources/broker.xml
@@ -15,10 +15,12 @@
         <max-disk-usage>-1</max-disk-usage>
         <security-enabled>false</security-enabled>
 
-        <queues>
-            <queue name="foo">
-                <address>test-jms</address>
-            </queue>
-        </queues>
+        <addresses>
+            <address name="test-jms">
+                <anycast>
+                    <queue name="test-jms"/>
+                </anycast>
+            </address>
+        </addresses>
     </core>
 </configuration>


### PR DESCRIPTION
Small fix to replace deprecated queues with addresses. Also disable max-usage with `-1` just as in JMS.