### PR TITLE
Ignore BigDecimal and BigInteger reflection hierarchy warnings

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -73,7 +73,7 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         private static final List<String> DEFAULT_IGNORED_PACKAGES = Arrays.asList("java.", "io.reactivex.",
                 "org.reactivestreams.");
         // if this gets more complicated we will need to move to some tree like structure
-        private static final Set<String> WHITELISTED_FROM_IGNORED_PACKAGES = new HashSet<>(
+        static final Set<String> WHITELISTED_FROM_IGNORED_PACKAGES = new HashSet<>(
                 Arrays.asList("java.math.BigDecimal", "java.math.BigInteger"));
 
         @Override
@@ -88,4 +88,15 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         }
 
     }
+
+    public static class IgnoreWhiteListedPredicate implements Predicate<DotName> {
+
+        public static IgnoreWhiteListedPredicate INSTANCE = new IgnoreWhiteListedPredicate();
+
+        @Override
+        public boolean test(DotName dotName) {
+            return DefaultIgnorePredicate.WHITELISTED_FROM_IGNORED_PACKAGES.contains(dotName.toString());
+        }
+    }
+
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyIgnoreWarningBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyIgnoreWarningBuildItem.java
@@ -1,5 +1,8 @@
 package io.quarkus.deployment.builditem.nativeimage;
 
+import java.util.Objects;
+import java.util.function.Predicate;
+
 import org.jboss.jandex.DotName;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -9,14 +12,28 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public final class ReflectiveHierarchyIgnoreWarningBuildItem extends MultiBuildItem {
 
-    private final DotName dotName;
+    private final Predicate<DotName> predicate;
 
-    public ReflectiveHierarchyIgnoreWarningBuildItem(DotName dotName) {
-        this.dotName = dotName;
+    public ReflectiveHierarchyIgnoreWarningBuildItem(Predicate<DotName> predicate) {
+        this.predicate = predicate;
     }
 
-    public DotName getDotName() {
-        return dotName;
+    public Predicate<DotName> getPredicate() {
+        return predicate;
+    }
+
+    public static class DotNameExclusion implements Predicate<DotName> {
+
+        private final DotName dotName;
+
+        public DotNameExclusion(DotName dotName) {
+            this.dotName = Objects.requireNonNull(dotName);
+        }
+
+        @Override
+        public boolean test(DotName input) {
+            return input.equals(dotName);
+        }
     }
 
 }

--- a/extensions/keycloak-admin-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
+++ b/extensions/keycloak-admin-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
@@ -21,7 +21,8 @@ public class KeycloakAdminClientProcessor {
     ReflectiveHierarchyIgnoreWarningBuildItem marker(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> prod) {
         prod.produce(new AdditionalApplicationArchiveMarkerBuildItem("org/keycloak/admin/client/"));
         prod.produce(new AdditionalApplicationArchiveMarkerBuildItem("org/keycloak/representations"));
-        return new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple(MultivaluedHashMap.class.getName()));
+        return new ReflectiveHierarchyIgnoreWarningBuildItem(new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(
+                DotName.createSimple(MultivaluedHashMap.class.getName())));
     }
 
     @BuildStep

--- a/extensions/resteasy-qute/deployment/src/main/java/io/quarkus/resteasy/qute/deployment/ResteasyQuteProcessor.java
+++ b/extensions/resteasy-qute/deployment/src/main/java/io/quarkus/resteasy/qute/deployment/ResteasyQuteProcessor.java
@@ -23,7 +23,8 @@ public class ResteasyQuteProcessor {
 
     @BuildStep
     ReflectiveHierarchyIgnoreWarningBuildItem ignoreReflectiveWarning() {
-        return new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple(TemplateInstance.class.getName()));
+        return new ReflectiveHierarchyIgnoreWarningBuildItem(new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(
+                DotName.createSimple(TemplateInstance.class.getName())));
     }
 
 }

--- a/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -130,11 +130,14 @@ public class SpringWebProcessor {
 
     @BuildStep
     public void ignoreReflectionHierarchy(BuildProducer<ReflectiveHierarchyIgnoreWarningBuildItem> ignore) {
-        ignore.produce(new ReflectiveHierarchyIgnoreWarningBuildItem(RESPONSE_ENTITY));
+        ignore.produce(new ReflectiveHierarchyIgnoreWarningBuildItem(
+                new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(RESPONSE_ENTITY)));
         ignore.produce(
-                new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.springframework.util.MimeType")));
+                new ReflectiveHierarchyIgnoreWarningBuildItem(new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(
+                        DotName.createSimple("org.springframework.util.MimeType"))));
         ignore.produce(
-                new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.springframework.util.MultiValueMap")));
+                new ReflectiveHierarchyIgnoreWarningBuildItem(new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(
+                        DotName.createSimple("org.springframework.util.MultiValueMap"))));
     }
 
     @BuildStep


### PR DESCRIPTION
These classes are never part of the Jandex index so there
is no point in warning about them.

Fixes: #9189