### PR TITLE
OptaPlanner: Fail fast if no constraint implementations are found

### DIFF
--- a/extensions/optaplanner/deployment/src/main/java/io/quarkus/optaplanner/deployment/OptaPlannerProcessor.java
+++ b/extensions/optaplanner/deployment/src/main/java/io/quarkus/optaplanner/deployment/OptaPlannerProcessor.java
@@ -151,21 +151,7 @@ class OptaPlannerProcessor {
         if (solverConfig.getEntityClassList() == null) {
             solverConfig.setEntityClassList(findEntityClassList(recorderContext, indexView));
         }
-        if (solverConfig.getScoreDirectorFactoryConfig() == null) {
-            ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
-            scoreDirectorFactoryConfig.setEasyScoreCalculatorClass(
-                    findImplementingClass(EasyScoreCalculator.class, indexView));
-            scoreDirectorFactoryConfig.setConstraintProviderClass(
-                    findImplementingClass(ConstraintProvider.class, indexView));
-            scoreDirectorFactoryConfig.setIncrementalScoreCalculatorClass(
-                    findImplementingClass(IncrementalScoreCalculator.class, indexView));
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            if (classLoader.getResource(SolverBuildTimeConfig.DEFAULT_SCORE_DRL_URL) != null) {
-                scoreDirectorFactoryConfig.setScoreDrlList(Collections.singletonList(
-                        SolverBuildTimeConfig.DEFAULT_SCORE_DRL_URL));
-            }
-            solverConfig.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
-        }
+        applyScoreDirectorFactoryProperties(indexView, solverConfig);
         optaPlannerBuildTimeConfig.solver.environmentMode.ifPresent(solverConfig::setEnvironmentMode);
         optaPlannerBuildTimeConfig.solver.moveThreadCount.ifPresent(solverConfig::setMoveThreadCount);
         applyTerminationProperties(solverConfig);
@@ -206,6 +192,35 @@ class OptaPlannerProcessor {
         return targetList.stream()
                 .map(target -> recorderContext.classProxy(target.asClass().name().toString()))
                 .collect(Collectors.toList());
+    }
+
+    private void applyScoreDirectorFactoryProperties(IndexView indexView, SolverConfig solverConfig) {
+        if (solverConfig.getScoreDirectorFactoryConfig() == null) {
+            ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+            scoreDirectorFactoryConfig.setEasyScoreCalculatorClass(
+                    findImplementingClass(EasyScoreCalculator.class, indexView));
+            scoreDirectorFactoryConfig.setConstraintProviderClass(
+                    findImplementingClass(ConstraintProvider.class, indexView));
+            scoreDirectorFactoryConfig.setIncrementalScoreCalculatorClass(
+                    findImplementingClass(IncrementalScoreCalculator.class, indexView));
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            if (classLoader.getResource(SolverBuildTimeConfig.DEFAULT_SCORE_DRL_URL) != null) {
+                scoreDirectorFactoryConfig.setScoreDrlList(Collections.singletonList(
+                        SolverBuildTimeConfig.DEFAULT_SCORE_DRL_URL));
+            }
+            if (scoreDirectorFactoryConfig.getEasyScoreCalculatorClass() == null
+                    && scoreDirectorFactoryConfig.getEasyScoreCalculatorClass() == null
+                    && scoreDirectorFactoryConfig.getConstraintProviderClass() == null
+                    && scoreDirectorFactoryConfig.getIncrementalScoreCalculatorClass() == null
+                    && scoreDirectorFactoryConfig.getScoreDrlList() == null) {
+                throw new IllegalStateException("No classes found that implement "
+                        + EasyScoreCalculator.class.getSimpleName() + ", "
+                        + ConstraintProvider.class.getSimpleName() + " or "
+                        + IncrementalScoreCalculator.class.getSimpleName() + ", nor a "
+                        + SolverBuildTimeConfig.DEFAULT_SCORE_DRL_URL + " resource.");
+            }
+            solverConfig.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
+        }
     }
 
     private <T> Class<? extends T> findImplementingClass(Class<T> targetClass, IndexView indexView) {


### PR DESCRIPTION
This is unrelated to the issue that if no optaplanner annotated classes exist, the extension should do nothing. This does NOT make that issue worse (nor fixes it, that fix is coming later).