### PR TITLE
Update to Vert.x 3.9.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -41,9 +41,9 @@
         <smallrye-fault-tolerance.version>4.2.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.1.2</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
-        <smallrye-reactive-streams-operators.version>1.0.12</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.0.12</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.0.3</smallrye-reactive-messaging.version>
+        <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
+        <smallrye-converter-api.version>1.0.13</smallrye-converter-api.version>
+        <smallrye-reactive-messaging.version>2.0.4</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.25.3</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -102,7 +102,7 @@
         <wildfly-elytron.version>1.11.4.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.1.1.Final</jboss-threads.version>
-        <vertx.version>3.9.0</vertx.version>
+        <vertx.version>3.9.1</vertx.version>
         <httpclient.version>4.5.12</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <httpasync.version>4.1.4</httpasync.version>
@@ -127,8 +127,8 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <mutiny.version>0.5.0</mutiny.version>
-        <axle-client.version>0.0.15</axle-client.version>
-        <mutiny-client.version>0.0.15</mutiny-client.version>
+        <axle-client.version>0.0.16</axle-client.version>
+        <mutiny-client.version>0.0.16</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>
         <debezium.version>1.1.1.Final</debezium.version>
         <zookeeper.version>3.5.7</zookeeper.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -34,9 +34,9 @@
            what we work with by self downloading it: -->
         <graal-sdk.version-for-documentation>19.3.1</graal-sdk.version-for-documentation>
         <rest-assured.version>4.1.1</rest-assured.version>
-        <axle-client.version>0.0.15</axle-client.version>
-        <mutiny-client.version>0.0.15</mutiny-client.version>
-        <vertx.version>3.9.0</vertx.version>
+        <axle-client.version>0.0.16</axle-client.version>
+        <mutiny-client.version>0.0.16</mutiny-client.version>
+        <vertx.version>3.9.1</vertx.version>
 
         <!-- Dev tools -->
         <freemarker.version>2.3.30</freemarker.version>

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -9,10 +9,6 @@
         <version>999-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <vertx.version>3.9.0</vertx.version>
-    </properties>
-
     <artifactId>quarkus-grpc</artifactId>
     <name>Quarkus - gRPC - Runtime</name>
     <description>Serve and consume gRPC services</description>


### PR DESCRIPTION
Update the following versions:

Vert.x -> 3.9.1
SmallRye Reactive Messaging -> 2.0.4
SmallRye Reactive Streams Operators and Reactive Converters -> 1.0.13
SmallRye Reactive Utils and Vert.x Mutiny Client -> 0.0.16