### PR TITLE
Add javax.json.JsonValue to types ignored for reflection

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
@@ -74,6 +74,7 @@ public final class ResteasyDotNames {
             // javax.json
             DotName.createSimple("javax.json.JsonObject"),
             DotName.createSimple("javax.json.JsonArray"),
+            DotName.createSimple("javax.json.JsonValue"),
 
             // Jackson
             DotName.createSimple("com.fasterxml.jackson.databind.JsonNode"),


### PR DESCRIPTION
using JsonValue in a REST client results in the "Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index" warning