### PR TITLE
Fix CodeFlowTest

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -179,7 +179,7 @@
         <quarkus-spring-security-api.version>5.2.Final</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <mvel2.version>2.4.7.Final</mvel2.version>
-        <htmlunit.version>2.36.0</htmlunit.version>
+        <htmlunit.version>2.40.0</htmlunit.version>
         <mockito.version>3.3.3</mockito.version>
         <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.7.2</antlr.version>

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -14,6 +14,7 @@ quarkus.oidc.authentication.cookie-path=/
 quarkus.oidc.authentication.extra-params.max-age=60
 quarkus.oidc.application-type=web-app
 
+
 # Tenant which does not need to restore a request path after redirect, client_secret_post method
 quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-1.client-id=quarkus-app
@@ -98,4 +99,5 @@ quarkus.http.auth.permission.post-logout.policy=permit
 quarkus.http.cors=true
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+quarkus.log.category."io.vertx.ext.auth.oauth2.impl.OAuth2UserImpl".level=TRACE
 #quarkus.log.category."org.apache.http".level=TRACE

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
@@ -139,7 +138,6 @@ public class CodeFlowTest {
     }
 
     @Test
-    @Disabled
     public void testRPInitiatedLogout() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/tenant-logout");
@@ -415,7 +413,6 @@ public class CodeFlowTest {
     }
 
     @Test
-    @Disabled
     public void testAccessTokenInjection() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/index.html");
@@ -502,11 +499,11 @@ public class CodeFlowTest {
     }
 
     private String getStateCookieStateParam(WebClient webClient, String tenantId) {
-        return getStateCookie(webClient, tenantId).getValue().split("___")[0];
+        return getStateCookie(webClient, tenantId).getValue().split("\\|")[0];
     }
 
     private String getStateCookieSavedPath(WebClient webClient, String tenantId) {
-        String[] parts = getStateCookie(webClient, tenantId).getValue().split("___");
+        String[] parts = getStateCookie(webClient, tenantId).getValue().split("\\|");
         return parts.length == 2 ? parts[1] : null;
     }
 
@@ -515,6 +512,6 @@ public class CodeFlowTest {
     }
 
     private String getIdToken(Cookie sessionCookie) {
-        return sessionCookie.getValue().split("___")[0];
+        return sessionCookie.getValue().split("\\|")[0];
     }
 }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -153,7 +153,7 @@ public class BearerTokenAuthorizationTest {
     }
 
     private String getStateCookieSavedPath(WebClient webClient, String tenantId) {
-        String[] parts = getStateCookie(webClient, tenantId).getValue().split("___");
+        String[] parts = getStateCookie(webClient, tenantId).getValue().split("\\|");
         return parts.length == 2 ? parts[1] : null;
     }
 }


### PR DESCRIPTION
Fixes #9454

This PR fixes sporadic 401s which can happen when a token signature contains the same sequence as the session cookie separator which is possible because `_` is a valid Base64URL encoding character with JWT signatures also being Base64URL-encoded

Note every CodeFlowTest test is complex so I can't guarantee this fix will eliminate the sporadic failures for good :-) but this fix certainly moves it in that direction :-)

CC @geoand @n1hility 