### PR TITLE
Make quarkus.kafka-streams.topics optional

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -423,7 +423,6 @@ Create the file `aggregator/src/main/resources/application.properties` with the 
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
 quarkus.kafka-streams.application-id=temperature-aggregator
 quarkus.kafka-streams.application-server=${hostname}:8080
-quarkus.kafka-streams.topics=weather-stations,temperature-values
 
 # pass-through options
 kafka-streams.cache.max.bytes.buffering=10240
@@ -436,8 +435,6 @@ kafka-streams.metrics.recording.level=DEBUG
 The options with the `quarkus.kafka-streams` prefix can be changed dynamically at application startup,
 e.g. via environment variables or system properties.
 `bootstrap-servers`, `application-id` and `application-server` are mapped to the Kafka Streams properties `bootstrap.servers`, `application.id` and `application.server`, respectively.
-`topics` is specific to Quarkus: the application will wait for all the given topics to exist before launching the Kafka Streams engine.
-This is to done to gracefully await the creation of topics that don't yet exist at application startup time.
 
 All the properties within the `kafka-streams` namespace are passed through as-is to the Kafka Streams engine.
 Changing their values requires a rebuild of the application.
@@ -1115,7 +1112,8 @@ Now start Docker Compose as described above
 
 If you are using the `quarkus-smallrye-health` extension, `quarkus-kafka-streams` will automatically add:
 
-* a readiness health check to validate that all topics declared in the `quarkus.kafka-streams.topics` property are created,
+* a readiness health check to validate that all topics statically declared in the Topology are created.
+This list of topics can be overridden via the `quarkus.kafka-streams.topics` property.
 * a liveness health check based on the Kafka Streams state.
 
 So when you access the `/health` endpoint of your application you will have information about the state of the Kafka Streams and the available and/or missing topics.
@@ -1153,7 +1151,7 @@ content-length: 454
 <1> Liveness health check. Also available at `/health/live` endpoint.
 <2> Readiness health check. Also available at `/health/ready` endpoint.
 
-So as you can see, the status is `DOWN` as soon as one of the `quarkus.kafka-streams.topics` is missing or the Kafka Streams `state` is not `RUNNING`.
+So as you can see, the status is `DOWN` as soon as one of the topics is missing or the Kafka Streams `state` is not `RUNNING`.
 
 If no topics are available, the `available_topics` key will not be present in the `data` field of the `Kafka Streams topics health check`.
 As well as if no topics are missing, the `missing_topics` key will not be present in the `data` field of the `Kafka Streams topics health check`.

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.kafka.streams.runtime;
 
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,8 +35,9 @@ public class KafkaStreamsRuntimeConfig {
      * A comma-separated list of topic names.
      * The pipeline will only be started once all these topics are present in the Kafka cluster.
      */
-    @ConfigItem
-    public List<String> topics;
+    @ConfigItem(defaultValueDocumentation = "All topics statically declared in the Topology, i.e. ignoring any topic " +
+            "resolved dynamically via source topicPattern or sink topicNameExtractor, or any internal topic")
+    public Optional<List<String>> topics;
 
     @Override
     public String toString() {
@@ -44,6 +46,6 @@ public class KafkaStreamsRuntimeConfig {
     }
 
     public List<String> getTrimmedTopics() {
-        return topics.stream().map(String::trim).collect(Collectors.toList());
+        return topics.orElse(Collections.emptyList()).stream().map(String::trim).collect(Collectors.toList());
     }
 }

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -23,7 +23,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -40,9 +40,11 @@ import io.quarkus.runtime.StartupEvent;
 /**
  * Manages the lifecycle of a Kafka Streams pipeline. If there's a producer
  * method returning a KS {@link Topology}, then this topology will be configured
- * and started. Optionally, before starting the pipeline, this manager will wait
- * for a given set of topics to be created, as KS itself will fail without all
- * input topics being created upfront.
+ * and started.
+ * <p>
+ * Before starting the pipeline, this manager will wait for a given set of topics to be created
+ * (either discovered from the topology, or via explicit configuration),
+ * as Kafka Streams itself will fail without all input topics being created upfront.
  */
 @ApplicationScoped
 public class KafkaStreamsTopologyManager {
@@ -55,6 +57,7 @@ public class KafkaStreamsTopologyManager {
     private volatile Instance<Topology> topology;
     private volatile Properties properties;
     private volatile Map<String, Object> adminClientConfig;
+    private volatile Collection<String> topicsToCheck;
 
     private volatile Instance<KafkaClientSupplier> kafkaClientSupplier;
     private volatile Instance<StateListener> stateListener;
@@ -132,9 +135,15 @@ public class KafkaStreamsTopologyManager {
 
         adminClientConfig = getAdminClientConfig(bootstrapServersConfig);
 
+        if (runtimeConfig.topics.isPresent()) {
+            topicsToCheck = runtimeConfig.getTrimmedTopics();
+        } else {
+            topicsToCheck = TopologyHelper.discoverStaticTopics(topology.get());
+        }
+
         executor.execute(() -> {
             try {
-                waitForTopicsToBeCreated(runtimeConfig.getTrimmedTopics());
+                waitForTopicsToBeCreated(topicsToCheck);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return;
@@ -157,48 +166,54 @@ public class KafkaStreamsTopologyManager {
         return streams;
     }
 
+    public Collection<String> getTopicsToCheck() {
+        return new HashSet<>(topicsToCheck);
+    }
+
     private void waitForTopicsToBeCreated(Collection<String> topicsToAwait)
             throws InterruptedException {
-        try (AdminClient adminClient = AdminClient.create(adminClientConfig)) {
-            while (true) {
-                try {
-                    ListTopicsResult topics = adminClient.listTopics();
-                    Set<String> topicNames = topics.names().get(10, TimeUnit.SECONDS);
+        if (!topicsToAwait.isEmpty()) {
+            try (Admin adminClient = Admin.create(adminClientConfig)) {
+                while (true) {
+                    try {
+                        ListTopicsResult topics = adminClient.listTopics();
+                        Set<String> topicNames = topics.names().get(10, TimeUnit.SECONDS);
 
-                    if (topicNames.containsAll(topicsToAwait)) {
-                        LOGGER.debug("All expected topics created");
-                        return;
-                    } else {
-                        Set<String> missing = new HashSet<>(topicsToAwait);
-                        missing.removeAll(topicNames);
-                        LOGGER.debug("Waiting for topic(s) to be created: " + missing);
+                        if (topicNames.containsAll(topicsToAwait)) {
+                            LOGGER.debug("All expected topics created: " + topicsToAwait);
+                            return;
+                        } else {
+                            Set<String> missing = new HashSet<>(topicsToAwait);
+                            missing.removeAll(topicNames);
+                            LOGGER.debug("Waiting for topic(s) to be created: " + missing);
+                        }
+
+                        Thread.sleep(1_000);
+                    } catch (ExecutionException | TimeoutException e) {
+                        LOGGER.error("Failed to get topic names from broker", e);
                     }
-
-                    Thread.sleep(1_000);
-                } catch (ExecutionException | TimeoutException e) {
-                    LOGGER.error("Failed to get topic names from broker", e);
                 }
             }
         }
     }
 
-    public Set<String> getMissingTopics(Collection<String> topicsToCheck)
-            throws InterruptedException {
+    public Set<String> getMissingTopics() throws InterruptedException {
         HashSet<String> missing = new HashSet<>(topicsToCheck);
+        if (!topicsToCheck.isEmpty()) {
+            // Assume Kafka admin client is not thread safe
+            try (Admin adminClient = Admin.create(adminClientConfig)) {
+                ListTopicsResult topics = adminClient.listTopics();
+                Set<String> topicNames = topics.names().get(10, TimeUnit.SECONDS);
 
-        try (AdminClient adminClient = AdminClient.create(adminClientConfig)) {
-            ListTopicsResult topics = adminClient.listTopics();
-            Set<String> topicNames = topics.names().get(10, TimeUnit.SECONDS);
-
-            if (topicNames.containsAll(topicsToCheck)) {
-                return Collections.EMPTY_SET;
-            } else {
-                missing.removeAll(topicNames);
+                if (topicNames.containsAll(topicsToCheck)) {
+                    return Collections.emptySet();
+                } else {
+                    missing.removeAll(topicNames);
+                }
+            } catch (ExecutionException | TimeoutException e) {
+                LOGGER.error("Failed to get topic names from broker", e);
             }
-        } catch (ExecutionException | TimeoutException e) {
-            LOGGER.error("Failed to get topic names from broker", e);
         }
-
         return missing;
     }
 

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/TopologyHelper.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/TopologyHelper.java
@@ -1,0 +1,39 @@
+package io.quarkus.kafka.streams.runtime;
+
+import static org.apache.kafka.streams.TopologyDescription.*;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription.Subtopology;
+
+/**
+ * Helper methods around KafkaStream Topology
+ */
+class TopologyHelper {
+
+    static Set<String> discoverStaticTopics(Topology topology) {
+        HashSet<String> sourceTopics = new HashSet<>();
+        HashSet<String> sinkTopics = new HashSet<>();
+
+        for (Subtopology subtopology : topology.describe().subtopologies()) {
+            for (Node node : subtopology.nodes()) {
+                if (node instanceof Source) {
+                    Optional.ofNullable(((Source) node).topicSet()).ifPresent(sourceTopics::addAll);
+                }
+                if (node instanceof Sink) {
+                    Optional.ofNullable(((Sink) node).topic()).ifPresent(sinkTopics::add);
+                }
+            }
+        }
+
+        // Ignore internal topics used to link sub-topologies together
+        Set<String> internalTopics = new HashSet<String>(sourceTopics);
+        internalTopics.retainAll(sinkTopics);
+        sourceTopics.addAll(sinkTopics);
+        sourceTopics.removeAll(internalTopics);
+        return sourceTopics;
+    }
+}

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheck.java
@@ -1,15 +1,11 @@
 package io.quarkus.kafka.streams.runtime.health;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
@@ -24,31 +20,16 @@ public class KafkaStreamsTopicsHealthCheck implements HealthCheck {
 
     private static final Logger LOGGER = Logger.getLogger(KafkaStreamsTopicsHealthCheck.class.getName());
 
-    @ConfigProperty(name = "quarkus.kafka-streams.topics")
-    public List<String> topics;
-
-    //    @ConfigProperty(name = "quarkus.kafka-streams.bootstrap-servers")
-    //    public List<String> bootstrapServers;
-
     @Inject
     private KafkaStreamsTopologyManager manager;
-
-    //    private String commaSeparatedBootstrapServersConfig;
-    private List<String> trimmedTopics;
-
-    @PostConstruct
-    public void init() {
-        //        commaSeparatedBootstrapServersConfig = String.join(",", bootstrapServers);
-        trimmedTopics = topics.stream().map(String::trim).collect(Collectors.toList());
-    }
 
     @Override
     public HealthCheckResponse call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Kafka Streams topics health check").up();
 
         try {
-            Set<String> missingTopics = manager.getMissingTopics(trimmedTopics);
-            List<String> availableTopics = new ArrayList<>(trimmedTopics);
+            Set<String> missingTopics = manager.getMissingTopics();
+            Collection<String> availableTopics = manager.getTopicsToCheck();
             availableTopics.removeAll(missingTopics);
 
             if (!availableTopics.isEmpty()) {

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/TopologyHelperTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/TopologyHelperTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.kafka.streams.runtime;
+
+import static org.apache.kafka.common.serialization.Serdes.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.*;
+import org.junit.jupiter.api.Test;
+
+public class TopologyHelperTest {
+
+    @Test
+    public void staticTopicsShouldBeDiscovered() {
+        Topology topology = new Topology();
+        topology.addSource("source", "topic1", "topic2");
+        topology.addSink("sink", "topic3", "source");
+
+        Set<String> topics = TopologyHelper.discoverStaticTopics(topology);
+
+        assertThat(topics).containsOnly("topic1", "topic2", "topic3");
+    }
+
+    @Test
+    public void dynamicTopicsShouldBeIgnored() {
+        Topology topology = new Topology();
+        topology.addSource("source", Pattern.compile("topic.*"));
+        topology.addSink("sink", (key, value, recordContext) -> "topic1", "source");
+
+        Set<String> topics = TopologyHelper.discoverStaticTopics(topology);
+
+        assertThat(topics).isEmpty();
+    }
+
+    @Test
+    public void internalSubTopologyTopicsShouldBeIgnored() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> ktable = builder.table(
+                "topic1",
+                Consumed.with(String(), String()));
+
+        KStream<String, String> stream = builder
+                .stream("topic2", Consumed.with(String(), String()))
+                .selectKey((id, value) -> id)
+                .join(
+                        ktable,
+                        (value1, value2) -> {
+                            return value1;
+                        },
+                        Joined.with(String(), String(), String()));
+
+        stream.to("topic3", Produced.with(new StringSerde(), new StringSerde()));
+
+        Set<String> topics = TopologyHelper.discoverStaticTopics(builder.build());
+
+        assertThat(topics).containsOnly("topic1", "topic2", "topic3");
+    }
+}

--- a/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
+++ b/extensions/kafka-streams/runtime/src/test/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsTopicsHealthCheckTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.kafka.streams.runtime.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
 
 import java.util.Collections;
 
@@ -26,21 +25,39 @@ public class KafkaStreamsTopicsHealthCheckTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        healthCheck.topics = Collections.singletonList("topic");
-        healthCheck.init();
     }
 
     @Test
     public void shouldBeUpIfNoMissingTopic() throws InterruptedException {
-        Mockito.when(manager.getMissingTopics(anyList())).thenReturn(Collections.emptySet());
+        Mockito.when(manager.getTopicsToCheck()).thenReturn(Collections.singleton("topic"));
+        Mockito.when(manager.getMissingTopics()).thenReturn(Collections.emptySet());
+
         HealthCheckResponse response = healthCheck.call();
+
         assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getData().get()).doesNotContainKey("missing_topics");
+        assertThat(response.getData().get()).containsKey("available_topics");
     }
 
     @Test
     public void shouldBeDownIfMissingTopic() throws InterruptedException {
-        Mockito.when(manager.getMissingTopics(anyList())).thenReturn(Collections.singleton("topic"));
+        Mockito.when(manager.getMissingTopics()).thenReturn(Collections.singleton("topic"));
+
         HealthCheckResponse response = healthCheck.call();
+
         assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+        assertThat(response.getData().get()).containsKey("missing_topics");
+        assertThat(response.getData().get()).doesNotContainKey("available_topics");
+    }
+
+    @Test
+    public void shouldBeUpIfNoTopicToCheck() throws InterruptedException {
+        Mockito.when(manager.getTopicsToCheck()).thenReturn(Collections.emptySet());
+        Mockito.when(manager.getMissingTopics()).thenReturn(Collections.emptySet());
+
+        HealthCheckResponse response = healthCheck.call();
+
+        assertThat(response.getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(response.getData()).isNotPresent();
     }
 }

--- a/integration-tests/kafka-streams/src/main/resources/application.properties
+++ b/integration-tests/kafka-streams/src/main/resources/application.properties
@@ -4,7 +4,6 @@ quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 
 quarkus.kafka-streams.bootstrap-servers=localhost:19092
 quarkus.kafka-streams.application-id=streams-test-pipeline
-quarkus.kafka-streams.topics=streams-test-categories,streams-test-customers
 
 # streams options
 kafka-streams.cache.max.bytes.buffering=10240

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsTest.java
@@ -124,7 +124,8 @@ public class KafkaStreamsTest {
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
                 .body("checks[0].status", CoreMatchers.is("DOWN"))
-                .body("checks[0].data.missing_topics", CoreMatchers.is("streams-test-customers,streams-test-categories"));
+                .body("checks[0].data.missing_topics",
+                        CoreMatchers.is("streams-test-customers,streams-test-categories,streams-test-customers-processed"));
 
         RestAssured.when().get("/health/live").then()
                 .statusCode(HttpStatus.SC_SERVICE_UNAVAILABLE)
@@ -141,7 +142,8 @@ public class KafkaStreamsTest {
                 .statusCode(HttpStatus.SC_OK)
                 .body("checks[0].name", CoreMatchers.is("Kafka Streams topics health check"))
                 .body("checks[0].status", CoreMatchers.is("UP"))
-                .body("checks[0].data.available_topics", CoreMatchers.is("streams-test-categories,streams-test-customers"));
+                .body("checks[0].data.available_topics",
+                        CoreMatchers.is("streams-test-customers,streams-test-categories,streams-test-customers-processed"));
 
         RestAssured.when().get("/health/live").then()
                 .statusCode(HttpStatus.SC_OK)


### PR DESCRIPTION
Closes #8909

- Default to discovering the topics directly from the Topology, excluding internal topics
- Support having no topics to check, in case the topology is fully dynamic and topics are not known at startup (i.e. topic pattern & TopicNameExtractor) and bypass admin client calls in such cases