### PR TITLE
Disable CP cache when using forced dependencies

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -76,6 +76,7 @@ public class QuarkusBootstrap implements Serializable {
     private final MavenArtifactResolver mavenArtifactResolver;
     private final AppArtifact managingProject;
     private final List<AppDependency> forcedDependencies;
+    private final boolean disableClasspathCache;
 
     private QuarkusBootstrap(Builder builder) {
         this.applicationRoot = builder.applicationRoot;
@@ -100,6 +101,7 @@ public class QuarkusBootstrap implements Serializable {
         this.mavenArtifactResolver = builder.mavenArtifactResolver;
         this.managingProject = builder.managingProject;
         this.forcedDependencies = new ArrayList<>(builder.forcedDependencies);
+        this.disableClasspathCache = builder.disableClasspathCache;
     }
 
     public CuratedApplication bootstrap() throws BootstrapException {
@@ -128,11 +130,15 @@ public class QuarkusBootstrap implements Serializable {
                 .setProjectRoot(getProjectRoot());
         if (mode == Mode.TEST || test) {
             appModelFactory.setTest(true);
-            appModelFactory.setEnableClasspathCache(true);
+            if (!disableClasspathCache) {
+                appModelFactory.setEnableClasspathCache(true);
+            }
         }
         if (mode == Mode.DEV) {
             appModelFactory.setDevMode(true);
-            appModelFactory.setEnableClasspathCache(true);
+            if (!disableClasspathCache) {
+                appModelFactory.setEnableClasspathCache(true);
+            }
         }
         return new CuratedApplication(this, appModelFactory.resolveAppModel());
     }
@@ -217,6 +223,7 @@ public class QuarkusBootstrap implements Serializable {
         MavenArtifactResolver mavenArtifactResolver;
         AppArtifact managingProject;
         List<AppDependency> forcedDependencies = new ArrayList<>();
+        boolean disableClasspathCache;
 
         public Builder() {
         }
@@ -314,6 +321,11 @@ public class QuarkusBootstrap implements Serializable {
 
         public Builder setDependenciesOrigin(DependenciesOrigin dependenciesOrigin) {
             this.dependenciesOrigin = dependenciesOrigin;
+            return this;
+        }
+
+        public Builder setDisableClasspathCache(boolean disableClasspathCache) {
+            this.disableClasspathCache = disableClasspathCache;
             return this;
         }
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -385,6 +385,11 @@ public class QuarkusUnitTest
                         .setProjectRoot(testLocation)
                         .setForcedDependencies(forcedDependencies.stream().map(d -> new AppDependency(d, "compile"))
                                 .collect(Collectors.toList()));
+                if (!forcedDependencies.isEmpty()) {
+                    //if we have forced dependencies we can't use the cache
+                    //as it can screw everything up
+                    builder.setDisableClasspathCache(true);
+                }
                 if (!allowTestClassOutsideDeployment) {
                     builder
                             .setBaseClassLoader(


### PR DESCRIPTION
If the cache is enabled the wrong dependencies will be used,
and if the forced dep test is the first to run this can cause
unrelated tests to fail.