### PR TITLE
Explicit test-kafka profile

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -34,8 +34,8 @@ on:
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11 -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-dynamodb -Dtest-mysql -Dtest-mariadb -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dnative-image.xmx=5g -Dnative -Dformat.skip install"
-  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-mariadb -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dformat.skip"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11 -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-dynamodb -Dtest-mysql -Dtest-mariadb -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dnative-image.xmx=5g -Dnative -Dformat.skip install"
+  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-mariadb -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-keycloak -Dformat.skip"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test

--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -54,7 +54,7 @@ jobs:
         run: mvn -B install -DskipTests -DskipITs -Dformat.skip
 
       - name: Run integration tests in native
-        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dtest-mssql -Dtest-mariadb -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test"
+        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-dynamodb -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dtest-kafka -Dtest-mssql -Dtest-mariadb -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test"
 
       - name: Report
         if: always()

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -184,16 +184,22 @@
 
     <profiles>
         <profile>
-            <id>docker</id>
+            <id>test-kafka</id>
             <activation>
                 <property>
-                    <name>docker</name>
+                    <name>test-kafka</name>
                 </property>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
                         </configuration>
@@ -221,7 +227,6 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <skip>false</skip>
                                     <systemProperties>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner
                                         </native.image.path>

--- a/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaSASLTestResource.java
+++ b/integration-tests/kafka/src/test/java/io/quarkus/it/kafka/KafkaSASLTestResource.java
@@ -23,7 +23,7 @@ public class KafkaSASLTestResource implements QuarkusTestResourceLifecycleManage
     @Override
     public Map<String, String> start() {
         try {
-            File directory = Testing.Files.createTestingDirectory("kafka-data", true);
+            File directory = Testing.Files.createTestingDirectory("sasl-kafka-data", true);
             File sslDir = sslDir(directory, true);
 
             Path ksPath = new File(sslDir, "kafka-keystore.p12").toPath();
@@ -82,7 +82,7 @@ public class KafkaSASLTestResource implements QuarkusTestResourceLifecycleManage
 
     public static File sslDir(File directory, boolean removeExistingContent) throws IOException {
         if (directory == null) {
-            directory = Testing.Files.createTestingDirectory("kafka-data", removeExistingContent);
+            directory = Testing.Files.createTestingDirectory("sasl-kafka-data", removeExistingContent);
         }
 
         File targetDir = directory.getParentFile().getParentFile();


### PR DESCRIPTION
Explicit test-kafka profile as `integration-tests/kafka` requires docker, this was introduced in https://github.com/quarkusio/quarkus/pull/8237.

Solution from 8237 worked partialyy, ok for JVM mode, but in native mode testsuite expected docker availability because of testcontainers.

Now the tests are enabled by explicit `-Dtest-kafka` and not as side effect of `-Dnative`