### PR TITLE
Register BigDecimal and BigInteger for reflection if necessary

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
@@ -18,6 +18,8 @@ import javax.ws.rs.ext.Provider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+
 public final class ResteasyDotNames {
 
     public static final DotName CONSUMES = DotName.createSimple(Consumes.class.getName());
@@ -62,17 +64,8 @@ public final class ResteasyDotNames {
 
         @Override
         public boolean test(DotName name) {
-            return ResteasyDotNames.TYPES_IGNORED_FOR_REFLECTION.contains(name) ||
-                    isInIgnoredPackage(name.toString());
-        }
-
-        private boolean isInIgnoredPackage(String name) {
-            for (String containerPackageName : PACKAGES_IGNORED_FOR_REFLECTION) {
-                if (name.startsWith(containerPackageName)) {
-                    return true;
-                }
-            }
-            return false;
+            return ResteasyDotNames.TYPES_IGNORED_FOR_REFLECTION.contains(name)
+                    || ReflectiveHierarchyBuildItem.DefaultIgnorePredicate.INSTANCE.test(name);
         }
     }
 
@@ -101,7 +94,4 @@ public final class ResteasyDotNames {
             // Vert-x
             DotName.createSimple("io.vertx.core.json.JsonArray"),
             DotName.createSimple("io.vertx.core.json.JsonObject")));
-
-    private static final List<String> PACKAGES_IGNORED_FOR_REFLECTION = Arrays.asList("java.", "io.reactivex.",
-            "org.reactivestreams.");
 }

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/BigKeysResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/BigKeysResource.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.resteasy.jackson;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/bigkeys")
+public class BigKeysResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Payload post(Payload payload) {
+        return payload;
+    }
+
+    public static class Payload {
+
+        private Map<BigDecimal, String> bdMap;
+
+        private Map<BigInteger, String> biMap;
+
+        public Map<BigDecimal, String> getBdMap() {
+            return bdMap;
+        }
+
+        public void setBdMap(Map<BigDecimal, String> bdMap) {
+            this.bdMap = bdMap;
+        }
+
+        public Map<BigInteger, String> getBiMap() {
+            return biMap;
+        }
+
+        public void setBiMap(Map<BigInteger, String> biMap) {
+            this.biMap = biMap;
+        }
+    }
+}

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/BigKeysResourceIT.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/BigKeysResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.jackson;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class BigKeysResourceIT extends BigKeysResourceTest {
+}

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/BigKeysResourceTest.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/BigKeysResourceTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.resteasy.jackson;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class BigKeysResourceTest {
+
+    @Test
+    public void test() throws IOException {
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body("{\"bdMap\":{\"1\":\"One\", \"2\":\"Two\"},  \"biMap\":{\"1\":\"One\", \"2\":\"Two\"}}")
+                .when().post("/bigkeys")
+                .then()
+                .statusCode(200)
+                .body("bdMap.1", equalTo("One"))
+                .body("biMap.2", equalTo("Two"));
+    }
+
+}


### PR DESCRIPTION
This is needed because Jackson can have trouble with these classes

Fixes: #8996