### PR TITLE
clarify building-native-image.adoc for Windows

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -172,7 +172,8 @@ Create a native executable using: `./mvnw package -Pnative`.
 .Issues with packaging on Windows
 ====
 The Microsoft Native Tools for Visual Studio must first be initialized before packaging. You can do this by starting
-the `x64 Native Tools Command Prompt` that was installed with the Visual Studio Build Tools.
+the `x64 Native Tools Command Prompt` that was installed with the Visual Studio Build Tools. At 
+`x64 Native Tools Command Prompt` you can navigate to your project folder and run `mvnw package -Pnative`.
 
 Another solution is to write a script to do this for you:
 
@@ -297,7 +298,8 @@ target directory you can specify the executable with the `-Dnative.image.path=` 
 
 == Creating a container
 
-IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment.
+IMPORTANT: Before going further, be sure to have a working container runtime (Docker, podman) environment. If you use Docker 
+on Windows you should share your project's drive at Docker Desktop file share settings.
 
 You can run the application in a container using the JAR produced by the Quarkus Maven Plugin.
 However, in this guide we focus on creating a container image using the produced native executable.


### PR DESCRIPTION
Two main messages for building native images at Windows:
1. Don't just run `mvnw package -Pnative` at cmd or PowerShell - it won't work.
2. Share drive with containers in Docker Desktop settings.

This simple truths are not obvious from existing docs. I spent couple of days figuring this out. And when my colleagues faced the same problems it became obvious, that documentation needs improvement.
I'm not so good with English, please feel free to change request or suggest wordings.

[https://github.com/quarkusio/quarkus-quickstarts/issues/407](url)