### PR TITLE
WIP - testresources cleanup

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceWithCleanupLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceWithCleanupLifecycleManager.java
@@ -1,0 +1,7 @@
+package io.quarkus.test.common;
+
+public interface QuarkusTestResourceWithCleanupLifecycleManager extends QuarkusTestResourceLifecycleManager {
+
+    default void cleanup() {
+    }
+}

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -3,6 +3,7 @@ package io.quarkus.test.common;
 import java.io.Closeable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,6 +80,23 @@ public class TestResourceManager implements Closeable {
             ConfigProviderResolver cpr = ConfigProviderResolver.instance();
             cpr.releaseConfig(cpr.getConfig());
         } catch (Throwable ignored) {
+        }
+    }
+
+    public void cleanup(Object testInstance) {
+        for (QuarkusTestResourceLifecycleManager testResource : testResources) {
+            if (!QuarkusTestResourceWithCleanupLifecycleManager.class.isAssignableFrom(testResource.getClass())) {
+                return;
+            }
+            QuarkusTestResourceWithCleanupLifecycleManager testResourceWithCleanup = (QuarkusTestResourceWithCleanupLifecycleManager) testResource;
+            QuarkusTestResource[] annotations = testInstance.getClass()
+                    .getDeclaredAnnotationsByType(QuarkusTestResource.class);
+            if (annotations.length > 0) {
+                if (Arrays.stream(annotations)
+                        .anyMatch(it -> QuarkusTestResourceWithCleanupLifecycleManager.class.isAssignableFrom(it.value()))) {
+                    testResourceWithCleanup.cleanup();
+                }
+            }
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -29,6 +29,7 @@ public class NativeTestExtension
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
         if (!failedBoot) {
+            extractState(context).testResourceManager.cleanup(context.getTestInstance().get());
             RestAssuredURLManager.clearURL();
             TestScopeManager.tearDown(true);
         }
@@ -95,10 +96,15 @@ public class NativeTestExtension
     @Override
     public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
         TestHTTPResourceManager.inject(testInstance);
+        ExtensionState state = extractState(context);
+        state.testResourceManager.inject(testInstance);
+    }
+
+    private ExtensionState extractState(ExtensionContext context) {
         ExtensionContext root = context.getRoot();
         ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
         ExtensionState state = store.get(ExtensionState.class.getName(), ExtensionState.class);
-        state.testResourceManager.inject(testInstance);
+        return state;
     }
 
     public class ExtensionState implements ExtensionContext.Store.CloseableResource {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -232,6 +232,11 @@ public class QuarkusTestExtension
                     .getDeclaredMethod("clearURL").invoke(null);
             runningQuarkusApplication.getClassLoader().loadClass(TestScopeManager.class.getName())
                     .getDeclaredMethod("tearDown", boolean.class).invoke(null, nativeImageTest);
+            ExtensionState state = context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).get(
+                    ExtensionState.class.getName(),
+                    ExtensionState.class);
+            state.testResourceManager.getClass().getMethod("cleanup", Object.class).invoke(state.testResourceManager,
+                    actualTestInstance);
         }
     }
 


### PR DESCRIPTION
I've been dealing with the issue of test resource being polluted by tests and as a result tests are affecting each other. So in pursuit of some cleanup procedure (which will differ depending on the actual test resource used) I did this sort of PoC. Could you please advise me if the direction is worth exploring and provide guidance?

@geoand would you have a chance to look at this? (Since we've talked about the topic on zulip before.)