### PR TITLE
Amazon services: remove dynamodb mentions from common config beans

### DIFF
--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AwsConfig.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AwsConfig.java
@@ -11,10 +11,10 @@ public class AwsConfig {
 
     // @formatter:off
     /**
-     * An Amazon Web Services region that hosts DynamoDB.
+     * An Amazon Web Services region that hosts the given service.
      *
      * It overrides region provider chain with static value of
-     * region with which the DynamoDB client should communicate.
+     * region with which the service client should communicate.
      *
      * If not set, region is retrieved via the default providers chain in the following order:
      *

--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/NettyHttpClientConfig.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/NettyHttpClientConfig.java
@@ -67,7 +67,7 @@ public class NettyHttpClientConfig {
     /**
      * The maximum amount of time that a connection should be allowed to remain open while idle.
      * <p>
-     * Currently has no effect if `quarkus.dynamodb.async-client.use-idle-connection-reaper` is false.
+     * Currently has no effect if `quarkus.<amazon-service>.async-client.use-idle-connection-reaper` is false.
      */
     @ConfigItem(defaultValue = "60S")
     public Duration connectionMaxIdleTime;
@@ -75,8 +75,8 @@ public class NettyHttpClientConfig {
     /**
      * Whether the idle connections in the connection pool should be closed.
      * <p>
-     * When enabled, connections left idling for longer than `quarkus.dynamodb.async-client.connection-max-idle-time` will be
-     * closed. This will not close connections currently in use.
+     * When enabled, connections left idling for longer than `quarkus.<amazon-service>.async-client.connection-max-idle-time`
+     * will be closed. This will not close connections currently in use.
      */
     @ConfigItem(defaultValue = "true")
     public boolean useIdleConnectionReaper;

--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SdkConfig.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SdkConfig.java
@@ -15,7 +15,7 @@ public class SdkConfig {
     /**
      * The endpoint URI with which the SDK should communicate.
      * <p>
-     * If not specified, an appropriate endpoint to be used for DynamoDB service and region.
+     * If not specified, an appropriate endpoint to be used for the given service and region.
      */
     @ConfigItem
     public Optional<URI> endpointOverride;

--- a/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientConfig.java
+++ b/extensions/amazon-services/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientConfig.java
@@ -68,8 +68,8 @@ public class SyncHttpClientConfig {
         /**
          * Whether the idle connections in the connection pool should be closed asynchronously.
          * <p>
-         * When enabled, connections left idling for longer than `quarkus.dynamodb.sync-client.connection-max-idle-time` will be
-         * closed.
+         * When enabled, connections left idling for longer than `quarkus.<amazon-service>.sync-client.connection-max-idle-time`
+         * will be closed.
          * This will not close connections currently in use.
          */
         @ConfigItem(defaultValue = "true")


### PR DESCRIPTION
Removed dynamodb mentions from the common config beans.