### PR TITLE
Allow extensions to configure Vertx

### DIFF
--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxOptionsConsumerBuildItem.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxOptionsConsumerBuildItem.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.core.deployment;
+
+import java.util.function.Consumer;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.vertx.core.VertxOptions;
+
+/**
+ * Provide a consumer of VertxOptions to allow customization of
+ * Vert.x system behavior, e.g. setting MetricsOptions to enable
+ * and configure a metrics provider.
+ * <p>
+ * Consumers will be called in priority order (lowest to highest)
+ * after VertxConfiguration has been read and applied.
+ */
+public final class VertxOptionsConsumerBuildItem extends MultiBuildItem implements Comparable<VertxOptionsConsumerBuildItem> {
+    private final Consumer<VertxOptions> optionsConsumer;
+    private final int priority;
+
+    public VertxOptionsConsumerBuildItem(Consumer<VertxOptions> optionsConsumer, int priority) {
+        this.optionsConsumer = optionsConsumer;
+        this.priority = priority;
+    }
+
+    public Consumer<VertxOptions> getConsumer() {
+        return optionsConsumer;
+    }
+
+    @Override
+    public int compareTo(VertxOptionsConsumerBuildItem o) {
+        return Integer.compare(this.priority, o.priority);
+    }
+}

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -49,8 +50,8 @@ public class VertxCoreRecorder {
     static volatile VertxSupplier vertx;
 
     public Supplier<Vertx> configureVertx(VertxConfiguration config,
-            LaunchMode launchMode, ShutdownContext shutdown) {
-        vertx = new VertxSupplier(config);
+            LaunchMode launchMode, ShutdownContext shutdown, List<Consumer<VertxOptions>> customizers) {
+        vertx = new VertxSupplier(config, customizers);
         if (launchMode != LaunchMode.DEVELOPMENT) {
             // we need this to be part of the last shutdown tasks because closing it early (basically before Arc)
             // could cause problem to beans that rely on Vert.x and contain shutdown tasks
@@ -77,12 +78,18 @@ public class VertxCoreRecorder {
         return vertx;
     }
 
-    public static Vertx initialize(VertxConfiguration conf) {
-        if (conf == null) {
-            return logVertxInitialization(Vertx.vertx());
+    public static Vertx initialize(VertxConfiguration conf, VertxOptionsCustomizer customizer) {
+
+        VertxOptions options = new VertxOptions();
+
+        if (conf != null) {
+            convertToVertxOptions(conf, options, true);
         }
 
-        VertxOptions options = convertToVertxOptions(conf, true);
+        // Allow extension customizers to do their thing
+        if (customizer != null) {
+            customizer.customize(options);
+        }
 
         Vertx vertx;
         if (options.getEventBusOptions().isClustered()) {
@@ -106,12 +113,11 @@ public class VertxCoreRecorder {
         return vertx;
     }
 
-    private static VertxOptions convertToVertxOptions(VertxConfiguration conf, boolean allowClustering) {
+    private static VertxOptions convertToVertxOptions(VertxConfiguration conf, VertxOptions options, boolean allowClustering) {
+
         if (!conf.useAsyncDNS) {
             System.setProperty(ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME, "true");
         }
-
-        VertxOptions options = new VertxOptions();
 
         if (allowClustering) {
             // Order matters, as the cluster options modifies the event bus options.
@@ -318,18 +324,35 @@ public class VertxCoreRecorder {
 
     static class VertxSupplier implements Supplier<Vertx> {
         final VertxConfiguration config;
+        final VertxOptionsCustomizer customizer;
         Vertx v;
 
-        VertxSupplier(VertxConfiguration config) {
+        VertxSupplier(VertxConfiguration config, List<Consumer<VertxOptions>> customizers) {
             this.config = config;
+            this.customizer = new VertxOptionsCustomizer(customizers);
         }
 
         @Override
         public synchronized Vertx get() {
             if (v == null) {
-                v = initialize(config);
+                v = initialize(config, customizer);
             }
             return v;
+        }
+    }
+
+    static class VertxOptionsCustomizer {
+        final List<Consumer<VertxOptions>> customizers;
+
+        VertxOptionsCustomizer(List<Consumer<VertxOptions>> customizers) {
+            this.customizers = customizers;
+        }
+
+        VertxOptions customize(VertxOptions options) {
+            for (Consumer<VertxOptions> x : customizers) {
+                x.accept(options);
+            }
+            return options;
         }
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -138,7 +138,7 @@ public class VertxHttpRecorder {
         }
         VertxConfiguration vertxConfiguration = new VertxConfiguration();
         ConfigInstantiator.handleObject(vertxConfiguration);
-        Vertx vertx = VertxCoreRecorder.initialize(vertxConfiguration);
+        Vertx vertx = VertxCoreRecorder.initialize(vertxConfiguration, null);
 
         try {
             HttpConfiguration config = new HttpConfiguration();

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -27,7 +27,7 @@ public class VertxProducerTest {
 
     @Test
     public void shouldNotFailWithoutConfig() {
-        producer.vertx = VertxCoreRecorder.initialize(null);
+        producer.vertx = VertxCoreRecorder.initialize(null, null);
         verifyProducer();
     }
 


### PR DESCRIPTION
Create a build item allowing other extensions to specify consumers of VertxOptions. These consumers will be invoked (in priority order) with VertxOptions after user configuration has been read, but before Vert.x has started.