### PR TITLE
Remove lambdas from RestClientBase

### DIFF
--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -9,7 +9,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import javax.net.ssl.HostnameVerifier;
 


### PR DESCRIPTION
It's policy to not use lambda's in runtime code