### PR TITLE
Fix the MongoDB bson artifact version and update the driver

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -158,7 +158,7 @@
         <osgi.version>6.0.0</osgi.version>
         <neo4j-java-driver.version>4.0.1</neo4j-java-driver.version>
         <mongo-client.version>4.0.0</mongo-client.version>
-        <mongo-crypt.version>1.0.0</mongo-crypt.version>
+        <mongo-crypt.version>1.0.1</mongo-crypt.version>
         <artemis.version>2.11.0</artemis.version>
         <proton-j.version>0.33.4</proton-j.version>
         <okhttp.version>3.14.6</okhttp.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -157,7 +157,7 @@
         <snakeyaml.version>1.26</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <neo4j-java-driver.version>4.0.1</neo4j-java-driver.version>
-        <mongo-client.version>4.0.0</mongo-client.version>
+        <mongo-client.version>4.0.3</mongo-client.version>
         <mongo-crypt.version>1.0.1</mongo-crypt.version>
         <artemis.version>2.11.0</artemis.version>
         <proton-j.version>0.33.4</proton-j.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1796,6 +1796,11 @@
             </dependency>
             <dependency>
                 <groupId>org.mongodb</groupId>
+                <artifactId>bson</artifactId>
+                <version>${mongo-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
                 <artifactId>mongodb-crypt</artifactId>
                 <version>${mongo-crypt.version}</version>
             </dependency>


### PR DESCRIPTION
Fixing the bson version avoids this issue, which is the reason I initially looked into that (some people had issues with custom Maven repositories and snapshot versions):
```
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/maven-metadata.xml (4.2 kB at 50 kB/s)
Downloaded from jboss-public-repository-group: https://repository.jboss.org/nexus/content/groups/public-jboss/org/mongodb/bson/maven-metadata.xml (3.8 kB at 4.1 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.10.0/bson-3.10.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.10.0/bson-3.10.0.pom (1.3 kB at 30 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.10.1/bson-3.10.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.10.1/bson-3.10.1.pom (1.3 kB at 16 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.10.2/bson-3.10.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.10.2/bson-3.10.2.pom (1.3 kB at 26 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta1/bson-3.11.0-beta1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta1/bson-3.11.0-beta1.pom (1.3 kB at 25 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta2/bson-3.11.0-beta2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta2/bson-3.11.0-beta2.pom (1.3 kB at 29 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta3/bson-3.11.0-beta3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta3/bson-3.11.0-beta3.pom (1.3 kB at 29 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta4/bson-3.11.0-beta4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-beta4/bson-3.11.0-beta4.pom (1.3 kB at 29 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-rc0/bson-3.11.0-rc0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0-rc0/bson-3.11.0-rc0.pom (1.3 kB at 14 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0/bson-3.11.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.0/bson-3.11.0.pom (1.3 kB at 14 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.1/bson-3.11.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.1/bson-3.11.1.pom (1.3 kB at 23 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.2/bson-3.11.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.11.2/bson-3.11.2.pom (1.3 kB at 16 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.0/bson-3.12.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.0/bson-3.12.0.pom (1.3 kB at 27 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.1/bson-3.12.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.1/bson-3.12.1.pom (1.3 kB at 14 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.2/bson-3.12.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.2/bson-3.12.2.pom (1.3 kB at 29 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.3/bson-3.12.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.3/bson-3.12.3.pom (1.3 kB at 12 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.4/bson-3.12.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/3.12.4/bson-3.12.4.pom (1.3 kB at 14 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.0-beta1/bson-4.0.0-beta1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.0-beta1/bson-4.0.0-beta1.pom (1.3 kB at 29 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.0-rc0/bson-4.0.0-rc0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.0-rc0/bson-4.0.0-rc0.pom (1.3 kB at 31 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.1/bson-4.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.1/bson-4.0.1.pom (1.3 kB at 24 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.2/bson-4.0.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.2/bson-4.0.2.pom (1.3 kB at 28 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.3/bson-4.0.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.0.3/bson-4.0.3.pom (1.3 kB at 31 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.1.0-beta1/bson-4.1.0-beta1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/mongodb/bson/4.1.0-beta1/bson-4.1.0-beta1.pom (1.3 kB at 29 kB/s)
```