### PR TITLE
Hibernate ORM improvements

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -274,8 +274,8 @@ public class FastBootMetadataBuilder {
         // Note: this one is not a boolean, just having the property enables it
         if (cfg.containsKey(JACC_ENABLED)) {
             LOG.warn("JACC is not supported. Disabling it.");
+            cfg.remove(JACC_ENABLED);
         }
-        cfg.remove(JACC_ENABLED);
 
         // here we are going to iterate the merged config settings looking for:
         // 1) additional JACC permissions

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -44,7 +44,6 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
-import org.hibernate.boot.registry.selector.internal.StrategySelectorBuilder;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.MetadataBuilderContributor;
 import org.hibernate.boot.spi.MetadataBuilderImplementor;
@@ -77,6 +76,7 @@ import io.quarkus.hibernate.orm.runtime.BuildTimeSettings;
 import io.quarkus.hibernate.orm.runtime.IntegrationSettings;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusIntegratorServiceImpl;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusJtaPlatform;
+import io.quarkus.hibernate.orm.runtime.customized.QuarkusStrategySelectorBuilder;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrations;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
 import io.quarkus.hibernate.orm.runtime.proxies.ProxyDefinitions;
@@ -199,12 +199,8 @@ public class FastBootMetadataBuilder {
         // N.B. support for custom IntegratorProvider injected via Properties (as
         // instance) removed
 
-        // N.B. support for custom StrategySelector removed
-        // TODO see to inject a custom
-        // org.hibernate.boot.registry.selector.spi.StrategySelector ?
-
-        QuarkusIntegratorServiceImpl integratorService = new QuarkusIntegratorServiceImpl(providedClassLoaderService);
-        final StrategySelectorBuilder strategySelectorBuilder = new StrategySelectorBuilder();
+        final QuarkusIntegratorServiceImpl integratorService = new QuarkusIntegratorServiceImpl(providedClassLoaderService);
+        final QuarkusStrategySelectorBuilder strategySelectorBuilder = new QuarkusStrategySelectorBuilder();
         final StrategySelector strategySelector = strategySelectorBuilder.buildSelector(providedClassLoaderService);
         return new BootstrapServiceRegistryImpl(true, providedClassLoaderService, strategySelector, integratorService);
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -65,6 +65,7 @@ import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.jpa.internal.util.LogHelper;
 import org.hibernate.jpa.internal.util.PersistenceUnitTransactionTypeHelper;
 import org.hibernate.jpa.spi.IdentifierGeneratorStrategyProvider;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.hibernate.service.Service;
@@ -256,6 +257,21 @@ public class FastBootMetadataBuilder {
         }
         //Agroal already does disable auto-commit, so Hibernate ORM should trust that:
         cfg.put(AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, Boolean.TRUE.toString());
+
+        /**
+         * Set CONNECTION_HANDLING to DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION
+         * as it generally performs better, at no known drawbacks.
+         * This is a new mode in Hibernate ORM, it might become the default in the future.
+         *
+         * @see org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode
+         */
+        {
+            final Object explicitSetting = cfg.get(AvailableSettings.CONNECTION_HANDLING);
+            if (explicitSetting == null) {
+                cfg.put(AvailableSettings.CONNECTION_HANDLING,
+                        PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION);
+            }
+        }
 
         if (readBooleanConfigurationValue(cfg, WRAP_RESULT_SETS)) {
             LOG.warn("Wrapping result sets is not supported. Setting " + WRAP_RESULT_SETS + " to false.");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusIntegratorServiceImpl.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusIntegratorServiceImpl.java
@@ -1,0 +1,30 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import java.util.LinkedHashSet;
+
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.integrator.spi.IntegratorService;
+
+/**
+ * This is similar to the default {@link IntegratorService} from Hibernate ORM,
+ * except that it doesn't come with default integrators as we prefer explicit
+ * control.
+ * 
+ * @see org.hibernate.integrator.internal.IntegratorServiceImpl
+ * @author Sanne Grinovero <sanne@hibernate.org>
+ */
+public final class QuarkusIntegratorServiceImpl implements IntegratorService {
+
+    private final LinkedHashSet<Integrator> integrators = new LinkedHashSet<Integrator>();
+
+    public QuarkusIntegratorServiceImpl(final ClassLoaderService classLoaderService) {
+        integrators.addAll(classLoaderService.loadJavaServices(Integrator.class));
+    }
+
+    @Override
+    public Iterable<Integrator> getIntegrators() {
+        return integrators;
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusStrategySelectorBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusStrategySelectorBuilder.java
@@ -1,0 +1,129 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.selector.StrategyRegistration;
+import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
+import org.hibernate.boot.registry.selector.internal.DefaultDialectSelector;
+import org.hibernate.boot.registry.selector.internal.DefaultJtaPlatformSelector;
+import org.hibernate.boot.registry.selector.internal.StrategySelectorImpl;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.internal.SimpleCacheKeysFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.persistent.PersistentTableBulkIdStrategy;
+import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
+import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+
+/**
+ * Similar to {@link org.hibernate.boot.registry.selector.internal.StrategySelectorBuilder} but
+ * omits registering the components we don't support, and uses a new pattern of registration
+ * meant to avoid class initializations.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org>
+ */
+public final class QuarkusStrategySelectorBuilder {
+
+    /**
+     * Builds the selector.
+     *
+     * @param classLoaderService The class loading service used to (attempt to) resolve any un-registered
+     *        strategy implementations.
+     *
+     * @return The selector.
+     */
+    public static StrategySelector buildSelector(ClassLoaderService classLoaderService) {
+        final StrategySelectorImpl strategySelector = new StrategySelectorImpl(classLoaderService);
+
+        // build the baseline...
+        strategySelector.registerStrategyLazily(Dialect.class, new DefaultDialectSelector());
+        strategySelector.registerStrategyLazily(JtaPlatform.class, new DefaultJtaPlatformSelector());
+        addTransactionCoordinatorBuilders(strategySelector);
+        addMultiTableBulkIdStrategies(strategySelector);
+        addImplicitNamingStrategies(strategySelector);
+        addCacheKeysFactories(strategySelector);
+
+        // Required to support well known extensions e.g. Envers
+        // TODO: should we introduce a new integrator SPI to limit these to extensions supported by Quarkus?
+        for (StrategyRegistrationProvider provider : classLoaderService.loadJavaServices(StrategyRegistrationProvider.class)) {
+            for (StrategyRegistration discoveredStrategyRegistration : provider.getStrategyRegistrations()) {
+                applyFromStrategyRegistration(strategySelector, discoveredStrategyRegistration);
+            }
+        }
+
+        return strategySelector;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void applyFromStrategyRegistration(
+            StrategySelectorImpl strategySelector,
+            StrategyRegistration<T> strategyRegistration) {
+        for (String name : strategyRegistration.getSelectorNames()) {
+            strategySelector.registerStrategyImplementor(
+                    strategyRegistration.getStrategyRole(),
+                    name,
+                    strategyRegistration.getStrategyImplementation());
+        }
+    }
+
+    private static void addTransactionCoordinatorBuilders(StrategySelectorImpl strategySelector) {
+        strategySelector.registerStrategyImplementor(
+                TransactionCoordinatorBuilder.class,
+                JdbcResourceLocalTransactionCoordinatorBuilderImpl.SHORT_NAME,
+                JdbcResourceLocalTransactionCoordinatorBuilderImpl.class);
+        strategySelector.registerStrategyImplementor(
+                TransactionCoordinatorBuilder.class,
+                JtaTransactionCoordinatorBuilderImpl.SHORT_NAME,
+                JtaTransactionCoordinatorBuilderImpl.class);
+    }
+
+    private static void addMultiTableBulkIdStrategies(StrategySelectorImpl strategySelector) {
+        strategySelector.registerStrategyImplementor(
+                MultiTableBulkIdStrategy.class,
+                PersistentTableBulkIdStrategy.SHORT_NAME,
+                PersistentTableBulkIdStrategy.class);
+        strategySelector.registerStrategyImplementor(
+                MultiTableBulkIdStrategy.class,
+                GlobalTemporaryTableBulkIdStrategy.SHORT_NAME,
+                GlobalTemporaryTableBulkIdStrategy.class);
+        strategySelector.registerStrategyImplementor(
+                MultiTableBulkIdStrategy.class,
+                LocalTemporaryTableBulkIdStrategy.SHORT_NAME,
+                LocalTemporaryTableBulkIdStrategy.class);
+    }
+
+    private static void addImplicitNamingStrategies(StrategySelectorImpl strategySelector) {
+        strategySelector.registerStrategyImplementor(
+                ImplicitNamingStrategy.class,
+                "default",
+                ImplicitNamingStrategyJpaCompliantImpl.class);
+        strategySelector.registerStrategyImplementor(
+                ImplicitNamingStrategy.class,
+                "jpa",
+                ImplicitNamingStrategyJpaCompliantImpl.class);
+        strategySelector.registerStrategyImplementor(
+                ImplicitNamingStrategy.class,
+                "component-path",
+                ImplicitNamingStrategyComponentPathImpl.class);
+    }
+
+    private static void addCacheKeysFactories(StrategySelectorImpl strategySelector) {
+        strategySelector.registerStrategyImplementor(
+                CacheKeysFactory.class,
+                DefaultCacheKeysFactory.SHORT_NAME,
+                DefaultCacheKeysFactory.class);
+        strategySelector.registerStrategyImplementor(
+                CacheKeysFactory.class,
+                SimpleCacheKeysFactory.SHORT_NAME,
+                SimpleCacheKeysFactory.class);
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceInitiator;
-import org.hibernate.boot.cfgxml.internal.ConfigLoader;
 import org.hibernate.boot.cfgxml.spi.LoadedConfig;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceInitiator;
@@ -54,6 +53,8 @@ import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
  */
 public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
 
+    private static final String DISABLED_FEATURE_MSG = "This feature was disabled in Quarkus - this method should not have invoked, please report";
+
     private final Map settings;
     private final List<StandardServiceInitiator> initiators = standardInitiatorList();
     private final List<ProvidedService> providedServices = new ArrayList<ProvidedService>();
@@ -62,7 +63,6 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
     private boolean autoCloseRegistry = true;
 
     private final BootstrapServiceRegistry bootstrapServiceRegistry;
-    private final ConfigLoader configLoader;
     private final LoadedConfig aggregatedCfgXml;
 
     public RecordableBootstrap(BootstrapServiceRegistry bootstrapServiceRegistry) {
@@ -80,7 +80,6 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
         super(bootstrapServiceRegistry, properties, loadedConfigBaseline, null);
         this.settings = properties;
         this.bootstrapServiceRegistry = bootstrapServiceRegistry;
-        this.configLoader = new ConfigLoader(bootstrapServiceRegistry);
         this.aggregatedCfgXml = loadedConfigBaseline;
     }
 
@@ -156,47 +155,16 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
         return bootstrapServiceRegistry;
     }
 
-    /**
-     * Read settings from a {@link java.util.Properties} file by resource name.
-     * <p>
-     * Differs from {@link #configure()} and {@link #configure(String)} in that here
-     * we expect to read a {@link java.util.Properties} file while for
-     * {@link #configure} we read the XML variant.
-     *
-     * @param resourceName The name by which to perform a resource look up for the
-     *        properties file.
-     *
-     * @return this, for method chaining
-     *
-     * @see #configure()
-     * @see #configure(String)
-     */
     @Override
     @SuppressWarnings({ "unchecked" })
     public StandardServiceRegistryBuilder loadProperties(String resourceName) {
-        settings.putAll(configLoader.loadProperties(resourceName));
-        return this;
+        throw new UnsupportedOperationException(DISABLED_FEATURE_MSG);
     }
 
-    /**
-     * Read settings from a {@link java.util.Properties} file by File reference
-     * <p>
-     * Differs from {@link #configure()} and {@link #configure(String)} in that here
-     * we expect to read a {@link java.util.Properties} file while for
-     * {@link #configure} we read the XML variant.
-     *
-     * @param file The properties File reference
-     *
-     * @return this, for method chaining
-     *
-     * @see #configure()
-     * @see #configure(String)
-     */
     @Override
     @SuppressWarnings({ "unchecked" })
     public StandardServiceRegistryBuilder loadProperties(File file) {
-        settings.putAll(configLoader.loadProperties(file));
-        return this;
+        throw new UnsupportedOperationException(DISABLED_FEATURE_MSG);
     }
 
     /**
@@ -214,35 +182,25 @@ public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
         return configure(DEFAULT_CFG_RESOURCE_NAME);
     }
 
-    /**
-     * Read setting information from an XML file using the named resource location.
-     *
-     * @param resourceName The named resource
-     *
-     * @return this, for method chaining
-     */
     @Override
     public StandardServiceRegistryBuilder configure(String resourceName) {
-        return configure(configLoader.loadConfigXmlResource(resourceName));
+        throw new UnsupportedOperationException(DISABLED_FEATURE_MSG);
     }
 
     @Override
     public StandardServiceRegistryBuilder configure(File configurationFile) {
-        return configure(configLoader.loadConfigXmlFile(configurationFile));
+        throw new UnsupportedOperationException(DISABLED_FEATURE_MSG);
     }
 
     @Override
     public StandardServiceRegistryBuilder configure(URL url) {
-        return configure(configLoader.loadConfigXmlUrl(url));
+        throw new UnsupportedOperationException(DISABLED_FEATURE_MSG);
     }
 
     @Override
     @SuppressWarnings({ "unchecked" })
     public StandardServiceRegistryBuilder configure(LoadedConfig loadedConfig) {
-        aggregatedCfgXml.merge(loadedConfig);
-        settings.putAll(loadedConfig.getConfigurationValues());
-
-        return this;
+        throw new UnsupportedOperationException(DISABLED_FEATURE_MSG);
     }
 
     /**


### PR DESCRIPTION
This takes advantage of the (previously merged) new version of Hibernate ORM `5.4.15.Final`.

Most notably:
 - significant reduction in classes initialized: about ~100 less being loaded
 - Use the new `DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION` connection release strategy, which was just introduced as a better fitting model for Agroal/Quarkus