### PR TITLE
Use the named annotation from the class

### DIFF
--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -102,9 +102,9 @@ public final class AmazonLambdaProcessor {
             reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, false, lambda));
 
             String cdiName = null;
-            List<AnnotationInstance> named = info.annotations().get(NAMED);
-            if (named != null && !named.isEmpty()) {
-                cdiName = named.get(0).value().asString();
+            AnnotationInstance named = info.classAnnotation(NAMED);
+            if (named != null) {
+                cdiName = named.value().asString();
             }
 
             ClassInfo current = info;


### PR DESCRIPTION
Currently it may accidentally pick one from a field or method

Fixes #9227