### PR TITLE
Mention "native application" in startup message when Quarkus is run as a native application

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/Timing.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Timing.java
@@ -3,6 +3,7 @@ package io.quarkus.runtime;
 import java.math.BigDecimal;
 import java.util.logging.Handler;
 
+import org.graalvm.nativeimage.ImageInfo;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.logging.InitialConfigurator;
@@ -81,10 +82,12 @@ public class Timing {
         final BigDecimal secondsRepresentation = convertToBigDecimalSeconds(bootTimeNanoSeconds);
         String safeAppName = (name == null || name.trim().isEmpty()) ? UNSET_VALUE : name;
         String safeAppVersion = (version == null || version.trim().isEmpty()) ? UNSET_VALUE : version;
+        final String nativeOrJvm = ImageInfo.inImageRuntimeCode() ? "native" : "on JVM";
         if (UNSET_VALUE.equals(safeAppName) || UNSET_VALUE.equals(safeAppVersion)) {
-            logger.infof("Quarkus %s started in %ss. %s", quarkusVersion, secondsRepresentation, httpServerInfo);
+            logger.infof("Quarkus %s %s started in %ss. %s", quarkusVersion, nativeOrJvm, secondsRepresentation,
+                    httpServerInfo);
         } else {
-            logger.infof("%s %s (powered by Quarkus %s) started in %ss. %s", name, version, quarkusVersion,
+            logger.infof("%s %s %s (powered by Quarkus %s) started in %ss. %s", name, version, nativeOrJvm, quarkusVersion,
                     secondsRepresentation, httpServerInfo);
         }
         logger.infof("Profile %s activated. %s", profile, liveCoding ? "Live Coding activated." : "");


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/8980

A trivial enhancement to the log message that gets printed when Quarkus application starts. If run as native application, this will now print something like:

```
2020-05-12 20:12:30,505 INFO  [io.quarkus] (main) quarkus-helloworld 1.0-SNAPSHOT (powered by Quarkus 999-SNAPSHOT) started as native application in 0.015s. Listening on: http://0.0.0.0:8080
```
(notice the `as native application` in the log message)
When run in JVM, the log message will be as usual:
```
2020-05-12 20:13:57,904 INFO  [io.quarkus] (main) quarkus-helloworld 1.0-SNAPSHOT (powered by Quarkus 999-SNAPSHOT) started in 0.981s. Listening on: http://0.0.0.0:8080
```
