### PR TITLE
Implement an annotation processor to mark Panache archives

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeTransformerBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeTransformerBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.builditem;
 
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.objectweb.asm.ClassVisitor;
@@ -18,16 +19,38 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
     final String classToTransform;
     final BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction;
 
+    /**
+     * A set of class names that need to be present in the const pool for the transformation to happen. These
+     * need to be in JVM internal format.
+     *
+     * The transformation is only applied if at least one of the entries in the const pool is present
+     *
+     * Note that this is an optimisation, and if another transformer is transforming the class anyway then
+     * this transformer will always be applied.
+     */
+    final Set<String> requireConstPoolEntry;
+
     public BytecodeTransformerBuildItem(String classToTransform,
             BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction) {
-        this(false, classToTransform, visitorFunction);
+        this(classToTransform, visitorFunction, null);
+    }
+
+    public BytecodeTransformerBuildItem(String classToTransform,
+            BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction, Set<String> requireConstPoolEntry) {
+        this(false, classToTransform, visitorFunction, requireConstPoolEntry);
     }
 
     public BytecodeTransformerBuildItem(boolean eager, String classToTransform,
             BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction) {
+        this(eager, classToTransform, visitorFunction, null);
+    }
+
+    public BytecodeTransformerBuildItem(boolean eager, String classToTransform,
+            BiFunction<String, ClassVisitor, ClassVisitor> visitorFunction, Set<String> requireConstPoolEntry) {
         this.eager = eager;
         this.classToTransform = classToTransform;
         this.visitorFunction = visitorFunction;
+        this.requireConstPoolEntry = requireConstPoolEntry;
     }
 
     public String getClassToTransform() {
@@ -36,6 +59,10 @@ public final class BytecodeTransformerBuildItem extends MultiBuildItem {
 
     public BiFunction<String, ClassVisitor, ClassVisitor> getVisitorFunction() {
         return visitorFunction;
+    }
+
+    public Set<String> getRequireConstPoolEntry() {
+        return requireConstPoolEntry;
     }
 
     public boolean isEager() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ConstPoolPredicate.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ConstPoolPredicate.java
@@ -1,0 +1,4 @@
+package io.quarkus.deployment.index;
+
+public class ConstPoolPredicate {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ConstPoolScanner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ConstPoolScanner.java
@@ -1,0 +1,92 @@
+package io.quarkus.deployment.index;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+public class ConstPoolScanner {
+
+    static final int CONSTANT_UTF8_TAG = 1;
+    static final int CONSTANT_INTEGER_TAG = 3;
+    static final int CONSTANT_FLOAT_TAG = 4;
+    static final int CONSTANT_LONG_TAG = 5;
+    static final int CONSTANT_DOUBLE_TAG = 6;
+    static final int CONSTANT_CLASS_TAG = 7;
+    static final int CONSTANT_STRING_TAG = 8;
+    static final int CONSTANT_FIELDREF_TAG = 9;
+    static final int CONSTANT_METHODREF_TAG = 10;
+    static final int CONSTANT_INTERFACE_METHODREF_TAG = 11;
+    static final int CONSTANT_NAME_AND_TYPE_TAG = 12;
+    static final int CONSTANT_METHOD_HANDLE_TAG = 15;
+    static final int CONSTANT_METHOD_TYPE_TAG = 16;
+    static final int CONSTANT_DYNAMIC_TAG = 17;
+    static final int CONSTANT_INVOKE_DYNAMIC_TAG = 18;
+    static final int CONSTANT_MODULE_TAG = 19;
+    static final int CONSTANT_PACKAGE_TAG = 20;
+
+    //TODO: at the moment this only looks for the class name, it does not make sure it is used
+    //by a class tag. In practice this is likely fine, especially as this is just used for optimisations.
+    public static boolean constPoolEntryPresent(byte[] classBody, Set<String> namesToLookFor) {
+        ByteBuffer data = ByteBuffer.wrap(classBody);
+        if (data.getInt() != 0xCAFEBABE) {
+            return false; //not a class file
+        }
+        data.getShort();//major
+        data.getShort();//minor
+        int constantPoolCount = data.getShort();
+        int currentCpInfoIndex = 1;
+        while (currentCpInfoIndex < constantPoolCount) {
+            currentCpInfoIndex++;
+            int cpInfoSize;
+            switch (data.get()) {
+                case CONSTANT_FIELDREF_TAG:
+                case CONSTANT_METHODREF_TAG:
+                case CONSTANT_INTERFACE_METHODREF_TAG:
+                case CONSTANT_INTEGER_TAG:
+                case CONSTANT_FLOAT_TAG:
+                case CONSTANT_NAME_AND_TYPE_TAG:
+                    cpInfoSize = 4;
+                    break;
+                case CONSTANT_DYNAMIC_TAG:
+                    cpInfoSize = 4;
+                    break;
+                case CONSTANT_INVOKE_DYNAMIC_TAG:
+                    cpInfoSize = 4;
+                    break;
+                case CONSTANT_LONG_TAG:
+                case CONSTANT_DOUBLE_TAG:
+                    cpInfoSize = 8;
+                    currentCpInfoIndex++;
+                    break;
+                case CONSTANT_UTF8_TAG:
+                    int strLength = 0xFFFF & data.getShort();
+                    cpInfoSize = 0;
+                    byte[] str = new byte[strLength];
+                    data.get(str);
+                    if (namesToLookFor.contains(new String(str, StandardCharsets.UTF_8))) {
+                        return true;
+                    }
+                    break;
+                case CONSTANT_METHOD_HANDLE_TAG:
+                    cpInfoSize = 3;
+                    break;
+                case CONSTANT_CLASS_TAG:
+                case CONSTANT_STRING_TAG:
+                case CONSTANT_METHOD_TYPE_TAG:
+                case CONSTANT_PACKAGE_TAG:
+                case CONSTANT_MODULE_TAG:
+                    cpInfoSize = 2;
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+            for (int j = 0; j < cpInfoSize; ++j) {
+                data.get();
+            }
+        }
+
+        return false;
+
+    }
+
+}

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -405,7 +405,7 @@ NOTE: The `stream` methods require a transaction to work.
 
 NOTE: The rest of the documentation show usages based on the active record pattern only,
 but keep in mind that they can be performed with the repository pattern as well.
-The repository pattern examples have been omitted for brevity. 
+The repository pattern examples have been omitted for brevity.
 
 == Advanced Query
 
@@ -944,7 +944,9 @@ That's all there is to it: with Panache, Hibernate ORM has never looked so trim 
 == Defining entities in external projects or jars
 
 Hibernate ORM with Panache relies on compile-time bytecode enhancements to your entities.
-If you define your entities in the same project where you build your Quarkus application, everything will work fine.
-If the entities come from external projects or jars, you can make sure that your jar is treated like a Quarkus application library
-by indexing it via Jandex, see link:cdi-reference#how-to-generate-a-jandex-index[How to Generate a Jandex Index] in the CDI guide.
-This will allow Quarkus to index and enhance your entities as if they were inside the current project.
+
+It attempts to identity archives with Panache entities (and consumers of Panache entities)
+by the presence of the marker file `META-INF/panache-archive.marker`. Panache includes an
+annotation processor that will automatically create this file in archives that depend on
+Panache (even indirectly). If you have disabled annotation processors you may need to create
+this file manually in some cases.

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -1077,7 +1077,9 @@ That's all there is to it: with Panache, MongoDB has never looked so trim and ne
 == Defining entities in external projects or jars
 
 MongoDB with Panache relies on compile-time bytecode enhancements to your entities.
-If you define your entities in the same project where you build your Quarkus application, everything will work fine.
-If the entities come from external projects or jars, you can make sure that your jar is treated like a Quarkus application library
-by indexing it via Jandex, see link:cdi-reference#how-to-generate-a-jandex-index[How to Generate a Jandex Index] in the CDI guide.
-This will allow Quarkus to index and enhance your entities as if they were inside the current project.
+
+It attempts to identity archives with Panache entities (and consumers of Panache entities)
+by the presence of the marker file `META-INF/panache-archive.marker`. Panache includes an
+annotation processor that will automatically create this file in archives that depend on
+Panache (even indirectly). If you have disabled annotation processors you may need to create
+this file manually in some cases.

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaEntityEnhancer.java
@@ -41,7 +41,7 @@ public class PanacheJpaEntityEnhancer extends PanacheEntityEnhancer<MetamodelInf
     private static final DotName DOTNAME_TRANSIENT = DotName.createSimple(Transient.class.getName());
 
     public PanacheJpaEntityEnhancer(IndexView index, List<PanacheMethodCustomizer> methodCustomizers) {
-        super(index, PanacheResourceProcessor.DOTNAME_PANACHE_ENTITY_BASE, methodCustomizers);
+        super(index, PanacheHibernateResourceProcessor.DOTNAME_PANACHE_ENTITY_BASE, methodCustomizers);
         modelInfo = new MetamodelInfo<>();
     }
 

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaRepositoryEnhancer.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheJpaRepositoryEnhancer.java
@@ -17,7 +17,7 @@ public class PanacheJpaRepositoryEnhancer extends PanacheRepositoryEnhancer {
             .createSimple(PanacheRepositoryBase.class.getName());
 
     public PanacheJpaRepositoryEnhancer(IndexView index) {
-        super(index, PanacheResourceProcessor.DOTNAME_PANACHE_REPOSITORY_BASE);
+        super(index, PanacheHibernateResourceProcessor.DOTNAME_PANACHE_REPOSITORY_BASE);
     }
 
     @Override

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -84,6 +84,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheMongoEntityEnhancer.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheMongoEntityEnhancer.java
@@ -31,7 +31,7 @@ public class PanacheMongoEntityEnhancer extends PanacheEntityEnhancer<MetamodelI
     final Map<String, EntityModel> entities = new HashMap<>();
 
     public PanacheMongoEntityEnhancer(IndexView index, List<PanacheMethodCustomizer> methodCustomizers) {
-        super(index, PanacheResourceProcessor.DOTNAME_PANACHE_ENTITY_BASE, methodCustomizers);
+        super(index, PanacheMongoResourceProcessor.DOTNAME_PANACHE_ENTITY_BASE, methodCustomizers);
         modelInfo = new MetamodelInfo<>();
     }
 

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheMongoRepositoryEnhancer.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheMongoRepositoryEnhancer.java
@@ -16,7 +16,7 @@ public class PanacheMongoRepositoryEnhancer extends PanacheRepositoryEnhancer {
     public final static DotName PANACHE_REPOSITORY_NAME = DotName.createSimple(PanacheMongoRepository.class.getName());
 
     public PanacheMongoRepositoryEnhancer(IndexView index) {
-        super(index, PanacheResourceProcessor.DOTNAME_PANACHE_REPOSITORY_BASE);
+        super(index, PanacheMongoResourceProcessor.DOTNAME_PANACHE_REPOSITORY_BASE);
     }
 
     @Override

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/ReactivePanacheMongoEntityEnhancer.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/ReactivePanacheMongoEntityEnhancer.java
@@ -31,7 +31,7 @@ public class ReactivePanacheMongoEntityEnhancer extends PanacheEntityEnhancer<Me
     final Map<String, EntityModel> entities = new HashMap<>();
 
     public ReactivePanacheMongoEntityEnhancer(IndexView index, List<PanacheMethodCustomizer> methodCustomizers) {
-        super(index, PanacheResourceProcessor.DOTNAME_MUTINY_PANACHE_ENTITY_BASE, methodCustomizers);
+        super(index, PanacheMongoResourceProcessor.DOTNAME_MUTINY_PANACHE_ENTITY_BASE, methodCustomizers);
         modelInfo = new MetamodelInfo<>();
     }
 

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/ReactivePanacheMongoRepositoryEnhancer.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/ReactivePanacheMongoRepositoryEnhancer.java
@@ -17,7 +17,7 @@ public class ReactivePanacheMongoRepositoryEnhancer extends PanacheRepositoryEnh
     public final static DotName PANACHE_REPOSITORY_NAME = DotName.createSimple(ReactivePanacheMongoRepository.class.getName());
 
     public ReactivePanacheMongoRepositoryEnhancer(IndexView index) {
-        super(index, PanacheResourceProcessor.DOTNAME_MUTINY_PANACHE_REPOSITORY_BASE);
+        super(index, PanacheMongoResourceProcessor.DOTNAME_MUTINY_PANACHE_REPOSITORY_BASE);
     }
 
     @Override

--- a/extensions/panache/mongodb-panache/runtime/pom.xml
+++ b/extensions/panache/mongodb-panache/runtime/pom.xml
@@ -59,6 +59,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
             </plugin>

--- a/extensions/panache/panache-common/runtime/pom.xml
+++ b/extensions/panache/panache-common/runtime/pom.xml
@@ -22,5 +22,15 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/runtime/PanacheAnnotationProcessor.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/runtime/PanacheAnnotationProcessor.java
@@ -1,0 +1,70 @@
+package io.quarkus.panache.common.runtime;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+/**
+ * An annotation processor that is used to generate a marker file, to tell Quarkus that this archive has a dependency on
+ * Pananche entities, and therefore may need to be transformed for enhanced field access.
+ *
+ * This works because any archive that depends on Panache will have a transitive dependency on panache-common, which
+ * contains this processor. The Javac compiler will then run this processor and create the marker file.
+ */
+public class PanacheAnnotationProcessor implements Processor {
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton("*");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        try {
+            FileObject marker = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "",
+                    "META-INF/panache-archive.marker");
+            try (OutputStream out = marker.openOutputStream()) {
+                out.write(
+                        "This file is a marker, it exists to tell Quarkus that this archive has a dependency on Panache, and may need to be transformed at build time"
+                                .getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    @Override
+    public Iterable<? extends Completion> getCompletions(Element element, AnnotationMirror annotation, ExecutableElement member,
+            String userText) {
+        return Collections.emptyList();
+    }
+}

--- a/extensions/panache/panache-common/runtime/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/extensions/panache/panache-common/runtime/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.quarkus.panache.common.runtime.PanacheAnnotationProcessor

--- a/extensions/panache/panache-mock/pom.xml
+++ b/extensions/panache/panache-mock/pom.xml
@@ -34,4 +34,14 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -21,6 +21,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import org.objectweb.asm.ClassVisitor;
 
 /**
@@ -280,10 +281,12 @@ public class CuratedApplication implements Serializable, Closeable {
 
     public QuarkusClassLoader createRuntimeClassLoader(QuarkusClassLoader loader,
             Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> bytecodeTransformers,
+            Map<String, Predicate<byte[]>> transformerPredicates,
             ClassLoader deploymentClassLoader, Map<String, byte[]> resources) {
         QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder("Quarkus Runtime ClassLoader",
                 loader, false)
                 .setAggregateParentResources(true);
+        builder.setTransformerPredicates(transformerPredicates);
         builder.setTransformerClassLoader(deploymentClassLoader);
         if (quarkusBootstrap.getApplicationRoot() != null) {
             builder.addElement(ClassPathElement.fromPath(quarkusBootstrap.getApplicationRoot()));


### PR DESCRIPTION
The logic here is that only libraries that are compiled
against panache will have this generated marker file, and
if this file is present this means that classes in the archive
may need to be transformed.

This is just a draft at the moment, a similar approach would
also need to be taken with Mongo.