### PR TITLE
Fix issues in the Quarkus code style

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -61,7 +61,8 @@ public class ClassTransformingBuildStep {
         // we also record if any additional archives needed transformation
         // when we copy these archives we will remove the problematic classes
         final ExecutorService executorPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-        final ConcurrentLinkedDeque<Future<TransformedClassesBuildItem.TransformedClass>> transformed = new ConcurrentLinkedDeque<>();
+        final ConcurrentLinkedDeque<Future<TransformedClassesBuildItem.TransformedClass>> transformed =
+                new ConcurrentLinkedDeque<>();
         try {
             ClassLoader transformCl = Thread.currentThread().getContextClassLoader();
             for (Map.Entry<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> entry : bytecodeTransformers

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -90,7 +90,8 @@ final public class Constants {
 
     public static final String DURATION_NOTE_ANCHOR = "duration-note-anchor";
     public static final String MEMORY_SIZE_NOTE_ANCHOR = "memory-size-note-anchor";
-    public static final String MORE_INFO_ABOUT_TYPE_FORMAT = " link:#%s[icon:question-circle[], title=More information about the %s format]";
+    public static final String MORE_INFO_ABOUT_TYPE_FORMAT =
+            " link:#%s[icon:question-circle[], title=More information about the %s format]";
     public static final String DURATION_INFORMATION = String.format(Constants.MORE_INFO_ABOUT_TYPE_FORMAT,
             Constants.DURATION_NOTE_ANCHOR, Duration.class.getSimpleName());
     public static final String MEMORY_SIZE_INFORMATION = String.format(Constants.MORE_INFO_ABOUT_TYPE_FORMAT,

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
@@ -208,7 +208,8 @@ public class DocGeneratorUtilTest {
     }
 
     @Test
-    public void shouldUseHyphenatedClassNameWithEverythingBeforeRuntimeOrDeploymentNamespaceReplacedByConfigRootNameWhenComputingConfigRootFileName() {
+    public void
+            shouldUseHyphenatedClassNameWithEverythingBeforeRuntimeOrDeploymentNamespaceReplacedByConfigRootNameWhenComputingConfigRootFileName() {
         String configRoot = "ClassName";
         String expected = "root-name-class-name.adoc";
         String fileName = computeConfigRootDocFileName(configRoot, "root-name");

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -67,7 +67,8 @@ public final class ConfigUtils {
      */
     public static SmallRyeConfigBuilder configBuilder(final boolean runTime, final boolean addDiscovered) {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
-        final ApplicationPropertiesConfigSource.InFileSystem inFileSystem = new ApplicationPropertiesConfigSource.InFileSystem();
+        final ApplicationPropertiesConfigSource.InFileSystem inFileSystem =
+                new ApplicationPropertiesConfigSource.InFileSystem();
         final ApplicationPropertiesConfigSource.InJar inJar = new ApplicationPropertiesConfigSource.InJar();
         final ApplicationPropertiesConfigSource.MpConfigInJar mpConfig = new ApplicationPropertiesConfigSource.MpConfigInJar();
         builder.withSources(inFileSystem, inJar, mpConfig, new DotEnvConfigSource());

--- a/devtools/aesh/src/main/java/io/quarkus/cli/commands/ListExtensionsCommand.java
+++ b/devtools/aesh/src/main/java/io/quarkus/cli/commands/ListExtensionsCommand.java
@@ -29,10 +29,12 @@ public class ListExtensionsCommand implements Command<CommandInvocation> {
     @Option(shortName = 'a', hasValue = false, description = "Display all extensions or just the installable.")
     private boolean all = false;
 
-    @Option(shortName = 'f', hasValue = true, description = "Select the output format among 'name' (display the name only), 'concise' (display name and description) and 'full' (concise format and version related columns).")
+    @Option(shortName = 'f', hasValue = true,
+            description = "Select the output format among 'name' (display the name only), 'concise' (display name and description) and 'full' (concise format and version related columns).")
     private String format = "concise";
 
-    @Option(shortName = 's', hasValue = true, description = "Search filter on extension list. The format is based on Java Pattern.")
+    @Option(shortName = 's', hasValue = true,
+            description = "Search filter on extension list. The format is based on Java Pattern.")
     private String searchPattern;
 
     @Option(shortName = 'p', description = "path to the project")

--- a/devtools/aesh/src/main/java/io/quarkus/cli/commands/QuarkusCommand.java
+++ b/devtools/aesh/src/main/java/io/quarkus/cli/commands/QuarkusCommand.java
@@ -10,9 +10,9 @@ import org.aesh.command.option.Option;
 /**
  * @author <a href="mailto:stalep@gmail.com">Ståle Pedersen</a>
  */
-@GroupCommandDefinition(name = QuarkusCommand.COMMAND_NAME, groupCommands = { ListExtensionsCommand.class,
-        AddExtensionCommand.class,
-        CreateProjectCommand.class }, description = "<command> [<args>] \n\nThese are the common quarkus commands used in various situations")
+@GroupCommandDefinition(name = QuarkusCommand.COMMAND_NAME,
+        groupCommands = { ListExtensionsCommand.class, AddExtensionCommand.class, CreateProjectCommand.class },
+        description = "<command> [<args>] \n\nThese are the common quarkus commands used in various situations")
 public class QuarkusCommand implements Command<CommandInvocation> {
     public static final String COMMAND_NAME = "quarkus";
 

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusListExtensions.java
@@ -34,7 +34,8 @@ public class QuarkusListExtensions extends QuarkusPlatformTask {
         return format;
     }
 
-    @Option(description = "Select the output format among 'name' (display the name only), 'concise' (display name and description) and 'full' (concise format and version related columns).", option = "format")
+    @Option(description = "Select the output format among 'name' (display the name only), 'concise' (display name and description) and 'full' (concise format and version related columns).",
+            option = "format")
     public void setFormat(String format) {
         this.format = format;
     }

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -36,7 +36,8 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
  *
  * @author Alexey Loubyansky
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class BuildMojo extends AbstractMojo {
 
     protected static final String QUARKUS_PACKAGE_UBER_JAR = "quarkus.package.uber-jar";

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -82,7 +82,8 @@ import io.quarkus.utilities.JavaBinFinder;
  * <p>
  * You can use this dev mode in a remote container environment with {@code remote-dev}.
  */
-@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DevMojo extends AbstractMojo {
 
     /**

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateConfigMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateConfigMojo.java
@@ -37,7 +37,8 @@ import io.quarkus.runner.bootstrap.GenerateConfigTask;
  *
  * @author Stuart Douglas
  */
-@Mojo(name = "generate-config", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "generate-config", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class GenerateConfigMojo extends AbstractMojo {
 
     /**

--- a/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/RemoteDevMojo.java
@@ -33,7 +33,8 @@ import io.smallrye.config.SmallRyeConfig;
 /**
  * The dev mojo, that connects to a remote host.
  */
-@Mojo(name = "remote-dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "remote-dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class RemoteDevMojo extends AbstractMojo {
 
     /**

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -109,9 +109,10 @@ public class AmazonLambdaRecorder {
             int namedTotal = namedHandlerClasses.size() + namedStreamHandlerClasses.size();
 
             if (unnamedTotal > 1 || namedTotal > 1 || (unnamedTotal > 0 && namedTotal > 0)) {
-                String errorMessage = "Multiple handler classes, either specify the quarkus.lambda.handler property, or make sure there is only a single "
-                        + RequestHandler.class.getName() + " or, " + RequestStreamHandler.class.getName()
-                        + " implementation in the deployment";
+                String errorMessage =
+                        "Multiple handler classes, either specify the quarkus.lambda.handler property, or make sure there is only a single "
+                                + RequestHandler.class.getName() + " or, " + RequestStreamHandler.class.getName()
+                                + " implementation in the deployment";
                 throw new RuntimeException(errorMessage);
             } else if (unnamedTotal == 0 && namedTotal == 0) {
                 String errorMessage = "Unable to find handler class, make sure your deployment includes a single "

--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientTransportRecorder.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientTransportRecorder.java
@@ -99,10 +99,11 @@ public class AmazonClientTransportRecorder {
         }
 
         if (asyncConfig.proxy.enabled && asyncConfig.proxy.endpoint.isPresent()) {
-            software.amazon.awssdk.http.nio.netty.ProxyConfiguration.Builder proxyBuilder = software.amazon.awssdk.http.nio.netty.ProxyConfiguration
-                    .builder().scheme(asyncConfig.proxy.endpoint.get().getScheme())
-                    .host(asyncConfig.proxy.endpoint.get().getHost())
-                    .nonProxyHosts(new HashSet<>(asyncConfig.proxy.nonProxyHosts.orElse(Collections.emptyList())));
+            software.amazon.awssdk.http.nio.netty.ProxyConfiguration.Builder proxyBuilder =
+                    software.amazon.awssdk.http.nio.netty.ProxyConfiguration
+                            .builder().scheme(asyncConfig.proxy.endpoint.get().getScheme())
+                            .host(asyncConfig.proxy.endpoint.get().getHost())
+                            .nonProxyHosts(new HashSet<>(asyncConfig.proxy.nonProxyHosts.orElse(Collections.emptyList())));
 
             if (asyncConfig.proxy.endpoint.get().getPort() != -1) {
                 proxyBuilder.port(asyncConfig.proxy.endpoint.get().getPort());

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/InterfaceConfigPropertiesUtil.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/InterfaceConfigPropertiesUtil.java
@@ -43,7 +43,7 @@ final class InterfaceConfigPropertiesUtil {
 
     /**
      * Add a method like this:
-     * 
+     *
      * <pre>
      *  &#64;Produces
      *  public SomeConfig produceSomeClass(Config config) {
@@ -157,9 +157,9 @@ final class InterfaceConfigPropertiesUtil {
                                 methodCreator.returnValue(result);
                             } else {
                                 // convert the String value and populate an Optional with it
-                                ConfigPropertiesUtil.ReadOptionalResponse readOptionalResponse = createReadOptionalValueAndConvertIfNeeded(
-                                        fullConfigName,
-                                        genericType, method.declaringClass().name(), methodCreator, config);
+                                ConfigPropertiesUtil.ReadOptionalResponse readOptionalResponse =
+                                        createReadOptionalValueAndConvertIfNeeded(fullConfigName, genericType,
+                                                method.declaringClass().name(), methodCreator, config);
 
                                 // return Optional.empty() if no config value was read
                                 readOptionalResponse.getIsPresentFalse()

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheKeyBuilder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheKeyBuilder.java
@@ -6,7 +6,8 @@ import java.util.Objects;
 
 public class CacheKeyBuilder {
 
-    public static final String NULL_KEYS_NOT_SUPPORTED_MSG = "Null keys are not supported by the Quarkus application data cache";
+    public static final String NULL_KEYS_NOT_SUPPORTED_MSG =
+            "Null keys are not supported by the Quarkus application data cache";
 
     /**
      * Builds a default immutable and unique cache key from a cache name. This key is intended to be used for no-args methods

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayProducer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayProducer.java
@@ -12,7 +12,8 @@ import org.flywaydb.core.Flyway;
 
 @ApplicationScoped
 public class FlywayProducer {
-    private static final String ERROR_NOT_READY = "The Flyway settings are not ready to be consumed: the %s configuration has not been injected yet";
+    private static final String ERROR_NOT_READY =
+            "The Flyway settings are not ready to be consumed: the %s configuration has not been injected yet";
 
     @Inject
     @Default

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/PostgreSQLParserSubstitutions.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/graal/PostgreSQLParserSubstitutions.java
@@ -18,7 +18,8 @@ import com.oracle.svm.core.annotate.TargetClass;
  * This substitution removes de PosgreSQL COPY statement support in Flyway to allow native image compilation
  * when the PostgreSQL Driver is not in the classpath.
  */
-@TargetClass(className = "org.flywaydb.core.internal.database.postgresql.PostgreSQLParser", onlyWith = PostgreSQLParserSubstitutions.Selector.class)
+@TargetClass(className = "org.flywaydb.core.internal.database.postgresql.PostgreSQLParser",
+        onlyWith = PostgreSQLParserSubstitutions.Selector.class)
 public final class PostgreSQLParserSubstitutions {
     @Alias
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias)

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -129,7 +129,8 @@ public final class HibernateOrmProcessor {
     private static final DotName PRODUCES = DotName.createSimple(Produces.class.getName());
 
     private static final String INTEGRATOR_SERVICE_FILE = "META-INF/services/org.hibernate.integrator.spi.Integrator";
-    private static final String SERVICE_CONTRIBUTOR_SERVICE_FILE = "META-INF/services/org.hibernate.service.spi.ServiceContributor";
+    private static final String SERVICE_CONTRIBUTOR_SERVICE_FILE =
+            "META-INF/services/org.hibernate.service.spi.ServiceContributor";
 
     /**
      * Hibernate ORM configuration

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -94,8 +94,9 @@ public final class FastBootEntityManagerFactoryBuilder implements EntityManagerF
         Throwable t = cause;
         while (t != null) {
             if (t instanceof NoSuchAlgorithmException) {
-                message += "Unable to enable SSL support. You might be in the case where you used the `quarkus.ssl.native=false` configuration"
-                        + " and SSL was not disabled automatically for your driver.";
+                message +=
+                        "Unable to enable SSL support. You might be in the case where you used the `quarkus.ssl.native=false` configuration"
+                                + " and SSL was not disabled automatically for your driver.";
                 break;
             }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -588,7 +588,8 @@ public class FastBootMetadataBuilder {
         if (metadataBuilderContributorSetting instanceof MetadataBuilderContributor) {
             metadataBuilderContributor = (MetadataBuilderContributor) metadataBuilderContributorSetting;
         } else if (metadataBuilderContributorSetting instanceof Class) {
-            metadataBuilderContributorImplClass = (Class<? extends MetadataBuilderContributor>) metadataBuilderContributorSetting;
+            metadataBuilderContributorImplClass =
+                    (Class<? extends MetadataBuilderContributor>) metadataBuilderContributorSetting;
         } else if (metadataBuilderContributorSetting instanceof String) {
             final ClassLoaderService classLoaderService = standardServiceRegistry.getService(ClassLoaderService.class);
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BootstrapOnlyProxyFactoryFactoryInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BootstrapOnlyProxyFactoryFactoryInitiator.java
@@ -18,7 +18,8 @@ public final class BootstrapOnlyProxyFactoryFactoryInitiator implements Standard
     /**
      * Singleton access
      */
-    public static final StandardServiceInitiator<ProxyFactoryFactory> INSTANCE = new BootstrapOnlyProxyFactoryFactoryInitiator();
+    public static final StandardServiceInitiator<ProxyFactoryFactory> INSTANCE =
+            new BootstrapOnlyProxyFactoryFactoryInitiator();
 
     @Override
     public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/entitymanager/TransactionScopedEntityManager.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/entitymanager/TransactionScopedEntityManager.java
@@ -29,7 +29,8 @@ import io.quarkus.runtime.BlockingOperationControl;
 
 public class TransactionScopedEntityManager implements EntityManager {
 
-    protected static final String TRANSACTION_IS_NOT_ACTIVE = "Transaction is not active, consider adding @Transactional to your method to automatically activate one.";
+    protected static final String TRANSACTION_IS_NOT_ACTIVE =
+            "Transaction is not active, consider adding @Transactional to your method to automatically activate one.";
     private final TransactionManager transactionManager;
     private final TransactionSynchronizationRegistry tsr;
     private final EntityManagerFactory emf;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordableBootstrap.java
@@ -53,7 +53,8 @@ import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
  */
 public final class RecordableBootstrap extends StandardServiceRegistryBuilder {
 
-    private static final String DISABLED_FEATURE_MSG = "This feature was disabled in Quarkus - this method should not have invoked, please report";
+    private static final String DISABLED_FEATURE_MSG =
+            "This feature was disabled in Quarkus - this method should not have invoked, please report";
 
     private final Map settings;
     private final List<StandardServiceInitiator> initiators = standardInitiatorList();

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/graal/Substitute_HibernateOrmIntegrationBooterImpl.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/graal/Substitute_HibernateOrmIntegrationBooterImpl.java
@@ -14,7 +14,8 @@ final class Substitute_HibernateOrmIntegrationBooterImpl {
         throw new IllegalStateException("Partial build state should have been generated during the static init phase.");
     }
 
-    @TargetClass(className = "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateOrmIntegrationBooterImpl", innerClass = "HibernateOrmIntegrationPartialBuildState")
+    @TargetClass(className = "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateOrmIntegrationBooterImpl",
+            innerClass = "HibernateOrmIntegrationPartialBuildState")
     final static class HibernateOrmIntegrationPartialBuildState {
 
     }

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/graal/JAXBSubstitutions.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/graal/JAXBSubstitutions.java
@@ -8,7 +8,8 @@ import java.util.function.BooleanSupplier;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "com.sun.xml.bind.v2.model.nav.ReflectionNavigator", onlyWith = Target_com_sun_xml_bind_v2_model_nav_ReflectionNavigator.Selector.class)
+@TargetClass(className = "com.sun.xml.bind.v2.model.nav.ReflectionNavigator",
+        onlyWith = Target_com_sun_xml_bind_v2_model_nav_ReflectionNavigator.Selector.class)
 final class Target_com_sun_xml_bind_v2_model_nav_ReflectionNavigator {
 
     @Substitute
@@ -40,7 +41,8 @@ final class Target_com_sun_xml_bind_v2_model_nav_ReflectionNavigator {
     }
 }
 
-@TargetClass(className = "com.sun.xml.bind.v2.runtime.reflect.opt.AccessorInjector", onlyWith = Target_com_sun_xml_bind_v2_runtime_reflect_opt_AccessorInjector.Selector.class)
+@TargetClass(className = "com.sun.xml.bind.v2.runtime.reflect.opt.AccessorInjector",
+        onlyWith = Target_com_sun_xml_bind_v2_runtime_reflect_opt_AccessorInjector.Selector.class)
 @Substitute
 final class Target_com_sun_xml_bind_v2_runtime_reflect_opt_AccessorInjector {
 
@@ -71,7 +73,8 @@ final class Target_com_sun_xml_bind_v2_runtime_reflect_opt_AccessorInjector {
     }
 }
 
-@TargetClass(className = "com.sun.xml.internal.bind.v2.model.annotation.LocatableAnnotation", onlyWith = Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnotation.Selector.class)
+@TargetClass(className = "com.sun.xml.internal.bind.v2.model.annotation.LocatableAnnotation",
+        onlyWith = Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnotation.Selector.class)
 final class Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnotation {
 
     @Substitute
@@ -84,7 +87,8 @@ final class Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnota
         throw new RuntimeException("Not implemented");
     }
 
-    @TargetClass(className = "com.sun.xml.internal.bind.v2.model.annotation.Locatable", onlyWith = Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnotation.Selector.class)
+    @TargetClass(className = "com.sun.xml.internal.bind.v2.model.annotation.Locatable",
+            onlyWith = Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnotation.Selector.class)
     static final class Locatable {
 
     }
@@ -103,7 +107,8 @@ final class Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnota
     }
 }
 
-@TargetClass(className = "com.sun.xml.internal.bind.v2.model.nav.ReflectionNavigator", onlyWith = Target_com_sun_xml_internal_bind_v2_model_nav_ReflectionNavigator.Selector.class)
+@TargetClass(className = "com.sun.xml.internal.bind.v2.model.nav.ReflectionNavigator",
+        onlyWith = Target_com_sun_xml_internal_bind_v2_model_nav_ReflectionNavigator.Selector.class)
 final class Target_com_sun_xml_internal_bind_v2_model_nav_ReflectionNavigator {
 
     @Substitute
@@ -135,7 +140,8 @@ final class Target_com_sun_xml_internal_bind_v2_model_nav_ReflectionNavigator {
     }
 }
 
-@TargetClass(className = "com.sun.xml.internal.bind.v2.runtime.reflect.opt.AccessorInjector", onlyWith = Target_com_sun_xml_internal_bind_v2_runtime_reflect_opt_AccessorInjector.Selector.class)
+@TargetClass(className = "com.sun.xml.internal.bind.v2.runtime.reflect.opt.AccessorInjector",
+        onlyWith = Target_com_sun_xml_internal_bind_v2_runtime_reflect_opt_AccessorInjector.Selector.class)
 @Substitute
 final class Target_com_sun_xml_internal_bind_v2_runtime_reflect_opt_AccessorInjector {
 

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
@@ -151,7 +151,8 @@ public class KeycloakPolicyEnforcerAuthorizer
                     PolicyEnforcerConfig.EnforcementMode.valueOf(config.policyEnforcer.enforcementMode));
             enforcerConfig.setHttpMethodAsScope(config.policyEnforcer.httpMethodAsScope);
 
-            KeycloakPolicyEnforcerConfig.KeycloakConfigPolicyEnforcer.PathCacheConfig pathCache = config.policyEnforcer.pathCache;
+            KeycloakPolicyEnforcerConfig.KeycloakConfigPolicyEnforcer.PathCacheConfig pathCache =
+                    config.policyEnforcer.pathCache;
 
             PolicyEnforcerConfig.PathCacheConfig pathCacheConfig = new PolicyEnforcerConfig.PathCacheConfig();
             pathCacheConfig.setLifespan(pathCache.lifespan);

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseProducer.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseProducer.java
@@ -19,7 +19,8 @@ public class LiquibaseProducer {
     /**
      * The error not ready message
      */
-    private static final String ERROR_NOT_READY = "The Liquibase settings are not ready to be consumed: the %s configuration has not been injected yet";
+    private static final String ERROR_NOT_READY =
+            "The Liquibase settings are not ready to be consumed: the %s configuration has not been injected yet";
 
     /**
      * The default data source

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/CDIDelegatingTransactionManager.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/CDIDelegatingTransactionManager.java
@@ -57,8 +57,9 @@ public class CDIDelegatingTransactionManager implements TransactionManager, Seri
      * Delegating transaction manager call to com.arjuna.ats.jta.{@link com.arjuna.ats.jta.TransactionManager}
      */
     public CDIDelegatingTransactionManager() {
-        delegate = (com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple) com.arjuna.ats.jta.TransactionManager
-                .transactionManager();
+        delegate =
+                (com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple) com.arjuna.ats.jta.TransactionManager
+                        .transactionManager();
     }
 
     /**

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/context/TransactionContext.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/context/TransactionContext.java
@@ -30,7 +30,8 @@ public class TransactionContext implements InjectableContext {
     // marker object to be put as a key for SynchronizationRegistry to gather all beans created in the scope
     private static final Object TRANSACTION_CONTEXT_MARKER = new Object();
 
-    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry = new TransactionSynchronizationRegistryImple();
+    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry =
+            new TransactionSynchronizationRegistryImple();
     private final TransactionManager transactionManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
 
     @Override
@@ -160,7 +161,8 @@ public class TransactionContext implements InjectableContext {
      */
     private static class TransactionContextState implements ContextState {
 
-        private final ConcurrentMap<Contextual<?>, ContextInstanceHandle<?>> mapBeanToInstanceHandle = new ConcurrentHashMap<>();
+        private final ConcurrentMap<Contextual<?>, ContextInstanceHandle<?>> mapBeanToInstanceHandle =
+                new ConcurrentHashMap<>();
 
         /**
          * Put the contextual bean and its handle to the container.

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/health/Neo4jHealthCheck.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/health/Neo4jHealthCheck.java
@@ -33,7 +33,8 @@ public class Neo4jHealthCheck implements HealthCheck {
     /**
      * Message logged before retrying a health check.
      */
-    private static final String MESSAGE_SESSION_EXPIRED = "Neo4j session has expired, retrying one single time to retrieve server health.";
+    private static final String MESSAGE_SESSION_EXPIRED =
+            "Neo4j session has expired, retrying one single time to retrieve server health.";
     /**
      * The default session config to use while connecting.
      */

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -102,7 +102,8 @@ final class Target_io_netty_handler_ssl_JdkAlpnApplicationProtocolNegotiator_Alp
 
 }
 
-@TargetClass(className = "io.netty.handler.ssl.JdkAlpnApplicationProtocolNegotiator$AlpnWrapper", onlyWith = JDK8OrEarlier.class)
+@TargetClass(className = "io.netty.handler.ssl.JdkAlpnApplicationProtocolNegotiator$AlpnWrapper",
+        onlyWith = JDK8OrEarlier.class)
 final class Target_io_netty_handler_ssl_JdkAlpnApplicationProtocolNegotiator_AlpnWrapperJava8 {
     @Substitute
     public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualChannel.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualChannel.java
@@ -53,8 +53,8 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 public class VirtualChannel extends AbstractChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(VirtualChannel.class);
     @SuppressWarnings({ "rawtypes" })
-    protected static final AtomicReferenceFieldUpdater<VirtualChannel, Future> FINISH_READ_FUTURE_UPDATER = AtomicReferenceFieldUpdater
-            .newUpdater(VirtualChannel.class, Future.class, "finishReadFuture");
+    protected static final AtomicReferenceFieldUpdater<VirtualChannel, Future> FINISH_READ_FUTURE_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(VirtualChannel.class, Future.class, "finishReadFuture");
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     private static final int MAX_READER_STACK_DEPTH = 8;
 

--- a/extensions/optaplanner/runtime/src/main/java/io/quarkus/optaplanner/nativeimage/Substitute_MemberAccessorFactory.java
+++ b/extensions/optaplanner/runtime/src/main/java/io/quarkus/optaplanner/nativeimage/Substitute_MemberAccessorFactory.java
@@ -37,7 +37,8 @@ public final class Substitute_MemberAccessorFactory {
                     // Intentionally fall through (no break)
                 case FIELD_OR_GETTER_METHOD:
                 case FIELD_OR_GETTER_METHOD_WITH_SETTER:
-                    boolean getterOnly = memberAccessorType != MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
+                    boolean getterOnly =
+                            memberAccessorType != MemberAccessorFactory.MemberAccessorType.FIELD_OR_GETTER_METHOD_WITH_SETTER;
                     ReflectionHelper.assertGetterMethod(method, annotationClass);
                     memberAccessor = new ReflectionBeanPropertyMemberAccessor(method, getterOnly);
                     break;

--- a/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/impl/PanacheMockMethodCustomizer.java
+++ b/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/impl/PanacheMockMethodCustomizer.java
@@ -14,14 +14,14 @@ import io.quarkus.panache.mock.PanacheMock;
 public class PanacheMockMethodCustomizer implements PanacheMethodCustomizer {
 
     private final static String PANACHE_MOCK_BINARY_NAME = PanacheMock.class.getName().replace('.', '/');
-    private final static String PANACHE_MOCK_INVOKE_REAL_METHOD_EXCEPTION_BINARY_NAME = PanacheMock.InvokeRealMethodException.class
-            .getName().replace('.', '/');
+    private final static String PANACHE_MOCK_INVOKE_REAL_METHOD_EXCEPTION_BINARY_NAME =
+            PanacheMock.InvokeRealMethodException.class.getName().replace('.', '/');
 
     @Override
     public void customize(Type entityClassSignature, MethodInfo method, MethodVisitor mv) {
         /*
          * Generated code:
-         * 
+         *
          * if(PanacheMock.IsMockEnabled && PanacheMock.isMocked(TestClass.class)) {
          * try {
          * return (int)PanacheMock.mockMethod(TestClass.class, "foo", new Class<?>[] {int.class}, new Object[] {arg});
@@ -29,9 +29,9 @@ public class PanacheMockMethodCustomizer implements PanacheMethodCustomizer {
          * // fall-through
          * }
          * }
-         * 
+         *
          * Bytecode approx:
-         * 
+         *
          * 0: getstatic #16 // Field PanacheMock.IsMockEnabled:Z
          * 3: ifeq 50
          * 6: ldc #1 // class MyTestMockito$TestClass
@@ -39,7 +39,7 @@ public class PanacheMockMethodCustomizer implements PanacheMethodCustomizer {
          * 11: ifeq 50
          * 14: ldc #1 // class MyTestMockito$TestClass
          * 16: ldc #26 // String foo
-         * 
+         *
          * 18: iconst_1
          * 19: anewarray #27 // class java/lang/Class
          * 22: dup
@@ -54,7 +54,7 @@ public class PanacheMockMethodCustomizer implements PanacheMethodCustomizer {
          * 34: iload_0
          * 35: invokestatic #35 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
          * 38: aastore
-         * 
+         *
          * 39: invokestatic #39 // Method
          * PanacheMock.mockMethod:(Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/Class;[Ljava/lang/Object;)Ljava/lang/Object;
          * 42: checkcast #30 // class java/lang/Integer

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ExternalRolesUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/ExternalRolesUserEntity.java
@@ -28,7 +28,8 @@ public class ExternalRolesUserEntity {
     @Password(PasswordType.CLEAR)
     public String pass;
 
-    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
     @ManyToMany
     @Roles
     public List<RoleEntity> roles = new ArrayList<>();

--- a/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheUserEntity.java
+++ b/extensions/security-jpa/deployment/src/test/java/io/quarkus/security/jpa/PanacheUserEntity.java
@@ -24,7 +24,8 @@ public class PanacheUserEntity extends PanacheEntity {
     @Password(PasswordType.CLEAR)
     public String pass;
 
-    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
+    @JoinTable(name = "test_user_role", joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
     @ManyToMany
     @Roles
     public List<PanacheRoleEntity> roles = new ArrayList<>();

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFaultToleranceOperationProvider.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/QuarkusFaultToleranceOperationProvider.java
@@ -22,12 +22,13 @@ public class QuarkusFaultToleranceOperationProvider implements FaultToleranceOpe
     private static final Logger LOG = Logger.getLogger(QuarkusFaultToleranceOperationProvider.class);
 
     private final Map<CacheKey, FaultToleranceOperation> operationCache = new ConcurrentHashMap<>();
-    private final Function<CacheKey, FaultToleranceOperation> cacheFunction = new Function<CacheKey, FaultToleranceOperation>() {
-        @Override
-        public FaultToleranceOperation apply(CacheKey key) {
-            return createAtRuntime(key);
-        }
-    };
+    private final Function<CacheKey, FaultToleranceOperation> cacheFunction =
+            new Function<CacheKey, FaultToleranceOperation>() {
+                @Override
+                public FaultToleranceOperation apply(CacheKey key) {
+                    return createAtRuntime(key);
+                }
+            };
 
     /**
      * Called by SmallryeFaultToleranceRecorder to init the operation cache.

--- a/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/SmallryeFaultToleranceRecorder.java
+++ b/extensions/smallrye-fault-tolerance/runtime/src/main/java/io/quarkus/smallrye/faulttolerance/runtime/SmallryeFaultToleranceRecorder.java
@@ -38,8 +38,8 @@ public class SmallryeFaultToleranceRecorder {
                             operation.validate();
 
                             // register the operation at validation time to avoid re-creating it at runtime
-                            QuarkusFaultToleranceOperationProvider.CacheKey cacheKey = new QuarkusFaultToleranceOperationProvider.CacheKey(
-                                    beanClass, method);
+                            QuarkusFaultToleranceOperationProvider.CacheKey cacheKey =
+                                    new QuarkusFaultToleranceOperationProvider.CacheKey(beanClass, method);
                             operationCache.put(cacheKey, operation);
                         } catch (FaultToleranceDefinitionException e) {
                             allExceptions.add(e);

--- a/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsRecorder.java
+++ b/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsRecorder.java
@@ -317,7 +317,8 @@ public class SmallRyeMetricsRecorder {
         if (!ImageInfo.inImageCode()
                 && com.sun.management.OperatingSystemMXBean.class.isAssignableFrom(operatingSystemMXBean.getClass())) {
             try {
-                com.sun.management.OperatingSystemMXBean internalOperatingSystemMXBean = (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
+                com.sun.management.OperatingSystemMXBean internalOperatingSystemMXBean =
+                        (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
                 meta = Metadata.builder()
                         .withName(PROCESS_CPU_LOAD)
                         .withType(MetricType.GAUGE)
@@ -351,7 +352,8 @@ public class SmallRyeMetricsRecorder {
         if (!ImageInfo.inImageCode()
                 && com.sun.management.OperatingSystemMXBean.class.isAssignableFrom(operatingSystemMXBean.getClass())) {
             try {
-                com.sun.management.OperatingSystemMXBean internalOperatingSystemMXBean = (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
+                com.sun.management.OperatingSystemMXBean internalOperatingSystemMXBean =
+                        (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
                 Metadata meta = Metadata.builder()
                         .withName(SYSTEM_CPU_LOAD)
                         .withType(MetricType.GAUGE)

--- a/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Fruit.java
+++ b/extensions/smallrye-opentracing/deployment/src/test/java/io/quarkus/smallrye/opentracing/deployment/Fruit.java
@@ -13,7 +13,8 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "known_fruits")
-@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name", hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+@NamedQuery(name = "Fruits.findAll", query = "SELECT f FROM Fruit f ORDER BY f.name",
+        hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
 @Cacheable
 public class Fruit {
 

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -40,7 +40,8 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
     private Map<String, WorkerExecutor> workerExecutors = new ConcurrentHashMap<>();
 
     public void terminate(
-            @Observes(notifyObserver = Reception.IF_EXISTS) @Priority(100) @BeforeDestroyed(ApplicationScoped.class) Object event) {
+            @Observes(
+                    notifyObserver = Reception.IF_EXISTS) @Priority(100) @BeforeDestroyed(ApplicationScoped.class) Object event) {
         if (!workerExecutors.isEmpty()) {
             for (WorkerExecutor executor : workerExecutors.values()) {
                 executor.close();

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -49,7 +49,8 @@ public class SpringDataJPAProcessor {
     private static final Pattern pattern = Pattern.compile("spring\\..*");
     public static final String SPRING_JPA_SHOW_SQL = "spring.jpa.show-sql";
     public static final String SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT = "spring.jpa.properties.hibernate.dialect";
-    public static final String SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT_STORAGE_ENGINE = "spring.jpa.properties.hibernate.dialect.storage_engine";
+    public static final String SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT_STORAGE_ENGINE =
+            "spring.jpa.properties.hibernate.dialect.storage_engine";
     public static final String SPRING_JPA_GENERATE_DDL = "spring.jpa.generate-ddl";
     public static final String SPRING_JPA_HIBERNATE_NAMING_PHYSICAL_STRATEGY = "spring.jpa.hibernate.naming.physical-strategy";
     public static final String SPRING_JPA_HIBERNATE_NAMING_IMPLICIT_STRATEGY = "spring.jpa.hibernate.naming.implicit-strategy";
@@ -58,8 +59,10 @@ public class SpringDataJPAProcessor {
     public static final String QUARKUS_HIBERNATE_ORM_LOG_SQL = "quarkus.hibernate-orm.log.sql";
     public static final String QUARKUS_HIBERNATE_ORM_DIALECT_STORAGE_ENGINE = "quarkus.hibernate-orm.dialect.storage-engine";
     public static final String QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION = "quarkus.hibernate-orm.database.generation";
-    public static final String QUARKUS_HIBERNATE_ORM_PHYSICAL_NAMING_STRATEGY = "quarkus.hibernate-orm.physical-naming-strategy";
-    public static final String QUARKUS_HIBERNATE_ORM_IMPLICIT_NAMING_STRATEGY = "quarkus.hibernate-orm.implicit-naming-strategy";
+    public static final String QUARKUS_HIBERNATE_ORM_PHYSICAL_NAMING_STRATEGY =
+            "quarkus.hibernate-orm.physical-naming-strategy";
+    public static final String QUARKUS_HIBERNATE_ORM_IMPLICIT_NAMING_STRATEGY =
+            "quarkus.hibernate-orm.implicit-naming-strategy";
     private static final String QUARKUS_HIBERNATE_ORM_SQL_LOAD_SCRIPT = "quarkus.hibernate-orm.sql-load-script";
 
     @BuildStep

--- a/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/SpringSecurityProcessor.java
+++ b/extensions/spring-security/deployment/src/main/java/io/quarkus/spring/security/deployment/SpringSecurityProcessor.java
@@ -50,7 +50,8 @@ import io.quarkus.spring.security.runtime.interceptor.check.PrincipalNameFromPar
 
 class SpringSecurityProcessor {
 
-    private static final String PARAMETER_EQ_PRINCIPAL_USERNAME_REGEX = "#(\\w+)(\\.(\\w+))?\\s+[=!]=\\s+(authentication.)?principal.username";
+    private static final String PARAMETER_EQ_PRINCIPAL_USERNAME_REGEX =
+            "#(\\w+)(\\.(\\w+))?\\s+[=!]=\\s+(authentication.)?principal.username";
     private static final Pattern PARAMETER_EQ_PRINCIPAL_USERNAME_PATTERN = Pattern
             .compile(PARAMETER_EQ_PRINCIPAL_USERNAME_REGEX);
 

--- a/extensions/undertow-websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/devmode/HotReplacementWebsocketEndpoint.java
+++ b/extensions/undertow-websockets/runtime/src/main/java/io/quarkus/undertow/websockets/runtime/devmode/HotReplacementWebsocketEndpoint.java
@@ -33,7 +33,8 @@ import org.jboss.logging.Logger;
 import io.quarkus.dev.spi.HotReplacementContext;
 import io.undertow.util.IoUtils;
 
-@ServerEndpoint(value = HotReplacementWebsocketEndpoint.QUARKUS_HOT_RELOAD, configurator = HotReplacementWebsocketEndpoint.ServerConfigurator.class)
+@ServerEndpoint(value = HotReplacementWebsocketEndpoint.QUARKUS_HOT_RELOAD,
+        configurator = HotReplacementWebsocketEndpoint.ServerConfigurator.class)
 public class HotReplacementWebsocketEndpoint {
 
     static final String QUARKUS_HOT_RELOAD = "/quarkus/live-reload";

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedFilterInitParam.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/AnnotatedFilterInitParam.java
@@ -13,7 +13,8 @@ import javax.servlet.annotation.WebInitParam;
 import javax.servlet.http.HttpFilter;
 
 @WebFilter(urlPatterns = SERVLET_ENDPOINT, description = "Haha Filter", initParams = {
-        @WebInitParam(name = "AnnotatedInitFilterParamName", value = "AnnotatedInitFilterParamValue", description = "Described filter init param")
+        @WebInitParam(name = "AnnotatedInitFilterParamName", value = "AnnotatedInitFilterParamValue",
+                description = "Described filter init param")
 })
 public class AnnotatedFilterInitParam extends HttpFilter {
 

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/HttpSessionContext.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/HttpSessionContext.java
@@ -126,8 +126,8 @@ public class HttpSessionContext implements InjectableContext, HttpSessionListene
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private ComputingCache<Key, ContextInstanceHandle<?>> getContextualInstances(HttpSession session) {
-        ComputingCache<Key, ContextInstanceHandle<?>> contextualInstances = (ComputingCache<Key, ContextInstanceHandle<?>>) session
-                .getAttribute(CONTEXTUAL_INSTANCES_KEY);
+        ComputingCache<Key, ContextInstanceHandle<?>> contextualInstances =
+                (ComputingCache<Key, ContextInstanceHandle<?>>) session.getAttribute(CONTEXTUAL_INSTANCES_KEY);
         if (contextualInstances == null) {
             synchronized (this) {
                 contextualInstances = (ComputingCache<Key, ContextInstanceHandle<?>>) session

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/JdkSubstitutions.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/graal/JdkSubstitutions.java
@@ -94,7 +94,8 @@ final class Package_jdk_internal_loader implements Function<TargetClass, String>
 }
 
 @Substitute
-@TargetClass(className = "sun.nio.ch.WindowsAsynchronousFileChannelImpl", innerClass = "DefaultIocpHolder", onlyWith = JDK11OrLater.class)
+@TargetClass(className = "sun.nio.ch.WindowsAsynchronousFileChannelImpl", innerClass = "DefaultIocpHolder",
+        onlyWith = JDK11OrLater.class)
 @Platforms({ Platform.WINDOWS.class })
 final class Target_sun_nio_ch_WindowsAsynchronousFileChannelImpl_DefaultIocpHolder {
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -177,27 +177,28 @@ public class BeanDeployment {
     }
 
     ContextRegistrar.RegistrationContext registerCustomContexts(List<ContextRegistrar> contextRegistrars) {
-        io.quarkus.arc.processor.ContextRegistrar.RegistrationContext registrationContext = new io.quarkus.arc.processor.ContextRegistrar.RegistrationContext() {
-            @Override
-            public <V> V put(Key<V> key, V value) {
-                return buildContext.put(key, value);
-            }
+        io.quarkus.arc.processor.ContextRegistrar.RegistrationContext registrationContext =
+                new io.quarkus.arc.processor.ContextRegistrar.RegistrationContext() {
+                    @Override
+                    public <V> V put(Key<V> key, V value) {
+                        return buildContext.put(key, value);
+                    }
 
-            @Override
-            public <V> V get(Key<V> key) {
-                return buildContext.get(key);
-            }
+                    @Override
+                    public <V> V get(Key<V> key) {
+                        return buildContext.get(key);
+                    }
 
-            @Override
-            public ContextConfigurator configure(Class<? extends Annotation> scopeAnnotation) {
-                return new ContextConfigurator(scopeAnnotation,
-                        c -> {
-                            ScopeInfo scope = new ScopeInfo(c.scopeAnnotation, c.isNormal);
-                            beanDefiningAnnotations.add(new BeanDefiningAnnotation(scope.getDotName(), null));
-                            customContexts.put(scope, c.creator);
-                        });
-            }
-        };
+                    @Override
+                    public ContextConfigurator configure(Class<? extends Annotation> scopeAnnotation) {
+                        return new ContextConfigurator(scopeAnnotation,
+                                c -> {
+                                    ScopeInfo scope = new ScopeInfo(c.scopeAnnotation, c.isNormal);
+                                    beanDefiningAnnotations.add(new BeanDefiningAnnotation(scope.getDotName(), null));
+                                    customContexts.put(scope, c.creator);
+                                });
+                    }
+                };
         for (ContextRegistrar contextRegistrar : contextRegistrars) {
             contextRegistrar.register(registrationContext);
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -248,33 +248,37 @@ public class SubclassGenerator extends AbstractGenerator {
         };
         // Shared interceptor chains
         Map<List<InterceptorInfo>, ResultHandle> interceptorChains = new HashMap<>();
-        Function<List<InterceptorInfo>, ResultHandle> interceptorChainsFun = new Function<List<InterceptorInfo>, ResultHandle>() {
-            @Override
-            public ResultHandle apply(List<InterceptorInfo> interceptors) {
-                if (interceptors.size() == 1) {
-                    // List<InvocationContextImpl.InterceptorInvocation> m1Chain = Collections.singletonList(...);
-                    InterceptorInfo interceptor = interceptors.get(0);
-                    ResultHandle interceptorInstance = interceptorInstanceToResultHandle.get(interceptor.getIdentifier());
-                    ResultHandle interceptionInvocation = constructor.invokeStaticMethod(
-                            MethodDescriptors.INTERCEPTOR_INVOCATION_AROUND_INVOKE,
-                            interceptorToResultHandle.get(interceptor.getIdentifier()), interceptorInstance);
-                    return constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_SINGLETON_LIST,
-                            interceptionInvocation);
-                } else {
-                    // List<InvocationContextImpl.InterceptorInvocation> m1Chain = new ArrayList<>();
-                    ResultHandle chainHandle = constructor.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
-                    for (InterceptorInfo interceptor : interceptors) {
-                        // m1Chain.add(InvocationContextImpl.InterceptorInvocation.aroundInvoke(p3,interceptorInstanceMap.get(InjectableInterceptor.getIdentifier())))
-                        ResultHandle interceptorInstance = interceptorInstanceToResultHandle.get(interceptor.getIdentifier());
-                        ResultHandle interceptionInvocation = constructor.invokeStaticMethod(
-                                MethodDescriptors.INTERCEPTOR_INVOCATION_AROUND_INVOKE,
-                                interceptorToResultHandle.get(interceptor.getIdentifier()), interceptorInstance);
-                        constructor.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, chainHandle, interceptionInvocation);
+        Function<List<InterceptorInfo>, ResultHandle> interceptorChainsFun =
+                new Function<List<InterceptorInfo>, ResultHandle>() {
+                    @Override
+                    public ResultHandle apply(List<InterceptorInfo> interceptors) {
+                        if (interceptors.size() == 1) {
+                            // List<InvocationContextImpl.InterceptorInvocation> m1Chain = Collections.singletonList(...);
+                            InterceptorInfo interceptor = interceptors.get(0);
+                            ResultHandle interceptorInstance =
+                                    interceptorInstanceToResultHandle.get(interceptor.getIdentifier());
+                            ResultHandle interceptionInvocation = constructor.invokeStaticMethod(
+                                    MethodDescriptors.INTERCEPTOR_INVOCATION_AROUND_INVOKE,
+                                    interceptorToResultHandle.get(interceptor.getIdentifier()), interceptorInstance);
+                            return constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_SINGLETON_LIST,
+                                    interceptionInvocation);
+                        } else {
+                            // List<InvocationContextImpl.InterceptorInvocation> m1Chain = new ArrayList<>();
+                            ResultHandle chainHandle = constructor.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
+                            for (InterceptorInfo interceptor : interceptors) {
+                                // m1Chain.add(InvocationContextImpl.InterceptorInvocation.aroundInvoke(p3,interceptorInstanceMap.get(InjectableInterceptor.getIdentifier())))
+                                ResultHandle interceptorInstance =
+                                        interceptorInstanceToResultHandle.get(interceptor.getIdentifier());
+                                ResultHandle interceptionInvocation = constructor.invokeStaticMethod(
+                                        MethodDescriptors.INTERCEPTOR_INVOCATION_AROUND_INVOKE,
+                                        interceptorToResultHandle.get(interceptor.getIdentifier()), interceptorInstance);
+                                constructor.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, chainHandle,
+                                        interceptionInvocation);
+                            }
+                            return chainHandle;
+                        }
                     }
-                    return chainHandle;
-                }
-            }
-        };
+                };
 
         int methodIdx = 1;
         for (Entry<MethodInfo, InterceptionInfo> entry : bean.getInterceptedMethods().entrySet()) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -125,8 +125,8 @@ public class CuratedApplication implements Serializable, Closeable {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(cl);
-            Class<? extends BiConsumer<CuratedApplication, Map<String, Object>>> clazz = (Class<? extends BiConsumer<CuratedApplication, Map<String, Object>>>) cl
-                    .loadClass(consumerName);
+            Class<? extends BiConsumer<CuratedApplication, Map<String, Object>>> clazz =
+                    (Class<? extends BiConsumer<CuratedApplication, Map<String, Object>>>) cl.loadClass(consumerName);
             BiConsumer<CuratedApplication, Map<String, Object>> biConsumer = clazz.newInstance();
             biConsumer.accept(this, params);
             return biConsumer;

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/BuildTreeMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/BuildTreeMojo.java
@@ -10,6 +10,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Displays Quarkus application build dependency tree including the deployment ones.
  */
-@Mojo(name = "build-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "build-tree", defaultPhase = LifecyclePhase.NONE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class BuildTreeMojo extends AbstractTreeMojo {
 }

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/DevModeTreeMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/DevModeTreeMojo.java
@@ -11,7 +11,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Displays Quarkus application dependency tree used to set up the classpath for the dev mode.
  */
-@Mojo(name = "dev-mode-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "dev-mode-tree", defaultPhase = LifecyclePhase.NONE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DevModeTreeMojo extends AbstractTreeMojo {
     @Override
     protected void setupResolver(BootstrapAppModelResolver modelResolver) {

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -40,7 +40,8 @@ import org.eclipse.aether.repository.RemoteRepository;
  *
  * @author Alexey Loubyansky
  */
-@Mojo(name = "extension-descriptor", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "extension-descriptor", defaultPhase = LifecyclePhase.PROCESS_RESOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private static final String GROUP_ID = "group-id";

--- a/independent-projects/ide-config/src/main/resources/eclipse-format.xml
+++ b/independent-projects/ide-config/src/main/resources/eclipse-format.xml
@@ -4,7 +4,7 @@
 <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>

--- a/independent-projects/ide-config/src/main/resources/eclipse-format.xml
+++ b/independent-projects/ide-config/src/main/resources/eclipse-format.xml
@@ -17,7 +17,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>

--- a/independent-projects/ide-config/src/main/resources/eclipse-format.xml
+++ b/independent-projects/ide-config/src/main/resources/eclipse-format.xml
@@ -9,7 +9,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>

--- a/integration-tests/main/src/main/java/io/quarkus/it/jaxb/mapper/codegen/feed/package-info.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/jaxb/mapper/codegen/feed/package-info.java
@@ -5,5 +5,6 @@
 // Generated on: 2014.09.12 at 03:00:35 PM CEST 
 //
 
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.w3.org/2005/Atom", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.w3.org/2005/Atom",
+        elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package io.quarkus.it.jaxb.mapper.codegen.feed;

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResource.java
@@ -246,7 +246,8 @@ public class TestResource {
     @GET
     @Path("/openapi/responses")
     @Produces("application/json")
-    @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class)))
+    @APIResponse(content = @Content(mediaType = "application/json",
+            schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class)))
     public Response openApiResponse() {
         MyOpenApiEntityV1 entity = new MyOpenApiEntityV1();
         entity.setName("my openapi entity name");
@@ -257,8 +258,10 @@ public class TestResource {
     @Path("/openapi/responses/{version}")
     @Produces("application/json")
     @APIResponses({
-            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class))),
-            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV2.class)))
+            @APIResponse(content = @Content(mediaType = "application/json",
+                    schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class))),
+            @APIResponse(content = @Content(mediaType = "application/json",
+                    schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV2.class)))
     })
     public Response openApiResponses(@PathParam("version") String version) {
         if ("v1".equals(version)) {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTOTPITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTOTPITCase.java
@@ -25,7 +25,8 @@ import io.quarkus.vault.test.VaultTestLifecycleManager;
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultTOTPITCase {
 
-    private static final String TEST_OTP_URL = "otpauth://totp/Vault:test@google.com?secret=Y64VEVMBTSXCYIWRSHRNDZW62MPGVU2G&issuer=Vault";
+    private static final String TEST_OTP_URL =
+            "otpauth://totp/Vault:test@google.com?secret=Y64VEVMBTSXCYIWRSHRNDZW62MPGVU2G&issuer=Vault";
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -106,8 +106,9 @@ public class TestResourceManager implements Closeable {
         Set<TestResourceClassEntry> alreadyAddedEntries = new HashSet<>();
         for (AnnotationInstance annotation : findQuarkusTestResourceInstances(index)) {
             try {
-                Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass = (Class<? extends QuarkusTestResourceLifecycleManager>) Class
-                        .forName(annotation.value().asString(), true, Thread.currentThread().getContextClassLoader());
+                Class<? extends QuarkusTestResourceLifecycleManager> testResourceClass =
+                        (Class<? extends QuarkusTestResourceLifecycleManager>) Class
+                                .forName(annotation.value().asString(), true, Thread.currentThread().getContextClassLoader());
 
                 AnnotationValue argsAnnotationValue = annotation.value("initArgs");
                 Map<String, String> args;
@@ -141,7 +142,8 @@ public class TestResourceManager implements Closeable {
 
         testResourceEntries.sort(new Comparator<TestResourceEntry>() {
 
-            private final QuarkusTestResourceLifecycleManagerComparator lifecycleManagerComparator = new QuarkusTestResourceLifecycleManagerComparator();
+            private final QuarkusTestResourceLifecycleManagerComparator lifecycleManagerComparator =
+                    new QuarkusTestResourceLifecycleManagerComparator();
 
             @Override
             public int compare(TestResourceEntry o1, TestResourceEntry o2) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceProvider.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/http/TestHTTPConfigSourceProvider.java
@@ -13,10 +13,12 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
  */
 public class TestHTTPConfigSourceProvider implements ConfigSourceProvider {
 
-    static final String TEST_URL_VALUE = "http://${quarkus.http.host:localhost}:${quarkus.http.test-port:8081}${quarkus.servlet.context-path:}";
+    static final String TEST_URL_VALUE =
+            "http://${quarkus.http.host:localhost}:${quarkus.http.test-port:8081}${quarkus.servlet.context-path:}";
     static final String TEST_URL_KEY = "test.url";
 
-    static final String TEST_URL_SSL_VALUE = "https://${quarkus.http.host:localhost}:${quarkus.http.test-ssl-port:8444}${quarkus.servlet.context-path:}";
+    static final String TEST_URL_SSL_VALUE =
+            "https://${quarkus.http.host:localhost}:${quarkus.http.test-ssl-port:8444}${quarkus.servlet.context-path:}";
     static final String TEST_URL_SSL_KEY = "test.url.ssl";
 
     static final Map<String, String> entries;


### PR DESCRIPTION
The current Quarkus code style limits maximum line length to 128 characters. Some rules, however, force programmers to exceed this limit by disallowing wrapping in certain situations.

Examples:
```
Class<? extends BiConsumer<CuratedApplication, Map<String, Object>>> clazz = (Class<? extends BiConsumer<CuratedApplication, Map<String, Object>>>) cl
        .loadClass(consumerName); // the previous line exceeds the line length limit by 34 characters
```
[assignment operator example](https://github.com/quarkusio/quarkus/blob/master/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java#L128)

```
@TargetClass(className = "com.sun.xml.internal.bind.v2.model.annotation.LocatableAnnotation", onlyWith = Target_com_sun_xml_internal_bind_v2_model_annotation_LocatableAnnotation.Selector.class) // cannot wrap between the two parameters
```
[annotation example](https://github.com/quarkusio/quarkus/blob/master/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/graal/JAXBSubstitutions.java#L74)

I am proposing the following fix to the Quarkus code style:
- allow line wrapping after the assignment operator
- allow line wrapping between annotation parameters
- allow line wrapping in method declarations

Motivation:
- These fixes give people more freedom on wrapping lines to fit the line length limit and thus, arguably, lead to an increase in the readability of the code.
- OptaPlanner project has recently adopted the Quarkus code style to join a consensus of a wider group of engineers rather than creating yet another one. Unfortunately, the issues described above manifest very often in the OptaPlanner codebase.
