### PR TITLE
Updated the version of keycloak version in bom from 9.0.2 to 9.0.3

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -95,7 +95,7 @@ jobs:
     needs: build-jdk11
     timeout-minutes: 120
     strategy:
-      fail-fast: ${{ github.repository == 'quarkusio/quarkus' }}
+      fail-fast: false
       matrix:
         java-version: [8, 11, 12]
 

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -103,7 +103,7 @@ jobs:
 
     services:
       keycloak:
-        image: quay.io/keycloak/keycloak:9.0.2
+        image: quay.io/keycloak/keycloak:9.0.3
         env:
           KEYCLOAK_USER: admin
           KEYCLOAK_PASSWORD: admin
@@ -465,7 +465,7 @@ jobs:
               -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M \
               -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true \
               -Dkeycloak.profile.feature.upload_scripts=enabled" \
-            -d quay.io/keycloak/keycloak:9.0.2
+            -d quay.io/keycloak/keycloak:9.0.3
         if: matrix.keycloak
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -183,7 +183,7 @@
         <jna.version>5.3.1</jna.version>
         <antlr.version>4.7.2</antlr.version>
         <quarkus-security.version>1.0.1.Final</quarkus-security.version>
-        <keycloak.version>9.0.2</keycloak.version>
+        <keycloak.version>9.0.3</keycloak.version>
         <logstash-gelf.version>1.14.0</logstash-gelf.version>
         <jsch.version>0.1.55</jsch.version>
         <jzlib.version>1.1.1</jzlib.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -79,7 +79,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update .github/workflows/ci-actions.yml to match the version -->
-        <keycloak.docker.image>quay.io/keycloak/keycloak:9.0.2</keycloak.docker.image>
+        <keycloak.docker.image>quay.io/keycloak/keycloak:9.0.3</keycloak.docker.image>
 
         <unboundid-ldap.version>4.0.13</unboundid-ldap.version>
 


### PR DESCRIPTION
The version of keycloak dependency is upgraded from 9.0.2 to 9.0.3