### PR TITLE
Added support for @InjectSpy

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -525,6 +525,72 @@ public class MockGreetingServiceTest {
 ----
 <1> Since we configured `greetingService` as a mock, the `GreetingResource` which uses the `GreetingService` bean, we get the mocked response instead of the response of the regular `GreetingService` bean
 
+==== Using Spies instead of Mocks with `@InjectSpy`
+
+Building on the features provided by `InjectMock`, Quarkus also allows users to effortlessly take advantage of link:https://site.mockito.org/[Mockito] for spying on the beans supported by `QuarkusMock`.
+This functionality is available via the `@io.quarkus.test.junit.mockito.InjectSpy` annotation which is available in the `quarkus-junit5-mockito` dependency.
+
+Sometimes when testing you only need to verify that a certain logical path was taken, or you only need to stub out a single method's response while still executing the rest of the methods on the Spied clone. Please see link:https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#spy-T-[Mockito documentation] for more details on Spy partial mocks.
+In either of those situations a Spy of the object is preferable.
+Using `@InjectSpy`, the previous example could be written as follows:
+
+[source,java]
+----
+@QuarkusTest
+public class SpyGreetingServiceTest {
+
+    @InjectSpy
+    GreetingService greetingService;
+
+    @Test
+    public void testDefaultGreeting() {
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("hello"));
+
+        Mockito.verify(greetingService, Mockito.times(1)).greet(); <1>
+    }
+
+    @Test
+    public void testOverrideGreeting() {
+        when(greetingService.greet()).thenReturn("hi"); <2>
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("hi")); <3>
+    }
+
+    @Path("greeting")
+    public static class GreetingResource {
+
+        final GreetingService greetingService;
+
+        public GreetingResource(GreetingService greetingService) {
+            this.greetingService = greetingService;
+        }
+
+        @GET
+        @Produces("text/plain")
+        public String greet() {
+            return greetingService.greet();
+        }
+    }
+
+    @ApplicationScoped
+    public static class GreetingService {
+        public String greet(){
+            return "hello";
+        }
+    }
+}
+----
+<1> Instead of overriding the value, we just want to ensure that the greet method on our `GreetingService` was called by this test.
+<2> Here we are telling the Spy to return "hi" instead of "hello". When the `GreetingResource` requests the greeting from `GreetingService` we get the mocked response instead of the response of the regular `GreetingService` bean
+<3> We are verifying that we get the mocked response from the Spy.
+
 ==== Using `@InjectMock` with `@RestClient`
 
 The `@RegisterRestClient` registers the implementation of the rest-client at runtime, and because the bean needs to be a regular scope, you have to annotate your interface with `@ApplicationScoped`. 

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithSpiesTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithSpiesTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.it.mockbean;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+
+@QuarkusTest
+class WithSpiesTest {
+
+    @InjectSpy
+    CapitalizerService capitalizerService;
+
+    @InjectSpy
+    MessageService messageService;
+
+    @InjectSpy
+    SuffixService suffixService;
+
+    @InjectSpy
+    @Named("first")
+    DummyService firstDummyService;
+
+    @InjectSpy
+    @Named("second")
+    DummyService secondDummyService;
+
+    @Test
+    @DisplayName("Verify default Greeting values are returned from Spied objects")
+    public void testGreet() {
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("HELLO"));
+        Mockito.verify(capitalizerService, Mockito.times(1)).capitalize(Mockito.eq("hello"));
+        Mockito.verify(messageService, Mockito.times(1)).getMessage();
+        Mockito.verify(suffixService, Mockito.times(1)).getSuffix();
+    }
+
+    @Test
+    @DisplayName("Verify default Dummy values are returned from Spied objects")
+    public void testDummy() {
+        given()
+                .when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .body(is("first/second"));
+        Mockito.verify(firstDummyService, Mockito.times(1)).returnDummyValue();
+        Mockito.verify(secondDummyService, Mockito.times(1)).returnDummyValue();
+    }
+
+    @Test
+    @DisplayName("Verify we can override default Greeting values are returned from Spied objects")
+    public void testOverrideGreet() {
+        Mockito.when(messageService.getMessage()).thenReturn("hi");
+        Mockito.when(suffixService.getSuffix()).thenReturn("!");
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(is("HI!"));
+    }
+
+    @Test
+    @DisplayName("Verify can override default Dummy values are returned from Spied objects")
+    public void testOverrideDummy() {
+        Mockito.when(firstDummyService.returnDummyValue()).thenReturn("1");
+        Mockito.when(secondDummyService.returnDummyValue()).thenReturn("2");
+        given()
+                .when().get("/dummy")
+                .then()
+                .statusCode(200)
+                .body(is("1/2"));
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectSpy.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectSpy.java
@@ -1,0 +1,15 @@
+package io.quarkus.test.junit.mockito;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When used on a field of a test class, the field becomes a Mockito spy,
+ * that is then used to spy on the normal scoped bean which the field represents
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectSpy {
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoSpiesCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/CreateMockitoSpiesCallback.java
@@ -1,0 +1,41 @@
+package io.quarkus.test.junit.mockito.internal;
+
+import java.lang.reflect.Field;
+
+import org.mockito.Mockito;
+
+import io.quarkus.arc.runtime.ClientProxyUnwrapper;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeAllCallback;
+import io.quarkus.test.junit.mockito.InjectSpy;
+
+public class CreateMockitoSpiesCallback implements QuarkusTestBeforeAllCallback {
+
+    @Override
+    public void beforeAll(Object testInstance) {
+        Class<?> current = testInstance.getClass();
+        while (current.getSuperclass() != null) {
+            for (Field field : current.getDeclaredFields()) {
+                InjectSpy injectSpyAnnotation = field.getAnnotation(InjectSpy.class);
+                if (injectSpyAnnotation != null) {
+                    Object beanInstance = CreateMockitoMocksCallback.getBeanInstance(testInstance, field, InjectSpy.class);
+                    Object spy = createSpyAndSetTestField(testInstance, field, beanInstance);
+                    MockitoMocksTracker.track(testInstance, spy, beanInstance);
+                }
+            }
+            current = current.getSuperclass();
+        }
+    }
+
+    private Object createSpyAndSetTestField(Object testInstance, Field field, Object beanInstance) {
+        ClientProxyUnwrapper unwrapper = new ClientProxyUnwrapper();
+        Object spy = Mockito.spy(unwrapper.apply(beanInstance));
+        field.setAccessible(true);
+        try {
+            field.set(testInstance, spy);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return spy;
+    }
+
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/MockitoMocksTracker.java
@@ -16,8 +16,7 @@ final class MockitoMocksTracker {
     }
 
     static void track(Object testInstance, Object mock, Object beanInstance) {
-        TEST_TO_USED_MOCKS.computeIfAbsent(testInstance, (k) -> new HashSet<>());
-        TEST_TO_USED_MOCKS.get(testInstance).add(new Mocked(mock, beanInstance));
+        TEST_TO_USED_MOCKS.computeIfAbsent(testInstance, k -> new HashSet<>()).add(new Mocked(mock, beanInstance));
     }
 
     static Set<Mocked> getMocks(Object testInstance) {

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
@@ -1,32 +1,16 @@
 package io.quarkus.test.junit.mockito.internal;
 
-import java.lang.reflect.Method;
-
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
 
 public class SetMockitoMockAsBeanMockCallback implements QuarkusTestBeforeEachCallback {
 
-    private volatile Method installMocksMethod;
-
     @Override
     public void beforeEach(Object testInstance) {
-        MockitoMocksTracker.getMocks(testInstance).forEach(m -> {
-            installMocks(m, m.beanInstance);
-        });
+        MockitoMocksTracker.getMocks(testInstance).forEach(this::installMock);
     }
 
-    // call MockSupport.installMock using reflection since it is not public
-    private void installMocks(MockitoMocksTracker.Mocked m, Object beanInstance) {
-        try {
-            if (installMocksMethod == null) {
-                installMocksMethod = Class.forName("io.quarkus.test.junit.MockSupport").getDeclaredMethod("installMock",
-                        Object.class,
-                        Object.class);
-                installMocksMethod.setAccessible(true);
-            }
-            installMocksMethod.invoke(null, beanInstance, m.mock);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private void installMock(MockitoMocksTracker.Mocked mocked) {
+        QuarkusMock.installMockForInstance(mocked.mock, mocked.beanInstance);
     }
 }

--- a/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeAllCallback
+++ b/test-framework/junit5-mockito/src/main/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeAllCallback
@@ -1,1 +1,2 @@
 io.quarkus.test.junit.mockito.internal.CreateMockitoMocksCallback
+io.quarkus.test.junit.mockito.internal.CreateMockitoSpiesCallback


### PR DESCRIPTION
This PR builds on #8327 to provide the ability to inject Mockito.spy objects instead of Mockito.mock objects. This is useful when you need to override a small subset of methods in a Bean or you just want to verify logic branching is going where you want.