### PR TITLE
Improve retrieving default database name

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoOperations.java
@@ -43,6 +43,8 @@ public class MongoOperations {
     public static final String ID = "_id";
     public static final String MONGODB_DATABASE = "quarkus.mongodb.database";
 
+    private static volatile String defaultDatabaseName;
+
     //
     // Instance methods
 
@@ -277,9 +279,20 @@ public class MongoOperations {
         if (entity != null && !entity.database().isEmpty()) {
             return mongoClient.getDatabase(entity.database());
         }
-        String databaseName = ConfigProvider.getConfig()
-                .getValue(MONGODB_DATABASE, String.class);
+        String databaseName = getDefaultDatabaseName();
         return mongoClient.getDatabase(databaseName);
+    }
+
+    private static String getDefaultDatabaseName() {
+        if (defaultDatabaseName == null) {
+            synchronized (MongoOperations.class) {
+                if (defaultDatabaseName == null) {
+                    defaultDatabaseName = ConfigProvider.getConfig()
+                            .getValue(MONGODB_DATABASE, String.class);
+                }
+            }
+        }
+        return defaultDatabaseName;
     }
 
     private static MongoClient mongoClient(MongoEntity entity) {


### PR DESCRIPTION
Calling `ConfigProvider.getConfig().getValue(MONGODB_DATABASE, String.class)` each time is costly (even on current master where it has been optimized).

Using a static volatile field lazilly  computed via a double-checked locking idiom improve performances (validated via CPU profiling).