### PR TITLE
Support Surefire 3.0.0-M4

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -27,7 +27,7 @@
         <scala.version>2.12.8</scala.version>
         <scala-plugin.version>4.1.1</scala-plugin.version>
 
-        <version.surefire.plugin>2.22.1</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M4</version.surefire.plugin>
 
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's

--- a/core/builder/pom.xml
+++ b/core/builder/pom.xml
@@ -64,7 +64,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/devtools/aesh/pom.xml
+++ b/devtools/aesh/pom.xml
@@ -41,7 +41,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>


### PR DESCRIPTION
The versions 2.x.x are EOL.
The new version 3.0.0-M4 has many bugfixes, e.g. JUnit5 improvements, wide JDK and OS support.