### PR TITLE
Amazon Lambda Test Framework - Improved error handling for shutdown

### DIFF
--- a/test-framework/amazon-lambda/src/main/java/io/quarkus/amazon/lambda/test/LambdaResourceManager.java
+++ b/test-framework/amazon-lambda/src/main/java/io/quarkus/amazon/lambda/test/LambdaResourceManager.java
@@ -36,7 +36,7 @@ public class LambdaResourceManager implements QuarkusTestResourceLifecycleManage
                 Map.Entry<String, String> req = null;
                 while (req == null) {
                     req = LambdaClient.REQUEST_QUEUE.poll(100, TimeUnit.MILLISECONDS);
-                    if (undertow == null || undertow.getWorker().isShutdown()) {
+                    if (undertow == null || undertow.getWorker() == null || undertow.getWorker().isShutdown()) {
                         return;
                     }
                 }


### PR DESCRIPTION
When running the unit tests for Amazon Lambda (from Native) or through the IDE you will see ugly shutdown exceptions, which create an impression something has gone wrong, in fact it is just the shutdown loop.

I've added some checks to better handle the shutdown.  The AbstractLambdaPollLoop, despite having a check if the thread is running, will enter this loop when shutting down, so a further check is required to avoid the nasty exceptions.

This was raised in #9101 and has been seen in others. 