### PR TITLE
Fix flyway resource inclusion in native image when build is triggered from a Windows machine

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.flyway;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -197,6 +198,7 @@ class FlywayProcessor {
         try (final Stream<Path> pathStream = Files.walk(Paths.get(path.toURI()))) {
             return pathStream.filter(Files::isRegularFile)
                     .map(it -> Paths.get(location, it.getFileName().toString()).toString())
+                    .map(it -> it.replace(File.separatorChar, '/'))
                     .peek(it -> LOGGER.debug("Discovered: " + it))
                     .collect(Collectors.toSet());
         }


### PR DESCRIPTION
… from a windows machine

Testing with version 1.5.0.CR1 (also happening with 1.4.2.Final)

When triggering the native-build from the a windows machine, the included native resource has left slashes triggering the test in io.quarkus.flyway.runtime.graal.QuarkusPathLocationScanner#canHandleMigrationFile to fail and so native-image doesn't run any migrations.

Log:
2020-05-23 15:12:42,725 INFO  [org.fly.cor.int.dat.DatabaseFactory] (main) Database: jdbc:postgresql://192.168.10.66:5432/audit_db (PostgreSQL 10.5)
2020-05-23 15:12:42,761 INFO  [org.fly.cor.int.com.DbMigrate] (main) Current version of schema "public": 1.0.0.00
2020-05-23 15:12:42,761 WARN  [org.fly.cor.int.com.DbMigrate] (main) Schema "public" has version 1.0.0.00, but no migration could be resolved in the configured locations ! Note this warning will become an error in Flyway 7.
2020-05-23 15:12:42,763 INFO  [org.fly.cor.int.com.DbMigrate] (main) Schema "public" is up to date. No migration necessary.



Simple debug of included resources:
[INFO] [org.hibernate.Version] HHH000412: Hibernate ORM core version 5.4.16.Final
++: NativeImageAutoFeatureStep
j=META-INF/services/io.agroal.api.security.AgroalSecurityProvider
j=db\migration\V1_0_0_00__Initial.sql
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui.js.gz
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui-bundle.js
j=META-INF/resources/webjars/swagger-ui/3.25.0/index.html.gz
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui.js.map
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui.css.gz
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui.js
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui-standalone-preset.js.map
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui-bundle.js.gz
j=META-INF/resources/webjars/swagger-ui/3.25.0/index.html
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui.css
j=META-INF/resources/webjars/swagger-ui/3.25.0/favicon-32x32.png
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui-bundle.js.map
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui-standalone-preset.js.gz
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui-standalone-preset.js
j=META-INF/resources/index.html
j=META-INF/resources/webjars/swagger-ui/3.25.0/oauth2-redirect.html
j=META-INF/resources/webjars/swagger-ui/3.25.0/favicon-16x16.png
j=META-INF/resources/webjars/swagger-ui/3.25.0/oauth2-redirect.html.gz
j=META-INF/resources/webjars/swagger-ui/3.25.0/swagger-ui.css.map
j=META-INF/services/javax.ws.rs.client.ClientBuilder
j=META-INF/quarkus-generated-openapi-doc.JSON
j=META-INF/quarkus-generated-openapi-doc.YAML
--: NativeImageAutoFeatureStep



