### PR TITLE
Add io to quarkusbuild task

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
@@ -4,15 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.platform.descriptor.QuarkusPlatformDescriptor;
 import io.quarkus.platform.tools.config.QuarkusPlatformConfig;
+import io.quarkus.test.devmode.util.DevModeTestUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -40,12 +45,7 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleTestBase {
     public void canRunListExtensions() throws IOException {
         createProject(SourceType.JAVA);
 
-        BuildResult build = GradleRunner.create()
-                .forwardOutput()
-                .withPluginClasspath()
-                .withArguments(arguments("listExtensions"))
-                .withProjectDir(projectRoot)
-                .build();
+        BuildResult build = runTask(arguments("listExtensions"));
 
         assertThat(build.task(":listExtensions").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         assertThat(build.getOutput()).contains("Quarkus - Core");
@@ -55,29 +55,18 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleTestBase {
     public void canGenerateConfig() throws IOException {
         createProject(SourceType.JAVA);
 
-        BuildResult build = GradleRunner.create()
-                .forwardOutput()
-                .withPluginClasspath()
-                .withArguments(arguments("generateConfig"))
-                .withProjectDir(projectRoot)
-                .build();
+        BuildResult build = runTask(arguments("generateConfig"));
 
         assertThat(build.task(":generateConfig").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         assertThat(projectRoot.toPath().resolve("src/main/resources/application.properties.example")).exists();
     }
-
 
     @ParameterizedTest(name = "Build {0} project")
     @EnumSource(SourceType.class)
     public void canBuild(SourceType sourceType) throws IOException, InterruptedException {
         createProject(sourceType);
 
-        BuildResult build = GradleRunner.create()
-                .forwardOutput()
-                .withPluginClasspath()
-                .withArguments(arguments("build", "--stacktrace"))
-                .withProjectDir(projectRoot)
-                .build();
+        BuildResult build = runTask(arguments("build", "--stacktrace"));
 
         assertThat(build.task(":build").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         // gradle build should not build the native image
@@ -85,6 +74,82 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleTestBase {
         Path buildDir = projectRoot.toPath().resolve("build");
         assertThat(buildDir).exists();
         assertThat(buildDir.resolve("foo-1.0.0-SNAPSHOT-runner")).doesNotExist();
+    }
+
+    @Test
+    public void canDetectUpToDateBuild() throws IOException {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(firstBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        BuildResult secondBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(secondBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.UP_TO_DATE);
+    }
+
+    @Test
+    public void canDetectResourceChangeWhenBuilding() throws IOException {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(firstBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        final File applicationProperties = projectRoot.toPath().resolve("src/main/resources/application.properties").toFile();
+        DevModeTestUtils.filter(applicationProperties, ImmutableMap.of("# Configuration file", "quarkus.http.port=8888"));
+
+        BuildResult secondBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(secondBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canDetectClassChangeWhenBuilding() throws IOException {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(firstBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        final File greetingResourceFile = projectRoot.toPath().resolve("src/main/java/org/acme/GreetingResource.java").toFile();
+        DevModeTestUtils.filter(greetingResourceFile, ImmutableMap.of("\"/greeting\"", "\"/test/hello\""));
+
+        BuildResult secondBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(secondBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canDetectClasspathChangeWhenBuilding() throws IOException {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(firstBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        runTask(arguments("addExtension", "--extensions=hibernate-orm"));
+        BuildResult secondBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+        assertThat(secondBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canDetectOutputChangeWhenBuilding() throws IOException {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+
+        assertThat(firstBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        Path runnerJar = projectRoot.toPath().resolve("build").resolve("foo-1.0.0-SNAPSHOT-runner.jar");
+        Files.delete(runnerJar);
+
+        BuildResult secondBuild = runTask(arguments("quarkusBuild", "--stacktrace"));
+
+        assertThat(secondBuild.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(runnerJar).exists();
+    }
+
+    private BuildResult runTask(List<String> arguments) {
+        return GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments(arguments)
+                .withProjectDir(projectRoot)
+                .build();
     }
 
     private void createProject(SourceType sourceType) throws IOException {

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -1,12 +1,17 @@
 package io.quarkus.gradle.tasks;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -46,6 +51,19 @@ public class QuarkusBuild extends QuarkusTask {
             + "specify one or more entries that should be excluded from the final jar", option = "ignored-entry")
     public void setIgnoredEntries(List<String> ignoredEntries) {
         this.ignoredEntries.addAll(ignoredEntries);
+    }
+
+    @Classpath
+    public FileCollection getClasspath() {
+        SourceSet mainSourceSet = QuarkusGradleUtils.getSourceSet(getProject(), SourceSet.MAIN_SOURCE_SET_NAME);
+        return mainSourceSet.getCompileClasspath().plus(mainSourceSet.getRuntimeClasspath())
+                .plus(mainSourceSet.getAnnotationProcessorPath())
+                .plus(mainSourceSet.getResources());
+    }
+
+    @OutputFile
+    public File getOutputDir() {
+        return new File(getProject().getBuildDir(), extension().finalName() + "-runner.jar");
     }
 
     @TaskAction

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusGradleUtils.java
@@ -32,13 +32,17 @@ public class QuarkusGradleUtils {
         return serializedModel;
     }
 
-    public static PathsCollection getOutputPaths(Project project) {
+    public static SourceSet getSourceSet(Project project, String sourceSetName) {
         final Convention convention = project.getConvention();
         JavaPluginConvention javaConvention = convention.findPlugin(JavaPluginConvention.class);
         if (javaConvention == null) {
             throw new IllegalArgumentException("The project does not include the Java plugin");
         }
-        final SourceSet mainSourceSet = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        return javaConvention.getSourceSets().getByName(sourceSetName);
+    }
+
+    public static PathsCollection getOutputPaths(Project project) {
+        final SourceSet mainSourceSet = getSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME);
         final PathsCollection.Builder builder = PathsCollection.builder();
         mainSourceSet.getOutput().getClassesDirs().filter(f -> f.exists()).forEach(f -> builder.add(f.toPath()));
         final File resourcesDir = mainSourceSet.getOutput().getResourcesDir();


### PR DESCRIPTION
This branch adds input and output to the `quarkusBuild` task. Thus, if nothing change, the task will be marked as `up-to-date`, and won't take any time to run. 
`quarkusBuild` task will run when there is a change detected either in the classpath (compile + runtime + resource) or if the output is missing.
I only declared the `-runner.jar` file as output as the native executable depends on quarkus properties. 
I also add tests which make sure that `quarkusBuild` runs when one of the following changes happen. 
close #9281 