### PR TITLE
Add a WebJars Locator extension that duplicates webjars locator behavior from Spring Boot

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -822,6 +822,19 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-webjars-locator-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Quarkus extension dependencies -->
+            <dependency>
+                <groupId>org.webjars</groupId>
+                <artifactId>webjars-locator</artifactId>
+                <version>0.39</version>
+            </dependency>
+
             <!-- Quarkus test dependencies -->
 
             <dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1075,6 +1075,11 @@
                 <artifactId>quarkus-picocli</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-webjars-locator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- External dependencies -->
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/FeatureBuildItem.java
@@ -111,6 +111,7 @@ public final class FeatureBuildItem extends MultiBuildItem {
     public static final String VERTX = "vertx";
     public static final String VERTX_WEB = "vertx-web";
     public static final String VERTX_GRAPHQL = "vertx-graphql";
+    public static final String WEBJARS_LOCATOR = "webjars-locator";
 
     private final String info;
 

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -29,6 +29,29 @@ was chosen as it is the standard location for resources in `jar` files as define
 Quarkus can be used without Servlet following this convention allows existing code that places its resources in this
 location to function correctly.
 
+=== WebJar Locator Support
+
+If you are using webjars, like the following JQuery one
+[source, xml]
+----
+<dependency>
+    <groupId>org.webjars</groupId>
+    <artifactId>jquery</artifactId>
+    <version>3.1.1</version>
+</dependency>
+----
+and rather write `/webjars/jquery/jquery.min.js` instead of `/webjars/jquery/3.1.1/jquery.min.js`
+in your HTML files, you can add the `quarkus-webjars-locator` extension to your project.
+To use it, add the following to your project's dependencies:
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-webjars-locator</artifactId>
+</dependency>
+----
+
 == Configuring the Context path
 
 By default Quarkus will serve content from under the root context. If you want to change this you can use the

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -33,6 +33,7 @@
         <module>vertx-http</module>
         <module>undertow</module>
         <module>undertow-websockets</module>
+        <module>webjars-locator</module>
 
         <!-- Monitoring -->
         <module>smallrye-health</module>

--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-webjars-locator-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-webjars-locator-deployment</artifactId>
+    <name>Quarkus - WebJar Locator - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>webjars-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-webjars-locator</artifactId>
+        </dependency>
+        
+        <!-- Tests -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <!-- Using setForcedDependencies only works if the dependency is in the pom's test scope. -->
+        <dependency>
+          <groupId>org.webjars</groupId>
+          <artifactId>jquery</artifactId>
+          <version>3.4.1</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.webjars</groupId>
+          <artifactId>momentjs</artifactId>
+          <version>2.24.0</version>
+          <scope>test</scope>
+        </dependency>
+        
+        <!-- DevMode has no setForcedDependencies, so need to add resteasy extension here -->
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
@@ -1,0 +1,42 @@
+package io.quarkus.webjar.locator.deployment;
+
+import java.util.Map;
+
+import org.webjars.WebJarAssetLocator;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.webjar.locator.runtime.WebJarLocatorRecorder;
+
+public class WebJarLocatorStandaloneBuildStep {
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void findWebjarsAndCreateHandler(
+            HttpBuildTimeConfig httpConfig,
+            BuildProducer<FeatureBuildItem> feature,
+            BuildProducer<RouteBuildItem> routes,
+            WebJarLocatorRecorder recorder) throws Exception {
+
+        WebJarAssetLocator webJarLocator = new WebJarAssetLocator();
+        Map<String, String> webjarNameToVersionMap = webJarLocator.getWebJars();
+
+        if (!webjarNameToVersionMap.isEmpty()) {
+            // The context path + the resources path
+            String rootPath = httpConfig.rootPath;
+            String webjarRootPath = (rootPath.endsWith("/")) ? rootPath + "webjars/" : rootPath + "/webjars/";
+            feature.produce(new FeatureBuildItem(FeatureBuildItem.WEBJARS_LOCATOR));
+            routes.produce(
+                    new RouteBuildItem(webjarRootPath + "*",
+                            recorder.getHandler(webjarRootPath, webjarNameToVersionMap),
+                            false));
+        }
+
+    }
+
+}

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/PostResource.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/PostResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.webjar.locator.test;
+
+import javax.annotation.PreDestroy;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+@Path("/post")
+public class PostResource {
+
+    @POST
+    public String modify(String data) {
+        return "Hello: " + data;
+    }
+
+    @PreDestroy
+    void destroy() {
+        throw new IllegalStateException("Something bad happened but dev mode should work fine");
+    }
+
+}

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.webjar.locator.test;
+
+import static org.hamcrest.core.Is.is;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class WebJarLocatorDevModeTest {
+    private static final String META_INF_RESOURCES = "META-INF/resources/";
+
+    @RegisterExtension
+    static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(PostResource.class)
+                    .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
+                    .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"));
+
+    @Test
+    public void testDevMode() {
+        // Test Endpoint
+        RestAssured.given().body("Stuart")
+                .when()
+                .post("/post")
+                .then()
+                .body(Matchers.equalTo("Hello: Stuart"));
+        // Test normal files
+        RestAssured.get("/").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/index.html").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/some/path/test.txt").then()
+                .statusCode(200)
+                .body(is("Test"));
+
+        // Test Existing Web Jars
+        RestAssured.get("/webjars/jquery/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test using version in url of existing Web Jar
+        RestAssured.get("/webjars/jquery/3.4.1/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test non-existing Web Jar
+        RestAssured.get("/webjars/bootstrap/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+
+        // Change a source file
+        test.modifySourceFile(PostResource.class, s -> s.replace("Hello:", "Hi:"));
+
+        // Test modified endpoint
+        RestAssured.given().body("Stuart")
+                .when()
+                .post("/post")
+                .then()
+                .body(Matchers.equalTo("Hi: Stuart"));
+
+        // Test normal files
+        RestAssured.get("/").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/index.html").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/some/path/test.txt").then()
+                .statusCode(200)
+                .body(is("Test"));
+
+        // Test Existing Web Jars
+        RestAssured.get("/webjars/jquery/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test using version in url of existing Web Jar
+        RestAssured.get("/webjars/jquery/3.4.1/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test non-existing Web Jar
+        RestAssured.get("/webjars/bootstrap/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+    }
+}

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.webjar.locator.test;
+
+import static org.hamcrest.core.Is.is;
+
+import java.util.Arrays;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WebJarLocatorTest {
+    private static final String META_INF_RESOURCES = "META-INF/resources/";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
+                    .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
+            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery", "3.4.1"),
+                    new AppArtifact("org.webjars", "momentjs", "2.24.0"),
+                    // We require another extension to provide basic web server capabilities
+                    new AppArtifact("io.quarkus", "quarkus-resteasy", "999-SNAPSHOT")));
+
+    @Test
+    public void test() {
+        // Test normal files
+        RestAssured.get("/").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/index.html").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/some/path/test.txt").then()
+                .statusCode(200)
+                .body(is("Test"));
+
+        // Test Existing Web Jars
+        RestAssured.get("/webjars/jquery/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test using version in url of existing Web Jar
+        RestAssured.get("/webjars/jquery/3.4.1/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test non-existing Web Jar
+        RestAssured.get("/webjars/bootstrap/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+    }
+}

--- a/extensions/webjars-locator/pom.xml
+++ b/extensions/webjars-locator/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-build-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../build-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-webjars-locator-parent</artifactId>
+    <name>Quarkus - WebJar Locator</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/webjars-locator/runtime/pom.xml
+++ b/extensions/webjars-locator/runtime/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-webjars-locator-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-webjars-locator</artifactId>
+    <name>Quarkus - WebJar Locator - Runtime</name>
+    <description>Simplify paths for WebJar dependencies</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/webjars-locator/runtime/src/main/java/io/quarkus/webjar/locator/runtime/WebJarLocatorRecorder.java
+++ b/extensions/webjars-locator/runtime/src/main/java/io/quarkus/webjar/locator/runtime/WebJarLocatorRecorder.java
@@ -1,0 +1,44 @@
+package io.quarkus.webjar.locator.runtime;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+@Recorder
+public class WebJarLocatorRecorder {
+
+    public Handler<RoutingContext> getHandler(String webjarsRootUrl, Map<String, String> webjarNameToVersionMap) {
+        return (event) -> {
+            String path = event.normalisedPath();
+            if (path.startsWith(webjarsRootUrl)) {
+                String rest = path.substring(webjarsRootUrl.length());
+                String webjar = rest.substring(0, rest.indexOf('/'));
+                if (webjarNameToVersionMap.containsKey(webjar)) {
+                    // Check this is not the actual path (ex: /webjars/jquery/${jquery.version}/...
+                    int endOfVersion = rest.indexOf('/', rest.indexOf('/') + 1);
+                    if (endOfVersion == -1) {
+                        endOfVersion = rest.length();
+                    }
+                    String nextPathEntry = rest.substring(rest.indexOf('/') + 1, endOfVersion);
+                    if (nextPathEntry.equals(webjarNameToVersionMap.get(webjar))) {
+                        // go to the next handler (which should be the static resource handler, if one exists)
+                        event.next();
+                    } else {
+                        // reroute to the real resource
+                        event.reroute(webjarsRootUrl + webjar + "/"
+                                + webjarNameToVersionMap.get(webjar) + rest.substring(rest.indexOf('/')));
+                    }
+                } else {
+                    // this is not a webjar that we know about
+                    event.fail(404);
+                }
+            } else {
+                // should not happen if route is set up correctly
+                event.next();
+            }
+        };
+    }
+
+}

--- a/extensions/webjars-locator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/webjars-locator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "WebJar Locator"
+metadata:
+  short-name: "webjars-locator"
+  keywords:
+  - "web"
+  - "webjar"
+  guide: ""
+  categories:
+  - "web"
+  status: "stable"

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -114,6 +114,7 @@
         <module>consul-config</module>
         <module>picocli</module>
         <module>picocli-native</module>
+        <module>webjars-locator</module>
 
         <!-- gRPC tests -->
         <module>grpc-plain-text</module>

--- a/integration-tests/webjars-locator/pom.xml
+++ b/integration-tests/webjars-locator/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-webjars-locator</artifactId>
+
+    <name>Quarkus - Integration Tests - WebJar Locator</name>
+    
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-webjars-locator</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.webjars</groupId>
+          <artifactId>jquery</artifactId>
+          <version>3.4.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.webjars</groupId>
+          <artifactId>momentjs</artifactId>
+          <version>2.24.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/Greeting.java
+++ b/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/Greeting.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.webjar.locator;
+
+import java.time.LocalDate;
+
+public class Greeting {
+
+    private final String message;
+    private final LocalDate date;
+
+    public Greeting(String message, LocalDate date) {
+        this.message = message;
+        this.date = date;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+}

--- a/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/GreetingResource.java
+++ b/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/GreetingResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.webjar.locator;
+
+import java.time.LocalDate;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/greeting")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Greeting hello() {
+        return new Greeting("hello", LocalDate.of(2019, 01, 01));
+    }
+}

--- a/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/MessageResource.java
+++ b/integration-tests/webjars-locator/src/main/java/io/quarkus/it/webjar/locator/MessageResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.webjar.locator;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/message")
+public class MessageResource {
+
+    @ConfigProperty(name = "message")
+    String message;
+
+    @GET
+    public String message() {
+        return message;
+    }
+
+}

--- a/integration-tests/webjars-locator/src/main/resources/application.properties
+++ b/integration-tests/webjars-locator/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+message=Production

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/ApplicationPropertiesOverrideIT.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/ApplicationPropertiesOverrideIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.webjar.locator;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+/**
+ * tests that application.properties is read from src/main/resources when running native image tests
+ * 
+ * This does not necessarily belong here, but main and test-extension have a lot of existing
+ * config that would need to be duplicated, so it is here out of convenience.
+ */
+@NativeImageTest
+class ApplicationPropertiesOverrideIT {
+
+    @Test
+    void testEndpoint() {
+        given()
+                .when().get("/message")
+                .then()
+                .statusCode(200)
+                .body(containsString("Production"));
+    }
+
+}

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/ApplicationPropertiesOverrideTest.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/ApplicationPropertiesOverrideTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.webjar.locator;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * tests that application.properties is read from src/test/resources
+ * 
+ * This does not necessarily belong here, but main and test-extension have a lot of existing
+ * config that would need to be duplicated, so it is here out of convenience.
+ */
+@QuarkusTest
+class ApplicationPropertiesOverrideTest {
+
+    @Test
+    void testEndpoint() {
+        given()
+                .when().get("/message")
+                .then()
+                .statusCode(200)
+                .body(containsString("Test"));
+    }
+
+}

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/GeneratedClassesTest.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/GeneratedClassesTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.webjar.locator;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class GeneratedClassesTest {
+
+    @Test
+    void testGeneratedContextResolver() {
+        assertNotNull(generatedContextResolver());
+    }
+
+    private Object generatedContextResolver() {
+        try {
+            Class<?> objectMapperResolverClass = Class
+                    .forName("io.quarkus.resteasy.common.runtime.jackson.QuarkusObjectMapperContextResolver");
+            return objectMapperResolverClass.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/GreetingResourceTest.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/GreetingResourceTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.webjar.locator;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class GreetingResourceTest {
+
+    @Test
+    void testEndpoint() {
+        given()
+                .when().get("/greeting")
+                .then()
+                .statusCode(200)
+                .body(containsString("hello"))
+                .body(containsString("[2019,1,1]"));
+    }
+
+}

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/GreetingResourceTestIT.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/GreetingResourceTestIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.webjar.locator;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class GreetingResourceTestIT extends GreetingResourceTest {
+}

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceTest.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.webjar.locator;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class WebJarResourceTest {
+
+    @Test
+    void testWebJar() {
+        // Test Existing Web Jars
+        RestAssured.get("/webjars/jquery/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test using version in url of existing Web Jar
+        RestAssured.get("/webjars/jquery/3.4.1/jquery.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test non-existing Web Jar
+        RestAssured.get("/webjars/bootstrap/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+    }
+}

--- a/integration-tests/webjars-locator/src/test/resources/application.properties
+++ b/integration-tests/webjars-locator/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+message=Test


### PR DESCRIPTION
…r from Spring Boot.

This reverts commit 7c9face3cd1424387d8db0015c34ea2da095da0e.

This caused CI failures and was reverted, even though the run was green. Reopened here to get more info on the failures.