### PR TITLE
Add codec section to the event bus guide

### DIFF
--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Asynchronous messages between beans
+= Quarkus - Using the event bus
 
 include::./attributes.adoc[]
 

--- a/docs/src/main/asciidoc/reactive-messaging.adoc
+++ b/docs/src/main/asciidoc/reactive-messaging.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-Quarkus allows different beans to interact using asynchronous messages, enforcing loose-coupling.
+Quarkus allows different beans to interact using asynchronous events, thus promoting loose-coupling.
 The messages are sent to _virtual addresses_.
 It offers 3 types of delivery mechanism:
 
@@ -362,3 +362,46 @@ You can also compile it as a native executable with:
 ----
 ./mvnw clean package -Pnative
 ----
+
+== Using codecs
+
+The https://vertx.io/docs/vertx-core/java/#event_bus[Vert.x Event Bus] uses codecs to _serialize_ and _deserialize_ objects.
+Quarkus provides a default codec for local delivery.
+So you can exchange objects as follows:
+
+[source, java]
+----
+@GET
+@Produces(MediaType.TEXT_PLAIN)
+@Path("{name}")
+public Uni<String> greeting(@PathParam String name) {
+    return bus.<String>request("greeting", new MyName(name))
+        .onItem().apply(Message::body);
+}
+
+@ConsumeEvent(value = "greeting")
+Uni<String> greeting(MyName name) {
+    return Uni.createFrom().item(() -> "Hello " + name.getName());
+}
+----
+
+If you want to use a specific codec, you need to explicitly set it on both ends:
+
+[source, java]
+----
+@GET
+@Produces(MediaType.TEXT_PLAIN)
+@Path("{name}")
+public Uni<String> greeting(@PathParam String name) {
+    return bus.<String>request("greeting", name,
+        new DeliveryOptions().setCodecName(MyNameCodec.class.getName())) // <1>
+        .onItem().apply(Message::body);
+}
+
+@ConsumeEvent(value = "greeting", codec = MyNameCodec.class)            // <2>
+Uni<String> greeting(MyName name) {
+    return Uni.createFrom().item(() -> "Hello "+name.getName());
+}
+----
+1. Set the name of the codec to use to send the message
+2. Set the codec to use to receive the message

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -709,7 +709,7 @@ There are many other facets of Quarkus using Vert.x underneath:
 
 * The event bus is the connecting tissue of Vert.x applications.
 Quarkus integrates it so different beans can interact with asynchronous messages.
-This part is covered in the link:reactive-messaging[Async Message Passing documentation].
+This part is covered in the link:reactive-event-bus[event bus documentation].
 
 * Data streaming and Apache Kafka are a important parts of modern systems.
 Quarkus integrates data streaming using Reactive Messaging.


### PR DESCRIPTION
This PR:

* adds a section about the usage of codecs to the event bus / `@ConsumeEvent` guide
* renames the guide to `reactive-event-bus` instead of `reactive-messaging` as `reactive-messaging` is something else

