### PR TITLE
Update testcontainers version and sync changes from kafka into BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -124,7 +124,7 @@
         <caffeine.version>2.8.0</caffeine.version>
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
-        <test-containers.version>1.12.4</test-containers.version>
+        <test-containers.version>1.14.1</test-containers.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <mutiny.version>0.5.0</mutiny.version>
         <axle-client.version>0.0.15</axle-client.version>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -104,26 +104,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.13.0</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Update testcontainers version, exclusions from kafka are not needed with new version

As pointed out by @bsideup bellow in the thread, `javax.` exclusions are no longer needed as they are not defined as a dependency.

https://mvnrepository.com/artifact/org.testcontainers/testcontainers/1.14.1