### PR TITLE
Increase timeout for grpc native tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -448,7 +448,7 @@ jobs:
               spring-boot-properties
               spring-cloud-config-client
           - category: gRPC
-            timeout: 45
+            timeout: 50
             test-modules: >
               grpc-health
               grpc-interceptors


### PR DESCRIPTION
Done because I saw a PR failing after on grpc after 45 minutes