### PR TITLE
Update reactive-messaging.adoc to add resteasy-mutiny

### DIFF
--- a/docs/src/main/asciidoc/reactive-messaging.adoc
+++ b/docs/src/main/asciidoc/reactive-messaging.adoc
@@ -30,7 +30,7 @@ If you are creating a new project, set the `extensions` parameter are follows:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=vertx-quickstart \
-    -Dextensions="vertx"
+    -Dextensions="vertx,resteasy-mutiny"
 cd vertx-quickstart
 ----
 
@@ -39,7 +39,7 @@ the `add-extension` command:
 
 [source]
 ----
-./mvnw quarkus:add-extension -Dextensions="vertx"
+./mvnw quarkus:add-extension -Dextensions="vertx,resteasy-mutiny"
 ----
 
 Otherwise, you can manually add this to the dependencies section of your `pom.xml` file:


### PR DESCRIPTION
I've encountered the following warn:

```
2020-05-16 13:37:10,994 WARN  [io.qua.res.com.dep.ResteasyCommonProcessor] (build-33) Quarkus detected the need for Mutiny reactive programming support, however the quarkus-resteasy-mutiny extensionwas not present. Reactive REST endpoints in your application that return Uni or Multi will not function as you expect until you add this extension. Endpoints that need Mutiny are: org.acme.vertx.EventResource{io.smallrye.mutiny.Uni<java.lang.String> greeting(java.lang.String name)}
```

This warn leads to an empty response:

```sh
$curl -w "\n" http://localhost:8080/async/Quarkus
```

This PR just resolve the issue by adding the missing extension.