### PR TITLE
Support injection of AgroalPoolInterceptor

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -20,6 +20,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 
 import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalPoolInterceptor;
 import io.quarkus.agroal.DataSource;
 import io.quarkus.agroal.runtime.AgroalRecorder;
 import io.quarkus.agroal.runtime.DataSourceJdbcBuildTimeConfig;
@@ -195,6 +196,9 @@ class AgroalProcessor {
                 .setDefaultScope(DotNames.SINGLETON).build());
         // add the @DataSource class otherwise it won't be registered as a qualifier
         additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(DataSource.class).build());
+
+        // add implementations of AgroalPoolInterceptor
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(AgroalPoolInterceptor.class));
 
         // create the DataSourceSupport bean that DataSourceProducer uses as a dependency
         DataSourceSupport dataSourceSupport = getDataSourceSupport(aggregatedBuildTimeConfigBuildItems, sslNativeConfig,

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/PoolInterceptorsTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/PoolInterceptorsTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.agroal.test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalPoolInterceptor;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PoolInterceptorsTest {
+
+    //tag::injection[]
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @Inject
+    @DataSource("another")
+    AgroalDataSource anotherDataSource;
+
+    @Inject
+    @DataSource("pure")
+    AgroalDataSource pureDataSource;
+    //end::injection[]
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                    .addClasses(PoolInterceptorsTest.class)
+                    .addClasses(DefaultInterceptor.class, AnotherInterceptor.class, AnotherPriorityInterceptor.class))
+            .withConfigurationResource("application-pool-interception.properties");
+
+    @Test
+    public void testDataSourceInjection() throws SQLException {
+        try (Connection connection = defaultDataSource.getConnection()) {
+            Assertions.assertEquals("INTERCEPTOR", connection.getSchema());
+        }
+        try (Connection connection = anotherDataSource.getConnection()) {
+            Assertions.assertEquals("PRIORITY", connection.getSchema());
+        }
+        try (Connection connection = pureDataSource.getConnection()) {
+            Assertions.assertEquals("PUBLIC", connection.getSchema());
+        }
+    }
+
+    // --- //
+
+    @Singleton
+    static class DefaultInterceptor implements AgroalPoolInterceptor {
+
+        @Override
+        public void onConnectionAcquire(Connection connection) {
+            try {
+                connection.setSchema("INTERCEPTOR");
+            } catch (SQLException e) {
+                Assertions.fail(e);
+            }
+        }
+    }
+
+    @Singleton
+    @DataSource("another")
+    static class AnotherInterceptor implements AgroalPoolInterceptor {
+
+        @Override
+        public void onConnectionAcquire(Connection connection) {
+            try {
+                connection.setSchema("LOW");
+            } catch (SQLException e) {
+                Assertions.fail(e);
+            }
+        }
+    }
+
+    @Singleton
+    @DataSource("another")
+    static class AnotherPriorityInterceptor implements AgroalPoolInterceptor {
+
+        @Override
+        public void onConnectionAcquire(Connection connection) {
+            try {
+                Assertions.assertEquals("LOW", connection.getSchema());
+                connection.setSchema("PRIORITY");
+            } catch (SQLException e) {
+                Assertions.fail(e);
+            }
+        }
+
+        @Override
+        public int getPriority() {
+            return 1;
+        }
+    }
+}

--- a/extensions/agroal/deployment/src/test/resources/application-pool-interception.properties
+++ b/extensions/agroal/deployment/src/test/resources/application-pool-interception.properties
@@ -1,0 +1,23 @@
+# default ds
+quarkus.datasource.url=jdbc:h2:mem:db0;
+quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.username=username1
+quarkus.datasource.min-size=0
+quarkus.datasource.max-size=2
+quarkus.datasource.new-connection-sql=CREATE SCHEMA IF NOT EXISTS INTERCEPTOR;
+
+# another ds
+quarkus.datasource.another.url=jdbc:h2:mem:db1
+quarkus.datasource.another.driver=org.h2.Driver
+quarkus.datasource.another.username=username1
+quarkus.datasource.another.min-size=0
+quarkus.datasource.another.max-size=2
+quarkus.datasource.another.new-connection-sql=CREATE SCHEMA IF NOT EXISTS LOW; CREATE SCHEMA IF NOT EXISTS PRIORITY;
+
+# a ds that does not have interception
+quarkus.datasource.pure.url=jdbc:h2:mem:db2
+quarkus.datasource.pure.driver=org.h2.Driver
+quarkus.datasource.pure.username=username1
+quarkus.datasource.pure.min-size=0
+quarkus.datasource.pure.max-size=2
+quarkus.datasource.pure.new-connection-sql=CREATE SCHEMA IF NOT EXISTS PURE;


### PR DESCRIPTION
This is fix for #5381 alternative to #5408 

Agroal 1.8 introduces a new interceptor mechanism suited to be used by applications. This PR allows CDI to detect and inject these interceptors into the right datasources.