### PR TITLE
Use deployment test dependencies for RESTEasy Mutiny tests

### DIFF
--- a/extensions/resteasy-mutiny/deployment/pom.xml
+++ b/extensions/resteasy-mutiny/deployment/pom.xml
@@ -43,17 +43,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonb</artifactId>
+            <artifactId>quarkus-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx</artifactId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This is needed to properly order the build.

It failed the build of the release as it wasn't properly ordered.