### PR TITLE
Avoid null values when resolving alternative priority

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -558,10 +558,24 @@ final class Beans {
 
     private static int compareAlternativeBeans(BeanInfo bean1, BeanInfo bean2) {
         // The highest priority wins
-        Integer priority2 = bean2.getDeclaringBean() != null ? bean2.getDeclaringBean().getAlternativePriority()
-                : bean2.getAlternativePriority();
-        Integer priority1 = bean1.getDeclaringBean() != null ? bean1.getDeclaringBean().getAlternativePriority()
-                : bean1.getAlternativePriority();
+        Integer priority1, priority2;
+
+        priority2 = bean2.getAlternativePriority();
+        if (priority2 == null) {
+            priority2 = bean2.getDeclaringBean().getAlternativePriority();
+        }
+
+        priority1 = bean1.getAlternativePriority();
+        if (priority1 == null) {
+            priority1 = bean1.getDeclaringBean().getAlternativePriority();
+        }
+
+        if (priority2 == null) {
+            return priority1 == null ? 0 : -1;
+        } else if (priority1 == null) {
+            return 1;
+        }
+
         return priority2.compareTo(priority1);
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -570,10 +570,11 @@ final class Beans {
             priority1 = bean1.getDeclaringBean().getAlternativePriority();
         }
 
-        if (priority2 == null) {
-            return priority1 == null ? 0 : -1;
-        } else if (priority1 == null) {
-            return 1;
+        if (priority2 == null || priority1 == null) {
+            throw new IllegalStateException(String.format(
+                    "Alternative Bean priority should not be null. %s has priority %s; %s has priority %s",
+                    bean1.getBeanClass(), priority1,
+                    bean2.getBeanClass(), priority2));
         }
 
         return priority2.compareTo(priority1);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/priority/AlternativePriorityResolutionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/priority/AlternativePriorityResolutionTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.arc.test.alternatives.priority;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.quarkus.arc.AlternativePriority;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.annotation.Priority;
+import javax.enterprise.inject.*;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AlternativePriorityResolutionTest {
+    @RegisterExtension
+    ArcTestContainer testContainer = new ArcTestContainer(NoParentAlternativePriorityProducer1.class,
+            NoParentAlternativePriorityProducer2.class, ParentAlternativePriorityProducer3.class,
+            PrioritizedConsumer.class, MessageBean.class);
+
+    @Test
+    public void testAlternativePriorityResolution() {
+        PrioritizedConsumer bean = Arc.container().instance(PrioritizedConsumer.class).get();
+        assertNotNull(bean, "PrioritizedConsumer bean should not be null");
+        assertEquals("jar", bean.ping());
+    }
+
+    @Singleton
+    static class PrioritizedConsumer {
+        @Inject
+        MessageBean messageBean;
+
+        String ping() {
+            return messageBean.ping();
+        }
+    }
+
+    @Singleton
+    static class NoParentAlternativePriorityProducer1 {
+
+        @Produces
+        @Singleton
+        @AlternativePriority(4)
+        public MessageBean createBar() {
+            return new MessageBean("jar");
+        };
+    }
+
+    @Singleton
+    static class NoParentAlternativePriorityProducer2 {
+
+        @Produces
+        @Singleton
+        @AlternativePriority(2)
+        public MessageBean createBar() {
+            return new MessageBean("far");
+        }
+    }
+
+    @Singleton
+    @Alternative
+    @Priority(2)
+    static class ParentAlternativePriorityProducer3 {
+        @Produces
+        @Singleton
+        public MessageBean createBar() {
+            return new MessageBean("car");
+        }
+    }
+
+    @Vetoed
+    static class MessageBean {
+        final String msg;
+
+        MessageBean(String msg) {
+            this.msg = msg;
+        }
+
+        public String ping() {
+            return msg;
+        }
+    }
+}


### PR DESCRIPTION
Avoid comparing null values when comparing alternative priorities
Resolves #8895 