### PR TITLE
InjectionPoint metadata - ignore java.lang.Deprecated...

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -33,14 +33,13 @@ import org.jboss.jandex.DotName;
 enum BuiltinBean {
 
     INSTANCE(ctx -> {
-        ResultHandle qualifiers = BeanGenerator.collectQualifiers(ctx.classOutput, ctx.clazzCreator, ctx.beanDeployment,
-                ctx.constructor,
-                ctx.injectionPoint,
-                ctx.annotationLiterals);
+        ResultHandle qualifiers = BeanGenerator.collectInjectionPointQualifiers(ctx.classOutput, ctx.clazzCreator,
+                ctx.beanDeployment,
+                ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals);
         ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getRequiredType());
-        ResultHandle annotationsHandle = BeanGenerator.collectAnnotations(ctx.classOutput, ctx.clazzCreator, ctx.beanDeployment,
-                ctx.constructor,
-                ctx.injectionPoint, ctx.annotationLiterals);
+        ResultHandle annotationsHandle = BeanGenerator.collectInjectionPointAnnotations(ctx.classOutput, ctx.clazzCreator,
+                ctx.beanDeployment,
+                ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals, ctx.injectionPointAnnotationsPredicate);
         ResultHandle javaMemberHandle = BeanGenerator.getJavaMemberHandle(ctx.constructor, ctx.injectionPoint,
                 ctx.reflectionRegistration);
         ResultHandle beanHandle;
@@ -253,11 +252,12 @@ enum BuiltinBean {
         final AnnotationLiteralProcessor annotationLiterals;
         final InjectionTargetInfo targetInfo;
         final ReflectionRegistration reflectionRegistration;
+        final Predicate<DotName> injectionPointAnnotationsPredicate;
 
         public GeneratorContext(ClassOutput classOutput, BeanDeployment beanDeployment, InjectionPointInfo injectionPoint,
                 ClassCreator clazzCreator, MethodCreator constructor, String providerName,
                 AnnotationLiteralProcessor annotationLiterals, InjectionTargetInfo targetInfo,
-                ReflectionRegistration reflectionRegistration) {
+                ReflectionRegistration reflectionRegistration, Predicate<DotName> injectionPointAnnotationsPredicate) {
             this.classOutput = classOutput;
             this.beanDeployment = beanDeployment;
             this.injectionPoint = injectionPoint;
@@ -267,6 +267,7 @@ enum BuiltinBean {
             this.annotationLiterals = annotationLiterals;
             this.targetInfo = targetInfo;
             this.reflectionRegistration = reflectionRegistration;
+            this.injectionPointAnnotationsPredicate = injectionPointAnnotationsPredicate;
         }
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -100,6 +100,8 @@ public final class DotNames {
     public static final DotName SHORT = create(Short.class);
     public static final DotName STRING = create(String.class);
 
+    public static final DotName DEPRECATED = create(Deprecated.class);
+
     private DotNames() {
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -45,10 +45,10 @@ public class InterceptorGenerator extends BeanGenerator {
 
     public InterceptorGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
-            Set<String> existingClasses,
-            Map<BeanInfo, String> beanToGeneratedName) {
+            Set<String> existingClasses, Map<BeanInfo, String> beanToGeneratedName,
+            Predicate<DotName> injectionPointAnnotationsPredicate) {
         super(annotationLiterals, applicationClassPredicate, privateMembers, generateSources, reflectionRegistration,
-                existingClasses, beanToGeneratedName);
+                existingClasses, beanToGeneratedName, injectionPointAnnotationsPredicate);
     }
 
     /**

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -63,11 +63,12 @@ public class ObserverGenerator extends AbstractGenerator {
     private final ReflectionRegistration reflectionRegistration;
     private final Set<String> existingClasses;
     private final Map<ObserverInfo, String> observerToGeneratedName;
+    private final Predicate<DotName> injectionPointAnnotationsPredicate;
 
     public ObserverGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
-            Set<String> existingClasses,
-            Map<ObserverInfo, String> observerToGeneratedName) {
+            Set<String> existingClasses, Map<ObserverInfo, String> observerToGeneratedName,
+            Predicate<DotName> injectionPointAnnotationsPredicate) {
         super(generateSources);
         this.annotationLiterals = annotationLiterals;
         this.applicationClassPredicate = applicationClassPredicate;
@@ -75,6 +76,7 @@ public class ObserverGenerator extends AbstractGenerator {
         this.reflectionRegistration = reflectionRegistration;
         this.existingClasses = existingClasses;
         this.observerToGeneratedName = observerToGeneratedName;
+        this.injectionPointAnnotationsPredicate = injectionPointAnnotationsPredicate;
     }
 
     /**
@@ -433,45 +435,51 @@ public class ObserverGenerator extends AbstractGenerator {
                             .generate(new GeneratorContext(classOutput, observer.getDeclaringBean().getDeployment(),
                                     injectionPoint, observerCreator, constructor,
                                     injectionPointToProviderField.get(injectionPoint),
-                                    annotationLiterals, observer, reflectionRegistration));
+                                    annotationLiterals, observer, reflectionRegistration, injectionPointAnnotationsPredicate));
                 } else {
                     if (injectionPoint.getResolvedBean().getAllInjectionPoints().stream()
                             .anyMatch(ip -> BuiltinBean.INJECTION_POINT.hasRawTypeDotName(ip.getRequiredType().name()))) {
                         // IMPL NOTE: Injection point resolves to a dependent bean that injects InjectionPoint metadata and so we need to wrap the injectable
                         // reference provider
-                        ResultHandle requiredQualifiersHandle = BeanGenerator.collectQualifiers(classOutput, observerCreator,
+                        ResultHandle requiredQualifiersHandle = BeanGenerator.collectInjectionPointQualifiers(classOutput,
+                                observerCreator,
                                 observer.getDeclaringBean().getDeployment(), constructor,
                                 injectionPoint,
                                 annotationLiterals);
-                        ResultHandle annotationsHandle = BeanGenerator.collectAnnotations(classOutput, observerCreator,
-                                observer.getDeclaringBean().getDeployment(), constructor,
-                                injectionPoint, annotationLiterals);
+                        ResultHandle annotationsHandle = BeanGenerator.collectInjectionPointAnnotations(classOutput,
+                                observerCreator,
+                                observer.getDeclaringBean().getDeployment(), constructor, injectionPoint, annotationLiterals,
+                                injectionPointAnnotationsPredicate);
                         ResultHandle javaMemberHandle = BeanGenerator.getJavaMemberHandle(constructor, injectionPoint,
                                 reflectionRegistration);
 
                         // Wrap the constructor arg in a Supplier so we can pass it to CurrentInjectionPointProvider c'tor.
                         ResultHandle delegateSupplier = constructor.newInstance(
-                                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, constructor.getMethodParam(paramIdx++));
+                                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, constructor.getMethodParam(paramIdx));
 
                         ResultHandle wrapHandle = constructor.newInstance(
                                 MethodDescriptor.ofConstructor(CurrentInjectionPointProvider.class, InjectableBean.class,
                                         Supplier.class, java.lang.reflect.Type.class,
                                         Set.class, Set.class, Member.class, int.class),
-                                constructor.getThis(), delegateSupplier,
+                                constructor.loadNull(), delegateSupplier,
                                 Types.getTypeHandle(constructor, injectionPoint.getRequiredType()),
                                 requiredQualifiersHandle, annotationsHandle, javaMemberHandle,
                                 constructor.load(injectionPoint.getPosition()));
+                        ResultHandle wrapSupplierHandle = constructor.newInstance(
+                                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, wrapHandle);
 
                         constructor.writeInstanceField(FieldDescriptor.of(observerCreator.getClassName(),
                                 injectionPointToProviderField.get(injectionPoint),
-                                Supplier.class.getName()), constructor.getThis(), wrapHandle);
+                                Supplier.class.getName()), constructor.getThis(), wrapSupplierHandle);
                     } else {
                         constructor.writeInstanceField(
                                 FieldDescriptor.of(observerCreator.getClassName(),
                                         injectionPointToProviderField.get(injectionPoint),
                                         Supplier.class.getName()),
-                                constructor.getThis(), constructor.getMethodParam(paramIdx++));
+                                constructor.getThis(), constructor.getMethodParam(paramIdx));
                     }
+                    // Next param injection point
+                    paramIdx++;
                 }
             }
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
@@ -139,7 +139,7 @@ public class InjectionPointMetadataTest {
     static class Controller {
 
         @FooAnnotation
-        @Deprecated // This annotations should be ingnored
+        @Deprecated // This annotations should be ignored
         @Inject
         Controlled controlled;
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.test.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -8,8 +9,12 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.test.ArcTestContainer;
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.AnnotatedConstructor;
@@ -21,6 +26,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -50,10 +56,12 @@ public class InjectionPointMetadataTest {
         AnnotatedField<Controller> annotatedField = (AnnotatedField<Controller>) injectionPoint.getAnnotated();
         assertEquals("controlled", annotatedField.getJavaMember().getName());
         assertEquals(Controlled.class, annotatedField.getBaseType());
+        assertEquals(2, annotatedField.getAnnotations().size());
         assertTrue(annotatedField.isAnnotationPresent(Inject.class));
+        assertTrue(annotatedField.isAnnotationPresent(FooAnnotation.class));
+        assertFalse(annotatedField.isAnnotationPresent(Deprecated.class));
         assertTrue(annotatedField.getAnnotation(Singleton.class) == null);
         assertTrue(annotatedField.getAnnotations(Singleton.class).isEmpty());
-        assertEquals(1, annotatedField.getAnnotations().size());
 
         // Method
         InjectionPoint methodInjectionPoint = controller.controlledMethod.injectionPoint;
@@ -103,9 +111,35 @@ public class InjectionPointMetadataTest {
         assertEquals(1, annotatedField.getAnnotations().size());
     }
 
+    @SuppressWarnings({ "unchecked", "serial" })
+    @Test
+    public void testObserverInjectionPointMetadata() {
+        AtomicReference<InjectionPoint> ip = new AtomicReference<>();
+        Arc.container().beanManager().getEvent().select(new TypeLiteral<AtomicReference<InjectionPoint>>() {
+        }).fire(ip);
+        InjectionPoint injectionPoint = ip.get();
+        assertNotNull(injectionPoint);
+        assertEquals(Controlled.class, injectionPoint.getType());
+        Set<Annotation> qualifiers = injectionPoint.getQualifiers();
+        assertEquals(1, qualifiers.size());
+        assertEquals(Default.class, qualifiers.iterator().next().annotationType());
+        Assertions.assertNull(injectionPoint.getBean());
+        assertNotNull(injectionPoint.getAnnotated());
+        assertTrue(injectionPoint.getAnnotated() instanceof AnnotatedParameter);
+        AnnotatedParameter<Controller> annotatedParam = (AnnotatedParameter<Controller>) injectionPoint.getAnnotated();
+        assertEquals(Controlled.class, annotatedParam.getBaseType());
+        assertEquals(1, annotatedParam.getAnnotations().size());
+        assertFalse(annotatedParam.isAnnotationPresent(Inject.class));
+        assertTrue(annotatedParam.isAnnotationPresent(FooAnnotation.class));
+        assertTrue(annotatedParam.getAnnotation(Singleton.class) == null);
+        assertTrue(annotatedParam.getAnnotations(Singleton.class).isEmpty());
+    }
+
     @Singleton
     static class Controller {
 
+        @FooAnnotation
+        @Deprecated // This annotations should be ingnored
         @Inject
         Controlled controlled;
 
@@ -126,6 +160,10 @@ public class InjectionPointMetadataTest {
             this.controlledMethod = controlled;
         }
 
+        void observe(@Observes AtomicReference<InjectionPoint> ip, @FooAnnotation Controlled controlled) {
+            ip.set(controlled.injectionPoint);
+        }
+
     }
 
     @Dependent
@@ -133,6 +171,11 @@ public class InjectionPointMetadataTest {
 
         @Inject
         InjectionPoint injectionPoint;
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface FooAnnotation {
 
     }
 


### PR DESCRIPTION
...when generating an injection point wrapper
- also fix ObserverGenerator InjectionPoint metadata support
- resolves #9242