### PR TITLE
Clean up redundant surefire config and use one version

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -215,6 +215,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
                     <configuration>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/core/builder/pom.xml
+++ b/core/builder/pom.xml
@@ -64,11 +64,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
                 <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
                     <threadCount>1</threadCount>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/devtools/aesh/pom.xml
+++ b/devtools/aesh/pom.xml
@@ -41,11 +41,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
                 <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
                     <threadCount>1</threadCount>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -81,14 +81,6 @@
 
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/extensions/hibernate-search-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-elasticsearch/deployment/pom.xml
@@ -42,9 +42,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/integration-tests/bootstrap-config/application/pom.xml
+++ b/integration-tests/bootstrap-config/application/pom.xml
@@ -54,14 +54,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
             </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/grpc-health/pom.xml
+++ b/integration-tests/grpc-health/pom.xml
@@ -107,15 +107,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/grpc-interceptors/pom.xml
+++ b/integration-tests/grpc-interceptors/pom.xml
@@ -103,15 +103,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/grpc-mutual-auth/pom.xml
+++ b/integration-tests/grpc-mutual-auth/pom.xml
@@ -103,15 +103,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/hibernate-orm-panache/pom.xml
+++ b/integration-tests/hibernate-orm-panache/pom.xml
@@ -154,10 +154,6 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                            </systemPropertyVariables>
-                            <argLine>${jacoco.agent.argLine}</argLine>
                             <includes>**/*PMT.java</includes>
                         </configuration>
                     </execution>

--- a/integration-tests/infinispan-client/pom.xml
+++ b/integration-tests/infinispan-client/pom.xml
@@ -130,9 +130,6 @@
         </resources>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <!-- Skip enforcer plugin as we want to use jboss marshalling for test class -->

--- a/integration-tests/infinispan-embedded/pom.xml
+++ b/integration-tests/infinispan-embedded/pom.xml
@@ -69,9 +69,6 @@
         </resources>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <!-- Skip enforcer plugin as we want to use jboss marshalling for test class -->

--- a/integration-tests/spring-data-jpa/pom.xml
+++ b/integration-tests/spring-data-jpa/pom.xml
@@ -87,10 +87,6 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                            </systemPropertyVariables>
-                            <argLine>${jacoco.agent.argLine}</argLine>
                             <includes>**/*PMT.java</includes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This came up in another PR: https://github.com/quarkusio/quarkus/pull/9523#discussion_r429457018

While working on this, I saw more potential "code smells" I'd like to address in subsequent PRs.

cc @geoand & @aloubyansky 