### PR TITLE
Added a new property to support more algorithms

### DIFF
--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/DigestAlgorithm.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/DigestAlgorithm.java
@@ -1,0 +1,23 @@
+package io.quarkus.elytron.security.runtime;
+
+import org.wildfly.security.password.interfaces.DigestPassword;
+
+public enum DigestAlgorithm {
+
+    DIGEST_MD5(DigestPassword.ALGORITHM_DIGEST_MD5),
+    DIGEST_SHA(DigestPassword.ALGORITHM_DIGEST_SHA),
+    DIGEST_SHA_256(DigestPassword.ALGORITHM_DIGEST_SHA_256),
+    DIGEST_SHA_384(DigestPassword.ALGORITHM_DIGEST_SHA_384),
+    DIGEST_SHA_512(DigestPassword.ALGORITHM_DIGEST_SHA_512),
+    DIGEST_SHA_512_256(DigestPassword.ALGORITHM_DIGEST_SHA_512_256);
+
+    private final String name;
+
+    DigestAlgorithm(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPropertiesFileRecorder.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPropertiesFileRecorder.java
@@ -29,7 +29,6 @@ import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.password.interfaces.ClearPassword;
-import org.wildfly.security.password.interfaces.DigestPassword;
 import org.wildfly.security.password.spec.DigestPasswordSpec;
 
 import io.quarkus.runtime.RuntimeValue;
@@ -143,7 +142,8 @@ public class ElytronPropertiesFileRecorder {
                                     .asUtf8String().hexDecode().drain();
 
                             password = PasswordFactory
-                                    .getInstance(DigestPassword.ALGORITHM_DIGEST_MD5, new WildFlyElytronPasswordProvider())
+                                    .getInstance(runtimeConfig.algorithm.getName(),
+                                            new WildFlyElytronPasswordProvider())
                                     .generatePassword(new DigestPasswordSpec(user, config.realmName, hashed));
                         } catch (Exception e) {
                             throw new RuntimeException("Unable to register password for user:" + user

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/MPRealmConfig.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/MPRealmConfig.java
@@ -41,7 +41,7 @@ public class MPRealmConfig {
     @Override
     public String toString() {
         return "MPRealmConfig{" +
-                ", realmName='" + realmName + '\'' +
+                "realmName='" + realmName + '\'' +
                 ", enabled=" + enabled +
                 '}';
     }

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/MPRealmRuntimeConfig.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/MPRealmRuntimeConfig.java
@@ -2,6 +2,8 @@ package io.quarkus.elytron.security.runtime;
 
 import java.util.Map;
 
+import org.wildfly.security.password.interfaces.DigestPassword;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -19,6 +21,14 @@ public class MPRealmRuntimeConfig {
      */
     @ConfigItem
     public boolean plainText;
+
+    /**
+     * Determine which algorithm to use.
+     * <p>
+     * This property is ignored if {@code plainText} is true.
+     */
+    @ConfigItem(defaultValue = DigestPassword.ALGORITHM_DIGEST_MD5)
+    public DigestAlgorithm algorithm;
 
     /**
      * The realm users user1=password\nuser2=password2... mapping.


### PR DESCRIPTION
Resolves #9122 

Added a new property `quarkus.security.users.embedded.algorithm` to use algorithms other than MD5. This will be ignored if `quarkus.security.users.embedded.plain-text` is set to true.
Supported values are(same as wildfly):

> ALGORITHM_DIGEST_MD5  (Default)
> ALGORITHM_DIGEST_SHA
> ALGORITHM_DIGEST_SHA_256
> ALGORITHM_DIGEST_SHA_384
> ALGORITHM_DIGEST_SHA_512
> ALGORITHM_DIGEST_SHA_512_256