### PR TITLE
Improve usability of @ConfigProperties

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ClassConfigPropertiesUtil.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ClassConfigPropertiesUtil.java
@@ -267,26 +267,37 @@ final class ClassConfigPropertiesUtil {
                  */
                 DotName fieldTypeDotName = fieldType.name();
                 ClassInfo fieldTypeClassInfo = applicationIndex.getClassByName(fieldType.name());
+                ResultHandle mpConfig = methodCreator.getMethodParam(0);
                 if (fieldTypeClassInfo != null) {
-                    if (!fieldTypeClassInfo.hasNoArgsConstructor()) {
-                        throw new IllegalArgumentException(
-                                "Nested configuration class '" + fieldTypeClassInfo + "' must contain a no-args constructor ");
+                    if (DotNames.ENUM.equals(fieldTypeClassInfo.superName())) {
+                        // just read the value from MP Config normally
+                        ResultHandle value = methodCreator.invokeInterfaceMethod(
+                                MethodDescriptor.ofMethod(Config.class, "getValue", Object.class, String.class, Class.class),
+                                mpConfig,
+                                methodCreator.load(getFullConfigName(prefixStr, namingStrategy, field)),
+                                methodCreator.loadClass(fieldTypeDotName.toString()));
+
+                        createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, value);
+                    } else {
+                        if (!fieldTypeClassInfo.hasNoArgsConstructor()) {
+                            throw new IllegalArgumentException(
+                                    "Nested configuration class '" + fieldTypeClassInfo
+                                            + "' must contain a no-args constructor ");
+                        }
+
+                        if (!Modifier.isPublic(fieldTypeClassInfo.flags())) {
+                            throw new IllegalArgumentException(
+                                    "Nested configuration class '" + fieldTypeClassInfo + "' must be public ");
+                        }
+
+                        ResultHandle nestedConfigObject = populateConfigObject(classLoader, fieldTypeClassInfo,
+                                getFullConfigName(prefixStr, namingStrategy, field), namingStrategy, failOnMismatchingMember,
+                                methodCreator,
+                                applicationIndex, configProperties);
+                        createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, nestedConfigObject);
                     }
-
-                    if (!Modifier.isPublic(fieldTypeClassInfo.flags())) {
-                        throw new IllegalArgumentException(
-                                "Nested configuration class '" + fieldTypeClassInfo + "' must be public ");
-                    }
-
-                    ResultHandle nestedConfigObject = populateConfigObject(classLoader, fieldTypeClassInfo,
-                            prefixStr + "." + namingStrategy.getName(field.name()), namingStrategy, failOnMismatchingMember,
-                            methodCreator,
-                            applicationIndex, configProperties);
-                    createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, nestedConfigObject);
-
                 } else {
-                    String fullConfigName = prefixStr + "." + namingStrategy.getName(field.name());
-                    ResultHandle config = methodCreator.getMethodParam(0);
+                    String fullConfigName = getFullConfigName(prefixStr, namingStrategy, field);
                     if (DotNames.OPTIONAL.equals(fieldTypeDotName)) {
                         Type genericType = determineSingleGenericType(field.type(),
                                 field.declaringClass().name());
@@ -296,14 +307,14 @@ final class ClassConfigPropertiesUtil {
                             ResultHandle setterValue = methodCreator.invokeInterfaceMethod(
                                     MethodDescriptor.ofMethod(Config.class, "getOptionalValue", Optional.class, String.class,
                                             Class.class),
-                                    config, methodCreator.load(fullConfigName),
+                                    mpConfig, methodCreator.load(fullConfigName),
                                     methodCreator.loadClass(genericType.name().toString()));
                             createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, setterValue);
                         } else {
                             // convert the String value and populate an Optional with it
                             ReadOptionalResponse readOptionalResponse = createReadOptionalValueAndConvertIfNeeded(
                                     fullConfigName,
-                                    genericType, field.declaringClass().name(), methodCreator, config);
+                                    genericType, field.declaringClass().name(), methodCreator, mpConfig);
                             createWriteValue(readOptionalResponse.getIsPresentTrue(), configObject, field, setter,
                                     useFieldAccess,
                                     readOptionalResponse.getIsPresentTrue().invokeStaticMethod(
@@ -329,7 +340,7 @@ final class ClassConfigPropertiesUtil {
 
                             ReadOptionalResponse readOptionalResponse = createReadOptionalValueAndConvertIfNeeded(
                                     fullConfigName,
-                                    fieldType, field.declaringClass().name(), methodCreator, config);
+                                    fieldType, field.declaringClass().name(), methodCreator, mpConfig);
 
                             // call the setter if the optional contained data
                             createWriteValue(readOptionalResponse.getIsPresentTrue(), configObject, field, setter,
@@ -342,7 +353,7 @@ final class ClassConfigPropertiesUtil {
                              */
                             ResultHandle setterValue = createReadMandatoryValueAndConvertIfNeeded(
                                     fullConfigName, fieldType,
-                                    field.declaringClass().name(), methodCreator, config);
+                                    field.declaringClass().name(), methodCreator, mpConfig);
                             createWriteValue(methodCreator, configObject, field, setter, useFieldAccess, setterValue);
 
                         }
@@ -380,6 +391,10 @@ final class ClassConfigPropertiesUtil {
         }
 
         return configObject;
+    }
+
+    private static String getFullConfigName(String prefixStr, ConfigProperties.NamingStrategy namingStrategy, FieldInfo field) {
+        return prefixStr + "." + namingStrategy.getName(field.name());
     }
 
     private static void createWriteValue(BytecodeCreator bytecodeCreator, ResultHandle configObject, FieldInfo field,

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ClassConfigPropertiesUtil.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ClassConfigPropertiesUtil.java
@@ -227,6 +227,9 @@ final class ClassConfigPropertiesUtil {
             // For each field of the class try to pull it out of MP Config and call the corresponding setter
             List<FieldInfo> fields = currentClassInHierarchy.fields();
             for (FieldInfo field : fields) {
+                if (Modifier.isStatic(field.flags())) { // nothing we need to do about static fields
+                    continue;
+                }
                 if (field.hasAnnotation(DotNames.CONFIG_PROPERTY)) {
                     LOGGER.warn(
                             "'@ConfigProperty' is ignored when added to a field of a class annotated with '@ConfigProperties'. Offending field is '"

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ClassConfigPropertiesUtil.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ClassConfigPropertiesUtil.java
@@ -352,10 +352,18 @@ final class ClassConfigPropertiesUtil {
             if (superClassDotName.equals(DotNames.OBJECT)) {
                 break;
             }
-            currentClassInHierarchy = applicationIndex.getClassByName(superClassDotName);
-            if (currentClassInHierarchy == null) {
+
+            ClassInfo newCurrentClassInHierarchy = applicationIndex.getClassByName(superClassDotName);
+            if (newCurrentClassInHierarchy == null) {
+                if (!superClassDotName.toString().startsWith("java.")) {
+                    LOGGER.warn("Class '" + superClassDotName + "' which is a parent class of '"
+                            + currentClassInHierarchy.name()
+                            + "' is not part of the Jandex index so its fields will be ignored. If you intended to include these fields, consider making the dependency part of the Jandex index by following the advice at: https://quarkus.io/guides/cdi-reference#bean_discovery");
+                }
                 break;
             }
+
+            currentClassInHierarchy = newCurrentClassInHierarchy;
         }
 
         for (ConfigPropertyBuildItemCandidate candidate : configPropertyBuildItemCandidates) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ConfigPropertiesMetadataBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ConfigPropertiesMetadataBuildItem.java
@@ -16,13 +16,15 @@ public final class ConfigPropertiesMetadataBuildItem extends MultiBuildItem {
     private final ClassInfo classInfo;
     private final String prefix;
     private final ConfigProperties.NamingStrategy namingStrategy;
+    private final boolean failOnMismatchingMember;
     private final boolean needsQualifier;
 
     public ConfigPropertiesMetadataBuildItem(ClassInfo classInfo, String prefix,
-            ConfigProperties.NamingStrategy namingStrategy, boolean needsQualifier) {
+            ConfigProperties.NamingStrategy namingStrategy, boolean failOnMismatchingMember, boolean needsQualifier) {
         this.classInfo = classInfo;
         this.prefix = sanitisePrefix(prefix);
         this.namingStrategy = namingStrategy;
+        this.failOnMismatchingMember = failOnMismatchingMember;
         this.needsQualifier = needsQualifier;
     }
 
@@ -36,6 +38,10 @@ public final class ConfigPropertiesMetadataBuildItem extends MultiBuildItem {
 
     public ConfigProperties.NamingStrategy getNamingStrategy() {
         return namingStrategy;
+    }
+
+    public boolean isFailOnMismatchingMember() {
+        return failOnMismatchingMember;
     }
 
     public boolean isNeedsQualifier() {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/DotNames.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/DotNames.java
@@ -22,6 +22,7 @@ final class DotNames {
     static final DotName LIST = DotName.createSimple(List.class.getName());
     static final DotName SET = DotName.createSimple(Set.class.getName());
     static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
+    static final DotName ENUM = DotName.createSimple(Enum.class.getName());
     static final DotName CONFIG_PROPERTIES = DotName.createSimple(ConfigProperties.class.getName());
     static final DotName CONFIG_PREFIX = DotName.createSimple(ConfigPrefix.class.getName());
     static final DotName CONFIG_PROPERTY = DotName.createSimple(ConfigProperty.class.getName());

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithAllPublicFieldsAndSuperclassConfigPropertiesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithAllPublicFieldsAndSuperclassConfigPropertiesTest.java
@@ -46,6 +46,10 @@ public class ClassWithAllPublicFieldsAndSuperclassConfigPropertiesTest {
         assertFalse(dummyBean.getOptionalStringList().isPresent());
         assertTrue(dummyBean.getOptionalIntList().isPresent());
         assertEquals(Arrays.asList(1, 2), dummyBean.getOptionalIntList().get());
+
+        assertEquals("s", DummyProperties.SOME_STRING);
+        assertEquals(1, DummyProperties.SOME_INT);
+        assertEquals("s2", SuperDuperDummyProperties.SOME_OTHER_STRING);
     }
 
     @Singleton
@@ -89,6 +93,9 @@ public class ClassWithAllPublicFieldsAndSuperclassConfigPropertiesTest {
     @ConfigProperties(prefix = "dummy")
     public static class DummyProperties extends SuperDummyProperties {
 
+        private static final String SOME_STRING = "s";
+        public static final int SOME_INT = 1;
+
         public String name;
         public String unset = "default";
         public List<Integer> numbers;
@@ -103,6 +110,9 @@ public class ClassWithAllPublicFieldsAndSuperclassConfigPropertiesTest {
     }
 
     public static class SuperDuperDummyProperties {
+
+        static final String SOME_OTHER_STRING = "s2";
+
         public Optional<List<Integer>> optionalIntList;
     }
 }

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithAllowedMissingSetterConfigPropertiesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithAllowedMissingSetterConfigPropertiesTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.arc.test.configproperties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.config.ConfigProperties;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClassWithAllowedMissingSetterConfigPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DummyBean.class, DummyProperties.class)
+                    .addAsResource(new StringAsset(
+                            "dummy.name=quarkus\ndummy.nested.numbers2=1,2\ndummy.unused=whatever"),
+                            "application.properties"));
+
+    @Inject
+    DummyBean dummyBean;
+
+    @Test
+    public void testConfiguredValues() {
+        assertEquals("quarkus", dummyBean.dummyProperties.name);
+        assertEquals(Arrays.asList(1, 2), dummyBean.dummyProperties.nested.numbers2);
+    }
+
+    @Singleton
+    public static class DummyBean {
+        @Inject
+        DummyProperties dummyProperties;
+    }
+
+    @ConfigProperties(prefix = "dummy", failOnMismatchingMember = false)
+    public static class DummyProperties {
+
+        private String name;
+        private List<Integer> numbers;
+        private NestedDummyProperties nested;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setNested(NestedDummyProperties nested) {
+            this.nested = nested;
+        }
+    }
+
+    public static class NestedDummyProperties extends ParentOfNestedDummyProperties {
+        private String name2;
+        private List<Integer> numbers2;
+
+        public void setNumbers2(List<Integer> numbers2) {
+            this.numbers2 = numbers2;
+        }
+    }
+
+    public static class ParentOfNestedDummyProperties {
+        private String whatever;
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithNotAllowedMissingSetterConfigPropertiesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithNotAllowedMissingSetterConfigPropertiesTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.arc.test.configproperties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.config.ConfigProperties;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClassWithNotAllowedMissingSetterConfigPropertiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DummyBean.class, DummyProperties.class)
+                    .addAsResource(new StringAsset(
+                            "dummy.name=quarkus\ndummy.unused=whatever"),
+                            "application.properties"))
+            .assertException(e -> {
+                assertEquals(IllegalArgumentException.class, e.getClass());
+                assertTrue(e.getMessage().contains("numbers"));
+            });
+
+    @Test
+    public void shouldNotBeInvoked() {
+        // This method should not be invoked
+        fail();
+    }
+
+    @Singleton
+    public static class DummyBean {
+        @Inject
+        DummyProperties dummyProperties;
+    }
+
+    @ConfigProperties(prefix = "dummy")
+    public static class DummyProperties {
+
+        private String name;
+        private List<Integer> numbers;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithoutGettersConfigPropertiesTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/configproperties/ClassWithoutGettersConfigPropertiesTest.java
@@ -24,7 +24,7 @@ public class ClassWithoutGettersConfigPropertiesTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(DummyBean.class, DummyProperties.class)
                     .addAsResource(new StringAsset(
-                            "dummy.name=quarkus\ndummy.numbers=1,2,3,4\ndummy.unused=whatever"),
+                            "dummy.name=quarkus\ndummy.my-enum=OPTIONAL\ndummy.numbers=1,2,3,4\ndummy.unused=whatever"),
                             "application.properties"));
 
     @Inject
@@ -32,22 +32,16 @@ public class ClassWithoutGettersConfigPropertiesTest {
 
     @Test
     public void testConfiguredValues() {
-        assertEquals("quarkus", dummyBean.getName());
-        assertEquals(Arrays.asList(1, 2, 3, 4), dummyBean.getNumbers());
+        DummyProperties dummyProperties = dummyBean.dummyProperties;
+        assertEquals("quarkus", dummyProperties.name);
+        assertEquals(Arrays.asList(1, 2, 3, 4), dummyProperties.numbers);
+        assertEquals(MyEnum.OPTIONAL, dummyProperties.myEnum);
     }
 
     @Singleton
     public static class DummyBean {
         @Inject
         DummyProperties dummyProperties;
-
-        String getName() {
-            return dummyProperties.name;
-        }
-
-        List<Integer> getNumbers() {
-            return dummyProperties.numbers;
-        }
     }
 
     @ConfigProperties(prefix = "dummy")
@@ -55,6 +49,7 @@ public class ClassWithoutGettersConfigPropertiesTest {
 
         public String name;
         public List<Integer> numbers;
+        public MyEnum myEnum;
 
         public void setName(String name) {
             this.name = name;
@@ -63,5 +58,11 @@ public class ClassWithoutGettersConfigPropertiesTest {
         public void setNumbers(List<Integer> numbers) {
             this.numbers = numbers;
         }
+    }
+
+    public enum MyEnum {
+        OPTIONAL,
+        ENUM_ONE,
+        Enum_Two
     }
 }

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/config/ConfigProperties.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/config/ConfigProperties.java
@@ -16,6 +16,7 @@ import io.quarkus.runtime.util.StringUtil;
 public @interface ConfigProperties {
 
     String UNSET_PREFIX = "<< unset >>";
+    boolean DEFAULT_FAIL_ON_MISMATCHING_MEMBER = true;
 
     /**
      * If the default is used, the class name will be used to determine the proper prefix
@@ -48,6 +49,11 @@ public @interface ConfigProperties {
      * quarkus.arc.config-properties-default-naming-strategy
      */
     NamingStrategy namingStrategy() default NamingStrategy.FROM_CONFIG;
+
+    /**
+     * Whether or not to fail when a non-public field of a class doesn't have a corresponding setter
+     */
+    boolean failOnMismatchingMember() default DEFAULT_FAIL_ON_MISMATCHING_MEMBER;
 
     enum NamingStrategy {
         FROM_CONFIG {

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesProcessor.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesProcessor.java
@@ -45,13 +45,13 @@ public class ConfigurationPropertiesProcessor {
 
     private ConfigPropertiesMetadataBuildItem createConfigPropertiesMetadataFromClass(AnnotationInstance annotation) {
         return new ConfigPropertiesMetadataBuildItem(annotation.target().asClass(), getPrefix(annotation),
-                ConfigProperties.NamingStrategy.VERBATIM, false);
+                ConfigProperties.NamingStrategy.VERBATIM, true, false);
     }
 
     private ConfigPropertiesMetadataBuildItem createConfigPropertiesMetadataFromMethod(AnnotationInstance annotation,
             IndexView index) {
         return new ConfigPropertiesMetadataBuildItem(index.getClassByName(annotation.target().asMethod().returnType().name()),
-                getPrefix(annotation), ConfigProperties.NamingStrategy.VERBATIM, false);
+                getPrefix(annotation), ConfigProperties.NamingStrategy.VERBATIM, true, false);
     }
 
     private String getPrefix(AnnotationInstance annotation) {


### PR DESCRIPTION
Introduces the following changes:

* Ensure that static fields don't break classes annotated with `@ConfigProperties`
* Give actionable warning when a parent class is not in the Jandex index
* Add ability to ignore missing setters (useful for migration purposes)
* Add support for enum values

cc @dejanb