### PR TITLE
Optimize Dockerfile.native for smaller docker-image size

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
@@ -16,13 +16,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 WORKDIR /work/
-COPY ${build_dir}/*-runner /work/application
-
-# set up permissions for user `1001`
-RUN chmod 775 /work /work/application \
-  && chown -R 1001 /work \
-  && chmod -R "g+rwX" /work \
-  && chown -R 1001:root /work
+COPY --chown=1001:root ${build_dir}/*-runner /work/application
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
Optimizing the native Dockerfile by combining the **copy** with the **chown** command. 
With that in place one docker-layer can be dropped. 
This safes 1x the size of the native executable.

For background read this blog-post: https://blog.mornati.net/docker-images-and-chown/

Tested the changed  Dockerfile.native with Windows10 and Ubuntu Linux, both using Docker 19.03.8.

**before change:**
```
docker images dev/simple:1.0
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
dev/simple          1.0                 db1611fb072c        28 seconds ago      164MB
```
```
docker history dev/simple:1.0
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
db1611fb072c        7 seconds ago       /bin/sh -c #(nop)  CMD ["./application" "-Dq…   0B                  
f642cf578ba7        7 seconds ago       /bin/sh -c #(nop)  USER 1001                    0B                  
aa93812566e5        8 seconds ago       /bin/sh -c #(nop)  EXPOSE 8080                  0B                  
ecd06c4fdc15        8 seconds ago       /bin/sh -c chmod 775 /work /work/application…   29.1MB              
00d68ba8db63        10 seconds ago      /bin/sh -c #(nop) COPY file:7f4154ec775be2da…   29.1MB              
7381d031be10        6 weeks ago         /bin/sh -c #(nop) WORKDIR /work/                0B                  
6ce38bb5210c        2 months ago                                                        4.23kB              
<missing>           2 months ago                                                        106MB               Imported from -
```

**after change:**
```
> docker images dev/simple:1.0
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
dev/simple          1.0                 97a4faa5c9bd        35 minutes ago      135MB
```
```
> docker history dev/simple:1.0
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
97a4faa5c9bd        32 minutes ago      /bin/sh -c #(nop)  CMD ["./application" "-Dq…   0B                  
0f8a16d0616d        32 minutes ago      /bin/sh -c #(nop)  USER 1001                    0B                  
45c1bf0e7f72        32 minutes ago      /bin/sh -c #(nop)  EXPOSE 8080                  0B                  
6c677db83e3a        32 minutes ago      /bin/sh -c #(nop) COPY --chown=1001:rootfile…   29.1MB              
7381d031be10        6 weeks ago         /bin/sh -c #(nop) WORKDIR /work/                0B                  
6ce38bb5210c        2 months ago                                                        4.23kB              
<missing>           2 months ago                                                        106MB               Imported from -
```