### PR TITLE
Introduce Maven ListExtensionsIT

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/AddExtensionIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/AddExtensionIT.java
@@ -2,14 +2,24 @@ package io.quarkus.maven.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
-import org.apache.maven.shared.invoker.*;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
 import org.junit.jupiter.api.Test;
 
 @DisableForNative

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -2,7 +2,12 @@ package io.quarkus.maven.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -12,7 +17,13 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
-import org.apache.maven.shared.invoker.*;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -19,8 +19,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import io.quarkus.maven.it.verifier.RunningInvoker;
 
 /**
@@ -75,7 +73,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         // Edit the "Hello" message.
         File source = new File(testDir, "src/main/java/org/acme/HelloResource.java");
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\";"));
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\";"));
 
         // Wait until we get "uuid"
         await()
@@ -87,7 +85,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
 
-        filter(source, ImmutableMap.of(uuid, "carambar"));
+        filter(source, Collections.singletonMap(uuid, "carambar"));
 
         // Wait until we get "carambar"
         await()
@@ -102,7 +100,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         // Edit the pom.xml.
         File source = new File(testDir, "pom.xml");
-        filter(source, ImmutableMap.of("<!-- insert test dependencies here -->",
+        filter(source, Collections.singletonMap("<!-- insert test dependencies here -->",
                 "        <dependency>\n" +
                         "            <groupId>io.quarkus</groupId>\n" +
                         "            <artifactId>quarkus-smallrye-openapi</artifactId>\n" +
@@ -122,7 +120,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         // Edit the "Hello" message.
         File source = new File(testDir, "rest/src/main/java/org/acme/HelloResource.java");
         final String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\";"));
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\";"));
 
         // Wait until we get "uuid"
         await()
@@ -134,7 +132,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
 
-        filter(source, ImmutableMap.of(uuid, "carambar"));
+        filter(source, Collections.singletonMap(uuid, "carambar"));
 
         // Wait until we get "carambar"
         await()
@@ -176,12 +174,12 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         // Edit the "Hello" message.
         File source = new File(testDir, "rest/src/main/java/org/acme/HelloResource.java");
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + UUID.randomUUID().toString() + "\";"));
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + UUID.randomUUID().toString() + "\";"));
 
         // Edit the greeting property.
         source = new File(testDir, "runner/src/main/resources/application.properties");
         final String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("greeting=bonjour", "greeting=" + uuid + ""));
+        filter(source, Collections.singletonMap("greeting=bonjour", "greeting=" + uuid + ""));
 
         // Wait until we get "uuid"
         await()
@@ -202,7 +200,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         // Edit the "Hello" message.
         File source = new File(testDir, "rest/src/main/java/org/acme/HelloResource.java");
         final String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\";"));
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\";"));
 
         // Wait until we get "uuid"
         await()
@@ -281,7 +279,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .until(() -> getHttpResponse("/app/deletion").contains("to be deleted"));
 
         // Remove InnerClass
-        filter(source, ImmutableMap.of("public static class InnerClass {}", ""));
+        filter(source, Collections.singletonMap("public static class InnerClass {}", ""));
 
         File helloClassFile = new File(testDir, "target/classes/org/acme/Hello.class");
         File innerClassFile = new File(testDir, "target/classes/org/acme/ClassDeletionResource$InnerClass.class");
@@ -320,7 +318,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         File source = new File(testDir, "src/main/java/org/acme/HelloResource.java");
         // Edit the "Hello" message and provide a random string.
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\";"));
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\";"));
 
         // Check that the random string is returned
         String greeting = getHttpResponse("/app/hello");
@@ -351,7 +349,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .until(source::isFile);
 
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("bonjour", uuid));
+        filter(source, Collections.singletonMap("bonjour", uuid));
 
         // Wait until we get "uuid"
         await()
@@ -461,7 +459,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         // Edit the "Hello" message.
         File source = new File(testDir, "src/main/java/org/acme/HelloResource.java");
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\"")); // No semi-colon
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\"")); // No semi-colon
 
         // Wait until we get "uuid"
         AtomicReference<String> last = new AtomicReference<>();
@@ -481,7 +479,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
-        filter(source, ImmutableMap.of("\"" + uuid + "\"", "\"carambar\";"));
+        filter(source, Collections.singletonMap("\"" + uuid + "\"", "\"carambar\";"));
 
         // Wait until we get "uuid"
         await()
@@ -495,7 +493,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         // Edit the JAX-RS resource to be package private
         File source = new File(testDir, "src/main/java/org/acme/HelloResource.java");
-        filter(source, ImmutableMap.of("public class HelloResource", "class HelloResource"));
+        filter(source, Collections.singletonMap("public class HelloResource", "class HelloResource"));
 
         runAndExpectError();
         // Wait until we get the error page
@@ -510,7 +508,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         assertThat(last.get()).containsIgnoringCase("Error restarting Quarkus");
 
-        filter(source, ImmutableMap.of("class HelloResource", "public class HelloResource"));
+        filter(source, Collections.singletonMap("class HelloResource", "public class HelloResource"));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
@@ -558,7 +556,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
 
-        filter(source, ImmutableMap.of("message", "foobarbaz"));
+        filter(source, Collections.singletonMap("message", "foobarbaz"));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
@@ -607,7 +605,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
                 .until(source::isFile);
 
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("Hola", uuid));
+        filter(source, Collections.singletonMap("Hola", uuid));
 
         // Wait until we get "uuid"
         await()

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/ListExtensionsIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/ListExtensionsIT.java
@@ -1,0 +1,82 @@
+package io.quarkus.maven.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.output.TeeOutputStream;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.InvocationOutputHandler;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
+import org.junit.jupiter.api.Test;
+
+@DisableForNative
+class ListExtensionsIT extends QuarkusPlatformAwareMojoTestBase {
+
+    private static final String VERTX_ARTIFACT_ID = "quarkus-vertx";
+    private static final String PROJECT_SOURCE_DIR = "projects/classic";
+    private File testDir;
+    private Invoker invoker;
+
+    @Test
+    void testListExtensions() throws MavenInvocationException, IOException {
+        testDir = initProject(PROJECT_SOURCE_DIR, "projects/testListExtensions");
+        invoker = initInvoker(testDir);
+
+        List<String> outputLogLines = listExtensions();
+
+        assertThat(outputLogLines).anyMatch(line -> line.contains(VERTX_ARTIFACT_ID));
+    }
+
+    @Test
+    void testListExtensionsWithManagedDependencyWithoutScope() throws MavenInvocationException, IOException {
+        testDir = initProject(PROJECT_SOURCE_DIR, "projects/testListExtensionsWithManagedDependencyWithoutScope");
+        invoker = initInvoker(testDir);
+        // Edit the pom.xml.
+        File source = new File(testDir, "pom.xml");
+        filter(source, Collections.singletonMap("<!-- insert managed dependencies here -->",
+                "      <dependency>\n" +
+                        "        <groupId>org.assertj</groupId>\n" +
+                        "        <artifactId>assertj-core</artifactId>\n" +
+                        "        <version>3.16.1</version>\n" +
+                        "      </dependency>"));
+
+        List<String> outputLogLines = listExtensions();
+
+        assertThat(outputLogLines).anyMatch(line -> line.contains(VERTX_ARTIFACT_ID));
+    }
+
+    private List<String> listExtensions()
+            throws MavenInvocationException, IOException {
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setBatchMode(true);
+        request.setGoals(Collections.singletonList(
+                getPluginGroupId() + ":" + getPluginArtifactId() + ":" + getPluginVersion() + ":list-extensions"));
+        getEnv().forEach(request::addShellEnvironment);
+
+        File outputLog = new File(testDir, "output.log");
+        InvocationOutputHandler outputHandler = new PrintStreamHandler(
+                new PrintStream(new TeeOutputStream(System.out, Files.newOutputStream(outputLog.toPath())), true, "UTF-8"),
+                true);
+        invoker.setOutputHandler(outputHandler);
+
+        File invokerLog = new File(testDir, "invoker.log");
+        PrintStreamLogger logger = new PrintStreamLogger(new PrintStream(new FileOutputStream(invokerLog), false, "UTF-8"),
+                InvokerLogger.DEBUG);
+        invoker.setLogger(logger);
+
+        invoker.execute(request);
+        return Files.readAllLines(outputLog.toPath());
+    }
+}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -17,8 +17,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import io.quarkus.maven.it.verifier.RunningInvoker;
 
 /**
@@ -37,7 +35,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Edit the "Hello" message.
         File source = new File(agentDir, "src/main/java/org/acme/HelloResource.java");
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\";"));
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\";"));
 
         // Wait until we get "uuid"
         await()
@@ -49,7 +47,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
 
-        filter(source, ImmutableMap.of(uuid, "carambar"));
+        filter(source, Collections.singletonMap(uuid, "carambar"));
 
         // Wait until we get "carambar"
         await()
@@ -115,7 +113,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
                 .until(source::isFile);
 
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("bonjour", uuid));
+        filter(source, Collections.singletonMap("bonjour", uuid));
 
         // Wait until we get "uuid"
         await()
@@ -166,7 +164,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Edit the "Hello" message.
         File source = new File(agentDir, "src/main/java/org/acme/HelloResource.java");
         String uuid = UUID.randomUUID().toString();
-        filter(source, ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\"")); // No semi-colon
+        filter(source, Collections.singletonMap("return \"hello\";", "return \"" + uuid + "\"")); // No semi-colon
 
         // Wait until we get "uuid"
         AtomicReference<String> last = new AtomicReference<>();
@@ -186,7 +184,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
                 .pollDelay(1, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
-        filter(source, ImmutableMap.of("\"" + uuid + "\"", "\"carambar\";"));
+        filter(source, Collections.singletonMap("\"" + uuid + "\"", "\"carambar\";"));
 
         // Wait until we get "uuid"
         await()
@@ -231,7 +229,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(source::isFile);
 
-        filter(source, ImmutableMap.of("message", "foobarbaz"));
+        filter(source, Collections.singletonMap("message", "foobarbaz"));
 
         await()
                 .pollDelay(1, TimeUnit.SECONDS)

--- a/integration-tests/maven/src/test/resources/projects/classic/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic/pom.xml
@@ -16,6 +16,7 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- insert managed dependencies here -->
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
This is a follow-up to #9169. `testListExtensionsWithManagedDependencyWithoutScope` fails as expected when reverting #9169.

cc @geoand

Btw, the stream and process handling seems a bit scattered but I didn't refactor anything.