### PR TITLE
Upgrade to Hibernate Search 6.0.0.Beta7

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -89,7 +89,7 @@
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.8</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.6.1</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.6.2</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.19</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -84,7 +84,7 @@
         <classmate.version>1.3.4</classmate.version>
         <hibernate-orm.version>5.4.15.Final</hibernate-orm.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.Beta6</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Beta7</hibernate-search.version>
         <narayana.version>5.10.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.8</agroal.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Maven plugin versions -->
         <elasticsearch-maven-plugin.version>6.15</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.6.1</elasticsearch-server.version>
+        <elasticsearch-server.version>7.6.2</elasticsearch-server.version>
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->

--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -602,7 +602,7 @@ Let's use Docker to start one of each:
 
 [source, shell]
 ----
-docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.1
+docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
 ----
 
 [source, shell]

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.search.elasticsearch;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,8 +16,11 @@ import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.N
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenFilterDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenizerDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.AbstractTypeMapping;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplate;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicType;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.FormatJsonAdapter;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplate;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplateJsonAdapterFactory;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMappingJsonAdapterFactory;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMapping;
@@ -37,27 +41,44 @@ class HibernateSearchClasses {
             org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping.class.getName());
     static final DotName TYPE_MAPPING_META_ANNOTATION = DotName.createSimple(TypeMapping.class.getName());
 
-    static final List<Class<?>> GSON_CLASSES = Arrays.asList(
-            AbstractTypeMapping.class,
-            DynamicType.class,
-            FormatJsonAdapter.class,
-            RoutingTypeJsonAdapter.class,
-            PropertyMapping.class,
-            PropertyMappingJsonAdapterFactory.class,
-            RootTypeMapping.class,
-            RootTypeMappingJsonAdapterFactory.class,
-            RoutingType.class,
-            IndexSettings.class,
-            Analysis.class,
-            AnalysisDefinition.class,
-            AnalyzerDefinition.class,
-            AnalyzerDefinitionJsonAdapterFactory.class,
-            NormalizerDefinition.class,
-            NormalizerDefinitionJsonAdapterFactory.class,
-            TokenizerDefinition.class,
-            TokenFilterDefinition.class,
-            CharFilterDefinition.class,
-            AnalysisDefinitionJsonAdapterFactory.class,
-            IndexAliasDefinition.class,
-            IndexAliasDefinitionJsonAdapterFactory.class);
+    static final List<DotName> GSON_CLASSES = new ArrayList<>();
+    static {
+        // TODO this type should be public; see https://hibernate.atlassian.net/browse/HSEARCH-3916
+        GSON_CLASSES.add(DotName.createSimple(
+                "org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplateJsonAdapterFactory"));
+
+        List<Class<?>> publicGsonClasses = Arrays.asList(
+                AbstractTypeMapping.class,
+                DynamicType.class,
+                FormatJsonAdapter.class,
+                RoutingTypeJsonAdapter.class,
+                PropertyMapping.class,
+                PropertyMappingJsonAdapterFactory.class,
+                RootTypeMapping.class,
+                RootTypeMappingJsonAdapterFactory.class,
+                RoutingType.class,
+                IndexSettings.class,
+                Analysis.class,
+                AnalysisDefinition.class,
+                AnalyzerDefinition.class,
+                AnalyzerDefinitionJsonAdapterFactory.class,
+                NormalizerDefinition.class,
+                NormalizerDefinitionJsonAdapterFactory.class,
+                TokenizerDefinition.class,
+                TokenFilterDefinition.class,
+                CharFilterDefinition.class,
+                AnalysisDefinitionJsonAdapterFactory.class,
+                IndexAliasDefinition.class,
+                IndexAliasDefinitionJsonAdapterFactory.class,
+                DynamicTemplate.class,
+                NamedDynamicTemplate.class,
+                NamedDynamicTemplateJsonAdapterFactory.class);
+        for (Class<?> publicGsonClass : publicGsonClasses) {
+            Class<?> currentClass = publicGsonClass;
+            while (currentClass != Object.class) {
+                GSON_CLASSES.add(DotName.createSimple(currentClass.getName()));
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+    }
 }

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -175,13 +175,7 @@ class HibernateSearchElasticsearchProcessor {
             }
         }
 
-        for (Class<?> gsonClass : GSON_CLASSES) {
-            Class<?> currentClass = gsonClass;
-            while (currentClass != Object.class) {
-                reflectiveClassCollector.add(DotName.createSimple(currentClass.getName()));
-                currentClass = currentClass.getSuperclass();
-            }
-        }
+        reflectiveClassCollector.addAll(GSON_CLASSES);
 
         String[] reflectiveClasses = reflectiveClassCollector.stream().map(DotName::toString).toArray(String[]::new);
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, reflectiveClasses));


### PR DESCRIPTION
@gsmet There's not much to put in the migration guide, and it's so obscure that personally I wouldn't include it. But for the sake of completeness, here you go:

``````
## Hibernate Search + Elasticsearch (Preview)

`ElasticsearchSearchQuery#explain(String, String)` now expects the name of the mapped type to be passed as the first argument, instead of the index name.
``````