### PR TITLE
Unify WireMock deps via build-parent + add to Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -142,6 +142,11 @@ update_configs:
       #Neo4j
       - match:
           dependency_name: "org.neo4j.driver:neo4j-java-driver"
+      #WireMock
+      - match:
+          dependency_name: "com.github.tomakehurst:wiremock-jre8"
+      - match:
+          dependency_name: "uk.co.automatictester:wiremock-maven-plugin"
   - package_manager: "java:gradle"
     directory: "/devtools/gradle"
     update_schedule: "daily"

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -83,6 +83,9 @@
 
         <unboundid-ldap.version>4.0.13</unboundid-ldap.version>
 
+        <wiremock-jre8.version>2.26.3</wiremock-jre8.version>
+        <wiremock-maven-plugin.version>6.0.0</wiremock-maven-plugin.version>
+
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>
         <jacoco.version>0.8.5</jacoco.version>
@@ -164,6 +167,34 @@
                 <artifactId>unboundid-ldapsdk</artifactId>
                 <version>${unboundid-ldap.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock-jre8</artifactId>
+                <version>${wiremock-jre8.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                    <exclusion> <!-- fix dependencyConvergence clash with junit-jupiter -->
+                        <groupId>org.opentest4j</groupId>
+                        <artifactId>opentest4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                   </exclusion>
+                </exclusions>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -381,7 +412,16 @@
                 <plugin>
                     <groupId>uk.co.automatictester</groupId>
                     <artifactId>wiremock-maven-plugin</artifactId>
-                    <version>5.0.1</version>
+                    <version>${wiremock-maven-plugin.version}</version>
+                    <dependencies>
+                        <!-- plugin defines "wiremock" artifactId (in provided scope), not the preferred "wiremock-jre8"
+                             which cannot be forced here, see https://issues.apache.org/jira/browse/MNG-6222 -->
+                        <dependency>
+                            <groupId>com.github.tomakehurst</groupId>
+                            <artifactId>wiremock</artifactId>
+                            <version>${wiremock-jre8.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/extensions/spring-cloud-config-client/runtime/pom.xml
+++ b/extensions/spring-cloud-config-client/runtime/pom.xml
@@ -46,30 +46,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
-            <version>2.26.3</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <exclusion> <!-- fix dependencyConvergence clash with junit-jupiter -->
-                    <groupId>org.opentest4j</groupId>
-                    <artifactId>opentest4j</artifactId>
-                </exclusion>
-                <exclusion>
-	                <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-               </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/integration-tests/elytron-security-oauth2/pom.xml
+++ b/integration-tests/elytron-security-oauth2/pom.xml
@@ -43,30 +43,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
-            <version>2.26.3</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <exclusion> <!-- fix dependencyConvergence clash with junit-jupiter -->
-                    <groupId>org.opentest4j</groupId>
-                    <artifactId>opentest4j</artifactId>
-                </exclusion>
-                <exclusion>
-    	            <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/integration-tests/spring-cloud-config-client/pom.xml
+++ b/integration-tests/spring-cloud-config-client/pom.xml
@@ -104,13 +104,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>com.github.tomakehurst</groupId>
-                                <artifactId>wiremock</artifactId>
-                                <version>2.25.1</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -49,9 +49,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>uk.co.deliverymind</groupId>
+                <groupId>uk.co.automatictester</groupId>
                 <artifactId>wiremock-maven-plugin</artifactId>
-                <version>2.7.0</version>
                 <executions>
                     <execution>
                         <phase>generate-test-sources</phase>


### PR DESCRIPTION
Addresses the concerns raised by @gsmet: https://github.com/quarkusio/quarkus/pull/8389#issuecomment-609634637

cc @geoand 

PS: I was not able to test `tcks/microprofile-rest-client` locally but I guess your CI will tell me when I screwed up. 😉 