### PR TITLE
Fix KafkaStreams liveness to allow rebalancing state

### DIFF
--- a/extensions/kafka-streams/runtime/pom.xml
+++ b/extensions/kafka-streams/runtime/pom.xml
@@ -39,6 +39,22 @@
             <artifactId>quarkus-smallrye-health</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java
@@ -23,7 +23,7 @@ public class KafkaStreamsStateHealthCheck implements HealthCheck {
         HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Kafka Streams state health check");
         try {
             KafkaStreams.State state = manager.getStreams().state();
-            responseBuilder.state(state == KafkaStreams.State.RUNNING)
+            responseBuilder.state(state.isRunningOrRebalancing())
                     .withData("state", state.name());
         } catch (Exception e) {
             responseBuilder.down().withData("technical_error", e.getMessage());

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsHealthCheckTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.kafka.streams.runtime.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
+
+public class KafkaStreamsHealthCheckTest {
+
+    @InjectMocks
+    KafkaStreamsStateHealthCheck healthCheck = new KafkaStreamsStateHealthCheck();
+
+    @Mock
+    private KafkaStreamsTopologyManager manager;
+
+    @Mock
+    private KafkaStreams streams;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(manager.getStreams()).thenReturn(streams);
+    }
+
+    @Test
+    public void shouldBeUpIfStateRunning() {
+        Mockito.when(streams.state()).thenReturn(KafkaStreams.State.RUNNING);
+        HealthCheckResponse response = healthCheck.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+    }
+
+    @Test
+    public void shouldBeUpIfStateRebalancing() {
+        Mockito.when(streams.state()).thenReturn(KafkaStreams.State.REBALANCING);
+        HealthCheckResponse response = healthCheck.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+    }
+
+    @Test
+    public void shouldBeDownIfStateCreated() {
+        Mockito.when(streams.state()).thenReturn(KafkaStreams.State.CREATED);
+        HealthCheckResponse response = healthCheck.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+    }
+
+}

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.kafka.streams.runtime.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+
+import java.util.Collections;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import io.quarkus.kafka.streams.runtime.KafkaStreamsTopologyManager;
+
+public class KafkaStreamsTopicsHealthCheckTest {
+
+    @InjectMocks
+    KafkaStreamsTopicsHealthCheck healthCheck = new KafkaStreamsTopicsHealthCheck();
+
+    @Mock
+    private KafkaStreamsTopologyManager manager;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        healthCheck.topics = Collections.singletonList("topic");
+        healthCheck.init();
+    }
+
+    @Test
+    public void shouldBeUpIfNoMissingTopic() throws InterruptedException {
+        Mockito.when(manager.getMissingTopics(anyList())).thenReturn(Collections.emptySet());
+        HealthCheckResponse response = healthCheck.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+    }
+
+    @Test
+    public void shouldBeDownIfMissingTopic() throws InterruptedException {
+        Mockito.when(manager.getMissingTopics(anyList())).thenReturn(Collections.singleton("topic"));
+        HealthCheckResponse response = healthCheck.call();
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+    }
+}


### PR DESCRIPTION
cf first step of #8922
The method State#isRunning() was renamed to State#isRunningOrRebalancing() in Kafka 2.5.0, hence the confusion in #8736
Also add some unit tests for health checks