### PR TITLE
Increase timeout for data1 native ci job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -313,7 +313,7 @@ jobs:
           - category: Data1
             mariadb: "true"
             mssql: "true"
-            timeout: 50
+            timeout: 55
             test-modules: >
               jpa-h2
               jpa-mariadb


### PR DESCRIPTION
Done because I saw a couple PRs timeout on this step