### PR TITLE
Fix method signature

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/RunningQuarkusApplicationImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/RunningQuarkusApplicationImpl.java
@@ -57,7 +57,7 @@ public class RunningQuarkusApplicationImpl implements RunningQuarkusApplication 
             Method getConfig = configProviderClass.getMethod("getConfig", ClassLoader.class);
             Thread.currentThread().setContextClassLoader(classLoader);
             Object config = getConfig.invoke(null, classLoader);
-            return (Iterable<String>) getConfig.getReturnType().getMethod("getPropertyNames", String.class, Class.class)
+            return (Iterable<String>) getConfig.getReturnType().getMethod("getPropertyNames")
                     .invoke(config);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
As shown in #8872, there is a `NoSuchMethodError` thrown in `RunningQuarkusApplicationImpl. getConfigKeys`.
 
The following method does not exist:

     org.eclipse.microprofile.config.Config.getPropertyNames(String, Class)

The method to get property names is :

     org.eclipse.microprofile.config.Config.getPropertyNames()