### PR TITLE
WIP: Add QUARKUS_CONFIG_LOCATION environment variable

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ApplicationPropertiesConfigSource.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ApplicationPropertiesConfigSource.java
@@ -96,12 +96,16 @@ public abstract class ApplicationPropertiesConfigSource extends PropertiesConfig
     }
 
     public static final class InFileSystem extends ApplicationPropertiesConfigSource {
+
+        private static final String QUARKUS_CONFIG_LOCATION_ENV = "QUARKUS_CONFIG_LOCATION";
+        private static final String DEFAULT_IN_FILE_SYSTEM_LOCATION = "config";
+
         public InFileSystem() {
             super(openStream(), 260);
         }
 
         private static InputStream openStream() {
-            final Path path = Paths.get("config", APPLICATION_PROPERTIES);
+            final Path path = Paths.get(getExternalConfigFilePath(), APPLICATION_PROPERTIES);
             if (Files.exists(path)) {
                 try {
                     return Files.newInputStream(path);
@@ -113,6 +117,10 @@ public abstract class ApplicationPropertiesConfigSource extends PropertiesConfig
             } else {
                 return null;
             }
+        }
+
+        private static String getExternalConfigFilePath() {
+            return System.getenv().getOrDefault(QUARKUS_CONFIG_LOCATION_ENV, DEFAULT_IN_FILE_SYSTEM_LOCATION);
         }
     }
 }

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -394,6 +394,7 @@ You can override these runtime properties with the following mechanisms (in decr
 in that file will override the default configuration. Furthermore any runtime properties added to this file that were not part of the original `application.properties` file
 _will also_ be taken into account.
   * This works in the same way for runner jar and the native executable
+  * The `$PWD/config` directory can be overridden by setting the `QUARKUS_CONFIG_LOCATION` environment variable.
 
 NOTE: Environment variables names are following the conversion rules of link:https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#default-configsources[Eclipse MicroProfile]
 


### PR DESCRIPTION
This pull request adds the ability to set the directory of external configuration. By default, it will still be `config/`

close #8820 