### PR TITLE
Fix #9025: turn non-distinct single columns into count(*), throw for …

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/pom.xml
@@ -29,6 +29,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-panache-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/test/java/io/quarkus/hibernate/orm/panache/common/runtime/QueryMatcherTest.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/test/java/io/quarkus/hibernate/orm/panache/common/runtime/QueryMatcherTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.orm.panache.common.runtime;
+
+import java.util.regex.Matcher;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class QueryMatcherTest {
+
+    @Test
+    public void testSelectMatcher() {
+        testMatch("from bar", null);
+        testMatch("select foo from bar", "from bar");
+        testMatch("  select   foo   from   bar  ", "from   bar  ");
+        testMatch("select foo as fff from bar", "from bar");
+        testMatch("select foo,bar from bar", "from bar");
+        testMatch("select foo , bar from bar", "from bar");
+        testMatch("select foo as f,bar as b from bar", "from bar");
+        testMatch("select foo as f , bar as b from bar", "from bar");
+
+        testMatch("select foo.bar.gee as f , bar.sup as b from bar", "from bar");
+
+        testMatch("select distinct foo from bar", "from bar");
+        testMatch("select distinct foo,bar from bar", "from bar");
+    }
+
+    private void testMatch(String select, String result) {
+        Matcher matcher = CommonPanacheQueryImpl.SELECT_PATTERN.matcher(select);
+        if (result != null) {
+            Assertions.assertTrue(matcher.matches());
+            Assertions.assertEquals(result, matcher.group(3));
+        } else {
+            Assertions.assertFalse(matcher.matches());
+        }
+    }
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Fruit.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Fruit.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.panache;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Fruit extends PanacheEntity {
+
+    public String name;
+    public String color;
+
+    public Fruit(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+
+    public Fruit() {
+    }
+
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1299,4 +1299,24 @@ public class TestEndpoint {
 
         return "OK";
     }
+
+    @GET
+    @Path("9025")
+    @Transactional
+    public String testBug9025() {
+        Fruit apple = new Fruit("apple", "red");
+        Fruit orange = new Fruit("orange", "orange");
+        Fruit banana = new Fruit("banana", "yellow");
+
+        Fruit.persist(apple, orange, banana);
+
+        PanacheQuery<Fruit> query = Fruit.find(
+                "select name, color from Fruit").page(Page.ofSize(1));
+
+        List<Fruit> results = query.list();
+
+        int pageCount = query.pageCount();
+
+        return "OK";
+    }
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -164,4 +164,9 @@ public class PanacheFunctionalityTest {
     public void testBug8254() {
         RestAssured.when().get("/test/8254").then().body(is("OK"));
     }
+
+    @Test
+    public void testBug9025() {
+        RestAssured.when().get("/test/9025").then().body(is("OK"));
+    }
 }


### PR DESCRIPTION
…distinct multi columns

This will support:

- non-distinct single/multi-column selects by turning them into count(*)
- distinct single column by turning them into count(distinct col)
- from.* into count(*)...

And barf at unsupported use-cases such as select distinct col1, col2...