### PR TITLE
Inject KafkaClientSupplier and State(Restore)Listener in KafkaStreams

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -26,9 +26,12 @@ import javax.inject.Singleton;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.ShutdownEvent;
@@ -53,12 +56,17 @@ public class KafkaStreamsTopologyManager {
     private volatile Properties properties;
     private volatile Map<String, Object> adminClientConfig;
 
+    private volatile Instance<KafkaClientSupplier> kafkaClientSupplier;
+    private volatile Instance<StateListener> stateListener;
+    private volatile Instance<StateRestoreListener> globalStateRestoreListener;
+
     KafkaStreamsTopologyManager() {
         executor = null;
     }
 
     @Inject
-    public KafkaStreamsTopologyManager(Instance<Topology> topology) {
+    public KafkaStreamsTopologyManager(Instance<Topology> topology, Instance<KafkaClientSupplier> kafkaClientSupplier,
+            Instance<StateListener> stateListener, Instance<StateRestoreListener> globalStateRestoreListener) {
         // No producer for Topology -> nothing to do
         if (topology.isUnsatisfied()) {
             LOGGER.debug("No Topology producer; Kafka Streams will not be started");
@@ -68,6 +76,9 @@ public class KafkaStreamsTopologyManager {
 
         this.executor = Executors.newSingleThreadExecutor();
         this.topology = topology;
+        this.kafkaClientSupplier = kafkaClientSupplier;
+        this.stateListener = stateListener;
+        this.globalStateRestoreListener = globalStateRestoreListener;
     }
 
     /**
@@ -106,7 +117,19 @@ public class KafkaStreamsTopologyManager {
 
         Properties streamsProperties = getStreamsProperties(properties, bootstrapServersConfig, runtimeConfig);
 
-        streams = new KafkaStreams(topology.get(), streamsProperties);
+        if (kafkaClientSupplier.isUnsatisfied()) {
+            streams = new KafkaStreams(topology.get(), streamsProperties);
+        } else {
+            streams = new KafkaStreams(topology.get(), streamsProperties, kafkaClientSupplier.get());
+        }
+
+        if (!stateListener.isUnsatisfied()) {
+            streams.setStateListener(stateListener.get());
+        }
+        if (!globalStateRestoreListener.isUnsatisfied()) {
+            streams.setGlobalStateRestoreListener(globalStateRestoreListener.get());
+        }
+
         adminClientConfig = getAdminClientConfig(bootstrapServersConfig);
 
         executor.execute(() -> {

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsPipeline.java
@@ -2,8 +2,11 @@ package io.quarkus.it.kafka.streams;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
 
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -50,5 +53,20 @@ public class KafkaStreamsPipeline {
                 .to("streams-test-customers-processed", Produced.with(Serdes.Integer(), enrichedCustomerSerde));
 
         return builder.build();
+    }
+
+    @Produces
+    @Singleton
+    CurrentStateListener stateListener() {
+        return new CurrentStateListener();
+    }
+
+    class CurrentStateListener implements StateListener {
+        State currentState;
+
+        @Override
+        public void onChange(State newState, State oldState) {
+            this.currentState = newState;
+        }
     }
 }

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import javax.inject.Inject;
+
 import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -18,10 +20,12 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.it.kafka.streams.KafkaStreamsPipeline.CurrentStateListener;
 import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
 import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -31,6 +35,9 @@ import io.restassured.RestAssured;
 @QuarkusTestResource(KafkaTestResource.class)
 @QuarkusTest
 public class KafkaStreamsTest {
+
+    @Inject
+    CurrentStateListener stateListener;
 
     private static Producer<Integer, Customer> createCustomerProducer() {
         Properties props = new Properties();
@@ -112,6 +119,7 @@ public class KafkaStreamsTest {
         assertCategoryCount(2, 1);
 
         testKafkaStreamsAliveAndReady();
+        Assertions.assertEquals(State.RUNNING, stateListener.currentState);
 
         // explicitly stopping the pipeline *before* the broker is shut down, as it
         // otherwise will time out


### PR DESCRIPTION
Fixes #8923

Enables user instrumentation (tracing, metrics, ...) of the KafkaStreams instance, by discovering beans of type KafkaClientSupplier, StateListener and StateRestoreListener, similar to discovery of Topology bean.
Some default instrumentation could come later come via the extension (cf #5471).