### PR TITLE
Updated JandexUtil to new subtyping

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
@@ -3,8 +3,11 @@ package io.quarkus.deployment.util;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
@@ -13,6 +16,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
 import org.jboss.jandex.TypeVariable;
 
 public final class JandexUtil {
@@ -57,138 +61,194 @@ public final class JandexUtil {
     public static List<Type> resolveTypeParameters(DotName input, DotName target, IndexView index) {
         final ClassInfo inputClassInfo = fetchFromIndex(input, index);
 
-        final ClassInfo targetClassInfo = fetchFromIndex(target, index);
-
-        final RecursiveMatchResult recursiveMatchResult = matchParametersRecursively(inputClassInfo, target,
-                Modifier.isInterface(targetClassInfo.flags()), index, new LinkedList<>());
-        if (recursiveMatchResult == null) {
+        Type startingType = getType(inputClassInfo, index);
+        final List<Type> result = findParametersRecursively(startingType, target,
+                new HashSet<>(), index);
+        // null means not found
+        if (result == null) {
             return Collections.emptyList();
         }
-        final List<Type> result = resolveTypeParameters(recursiveMatchResult);
-
-        if (result.size() != recursiveMatchResult.argumentsOfMatch.size()) {
-            throw new IllegalStateException("Unable to properly match generic types");
-        }
 
         return result;
     }
 
-    private static List<Type> resolveTypeParameters(RecursiveMatchResult recursiveMatchResult) {
-        final List<Type> result = new ArrayList<>();
-        for (int i = 0; i < recursiveMatchResult.argumentsOfMatch.size(); i++) {
-            final Type argument = recursiveMatchResult.argumentsOfMatch.get(i);
-            if (argument instanceof ClassType) {
-                result.add(argument);
-            } else if (argument instanceof ParameterizedType) {
-                ParameterizedType argumentParameterizedType = argument.asParameterizedType();
-                List<Type> resolvedTypes = new ArrayList<>(argumentParameterizedType.arguments().size());
-                for (Type argType : argumentParameterizedType.arguments()) {
-                    if (argType instanceof TypeVariable) {
-                        resolvedTypes.add(findTypeFromTypeVariable(recursiveMatchResult, argType.asTypeVariable()));
-                    } else {
-                        resolvedTypes.add(argType);
-                    }
-                }
-                result.add(ParameterizedType.create(argumentParameterizedType.name(), resolvedTypes.toArray(new Type[0]),
-                        argumentParameterizedType.owner()));
-            } else if (argument instanceof TypeVariable) {
-                Type typeFromTypeVariable = findTypeFromTypeVariable(recursiveMatchResult, argument.asTypeVariable());
-                if (typeFromTypeVariable != null) {
-                    result.add(typeFromTypeVariable);
-                }
-            } else if (argument instanceof ArrayType) {
-                ArrayType argumentAsArrayType = argument.asArrayType();
-                Type componentType = argumentAsArrayType.component();
-                if (componentType instanceof TypeVariable) { // should always be the case
-                    Type typeFromTypeVariable = findTypeFromTypeVariable(recursiveMatchResult, componentType.asTypeVariable());
-                    if (typeFromTypeVariable != null) {
-                        result.add(ArrayType.create(typeFromTypeVariable, argumentAsArrayType.dimensions()));
-                    }
-                }
-            }
+    /**
+     * Creates a type for a ClassInfo
+     */
+    private static Type getType(ClassInfo inputClassInfo, IndexView index) {
+        List<TypeVariable> typeParameters = inputClassInfo.typeParameters();
+        if (typeParameters.isEmpty())
+            return ClassType.create(inputClassInfo.name(), Kind.CLASS);
+        Type owner = null;
+        // ignore owners for non-static classes
+        if (inputClassInfo.enclosingClass() != null && !Modifier.isStatic(inputClassInfo.flags())) {
+            owner = getType(fetchFromIndex(inputClassInfo.enclosingClass(), index), index);
         }
-        return result;
+        return ParameterizedType.create(inputClassInfo.name(), typeParameters.toArray(new Type[0]), owner);
     }
 
-    private static Type findTypeFromTypeVariable(RecursiveMatchResult recursiveMatchResult, TypeVariable typeVariable) {
-        String unmatchedParameter = typeVariable.identifier();
-
-        for (RecursiveMatchLevel recursiveMatchLevel : recursiveMatchResult.recursiveMatchLevels) {
-            Type matchingCapturedType = null;
-            for (int j = 0; j < recursiveMatchLevel.definitions.size(); j++) {
-                final Type definition = recursiveMatchLevel.definitions.get(j);
-                if ((definition instanceof TypeVariable)
-                        && unmatchedParameter.equals(definition.asTypeVariable().identifier())) {
-                    matchingCapturedType = recursiveMatchLevel.captures.get(j);
-                    break; // out of the definitions loop
-                }
-            }
-            // at this point their MUST be a match, if there isn't we have made some mistake in the implementation
-            if (matchingCapturedType == null) {
-                throw new IllegalStateException("Error retrieving generic types");
-            }
-            if (isDirectlyHandledType(matchingCapturedType)) {
-                // search is over
-                return matchingCapturedType;
-            }
-            if (matchingCapturedType instanceof TypeVariable) {
-                // continue the search in the lower levels using the new name
-                unmatchedParameter = matchingCapturedType.asTypeVariable().identifier();
-            }
-        }
-
-        return null;
-    }
-
-    private static boolean isDirectlyHandledType(Type matchingCapturedType) {
-        return (matchingCapturedType instanceof ClassType) ||
-                (matchingCapturedType instanceof ParameterizedType);
-    }
-
-    private static RecursiveMatchResult matchParametersRecursively(ClassInfo inputClassInfo, DotName target,
-            boolean isTargetAnInterface,
-            IndexView index, List<RecursiveMatchLevel> visitedTypes) {
-
-        if (isTargetAnInterface) {
-            final List<Type> interfaceTypes = inputClassInfo.interfaceTypes();
-            final List<Type> nonMatchingInterfaces = new ArrayList<>();
-            for (Type interfaceType : interfaceTypes) {
-                if (target.equals(interfaceType.name())) {
-                    return getRecursiveMatchResult(visitedTypes, interfaceType);
-                }
-                // we only check the other interfaces if we didn't find anything
-                // this ensures that we also use the "closest" path to the target interface
-                nonMatchingInterfaces.add(interfaceType);
-            }
-
-            // go through the non matching interfaces and check if any of one of them extends the target
-            for (Type otherInterface : nonMatchingInterfaces) {
-                final RecursiveMatchResult recursiveMatchResult = matchParametersRecursively(
-                        fetchFromIndex(otherInterface.name(), index), target, isTargetAnInterface, index,
-                        addArgumentIfNeeded(otherInterface, index, visitedTypes));
-                if (recursiveMatchResult != null) {
-                    return recursiveMatchResult;
-                }
-            }
-        }
-
-        // check if the super class is a match - if not keep going up the type hierarchy until we reach object
-        final Type superClassType = inputClassInfo.superClassType();
-        if (target.equals(superClassType.name())) {
-            return getRecursiveMatchResult(visitedTypes, superClassType);
-        }
-        if (OBJECT.equals(superClassType.name())) {
+    /**
+     * Finds the type arguments passed from the starting type to the given target type, mapping
+     * generics when found, on the way down. Returns null if not found.
+     */
+    private static List<Type> findParametersRecursively(Type type, DotName target,
+            Set<DotName> visitedTypes, IndexView index) {
+        DotName name = type.name();
+        // cache results first
+        if (!visitedTypes.add(name)) {
             return null;
         }
-        return matchParametersRecursively(fetchFromIndex(superClassType.name(), index), target, isTargetAnInterface, index,
-                addArgumentIfNeeded(superClassType, index, visitedTypes));
+
+        // always end at Object
+        if (OBJECT.equals(name)) {
+            return null;
+        }
+
+        final ClassInfo inputClassInfo = fetchFromIndex(name, index);
+
+        // look at the current type
+        if (target.equals(name)) {
+            Type thisType = getType(inputClassInfo, index);
+            if (thisType.kind() == Kind.CLASS)
+                return Collections.emptyList();
+            else
+                return thisType.asParameterizedType().arguments();
+        }
+
+        // superclasses first
+        Type superClassType = inputClassInfo.superClassType();
+        List<Type> superResult = findParametersRecursively(superClassType, target, visitedTypes, index);
+        if (superResult != null) {
+            // map any returned type parameters to our type arguments on the way down
+            return mapTypeArguments(superClassType, superResult, index);
+        }
+
+        // interfaces second
+        for (Type interfaceType : inputClassInfo.interfaceTypes()) {
+            List<Type> ret = findParametersRecursively(interfaceType, target, visitedTypes, index);
+            if (ret != null) {
+                // map any returned type parameters to our type arguments on the way down
+                return mapTypeArguments(interfaceType, ret, index);
+            }
+        }
+
+        // not found
+        return null;
     }
 
-    private static RecursiveMatchResult getRecursiveMatchResult(List<RecursiveMatchLevel> visitedTypes, Type superClassType) {
-        if (superClassType instanceof ParameterizedType) {
-            return new RecursiveMatchResult(superClassType.asParameterizedType().arguments(), visitedTypes);
+    /**
+     * Maps any type parameters in typeArgumentsFromSupertype from the type parameters declared in appliedType's declaration
+     * to the type arguments we passed in appliedType
+     */
+    private static List<Type> mapTypeArguments(Type appliedType, List<Type> typeArgumentsFromSupertype, IndexView index) {
+        // no type arguments to map
+        if (typeArgumentsFromSupertype.isEmpty()) {
+            return typeArgumentsFromSupertype;
         }
-        return null;
+        // extra easy if all the type args don't contain any type parameters
+        if (!containsTypeParameters(typeArgumentsFromSupertype)) {
+            return typeArgumentsFromSupertype;
+        }
+
+        // this can't fail since we got a result
+        ClassInfo superType = fetchFromIndex(appliedType.name(), index);
+
+        // if our supertype has no type parameters, we don't need any mapping
+        if (superType.typeParameters().isEmpty()) {
+            return typeArgumentsFromSupertype;
+        }
+
+        // figure out which arguments we passed to the supertype
+        List<Type> appliedArguments;
+
+        // we passed them explicitely
+        if (appliedType.kind() == Kind.PARAMETERIZED_TYPE) {
+            appliedArguments = appliedType.asParameterizedType().arguments();
+        } else {
+            // raw supertype: use bounds
+            appliedArguments = new ArrayList<>(superType.typeParameters().size());
+            for (TypeVariable typeVariable : superType.typeParameters()) {
+                if (!typeVariable.bounds().isEmpty()) {
+                    appliedArguments.add(typeVariable.bounds().get(0));
+                } else {
+                    appliedArguments.add(ClassType.create(OBJECT, Kind.CLASS));
+                }
+            }
+        }
+
+        // it's a problem if we got different arguments to the parameters declared
+        if (appliedArguments.size() != superType.typeParameters().size()) {
+            throw new IllegalArgumentException("Our supertype instance " + appliedType
+                    + " does not match supertype declared arguments: " + superType.typeParameters());
+        }
+        // build the mapping
+        Map<String, Type> mapping = new HashMap<>();
+        for (int i = 0; i < superType.typeParameters().size(); i++) {
+            TypeVariable typeParameter = superType.typeParameters().get(i);
+            mapping.put(typeParameter.identifier(), appliedArguments.get(i));
+        }
+        // and map
+        return mapGenerics(typeArgumentsFromSupertype, mapping);
+    }
+
+    private static boolean containsTypeParameters(List<Type> typeArgumentsFromSupertype) {
+        for (Type type : typeArgumentsFromSupertype) {
+            if (containsTypeParameters(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsTypeParameters(Type type) {
+        switch (type.kind()) {
+            case ARRAY:
+                return containsTypeParameters(type.asArrayType().component());
+            case PARAMETERIZED_TYPE:
+                ParameterizedType parameterizedType = type.asParameterizedType();
+                if (parameterizedType.owner() != null
+                        && containsTypeParameters(parameterizedType.owner()))
+                    return true;
+                return containsTypeParameters(parameterizedType.arguments());
+            case TYPE_VARIABLE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static List<Type> mapGenerics(List<Type> types, Map<String, Type> mapping) {
+        List<Type> ret = new ArrayList<>(types.size());
+        for (Type type : types) {
+            ret.add(mapGenerics(type, mapping));
+        }
+        return ret;
+    }
+
+    private static Type mapGenerics(Type type, Map<String, Type> mapping) {
+        switch (type.kind()) {
+            case ARRAY:
+                ArrayType arrayType = type.asArrayType();
+                return ArrayType.create(mapGenerics(arrayType.component(), mapping), arrayType.dimensions());
+            case CLASS:
+                return type;
+            case PARAMETERIZED_TYPE:
+                ParameterizedType parameterizedType = type.asParameterizedType();
+                Type owner = null;
+                if (parameterizedType.owner() != null) {
+                    owner = mapGenerics(parameterizedType.owner(), mapping);
+                }
+                return ParameterizedType.create(parameterizedType.name(),
+                        mapGenerics(parameterizedType.arguments(), mapping).toArray(new Type[0]), owner);
+            case TYPE_VARIABLE:
+                Type ret = mapping.get(type.asTypeVariable().identifier());
+                if (ret == null) {
+                    throw new IllegalArgumentException("Missing type argument mapping for " + type);
+                }
+                return ret;
+            default:
+                throw new IllegalArgumentException("Illegal type in hierarchy: " + type);
+        }
     }
 
     private static ClassInfo fetchFromIndex(DotName dotName, IndexView index) {
@@ -199,48 +259,4 @@ public final class JandexUtil {
         return classInfo;
     }
 
-    private static List<RecursiveMatchLevel> addArgumentIfNeeded(Type type, IndexView index,
-            List<RecursiveMatchLevel> visitedTypes) {
-        final List<RecursiveMatchLevel> newVisitedTypes = new LinkedList<>(visitedTypes);
-        if (type instanceof ParameterizedType) {
-            final ClassInfo classInfo = fetchFromIndex(type.name(), index);
-            final RecursiveMatchLevel recursiveMatchLevel = new RecursiveMatchLevel(classInfo.typeParameters(),
-                    type.asParameterizedType().arguments());
-            newVisitedTypes.add(0, recursiveMatchLevel);
-        } else if (type instanceof ClassType) {
-            // we need to check if the class contains any bounds
-            final ClassInfo classInfo = index.getClassByName(type.name());
-            if ((classInfo != null) && !classInfo.typeParameters().isEmpty()) {
-                // in this case we just use the first bound as the capture type
-                // TODO do we need something more sophisticated than this?
-                List<Type> captures = new ArrayList<>(classInfo.typeParameters().size());
-                for (TypeVariable typeParameter : classInfo.typeParameters()) {
-                    captures.add(typeParameter.bounds().get(0));
-                }
-                final RecursiveMatchLevel recursiveMatchLevel = new RecursiveMatchLevel(classInfo.typeParameters(), captures);
-                newVisitedTypes.add(0, recursiveMatchLevel);
-            }
-        }
-        return newVisitedTypes;
-    }
-
-    private static class RecursiveMatchResult {
-        private final List<Type> argumentsOfMatch;
-        private final List<RecursiveMatchLevel> recursiveMatchLevels;
-
-        public RecursiveMatchResult(List<Type> argumentsOfMatch, List<RecursiveMatchLevel> recursiveMatchLevels) {
-            this.argumentsOfMatch = argumentsOfMatch;
-            this.recursiveMatchLevels = recursiveMatchLevels;
-        }
-    }
-
-    private static class RecursiveMatchLevel {
-        private final List<? extends Type> definitions;
-        private final List<? extends Type> captures;
-
-        public RecursiveMatchLevel(List<? extends Type> definitions, List<? extends Type> captures) {
-            this.definitions = definitions;
-            this.captures = captures;
-        }
-    }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/JandexUtilTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.deployment.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,15 +12,13 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
 import org.junit.jupiter.api.Test;
 
 public class JandexUtilTest {
 
     private static final DotName SIMPLE = DotName.createSimple(Single.class.getName());
     private static final DotName MULTIPLE = DotName.createSimple(Multiple.class.getName());
-    private static final DotName STRING = DotName.createSimple(String.class.getName());
-    private static final DotName INTEGER = DotName.createSimple(Integer.class.getName());
-    private static final DotName DOUBLE = DotName.createSimple(Double.class.getName());
 
     @Test
     public void testInterfaceNotInHierarchy() {
@@ -34,17 +31,15 @@ public class JandexUtilTest {
     @Test
     public void testNoTypePassed() {
         final Index index = index(Single.class, SingleImplNoType.class);
-        final DotName impl = DotName.createSimple(SingleImplNoType.class.getName());
-        final List<Type> result = JandexUtil.resolveTypeParameters(impl, SIMPLE, index);
-        assertThat(result).isEmpty();
+        checkRepoArg(index, SingleImplNoType.class, Single.class, Object.class);
     }
 
     @Test
     public void testAbstractSingle() {
         final Index index = index(Single.class, AbstractSingle.class);
         final DotName impl = DotName.createSimple(AbstractSingle.class.getName());
-        assertThatThrownBy(() -> JandexUtil.resolveTypeParameters(impl, SIMPLE, index))
-                .isInstanceOf(IllegalStateException.class);
+        List<Type> ret = JandexUtil.resolveTypeParameters(impl, SIMPLE, index);
+        assertThat(ret).hasSize(1).allMatch(t -> t.kind() == Kind.TYPE_VARIABLE && t.asTypeVariable().identifier().equals("S"));
     }
 
     @Test


### PR DESCRIPTION
So, @geoand @dmlloyd WDYT of this?

I reimplemented it like I explained on zulip, with proper comments.

I think the implementation is easier to understand and optimal in that we only apply the mapping on the way down from a result.

Now, I had to change two tests because I disagreed about the results:

- One was looking up type args of `Foo<T>` from `Bar<S> implements Foo<S>` and used to throw. I'm not sure what the criteria was for throwing, but IMO the type arguments we're looking for are just `[S]`, so I altered the test. CI can tell us if we used it a way that expected the exception.
- One was looking up type args of `Foo<T>` from Bar implements Foo` and used to return `[]`, while IMO this is simple erasure and the type arg is effectively `[Object]`.

Note that while doing this I realised we've zero tests for component types (inner types) or unresolved type variables (not sure how those can happen). But probably it's fine to wait for a bug to be reported.