### PR TITLE
Increase timeout for Cache CI group

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -394,7 +394,7 @@ jobs:
               oidc-tenancy
               keycloak-authorization
           - category: Cache
-            timeout: 30
+            timeout: 35
             test-modules: >
               infinispan-cache-jpa
               infinispan-client


### PR DESCRIPTION
Done because I've seem various PR fail by hitting the 30min
limit for the cache group