### PR TITLE
Create tenant-specific code flow cookies

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -73,6 +73,10 @@ public class OidcRecorder {
             return null;
         }
 
+        if (!oidcConfig.tenantId.isPresent()) {
+            oidcConfig.tenantId = Optional.of(tenantId);
+        }
+
         OAuth2ClientOptions options = new OAuth2ClientOptions();
 
         if (oidcConfig.getClientId().isPresent()) {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantLogout.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantLogout.java
@@ -25,7 +25,7 @@ public class TenantLogout {
     @GET
     @Path("post-logout")
     public String postLogout(@QueryParam("state") String postLogoutState) {
-        Cookie cookie = headers.getCookies().get("q_post_logout");
+        Cookie cookie = headers.getCookies().get("q_post_logout_tenant-logout");
         if (cookie == null) {
             throw new InternalServerErrorException("q_post_logout cookie is not available");
         }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -24,7 +24,7 @@ public class TenantResource {
     @GET
     @RolesAllowed("user")
     public String userName(@PathParam("tenant") String tenant) {
-        return tenant + ":" + ("tenant-web-app".equals(tenant) ? getNameWebAppType() : getNameServiceType());
+        return tenant + ":" + (tenant.startsWith("tenant-web-app") ? getNameWebAppType() : getNameServiceType());
     }
 
     private String getNameWebAppType() {

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -26,7 +26,14 @@ quarkus.oidc.tenant-web-app.client-id=quarkus-app-webapp
 quarkus.oidc.tenant-web-app.credentials.secret=secret
 quarkus.oidc.tenant-web-app.application-type=web-app
 
+# Tenant Web App2
+quarkus.oidc.tenant-web-app2.auth-server-url=${keycloak.url}/realms/quarkus-webapp2
+quarkus.oidc.tenant-web-app2.client-id=quarkus-app-webapp2
+quarkus.oidc.tenant-web-app2.credentials.secret=secret
+quarkus.oidc.tenant-web-app2.application-type=web-app
+
 quarkus.oidc.tenant-public-key.client-id=test
 quarkus.oidc.tenant-public-key.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEqFyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwRTYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5eUF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYnsIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9xnQIDAQAB
 
 smallrye.jwt.sign.key-location=/privateKey.pem
+

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -26,7 +26,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 
     @Override
     public Map<String, String> start() {
-        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp")) {
+        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2")) {
             RealmRepresentation realm = createRealm(KEYCLOAK_REALM + realmId);
 
             realm.getClients().add(createClient("quarkus-app-" + realmId));
@@ -92,7 +92,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         client.setDirectAccessGrantsEnabled(true);
         client.setEnabled(true);
         client.setDefaultRoles(new String[] { "role-" + clientId });
-        if ("quarkus-app-webapp".equals(clientId)) {
+        if (clientId.startsWith("quarkus-app-webapp")) {
             client.setRedirectUris(Arrays.asList("*"));
             client.setDefaultClientScopes(Arrays.asList("microprofile-jwt"));
         }
@@ -120,7 +120,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
 
     @Override
     public void stop() {
-        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp")) {
+        for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2")) {
             RestAssured
                     .given()
                     .auth().oauth2(getAdminAccessToken())


### PR DESCRIPTION
In the code flow all the cookie will be qualified, in the default configuration the cookie names remain the same (`q_state`, `q_session`, `q_post_logout`) in all other cases they would be named as `q_state_tenant-a`, `q_session_tenant-a`, `q_post_logout_tenant-a` for `tenant-a`, etc