### PR TITLE
Trigger project compilation whenever there's a pom.xml change

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -310,7 +310,7 @@ public class DevMojo extends AbstractMojo {
 
             DevModeRunner runner = new DevModeRunner(args);
 
-            runner.prepare();
+            runner.prepare(false);
             Map<Path, Long> pomFiles = readPomFileTimestamps(runner);
             runner.run();
             long nextCheck = System.currentTimeMillis() + 100;
@@ -324,18 +324,19 @@ public class DevMojo extends AbstractMojo {
                     if (!runner.process.isAlive()) {
                         return;
                     }
-                    boolean changed = false;
+                    final Set<Path> changed = new HashSet<>();
                     for (Map.Entry<Path, Long> e : pomFiles.entrySet()) {
                         long t = Files.getLastModifiedTime(e.getKey()).toMillis();
                         if (t > e.getValue()) {
-                            changed = true;
+                            changed.add(e.getKey());
                             pomFiles.put(e.getKey(), t);
                         }
                     }
-                    if (changed) {
+                    if (!changed.isEmpty()) {
+                        getLog().info("Changes detected to " + changed + ", restarting dev mode");
                         DevModeRunner newRunner = new DevModeRunner(args);
                         try {
-                            newRunner.prepare();
+                            newRunner.prepare(true);
                         } catch (Exception e) {
                             getLog().info("Could not load changed pom.xml file, changes not applied", e);
                             continue;
@@ -368,19 +369,23 @@ public class DevMojo extends AbstractMojo {
 
         //if the user did not compile we run it for them
         if (compileNeeded) {
-            // compile the Kotlin sources if needed
-            final String kotlinMavenPluginKey = ORG_JETBRAINS_KOTLIN + ":" + KOTLIN_MAVEN_PLUGIN;
-            final Plugin kotlinMavenPlugin = project.getPlugin(kotlinMavenPluginKey);
-            if (kotlinMavenPlugin != null) {
-                executeCompileGoal(kotlinMavenPlugin, ORG_JETBRAINS_KOTLIN, KOTLIN_MAVEN_PLUGIN);
-            }
+            triggerCompile();
+        }
+    }
 
-            // Compile the Java sources if needed
-            final String compilerPluginKey = ORG_APACHE_MAVEN_PLUGINS + ":" + MAVEN_COMPILER_PLUGIN;
-            final Plugin compilerPlugin = project.getPlugin(compilerPluginKey);
-            if (compilerPlugin != null) {
-                executeCompileGoal(compilerPlugin, ORG_APACHE_MAVEN_PLUGINS, MAVEN_COMPILER_PLUGIN);
-            }
+    private void triggerCompile() throws MojoExecutionException {
+        // compile the Kotlin sources if needed
+        final String kotlinMavenPluginKey = ORG_JETBRAINS_KOTLIN + ":" + KOTLIN_MAVEN_PLUGIN;
+        final Plugin kotlinMavenPlugin = project.getPlugin(kotlinMavenPluginKey);
+        if (kotlinMavenPlugin != null) {
+            executeCompileGoal(kotlinMavenPlugin, ORG_JETBRAINS_KOTLIN, KOTLIN_MAVEN_PLUGIN);
+        }
+
+        // Compile the Java sources if needed
+        final String compilerPluginKey = ORG_APACHE_MAVEN_PLUGINS + ":" + MAVEN_COMPILER_PLUGIN;
+        final Plugin compilerPlugin = project.getPlugin(compilerPluginKey);
+        if (compilerPlugin != null) {
+            executeCompileGoal(compilerPlugin, ORG_APACHE_MAVEN_PLUGINS, MAVEN_COMPILER_PLUGIN);
         }
     }
 
@@ -494,7 +499,10 @@ public class DevMojo extends AbstractMojo {
         /**
          * Attempts to prepare the dev mode runner.
          */
-        void prepare() throws Exception {
+        void prepare(final boolean triggerCompile) throws Exception {
+            if (triggerCompile) {
+                triggerCompile();
+            }
             if (debug == null) {
                 // debug mode not specified
                 // make sure 5005 is not used, we don't want to just fail if something else is using it


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/9070

A `pom.xml` change realisitically would usually involve changes to dependencies and other similar things which really would need a rebuild of the project (not just restarting the dev mode). The commit in this PR force triggers a `compilation` of the project before triggering the new run of the dev mode.
One thing I haven't checked in detail is how multi-module projects should be handled (should each of the projects be `compile`d before automatically restarting dev mode)? I don't know how it's handled currently.

In the meantime, this current change should help with simple one module quarkus projects. This PR contains a test case which reproduces the issue and verifies the fix.