### PR TITLE
fix (#6679): Use of BuildInfo in k8s processor

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -717,8 +717,8 @@ class KubernetesProcessor {
         BuildInfo buildInfo = new BuildInfo(app.getName(), app.getVersion(),
                 "jar", project.getBuildInfo().getBuildTool(),
                 artifactPath,
-                project.getBuildInfo().getOutputFile(),
-                project.getBuildInfo().getClassOutputDir());
+                project.getBuildInfo().getClassOutputDir(),
+                project.getBuildInfo().getResourceDir());
 
         return new Project(project.getRoot(), buildInfo, project.getScmInfo());
     }


### PR DESCRIPTION
Fixes #6679

The way `BuildInfo` was used could lead to information being lost / chewed possibly leading to issues when using non maven build tools. It was also confusing.