### PR TITLE
Don't try to load project workspace from the MAVEN_PROJECTBASEDIR if it doesn't contain a pom.xml

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -720,6 +720,12 @@ public class BootstrapMavenContext {
                 return null;
             }
         }
-        return Paths.get(rootBaseDir);
+        final Path rootProjectBaseDirPath = Paths.get(rootBaseDir);
+        // if the root project dir set by the Maven process (through the env variable) doesn't have a pom.xml
+        // then it probably isn't relevant
+        if (!Files.exists(rootProjectBaseDirPath.resolve("pom.xml"))) {
+            return null;
+        }
+        return rootProjectBaseDirPath;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/9013

The Maven launcher script internally sets the `MAVEN_PROJECTBASEDIR` to any directory that has a `.mvn` directory, within the filesystem hierarchy (starting from current directory)[1]. Quarkus uses this value to try and load the current project workspace. It's not guaranteed that this directory will always have a `pom.xml` file. In such cases, users end up with the error seen in the linked issue.

The commit here does an additional check to verify if the pom.xml does indeed exist in the inferred root project directory and if it doesn't then it uses the current pom.xml to load the workspace.

[1] https://github.com/apache/maven/blob/master/apache-maven/src/bin/mvn#L120