### PR TITLE
Don't repeat query params in access log

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/AccessLogFileTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/accesslog/AccessLogFileTestCase.java
@@ -90,7 +90,7 @@ public class AccessLogFileTestCase {
 
     @Test
     public void testSingleLogMessageToFile() throws IOException, InterruptedException {
-        RestAssured.get("/does-not-exist");
+        RestAssured.get("/does-not-exist?foo=bar");
 
         Awaitility.given().pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
@@ -105,6 +105,10 @@ public class AccessLogFileTestCase {
                         String data = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
                         Assertions.assertTrue(data.contains("404"));
                         Assertions.assertTrue(data.contains("/does-not-exist"));
+                        Assertions.assertTrue(data.contains("?foo=bar"),
+                                "access log is missing query params");
+                        Assertions.assertFalse(data.contains("?foo=bar?foo=bar"),
+                                "access log contains duplicated query params");
                     }
                 });
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestLineAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestLineAttribute.java
@@ -23,10 +23,6 @@ public class RequestLineAttribute implements ExchangeAttribute {
                 .append(exchange.request().method())
                 .append(' ')
                 .append(exchange.request().uri());
-        if (exchange.request().query() != null) {
-            sb.append('?');
-            sb.append(exchange.request().query());
-        }
         sb.append(' ')
                 .append(exchange.request().version());
         return sb.toString();


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/9295

The `"%r"` format specifier used by the `common` access log implies the request line. The implementation in `RequestLineAttribute` currently uses `exchange.request().uri()` which includes both the request path and query params (the javadoc of that `io.vertx.core.http.HttpServerRequest.uri()` doesn't explain much of what to expect of the return value but at least the implementation returns both the path and the query params. So there's no need to additionally append the query params explicitly. The commit in this PR fixes that and includes a test to reproduce the issue and verify the fix.