### PR TITLE
SongResourceIT for spring-data-jpa module

### DIFF
--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/SongResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/SongResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.spring.data.jpa;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class SongResourceIT extends SongResourceTest {
+
+}


### PR DESCRIPTION
SongResourceIT for spring-data-jpa module

SongResourceTest didn't have `@NativeImageTest` equivalent
