### PR TITLE
Add the singleton scope to beans produced by the JsonbProducer

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -182,7 +182,7 @@ public class FooSerializerRegistrationCustomizer implements JsonbConfigCustomize
 }
 ----
 
-A more advanced option would be to directly provide a bean of `javax.json.bind.JsonbConfig` or in the extreme case to provide a bean of type `javax.json.bind.Jsonb`.
+A more advanced option would be to directly provide a bean of `javax.json.bind.JsonbConfig` (with a `Dependent` scope) or in the extreme case to provide a bean of type `javax.json.bind.Jsonb` (with a `Singleton` scope).
 If the latter approach is leveraged it is very important to manually inject and apply all `io.quarkus.jsonb.JsonbConfigCustomizer` beans in the CDI producer that produces `javax.json.bind.Jsonb`.
 Failure to do so will prevent JSON-B specific customizations provided by various extensions from being applied.
 

--- a/extensions/jsonb/runtime/src/main/java/io/quarkus/jsonb/JsonbProducer.java
+++ b/extensions/jsonb/runtime/src/main/java/io/quarkus/jsonb/JsonbProducer.java
@@ -1,5 +1,6 @@
 package io.quarkus.jsonb;
 
+import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
@@ -13,6 +14,7 @@ import io.quarkus.arc.DefaultBean;
 public class JsonbProducer {
 
     @Produces
+    @Dependent //JsonbConfig is not thread safe so it must not be made singleton.
     @DefaultBean
     public JsonbConfig jsonbConfig(Instance<JsonbConfigCustomizer> customizers) {
         JsonbConfig jsonbConfig = new JsonbConfig();
@@ -23,6 +25,7 @@ public class JsonbProducer {
     }
 
     @Produces
+    @Singleton
     @DefaultBean
     public Jsonb jsonb(JsonbConfig jsonbConfig) {
         return JsonbBuilder.create(jsonbConfig);


### PR DESCRIPTION
This avoids re-creating the bean each time.

The cost to create the bean has shown up in some startup profile for kafka messaging based application, when using the provided JsonbSerializer/Deserializer they recover a Jsonb instance from Arc and multiple ones was created.
After this fix none are created (Jsonb is created once for all usage).