### PR TITLE
Make QuarkusUnitTest#afterAll() safer

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -462,7 +462,9 @@ public class QuarkusUnitTest
             if (afterUndeployListener != null) {
                 afterUndeployListener.run();
             }
-            curatedApplication.close();
+            if (curatedApplication != null) {
+                curatedApplication.close();
+            }
         } finally {
             System.clearProperty("test.url");
             Thread.currentThread().setContextClassLoader(originalClassLoader);
@@ -471,9 +473,10 @@ public class QuarkusUnitTest
             if (deploymentDir != null) {
                 FileUtil.deleteDirectory(deploymentDir);
             }
-        }
-        if (afterAllCustomizer != null) {
-            afterAllCustomizer.run();
+
+            if (afterAllCustomizer != null) {
+                afterAllCustomizer.run();
+            }
         }
     }
 


### PR DESCRIPTION
Noted in the JDK 8 failure we currently have.