### PR TITLE
ArC - fix producer method validation

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unproxyable/ProducerAddMissingNoargsConstructorTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unproxyable/ProducerAddMissingNoargsConstructorTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.arc.test.unproxyable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ProducerAddMissingNoargsConstructorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProducerAddMissingNoargsConstructorTest.class, MyProducer.class, MyBean.class));
+
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void testConstructorWasAdded() {
+        assertEquals("bar", bean.getFoo());
+    }
+
+    @Singleton
+    static class MyProducer {
+
+        @Produces
+        @ApplicationScoped
+        MyBean produce() {
+            return new MyBean("bar");
+        }
+
+    }
+
+    static class MyBean extends BeanBase {
+
+        final String foo;
+
+        // The absence of a no-args constructor should normally result in deployment exception
+        public MyBean(String foo) {
+            this.foo = foo;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+    }
+
+    static class BeanBase {
+
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unproxyable/ProducerFailedToAddMissingNoargsConstructorTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unproxyable/ProducerFailedToAddMissingNoargsConstructorTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.unproxyable;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ProducerFailedToAddMissingNoargsConstructorTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ProducerFailedToAddMissingNoargsConstructorTest.class, MyProducer.class, MyBean.class,
+                            MyBase.class))
+            .setExpectedException(DeploymentException.class);
+
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void testConstructorWasNotAdded() {
+        fail();
+    }
+
+    @Singleton
+    static class MyProducer {
+
+        @Produces
+        @ApplicationScoped
+        MyBean produce() {
+            return new MyBean("bar");
+        }
+
+    }
+
+    static class MyBean extends MyBase {
+
+        public MyBean(String foo) {
+            super(foo);
+        }
+
+    }
+
+    static class MyBase {
+
+        public MyBase(String foo) {
+        }
+
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -669,7 +669,7 @@ final class Beans {
                     if (!DotNames.OBJECT.equals(superName)) {
                         ClassInfo superClass = bean.getDeployment().getIndex().getClassByName(beanClass.superName());
                         if (superClass == null || !superClass.hasNoArgsConstructor()) {
-                            // Bean class extend a class without no-args constructor
+                            // Bean class extends a class without no-args constructor
                             // It is not possible to generate a no-args constructor reliably
                             superName = null;
                         }
@@ -679,9 +679,10 @@ final class Beans {
                         bytecodeTransformerConsumer.accept(new BytecodeTransformer(beanClass.name().toString(),
                                 new NoArgConstructorTransformFunction(superClassName)));
                     } else {
-                        errors.add(new DeploymentException(String
-                                .format("It is not possible to add a synthetic constructor with no parameters to the unproxyable bean class: %s",
-                                        beanClass)));
+                        errors.add(new DeploymentException(
+                                "It's not possible to add a synthetic constructor with no parameters to the unproxyable bean class: "
+                                        +
+                                        beanClass));
                     }
                 } else {
                     errors.add(new DeploymentException(String
@@ -731,19 +732,19 @@ final class Beans {
                         if (!DotNames.OBJECT.equals(superName)) {
                             ClassInfo superClass = bean.getDeployment().getIndex().getClassByName(returnTypeClass.superName());
                             if (superClass == null || !superClass.hasNoArgsConstructor()) {
-                                // Bean class extend a class without no-args constructor
+                                // Bean class extends a class without no-args constructor
                                 // It is not possible to generate a no-args constructor reliably
                                 superName = null;
-                            } else {
-                                errors.add(new DeploymentException(String
-                                        .format("It is not possible to add a synthetic constructor with no parameters to the unproxyable return type of: %s",
-                                                bean)));
                             }
                         }
                         if (superName != null) {
                             String superClassName = superName.toString().replace('.', '/');
                             bytecodeTransformerConsumer.accept(new BytecodeTransformer(returnTypeClass.name().toString(),
                                     new NoArgConstructorTransformFunction(superClassName)));
+                        } else {
+                            errors.add(new DeploymentException(String
+                                    .format("It's not possible to add a synthetic constructor with no parameters to the unproxyable return type of "
+                                            + bean)));
                         }
                     } else {
                         errors.add(new DefinitionException(String


### PR DESCRIPTION
- no-args constructor transformation is not possible if a superclass
does not declare a no-args constructor