### PR TITLE
Use the deployment dependency for test to properly order the build

### DIFF
--- a/extensions/smallrye-context-propagation/deployment/pom.xml
+++ b/extensions/smallrye-context-propagation/deployment/pom.xml
@@ -77,7 +77,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
+            <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This causes a failure when releasing because the deployment artifact has
not been built.