### PR TITLE
Panache optional predicate

### DIFF
--- a/extensions/panache/mongodb-panache/runtime/src/test/java/io/quarkus/mongodb/panache/runtime/MongoOperationsTest.java
+++ b/extensions/panache/mongodb-panache/runtime/src/test/java/io/quarkus/mongodb/panache/runtime/MongoOperationsTest.java
@@ -189,6 +189,21 @@ class MongoOperationsTest {
     }
 
     @Test
+    public void testBindOptionalPredicateByIndex() {
+        String query = MongoOperations.bindFilter(Object.class, "field? = ?1 and isOk = ?2", new Object[] { "a value", true });
+        assertEquals("{'field':'a value','isOk':true}", query);
+
+        query = MongoOperations.bindFilter(Object.class, "field? = ?1 and isOk = ?2", new Object[] { null, true });
+        assertEquals("{'isOk':true}", query);
+
+        query = MongoOperations.bindFilter(Object.class, "field? = ?1", new Object[] { "a value" });
+        assertEquals("{'field':'a value'}", query);
+
+        query = MongoOperations.bindFilter(Object.class, "field? = ?1", new Object[] { null });
+        assertEquals("{}", query);
+    }
+
+    @Test
     public void testBindEnhancedFilterByName() {
         String query = MongoOperations.bindFilter(Object.class, "field = :field",
                 Parameters.with("field", "a value").map());
@@ -238,6 +253,25 @@ class MongoOperationsTest {
         query = MongoOperations.bindFilter(Object.class, "field like :field",
                 Parameters.with("field", "a value").map());
         assertEquals("{'field':{'$regex':'a value'}}", query);
+    }
+
+    @Test
+    public void testBindOptionalPredicateByName() {
+        String query = MongoOperations.bindFilter(Object.class, "field? = :field and isOk = :isOk",
+                Parameters.with("field", "a value").and("isOk", true).map());
+        assertEquals("{'field':'a value','isOk':true}", query);
+
+        query = MongoOperations.bindFilter(Object.class, "field? = :field and isOk = :isOk",
+                Parameters.with("field", null).and("isOk", true).map());
+        assertEquals("{'isOk':true}", query);
+
+        query = MongoOperations.bindFilter(Object.class, "field? = :field",
+                Parameters.with("field", "a value").map());
+        assertEquals("{'field':'a value'}", query);
+
+        query = MongoOperations.bindFilter(Object.class, "field? = :field",
+                Parameters.with("field", null).map());
+        assertEquals("{}", query);
     }
 
     @Test

--- a/extensions/panache/panacheql/src/main/antlr4/io/quarkus/panacheql/internal/HqlLexer.g4
+++ b/extensions/panache/panacheql/src/main/antlr4/io/quarkus/panacheql/internal/HqlLexer.g4
@@ -223,7 +223,7 @@ NULL 	: [nN] [uU] [lL] [lL];
 
 // Identifiers
 IDENTIFIER
-	:	('a'..'z'|'A'..'Z'|'_'|'$'|'\u0080'..'\ufffe')('a'..'z'|'A'..'Z'|'_'|'$'|'0'..'9'|'\u0080'..'\ufffe')*
+	:	('a'..'z'|'A'..'Z'|'_'|'$'|'\u0080'..'\ufffe')('a'..'z'|'A'..'Z'|'_'|'$'|'0'..'9'|'\u0080'..'\ufffe')*('?')?
 	;
 
 QUOTED_IDENTIFIER


### PR DESCRIPTION
I prototype optional predicates as discussed here: #2303
This is a draft PR to discuss the implementation.

For the sake of simplicity, as MongoDB already use the parse I implement it for MongoDB only.

This PR enable this for MongoDB with Panache:

```
Person.find("name? = ?1 and status = ?2", "Loïc", Status.ALIVE)
=> generates the following query : {'name' : 'Loïc', 'status' : 'ALIVE'}
Person.find("name? = ?1 and status = ?2", null, Status.ALIVE)
=> generates the following query : { 'status' : 'ALIVE'}
Person.find("name? = ?1", null)
=> generates the following query : { }
```