### PR TITLE
Explicitly set the io.netty.machineId system property to prevent potential slowdown during Netty channel initialization

### DIFF
--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
@@ -14,9 +14,12 @@ public class NettyRecorder {
 
     private static final Logger log = Logger.getLogger(NettyRecorder.class);
 
+    // TODO: Remove this method (maybe in 1.6.x of Quarkus or later) if there are no user reports
+    // of the WARN message issued from this method. See comments in https://github.com/quarkusio/quarkus/pull/9246
+    // for details
     public void eagerlyInitChannelId() {
         //this class is slow to init and can block the IO thread and cause a warning
-        //we init it from a throway thread to stop this
+        //we init it from a throwaway thread to stop this
         //we do it from another thread so as not to affect start time
         new Thread(new Runnable() {
             @Override
@@ -24,9 +27,9 @@ public class NettyRecorder {
                 long start = System.currentTimeMillis();
                 DefaultChannelId.newInstance();
                 if (System.currentTimeMillis() - start > 1000) {
-                    log.warn(
-                            "Localhost lookup took more than one second, you need to add a /etc/hosts entry to improve Quarkus startup time. "
-                                    + "On Windows the path is C:\\Windows\\System32\\Drivers\\etc\\hosts. See https://thoeni.io/post/macos-sierra-java/ for macOS details.");
+                    log.warn("Netty DefaultChannelId initialization (with io.netty.machineId" +
+                            " system property set to " + System.getProperty("io.netty.machineId")
+                            + ") took more than a second");
                 }
             }
         }).start();


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/8822

As noted in the linked issue, this should prevent potential slowdown when the `DefaultChannelId` is initialized. With this system property being set, the `DefaultChannelId` implementation will now bypass the potentially expensive "best" MAC address determination.
This commit also changes the `WARN` message to be a bit more accurate about what it is complaining about. The previous message wasn't accurate since the slowdown didn't necessarily have to do with the `localhost` lookup.