### PR TITLE
Remove Reactive Messaging in-memory-connector from bom in 1.3.x

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2444,11 +2444,6 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
                 <exclusions>


### PR DESCRIPTION
fixes #9540

cc @michalszynkiewicz @cescoffier 