### PR TITLE
Add limit parameter to the Panache REST list operation

### DIFF
--- a/extensions/panache/panache-rest-common/deployment/src/main/java/io/quarkus/panache/rest/common/deployment/DataAccessImplementor.java
+++ b/extensions/panache/panache-rest-common/deployment/src/main/java/io/quarkus/panache/rest/common/deployment/DataAccessImplementor.java
@@ -9,6 +9,8 @@ public interface DataAccessImplementor {
 
     ResultHandle listAll(BytecodeCreator creator);
 
+    ResultHandle list(BytecodeCreator creator, ResultHandle limit);
+
     ResultHandle persist(BytecodeCreator creator, ResultHandle entity);
 
     ResultHandle update(BytecodeCreator creator, ResultHandle entity);

--- a/extensions/panache/panache-rest-common/deployment/src/main/java/io/quarkus/panache/rest/common/deployment/methods/ListHalMethodImplementor.java
+++ b/extensions/panache/panache-rest-common/deployment/src/main/java/io/quarkus/panache/rest/common/deployment/methods/ListHalMethodImplementor.java
@@ -1,12 +1,23 @@
 package io.quarkus.panache.rest.common.deployment.methods;
 
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+
 import java.util.Collection;
 
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.panache.rest.common.PanacheCrudResource;
 import io.quarkus.panache.rest.common.deployment.DataAccessImplementor;
 import io.quarkus.panache.rest.common.deployment.MethodImplementor;
@@ -20,23 +31,42 @@ public final class ListHalMethodImplementor implements MethodImplementor {
 
     private final String entityClassName;
 
-    public ListHalMethodImplementor(DataAccessImplementor dataAccessImplementor, String entityClassName) {
+    private final FieldDescriptor uriInfoField;
+
+    public ListHalMethodImplementor(DataAccessImplementor dataAccessImplementor, String entityClassName,
+            FieldDescriptor uriInfoField) {
         this.dataAccessImplementor = dataAccessImplementor;
         this.entityClassName = entityClassName;
+        this.uriInfoField = uriInfoField;
     }
 
     /**
      * Implements HAL version of {@link PanacheCrudResource#list()}.
      * Generated code looks more or less like this:
-     * 
+     *
      * <pre>
      * {@code
      *     &#64;GET
      *     &#64;Path("entities")
      *     &#64;Produces({"application/hal+json"})
      *     public HalCollectionWrapper listHal() {
-     *         List entities = BookEntity.listAll();
-     *         return new HalCollectionWrapper(entities, Entity.class);
+     *         MultivaluedMap<String, String> params = uriInfo.getQueryParameters(true);
+     *         if (params.containsKey("limit")) {
+     *             return new HalCollectionWrapper(Entity.listAll(), Entity.class);
+     *         } else {
+     *             int limit;
+     *             try {
+     *                 limit = Integer.parseInt(params.getFirst("limit"));
+     *                 if (limit <= 0) {
+     *                     throw new BadRequestException("Limit cannot be negative");
+     *                 }
+     *             } catch (NumberFormatException var5) {
+     *                 throw new BadRequestException("Limit has to be an integer");
+     *             }
+     *             PanacheQuery query = Entity.findAll();
+     *             query.range(0, limit - 1);
+     *             return return new HalCollectionWrapper(query.list(), Entity.class);
+     *         }
      *     }
      * }
      * </pre>
@@ -50,9 +80,45 @@ public final class ListHalMethodImplementor implements MethodImplementor {
         ResourceAnnotator.addPath(methodCreator, UrlImplementor.getCollectionUrl(entityClassName));
         ResourceAnnotator.addProduces(methodCreator, ResourceAnnotator.APPLICATION_HAL_JSON);
 
-        ResultHandle entities = dataAccessImplementor.listAll(methodCreator);
-        methodCreator.returnValue(wrapEntities(methodCreator, entities, entityClassName));
+        ResultHandle queryParameters = getQueryParameters(methodCreator);
+        BranchResult ifHasLimit = methodCreator.ifTrue(hasLimit(methodCreator, queryParameters));
+
+        // Has limit
+        AssignableResultHandle limit = ifHasLimit.trueBranch().createVariable(int.class);
+        setLimit(ifHasLimit.trueBranch(), queryParameters, limit);
+        ifHasLimit.trueBranch().returnValue(wrapEntities(ifHasLimit.trueBranch(),
+                dataAccessImplementor.list(ifHasLimit.trueBranch(), limit), entityClassName));
+        // Does not have limit
+        ifHasLimit.falseBranch().returnValue(wrapEntities(ifHasLimit.falseBranch(),
+                dataAccessImplementor.listAll(ifHasLimit.falseBranch()), entityClassName));
         methodCreator.close();
+    }
+
+    private ResultHandle getQueryParameters(BytecodeCreator creator) {
+        ResultHandle uriInfo = creator.readInstanceField(uriInfoField, creator.getThis());
+        return creator.invokeInterfaceMethod(
+                ofMethod(UriInfo.class, "getQueryParameters", MultivaluedMap.class, boolean.class),
+                uriInfo, creator.load(true));
+    }
+
+    private ResultHandle hasLimit(BytecodeCreator creator, ResultHandle queryParameters) {
+        return creator.invokeInterfaceMethod(ofMethod(MultivaluedMap.class, "containsKey", boolean.class, Object.class),
+                queryParameters, creator.load("limit"));
+    }
+
+    private void setLimit(BytecodeCreator creator, ResultHandle queryParameters, AssignableResultHandle limitVariable) {
+        TryBlock tryBlock = creator.tryBlock();
+        ResultHandle stringLimit = tryBlock.invokeInterfaceMethod(
+                ofMethod(MultivaluedMap.class, "getFirst", Object.class, Object.class),
+                queryParameters, tryBlock.load("limit"));
+        tryBlock.assign(limitVariable,
+                tryBlock.invokeStaticMethod(ofMethod(Integer.class, "parseInt", int.class, String.class), stringLimit));
+        tryBlock.ifLessEqualZero(limitVariable).trueBranch()
+                .throwException(BadRequestException.class, "Limit cannot be negative");
+
+        CatchBlockCreator catchBlockCreator = tryBlock.addCatch(NumberFormatException.class);
+        catchBlockCreator.throwException(BadRequestException.class, "Limit has to be an integer");
+        catchBlockCreator.close();
     }
 
     private ResultHandle wrapEntities(BytecodeCreator creator, ResultHandle entities, String entityType) {

--- a/extensions/panache/panache-rest-common/deployment/src/main/java/io/quarkus/panache/rest/common/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/panache-rest-common/deployment/src/main/java/io/quarkus/panache/rest/common/deployment/methods/ListMethodImplementor.java
@@ -1,9 +1,22 @@
 package io.quarkus.panache.rest.common.deployment.methods;
 
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+
 import java.util.List;
 
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.panache.rest.common.PanacheCrudResource;
 import io.quarkus.panache.rest.common.deployment.DataAccessImplementor;
 import io.quarkus.panache.rest.common.deployment.MethodImplementor;
@@ -18,15 +31,19 @@ public final class ListMethodImplementor implements MethodImplementor {
 
     private final String entityClassName;
 
-    public ListMethodImplementor(DataAccessImplementor dataAccessImplementor, String entityClassName) {
+    private final FieldDescriptor uriInfoField;
+
+    public ListMethodImplementor(DataAccessImplementor dataAccessImplementor, String entityClassName,
+            FieldDescriptor uriInfoField) {
         this.dataAccessImplementor = dataAccessImplementor;
         this.entityClassName = entityClassName;
+        this.uriInfoField = uriInfoField;
     }
 
     /**
      * Implements {@link PanacheCrudResource#list()}.
      * Generated code looks more or less like this:
-     * 
+     *
      * <pre>
      * {@code
      *     &#64;GET
@@ -37,7 +54,23 @@ public final class ListMethodImplementor implements MethodImplementor {
      *         entityClassName = "com.example.Entity"
      *     )
      *     public List list() {
-     *         return Entity.listAll();
+     *         MultivaluedMap<String, String> params = uriInfo.getQueryParameters(true);
+     *         if (params.containsKey("limit")) {
+     *             return Entity.listAll();
+     *         } else {
+     *             int limit;
+     *             try {
+     *                 limit = Integer.parseInt(params.getFirst("limit"));
+     *                 if (limit <= 0) {
+     *                     throw new BadRequestException("Limit cannot be negative");
+     *                 }
+     *             } catch (NumberFormatException var5) {
+     *                 throw new BadRequestException("Limit has to be an integer");
+     *             }
+     *             PanacheQuery query = Entity.findAll();
+     *             query.range(0, limit - 1);
+     *             return query.list();
+     *         }
      *     }
      * }
      * </pre>
@@ -52,7 +85,43 @@ public final class ListMethodImplementor implements MethodImplementor {
         ResourceAnnotator.addProduces(methodCreator, ResourceAnnotator.APPLICATION_JSON);
         ResourceAnnotator.addLinks(methodCreator, entityClassName, "list");
 
-        methodCreator.returnValue(dataAccessImplementor.listAll(methodCreator));
+        ResultHandle queryParameters = getQueryParameters(methodCreator);
+        BranchResult ifHasLimit = methodCreator.ifTrue(hasLimit(methodCreator, queryParameters));
+
+        // Has limit
+        AssignableResultHandle limit = ifHasLimit.trueBranch().createVariable(int.class);
+        setLimit(ifHasLimit.trueBranch(), queryParameters, limit);
+        ifHasLimit.trueBranch().returnValue(dataAccessImplementor.list(ifHasLimit.trueBranch(), limit));
+        // Does not have limit
+        ifHasLimit.falseBranch().returnValue(dataAccessImplementor.listAll(ifHasLimit.falseBranch()));
+
         methodCreator.close();
+    }
+
+    private ResultHandle getQueryParameters(BytecodeCreator creator) {
+        ResultHandle uriInfo = creator.readInstanceField(uriInfoField, creator.getThis());
+        return creator.invokeInterfaceMethod(
+                ofMethod(UriInfo.class, "getQueryParameters", MultivaluedMap.class, boolean.class),
+                uriInfo, creator.load(true));
+    }
+
+    private ResultHandle hasLimit(BytecodeCreator creator, ResultHandle queryParameters) {
+        return creator.invokeInterfaceMethod(ofMethod(MultivaluedMap.class, "containsKey", boolean.class, Object.class),
+                queryParameters, creator.load("limit"));
+    }
+
+    private void setLimit(BytecodeCreator creator, ResultHandle queryParameters, AssignableResultHandle limitVariable) {
+        TryBlock tryBlock = creator.tryBlock();
+        ResultHandle stringLimit = tryBlock.invokeInterfaceMethod(
+                ofMethod(MultivaluedMap.class, "getFirst", Object.class, Object.class),
+                queryParameters, tryBlock.load("limit"));
+        tryBlock.assign(limitVariable,
+                tryBlock.invokeStaticMethod(ofMethod(Integer.class, "parseInt", int.class, String.class), stringLimit));
+        tryBlock.ifLessEqualZero(limitVariable).trueBranch()
+                .throwException(BadRequestException.class, "Limit cannot be negative");
+
+        CatchBlockCreator catchBlockCreator = tryBlock.addCatch(NumberFormatException.class);
+        catchBlockCreator.throwException(BadRequestException.class, "Limit has to be an integer");
+        catchBlockCreator.close();
     }
 }

--- a/extensions/panache/panache-rest-hibernate-orm/deployment/src/main/java/io/quarkus/panache/rest/hibernate/orm/deployment/EntityDataAccessImplementor.java
+++ b/extensions/panache/panache-rest-hibernate-orm/deployment/src/main/java/io/quarkus/panache/rest/hibernate/orm/deployment/EntityDataAccessImplementor.java
@@ -9,6 +9,7 @@ import javax.persistence.EntityManager;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.rest.common.deployment.DataAccessImplementor;
 
@@ -28,6 +29,16 @@ final class EntityDataAccessImplementor implements DataAccessImplementor {
     @Override
     public ResultHandle listAll(BytecodeCreator creator) {
         return creator.invokeStaticMethod(ofMethod(entityClassName, "listAll", List.class));
+    }
+
+    @Override
+    public ResultHandle list(BytecodeCreator creator, ResultHandle limit) {
+        ResultHandle query = creator.invokeStaticMethod(ofMethod(entityClassName, "findAll", PanacheQuery.class));
+        ResultHandle maxRange = creator.invokeStaticMethod(ofMethod(Integer.class, "sum", int.class, int.class, int.class),
+                limit, creator.load(-1));
+        creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "range", PanacheQuery.class, int.class, int.class),
+                query, creator.load(0), maxRange);
+        return creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "list", List.class), query);
     }
 
     @Override

--- a/extensions/panache/panache-rest-hibernate-orm/deployment/src/main/java/io/quarkus/panache/rest/hibernate/orm/deployment/RepositoryDataAccessImplementor.java
+++ b/extensions/panache/panache-rest-hibernate-orm/deployment/src/main/java/io/quarkus/panache/rest/hibernate/orm/deployment/RepositoryDataAccessImplementor.java
@@ -12,6 +12,7 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.rest.common.deployment.DataAccessImplementor;
@@ -34,6 +35,17 @@ final class RepositoryDataAccessImplementor implements DataAccessImplementor {
     public ResultHandle listAll(BytecodeCreator creator) {
         return creator.invokeInterfaceMethod(ofMethod(PanacheRepositoryBase.class, "listAll", List.class),
                 getRepositoryInstance(creator));
+    }
+
+    @Override
+    public ResultHandle list(BytecodeCreator creator, ResultHandle limit) {
+        ResultHandle query = creator.invokeInterfaceMethod(ofMethod(PanacheRepositoryBase.class, "findAll", PanacheQuery.class),
+                getRepositoryInstance(creator));
+        ResultHandle maxRange = creator.invokeStaticMethod(ofMethod(Integer.class, "sum", int.class, int.class, int.class),
+                limit, creator.load(-1));
+        creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "range", PanacheQuery.class, int.class, int.class),
+                query, creator.load(0), maxRange);
+        return creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "list", List.class), query);
     }
 
     @Override

--- a/integration-tests/panache-rest-hibernate-orm/src/test/java/io/quarkus/it/panache/rest/common/AbstractBookCrudResourceTest.java
+++ b/integration-tests/panache-rest-hibernate-orm/src/test/java/io/quarkus/it/panache/rest/common/AbstractBookCrudResourceTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.time.LocalDate;
 import java.util.AbstractMap;
@@ -30,7 +31,7 @@ public abstract class AbstractBookCrudResourceTest {
 
     private static final AuthorDto DOSTOEVSKY = new AuthorDto(1L, "Fyodor Dostoevsky", LocalDate.of(1821, 11, 11));
 
-    private static final AuthorDto ORWELL = new AuthorDto(2L, "George Orwell", LocalDate.of(1903, 06, 25));
+    private static final AuthorDto ORWELL = new AuthorDto(2L, "George Orwell", LocalDate.of(1903, 6, 25));
 
     private static final List<ReviewDto> CRIME_AND_PUNISHMENT_REVIEWS = Arrays.asList(
             new ReviewDto("first", "Captivating"),
@@ -84,6 +85,14 @@ public abstract class AbstractBookCrudResourceTest {
     }
 
     @Test
+    void shouldGetAllWithLimit() {
+        given().queryParam("limit", "1")
+                .when().get()
+                .then().statusCode(200)
+                .and().body("title", hasSize(1));
+    }
+
+    @Test
     void shouldGetAllBooksWithHal() {
         Response response = getAll(APPLICATION_HAL_JSON);
         assertThat(response.getStatusCode()).isEqualTo(200);
@@ -101,6 +110,15 @@ public abstract class AbstractBookCrudResourceTest {
 
         assertHalBook(firstExpectedBook, actualBooks.getJsonObject(0));
         assertHalBook(secondExpectedBook, actualBooks.getJsonObject(1));
+    }
+
+    @Test
+    void shouldGetAllWithHalAndLimit() {
+        given().queryParam("limit", "1")
+                .and().accept(APPLICATION_HAL_JSON)
+                .when().get()
+                .then().statusCode(200)
+                .and().body("_embedded." + getResourceName() + ".title", hasSize(1));
     }
 
     @Test


### PR DESCRIPTION
Implements a limit query parameter support for Panache REST.

E.g. for a `Book` entity resource a `GET /books?limit=2` request would return only two books or less.

cc @geoand 