### PR TITLE
Avoid build failures when cleaning up Gradle dev mode tests

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -61,7 +61,7 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleTestBase {
             DevModeTestUtils.awaitUntilServerDown();
 
             if (projectDir != null && projectDir.isDirectory()) {
-                FileUtils.deleteDirectory(projectDir);
+                FileUtils.deleteQuietly(projectDir);
             }
         }
     }


### PR DESCRIPTION
We had several failures related to that with the build failing because
it was unable to delete a Gradle file. It's probably related to the
daemon but I couldn't find a reliable way to avoid starting the daemon
with the Gradle TestKit - I just found several people complaining about
it not working very well.

It's not a big deal if we let a couple of files survive the build from
time to time.