### PR TITLE
Usage section added to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,67 @@ By default the build will use the native image server. This speeds up the build,
 not being invalidated correctly in some cases. To run a build with a new instance of the server you can use
 `./mvnw install -Dnative-image.new-server=true`.
 
+
+## Usage
+
+After the build was successful, the artifacts are available in your local Maven repository.
+
+To include them into your project a few things have to be changed.
+
+#### With Gradle
+
+
+*gradle.properties*
+
+```
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPluginVersion=999-SNAPSHOT
+quarkusPlatformVersion=999-SNAPSHOT
+quarkusPlatformGroupId=io.quarkus
+```
+
+*settings.gradle*
+
+```
+pluginManagement {
+    repositories {
+        mavenLocal() // add mavenLocal() to first position
+        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    .
+    .
+    .
+}
+```
+ 
+*build.gradle*
+
+```
+repositories {
+    mavenLocal() // add mavenLocal() to first position
+    jcenter()
+    mavenCentral()
+}
+```
+
+#### With Maven
+
+*pom.xml*
+
+```
+<properties>
+    <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    .
+    .
+    .
+</properties>
+```
+
 ### MicroProfile TCK's
 
 Quarkus has a TCK module in `tcks` where all the MicroProfile TCK's are set up for you to run if you wish. These 


### PR DESCRIPTION
I´ve added a short usage section to make it a bit clearer how to use artifacts in your project after you´ve build it locally.
As I´m using Gradle myself I´ve only added the Gradle subsection, so if Maven is relevant too it should be added as well