### PR TITLE
Support custom MessageBodyWriters and MessageBodyReaders

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -160,7 +161,14 @@ public class ResteasyCommonProcessor {
         MediaTypeMap<String> categorizedContextResolvers = new MediaTypeMap<>();
         Set<String> otherProviders = new HashSet<>();
 
-        categorizeProviders(availableProviders, categorizedReaders, categorizedWriters, categorizedContextResolvers,
+        Set<String> allProviders = new LinkedHashSet<>();
+        allProviders.addAll(availableProviders);
+        allProviders.addAll(ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
+                "META-INF/services/" + MessageBodyReader.class.getName()));
+        allProviders.addAll(ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
+                "META-INF/services/" + MessageBodyWriter.class.getName()));
+
+        categorizeProviders(allProviders, categorizedReaders, categorizedWriters, categorizedContextResolvers,
                 otherProviders);
 
         // add the other providers detected

--- a/integration-tests/resteasy-jackson/pom.xml
+++ b/integration-tests/resteasy-jackson/pom.xml
@@ -21,7 +21,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-yaml-provider</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
@@ -15,4 +15,12 @@ public class GreetingResource {
     public Greeting hello() {
         return new Greeting("hello", LocalDate.of(2019, 01, 01));
     }
+
+    @GET
+    @Path("/yaml")
+    @Produces("application/yaml")
+    public Greeting helloYaml() {
+        return new Greeting("hello", null);
+    }
+
 }

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTest.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTest.java
@@ -20,4 +20,14 @@ class GreetingResourceTest {
                 .body(containsString("[2019,1,1]"));
     }
 
+    @Test
+    void testYAMLEndpoint() {
+        given()
+                .when().get("/greeting/yaml")
+                .then()
+                .statusCode(200)
+                .contentType("application/yaml")
+                .body(containsString("message: \"hello\""));
+    }
+
 }


### PR DESCRIPTION
eg. YAML is now supported by simply adding a dependency to com.fasterxml.jackson.jaxrs:jackson-jaxrs-yaml-provider