### PR TITLE
Unify handling of Kubernetes env vars definition

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -247,41 +247,69 @@ To add a key/value pair as an environment variable in the generated resources:
 
 [source]
 ----
-quarkus.kubernetes.env-vars.my-env-var.value=foobar
+quarkus.kubernetes.env.vars.my-env-var=foobar
 ----
 
 The command above will add `MY_ENV_VAR=foobar` as an environment variable.
 Please note that the key `my-env-var` will be converted to uppercase and dashes will be replaced by underscores resulting in `MY_ENV_VAR`.
 
-You may also have noticed that in contrast to labels and annotations for environment variables you don't just use a `key=value` approach.
-That is because for environment variables there are additional options rather than just setting a value.
-
 ===== Environment variables from Secret
 
-To add all key/value pairs of a `Secret` as environment variables just apply the following configuration:
+To add all key/value pairs of `Secret` as environment variables just apply the following configuration, separating each `Secret`
+to be used as source by a comma (`,`):
 
 [source]
 ----
-quarkus.kubernetes.env-vars.my-env-var.secret=my-secret
+quarkus.kubernetes.env.secrets=my-secret,my-other-secret
 ----
-
-NOTE: you might be wondering why you need to have a `my-env-var` part to your property even though this property triggers the
-injection of multiple values as defined in the specified secret. In fact, you can use any valid name for that property that is
-not already used to inject a variable as this name will be disregarded. This is currently required for the
-property processor to properly identify a secret whose values need to be injected.
 
 ===== Environment variables from ConfigMap
 
-To add all key/value pairs of a `ConfigMap` as environment variables just apply the following configuration:
+To add all key/value pairs from `ConfigMap` as environment variables just apply the following configuration, separating each
+`ConfigMap` to be used as source by a comma (`,`):
 
 [source]
 ----
-quarkus.kubernetes.env-vars.my-env-var.configmap=my-secret
+quarkus.kubernetes.env.configmaps=my-config-map,another-config-map
 ----
 
-NOTE: you might be wondering why you need to have a `my-env-var` part to your property even though this property triggers the injection of multiple values as defined in the specified ConfigMap.
-In fact, you can use any valid name for that property that is not already used to inject a variable as this name will be disregarded.
-This is currently required for the property processor to properly identify a ConfigMap whose values need to be injected.
+===== Environment variables from fields
+
+It's also possible to use the value from another field to add a new environment variable by specifying the path of the field to
+be used as a source, as follows:
+
+[source]
+----
+quarkus.kubernetes.env.fields.foo=metadata.name
+----
+
+===== Validation
+
+A conflict between two definitions, e.g. mistakenly assigning both a value and specifying that a variable is derived
+from a field, will result in an error being thrown at build time so that you get the opportunity to fix the issue before you
+deploy your application to your cluster where it might be more difficult to diagnose the source of the issue.
+
+Similarly, two redundant definitions, e.g. defining an injection from the same secret twice, will not cause an issue but will
+indeed report a warning to let you know that you might not have intended to duplicate that definition.
+
+===== Backwards compatibility
+
+Previous versions of the Kubernetes extension supported a different syntax to add environment variables. The older syntax is
+still supported but is deprecated and it's advised that you migrate to the new syntax.
+
+.Old vs. new syntax
+|====
+|                       |Old                                                    | New                                                 |
+| Plain variable        |`quarkus.kubernetes.env-vars.my-env-var.value=foobar`  | `quarkus.kubernetes.env.vars.my-env-var=foobar`     |
+| From field            |`quarkus.kubernetes.env-vars.my-env-var.field=foobar`  | `quarkus.kubernetes.env.fields.my-env-var=foobar`   |
+| All from `ConfigMap`  |`quarkus.kubernetes.env-vars.xxx.configmap=foobar`     | `quarkus.kubernetes.env.configmaps=foobar`          |
+| All from `Secret`     |`quarkus.kubernetes.env-vars.xxx.secret=foobar`        | `quarkus.kubernetes.env.secrets=foobar`             |
+|====
+
+NOTE: If you redefine the same variable using the new syntax while keeping the old syntax, **ONLY** the new version will be kept
+and a warning will be issued to alert you of the problem. For example, if you define both
+`quarkus.kubernetes.env-vars.my-env-var.value=foobar` and `quarkus.kubernetes.env.vars.my-env-var=newValue`, the extension will
+only generate an environment variable `MY_ENV_VAR=newValue` and issue a warning.
 
 ==== Mounting volumes
 

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesEnvBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesEnvBuildItem.java
@@ -5,24 +5,96 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 public final class KubernetesEnvBuildItem extends MultiBuildItem {
 
-    private final String name;
-    private final String value;
-    private final String secret;
-    private final String configmap;
-    private final String field;
-    private final String target;
+    public enum EnvType {
+        var(false),
+        field(false),
+        secret(true),
+        configmap(true);
 
-    public KubernetesEnvBuildItem(String name, String value, String target) {
-        this(name, value, null, null, null, target);
+        public final boolean allowMultipleDefinitions;
+
+        EnvType(boolean allowMultipleDefinitions) {
+            this.allowMultipleDefinitions = allowMultipleDefinitions;
+        }
+
+        public boolean mightConflictWith(EnvType type) {
+            if (this == type) {
+                return true;
+            }
+
+            switch (this) {
+                case field:
+                    return type == var;
+                case var:
+                    return type == field;
+                case secret:
+                    return type == configmap;
+                case configmap:
+                    return type == secret;
+                default:
+                    return false;
+            }
+        }
     }
 
-    public KubernetesEnvBuildItem(String name, String value, String secret, String configmap, String field, String target) {
+    private final String name;
+    private final String value;
+    private final EnvType type;
+    private final String target;
+    private final boolean oldStyle;
+
+    public static EnvType getEnvType(String secret, String configmap, String field) {
+        final EnvType type;
+        if (secret != null) {
+            type = EnvType.secret;
+        } else if (configmap != null) {
+            type = EnvType.configmap;
+        } else if (field != null) {
+            type = EnvType.field;
+        } else {
+            type = EnvType.var;
+        }
+        return type;
+    }
+
+    public KubernetesEnvBuildItem(String name, String value, String target) {
+        this(EnvType.var, name, value, target);
+    }
+
+    public KubernetesEnvBuildItem(EnvType type, String name, String value, String target, boolean oldStyle) {
         this.name = name;
         this.value = value;
-        this.secret = secret;
-        this.configmap = configmap;
-        this.field = field;
+        this.type = type;
         this.target = target;
+        this.oldStyle = oldStyle;
+    }
+
+    public KubernetesEnvBuildItem(EnvType type, String name, String value, String target) {
+        this(type, name, value, target, false);
+    }
+
+    public String getConfigMap() {
+        return getValueIfMatching(EnvType.configmap);
+    }
+
+    public String getSecret() {
+        return getValueIfMatching(EnvType.secret);
+    }
+
+    public String getField() {
+        return getValueIfMatching(EnvType.field);
+    }
+
+    public String getVar() {
+        return getValueIfMatching(EnvType.var);
+    }
+
+    public boolean isOldStyle() {
+        return oldStyle;
+    }
+
+    private String getValueIfMatching(EnvType type) {
+        return this.type == type ? value : null;
     }
 
     public String getName() {
@@ -33,20 +105,39 @@ public final class KubernetesEnvBuildItem extends MultiBuildItem {
         return value;
     }
 
-    public String getSecret() {
-        return secret;
-    }
-
-    public String getConfigmap() {
-        return configmap;
-    }
-
-    public String getField() {
-        return field;
+    public EnvType getType() {
+        return type;
     }
 
     public String getTarget() {
         return target;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        KubernetesEnvBuildItem that = (KubernetesEnvBuildItem) o;
+
+        if (!name.equals(that.name))
+            return false;
+        if (!value.equals(that.value))
+            return false;
+        if (type != that.type)
+            return false;
+        return target.equals(that.target);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + value.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + target.hashCode();
+        return result;
     }
 
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConfig.java
@@ -1,28 +1,25 @@
 
 package io.quarkus.kubernetes.deployment;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
+import io.dekorate.kubernetes.config.Env;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 @ConfigGroup
-public class ContainerConfig {
+public class ContainerConfig implements EnvVarHolder {
 
     /**
      * The container image.
      */
     @ConfigItem
     Optional<String> image;
-
-    /**
-     * Environment variables to add to all containers.
-     */
-    @ConfigItem
-    Map<String, EnvConfig> envVars;
 
     /**
      * Working directory.
@@ -92,5 +89,56 @@ public class ContainerConfig {
      */
     @ConfigItem
     Map<String, MountConfig> mounts;
+
+    /**
+     * Environment variables to add to all containers using the old syntax.
+     *
+     * @deprecated Use {@link #env} instead using the new syntax as follows:
+     *             <ul>
+     *             <li>{@code quarkus.kubernetes.env-vars.foo.field=fieldName} becomes
+     *             {@code quarkus.kubernetes.env.fields.foo=fieldName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.envvar.value=value} becomes
+     *             {@code quarkus.kubernetes.env.vars.envvar=value}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.bar.configmap=configName} becomes
+     *             {@code quarkus.kubernetes.env.configmaps=configName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.baz.secret=secretName} becomes
+     *             {@code quarkus.kubernetes.env.secrets=secretName}</li>
+     *             </ul>
+     */
+    @ConfigItem
+    @Deprecated
+    Map<String, EnvConfig> envVars;
+
+    /**
+     * Environment variables to add to all containers.
+     */
+    @ConfigItem
+    EnvVarsConfig env;
+
+    /**
+     * @deprecated use {@link #getEnv()} instead
+     */
+    @Deprecated
+    public Map<String, EnvConfig> getEnvVars() {
+        return envVars;
+    }
+
+    public EnvVarsConfig getEnv() {
+        return env;
+    }
+
+    @Override
+    public String getTargetPlatformName() {
+        // ContainerConfig doesn't need a deployment target since it doesn't need to process KubernetesEnvBuildItem apart to
+        // convert them to Env instances once processed by the EnvVarValidator. This trick is used to be able to reuse the
+        // logic supporting old and new env var syntax.
+        return null;
+    }
+
+    public Collection<Env> convertToEnvs() {
+        return convertToBuildItems().stream()
+                .map(kebi -> new Env(kebi.getName(), kebi.getValue(), kebi.getSecret(), kebi.getConfigMap(), kebi.getField()))
+                .collect(Collectors.toList());
+    }
 
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ContainerConverter.java
@@ -18,7 +18,7 @@ public class ContainerConverter {
         c.workingDir.ifPresent(w -> b.withWorkingDir(w));
         c.readinessProbe.ifPresent(p -> b.withReadinessProbe(ProbeConverter.convert(p)));
         c.livenessProbe.ifPresent(p -> b.withLivenessProbe(ProbeConverter.convert(p)));
-        c.envVars.entrySet().forEach(e -> b.addToEnvVars(EnvConverter.convert(e)));
+        b.addAllToEnvVars(c.convertToEnvs());
         c.ports.entrySet().forEach(e -> b.addToPorts(PortConverter.convert(e)));
         c.mounts.entrySet().forEach(e -> b.addToMounts(MountConverter.convert(e)));
         return b;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
@@ -1,25 +1,42 @@
 
 package io.quarkus.kubernetes.deployment;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import io.dekorate.kubernetes.config.Env;
 import io.dekorate.kubernetes.config.EnvBuilder;
 
 public class EnvConverter {
-
     public static Env convert(Map.Entry<String, EnvConfig> e) {
-        return convert(e.getValue()).withName(e.getKey().toUpperCase().replaceAll(Pattern.quote("-"), "_")).build();
+        return convert(e.getValue()).withName(convertName(e.getKey())).build();
     }
 
     private static EnvBuilder convert(EnvConfig env) {
         EnvBuilder b = new EnvBuilder();
-        env.name.ifPresent(v -> b.withName(v));
-        env.value.ifPresent(v -> b.withValue(v));
-        env.secret.ifPresent(v -> b.withSecret(v));
-        env.configmap.ifPresent(v -> b.withConfigmap(v));
-        env.field.ifPresent(v -> b.withField(v));
+        env.name.ifPresent(b::withName);
+        env.value.ifPresent(b::withValue);
+        env.secret.ifPresent(b::withSecret);
+        env.configmap.ifPresent(b::withConfigmap);
+        env.field.ifPresent(b::withField);
         return b;
+    }
+
+    public static List<Env> convert(EnvVarsConfig e) {
+        List<Env> envs = new LinkedList<>();
+        e.secrets.ifPresent(sl -> sl.forEach(s -> envs.add(new EnvBuilder().withName(convertName(s)).withSecret(s).build())));
+        e.configmaps
+                .ifPresent(cl -> cl.forEach(c -> envs.add(new EnvBuilder().withName(convertName(c)).withConfigmap(c).build())));
+        e.vars.forEach((k, v) -> envs.add(new EnvBuilder().withName(convertName(k)).withValue(v).build()));
+        e.fields.forEach((k, v) -> {
+            // env vars from fields need to have their name set in addition to their field field :)
+            envs.add(new EnvBuilder().withName(convertName(k)).withField(convertName(k)).withValue(v).build());
+        });
+        return envs;
+    }
+
+    public static String convertName(String name) {
+        return name != null ? name.toUpperCase().replace("-", "_") : null;
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarHolder.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarHolder.java
@@ -1,0 +1,66 @@
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.spi.KubernetesEnvBuildItem.EnvType.configmap;
+import static io.quarkus.kubernetes.spi.KubernetesEnvBuildItem.EnvType.field;
+import static io.quarkus.kubernetes.spi.KubernetesEnvBuildItem.EnvType.secret;
+import static io.quarkus.kubernetes.spi.KubernetesEnvBuildItem.EnvType.var;
+
+import java.util.Collection;
+import java.util.Map;
+
+import io.quarkus.kubernetes.spi.KubernetesEnvBuildItem;
+
+/**
+ * Common interface for configuration entities holding environment variables meant to be injected into containers.
+ */
+public interface EnvVarHolder {
+    /**
+     * Retrieves the definition of environment variables to add to the application's container.
+     *
+     * @return the associated {@link EnvVarsConfig} holding the definition of which environment variables to add
+     */
+    EnvVarsConfig getEnv();
+
+    /**
+     * @deprecated use {@link #getEnv()} instead
+     */
+    @Deprecated
+    Map<String, EnvConfig> getEnvVars();
+
+    /**
+     * Specifies which the name of the platform this EnvVarHolder targets. This name, when needed, is used by dekorate to
+     * generate the descriptor associated with the targeted deployment platform.
+     *
+     * @return the name of the targeted platform e.g. {@link Constants#KUBERNETES}
+     */
+    String getTargetPlatformName();
+
+    /**
+     * Converts the environment variable configuration held by this EnvVarHolder (as returned by {@link #getEnv()} and
+     * {@link #getEnvVars()}) into a collection of associated {@link KubernetesEnvBuildItem}.
+     *
+     * @return a collection of {@link KubernetesEnvBuildItem} corresponding to the environment variable configurations
+     */
+    default Collection<KubernetesEnvBuildItem> convertToBuildItems() {
+        final EnvVarValidator validator = new EnvVarValidator();
+
+        // first process old-style configuration, this relies on each configuration having a name
+        final String target = getTargetPlatformName();
+        getEnvVars().forEach((key, envConfig) -> {
+            envConfig.secret.ifPresent(s -> validator.process(new KubernetesEnvBuildItem(secret, s, s, target, true)));
+            envConfig.configmap.ifPresent(cm -> validator.process(new KubernetesEnvBuildItem(configmap, cm, cm, target, true)));
+            envConfig.field.ifPresent(f -> validator.process(new KubernetesEnvBuildItem(field, key, f, target, true)));
+            envConfig.value.ifPresent(v -> validator.process(new KubernetesEnvBuildItem(var, key, v, target, true)));
+        });
+
+        // override old-style with newer versions if present
+        final EnvVarsConfig c = getEnv();
+        c.vars.forEach((k, v) -> validator.process(new KubernetesEnvBuildItem(var, k, v, target)));
+        c.fields.forEach((k, v) -> validator.process(new KubernetesEnvBuildItem(field, k, v, target)));
+        c.configmaps
+                .ifPresent(cl -> cl.forEach(cm -> validator.process(new KubernetesEnvBuildItem(configmap, cm, cm, target))));
+        c.secrets.ifPresent(sl -> sl.forEach(s -> validator.process(new KubernetesEnvBuildItem(secret, s, s, target))));
+
+        return validator.getBuildItems();
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarValidator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarValidator.java
@@ -1,0 +1,167 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.kubernetes.spi.KubernetesEnvBuildItem;
+
+/**
+ * Validates that the set of provided environment variables is valid.
+ */
+public class EnvVarValidator {
+    private static final Logger log = Logger.getLogger(EnvVarValidator.class);
+    private final Map<ItemKey, KubernetesEnvBuildItem> items = new HashMap<>();
+    private final Set<String> knownNames = new HashSet<>();
+    private final Map<String, Set<KubernetesEnvBuildItem>> errors = new HashMap<>();
+
+    /**
+     * Processes the specified {@link KubernetesEnvBuildItem} to check whether it's valid with respect to the set of already
+     * known configuration, accumulating errors or outputting warnings if needed.
+     *
+     * @param item the {@link KubernetesEnvBuildItem} to validate
+     */
+    void process(KubernetesEnvBuildItem item) {
+        final String name = item.getName();
+        final KEBIWrapper wrapper = new KEBIWrapper(item);
+        // check if we already have defined a build item with the same name
+        if (knownNames.contains(name)) {
+            final KubernetesEnvBuildItem.EnvType type = item.getType();
+            // as the item might not get added, reset the wrapper's state
+            wrapper.setNeedingAdding(false);
+            // then go through already added items to check if the item needs to be added, warning logged or error added
+            items.values().stream().filter(kebi -> name.equals(kebi.getName())).forEach(existing -> {
+                final KubernetesEnvBuildItem.EnvType existingType = existing.getType();
+                // if the type doesn't allow multiple definitions, we need to check if we're adding a "compatible" env var
+                if (!existingType.allowMultipleDefinitions) {
+                    // check if we have a conflict and thus an error
+                    if (existingType.mightConflictWith(type)) {
+                        // but we first need to check if we're not simply replacing an old style definition by a new one
+                        final boolean currentIsNew = existing.isOldStyle() && !item.isOldStyle();
+                        final boolean existingIsNew = item.isOldStyle() && !existing.isOldStyle();
+                        if ((currentIsNew || existingIsNew) && existingType.equals(type)) {
+                            // only keep definition using new style and output warning
+                            log.warn("Duplicate definition of '" + name
+                                    + "' environment variable. ONLY the quarkus.kubernetes.env prefixed version will be kept: "
+                                    + (currentIsNew ? describe(item) : describe(existing)));
+                            if (currentIsNew) {
+                                // replace existing, old-style value by current, new-style one
+                                wrapper.setNeedingAdding(true);
+                            }
+                        } else {
+                            addError(item, existing);
+                        }
+                    } else {
+                        // we're not dealing with a potentially conflicting var so add the new item
+                        wrapper.setNeedingAdding(true);
+                    }
+                } else {
+                    if (existingType.mightConflictWith(type)) {
+                        log.warn("Ignoring duplicate definition of " + describe(item));
+                    }
+                    wrapper.setNeedingAdding(true);
+
+                }
+            });
+        }
+        if (wrapper.isNeedingAdding()) {
+            items.put(ItemKey.keyFor(item), item);
+        }
+        knownNames.add(name);
+    }
+
+    private void addError(KubernetesEnvBuildItem item, KubernetesEnvBuildItem existing) {
+        final Set<KubernetesEnvBuildItem> inError = errors.computeIfAbsent(item.getName(), k -> new LinkedHashSet<>());
+        inError.add(existing);
+        inError.add(item);
+    }
+
+    /**
+     * Retrieves a collection of validated {@link KubernetesEnvBuildItem} once all of them have been processed.
+     *
+     * @return a collection of validated {@link KubernetesEnvBuildItem}
+     * @throws IllegalArgumentException if the processed items result in an invalid configuration
+     */
+    Collection<KubernetesEnvBuildItem> getBuildItems() {
+        if (errors.isEmpty()) {
+            return items.values();
+        }
+        throw new IllegalArgumentException(getError());
+    }
+
+    private String getError() {
+        String error = "Found conflicts in environment variable definitions:\n";
+        error += errors.entrySet().stream()
+                .map(e -> {
+                    final String conflicting = e.getValue().stream()
+                            .map(this::describe)
+                            .collect(Collectors.joining(" redefined as "));
+                    return String.format("\t\t- '%s': first defined as %s", e.getKey(), conflicting);
+                })
+                .collect(Collectors.joining("\n"));
+        return error;
+    }
+
+    private String describe(KubernetesEnvBuildItem kebi) {
+        return String.format("'%s' env var with value '%s'", kebi.getType().name(), kebi.getValue());
+    }
+
+    private static final class KEBIWrapper {
+        private final KubernetesEnvBuildItem item;
+        private boolean needingAdding;
+
+        KEBIWrapper(KubernetesEnvBuildItem item) {
+            this.item = item;
+            needingAdding = true;
+        }
+
+        public boolean isNeedingAdding() {
+            return needingAdding;
+        }
+
+        public void setNeedingAdding(boolean needingAdding) {
+            this.needingAdding = needingAdding;
+        }
+    }
+
+    private static final class ItemKey {
+        private final KubernetesEnvBuildItem.EnvType type;
+        private final String name;
+
+        ItemKey(KubernetesEnvBuildItem.EnvType type, String name) {
+            this.type = type;
+            this.name = name;
+        }
+
+        public static ItemKey keyFor(KubernetesEnvBuildItem item) {
+            return new ItemKey(item.getType(), item.getName());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            ItemKey itemKey = (ItemKey) o;
+
+            if (type != itemKey.type)
+                return false;
+            return name.equals(itemKey.name);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = type.hashCode();
+            result = 31 * result + name.hashCode();
+            return result;
+        }
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarsConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarsConfig.java
@@ -1,0 +1,38 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * The configuration specifying which environment variables to inject into the application's container.
+ */
+@ConfigGroup
+public class EnvVarsConfig {
+    /**
+     * The optional list of Secret names to load environment variables from.
+     */
+    @ConfigItem
+    Optional<List<String>> secrets;
+
+    /**
+     * The optional list of ConfigMap names to load environment variables from.
+     */
+    @ConfigItem
+    Optional<List<String>> configmaps;
+
+    /**
+     * The map associating environment variable names to their associated field references they take their value from.
+     */
+    @ConfigItem
+    Map<String, String> fields;
+
+    /**
+     * The map associating environment name to its associated value.
+     */
+    @ConfigItem
+    Map<String, String> vars;
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -52,12 +52,6 @@ public class KnativeConfig implements PlatformConfiguration {
     boolean addBuildTimestamp;
 
     /**
-     * Environment variables to add to all containers
-     */
-    @ConfigItem
-    Map<String, EnvConfig> envVars;
-
-    /**
      * Working directory
      */
     @ConfigItem
@@ -210,8 +204,9 @@ public class KnativeConfig implements PlatformConfiguration {
         return addBuildTimestamp;
     }
 
-    public Map<String, EnvConfig> getEnvVars() {
-        return envVars;
+    @Override
+    public String getTargetPlatformName() {
+        return Constants.KNATIVE;
     }
 
     public Optional<String> getWorkingDir() {
@@ -298,4 +293,37 @@ public class KnativeConfig implements PlatformConfiguration {
         return containers;
     }
 
+    /**
+     * Environment variables to add to all containers using the old syntax.
+     *
+     * @deprecated Use {@link #env} instead using the new syntax as follows:
+     *             <ul>
+     *             <li>{@code quarkus.kubernetes.env-vars.foo.field=fieldName} becomes
+     *             {@code quarkus.kubernetes.env.fields.foo=fieldName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.envvar.value=value} becomes
+     *             {@code quarkus.kubernetes.env.vars.envvar=value}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.bar.configmap=configName} becomes
+     *             {@code quarkus.kubernetes.env.configmaps=configName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.baz.secret=secretName} becomes
+     *             {@code quarkus.kubernetes.env.secrets=secretName}</li>
+     *             </ul>
+     */
+    @ConfigItem
+    @Deprecated
+    Map<String, EnvConfig> envVars;
+
+    /**
+     * Environment variables to add to all containers.
+     */
+    @ConfigItem
+    EnvVarsConfig env;
+
+    @Deprecated
+    public Map<String, EnvConfig> getEnvVars() {
+        return envVars;
+    }
+
+    public EnvVarsConfig getEnv() {
+        return env;
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -52,12 +52,6 @@ public class KubernetesConfig implements PlatformConfiguration {
     boolean addBuildTimestamp;
 
     /**
-     * Environment variables to add to all containers
-     */
-    @ConfigItem
-    Map<String, EnvConfig> envVars;
-
-    /**
      * Working directory
      */
     @ConfigItem
@@ -230,8 +224,43 @@ public class KubernetesConfig implements PlatformConfiguration {
         return addBuildTimestamp;
     }
 
+    @Override
+    public String getTargetPlatformName() {
+        return Constants.KUBERNETES;
+    }
+
+    /**
+     * Environment variables to add to all containers using the old syntax.
+     *
+     * @deprecated Use {@link #env} instead using the new syntax as follows:
+     *             <ul>
+     *             <li>{@code quarkus.kubernetes.env-vars.foo.field=fieldName} becomes
+     *             {@code quarkus.kubernetes.env.fields.foo=fieldName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.foo.value=value} becomes
+     *             {@code quarkus.kubernetes.env.vars.foo=bar}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.bar.configmap=configName} becomes
+     *             {@code quarkus.kubernetes.env.configmaps=configName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.baz.secret=secretName} becomes
+     *             {@code quarkus.kubernetes.env.secrets=secretName}</li>
+     *             </ul>
+     */
+    @ConfigItem
+    @Deprecated
+    Map<String, EnvConfig> envVars;
+
+    /**
+     * Environment variables to add to all containers.
+     */
+    @ConfigItem
+    EnvVarsConfig env;
+
+    @Deprecated
     public Map<String, EnvConfig> getEnvVars() {
         return envVars;
+    }
+
+    public EnvVarsConfig getEnv() {
+        return env;
     }
 
     public Optional<String> getWorkingDir() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -53,12 +53,6 @@ public class OpenshiftConfig implements PlatformConfiguration {
     boolean addBuildTimestamp;
 
     /**
-     * Environment variables to add to all containers
-     */
-    @ConfigItem
-    Map<String, EnvConfig> envVars;
-
-    /**
      * Working directory
      */
     @ConfigItem
@@ -223,10 +217,6 @@ public class OpenshiftConfig implements PlatformConfiguration {
         return addBuildTimestamp;
     }
 
-    public Map<String, EnvConfig> getEnvVars() {
-        return envVars;
-    }
-
     public Optional<String> getWorkingDir() {
         return workingDir;
     }
@@ -318,5 +308,44 @@ public class OpenshiftConfig implements PlatformConfiguration {
     @Override
     public boolean isExpose() {
         return false;
+    }
+
+    @Override
+    public String getTargetPlatformName() {
+        return Constants.OPENSHIFT;
+    }
+
+    /**
+     * Environment variables to add to all containers using the old syntax.
+     *
+     * @deprecated Use {@link #env} instead using the new syntax as follows:
+     *             <ul>
+     *             <li>{@code quarkus.kubernetes.env-vars.foo.field=fieldName} becomes
+     *             {@code quarkus.kubernetes.env.fields.foo=fieldName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.envvar.value=value} becomes
+     *             {@code quarkus.kubernetes.env.vars.envvar=value}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.bar.configmap=configName} becomes
+     *             {@code quarkus.kubernetes.env.configmaps=configName}</li>
+     *             <li>{@code quarkus.kubernetes.env-vars.baz.secret=secretName} becomes
+     *             {@code quarkus.kubernetes.env.secrets=secretName}</li>
+     *             </ul>
+     */
+    @ConfigItem
+    @Deprecated
+    Map<String, EnvConfig> envVars;
+
+    /**
+     * Environment variables to add to all containers.
+     */
+    @ConfigItem
+    EnvVarsConfig env;
+
+    @Deprecated
+    public Map<String, EnvConfig> getEnvVars() {
+        return envVars;
+    }
+
+    public EnvVarsConfig getEnv() {
+        return env;
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.annotation.ServiceType;
 
-public interface PlatformConfiguration {
+public interface PlatformConfiguration extends EnvVarHolder {
 
     Optional<String> getPartOf();
 
@@ -21,8 +21,6 @@ public interface PlatformConfiguration {
     Map<String, String> getAnnotations();
 
     boolean isAddBuildTimestamp();
-
-    Map<String, EnvConfig> getEnvVars();
 
     Optional<String> getWorkingDir();
 

--- a/extensions/kubernetes/vanilla/deployment/src/test/java/io/quarkus/kubernetes/deployment/EnvVarValidatorTest.java
+++ b/extensions/kubernetes/vanilla/deployment/src/test/java/io/quarkus/kubernetes/deployment/EnvVarValidatorTest.java
@@ -1,0 +1,155 @@
+package io.quarkus.kubernetes.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.kubernetes.spi.KubernetesEnvBuildItem;
+
+class EnvVarValidatorTest {
+
+    private EnvVarValidator validator;
+
+    @BeforeEach
+    void init() {
+        this.validator = new EnvVarValidator();
+    }
+
+    @Test
+    void getBuildItemsShouldReturnEmptyOnNoItems() {
+        assertTrue(validator.getBuildItems().isEmpty());
+    }
+
+    @Test
+    void getBuildItemsOneItemShouldWork() {
+        final KubernetesEnvBuildItem initial = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.var, "name", "value",
+                "kubernetes");
+        validator.process(initial);
+        final Collection<KubernetesEnvBuildItem> items = validator.getBuildItems();
+        assertEquals(1, items.size());
+        assertEquals(initial, items.stream().findFirst().orElseGet(() -> fail("no item was found when one was expected")));
+    }
+
+    @Test
+    void getBuildItemsTwoConflictingItemsShouldFail() {
+        final String name = "name";
+        final String value1 = "foo";
+        final String value2 = "bar";
+        final KubernetesEnvBuildItem first = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.var, name, value1,
+                "kubernetes");
+        final KubernetesEnvBuildItem second = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.field, name, value2,
+                "kubernetes");
+        validator.process(first);
+        validator.process(second);
+        try {
+            validator.getBuildItems();
+            fail();
+        } catch (Exception e) {
+            final String message = e.getMessage();
+            assertTrue(message.contains(name) && message.contains(value1) && message.contains(value2));
+        }
+    }
+
+    @Test
+    void getBuildItemsTwoRedundantItemsShouldResultInOnlyOneItem() {
+        final String name = "name";
+        final String value1 = "foo";
+        final KubernetesEnvBuildItem first = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.configmap, name, value1,
+                "kubernetes");
+        final KubernetesEnvBuildItem second = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.configmap, name, value1,
+                "kubernetes");
+        validator.process(first);
+        validator.process(second);
+        final Collection<KubernetesEnvBuildItem> items = validator.getBuildItems();
+        assertEquals(1, items.size());
+        assertEquals(first, items.stream().findFirst().orElseGet(() -> fail("no item was found when one was expected")));
+    }
+
+    @Test
+    void getBuildItemsSimilarlyNamedCompatibleItemsShouldWork() {
+        final String name = "name";
+        final String value1 = "foo";
+        final KubernetesEnvBuildItem first = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.var, name, value1,
+                "kubernetes");
+        final KubernetesEnvBuildItem second = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.secret, name, name,
+                "kubernetes");
+        final KubernetesEnvBuildItem third = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.configmap, name, name,
+                "kubernetes");
+        validator.process(first);
+        validator.process(second);
+        validator.process(third);
+        Collection<KubernetesEnvBuildItem> items = validator.getBuildItems();
+        assertEquals(3, items.size());
+        assertTrue(items.contains(first) && items.contains(second) && items.contains(third));
+
+        // check different order
+        validator = new EnvVarValidator();
+        validator.process(third);
+        validator.process(first);
+        validator.process(second);
+        items = validator.getBuildItems();
+        assertEquals(3, items.size());
+        assertTrue(items.contains(first) && items.contains(second) && items.contains(third));
+    }
+
+    @Test
+    void getBuildItemsSameItemsOldAndNewShouldWork() {
+        final String name = "name";
+        final String value1 = "foo";
+        final KubernetesEnvBuildItem oldStyleVar = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.var, name, value1,
+                "kubernetes", true);
+        final KubernetesEnvBuildItem newStyleVar = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.var, name,
+                "newValue",
+                "kubernetes", false);
+        validator.process(oldStyleVar);
+        validator.process(newStyleVar);
+        Collection<KubernetesEnvBuildItem> items = validator.getBuildItems();
+        assertEquals(1, items.size());
+        assertTrue(items.contains(newStyleVar));
+
+        // check reverse order
+        validator = new EnvVarValidator();
+        validator.process(newStyleVar);
+        validator.process(oldStyleVar);
+        items = validator.getBuildItems();
+        assertEquals(1, items.size());
+        assertTrue(items.contains(newStyleVar));
+    }
+
+    @Test
+    void getBuildItemsTwoConflictingItemsUsingDifferentStylesShouldFail() {
+        final String name = "name";
+        final String value1 = "foo";
+        final String value2 = "bar";
+        final KubernetesEnvBuildItem first = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.var, name, value1,
+                "kubernetes", true);
+        final KubernetesEnvBuildItem second = new KubernetesEnvBuildItem(KubernetesEnvBuildItem.EnvType.field, name, value2,
+                "kubernetes");
+        validator.process(first);
+        validator.process(second);
+        try {
+            validator.getBuildItems();
+            fail();
+        } catch (Exception e) {
+            final String message = e.getMessage();
+            assertTrue(message.contains(name) && message.contains(value1) && message.contains(value2));
+        }
+
+        // check different order
+        validator = new EnvVarValidator();
+        validator.process(second);
+        validator.process(first);
+        try {
+            validator.getBuildItems();
+            fail();
+        } catch (Exception e) {
+            final String message = e.getMessage();
+            assertTrue(message.contains(name) && message.contains(value1) && message.contains(value2));
+        }
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithConflictingEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithConflictingEnvTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithConflictingEnvTest {
+    private static final String APPLICATION_NAME = "conflicting";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .assertBuildException(e -> assertThat(e)
+                    .isInstanceOf(RuntimeException.class)
+                    .hasCauseInstanceOf(BuildException.class)
+                    .hasMessageContaining(
+                            "- 'envvar': first defined as 'var' env var with value 'value' redefined as 'field' env var with value 'field'"))
+            .withConfigurationResource("kubernetes-with-" + APPLICATION_NAME + "-env.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void buildShouldFail() throws IOException {
+        fail("Build should have failed and therefore this method should not have been called");
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMixedStyleEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMixedStyleEnvTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithMixedStyleEnvTest {
+    private static final String APPLICATION_NAME = "mixed-style";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-" + APPLICATION_NAME + "-env.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APPLICATION_NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "FROMFIELD".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(
+                                            env -> assertThat(env.getValueFrom().getFieldRef().getFieldPath())
+                                                    .isEqualTo("metadata.name"));
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "ENVVAR".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(env -> assertThat(env.getValue()).isEqualTo("value"));
+                            final List<EnvFromSource> envFrom = container.getEnvFrom();
+                            assertThat(envFrom).hasSize(2);
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getSecretRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getSecretRef().getName()).isEqualTo("secretName"));
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getConfigMapRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getConfigMapRef().getName()).isEqualTo("configName"));
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithNewStyleEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithNewStyleEnvTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithNewStyleEnvTest {
+
+    private static final String APPLICATION_NAME = "new-style-env";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-new-style-env.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APPLICATION_NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "FROMFIELD".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(
+                                            env -> assertThat(env.getValueFrom().getFieldRef().getFieldPath())
+                                                    .isEqualTo("metadata.name"));
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "ENVVAR".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(env -> assertThat(env.getValue()).isEqualTo("value"));
+                            final List<EnvFromSource> envFrom = container.getEnvFrom();
+                            assertThat(envFrom).hasSize(2);
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getSecretRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getSecretRef().getName()).isEqualTo("secretName"));
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getConfigMapRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getConfigMapRef().getName()).isEqualTo("configName"));
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithOldStyleEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithOldStyleEnvTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithOldStyleEnvTest {
+
+    private static final String APPLICATION_NAME = "old-style-env";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-old-style-env.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APPLICATION_NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "FROMFIELD".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(
+                                            env -> assertThat(env.getValueFrom().getFieldRef().getFieldPath())
+                                                    .isEqualTo("metadata.name"));
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "ENVVAR".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(env -> assertThat(env.getValue()).isEqualTo("value"));
+                            final List<EnvFromSource> envFrom = container.getEnvFrom();
+                            assertThat(envFrom).hasSize(2);
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getSecretRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getSecretRef().getName()).isEqualTo("secretName"));
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getConfigMapRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getConfigMapRef().getName()).isEqualTo("configName"));
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithWarningsEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithWarningsEnvTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithWarningsEnvTest {
+    private static final String APPLICATION_NAME = "warnings";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setLogRecordPredicate(r -> "io.quarkus.kubernetes.deployment.EnvVarValidator".equals(r.getLoggerName()))
+            .withConfigurationResource("kubernetes-with-" + APPLICATION_NAME + "-env.properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void ensureProperQuarkusPropertiesLogged() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APPLICATION_NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).hasOnlyOneElementSatisfying(container -> {
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "MY_FIELD".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(
+                                            env -> assertThat(env.getValueFrom().getFieldRef().getFieldPath())
+                                                    .isEqualTo("newField"));
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "MY_VAR".equals(env.getName()))
+                                    .hasOnlyOneElementSatisfying(env -> assertThat(env.getValue()).isEqualTo("newVariable"));
+                            final List<EnvFromSource> envFrom = container.getEnvFrom();
+                            assertThat(envFrom).hasSize(2);
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getSecretRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getSecretRef().getName()).isEqualTo("secret"));
+                            assertThat(envFrom)
+                                    .filteredOn(e -> e.getConfigMapRef() != null)
+                                    .hasOnlyOneElementSatisfying(
+                                            e -> assertThat(e.getConfigMapRef().getName()).isEqualTo("configMap"));
+                        });
+                    });
+                });
+            });
+        });
+
+        List<LogRecord> buildLogRecords = prodModeTestResults.getRetainedBuildLogRecords();
+        assertThat(buildLogRecords).hasSize(4);
+        assertThat(buildLogRecords)
+                .filteredOn(r -> r.getMessage().contains("my-field"))
+                .hasOnlyOneElementSatisfying(r -> assertThat(r.getMessage()).contains("newField"));
+        assertThat(buildLogRecords)
+                .filteredOn(r -> r.getMessage().contains("my-var"))
+                .hasOnlyOneElementSatisfying(r -> assertThat(r.getMessage()).contains("newVariable"));
+        assertThat(buildLogRecords)
+                .filteredOn(r -> r.getMessage().contains("configMap"))
+                .hasSize(1);
+        assertThat(buildLogRecords)
+                .filteredOn(r -> r.getMessage().contains("secret"))
+                .hasSize(1);
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-conflicting-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-conflicting-env.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.env.fields.envvar=field
+quarkus.kubernetes.env.vars.envvar=value

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-mixed-style-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-mixed-style-env.properties
@@ -1,0 +1,6 @@
+quarkus.kubernetes.env-vars.envvar.value=value
+quarkus.kubernetes.env-vars.my-name.secret=secretName
+quarkus.kubernetes.env.fields.fromfield=metadata.name
+quarkus.kubernetes.env.configmaps=configName
+
+

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-new-style-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-new-style-env.properties
@@ -1,0 +1,4 @@
+quarkus.kubernetes.env.fields.fromfield=metadata.name
+quarkus.kubernetes.env.vars.envvar=value
+quarkus.kubernetes.env.configmaps=configName
+quarkus.kubernetes.env.secrets=secretName

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-old-style-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-old-style-env.properties
@@ -1,0 +1,4 @@
+quarkus.kubernetes.env-vars.fromfield.field=metadata.name
+quarkus.kubernetes.env-vars.envvar.value=value
+quarkus.kubernetes.env-vars.my-name.configmap=configName
+quarkus.kubernetes.env-vars.my-name.secret=secretName

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-warnings-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-warnings-env.properties
@@ -1,0 +1,8 @@
+quarkus.kubernetes.env.fields.my-field=newField
+quarkus.kubernetes.env-vars.my-field.field=oldField
+quarkus.kubernetes.env-vars.my-var.value=oldVariable
+quarkus.kubernetes.env.vars.my-var=newVariable
+quarkus.kubernetes.env.configmaps=configMap
+quarkus.kubernetes.env-vars.xxx.configmap=configMap
+quarkus.kubernetes.env.secrets=secret
+quarkus.kubernetes.env-vars.xxx.secret=secret


### PR DESCRIPTION
Fixes #8792

Initial implementation for option 1 as discussed in #8792 to get some feedback

Still to be done:
- [x] Fix issue with duplicated field definition (~~seems linked to dekorateio/dekorate#473~~) 
- [x] Doc updates
- [x] Support older style
- [x] Decide on what to do in case of conflicts (see https://github.com/quarkusio/quarkus/issues/8792#issuecomment-621082359 and subsequent comments)
- [x] Support defining multiple configmaps / secrets
- [x] Add integration tests
- [x] Check dev mode