### PR TITLE
Support to rename properties and renamed enable props to enabled

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigItem.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigItem.java
@@ -61,4 +61,15 @@ public @interface ConfigItem {
      * @return the default value documentation
      */
     String defaultValueDocumentation() default "";
+
+    /**
+     * To ensure backward compatibility with earlier names when a property is renamed.
+     * Will be ignored if the property exists with current name else this will be used to resolve the value and
+     * a warning will be printed that the given property key is deprecated.
+     * If properties are present for multiple deprecated names, then the first one(in the below array) to get resolved
+     * will be used and rest will be ignored.
+     *
+     * @return deprecated names for the Item.
+     */
+    String[] deprecatedNames() default {};
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigDiagnostic.java
@@ -47,6 +47,10 @@ public final class ConfigDiagnostic {
         log.warnf("Configuration key \"%s\" is deprecated", name);
     }
 
+    public static void deprecated(String deprecatedName, String name) {
+        log.warnf("Configuration key \"%s\" is deprecated; please use this instead \"%s\"", deprecatedName, name);
+    }
+
     public static void unknown(String name) {
         log.warnf("Unrecognized configuration key \"%s\" was provided; it will be ignored", name);
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/AsyncConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/AsyncConfig.java
@@ -11,8 +11,8 @@ public class AsyncConfig {
     /**
      * Indicates whether to log asynchronously
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    boolean enable;
+    @ConfigItem(name = ConfigItem.PARENT, deprecatedNames = "enable")
+    boolean enabled;
     /**
      * The queue length to use before flushing writing
      */

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/ConsoleConfig.java
@@ -12,8 +12,8 @@ public class ConsoleConfig {
     /**
      * If console logging should be enabled
      */
-    @ConfigItem(defaultValue = "true")
-    boolean enable;
+    @ConfigItem(defaultValue = "true", deprecatedNames = "enable")
+    boolean enabled;
 
     /**
      * The log format. Note that this value will be ignored if an extension is present that takes

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -19,8 +19,8 @@ public class FileConfig {
     /**
      * If file logging should be enabled
      */
-    @ConfigItem
-    boolean enable;
+    @ConfigItem(deprecatedNames = "enable")
+    boolean enabled;
 
     /**
      * The log format

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -96,18 +96,18 @@ public class LoggingSetupRecorder {
 
         final ArrayList<Handler> handlers = new ArrayList<>(3 + additionalHandlers.size());
 
-        if (config.console.enable) {
+        if (config.console.enabled) {
             final Handler consoleHandler = configureConsoleHandler(config.console, errorManager, filterElements,
                     possibleFormatters, possibleBannerSupplier);
             errorManager = consoleHandler.getErrorManager();
             handlers.add(consoleHandler);
         }
 
-        if (config.file.enable) {
+        if (config.file.enabled) {
             handlers.add(configureFileHandler(config.file, errorManager, filterElements));
         }
 
-        if (config.syslog.enable) {
+        if (config.syslog.enabled) {
             final Handler syslogHandler = configureSyslogHandler(config.syslog, errorManager, filterElements);
             if (syslogHandler != null) {
                 handlers.add(syslogHandler);
@@ -257,7 +257,7 @@ public class LoggingSetupRecorder {
         consoleHandler.setErrorManager(defaultErrorManager);
         consoleHandler.setFilter(new LogCleanupFilter(filterElements));
 
-        final Handler handler = config.async.enable ? createAsyncHandler(config.async, config.level, consoleHandler)
+        final Handler handler = config.async.enabled ? createAsyncHandler(config.async, config.level, consoleHandler)
                 : consoleHandler;
 
         if (formatterWarning) {
@@ -300,7 +300,7 @@ public class LoggingSetupRecorder {
         handler.setErrorManager(errorManager);
         handler.setLevel(config.level);
         handler.setFilter(new LogCleanupFilter(filterElements));
-        if (config.async.enable) {
+        if (config.async.enabled) {
             return createAsyncHandler(config.async, config.level, handler);
         }
         return handler;
@@ -324,7 +324,7 @@ public class LoggingSetupRecorder {
             handler.setFormatter(formatter);
             handler.setErrorManager(errorManager);
             handler.setFilter(new LogCleanupFilter(filterElements));
-            if (config.async.enable) {
+            if (config.async.enabled) {
                 return createAsyncHandler(config.async, config.level, handler);
             }
             return handler;

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/SyslogConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/SyslogConfig.java
@@ -17,8 +17,8 @@ public class SyslogConfig {
     /**
      * If syslog logging should be enabled
      */
-    @ConfigItem
-    boolean enable;
+    @ConfigItem(deprecatedNames = "enable")
+    boolean enabled;
 
     /**
      *


### PR DESCRIPTION
Fixes #9121 

- Added Support for renaming config properties.
- Older Property names can now be deprecated and a warning will be shown to user.
- If value for current name is present, then properties corresponding to deprecated names(if present) will be ignored.
- If multiple deprecations exist for a single field, then the first one to get resolved will be used and properties corresponding to following names(if present) will be ignored.
- Renamed enable properties to enabled.
