### PR TITLE
Improve query performance by using BsonDocument.parse

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactiveMongoOperations.java
@@ -337,7 +337,7 @@ public class ReactiveMongoOperations {
     @SuppressWarnings("rawtypes")
     public static ReactivePanacheQuery<?> find(Class<?> entityClass, String query, Sort sort, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         Document docSort = sortToDocument(sort);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return new ReactivePanacheQueryImpl(collection, docQuery, docSort);
@@ -428,7 +428,7 @@ public class ReactiveMongoOperations {
     @SuppressWarnings("rawtypes")
     public static ReactivePanacheQuery<?> find(Class<?> entityClass, String query, Sort sort, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         Document docSort = sortToDocument(sort);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return new ReactivePanacheQueryImpl(collection, docQuery, docSort);
@@ -574,14 +574,14 @@ public class ReactiveMongoOperations {
 
     public static Uni<Long> count(Class<?> entityClass, String query, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return collection.countDocuments(docQuery);
     }
 
     public static Uni<Long> count(Class<?> entityClass, String query, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return collection.countDocuments(docQuery);
     }
@@ -609,14 +609,14 @@ public class ReactiveMongoOperations {
 
     public static Uni<Long> delete(Class<?> entityClass, String query, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         return collection.deleteMany(docQuery).map(deleteResult -> deleteResult.getDeletedCount());
     }
 
     public static Uni<Long> delete(Class<?> entityClass, String query, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         return collection.deleteMany(docQuery).map(deleteResult -> deleteResult.getDeletedCount());
     }
@@ -644,15 +644,15 @@ public class ReactiveMongoOperations {
     }
 
     private static ReactivePanacheUpdate executeUpdate(Class<?> entityClass, String update, Object... params) {
-        String bindUpdate = ReactiveMongoOperations.bindUpdate(entityClass, update, params);
-        Document docUpdate = Document.parse(bindUpdate);
+        String bindUpdate = bindUpdate(entityClass, update, params);
+        BsonDocument docUpdate = BsonDocument.parse(bindUpdate);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         return new ReactivePanacheUpdateImpl(entityClass, docUpdate, collection);
     }
 
     private static ReactivePanacheUpdate executeUpdate(Class<?> entityClass, String update, Map<String, Object> params) {
-        String bindUpdate = ReactiveMongoOperations.bindUpdate(entityClass, update, params);
-        Document docUpdate = Document.parse(bindUpdate);
+        String bindUpdate = bindUpdate(entityClass, update, params);
+        BsonDocument docUpdate = BsonDocument.parse(bindUpdate);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
         return new ReactivePanacheUpdateImpl(entityClass, docUpdate, collection);
     }

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheQueryImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.bson.Document;
+import org.bson.conversions.Bson;
 
 import io.quarkus.mongodb.FindOptions;
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
@@ -18,22 +19,22 @@ import io.smallrye.mutiny.Uni;
 
 public class ReactivePanacheQueryImpl<Entity> implements ReactivePanacheQuery<Entity> {
     private ReactiveMongoCollection collection;
-    private Document mongoQuery;
-    private Document sort;
-    private Document projections;
+    private Bson mongoQuery;
+    private Bson sort;
+    private Bson projections;
 
     private Page page;
     private Uni<Long> count;
 
     private Range range;
 
-    ReactivePanacheQueryImpl(ReactiveMongoCollection<? extends Entity> collection, Document mongoQuery, Document sort) {
+    ReactivePanacheQueryImpl(ReactiveMongoCollection<? extends Entity> collection, Bson mongoQuery, Bson sort) {
         this.collection = collection;
         this.mongoQuery = mongoQuery;
         this.sort = sort;
     }
 
-    private ReactivePanacheQueryImpl(ReactivePanacheQueryImpl previousQuery, Document projections) {
+    private ReactivePanacheQueryImpl(ReactivePanacheQueryImpl previousQuery, Bson projections) {
         this.collection = previousQuery.collection;
         this.mongoQuery = previousQuery.mongoQuery;
         this.sort = previousQuery.sort;

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheUpdateImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/reactive/runtime/ReactivePanacheUpdateImpl.java
@@ -2,7 +2,8 @@ package io.quarkus.mongodb.panache.reactive.runtime;
 
 import java.util.Map;
 
-import org.bson.Document;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
 
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheUpdate;
 import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
@@ -11,10 +12,10 @@ import io.smallrye.mutiny.Uni;
 
 public class ReactivePanacheUpdateImpl implements ReactivePanacheUpdate {
     private Class<?> entityClass;
-    private Document update;
+    private Bson update;
     private ReactiveMongoCollection<?> collection;
 
-    public ReactivePanacheUpdateImpl(Class<?> entityClass, Document update, ReactiveMongoCollection<?> collection) {
+    public ReactivePanacheUpdateImpl(Class<?> entityClass, Bson update, ReactiveMongoCollection<?> collection) {
         this.entityClass = entityClass;
         this.update = update;
         this.collection = collection;
@@ -23,14 +24,14 @@ public class ReactivePanacheUpdateImpl implements ReactivePanacheUpdate {
     @Override
     public Uni<Long> where(String query, Object... params) {
         String bindQuery = ReactiveMongoOperations.bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         return collection.updateMany(docQuery, update).map(result -> result.getModifiedCount());
     }
 
     @Override
     public Uni<Long> where(String query, Map<String, Object> params) {
         String bindQuery = ReactiveMongoOperations.bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         return collection.updateMany(docQuery, update).map(result -> result.getModifiedCount());
     }
 
@@ -41,6 +42,6 @@ public class ReactivePanacheUpdateImpl implements ReactivePanacheUpdate {
 
     @Override
     public Uni<Long> all() {
-        return collection.updateMany(new Document(), update).map(result -> result.getModifiedCount());
+        return collection.updateMany(new BsonDocument(), update).map(result -> result.getModifiedCount());
     }
 }

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/MongoOperations.java
@@ -313,7 +313,7 @@ public class MongoOperations {
     @SuppressWarnings("rawtypes")
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Sort sort, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         Document docSort = sortToDocument(sort);
         MongoCollection collection = mongoCollection(entityClass);
         return new PanacheQueryImpl(collection, docQuery, docSort);
@@ -400,7 +400,7 @@ public class MongoOperations {
     @SuppressWarnings("rawtypes")
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Sort sort, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         Document docSort = sortToDocument(sort);
         MongoCollection collection = mongoCollection(entityClass);
         return new PanacheQueryImpl(collection, docQuery, docSort);
@@ -546,14 +546,14 @@ public class MongoOperations {
 
     public static long count(Class<?> entityClass, String query, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         MongoCollection collection = mongoCollection(entityClass);
         return collection.countDocuments(docQuery);
     }
 
     public static long count(Class<?> entityClass, String query, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         MongoCollection collection = mongoCollection(entityClass);
         return collection.countDocuments(docQuery);
     }
@@ -582,14 +582,14 @@ public class MongoOperations {
 
     public static long delete(Class<?> entityClass, String query, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         MongoCollection collection = mongoCollection(entityClass);
         return collection.deleteMany(docQuery).getDeletedCount();
     }
 
     public static long delete(Class<?> entityClass, String query, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         MongoCollection collection = mongoCollection(entityClass);
         return collection.deleteMany(docQuery).getDeletedCount();
     }
@@ -617,15 +617,15 @@ public class MongoOperations {
     }
 
     private static PanacheUpdate executeUpdate(Class<?> entityClass, String update, Object... params) {
-        String bindUpdate = MongoOperations.bindUpdate(entityClass, update, params);
-        Document docUpdate = Document.parse(bindUpdate);
+        String bindUpdate = bindUpdate(entityClass, update, params);
+        BsonDocument docUpdate = BsonDocument.parse(bindUpdate);
         MongoCollection collection = mongoCollection(entityClass);
         return new PanacheUpdateImpl(entityClass, docUpdate, collection);
     }
 
     private static PanacheUpdate executeUpdate(Class<?> entityClass, String update, Map<String, Object> params) {
-        String bindUpdate = MongoOperations.bindUpdate(entityClass, update, params);
-        Document docUpdate = Document.parse(bindUpdate);
+        String bindUpdate = bindUpdate(entityClass, update, params);
+        BsonDocument docUpdate = BsonDocument.parse(bindUpdate);
         MongoCollection collection = mongoCollection(entityClass);
         return new PanacheUpdateImpl(entityClass, docUpdate, collection);
     }

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheQueryImpl.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.bson.Document;
+import org.bson.conversions.Bson;
 
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
@@ -19,22 +20,22 @@ import io.quarkus.panache.common.exception.PanacheQueryException;
 
 public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     private MongoCollection collection;
-    private Document mongoQuery;
-    private Document sort;
-    private Document projections;
+    private Bson mongoQuery;
+    private Bson sort;
+    private Bson projections;
 
     private Page page;
     private Long count;
 
     private Range range;
 
-    PanacheQueryImpl(MongoCollection<? extends Entity> collection, Document mongoQuery, Document sort) {
+    PanacheQueryImpl(MongoCollection<? extends Entity> collection, Bson mongoQuery, Bson sort) {
         this.collection = collection;
         this.mongoQuery = mongoQuery;
         this.sort = sort;
     }
 
-    private PanacheQueryImpl(PanacheQueryImpl previousQuery, Document projections) {
+    private PanacheQueryImpl(PanacheQueryImpl previousQuery, Bson projections) {
         this.collection = previousQuery.collection;
         this.mongoQuery = previousQuery.mongoQuery;
         this.sort = previousQuery.sort;

--- a/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheUpdateImpl.java
+++ b/extensions/panache/mongodb-panache/runtime/src/main/java/io/quarkus/mongodb/panache/runtime/PanacheUpdateImpl.java
@@ -2,7 +2,8 @@ package io.quarkus.mongodb.panache.runtime;
 
 import java.util.Map;
 
-import org.bson.Document;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
 
 import com.mongodb.client.MongoCollection;
 
@@ -11,10 +12,10 @@ import io.quarkus.panache.common.Parameters;
 
 public class PanacheUpdateImpl implements PanacheUpdate {
     private Class<?> entityClass;
-    private Document update;
+    private Bson update;
     private MongoCollection collection;
 
-    public PanacheUpdateImpl(Class<?> entityClass, Document update, MongoCollection collection) {
+    public PanacheUpdateImpl(Class<?> entityClass, Bson update, MongoCollection collection) {
         this.entityClass = entityClass;
         this.update = update;
         this.collection = collection;
@@ -23,14 +24,14 @@ public class PanacheUpdateImpl implements PanacheUpdate {
     @Override
     public long where(String query, Object... params) {
         String bindQuery = MongoOperations.bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         return collection.updateMany(docQuery, update).getModifiedCount();
     }
 
     @Override
     public long where(String query, Map<String, Object> params) {
         String bindQuery = MongoOperations.bindFilter(entityClass, query, params);
-        Document docQuery = Document.parse(bindQuery);
+        BsonDocument docQuery = BsonDocument.parse(bindQuery);
         return collection.updateMany(docQuery, update).getModifiedCount();
     }
 
@@ -41,6 +42,6 @@ public class PanacheUpdateImpl implements PanacheUpdate {
 
     @Override
     public long all() {
-        return collection.updateMany(new Document(), update).getModifiedCount();
+        return collection.updateMany(new BsonDocument(), update).getModifiedCount();
     }
 }


### PR DESCRIPTION
Currently, we parse Query using `Document.parse` this triggers a `CodecConfiurationException` on each call to parse but works.

The cost of creating the exception is important, replacing it with `BsonDocument.parse` make it disapears.

I also update the constructors of `PanacheQueryImpl`, `PanacheUpdateImpl` and their reactive conterpart with the `Bson` type that is the super type of `BsonDocument` and `Document` so this is more future proof.

### Detailed explainations:
In MongoDB everything is a document (serialized in BSON - Binary JSON), including a query (a filter in MongoDB terms) and an update statement.

With the Java driver, there is three ways to express a document:

- **BasicDBObject** (or DBOBject it's super type): the legacy (driver v2) type
- **BsonDocument**: a type safe Document where all fields needs to be of one of the known BSON type (using the `BsonValue` type)
- **Document**: a way to express a document with all fields as `Object`, translated into a BSON type via a Codec. We use this type inside MongoDB with Panache to serialize the entity to the database thanks to the Pojo Codec.

All these three types implements `Bson`. All the MongoDB operations on a collection takes `Bson` type parameters so we can use all three types as we want.

Using `Document` to parse a query was an error as it is designed to be used with Codec and objects, not to parse a query String.

Using `BsonDocument` is more natural.

`PanacheEntityBase` and `PanacheRepositoryBase` have overload find/list/stream/count/delete methods that takes a `Document` query to allow more complex use cases, I didn't refactor them to `BsonDocument` as it would be an incompatible change, I didn't refactor them to `Bson` neither but I could be done without any issue as `Document` implements `Bson`.