### PR TITLE
Add kdoc for developers and add autoboxing code for non-nullable ID types

### DIFF
--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -71,6 +71,14 @@
         </dependency>
     </dependencies>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+        </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>
@@ -137,7 +145,9 @@
                     <execution>
                         <id>java-compile</id>
                         <phase>compile</phase>
-                        <goals> <goal>compile</goal> </goals>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
                     </execution>
                     <execution>
                         <id>java-test-compile</id>
@@ -145,6 +155,34 @@
                         <goals> <goal>testCompile</goal> </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>0.10.1</version>
+                <executions>
+                    <execution>
+                        <id>javadoc</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jdkVersion>8</jdkVersion>
+                    <outputFormat>html</outputFormat>
+                    <sourceDirectories>
+                        <sourceDirectory>src/main/kotlin</sourceDirectory>
+                    </sourceDirectories>
+                    <externalDocumentationLinks>
+                        <link>
+                            <!-- Root URL of the generated documentation to link with. The trailing slash is required! -->
+                            <url>https://docs.oracle.com/javase/8/docs/api/</url>
+                            <packageListUrl>https://docs.oracle.com/javase/8/docs/api/package-list</packageListUrl>
+                        </link>
+                    </externalDocumentationLinks>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/runtime/JpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/runtime/JpaOperations.java
@@ -17,136 +17,96 @@ import io.quarkus.panache.common.Sort;
 
 public class JpaOperations {
 
-    private static class KotlinJpaOperations extends AbstractJpaOperations<PanacheQueryImpl<?>> {
-
-        @Override
-        protected PanacheQueryImpl<?> createPanacheQuery(EntityManager em, String query, String orderBy,
-                Object paramsArrayOrMap) {
-            return new PanacheQueryImpl<>(em, query, orderBy, paramsArrayOrMap);
-        }
-
-        @Override
-        protected List<?> list(PanacheQueryImpl<?> query) {
-            return query.list();
-        }
-
-        @Override
-        protected Stream<?> stream(PanacheQueryImpl<?> query) {
-            return query.stream();
-        }
-
-    }
-
     private static final KotlinJpaOperations delegate = new KotlinJpaOperations();
+
+    public static Query bindParameters(Query query, Object[] params) {
+        return AbstractJpaOperations.bindParameters(query, params);
+    }
 
     //
     // Instance methods
 
-    public static void persist(Object entity) {
-        delegate.persist(entity);
+    public static Query bindParameters(Query query, Map<String, Object> params) {
+        return AbstractJpaOperations.bindParameters(query, params);
     }
 
-    public static void persist(EntityManager em, Object entity) {
-        delegate.persist(em, entity);
+    public static long count(Class<?> entityClass) {
+        return delegate.count(entityClass);
     }
 
-    public static void persist(Iterable<?> entities) {
-        delegate.persist(entities);
+    public static long count(Class<?> entityClass, String query, Object... params) {
+        return delegate.count(entityClass, query, params);
     }
 
-    public static void persist(Object firstEntity, Object... entities) {
-        delegate.persist(firstEntity, entities);
+    public static long count(Class<?> entityClass, String query, Map<String, Object> params) {
+        return delegate.count(entityClass, query, params);
     }
 
-    public static void persist(Stream<?> entities) {
-        delegate.persist(entities);
+    public static long count(Class<?> entityClass, String query, Parameters params) {
+        return delegate.count(entityClass, query, params);
+    }
+
+    static String createFindQuery(Class<?> entityClass, String query, int paramCount) {
+        return delegate.createFindQuery(entityClass, query, paramCount);
     }
 
     public static void delete(Object entity) {
         delegate.delete(entity);
     }
 
-    public static boolean isPersistent(Object entity) {
-        return delegate.isPersistent(entity);
-    }
-
-    public static void flush() {
-        delegate.flush();
+    public static long delete(Class<?> entityClass, String query, Object... params) {
+        return delegate.delete(entityClass, query, params);
     }
 
     //
     // Private stuff
 
-    public static EntityManager getEntityManager() {
-        return delegate.getEntityManager();
+    public static long delete(Class<?> entityClass, String query, Map<String, Object> params) {
+        return delegate.delete(entityClass, query, params);
     }
 
-    public static TransactionManager getTransactionManager() {
-        return delegate.getTransactionManager();
+    public static long delete(Class<?> entityClass, String query, Parameters params) {
+        return delegate.delete(entityClass, query, params);
     }
 
-    public static Query bindParameters(Query query, Object[] params) {
-        return AbstractJpaOperations.bindParameters(query, params);
+    public static long deleteAll(Class<?> entityClass) {
+        return delegate.deleteAll(entityClass);
     }
 
-    public static Query bindParameters(Query query, Map<String, Object> params) {
-        return AbstractJpaOperations.bindParameters(query, params);
+    public static boolean deleteById(Class<?> entityClass, Object id) {
+        return delegate.deleteById(entityClass, id);
     }
 
-    static int paramCount(Object[] params) {
-        return delegate.paramCount(params);
+    public static int executeUpdate(String query, Object... params) {
+        return delegate.executeUpdate(query, params);
     }
 
-    static int paramCount(Map<String, Object> params) {
-        return delegate.paramCount(params);
+    public static int executeUpdate(String query, Map<String, Object> params) {
+        return delegate.executeUpdate(query, params);
     }
 
-    //
-    //    private static String getEntityName(Class<?> entityClass) {
-    //        return delegate.getEntityName(entityClass);
-    //    }
-    //
-    static String createFindQuery(Class<?> entityClass, String query, int paramCount) {
-        return delegate.createFindQuery(entityClass, query, paramCount);
-    }
-    //
-    //    static boolean isNamedQuery(String query) {
-    //        return delegate.isNamedQuery(query);
-    //    }
-    //
-    //    private static String createCountQuery(Class<?> entityClass, String query, int paramCount) {
-    //        return delegate.createCountQuery(entityClass, query, paramCount);
-    //    }
-    //
-    //    private static String createUpdateQuery(Class<?> entityClass, String query, int paramCount) {
-    //        return delegate.createUpdateQuery(entityClass, query, paramCount);
-    //    }
-    //
-    //    private static String createDeleteQuery(Class<?> entityClass, String query, int paramCount) {
-    //        return delegate.createDeleteQuery(entityClass, query, paramCount);
-    //    }
-
-    public static String toOrderBy(Sort sort) {
-        return delegate.toOrderBy(sort);
+    public static int executeUpdate(Class<?> entityClass, String query, Object... params) {
+        return delegate.executeUpdate(entityClass, query, params);
     }
 
-    //
-    // Queries
-
-    public static Object findById(Class<?> entityClass, Object id) {
-        return delegate.findById(entityClass, id);
+    public static int executeUpdate(Class<?> entityClass, String query, Map<String, Object> params) {
+        return delegate.executeUpdate(entityClass, query, params);
     }
 
-    public static Object findById(Class<?> entityClass, Object id, LockModeType lockModeType) {
-        return delegate.findById(entityClass, id, lockModeType);
+    public static boolean exists(Class<?> entityClass) {
+        return delegate.exists(entityClass);
     }
 
-    public static Optional<?> findByIdOptional(Class<?> entityClass, Object id) {
-        return delegate.findByIdOptional(entityClass, id);
+    public static boolean exists(Class<?> entityClass, String query, Object... params) {
+        return delegate.exists(entityClass, query, params);
     }
 
-    public static Optional<?> findByIdOptional(Class<?> entityClass, Object id, LockModeType lockModeType) {
-        return delegate.findByIdOptional(entityClass, id, lockModeType);
+    public static boolean exists(Class<?> entityClass, String query, Map<String, Object> params) {
+        return delegate.exists(entityClass, query, params);
+    }
+
+    public static boolean exists(Class<?> entityClass, String query, Parameters params) {
+        return delegate.exists(entityClass, query, params);
     }
 
     public static PanacheQuery<?> find(Class<?> entityClass, String query, Object... params) {
@@ -173,6 +133,50 @@ public class JpaOperations {
         return delegate.find(entityClass, query, sort, params);
     }
 
+    public static PanacheQuery<?> findAll(Class<?> entityClass) {
+        return delegate.findAll(entityClass);
+    }
+
+    public static PanacheQuery<?> findAll(Class<?> entityClass, Sort sort) {
+        return delegate.findAll(entityClass, sort);
+    }
+
+    public static Object findById(Class<?> entityClass, Object id) {
+        return delegate.findById(entityClass, id);
+    }
+
+    public static Object findById(Class<?> entityClass, Object id, LockModeType lockModeType) {
+        return delegate.findById(entityClass, id, lockModeType);
+    }
+
+    public static Optional<?> findByIdOptional(Class<?> entityClass, Object id) {
+        return delegate.findByIdOptional(entityClass, id);
+    }
+
+    public static Optional<?> findByIdOptional(Class<?> entityClass, Object id, LockModeType lockModeType) {
+        return delegate.findByIdOptional(entityClass, id, lockModeType);
+    }
+
+    public static void flush() {
+        delegate.flush();
+    }
+
+    public static EntityManager getEntityManager() {
+        return delegate.getEntityManager();
+    }
+
+    public static TransactionManager getTransactionManager() {
+        return delegate.getTransactionManager();
+    }
+
+    public static IllegalStateException implementationInjectionMissing() {
+        return delegate.implementationInjectionMissing();
+    }
+
+    public static boolean isPersistent(Object entity) {
+        return delegate.isPersistent(entity);
+    }
+
     public static List<?> list(Class<?> entityClass, String query, Object... params) {
         return delegate.list(entityClass, query, params);
     }
@@ -195,6 +199,46 @@ public class JpaOperations {
 
     public static List<?> list(Class<?> entityClass, String query, Sort sort, Parameters params) {
         return delegate.list(entityClass, query, sort, params);
+    }
+
+    public static List<?> listAll(Class<?> entityClass) {
+        return delegate.listAll(entityClass);
+    }
+
+    public static List<?> listAll(Class<?> entityClass, Sort sort) {
+        return delegate.listAll(entityClass, sort);
+    }
+
+    static int paramCount(Object[] params) {
+        return delegate.paramCount(params);
+    }
+
+    static int paramCount(Map<String, Object> params) {
+        return delegate.paramCount(params);
+    }
+
+    public static void persist(Object entity) {
+        delegate.persist(entity);
+    }
+
+    public static void persist(EntityManager em, Object entity) {
+        delegate.persist(em, entity);
+    }
+
+    public static void persist(Iterable<?> entities) {
+        delegate.persist(entities);
+    }
+
+    public static void persist(Object firstEntity, Object... entities) {
+        delegate.persist(firstEntity, entities);
+    }
+
+    public static void persist(Stream<?> entities) {
+        delegate.persist(entities);
+    }
+
+    public static void setRollbackOnly() {
+        delegate.setRollbackOnly();
     }
 
     public static Stream<?> stream(Class<?> entityClass, String query, Object... params) {
@@ -221,22 +265,6 @@ public class JpaOperations {
         return delegate.stream(entityClass, query, sort, params);
     }
 
-    public static PanacheQuery<?> findAll(Class<?> entityClass) {
-        return delegate.findAll(entityClass);
-    }
-
-    public static PanacheQuery<?> findAll(Class<?> entityClass, Sort sort) {
-        return delegate.findAll(entityClass, sort);
-    }
-
-    public static List<?> listAll(Class<?> entityClass) {
-        return delegate.listAll(entityClass);
-    }
-
-    public static List<?> listAll(Class<?> entityClass, Sort sort) {
-        return delegate.listAll(entityClass, sort);
-    }
-
     public static Stream<?> streamAll(Class<?> entityClass) {
         return delegate.streamAll(entityClass);
     }
@@ -245,76 +273,8 @@ public class JpaOperations {
         return delegate.streamAll(entityClass, sort);
     }
 
-    public static long count(Class<?> entityClass) {
-        return delegate.count(entityClass);
-    }
-
-    public static long count(Class<?> entityClass, String query, Object... params) {
-        return delegate.count(entityClass, query, params);
-    }
-
-    public static long count(Class<?> entityClass, String query, Map<String, Object> params) {
-        return delegate.count(entityClass, query, params);
-    }
-
-    public static long count(Class<?> entityClass, String query, Parameters params) {
-        return delegate.count(entityClass, query, params);
-    }
-
-    public static boolean exists(Class<?> entityClass) {
-        return delegate.exists(entityClass);
-    }
-
-    public static boolean exists(Class<?> entityClass, String query, Object... params) {
-        return delegate.exists(entityClass, query, params);
-    }
-
-    public static boolean exists(Class<?> entityClass, String query, Map<String, Object> params) {
-        return delegate.exists(entityClass, query, params);
-    }
-
-    public static boolean exists(Class<?> entityClass, String query, Parameters params) {
-        return delegate.exists(entityClass, query, params);
-    }
-
-    public static long deleteAll(Class<?> entityClass) {
-        return delegate.deleteAll(entityClass);
-    }
-
-    public static boolean deleteById(Class<?> entityClass, Object id) {
-        return delegate.deleteById(entityClass, id);
-    }
-
-    public static long delete(Class<?> entityClass, String query, Object... params) {
-        return delegate.delete(entityClass, query, params);
-    }
-
-    public static long delete(Class<?> entityClass, String query, Map<String, Object> params) {
-        return delegate.delete(entityClass, query, params);
-    }
-
-    public static long delete(Class<?> entityClass, String query, Parameters params) {
-        return delegate.delete(entityClass, query, params);
-    }
-
-    public static IllegalStateException implementationInjectionMissing() {
-        return delegate.implementationInjectionMissing();
-    }
-
-    public static int executeUpdate(String query, Object... params) {
-        return delegate.executeUpdate(query, params);
-    }
-
-    public static int executeUpdate(String query, Map<String, Object> params) {
-        return delegate.executeUpdate(query, params);
-    }
-
-    public static int executeUpdate(Class<?> entityClass, String query, Object... params) {
-        return delegate.executeUpdate(entityClass, query, params);
-    }
-
-    public static int executeUpdate(Class<?> entityClass, String query, Map<String, Object> params) {
-        return delegate.executeUpdate(entityClass, query, params);
+    public static String toOrderBy(Sort sort) {
+        return delegate.toOrderBy(sort);
     }
 
     public static int update(Class<?> entityClass, String query, Map<String, Object> params) {
@@ -329,8 +289,24 @@ public class JpaOperations {
         return delegate.update(entityClass, query, params);
     }
 
-    public static void setRollbackOnly() {
-        delegate.setRollbackOnly();
+    private static class KotlinJpaOperations extends AbstractJpaOperations<PanacheQueryImpl<?>> {
+
+        @Override
+        protected PanacheQueryImpl<?> createPanacheQuery(EntityManager em, String query, String orderBy,
+                Object paramsArrayOrMap) {
+            return new PanacheQueryImpl<>(em, query, orderBy, paramsArrayOrMap);
+        }
+
+        @Override
+        protected List<?> list(PanacheQueryImpl<?> query) {
+            return query.list();
+        }
+
+        @Override
+        protected Stream<?> stream(PanacheQueryImpl<?> query) {
+            return query.stream();
+        }
+
     }
 
 }

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/runtime/PanacheQueryImpl.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.orm.panache.kotlin.runtime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
@@ -40,42 +39,42 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     public PanacheQuery<Entity> page(@NotNull Page page) {
         delegate.page(page);
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> page(int pageIndex, int pageSize) {
         delegate.page(pageIndex, pageSize);
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> nextPage() {
         delegate.nextPage();
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> previousPage() {
         delegate.previousPage();
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> firstPage() {
         delegate.firstPage();
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> lastPage() {
         delegate.lastPage();
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @Override
@@ -103,28 +102,28 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     public PanacheQuery<Entity> range(int startIndex, int lastIndex) {
         delegate.range(startIndex, lastIndex);
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> withLock(@NotNull LockModeType lockModeType) {
         delegate.withLock(lockModeType);
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> withHint(@NotNull String hintName, @NotNull Object value) {
         delegate.withHint(hintName, value);
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> filter(@NotNull String filterName, @NotNull Parameters parameters) {
         delegate.filter(filterName, parameters.map());
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -132,14 +131,14 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
     @Override
     public PanacheQuery<Entity> filter(@NotNull String filterName, @NotNull Map<String, ? extends Object> parameters) {
         delegate.filter(filterName, (Map) parameters);
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     @NotNull
     @Override
     public PanacheQuery<Entity> filter(@NotNull String filterName) {
         delegate.filter(filterName, Collections.emptyMap());
-        return (PanacheQuery<Entity>) this;
+        return this;
     }
 
     // Results
@@ -168,19 +167,7 @@ public class PanacheQueryImpl<Entity> implements PanacheQuery<Entity> {
 
     @NotNull
     @Override
-    public Optional<Entity> firstResultOptional() {
-        return delegate.firstResultOptional();
-    }
-
-    @NotNull
-    @Override
     public Entity singleResult() {
         return delegate.singleResult();
-    }
-
-    @NotNull
-    @Override
-    public Optional<Entity> singleResultOptional() {
-        return delegate.singleResultOptional();
     }
 }

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
@@ -7,6 +7,12 @@ import io.quarkus.panache.common.impl.GenerateBridge
 import java.util.stream.Stream
 import javax.persistence.LockModeType
 
+/**
+ * Defines methods to be used via the companion objects of entities.
+ *
+ * @param Entity the entity type
+ * @param Id the ID type
+ */
 interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
 
     /**
@@ -16,7 +22,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * @return the entity found, or `null` if not found.
      */
     @GenerateBridge(targetReturnTypeErased = true)
-    fun findById(id: Id): Entity = injectionMissing()
+    fun findById(id: Id): Entity? = injectionMissing()
 
     /**
      * Find an entity of this type by ID and lock it.
@@ -26,19 +32,17 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * @return the entity found, or `null` if not found.
      */
     @GenerateBridge(targetReturnTypeErased = true)
-    fun findById(id: Id, lockModeType: LockModeType): Entity = injectionMissing()
+    fun findById(id: Id, lockModeType: LockModeType): Entity? = injectionMissing()
 
     /**
      * Find entities using a query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun find(query: String, vararg params: Any): PanacheQuery<Entity> = injectionMissing()
@@ -46,15 +50,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Find entities using a query and the given sort options, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun find(query: String, sort: Sort, vararg params: Any): PanacheQuery<Entity> = injectionMissing()
@@ -62,14 +64,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Find entities using a query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun find(query: String, params: Map<String, Any>): PanacheQuery<Entity> = injectionMissing()
@@ -77,15 +77,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Find entities using a query and the given sort options, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params [Map] of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun find(query: String, sort: Sort, params: Map<String, Any>): PanacheQuery<Entity> = injectionMissing()
@@ -93,14 +91,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Find entities using a query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun find(query: String, params: Parameters): PanacheQuery<Entity> = injectionMissing()
@@ -108,15 +104,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Find entities using a query and the given sort options, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
-     * @param params [Parameters] of indexed parameters
+     * @param params Parameters of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun find(query: String, sort: Sort, params: Parameters): PanacheQuery<Entity> = injectionMissing()
@@ -125,9 +119,9 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find all entities of this type.
      *
      * @return a new [PanacheQuery] instance to find all entities of this type.
-     * @see .findAll
-     * @see .listAll
-     * @see .streamAll
+     * @see [PanacheCompanion.findAll]
+     * @see [PanacheCompanion.listAll]
+     * @see [PanacheCompanion.streamAll]
      */
     @GenerateBridge
     fun findAll(): PanacheQuery<Entity> = injectionMissing()
@@ -137,9 +131,9 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      *
      * @param sort the sort order to use
      * @return a new [PanacheQuery] instance to find all entities of this type.
-     * @see .findAll
-     * @see .listAll
-     * @see .streamAll
+     * @see [PanacheCompanion.findAll]
+     * @see [PanacheCompanion.listAll]
+     * @see [PanacheCompanion.streamAll]
      */
     @GenerateBridge
     fun findAll(sort: Sort): PanacheQuery<Entity> = injectionMissing()
@@ -148,14 +142,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find entities matching a query, with optional indexed parameters.
      * This method is a shortcut for `find(query, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun list(query: String, vararg params: Any): List<Entity> = injectionMissing()
@@ -164,15 +156,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find entities matching a query and the given sort options, with optional indexed parameters.
      * This method is a shortcut for `find(query, sort, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun list(query: String, sort: Sort, vararg params: Any): List<Entity> = injectionMissing()
@@ -181,14 +171,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find entities matching a query, with named parameters.
      * This method is a shortcut for `find(query, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun list(query: String, params: Map<String, Any>): List<Entity> = injectionMissing()
@@ -197,15 +185,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find entities matching a query and the given sort options, with named parameters.
      * This method is a shortcut for `find(query, sort, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params [Map] of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun list(query: String, sort: Sort, params: Map<String, Any>): List<Entity> = injectionMissing()
@@ -214,14 +200,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find entities matching a query, with named parameters.
      * This method is a shortcut for `find(query, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun list(query: String, params: Parameters): List<Entity> = injectionMissing()
@@ -230,15 +214,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Find entities matching a query and the given sort options, with named parameters.
      * This method is a shortcut for `find(query, sort, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
-     * @param params [Parameters] of indexed parameters
+     * @param params Parameters of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheCompanion.list]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.stream]
      */
     @GenerateBridge
     fun list(query: String, sort: Sort, params: Parameters): List<Entity> = injectionMissing()
@@ -248,9 +230,9 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * This method is a shortcut for `findAll().list()`.
      *
      * @return a [List] containing all results, without paging
-     * @see .listAll
-     * @see .findAll
-     * @see .streamAll
+     * @see [PanacheCompanion.listAll]
+     * @see [PanacheCompanion.findAll]
+     * @see [PanacheCompanion.streamAll]
      */
     @GenerateBridge
     fun listAll(): List<Entity> = injectionMissing()
@@ -261,9 +243,9 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      *
      * @param sort the sort order to use
      * @return a [List] containing all results, without paging
-     * @see .listAll
-     * @see .findAll
-     * @see .streamAll
+     * @see [PanacheCompanion.listAll]
+     * @see [PanacheCompanion.findAll]
+     * @see [PanacheCompanion.streamAll]
      */
     @GenerateBridge
     fun listAll(sort: Sort): List<Entity> = injectionMissing()
@@ -274,14 +256,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.stream]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
      */
     @GenerateBridge
     fun stream(query: String, vararg params: Any): Stream<Entity> = injectionMissing()
@@ -292,15 +272,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.stream]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
      */
     @GenerateBridge
     fun stream(query: String, sort: Sort, vararg params: Any): Stream<Entity> = injectionMissing()
@@ -311,14 +289,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.stream]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
      */
     @GenerateBridge
     fun stream(query: String, params: Map<String, Any>): Stream<Entity> = injectionMissing()
@@ -329,15 +305,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params [Map] of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.stream]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
      */
     @GenerateBridge
     fun stream(query: String, sort: Sort, params: Map<String, Any>): Stream<Entity> = injectionMissing()
@@ -348,14 +322,12 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @param query a query string
+     * @param params Parameters of named parameters
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.stream]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
      */
     @GenerateBridge
     fun stream(query: String, params: Parameters): Stream<Entity> = injectionMissing()
@@ -366,15 +338,13 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
-     * @param params [Parameters] of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @param params Parameters of indexed parameters
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.stream]
+     * @see [PanacheCompanion.find]
+     * @see [PanacheCompanion.list]
      */
     @GenerateBridge
     fun stream(query: String, sort: Sort, params: Parameters): Stream<Entity> = injectionMissing()
@@ -385,10 +355,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @return a [Stream] containing all results, without paging
-     * @see .streamAll
-     * @see .findAll
-     * @see .listAll
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.streamAll]
+     * @see [PanacheCompanion.findAll]
+     * @see [PanacheCompanion.listAll]
      */
     @GenerateBridge
     fun streamAll(): Stream<Entity> = injectionMissing()
@@ -400,10 +370,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
      * @param sort the sort order to use
-     * @return a [Stream] containing all results, without paging
-     * @see .streamAll
-     * @see .findAll
-     * @see .listAll
+     * @return a Stream containing all results, without paging
+     * @see [PanacheCompanion.streamAll]
+     * @see [PanacheCompanion.findAll]
+     * @see [PanacheCompanion.listAll]
      */
     @GenerateBridge
     fun streamAll(sort: Sort): Stream<Entity> = injectionMissing()
@@ -412,9 +382,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Counts the number of this type of entity in the database.
      *
      * @return the number of this type of entity in the database.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheCompanion.count]
      */
     @GenerateBridge
     fun count(): Long = injectionMissing()
@@ -422,12 +390,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Counts the number of this type of entity matching the given query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return the number of entities counted.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheCompanion.count]
      */
     @GenerateBridge
     fun count(query: String, vararg params: Any): Long = injectionMissing()
@@ -435,12 +401,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return the number of entities counted.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheCompanion.count]
      */
     @GenerateBridge
     fun count(query: String, params: Map<String, Any>): Long = injectionMissing()
@@ -448,12 +412,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return the number of entities counted.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheCompanion.count]
      */
     @GenerateBridge
     fun count(query: String, params: Parameters): Long = injectionMissing()
@@ -462,9 +424,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Delete all entities of this type from the database.
      *
      * @return the number of entities deleted.
-     * @see .delete
-     * @see .delete
-     * @see .delete
+     * @see [PanacheCompanion.delete]
      */
     @GenerateBridge
     fun deleteAll(): Long = injectionMissing()
@@ -472,15 +432,38 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Delete all entities of this type matching the given query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return the number of entities deleted.
-     * @see .deleteAll
-     * @see .delete
-     * @see .delete
+     * @see [PanacheCompanion.deleteAll]
+     * @see [PanacheCompanion.delete]
      */
     @GenerateBridge
     fun delete(query: String, vararg params: Any): Long = injectionMissing()
+
+    /**
+     * Delete all entities of this type matching the given query, with named parameters.
+     *
+     * @param query a query string
+     * @param params [Map] of named parameters
+     * @return the number of entities deleted.
+     * @see [PanacheCompanion.deleteAll]
+     * @see [PanacheCompanion.delete]
+     */
+    @GenerateBridge
+    fun delete(query: String, params: Map<String, Any>): Long = injectionMissing()
+
+    /**
+     * Delete all entities of this type matching the given query, with named parameters.
+     *
+     * @param query a query string
+     * @param params Parameters of named parameters
+     * @return the number of entities deleted.
+     * @see [PanacheCompanion.deleteAll]
+     * @see [PanacheCompanion.delete]
+     */
+    @GenerateBridge
+    fun delete(query: String, params: Parameters): Long = injectionMissing()
 
     /**
      * Delete an entity of this type by ID.
@@ -492,38 +475,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     fun deleteById(id: Id): Boolean = throw JpaOperations.implementationInjectionMissing()
 
     /**
-     * Delete all entities of this type matching the given query, with named parameters.
-     *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Map] of named parameters
-     * @return the number of entities deleted.
-     * @see .deleteAll
-     * @see .delete
-     * @see .delete
-     */
-    @GenerateBridge
-    fun delete(query: String, params: Map<String, Any>): Long = injectionMissing()
-
-    /**
-     * Delete all entities of this type matching the given query, with named parameters.
-     *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
-     * @return the number of entities deleted.
-     * @see .deleteAll
-     * @see .delete
-     * @see .delete
-     */
-    @GenerateBridge
-    fun delete(query: String, params: Parameters): Long = injectionMissing()
-
-    /**
      * Persist all given entities.
      *
      * @param entities the entities to persist
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheCompanion.persist]
      */
     fun persist(entities: Iterable<Entity>) {
         JpaOperations.persist(entities)
@@ -533,9 +488,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Persist all given entities.
      *
      * @param entities the entities to persist
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheCompanion.persist]
      */
     fun persist(entities: Stream<Entity>) {
         JpaOperations.persist(entities)
@@ -545,22 +498,19 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * Persist all given entities.
      *
      * @param entities the entities to persist
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheCompanion.persist]
      */
-    fun persist(firstEntity: Any, vararg entities: Any) {
+    fun persist(firstEntity: Entity, vararg entities: Entity) {
         JpaOperations.persist(firstEntity, *entities)
     }
 
     /**
-     * Update all entities of this type matching the given query, with mandatory indexed parameters.
+     * Update all entities of this type matching the given query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return the number of entities updated.
-     * @see .update
-     * @see .update
+     * @see [PanacheCompanion.update]
      */
     @GenerateBridge
     fun update(query: String, vararg params: Any): Int = injectionMissing()
@@ -568,11 +518,10 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Update all entities of this type matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return the number of entities updated.
-     * @see .update
-     * @see .update
+     * @see [PanacheCompanion.update]
      */
     @GenerateBridge
     fun update(query: String, params: Map<String, Any>): Int = injectionMissing()
@@ -580,13 +529,11 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
     /**
      * Update all entities of this type matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return the number of entities updated.
-     * @see .update
-     * @see .update
+     * @see [PanacheCompanion.update]
      */
     @GenerateBridge
     fun update(query: String, params: Parameters): Int = injectionMissing()
 }
-

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheEntity.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheEntity.kt
@@ -5,12 +5,35 @@ import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
+/**
+ * Represents an entity with a generated ID field [id] of type [Long]. If your
+ * Hibernate entities extend this class they gain the ID field and auto-generated accessors
+ * to all their public fields (unless annotated with [Transient]), as well as all
+ * the useful methods from [PanacheEntityBase].
+ * <p>
+ * If you want a custom ID type or strategy, you can directly extend [PanacheEntityBase]
+ * instead, and write your own ID field. You will still get auto-generated accessors and
+ * all the useful methods.
+ *
+ * @see PanacheEntityBase
+ */
 @MappedSuperclass
 open class PanacheEntity: PanacheEntityBase {
+    /**
+     * The auto-generated ID field. This field is set by Hibernate ORM when this entity
+     * is persisted.
+     *
+     * @see [PanacheEntity.persist]
+     */
     @Id
     @GeneratedValue
     @JvmField
     var id: Long? = null
 
-    override fun toString() = this.javaClass.simpleName + "<" + id + ">"
+    /**
+     * Default toString() implementation
+     *
+     * @return the class type and ID type
+     */
+    override fun toString() = "${javaClass.simpleName}<$id>"
 }

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheEntityBase.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheEntityBase.kt
@@ -4,19 +4,64 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import io.quarkus.hibernate.orm.panache.kotlin.runtime.JpaOperations
 import javax.json.bind.annotation.JsonbTransient
 
+/**
+ * Represents an entity. If your Hibernate entities extend this class they gain auto-generated accessors
+ * to all their public fields (unless annotated with [Transient]), as well as a lot of useful
+ * methods. Unless you have a custom ID strategy, you should not extend this class directly but extend
+ * [PanacheEntity] instead.
+ *
+ * @see PanacheEntity
+ */
 interface PanacheEntityBase {
+    /**
+     * Returns true if this entity is persistent in the database. If yes, all modifications to
+     * its persistent fields will be automatically committed to the database at transaction
+     * commit time.
+     *
+     * @return true if this entity is persistent in the database.
+     */
     @JsonbTransient
     @JsonIgnore
-    fun isPersistent() = JpaOperations.isPersistent(this)
+    fun isPersistent(): Boolean = JpaOperations.isPersistent(this)
 
-    fun persist() = JpaOperations.persist(this)
+    /**
+     * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
+     *
+     * @see PanacheEntityBase.isPersistent
+     * @see PanacheEntityBase.flush
+     * @see PanacheEntityBase.persistAndFlush
+     */
+    fun persist() {
+        JpaOperations.persist(this)
+    }
 
+    /**
+     * Persist this entity in the database, if not already persisted. This will set your ID field if it is not already set.
+     * Then flushes all pending changes to the database.
+     *
+     * @see [PanacheEntityBase.isPersistent]
+     * @see [PanacheEntityBase.flush]
+     * @see [PanacheEntityBase.persist]
+     */
     fun persistAndFlush() {
         JpaOperations.persist(this)
         JpaOperations.flush()
     }
 
-    fun delete() = JpaOperations.delete(this)
+    /**
+     * Delete this entity from the database, if it is already persisted.
+     *
+     * @see [PanacheEntityBase.isPersistent]
+     * @see [PanacheCompanion.deleteAll]
+     */
+    fun delete() {
+        JpaOperations.delete(this)
+    }
 
-    fun flush() = JpaOperations.flush()
+    /**
+     * Flushes all pending changes to the database.
+     */
+    fun flush() {
+        JpaOperations.flush()
+    }
 }

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheQuery.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheQuery.kt
@@ -2,22 +2,21 @@ package io.quarkus.hibernate.orm.panache.kotlin
 
 import io.quarkus.panache.common.Page
 import io.quarkus.panache.common.Parameters
-import java.util.Optional
-import java.util.stream.Stream
-import javax.persistence.LockModeType
-import javax.persistence.NonUniqueResultException
 import org.hibernate.Session
 import org.hibernate.annotations.Filter
 import org.hibernate.annotations.FilterDef
+import java.util.stream.Stream
+import javax.persistence.LockModeType
+import javax.persistence.NonUniqueResultException
 
 /**
  * Interface representing an entity query, which abstracts the use of paging, getting the number of results, and
- * operating on [List] or [Stream].
+ * operating on [List] or java.util.Stream.
  *
  * Instances of this interface cannot mutate the query itself or its parameters: only paging information can be
  * modified, and instances of this interface can be reused to obtain multiple pages of results.
  *
- * @param <Entity> The entity type being queried
+ * @param Entity The entity type being queried
  */
 interface PanacheQuery<Entity: Any> {
     /**
@@ -26,15 +25,14 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return a new query with the same state as the previous one (params, page, range, lockMode, hints, ...).
      */
-    fun <Entity : Any> project(type: Class<Entity>?): PanacheQuery<Entity>
+    fun <NewEntity: Any> project(type: Class<NewEntity>): PanacheQuery<NewEntity>
 
     /**
      * Sets the current page.
      *
      * @param page the new page
      * @return this query, modified
-     * @see .page
-     * @see .page
+     * @see [PanacheQuery.page]
      */
     fun page(page: Page): PanacheQuery<Entity>
 
@@ -44,8 +42,7 @@ interface PanacheQuery<Entity: Any> {
      * @param pageIndex the page index
      * @param pageSize the page size
      * @return this query, modified
-     * @see .page
-     * @see .page
+     * @see [PanacheQuery.page]
      */
     fun page(pageIndex: Int, pageSize: Int): PanacheQuery<Entity>
 
@@ -54,7 +51,7 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return this query, modified
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .previousPage
+     * @see [PanacheQuery.previousPage]
      */
     fun nextPage(): PanacheQuery<Entity>
 
@@ -63,7 +60,7 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return this query, modified
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .nextPage
+     * @see [PanacheQuery.nextPage]
      */
     fun previousPage(): PanacheQuery<Entity>
 
@@ -72,7 +69,7 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return this query, modified
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .lastPage
+     * @see [PanacheQuery.lastPage]
      */
     fun firstPage(): PanacheQuery<Entity>
 
@@ -81,8 +78,8 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return this query, modified
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .firstPage
-     * @see .count
+     * @see [PanacheQuery.firstPage]
+     * @see [PanacheQuery.count]
      */
     fun lastPage(): PanacheQuery<Entity>
 
@@ -92,8 +89,8 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return true if there is another page to read
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .hasPreviousPage
-     * @see .count
+     * @see [PanacheQuery.hasPreviousPage]
+     * @see [PanacheQuery.count]
      */
     fun hasNextPage(): Boolean
 
@@ -102,7 +99,7 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return true if there is a previous page to read
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .hasNextPage
+     * @see [PanacheQuery.hasNextPage]
      */
     fun hasPreviousPage(): Boolean
 
@@ -120,8 +117,7 @@ interface PanacheQuery<Entity: Any> {
      *
      * @return the current page
      * @throws UnsupportedOperationException if a page hasn't been set or if a range is already set
-     * @see .page
-     * @see .page
+     * @see [PanacheQuery.page]
      */
     fun page(): Page
 
@@ -161,7 +157,7 @@ interface PanacheQuery<Entity: Any> {
      * will modify the session's filters for the duration of obtaining the results (not while building
      * the query). Enabled filters will be removed from the session afterwards, but no effort is made to
      * preserve filters enabled on the session outside of this API.
-     * 
+     *
      * @param filterName The name of the filter to enable
      * @param parameters The set of parameters for the filter, if the filter requires parameters
      * @return this query, modified
@@ -177,7 +173,7 @@ interface PanacheQuery<Entity: Any> {
      * will modify the session's filters for the duration of obtaining the results (not while building
      * the query). Enabled filters will be removed from the session afterwards, but no effort is made to
      * preserve filters enabled on the session outside of this API.
-     * 
+     *
      * @param filterName The name of the filter to enable
      * @param parameters The set of parameters for the filter, if the filter requires parameters
      * @return this query, modified
@@ -193,7 +189,7 @@ interface PanacheQuery<Entity: Any> {
      * will modify the session's filters for the duration of obtaining the results (not while building
      * the query). Enabled filters will be removed from the session afterwards, but no effort is made to
      * preserve filters enabled on the session outside of this API.
-     * 
+     *
      * @param filterName The name of the filter to enable
      * @return this query, modified
      */
@@ -201,7 +197,7 @@ interface PanacheQuery<Entity: Any> {
 
     /**
      * Reads and caches the total number of entities this query operates on. This causes a database
-     * query with `SELECT COUNT(*)` and a query equivalent to the current query, minus
+     * query with <code>SELECT COUNT(*)</code> and a query equivalent to the current query, minus
      * ordering.
      *
      * @return the total number of entities this query operates on, cached.
@@ -212,19 +208,17 @@ interface PanacheQuery<Entity: Any> {
      * Returns the current page of results as a [List].
      *
      * @return the current page of results as a [List].
-     * @see .stream
-     * @see .page
-     * @see .page
+     * @see [PanacheQuery.stream]
+     * @see [PanacheQuery.page]
      */
     fun list(): List<Entity>
 
     /**
-     * Returns the current page of results as a [Stream].
+     * Returns the current page of results as a Stream.
      *
-     * @return the current page of results as a [Stream].
-     * @see .list
-     * @see .page
-     * @see .page
+     * @return the current page of results as a Stream.
+     * @see [PanacheQuery.list]
+     * @see [PanacheQuery.page]
      */
     fun stream(): Stream<Entity>
 
@@ -233,18 +227,9 @@ interface PanacheQuery<Entity: Any> {
      * a single result.
      *
      * @return the first result of the current page index, or null if there are no results.
-     * @see .singleResult
+     * @see [PanacheQuery.singleResult]
      */
     fun firstResult(): Entity?
-
-    /**
-     * Returns the first result of the current page index. This ignores the current page size to fetch
-     * a single result.
-     *
-     * @return if found, an optional containing the entity, else `Optional.empty()`.
-     * @see .singleResultOptional
-     */
-    fun firstResultOptional(): Optional<Entity>
 
     /**
      * Executes this query for the current page and return a single result.
@@ -252,16 +237,7 @@ interface PanacheQuery<Entity: Any> {
      * @return the single result (throws if there is not exactly one)
      * @throws NoResultException if there is no result
      * @throws NonUniqueResultException if there are more than one result
-     * @see .firstResult
+     * @see [PanacheQuery.firstResult]
      */
-    fun singleResult(): Entity
-
-    /**
-     * Executes this query for the current page and return a single result.
-     *
-     * @return if found, an optional containing the entity, else `Optional.empty()`.
-     * @throws NonUniqueResultException if there are more than one result
-     * @see .firstResultOptional
-     */
-    fun singleResultOptional(): Optional<Entity>
+    fun singleResult(): Entity?
 }

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepository.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepository.kt
@@ -2,9 +2,9 @@ package io.quarkus.hibernate.orm.panache.kotlin
 
 /**
  * Represents a Repository for a specific type of entity `Entity`, with an ID type of `Long`. Implementing this
- * repository will gain you the exact same useful methods that are on [PanacheEntityBase]. If you have a custom ID
- * strategy, you should implement [PanacheRepositoryBase] instead.
+ * interface will gain you the exact same useful methods that are on [PanacheEntity] and [PanacheCompanion]. If you
+ * have a custom ID strategy, you should implement [PanacheRepositoryBase] instead.
  *
- * @param <Entity> The type of entity to operate on
+ * @param Entity The type of entity to operate on
  */
 interface PanacheRepository<Entity : Any>: PanacheRepositoryBase<Entity, Long>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepositoryBase.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheRepositoryBase.kt
@@ -8,34 +8,31 @@ import java.util.stream.Stream
 import javax.persistence.LockModeType
 
 /**
- * Represents a Repository for a specific type of entity `Entity`, with an ID type
- * of `Long`. Implementing this repository will gain you the exact same useful methods
- * that are on [PanacheEntityBase]. If you have a custom ID strategy, you should
- * implement [PanacheRepositoryBase] instead.
+ * Represents a Repository for a specific type of entity `Entity`, with an ID type of `Id`. Implementing this interface
+ * will gain you the exact same useful methods that are on [PanacheEntity] and [PanacheCompanion].
  *
- * @param <Entity> The type of entity to operate on
+ * @param Entity The type of entity to operate on
+ * @param Id The ID type of the entity
  */
 interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Persist the given entity in the database, if not already persisted.
      *
      * @param entity the entity to persist.
-     * @see .isPersistent
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheRepositoryBase.isPersistent]
+     * @see [PanacheRepositoryBase.persist]
      */
-    fun persist(entity: Entity) = JpaOperations.persist(entity)
+    fun persist(entity: Entity) {
+        JpaOperations.persist(entity)
+    }
 
     /**
      * Persist the given entity in the database, if not already persisted.
      * Then flushes all pending changes to the database.
      *
      * @param entity the entity to persist.
-     * @see .isPersistent
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheRepositoryBase.isPersistent]
+     * @see [PanacheRepositoryBase.persist]
      */
     fun persistAndFlush(entity: Entity) {
         JpaOperations.persist(entity)
@@ -46,13 +43,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Delete the given entity from the database, if it is already persisted.
      *
      * @param entity the entity to delete.
-     * @see .isPersistent
-     * @see .delete
-     * @see .delete
-     * @see .delete
-     * @see .deleteAll
+     * @see [PanacheRepositoryBase.isPersistent]
+     * @see [PanacheRepositoryBase.delete]
+     * @see [PanacheRepositoryBase.deleteAll]
      */
-    fun delete(entity: Entity) = JpaOperations.delete(entity)
+    fun delete(entity: Entity) {
+        JpaOperations.delete(entity)
+    }
 
     /**
      * Returns true if the given entity is persistent in the database. If yes, all modifications to
@@ -67,7 +64,9 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Flushes all pending changes to the database.
      */
-    fun flush() = JpaOperations.flush()
+    fun flush() {
+        JpaOperations.flush()
+    }
 
     /**
      * Find an entity of this type by ID.
@@ -76,7 +75,7 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * @return the entity found, or `null` if not found.
      */
     @GenerateBridge(targetReturnTypeErased = true)
-    fun findById(id: Id?): Entity? = injectionMissing()
+    fun findById(id: Id): Entity? = injectionMissing()
 
     /**
      * Find an entity of this type by ID and lock it.
@@ -86,19 +85,17 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * @return the entity found, or `null` if not found.
      */
     @GenerateBridge(targetReturnTypeErased = true)
-    fun findById(id: Id?, lockModeType: LockModeType): Entity? = injectionMissing()
+    fun findById(id: Id, lockModeType: LockModeType): Entity? = injectionMissing()
 
     /**
      * Find entities using a query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun find(query: String, vararg params: Any): PanacheQuery<Entity> = injectionMissing()
@@ -106,15 +103,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Find entities using a query and the given sort options, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun find(query: String, sort: Sort, vararg params: Any): PanacheQuery<Entity> = injectionMissing()
@@ -122,14 +117,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Find entities using a query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun find(query: String, params: Map<String, Any>): PanacheQuery<Entity> = injectionMissing()
@@ -137,15 +130,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Find entities using a query and the given sort options, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params [Map] of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun find(query: String, sort: Sort, params: Map<String, Any>): PanacheQuery<Entity> = injectionMissing()
@@ -153,14 +144,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Find entities using a query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun find(query: String, params: Parameters): PanacheQuery<Entity> = injectionMissing()
@@ -168,15 +157,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Find entities using a query and the given sort options, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
-     * @param params [Parameters] of indexed parameters
+     * @param params Parameters of indexed parameters
      * @return a new [PanacheQuery] instance for the given query
-     * @see .find
-     * @see .find
-     * @see .find
-     * @see .list
-     * @see .stream
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun find(query: String, sort: Sort, params: Parameters): PanacheQuery<Entity> = injectionMissing()
@@ -185,9 +172,9 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find all entities of this type.
      *
      * @return a new [PanacheQuery] instance to find all entities of this type.
-     * @see .findAll
-     * @see .listAll
-     * @see .streamAll
+     * @see [PanacheRepositoryBase.findAll]
+     * @see [PanacheRepositoryBase.listAll]
+     * @see [PanacheRepositoryBase.streamAll]
      */
     @GenerateBridge
     fun findAll(): PanacheQuery<Entity> = injectionMissing()
@@ -197,9 +184,9 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      *
      * @param sort the sort order to use
      * @return a new [PanacheQuery] instance to find all entities of this type.
-     * @see .findAll
-     * @see .listAll
-     * @see .streamAll
+     * @see [PanacheRepositoryBase.findAll]
+     * @see [PanacheRepositoryBase.listAll]
+     * @see [PanacheRepositoryBase.streamAll]
      */
     @GenerateBridge
     fun findAll(sort: Sort): PanacheQuery<Entity> = injectionMissing()
@@ -208,14 +195,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find entities matching a query, with optional indexed parameters.
      * This method is a shortcut for `find(query, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun list(query: String, vararg params: Any): List<Entity> = injectionMissing()
@@ -224,15 +209,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find entities matching a query and the given sort options, with optional indexed parameters.
      * This method is a shortcut for `find(query, sort, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun list(query: String, sort: Sort, vararg params: Any): List<Entity> = injectionMissing()
@@ -241,14 +224,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find entities matching a query, with named parameters.
      * This method is a shortcut for `find(query, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun list(query: String, params: Map<String, Any>): List<Entity> = injectionMissing()
@@ -257,15 +238,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find entities matching a query and the given sort options, with named parameters.
      * This method is a shortcut for `find(query, sort, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params [Map] of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun list(query: String, sort: Sort, params: Map<String, Any>): List<Entity> = injectionMissing()
@@ -274,14 +253,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find entities matching a query, with named parameters.
      * This method is a shortcut for `find(query, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun list(query: String, params: Parameters): List<Entity> = injectionMissing()
@@ -290,15 +267,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Find entities matching a query and the given sort options, with named parameters.
      * This method is a shortcut for `find(query, sort, params).list()`.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
-     * @param params [Parameters] of indexed parameters
+     * @param params Parameters of indexed parameters
      * @return a [List] containing all results, without paging
-     * @see .list
-     * @see .list
-     * @see .list
-     * @see .find
-     * @see .stream
+     * @see [PanacheRepositoryBase.list]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.stream]
      */
     @GenerateBridge
     fun list(query: String, sort: Sort, params: Parameters): List<Entity> = injectionMissing()
@@ -308,9 +283,9 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * This method is a shortcut for `findAll().list()`.
      *
      * @return a [List] containing all results, without paging
-     * @see .listAll
-     * @see .findAll
-     * @see .streamAll
+     * @see [PanacheRepositoryBase.listAll]
+     * @see [PanacheRepositoryBase.findAll]
+     * @see [PanacheRepositoryBase.streamAll]
      */
     @GenerateBridge
     fun listAll(): List<Entity> = injectionMissing()
@@ -321,9 +296,9 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      *
      * @param sort the sort order to use
      * @return a [List] containing all results, without paging
-     * @see .listAll
-     * @see .findAll
-     * @see .streamAll
+     * @see [PanacheRepositoryBase.listAll]
+     * @see [PanacheRepositoryBase.findAll]
+     * @see [PanacheRepositoryBase.streamAll]
      */
     @GenerateBridge
     fun listAll(sort: Sort): List<Entity> = injectionMissing()
@@ -334,18 +309,15 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.stream]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
     fun stream(query: String, vararg params: Any): Stream<Entity> = injectionMissing()
-
 
     /**
      * Find entities matching a query and the given sort options, with optional indexed parameters.
@@ -353,15 +325,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params optional sequence of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.stream]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
     fun stream(query: String, sort: Sort, vararg params: Any): Stream<Entity> = injectionMissing()
@@ -372,14 +342,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.stream]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
     fun stream(query: String, params: Map<String, Any>): Stream<Entity> = injectionMissing()
@@ -390,15 +358,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
      * @param params [Map] of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.stream]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
     fun stream(query: String, sort: Sort, params: Map<String, Any>): Stream<Entity> = injectionMissing()
@@ -409,14 +375,12 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @param query a query string
+     * @param params Parameters of named parameters
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.stream]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
     fun stream(query: String, params: Parameters): Stream<Entity> = injectionMissing()
@@ -427,15 +391,13 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param sort the sort strategy to use
-     * @param params [Parameters] of indexed parameters
-     * @return a [Stream] containing all results, without paging
-     * @see .stream
-     * @see .stream
-     * @see .stream
-     * @see .find
-     * @see .list
+     * @param params Parameters of indexed parameters
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.stream]
+     * @see [PanacheRepositoryBase.find]
+     * @see [PanacheRepositoryBase.list]
      */
     @GenerateBridge
     fun stream(query: String, sort: Sort, params: Parameters): Stream<Entity> = injectionMissing()
@@ -446,35 +408,34 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * It requires a transaction to work.
      * Without a transaction, the underlying cursor can be closed before the end of the stream.
      *
-     * @return a [Stream] containing all results, without paging
-     * @see .streamAll
-     * @see .findAll
-     * @see .listAll
-     */
-    @GenerateBridge
-    fun streamAll(sort: Sort): Stream<Entity> = injectionMissing()
-
-    /**
-     * Find all entities of this type, in the given order.
-     * This method is a shortcut for `findAll().stream()`.
-     * It requires a transaction to work.
-     * Without a transaction, the underlying cursor can be closed before the end of the stream.
-     *
-     * @return a [Stream] containing all results, without paging
-     * @see .streamAll
-     * @see .findAll
-     * @see .listAll
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.streamAll]
+     * @see [PanacheRepositoryBase.findAll]
+     * @see [PanacheRepositoryBase.listAll]
      */
     @GenerateBridge
     fun streamAll(): Stream<Entity> = injectionMissing()
 
     /**
+     * Find all entities of this type, in the given order.
+     * This method is a shortcut for `findAll(sort).stream()`.
+     * It requires a transaction to work.
+     * Without a transaction, the underlying cursor can be closed before the end of the stream.
+     *
+     * @param sort the sort order to use
+     * @return a Stream containing all results, without paging
+     * @see [PanacheRepositoryBase.streamAll]
+     * @see [PanacheRepositoryBase.findAll]
+     * @see [PanacheRepositoryBase.listAll]
+     */
+    @GenerateBridge
+    fun streamAll(sort: Sort): Stream<Entity> = injectionMissing()
+
+    /**
      * Counts the number of this type of entity in the database.
      *
      * @return the number of this type of entity in the database.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheRepositoryBase.count]
      */
     @GenerateBridge
     fun count(): Long = injectionMissing()
@@ -482,12 +443,10 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Counts the number of this type of entity matching the given query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return the number of entities counted.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheRepositoryBase.count]
      */
     @GenerateBridge
     fun count(query: String, vararg params: Any): Long = injectionMissing()
@@ -495,12 +454,10 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return the number of entities counted.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheRepositoryBase.count]
      */
     @GenerateBridge
     fun count(query: String, params: Map<String, Any>): Long = injectionMissing()
@@ -508,12 +465,10 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Counts the number of this type of entity matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return the number of entities counted.
-     * @see .count
-     * @see .count
-     * @see .count
+     * @see [PanacheRepositoryBase.count]
      */
     @GenerateBridge
     fun count(query: String, params: Parameters): Long = injectionMissing()
@@ -522,9 +477,7 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Delete all entities of this type from the database.
      *
      * @return the number of entities deleted.
-     * @see .delete
-     * @see .delete
-     * @see .delete
+     * @see [PanacheRepositoryBase.delete]
      */
     @GenerateBridge
     fun deleteAll(): Long = injectionMissing()
@@ -532,12 +485,11 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Delete all entities of this type matching the given query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return the number of entities deleted.
-     * @see .deleteAll
-     * @see .delete
-     * @see .delete
+     * @see [PanacheRepositoryBase.deleteAll]
+     * @see [PanacheRepositoryBase.delete]
      */
     @GenerateBridge
     fun delete(query: String, vararg params: Any): Long = injectionMissing()
@@ -545,12 +497,11 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Delete all entities of this type matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return the number of entities deleted.
-     * @see .deleteAll
-     * @see .delete
-     * @see .delete
+     * @see [PanacheRepositoryBase.deleteAll]
+     * @see [PanacheRepositoryBase.delete]
      */
     @GenerateBridge
     fun delete(query: String, params: Map<String, Any>): Long = injectionMissing()
@@ -558,12 +509,11 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Delete all entities of this type matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return the number of entities deleted.
-     * @see .deleteAll
-     * @see .delete
-     * @see .delete
+     * @see [PanacheRepositoryBase.deleteAll]
+     * @see [PanacheRepositoryBase.delete]
      */
     @GenerateBridge
     fun delete(query: String, params: Parameters): Long = injectionMissing()
@@ -581,40 +531,39 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
      * Persist all given entities.
      *
      * @param entities the entities to persist
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheRepositoryBase.persist]
      */
-    fun persist(entities: Iterable<Entity>) = JpaOperations.persist(entities)
+    fun persist(entities: Iterable<Entity>) {
+        JpaOperations.persist(entities)
+    }
 
     /**
      * Persist all given entities.
      *
      * @param entities the entities to persist
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheRepositoryBase.persist]
      */
-    fun persist(entities: Stream<Entity>) = JpaOperations.persist(entities)
+    fun persist(entities: Stream<Entity>) {
+        JpaOperations.persist(entities)
+    }
 
     /**
      * Persist all given entities.
      *
      * @param entities the entities to persist
-     * @see .persist
-     * @see .persist
-     * @see .persist
+     * @see [PanacheRepositoryBase.persist]
      */
-    fun persist(firstEntity: Entity, vararg entities: Entity) = JpaOperations.persist(firstEntity, *entities)
+    fun persist(firstEntity: Entity, vararg entities: Entity) {
+        JpaOperations.persist(firstEntity, *entities)
+    }
 
     /**
      * Update all entities of this type matching the given query, with optional indexed parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params optional sequence of indexed parameters
      * @return the number of entities updated.
-     * @see .update
-     * @see .update
+     * @see [PanacheRepositoryBase.update]
      */
     @GenerateBridge
     fun update(query: String, vararg params: Any): Int = injectionMissing()
@@ -622,11 +571,10 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Update all entities of this type matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
+     * @param query a query string
      * @param params [Map] of named parameters
      * @return the number of entities updated.
-     * @see .update
-     * @see .update
+     * @see [PanacheRepositoryBase.update]
      */
     @GenerateBridge
     fun update(query: String, params: Map<String, Any>): Int = injectionMissing()
@@ -634,12 +582,11 @@ interface PanacheRepositoryBase<Entity : Any, Id: Any> {
     /**
      * Update all entities of this type matching the given query, with named parameters.
      *
-     * @param query a [query string][io.quarkus.hibernate.orm.panache]
-     * @param params [Parameters] of named parameters
+     * @param query a query string
+     * @param params Parameters of named parameters
      * @return the number of entities updated.
-     * @see .update
-     * @see .update
+     * @see [PanacheRepositoryBase.update]
      */
     @GenerateBridge
     fun update(query: String, params: Parameters): Int = injectionMissing()
-} 
+}

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/TestEndpoint.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/TestEndpoint.kt
@@ -137,7 +137,7 @@ class TestEndpoint {
         Assertions.assertEquals(person, Person.find("name", "stef").firstResult())
         Assertions.assertEquals(person, Person.find("name", "stef").singleResult())
 
-        var byId: Person = Person.findById(person.id!!)
+        var byId: Person? = person.id?.let { Person.findById(it) }
         Assertions.assertEquals(person, byId)
         Assertions.assertEquals("Person<" + person.id + ">", byId.toString())
 
@@ -145,7 +145,7 @@ class TestEndpoint {
 //        Assertions.assertEquals(person, byId)
 //        Assertions.assertEquals("Person<" + person.id + ">", byId.toString())
 
-        byId = Person.findById(person.id!!, LockModeType.PESSIMISTIC_READ)
+        byId = person.id?.let { Person.findById(it, LockModeType.PESSIMISTIC_READ) }
         Assertions.assertEquals(person, byId)
         Assertions.assertEquals("Person<" + person.id + ">", byId.toString())
 
@@ -481,11 +481,7 @@ class TestEndpoint {
         } catch (x: NoResultException) {
         }
 
-        Assertions.assertFalse(personRepository.findAll().singleResultOptional().isPresent())
-
         Assertions.assertNull(personRepository.findAll().firstResult())
-
-        Assertions.assertFalse(personRepository.findAll().firstResultOptional().isPresent())
 
         var person: Person = makeSavedPersonDao()
         Assertions.assertNotNull(person.id)
@@ -515,7 +511,6 @@ class TestEndpoint {
 
         Assertions.assertEquals(person, personRepository.findAll().firstResult())
         Assertions.assertEquals(person, personRepository.findAll().singleResult())
-//        Assertions.assertEquals(person, personDao.findAll().singleResultOptional().get())
 
         persons = personRepository.find("name = ?1", "stef").list()
         Assertions.assertEquals(1, persons.size)
@@ -566,19 +561,12 @@ class TestEndpoint {
 
         Assertions.assertEquals(person, personRepository.find("name", "stef").firstResult())
         Assertions.assertEquals(person, personRepository.find("name", "stef").singleResult())
-//        Assertions.assertEquals(person, personDao.find("name", "stef").singleResultOptional().get())
 
-        var byId = personRepository.findById(person.id)
+        var byId = person.id?.let { personRepository.findById(it) }
         Assertions.assertEquals(person, byId)
 
-//        byId = personDao.findByIdOptional(person.id).get()
-//        Assertions.assertEquals(person, byId)
-
-        byId = personRepository.findById(person.id, LockModeType.PESSIMISTIC_READ)
+        byId = person.id?.let { personRepository.findById(it, LockModeType.PESSIMISTIC_READ) }
         Assertions.assertEquals(person, byId)
-
-//        byId = personDao.findByIdOptional(person.id, LockModeType.PESSIMISTIC_READ).get()
-//        Assertions.assertEquals(person, byId)
 
         personRepository.delete(person)
         Assertions.assertEquals(0, personRepository.count())


### PR DESCRIPTION
add autoboxing code for non-nullable ID types

kotlinc implements `Int` as java `int` and `Int?` as a java `Integer` e.g. so some autoboxing code is needed to upconvert those primitives to the wrapper types.  This appears to have only affected the repository side of world for reasons I haven't quite ascertained.