### PR TITLE
NettyProcessor - init EventLoopGroup synthetic beans RUN_TIME

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java
@@ -15,6 +15,7 @@ import io.quarkus.arc.runtime.ArcRecorder;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.util.HashUtil;
@@ -42,6 +43,7 @@ public class SyntheticBeansProcessor {
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
+    @Produce(SyntheticBeansRuntimeInitBuildItem.class)
     @BuildStep
     ServiceStartBuildItem initRuntime(ArcRecorder recorder, List<SyntheticBeanBuildItem> syntheticBeans,
             BeanRegistrationPhaseBuildItem beanRegistration, BuildProducer<BeanConfiguratorBuildItem> configurators) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansRuntimeInitBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansRuntimeInitBuildItem.java
@@ -1,0 +1,10 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+
+/**
+ * This build item should be consumed by build steps that require RUNTIME_INIT synthetic beans to be initialized.
+ */
+public final class SyntheticBeansRuntimeInitBuildItem extends EmptyBuildItem {
+
+}

--- a/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx-core/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -57,12 +57,6 @@ class VertxCoreProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    EventLoopSupplierBuildItem eventLoop(VertxCoreRecorder recorder) {
-        return new EventLoopSupplierBuildItem(recorder.mainSupplier(), recorder.bossSupplier());
-    }
-
-    @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
     IOThreadDetectorBuildItem ioThreadDetector(VertxCoreRecorder recorder) {
         return new IOThreadDetectorBuildItem(recorder.detector());
     }
@@ -72,7 +66,8 @@ class VertxCoreProcessor {
     CoreVertxBuildItem build(VertxCoreRecorder recorder,
             LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown, VertxConfiguration config,
             List<VertxOptionsConsumerBuildItem> vertxOptionsConsumers,
-            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            BuildProducer<EventLoopSupplierBuildItem> eventLoops,
             BuildProducer<ServiceStartBuildItem> serviceStartBuildItem) {
 
         Collections.sort(vertxOptionsConsumers);
@@ -83,12 +78,15 @@ class VertxCoreProcessor {
 
         Supplier<Vertx> vertx = recorder.configureVertx(config,
                 launchMode.getLaunchMode(), shutdown, consumers);
-        syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(Vertx.class)
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(Vertx.class)
                 .types(Vertx.class)
                 .scope(Singleton.class)
                 .unremovable()
                 .setRuntimeInit()
                 .supplier(vertx).done());
+
+        // Event loops are only usable after the core vertx instance is configured
+        eventLoops.produce(new EventLoopSupplierBuildItem(recorder.mainSupplier(), recorder.bossSupplier()));
 
         return new CoreVertxBuildItem(vertx);
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/bridgemethod/SameDescriptorDifferentReturnTypeMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/bridgemethod/SameDescriptorDifferentReturnTypeMethodTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.arc.test.clientproxy.bridgemethod;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.io.IOException;
+import java.io.Serializable;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SameDescriptorDifferentReturnTypeMethodTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(LoopProducer.class, Loop.class, SuperLoop.class);
+
+    @Test
+    public void testProxy() throws IOException {
+        Serializable ret = Arc.container().instance(SuperLoop.class).get().next();
+        assertEquals(9, ret);
+    }
+
+    @Dependent
+    static class LoopProducer {
+
+        @Produces
+        @ApplicationScoped
+        Loop produce() {
+            return new Loop() {
+
+                @Override
+                public Integer next() {
+                    return 9;
+                }
+            };
+        }
+
+    }
+
+    interface Loop extends SuperLoop {
+
+        // Since JDK8+ a "Serializable next()" bridge method is also generated 
+        Integer next();
+    }
+
+    interface SuperLoop {
+
+        Serializable next();
+
+    }
+
+}


### PR DESCRIPTION
- make EventLoopGroup beans singletons (client proxies cause problems
with some Netty classes compiled with JDK6)
- init Vertx event loops during RUN_TIME (they are not usable during
STATIC_INIT)
- introduce the EventLoopReadyBuildItem empty build item
- also add a test for client proxies and covariant return types (bridge
methods are generated by the compiler in JDK8+)