### PR TITLE
Update MP Metrics API to 2.3.2

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -60,7 +60,7 @@
         <!-- MicroProfile TCK versions -->
         <microprofile-health-api.version>2.2</microprofile-health-api.version>
         <microprofile-config-api.version>1.4</microprofile-config-api.version>
-        <microprofile-metrics-api.version>2.3</microprofile-metrics-api.version>
+        <microprofile-metrics-api.version>2.3.2</microprofile-metrics-api.version>
         <microprofile-fault-tolerance-api.version>2.1</microprofile-fault-tolerance-api.version>
         <microprofile-reactive-messaging-api.version>1.0</microprofile-reactive-messaging-api.version>
         <microprofile-rest-client-api.version>1.4.1</microprofile-rest-client-api.version>


### PR DESCRIPTION
Includes TCK fix for https://github.com/eclipse/microprofile-metrics/issues/537 (intermittently failing `ConcurrentGaugedClassBeanTest`)