### PR TITLE
Add Credentials SPI Extension

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -750,6 +750,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-credentials-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-logging-json-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -973,7 +973,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-vault-spi</artifactId>
+                <artifactId>quarkus-credentials</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/extensions/agroal/deployment/pom.xml
+++ b/extensions/agroal/deployment/pom.xml
@@ -40,13 +40,16 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-metrics-spi</artifactId>
         </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/agroal/runtime/pom.xml
+++ b/extensions/agroal/runtime/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vault-spi</artifactId>
+            <artifactId>quarkus-credentials</artifactId>
         </dependency>
 
         <dependency>

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalVaultCredentialsProviderPassword.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalVaultCredentialsProviderPassword.java
@@ -1,9 +1,10 @@
 package io.quarkus.agroal.runtime;
 
+import java.util.Map;
 import java.util.Properties;
 
 import io.agroal.api.security.SimplePassword;
-import io.quarkus.vault.CredentialsProvider;
+import io.quarkus.credentials.CredentialsProvider;
 
 public class AgroalVaultCredentialsProviderPassword extends SimplePassword {
 
@@ -16,6 +17,9 @@ public class AgroalVaultCredentialsProviderPassword extends SimplePassword {
 
     @Override
     public Properties asProperties() {
-        return credentialsProvider.getCredentials(getWord());
+        Properties properties = new Properties();
+        Map<String, String> credentials = credentialsProvider.getCredentials(getWord());
+        credentials.entrySet().forEach(entry -> properties.setProperty(entry.getKey(), entry.getValue()));
+        return properties;
     }
 }

--- a/extensions/credentials/deployment/pom.xml
+++ b/extensions/credentials/deployment/pom.xml
@@ -3,41 +3,33 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-datasource-parent</artifactId>
+        <artifactId>quarkus-credentials-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-datasource</artifactId>
-    <name>Quarkus - Datasource - Runtime</name>
-    <description>Configure your datasources</description>
+    <artifactId>quarkus-credentials-deployment</artifactId>
+    <name>Quarkus - Credentials - Deployment</name>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-datasource-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-credentials</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
@@ -52,4 +44,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/extensions/credentials/deployment/src/main/java/io/quarkus/credentials/CredentialsProcessor.java
+++ b/extensions/credentials/deployment/src/main/java/io/quarkus/credentials/CredentialsProcessor.java
@@ -1,0 +1,16 @@
+package io.quarkus.credentials;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+
+public class CredentialsProcessor {
+
+    @BuildStep
+    AdditionalBeanBuildItem registerAdditionalBeans() {
+        return new AdditionalBeanBuildItem.Builder()
+                .setUnremovable()
+                .addBeanClass(CredentialsProvider.class)
+                .build();
+    }
+
+}

--- a/extensions/credentials/pom.xml
+++ b/extensions/credentials/pom.xml
@@ -3,14 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-agroal-parent</artifactId>
+        <artifactId>quarkus-build-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../../agroal</relativePath>
+        <relativePath>../../build-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-vault-spi</artifactId>
-    <name>Quarkus - Vault - SPI</name>
+    <artifactId>quarkus-credentials-parent</artifactId>
+    <name>Quarkus - Credentials</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
 
 </project>

--- a/extensions/credentials/runtime/pom.xml
+++ b/extensions/credentials/runtime/pom.xml
@@ -3,19 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-build-parent</artifactId>
+        <artifactId>quarkus-credentials-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../../build-parent/pom.xml</relativePath>
+        <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-vault-parent</artifactId>
-    <name>Quarkus - Vault</name>
-    <packaging>pom</packaging>
-    <modules>
-        <module>deployment</module>
-        <module>runtime</module>
-    </modules>
+    <artifactId>quarkus-credentials</artifactId>
+    <name>Quarkus - Credentials - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.arc</groupId>
+            <artifactId>arc</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/CredentialsProvider.java
+++ b/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/CredentialsProvider.java
@@ -1,12 +1,12 @@
-package io.quarkus.vault;
+package io.quarkus.credentials;
 
-import java.util.Properties;
+import java.util.Map;
 
 public interface CredentialsProvider {
 
     String USER_PROPERTY_NAME = "user";
     String PASSWORD_PROPERTY_NAME = "password";
 
-    Properties getCredentials(String credentialsProviderName);
+    Map<String, String> getCredentials(String credentialsProviderName);
 
 }

--- a/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/runtime/CredentialsProviderFinder.java
+++ b/extensions/credentials/runtime/src/main/java/io/quarkus/credentials/runtime/CredentialsProviderFinder.java
@@ -1,0 +1,22 @@
+package io.quarkus.credentials.runtime;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.credentials.CredentialsProvider;
+
+public class CredentialsProviderFinder {
+
+    public static CredentialsProvider find(String type) {
+        ArcContainer container = Arc.container();
+        CredentialsProvider credentialsProvider = type != null
+                ? (CredentialsProvider) container.instance(type).get()
+                : container.instance(CredentialsProvider.class).get();
+
+        if (credentialsProvider == null) {
+            throw new RuntimeException("unable to find credentials provider of type " + (type == null ? "default" : type));
+        }
+
+        return credentialsProvider;
+    }
+
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -162,6 +162,7 @@
 
         <!-- Vault -->
         <module>vault</module>
+        <module>credentials</module>
 
         <!-- GraphQL -->
         <module>vertx-graphql</module>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-mysql-client</artifactId>
         </dependency>
         <dependency>
@@ -72,6 +76,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.reactive.mysql.client;
+
+import static io.restassured.RestAssured.given;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CredentialsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(CustomCredentialsProvider.class)
+                    .addClass(CredentialsTestResource.class)
+                    .addAsResource("application-credentials.properties", "application.properties"));
+
+    @Test
+    public void testConnect() {
+        given()
+                .when().get("/test")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.equalTo("OK"));
+    }
+
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTestResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CredentialsTestResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.reactive.mysql.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.vertx.mutiny.mysqlclient.MySQLPool;
+
+@Path("/test")
+public class CredentialsTestResource {
+
+    @Inject
+    MySQLPool client;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> connect() {
+
+        return client.query("SELECT 1").execute()
+                .map(mysqlRowSet -> {
+                    assertEquals(1, mysqlRowSet.size());
+                    assertEquals(1, mysqlRowSet.iterator().next().getInteger(0));
+                    return "OK";
+                })
+                .subscribeAsCompletionStage();
+    }
+
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CustomCredentialsProvider.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/CustomCredentialsProvider.java
@@ -1,0 +1,27 @@
+package io.quarkus.reactive.mysql.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Unremovable
+public class CustomCredentialsProvider implements CredentialsProvider {
+
+    private static final Logger log = Logger.getLogger(CustomCredentialsProvider.class.getName());
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(USER_PROPERTY_NAME, "hibernate_orm_test");
+        properties.put(PASSWORD_PROPERTY_NAME, "hibernate_orm_test");
+        log.info("credentials provider returning " + properties);
+        return properties;
+    }
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/resources/application-credentials.properties
+++ b/extensions/reactive-mysql-client/deployment/src/test/resources/application-credentials.properties
@@ -1,0 +1,3 @@
+quarkus.datasource.db-kind=mysql
+quarkus.datasource.credentials-provider=custom
+quarkus.datasource.reactive.url=${reactive-mysql.url}

--- a/extensions/reactive-mysql-client/runtime/pom.xml
+++ b/extensions/reactive-mysql-client/runtime/pom.xml
@@ -52,6 +52,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-mysql-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials</artifactId>
+        </dependency>
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -1,6 +1,13 @@
 package io.quarkus.reactive.mysql.client.runtime;
 
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+
+import java.util.Map;
+
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.datasource.runtime.DataSourceRuntimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.datasource.runtime.LegacyDataSourceRuntimeConfig;
@@ -17,7 +24,6 @@ import io.vertx.sqlclient.PoolOptions;
 @Recorder
 @SuppressWarnings("deprecation")
 public class MySQLPoolRecorder {
-
     public RuntimeValue<MySQLPool> configureMySQLPool(RuntimeValue<Vertx> vertx, BeanContainer container,
             DataSourcesRuntimeConfig dataSourcesRuntimeConfig,
             DataSourceReactiveRuntimeConfig dataSourceReactiveRuntimeConfig,
@@ -88,6 +94,22 @@ public class MySQLPoolRecorder {
 
         if (dataSourceRuntimeConfig.password.isPresent()) {
             mysqlConnectOptions.setPassword(dataSourceRuntimeConfig.password.get());
+        }
+
+        // credentials provider
+        if (dataSourceRuntimeConfig.credentialsProvider.isPresent()) {
+            String type = dataSourceRuntimeConfig.credentialsProviderType.orElse(null);
+            CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(type);
+            String name = dataSourceRuntimeConfig.credentialsProvider.get();
+            Map<String, String> credentials = credentialsProvider.getCredentials(name);
+            String user = credentials.get(USER_PROPERTY_NAME);
+            String password = credentials.get(PASSWORD_PROPERTY_NAME);
+            if (user != null) {
+                mysqlConnectOptions.setUser(user);
+            }
+            if (password != null) {
+                mysqlConnectOptions.setPassword(user);
+            }
         }
 
         if (dataSourceReactiveMySQLConfig.cachePreparedStatements.isPresent()) {

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
         </dependency>
         <dependency>
@@ -56,6 +60,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.reactive.pg.client;
+
+import static io.restassured.RestAssured.given;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CredentialsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(CustomCredentialsProvider.class)
+                    .addClass(CredentialsTestResource.class)
+                    .addAsResource("application-credentials.properties", "application.properties"));
+
+    @Test
+    public void testConnect() {
+        given()
+                .when().get("/test")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.equalTo("OK"));
+    }
+
+}

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTestResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CredentialsTestResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.vertx.mutiny.pgclient.PgPool;
+
+@Path("/test")
+public class CredentialsTestResource {
+
+    @Inject
+    PgPool client;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<String> connect() {
+
+        return client.query("SELECT 1").execute()
+                .map(pgRowSet -> {
+                    assertEquals(1, pgRowSet.size());
+                    assertEquals(1, pgRowSet.iterator().next().getInteger(0));
+                    return "OK";
+                })
+                .subscribeAsCompletionStage();
+    }
+
+}

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CustomCredentialsProvider.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/CustomCredentialsProvider.java
@@ -1,0 +1,27 @@
+package io.quarkus.reactive.pg.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Unremovable
+public class CustomCredentialsProvider implements CredentialsProvider {
+
+    private static final Logger log = Logger.getLogger(CustomCredentialsProvider.class.getName());
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(USER_PROPERTY_NAME, "hibernate_orm_test");
+        properties.put(PASSWORD_PROPERTY_NAME, "hibernate_orm_test");
+        log.info("credentials provider returning " + properties);
+        return properties;
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/test/resources/application-credentials.properties
+++ b/extensions/reactive-pg-client/deployment/src/test/resources/application-credentials.properties
@@ -1,0 +1,3 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.credentials-provider=custom
+quarkus.datasource.reactive.url=${reactive-postgres.url}

--- a/extensions/reactive-pg-client/runtime/pom.xml
+++ b/extensions/reactive-pg-client/runtime/pom.xml
@@ -40,7 +40,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-pg-client</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials</artifactId>
+        </dependency>
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -1,6 +1,13 @@
 package io.quarkus.reactive.pg.client.runtime;
 
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+
+import java.util.Map;
+
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.credentials.runtime.CredentialsProviderFinder;
 import io.quarkus.datasource.runtime.DataSourceRuntimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
 import io.quarkus.datasource.runtime.LegacyDataSourceRuntimeConfig;
@@ -89,6 +96,22 @@ public class PgPoolRecorder {
 
         if (dataSourceRuntimeConfig.password.isPresent()) {
             pgConnectOptions.setPassword(dataSourceRuntimeConfig.password.get());
+        }
+
+        // credentials provider
+        if (dataSourceRuntimeConfig.credentialsProvider.isPresent()) {
+            String type = dataSourceRuntimeConfig.credentialsProviderType.orElse(null);
+            CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(type);
+            String name = dataSourceRuntimeConfig.credentialsProvider.get();
+            Map<String, String> credentials = credentialsProvider.getCredentials(name);
+            String user = credentials.get(USER_PROPERTY_NAME);
+            String password = credentials.get(PASSWORD_PROPERTY_NAME);
+            if (user != null) {
+                pgConnectOptions.setUser(user);
+            }
+            if (password != null) {
+                pgConnectOptions.setPassword(user);
+            }
         }
 
         if (dataSourceReactivePostgreSQLConfig.cachePreparedStatements.isPresent()) {

--- a/extensions/vault/deployment/pom.xml
+++ b/extensions/vault/deployment/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
@@ -60,7 +60,6 @@ public class VaultProcessor {
         return new AdditionalBeanBuildItem.Builder()
                 .setUnremovable()
                 .addBeanClass(VaultServiceProducer.class)
-                .addBeanClass(CredentialsProvider.class)
                 .addBeanClass(VaultKVSecretEngine.class)
                 .build();
     }

--- a/extensions/vault/runtime/pom.xml
+++ b/extensions/vault/runtime/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vault-spi</artifactId>
+            <artifactId>quarkus-credentials</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
@@ -1,8 +1,9 @@
 package io.quarkus.vault.runtime;
 
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
-import io.quarkus.vault.CredentialsProvider;
+import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.runtime.config.CredentialsProviderConfig;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
@@ -21,7 +22,7 @@ public class VaultCredentialsProvider implements CredentialsProvider {
     }
 
     @Override
-    public Properties getCredentials(String credentialsProviderName) {
+    public Map<String, String> getCredentials(String credentialsProviderName) {
 
         CredentialsProviderConfig config = serverConfig.credentialsProvider.get(credentialsProviderName);
 
@@ -35,8 +36,8 @@ public class VaultCredentialsProvider implements CredentialsProvider {
 
         if (config.kvPath.isPresent()) {
             String password = vaultKvManager.readSecret(config.kvPath.get()).get(config.kvKey);
-            Properties result = new Properties();
-            result.setProperty(PASSWORD_PROPERTY_NAME, password);
+            Map<String, String> result = new HashMap<>();
+            result.put(PASSWORD_PROPERTY_NAME, password);
             return result;
         }
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultDbManager.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultDbManager.java
@@ -1,9 +1,10 @@
 package io.quarkus.vault.runtime;
 
-import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
-import static io.quarkus.vault.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
 
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.jboss.logging.Logger;
@@ -29,12 +30,12 @@ public class VaultDbManager {
         this.serverConfig = serverConfig;
     }
 
-    public Properties getDynamicDbCredentials(String databaseCredentialsRole) {
+    public Map<String, String> getDynamicDbCredentials(String databaseCredentialsRole) {
         String clientToken = vaultAuthManager.getClientToken();
         VaultDynamicDatabaseCredentials currentCredentials = credentialsCache.get(databaseCredentialsRole);
         VaultDynamicDatabaseCredentials credentials = getCredentials(currentCredentials, clientToken, databaseCredentialsRole);
         credentialsCache.put(databaseCredentialsRole, credentials);
-        Properties properties = new Properties();
+        Map<String, String> properties = new HashMap<>();
         properties.put(USER_PROPERTY_NAME, credentials.username);
         properties.put(PASSWORD_PROPERTY_NAME, credentials.password);
         return properties;

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultServiceProducer.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultServiceProducer.java
@@ -5,7 +5,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 
-import io.quarkus.vault.CredentialsProvider;
+import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.vault.VaultKVSecretEngine;
 import io.quarkus.vault.VaultSystemBackendEngine;
 import io.quarkus.vault.VaultTOTPSecretEngine;

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/CredentialsProviderConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/CredentialsProviderConfig.java
@@ -1,6 +1,6 @@
 package io.quarkus.vault.runtime.config;
 
-import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 
 import java.util.Optional;
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -1,6 +1,6 @@
 package io.quarkus.vault.runtime.config;
 
-import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.vault.runtime.LogConfidentialityLevel.MEDIUM;
 import static io.quarkus.vault.runtime.config.VaultCacheEntry.tryReturnLastKnownValue;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_CONNECT_TIMEOUT;

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
@@ -1,15 +1,15 @@
 package io.quarkus.vault.runtime;
 
-import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
-import static io.quarkus.vault.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
 import static java.time.Instant.EPOCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
@@ -54,7 +54,7 @@ public class VaultDbManagerTest {
         vaultRenewLease.leaseDurationSecs = 10;
         vaultRenewLease.renewable = true;
 
-        Properties properties = vaultDbManager.getDynamicDbCredentials(mydbrole);
+        Map<String, String> properties = vaultDbManager.getDynamicDbCredentials(mydbrole);
         assertEquals("bob", properties.get(USER_PROPERTY_NAME));
         assertEquals("sinclair1", properties.get(PASSWORD_PROPERTY_NAME));
 

--- a/independent-projects/tools/platform-descriptor-resolver-json/src/test/resources/quarkus-bom/pom.xml
+++ b/independent-projects/tools/platform-descriptor-resolver-json/src/test/resources/quarkus-bom/pom.xml
@@ -466,7 +466,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-vault-spi</artifactId>
+                <artifactId>quarkus-credentials</artifactId>
                 <version>${project.version}</version>
             </dependency>
 -->

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.vault;
 
-import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
-import static io.quarkus.vault.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
 import static io.quarkus.vault.runtime.VaultAuthManager.USERPASS_WRAPPING_TOKEN_PASSWORD_KEY;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.APPROLE;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
-import java.util.Properties;
 
 import javax.inject.Inject;
 
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.runtime.Base64String;
@@ -106,11 +106,11 @@ public class VaultITCase {
 
     @Test
     public void credentialsProvider() {
-        Properties staticCredentials = credentialsProvider.getCredentials("static");
+        Map<String, String> staticCredentials = credentialsProvider.getCredentials("static");
         assertEquals("{" + PASSWORD_PROPERTY_NAME + "=" + DB_PASSWORD + "}", staticCredentials.toString());
 
-        Properties dynamicCredentials = credentialsProvider.getCredentials("dynamic");
-        String username = dynamicCredentials.getProperty(USER_PROPERTY_NAME);
+        Map<String, String> dynamicCredentials = credentialsProvider.getCredentials("dynamic");
+        String username = dynamicCredentials.get(USER_PROPERTY_NAME);
         assertTrue(username.startsWith("v-" + USERPASS.name().toLowerCase() + "-" + VAULT_DBROLE + "-"));
     }
 

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -1,6 +1,6 @@
 package io.quarkus.vault.test;
 
-import static io.quarkus.vault.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.vault.runtime.VaultAuthManager.USERPASS_WRAPPING_TOKEN_PASSWORD_KEY;
 import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,6 +42,7 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.OutputFrame;
 
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.VaultKVSecretEngine;
@@ -226,7 +228,10 @@ public class VaultTestExtension {
         postgresContainer.start();
         execPostgres(format("psql -U %s -d %s -f %s", DB_USERNAME, DB_NAME, TMP_POSTGRES_INIT_SQL_FILE));
 
+        Consumer<OutputFrame> consumer = outputFrame -> System.out.print("VAULT >> " + outputFrame.getUtf8String());
+        vaultContainer.setLogConsumers(Arrays.asList(consumer));
         vaultContainer.start();
+
         initVault();
         log.info("vault has started with root token: " + rootToken);
     }


### PR DESCRIPTION
Extracts the `CredentialsProvider` interface and move it into its own `credentials` extension, to prepare for more provider implementations (either custom, or provided by quarkus as other extensions, such as support for Azure Vault).

In this PR we will also 

* support the interface in the reactive pg client, as discussed in https://github.com/quarkusio/quarkus/issues/8826#issuecomment-619927442
* document how to implement a new provider (custom or qurkus based)

Fixes https://github.com/quarkusio/quarkus/issues/8828 and https://github.com/quarkusio/quarkus/issues/8826.

see also 

 * [datasource credentials from Azure KeyVault](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/datasource.20credentials.20from.20Azure.20KeyVault), 
 * [custom provider example](https://github.com/gsmet/quarkus-credentials-provider)
 * https://github.com/quarkusio/quarkus/issues/6896
