### PR TITLE
Use the correct file path separator when communicating with remote endpoint in remote-dev mode

### DIFF
--- a/extensions/undertow-websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/devmode/HotReplacementWebsocketEndpoint.java
+++ b/extensions/undertow-websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/devmode/HotReplacementWebsocketEndpoint.java
@@ -1,10 +1,13 @@
 package io.quarkus.undertow.websockets.runtime.devmode;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -96,7 +99,14 @@ public class HotReplacementWebsocketEndpoint {
             return;
         }
         try {
-            con.connection.getBasicRemote().sendBinary(ByteBuffer.wrap(new byte[] { CLASS_CHANGE_REQUEST }));
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            baos.write(CLASS_CHANGE_REQUEST);
+            // write out the file path separator that we expect the changed classes'/resources'
+            // to use in its response
+            for (final byte b : File.separator.getBytes(StandardCharsets.UTF_8)) {
+                baos.write(b);
+            }
+            con.connection.getBasicRemote().sendBinary(ByteBuffer.wrap(baos.toByteArray()));
         } catch (IOException e) {
             try {
                 con.connection.close();


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/8803

When a `CLASS_CHANGE_REQUEST` is sent, the response includes the paths (and their changed content) of the changed resources/classes. If the file path separator differs between these server/agent, then the path sent across as a response isn't properly interpreted (using `java.nio.file.Path` APIs) when updating the files locally.

The change in this commit, sends across the file path separator (that corresponds to the OS issuing the request) within the `CLASS_CHANGE_REQUEST`. The response is then expected to use this file path separator to represent the changed file paths.

I haven't added any new tests, given the nature of this change. However, I have run the existing `RemoteDevMojoIT` tests and they have passed without any issues.
