### PR TITLE
Gradle devmode: set quarkus.application.* properties

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/devmode/InjectQuarkusAppPropertiesDevModeTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/devmode/InjectQuarkusAppPropertiesDevModeTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InjectQuarkusAppPropertiesDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "inject-quarkus-app-properties";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] {"clean", "quarkusDev", "-s"};
+    }
+
+    protected void testDevMode() throws Exception {
+
+        assertThat(getHttpResponse("/hello")).contains("code-with-quarkus 1.0.0-SNAPSHOT");
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/gradle.properties
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/settings.gradle
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/main/java/org/acme/ExampleResource.java
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,24 @@
+package org.acme;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @ConfigProperty(name = "my-app-name")
+    String appName;
+    @ConfigProperty(name = "quarkus.application.version")
+    String appVersion;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return appName + " " + appVersion;
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>code-with-quarkus - 1.0.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme</li>
+                <li>ArtifactId: code-with-quarkus</li>
+                <li>Version: 1.0.0-SNAPSHOT</li>
+                <li>Quarkus Version: 1.3.2.Final</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/main/resources/application.properties
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+# Configuration file
+# key = value
+my-app-name=${quarkus.application.name}

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/test/java/org/acme/ExampleResourceTest.java
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,29 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class ExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Hello from Test"));
+    }
+
+    @Test
+    public void testTestOnly() {
+      given()
+          .when().get("test-only")
+          .then()
+              .statusCode(200)
+              .body(is("Test only"));
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/test/resources/application.properties
+++ b/devtools/gradle/src/functionalTest/resources/inject-quarkus-app-properties/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+# Configuration file
+# key = value
+example.message=Hello from Test
+test-only=Test only
+

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -189,7 +190,24 @@ public class QuarkusDev extends QuarkusTask {
                     "this should not happen as build should have been executed first. " +
                     "Does the project have any source files?");
         }
+
         DevModeContext context = new DevModeContext();
+        context.setProjectDir(project.getProjectDir());
+        for (Map.Entry<Object, Object> e : System.getProperties().entrySet()) {
+            context.getSystemProperties().put(e.getKey().toString(), (String) e.getValue());
+        }
+        for (Map.Entry<String, ?> e : project.getProperties().entrySet()) {
+            if (e.getValue() instanceof String) {
+                context.getBuildSystemProperties().put(e.getKey(), e.getValue().toString());
+            }
+        }
+
+        //  this is a minor hack to allow ApplicationConfig to be populated with defaults
+        context.getBuildSystemProperties().putIfAbsent("quarkus.application.name", project.getName());
+        if (project.getVersion() != null) {
+            context.getBuildSystemProperties().putIfAbsent("quarkus.application.version", project.getVersion().toString());
+        }
+
         context.setSourceEncoding(getSourceEncoding());
         try {
             List<String> args = new ArrayList<>();


### PR DESCRIPTION
Fixes #9177
To be more precise, it fixes the failure reported in the description of the mentioned issue.
Trying to reproduce the issue with the platform snapshot and quarkus snapshot I found another issue related to versions alignment of the deployment dependencies. This is partly fixed in this PR by collecting the enforced platforms (BOMs) in the project and enforcing them when resolving deployment dependencies.