### PR TITLE
Enable Hibernate ORM multitenancy IT on CI

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -144,7 +144,7 @@ jobs:
           MYSQL_USER: hibernate_orm_test
           MYSQL_PASSWORD: hibernate_orm_test
           MYSQL_DATABASE: hibernate_orm_test
-          MYSQL_RANDOM_ROOT_PASSWORD: true
+          MYSQL_ROOT_PASSWORD: secret
         ports:
           - 127.0.0.1:3308:3306
       mssql:
@@ -320,6 +320,7 @@ jobs:
               jpa-mssql
               jpa-derby
               jpa-without-entity
+              hibernate-tenancy
           - category: Data2
             mysql: "true"
             postgres: "true"
@@ -476,7 +477,7 @@ jobs:
       - name: Maria DB Service
         run: |
           docker run --rm --publish 3308:3306 --name build-mariadb \
-            -e MYSQL_USER=$DB_USER -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_NAME -e MYSQL_RANDOM_ROOT_PASSWORD=true \
+            -e MYSQL_USER=$DB_USER -e MYSQL_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=$DB_NAME -e MYSQL_ROOT_PASSWORD=secret \
             -d mariadb:10.4
         if: matrix.mariadb
       - name: MS-SQL Service

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -34,8 +34,8 @@ on:
 env:
   # Workaround testsuite locale issue
   LANG: en_US.UTF-8
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11 -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-amazon-services -Dtest-mysql -Dtest-mariadb -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dnative-image.xmx=5g -Dnative -Dformat.skip install"
-  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-mariadb -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-amazon-services -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-keycloak -Dformat.skip"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings .github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11 -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-amazon-services -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dnative-image.xmx=5g -Dnative -Dformat.skip install"
+  JVM_TEST_MAVEN_OPTS: "-e -B --settings .github/mvn-settings.xml -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-amazon-services -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-keycloak -Dformat.skip"
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
@@ -89,8 +89,6 @@ public class DataSourceTenantConnectionResolver implements TenantConnectionResol
 
     private static class TenantConnectionProvider extends QuarkusConnectionProvider {
 
-        private static final long serialVersionUID = 1L;
-
         private final String tenantId;
 
         public TenantConnectionProvider(String tenantId, AgroalDataSource dataSource) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateCurrentTenantIdentifierResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateCurrentTenantIdentifierResolver.java
@@ -12,7 +12,7 @@ import io.quarkus.arc.InstanceHandle;
  * @author Michael Schnell
  *
  */
-public class HibernateCurrentTenantIdentifierResolver implements CurrentTenantIdentifierResolver {
+public final class HibernateCurrentTenantIdentifierResolver implements CurrentTenantIdentifierResolver {
 
     private static final Logger LOG = Logger.getLogger(HibernateCurrentTenantIdentifierResolver.class);
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateMultiTenantConnectionProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/HibernateMultiTenantConnectionProvider.java
@@ -16,7 +16,7 @@ import io.quarkus.arc.InstanceHandle;
  * @author Michael Schnell
  *
  */
-public class HibernateMultiTenantConnectionProvider extends AbstractMultiTenantConnectionProvider {
+public final class HibernateMultiTenantConnectionProvider extends AbstractMultiTenantConnectionProvider {
 
     private static final Logger LOG = Logger.getLogger(HibernateMultiTenantConnectionProvider.class);
 
@@ -33,12 +33,14 @@ public class HibernateMultiTenantConnectionProvider extends AbstractMultiTenantC
     }
 
     @Override
-    protected ConnectionProvider selectConnectionProvider(String tenantIdentifier) {
+    protected ConnectionProvider selectConnectionProvider(final String tenantIdentifier) {
         LOG.debugv("selectConnectionProvider({0})", tenantIdentifier);
 
         ConnectionProvider provider = providerMap.get(tenantIdentifier);
         if (provider == null) {
-            return providerMap.computeIfAbsent(tenantIdentifier, tid -> resolveConnectionProvider(tid));
+            final ConnectionProvider connectionProvider = resolveConnectionProvider(tenantIdentifier);
+            providerMap.put(tenantIdentifier, connectionProvider);
+            return connectionProvider;
         }
         return provider;
 

--- a/integration-tests/hibernate-tenancy/README.md
+++ b/integration-tests/hibernate-tenancy/README.md
@@ -27,12 +27,20 @@ You can then run the tests as follows (either with `-Dnative` or not):
 mvn clean install -Dtest-mariadb
 ```
 
-If you have specific requirements, you can define a specific connection URL with `-Djdbc:mariadb://localhost:3306/hibernate_orm_test`.
+If you have specific requirements, you can define a specific connection URL with `-Dmariadb.base_url=jdbc:mariadb://...`.
+Note that this specific integration test module module requires permissions to create additional users and databases, hence the `mariadb.base_url` variable
+should not include the database name: check the `application.properties` to see how it's used.
 
 To run the MariaDB server "manually" via command line for testing, the following command line could be useful:
 
 ```
 docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mariadb -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_ROOT_PASSWORD=secret -p 3306:3306 mariadb:10.4
+```
+
+or if you prefer podman, this won't need root permissions:
+
+```
+podman run --rm=true --net=host --memory-swappiness=0 --tmpfs /var/lib/mysql:rw --tmpfs /var/log:rw --name mariadb_demo -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_ROOT_PASSWORD=secret -p 3306:3306 mariadb:10.4
 ```
 
 N.B. it takes a while for MariaDB to be actually booted and accepting connections.

--- a/integration-tests/hibernate-tenancy/pom.xml
+++ b/integration-tests/hibernate-tenancy/pom.xml
@@ -16,7 +16,7 @@
 	<description>Module that contains Hibernate Multitenancy related tests running with the MariaDB database</description>
 
 	<properties>
-		<mariadb.url>jdbc:mariadb://localhost:3306</mariadb.url>
+		<mariadb.base_url>jdbc:mariadb://localhost:3306</mariadb.base_url>
 		<mariadb.image>mariadb:10.4</mariadb.image>
 	</properties>
 

--- a/integration-tests/hibernate-tenancy/src/main/resources/application.properties
+++ b/integration-tests/hibernate-tenancy/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 # Hibernate ORM settings 
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=DATABASE
-quarkus.hibernate-orm.validate-tenant-in-current-sessions=false
 
 # Maria DB URL
 mariadb.url=jdbc:mariadb://localhost:3306

--- a/integration-tests/hibernate-tenancy/src/main/resources/application.properties
+++ b/integration-tests/hibernate-tenancy/src/main/resources/application.properties
@@ -10,6 +10,8 @@ quarkus.datasource.jdbc.url=${mariadb.base_url}/hibernate_orm_test
 quarkus.datasource.jdbc.max-size=1
 quarkus.datasource.jdbc.min-size=1
 quarkus.flyway.migrate-at-start=true
+#Reset Flyway metadata at boot, as the database might have been tainted by previous integration tests:
+quarkus.flyway.clean-at-start=true
 quarkus.flyway.locations=classpath:database/default
 
 # DATABASE Tenant 'base' Configuration
@@ -20,6 +22,7 @@ quarkus.datasource.base.jdbc.url=${mariadb.base_url}/base
 quarkus.datasource.base.jdbc.max-size=1
 quarkus.datasource.base.jdbc.min-size=1
 quarkus.flyway.base.migrate-at-start=true
+quarkus.flyway.base.clean-at-start=true
 quarkus.flyway.base.locations=classpath:database/base
 
 # DATABASE Tenant 'mycompany' Configuration
@@ -30,5 +33,6 @@ quarkus.datasource.mycompany.jdbc.url=${mariadb.base_url}/mycompany
 quarkus.datasource.mycompany.jdbc.max-size=1
 quarkus.datasource.mycompany.jdbc.min-size=1
 quarkus.flyway.mycompany.migrate-at-start=true
+quarkus.flyway.mycompany.clean-at-start=true
 quarkus.flyway.mycompany.locations=classpath:database/mycompany
 

--- a/integration-tests/hibernate-tenancy/src/main/resources/application.properties
+++ b/integration-tests/hibernate-tenancy/src/main/resources/application.properties
@@ -2,14 +2,11 @@
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=DATABASE
 
-# Maria DB URL
-mariadb.url=jdbc:mariadb://localhost:3306
-
 # Default DB Configuration
 quarkus.datasource.db-kind=mariadb
 quarkus.datasource.username=root
 quarkus.datasource.password=secret
-quarkus.datasource.jdbc.url=${mariadb.url}/hibernate_orm_test
+quarkus.datasource.jdbc.url=${mariadb.base_url}/hibernate_orm_test
 quarkus.datasource.jdbc.max-size=1
 quarkus.datasource.jdbc.min-size=1
 quarkus.flyway.migrate-at-start=true
@@ -19,7 +16,7 @@ quarkus.flyway.locations=classpath:database/default
 quarkus.datasource.base.db-kind=mariadb
 quarkus.datasource.base.username=jane
 quarkus.datasource.base.password=abc
-quarkus.datasource.base.jdbc.url=${mariadb.url}/base
+quarkus.datasource.base.jdbc.url=${mariadb.base_url}/base
 quarkus.datasource.base.jdbc.max-size=1
 quarkus.datasource.base.jdbc.min-size=1
 quarkus.flyway.base.migrate-at-start=true
@@ -29,7 +26,7 @@ quarkus.flyway.base.locations=classpath:database/base
 quarkus.datasource.mycompany.db-kind=mariadb
 quarkus.datasource.mycompany.username=john
 quarkus.datasource.mycompany.password=def
-quarkus.datasource.mycompany.jdbc.url=${mariadb.url}/mycompany
+quarkus.datasource.mycompany.jdbc.url=${mariadb.base_url}/mycompany
 quarkus.datasource.mycompany.jdbc.max-size=1
 quarkus.datasource.mycompany.jdbc.min-size=1
 quarkus.flyway.mycompany.migrate-at-start=true

--- a/integration-tests/hibernate-tenancy/src/main/resources/database/default/V1.0.0__init_databases.sql
+++ b/integration-tests/hibernate-tenancy/src/main/resources/database/default/V1.0.0__init_databases.sql
@@ -1,9 +1,9 @@
-CREATE DATABASE base;
-CREATE USER 'jane'@'%' IDENTIFIED BY 'abc';
+CREATE DATABASE IF NOT EXISTS base;
+CREATE USER IF NOT EXISTS 'jane'@'%' IDENTIFIED BY 'abc';
 GRANT ALL privileges ON base.* TO 'jane'@'%';
 
-CREATE DATABASE mycompany;
-CREATE USER 'john'@'%' IDENTIFIED BY 'def';
+CREATE DATABASE IF NOT EXISTS mycompany;
+CREATE USER IF NOT EXISTS 'john'@'%' IDENTIFIED BY 'def';
 GRANT ALL privileges ON mycompany.* TO 'john'@'%';
 
 FLUSH PRIVILEGES;

--- a/integration-tests/jpa-mariadb/README.md
+++ b/integration-tests/jpa-mariadb/README.md
@@ -35,6 +35,12 @@ To run the MariaDB server "manually" via command line for testing, the following
 docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mariadb -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mariadb:10.4
 ```
 
+or if you prefer podman, this won't need root permissions:
+
+```
+podman run --rm=true --net=host --memory-swappiness=0 --tmpfs /var/lib/mysql:rw --tmpfs /var/log:rw --name mariadb_demo -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_ROOT_PASSWORD=secret -p 3306:3306 mariadb:10.4
+```
+
 N.B. it takes a while for MariaDB to be actually booted and accepting connections.
 
 After it's fully booted, you can run all integration tests via


### PR DESCRIPTION
Fixes #9389 

The multi-tenancy integration tests require root access to the MariaDB instance, so that it can create multiple databases to test the dybanamic DB switching ability.

The integration tests of these modules were not enabled so far.