### PR TITLE
If MP-CP is enabled, make REST Client use it as ExecutorService, to allow for CP in filters

### DIFF
--- a/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/EchoClient.java
+++ b/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/EchoClient.java
@@ -1,5 +1,7 @@
 package io.quarkus.restclient.registerprovider;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -19,4 +21,20 @@ public interface EchoClient {
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.TEXT_PLAIN)
     String echo(@QueryParam("message") String message);
+
+    @Path("call-client")
+    @GET
+    String callClient();
+
+    @Path("called-from-client")
+    @GET
+    String calledFromClient(@QueryParam("uniqueNumber") int uniqueNumber);
+
+    @Path("async/call-client")
+    @GET
+    CompletionStage<String> asyncCallClient();
+
+    @Path("async/called-from-client")
+    @GET
+    CompletionStage<String> asyncCalledFromClient(@QueryParam("uniqueNumber") int uniqueNumber);
 }

--- a/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/EchoResource.java
+++ b/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/EchoResource.java
@@ -1,17 +1,108 @@
 package io.quarkus.restclient.registerprovider;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+
 @Path("/echo")
 public class EchoResource {
 
+    @RestClient
+    EchoClient client;
+
+    @Inject
+    MyRequestBean requestBean;
+
+    @Inject
+    MethodsCollector methodsCollector;
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
     public String echo(@QueryParam("message") String message) {
         return message;
+    }
+
+    @Path("call-client")
+    @GET
+    public String callClient() {
+        // make sure we have a request context
+        ManagedContext requestContext = Arc.container().requestContext();
+        Assertions.assertTrue(requestContext.isActive());
+        Assertions.assertNotNull(requestBean);
+        // this should not end up in the client filter context
+        ResteasyContext.pushContext(String.class, "callClient SERVER CONTEXT");
+        // call the client
+        String ret = client.calledFromClient(requestBean.getUniqueNumber());
+        // make sure the filter got the same request context as we have
+        Assertions.assertEquals(requestBean.getUniqueNumber(), methodsCollector.getRequestBeanFromFilter());
+        // should not have passed from the client context to here
+        Assertions.assertNull(ResteasyContext.getContextData(Long.class));
+        return ret;
+    }
+
+    @Path("called-from-client")
+    @GET
+    public String calledFromClient(@QueryParam("uniqueNumber") int uniqueNumber) {
+        // make sure we have a different request context to call-client
+        ManagedContext requestContext = Arc.container().requestContext();
+        Assertions.assertTrue(requestContext.isActive());
+        Assertions.assertNotNull(requestBean);
+        Assertions.assertNotEquals(uniqueNumber, requestBean.getUniqueNumber());
+        // should not have passed from call-client to here
+        Assertions.assertNull(ResteasyContext.getContextData(String.class));
+        // should not have passed from call-client to here
+        Assertions.assertNull(ResteasyContext.getContextData(Long.class));
+        return "OK";
+    }
+
+    @Path("async/call-client")
+    @GET
+    public CompletionStage<String> asyncCallClient() {
+        // make sure we have a request context
+        ManagedContext requestContext = Arc.container().requestContext();
+        Assertions.assertTrue(requestContext.isActive());
+        Assertions.assertNotNull(requestBean);
+        int req = requestBean.getUniqueNumber();
+        // this should not end up in the client filter context
+        ResteasyContext.pushContext(String.class, "callClient SERVER CONTEXT");
+        // call the client
+        return client.asyncCalledFromClient(req)
+                .thenApply(ret -> {
+                    // make sure the filter got the same request context as we have
+                    Assertions.assertEquals(req, methodsCollector.getRequestBeanFromFilter());
+                    // should not have passed from the client context to here
+                    Assertions.assertNull(ResteasyContext.getContextData(Long.class));
+                    return ret;
+                });
+    }
+
+    @Path("async/called-from-client")
+    @GET
+    public CompletionStage<String> asyncCalledFromClient(@QueryParam("uniqueNumber") int uniqueNumber) {
+        // make sure we have a different request context to call-client
+        ManagedContext requestContext = Arc.container().requestContext();
+        Assertions.assertTrue(requestContext.isActive());
+        Assertions.assertNotNull(requestBean);
+        Assertions.assertNotEquals(uniqueNumber, requestBean.getUniqueNumber());
+        // should not have passed from call-client to here
+        Assertions.assertNull(ResteasyContext.getContextData(String.class));
+        // should not have passed from call-client to here
+        Assertions.assertNull(ResteasyContext.getContextData(Long.class));
+        return CompletableFuture.completedFuture("OK");
     }
 }

--- a/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/MethodsCollector.java
+++ b/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/MethodsCollector.java
@@ -9,6 +9,7 @@ import javax.inject.Singleton;
 public class MethodsCollector {
 
     private final List<String> methods = new CopyOnWriteArrayList<>();
+    private int requestBeanFromFilter;
 
     void collect(String method) {
         methods.add(method);
@@ -16,6 +17,14 @@ public class MethodsCollector {
 
     List<String> getMethods() {
         return methods;
+    }
+
+    public void setRequestBeanFromFilter(int uniqueNumber) {
+        this.requestBeanFromFilter = uniqueNumber;
+    }
+
+    public int getRequestBeanFromFilter() {
+        return requestBeanFromFilter;
     }
 
 }

--- a/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/MyFilter.java
+++ b/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/MyFilter.java
@@ -6,13 +6,31 @@ import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.arc.Arc;
+
 public class MyFilter implements ClientRequestFilter {
 
     @Inject
     MethodsCollector collector;
 
+    @Inject
+    MyRequestBean requestBean;
+
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
+        if (requestContext.getUri().toString().contains("/called-from-client?")) {
+            // make sure we have a request context
+            Assertions.assertTrue(Arc.container().requestContext().isActive());
+            // remember which request context for later examination
+            collector.setRequestBeanFromFilter(requestBean.getUniqueNumber());
+            // make sure we don't inherit the server's resteasy context
+            Assertions.assertNull(ResteasyContext.getContextData(String.class));
+            // add to the client context
+            ResteasyContext.pushContext(Long.class, 42l);
+        }
         collector.collect(requestContext.getMethod());
     }
 }

--- a/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/MyRequestBean.java
+++ b/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/MyRequestBean.java
@@ -1,0 +1,10 @@
+package io.quarkus.restclient.registerprovider;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class MyRequestBean {
+    int getUniqueNumber() {
+        return System.identityHashCode(this);
+    }
+}

--- a/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/RegisterProviderTest.java
+++ b/extensions/rest-client/deployment/src/test/java/io/quarkus/restclient/registerprovider/RegisterProviderTest.java
@@ -2,6 +2,8 @@ package io.quarkus.restclient.registerprovider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.concurrent.ExecutionException;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -18,7 +20,8 @@ public class RegisterProviderTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(EchoResource.class, EchoClient.class, MyFilter.class, MethodsCollector.class)
+                    .addClasses(EchoResource.class, EchoClient.class, MyFilter.class, MethodsCollector.class,
+                            MyRequestBean.class)
                     .addAsResource(new StringAsset("io.quarkus.restclient.registerprovider.EchoClient/mp-rest/url=${test.url}"),
                             "application.properties"));
 
@@ -36,4 +39,9 @@ public class RegisterProviderTest {
         assertEquals("GET", collector.getMethods().get(0));
     }
 
+    @Test
+    public void testContextPropagation() throws InterruptedException, ExecutionException {
+        assertEquals("OK", client.callClient());
+        assertEquals("OK", client.asyncCallClient().toCompletableFuture().get());
+    }
 }

--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -15,7 +15,11 @@ import javax.net.ssl.HostnameVerifier;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 
 public class RestClientBase {
 
@@ -50,6 +54,11 @@ public class RestClientBase {
         configureTimeouts(builder);
         configureProviders(builder);
         configureSsl(builder);
+        // If we have context propagation, then propagate context to the async client threads
+        InstanceHandle<ManagedExecutor> managedExecutor = Arc.container().instance(ManagedExecutor.class);
+        if (managedExecutor.isAvailable()) {
+            builder.executorService(managedExecutor.get());
+        }
 
         return builder.build(proxyType);
     }


### PR DESCRIPTION
Fixes #8538 