### PR TITLE
refactor: cleanup some unused variable initialization in JibProcessor

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -108,10 +108,9 @@ public class JibProcessor {
 
         JibContainerBuilder jibContainerBuilder = createContainerBuilderFromNative(containerImageConfig, jibConfig,
                 nativeImage, containerImageLabels);
-        JibContainer container = containerize(applicationInfo, containerImageConfig, jibContainerBuilder,
-                pushRequest.isPresent());
 
-        ImageReference targetImage = container.getTargetImage();
+        containerize(applicationInfo, containerImageConfig, jibContainerBuilder, pushRequest.isPresent());
+
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container", Collections.emptyMap()));
     }
 


### PR DESCRIPTION
Noticed this while reviewing Jib related PR