### PR TITLE
Increase timeout for Amazon native tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -354,7 +354,7 @@ jobs:
               narayana-jta
           - category: Amazon
             amazonServices: "true"
-            timeout: 20
+            timeout: 25
             test-modules: >
               amazon-services
               amazon-lambda


### PR DESCRIPTION
I saw a few PRs timeout on Amazon native tests