### PR TITLE
Netty EventLoopGroup qualifiers - add annotation literals

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -169,12 +169,14 @@ class NettyProcessor {
                 .supplier(boss)
                 .scope(ApplicationScoped.class)
                 .addQualifier(BossEventLoopGroup.class)
+                .unremovable()
                 .done());
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(EventLoopGroup.class)
                 .supplier(main)
                 .scope(ApplicationScoped.class)
                 .addQualifier(MainEventLoopGroup.class)
+                .unremovable()
                 .done());
     }
 

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/BossEventLoopGroup.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/BossEventLoopGroup.java
@@ -3,9 +3,21 @@ package io.quarkus.netty;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BossEventLoopGroup {
+
+    /**
+     * Supports inline instantiation of this qualifier.
+     */
+    public static final class Literal extends AnnotationLiteral<BossEventLoopGroup> implements BossEventLoopGroup {
+
+        public static final Literal INSTANCE = new Literal();
+
+        private static final long serialVersionUID = 1L;
+
+    }
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/MainEventLoopGroup.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/MainEventLoopGroup.java
@@ -3,9 +3,21 @@ package io.quarkus.netty;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MainEventLoopGroup {
+
+    /**
+     * Supports inline instantiation of this qualifier.
+     */
+    public static final class Literal extends AnnotationLiteral<MainEventLoopGroup> implements MainEventLoopGroup {
+
+        public static final Literal INSTANCE = new Literal();
+
+        private static final long serialVersionUID = 1L;
+
+    }
 }


### PR DESCRIPTION
- to ease the programmatic lookup of EventLoopGroup beans