### PR TITLE
Auto-label issues on area/kafka-streams

### DIFF
--- a/.github/autoissuelabeler.yml
+++ b/.github/autoissuelabeler.yml
@@ -61,3 +61,7 @@
   title: "(?i).*jib.*"
   description: "(?i).*jib.*"
   addcomment: "/cc @geoand"
+- labels: [area/kafka-streams]
+  title: "(?i).*k(afka)?(\s|-)?stream.*"
+  description: "(?i).*k(afka)?(\s|-)?stream.*"
+  addcomment: "/cc @gunnarmorling"


### PR DESCRIPTION
I just noticed new issues were not labelled, making them harder to find - in particular due to the many variations used in practice.

Should cover variations like "Kafka Stream", "KStreams", "KafkaStreams" and "kafka-streams"