### PR TITLE
Add swagger-ui to dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -110,6 +110,9 @@ update_configs:
           dependency_name: "io.smallrye.reactive:smallrye-reactive-messaging"
       - match:
           dependency_name: "io.smallrye.reactive:smallrye-reactive-streams-operators"
+      # Swagger-UI
+      - match:
+          dependency_name: "org.webjars:swagger-ui"
       # Tika
       - match:
           dependency_name: "org.apache.tika:tika-parsers"


### PR DESCRIPTION
I noticed Quarkus is still on 3.25.0.
3.25.3 came out a few days ago.

https://github.com/webjars/swagger-ui/releases
https://github.com/swagger-api/swagger-ui/releases

cc @stuartwdouglas 