### PR TITLE
QuarkusTestExtension enum lookup via name() not toString().

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -507,7 +507,7 @@ public class QuarkusTestExtension
             for (Object arg : originalArguments) {
                 if (arg != null && arg.getClass().isEnum()) {
                     argumentsFromTccl.add(Enum.valueOf((Class<Enum>) Class.forName(arg.getClass().getName(), false,
-                            Thread.currentThread().getContextClassLoader()), arg.toString()));
+                            Thread.currentThread().getContextClassLoader()), ((Enum)arg).name()));
                 } else {
                     // we can't do anything but hope for the best...
                     argumentsFromTccl.add(arg);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -507,7 +507,7 @@ public class QuarkusTestExtension
             for (Object arg : originalArguments) {
                 if (arg != null && arg.getClass().isEnum()) {
                     argumentsFromTccl.add(Enum.valueOf((Class<Enum>) Class.forName(arg.getClass().getName(), false,
-                            Thread.currentThread().getContextClassLoader()), ((Enum)arg).name()));
+                            Thread.currentThread().getContextClassLoader()), ((Enum) arg).name()));
                 } else {
                     // we can't do anything but hope for the best...
                     argumentsFromTccl.add(arg);


### PR DESCRIPTION
Enum::toString can be overridden and may not match the Enum constant.  Enum::name is used for that purpose.