### PR TITLE
Increase timeout of data3 native tests group

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -360,7 +360,7 @@ jobs:
               reactive-mysql-client
           - category: Data3
             postgres: "true"
-            timeout: 50
+            timeout: 55
             test-modules: >
               flyway
               hibernate-orm-panache


### PR DESCRIPTION
Done because that group has been timing out lately
on various PRs