### PR TITLE
Translation between a Java exception and a gRPC error status

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/ServerCalls.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/ServerCalls.java
@@ -147,7 +147,16 @@ public class ServerCalls {
         if (throwable instanceof StatusException || throwable instanceof StatusRuntimeException) {
             return throwable;
         } else {
-            return Status.fromThrowable(throwable).asException();
+            String desc = throwable.getClass().getName();
+            if (throwable.getMessage() != null) {
+                desc += " - " + throwable.getMessage();
+            }
+            if (throwable instanceof IllegalArgumentException) {
+                return Status.INVALID_ARGUMENT.withDescription(desc).asException();
+            }
+            return Status.fromThrowable(throwable)
+                    .withDescription(desc)
+                    .asException();
         }
     }
 }


### PR DESCRIPTION
Improve the transformation from Java exception to gRPC status, so the description contains the primary message.

When using `grpcurl` it provides some hint about the issue as by default the description was empty and the status `unknown`.