### PR TITLE
Bring back DotName ctor for ReflectiveHierarchyIgnoreWarningBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyIgnoreWarningBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyIgnoreWarningBuildItem.java
@@ -14,6 +14,11 @@ public final class ReflectiveHierarchyIgnoreWarningBuildItem extends MultiBuildI
 
     private final Predicate<DotName> predicate;
 
+    // used by external extensions
+    public ReflectiveHierarchyIgnoreWarningBuildItem(DotName dotName) {
+        this.predicate = new DotNameExclusion(dotName);
+    }
+
     public ReflectiveHierarchyIgnoreWarningBuildItem(Predicate<DotName> predicate) {
         this.predicate = predicate;
     }


### PR DESCRIPTION
This is done because there are external extensions that depend on it

Fixes: #8893, #8593, #8694