### PR TITLE
Fix quarkus-logging-json not working with native images

### DIFF
--- a/extensions/logging-json/deployment/pom.xml
+++ b/extensions/logging-json/deployment/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-logging-json</artifactId>
         </dependency>
         <!-- test dependencies -->

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -131,6 +131,12 @@
             <artifactId>quarkus-smallrye-context-propagation</artifactId>
         </dependency>
 
+        <!-- JSON Logging -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
- add jsonp-deployment module in logging-json deployment module so that `JsonProviderImpl` is registered for reflection.
- add loggin-json dependency in `integration/main` module so that it gets tested natively.

Fixes #8855 
