### PR TITLE
Add .factorypath to .gitignore (Visual Studio Code)

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/gitignore.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/gitignore.ftl
@@ -15,6 +15,7 @@ nb-configuration.xml
 
 # Visual Studio Code
 .vscode
+.factorypath
 
 # OSX
 .DS_Store


### PR DESCRIPTION
Visual Studio Code makes use of an additional file ".factorypath".
It would be useful to add these to .gitignore to make it easier for anyone using vscode.