### PR TITLE
Properly support JUnit 5 parameters on test methods

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkus/it/arc/UnusedBean.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/arc/UnusedBean.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.arc;
 
+import java.util.List;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
@@ -12,6 +14,53 @@ public class UnusedBean {
 
     public InjectionPoint getInjectionPoint() {
         return injectionPoint;
+    }
+
+    public DummyResult dummy(DummyInput dummyInput) {
+        return new DummyResult(dummyInput.getName() + "/"
+                + dummyInput.getNestedDummyInput().getNums().stream().mapToInt(Integer::intValue).sum());
+    }
+
+    public static class DummyResult {
+        private final String result;
+
+        public DummyResult(String result) {
+            this.result = result;
+        }
+
+        public String getResult() {
+            return result;
+        }
+    }
+
+    public static class DummyInput {
+        private final String name;
+        private final NestedDummyInput nestedDummyInput;
+
+        public DummyInput(String name, NestedDummyInput nestedDummyInput) {
+            this.name = name;
+            this.nestedDummyInput = nestedDummyInput;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public NestedDummyInput getNestedDummyInput() {
+            return nestedDummyInput;
+        }
+    }
+
+    public static class NestedDummyInput {
+        private final List<Integer> nums;
+
+        public NestedDummyInput(List<Integer> nums) {
+            this.nums = nums;
+        }
+
+        public List<Integer> getNums() {
+            return nums;
+        }
     }
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MethodSourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MethodSourceTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.quarkus.it.arc.UnusedBean;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class MethodSourceTest {
+
+    @Inject
+    UnusedBean unusedBean;
+
+    @ParameterizedTest
+    @MethodSource("provideDummyInput")
+    public void testParameterResolver(UnusedBean.DummyInput dummyInput, Matcher<String> matcher) {
+        UnusedBean.DummyResult dummyResult = unusedBean.dummy(dummyInput);
+        assertThat(dummyResult.getResult(), matcher);
+    }
+
+    private static Collection<Arguments> provideDummyInput() {
+        return Arrays.asList(
+                Arguments.of(
+                        new UnusedBean.DummyInput("whatever", new UnusedBean.NestedDummyInput(Arrays.asList(1, 2, 3))),
+                        CoreMatchers.is("whatever/6")),
+                Arguments.of(
+                        new UnusedBean.DummyInput("hi", new UnusedBean.NestedDummyInput(Collections.emptyList())),
+                        CoreMatchers.is("hi/0")));
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ParameterResolverTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ParameterResolverTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import io.quarkus.it.arc.UnusedBean;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@ExtendWith(ParameterResolverTest.UnusedBeanDummyInputResolver.class)
+public class ParameterResolverTest {
+
+    @Inject
+    UnusedBean unusedBean;
+
+    @Test
+    public void testParameterResolver(UnusedBean.DummyInput dummyInput) {
+        UnusedBean.DummyResult dummyResult = unusedBean.dummy(dummyInput);
+        assertEquals("whatever/6", dummyResult.getResult());
+    }
+
+    public static class UnusedBeanDummyInputResolver implements ParameterResolver {
+
+        @Override
+        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+                throws ParameterResolutionException {
+            return UnusedBean.DummyInput.class.getName().equals(parameterContext.getParameter().getType().getName());
+        }
+
+        @Override
+        public Object resolveParameter(ParameterContext parameterContext,
+                ExtensionContext extensionContext) throws ParameterResolutionException {
+            return new UnusedBean.DummyInput("whatever", new UnusedBean.NestedDummyInput(Arrays.asList(1, 2, 3)));
+        }
+    }
+
+}

--- a/test-framework/junit5/pom.xml
+++ b/test-framework/junit5/pom.xml
@@ -38,6 +38,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <!-- Avoid adding this to the BOM / Version has to be kept in sync with what optaplanner uses otherwise the enforcer complains -->
+            <version>1.4.11.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/DeepClone.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/DeepClone.java
@@ -1,0 +1,11 @@
+package io.quarkus.test.junit.internal;
+
+/**
+ * Strategy to deep clone an object
+ *
+ * Used in order to clone an object loaded from one ClassLoader into another
+ */
+public interface DeepClone {
+
+    Object clone(Object objectToClone);
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/XStreamDeepClone.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/XStreamDeepClone.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.junit.internal;
+
+import com.thoughtworks.xstream.XStream;
+
+/**
+ * Super simple cloning strategy that just serializes to XML and deserializes it using xstream
+ */
+public class XStreamDeepClone implements DeepClone {
+
+    private final XStream xStream;
+
+    public XStreamDeepClone(ClassLoader classLoader) {
+        xStream = new XStream();
+        XStream.setupDefaultSecurity(xStream);
+        xStream.allowTypesByRegExp(new String[] { ".*" });
+        xStream.setClassLoader(classLoader);
+    }
+
+    public Object clone(Object objectToClone) {
+        final String serialized = xStream.toXML(objectToClone);
+        return xStream.fromXML(serialized);
+    }
+}


### PR DESCRIPTION
This is done by deep-cloning the objects into the TCCL
before actually passing them to the test

Fixes #8251, fixes #8703, fixes #8978