### PR TITLE
Fix deletion of function.zip in amazon-lambda

### DIFF
--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
@@ -102,7 +102,7 @@ public class FunctionZipProcessor {
         Path zipDir = findNativeZipDir(target.getOutputDirectory());
 
         Path zipPath = target.getOutputDirectory().resolve("function.zip");
-        Files.delete(zipPath);
+        Files.deleteIfExists(zipPath);
         try (ZipArchiveOutputStream zip = new ZipArchiveOutputStream(zipPath.toFile())) {
             String executableName = "bootstrap";
             if (zipDir != null) {


### PR DESCRIPTION
Make the function.zip deletion use deleteIfExists instead of delete to prevent the need to have a function.zip in your target directory already. 

Fixes: #8886