### PR TITLE
Don't transform internal classes

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheResourceProcessor.java
@@ -150,7 +150,10 @@ public final class PanacheResourceProcessor {
             PanacheFieldAccessEnhancer panacheFieldAccessEnhancer = new PanacheFieldAccessEnhancer(modelInfo);
             for (ClassInfo classInfo : index.getIndex().getKnownClasses()) {
                 String className = classInfo.name().toString();
-                if (!modelClasses.contains(className)) {
+                //these classes can end up as application archives
+                //but there is no way they can reference entities
+                if (!modelClasses.contains(className) && !className.startsWith("io.smallrye.")
+                        && !className.startsWith("org.jboss.narayana.")) {
                     transformers.produce(new BytecodeTransformerBuildItem(className, panacheFieldAccessEnhancer));
                 }
             }


### PR DESCRIPTION
Some SmallRye and Narayna archives are application
archives as they have a beans.xml file or a jandex index.

These won't be references a users panache entity though,
so there is no need to transform them.