### PR TITLE
Fix #6717 by making hibernate-orm-panache-kotlin IT test depend on H2

### DIFF
--- a/integration-tests/hibernate-orm-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-orm-panache-kotlin/pom.xml
@@ -36,11 +36,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-postgresql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
It never really needed PG, but it does need the H2 substitutions and classpath