### PR TITLE
Fix dependency cycle between the Mutiny RSO and Context Propagation

### DIFF
--- a/extensions/reactive-streams-operators/mutiny-reactive-streams-operators/deployment/pom.xml
+++ b/extensions/reactive-streams-operators/mutiny-reactive-streams-operators/deployment/pom.xml
@@ -23,10 +23,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix dependency cycle between the Mutiny implementation of reactive streams operators and context propagation.