### PR TITLE
Make access logging work in native mode

### DIFF
--- a/integration-tests/vertx-http/pom.xml
+++ b/integration-tests/vertx-http/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>vertx-web-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/SimpleResource.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/SimpleResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.vertx;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ *
+ */
+@Path("/simple")
+public class SimpleResource {
+    @GET
+    @Path("/access-log-test-endpoint")
+    public String accessLogTest() {
+        return "passed";
+    }
+}

--- a/integration-tests/vertx-http/src/main/resources/application.properties
+++ b/integration-tests/vertx-http/src/main/resources/application.properties
@@ -4,3 +4,7 @@ quarkus.http.ssl.certificate.key-store-password=password
 quarkus.http.ssl.certificate.trust-store-file=server-truststore.jks
 quarkus.http.ssl.certificate.trust-store-password=password
 quarkus.http.ssl.client-auth=REQUIRED
+quarkus.http.access-log.enabled=true
+quarkus.http.access-log.log-to-file=true
+quarkus.http.access-log.base-file-name=quarkus-access-log
+quarkus.http.access-log.log-directory=target

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCase.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.vertx;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class AccessLogTestCase {
+
+    /**
+     * Fires a HTTP request, to an application which has access log enabled and then checks
+     * the access-log contents to verify that the request was logged
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAccessLogContent() throws Exception {
+        final Path logDirectory = Paths.get(".", "target");
+        final String queryParamVal = UUID.randomUUID().toString();
+        final String targetUri = "/simple/access-log-test-endpoint?foo=" + queryParamVal;
+        RestAssured.when().get(targetUri).then().body(containsString("passed"));
+        Awaitility.given().pollInterval(100, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(new ThrowingRunnable() {
+                    @Override
+                    public void run() throws Throwable {
+                        final Path accessLogFilePath = logDirectory.resolve("quarkus-access-log.log");
+                        Assertions.assertTrue(Files.exists(accessLogFilePath),
+                                "access log file " + accessLogFilePath + " is missing");
+                        String data = new String(Files.readAllBytes(accessLogFilePath), StandardCharsets.UTF_8);
+                        Assertions.assertTrue(data.contains(targetUri),
+                                "access log doesn't contain an entry for " + targetUri);
+                        Assertions.assertTrue(data.contains("?foo=" + queryParamVal),
+                                "access log is missing query params");
+                        Assertions.assertFalse(data.contains("?foo=" + queryParamVal + "?foo=" + queryParamVal),
+                                "access log contains duplicated query params");
+                    }
+                });
+    }
+
+}

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCaseIT.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/AccessLogTestCaseIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.vertx;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class AccessLogTestCaseIT extends AccessLogTestCase {
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/9047

Right now, access logging isn't working in native mode as reported in the issue. This is because the `ExchangeAttributeBuilder`(s) which are responsible for handling the access log format specifier are `ServiceLoader` based interfaces and as such need to be explicitly registered in native image for them to be available.

The commit here explicitly makes them available in native mode and also includes a test to reproduce the issue and verify the fix.