### PR TITLE
Fix argLine handling in two integration-tests modules

### DIFF
--- a/integration-tests/hibernate-validator/pom.xml
+++ b/integration-tests/hibernate-validator/pom.xml
@@ -72,8 +72,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- force the locale as we want to explicitly test message interpolation -->
-                    <argLine>-Duser.language=en</argLine>
+                    <systemPropertyVariables>
+                        <!-- force the locale as we want to explicitly test message interpolation -->
+                        <user.language>en</user.language>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
@@ -99,9 +101,9 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <!-- force the locale as we want to explicitly test message interpolation -->
-                                    <argLine>-Duser.language=en</argLine>
                                     <systemPropertyVariables>
+                                        <!-- force the locale as we want to explicitly test message interpolation -->
+                                        <user.language>en</user.language>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/integration-tests/rest-client/pom.xml
+++ b/integration-tests/rest-client/pom.xml
@@ -67,8 +67,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<!-- force the locale as we want to explicitly test message interpolation -->
-					<argLine>-Duser.language=en</argLine>
+					<systemPropertyVariables>
+						<!-- force the locale as we want to explicitly test message interpolation -->
+						<user.language>en</user.language>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -94,9 +96,9 @@
 									<goal>verify</goal>
 								</goals>
 								<configuration>
-									<!-- force the locale as we want to explicitly test message interpolation -->
-									<argLine>-Duser.language=en</argLine>
 									<systemPropertyVariables>
+										<!-- force the locale as we want to explicitly test message interpolation -->
+										<user.language>en</user.language>
 										<native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
 									</systemPropertyVariables>
 								</configuration>


### PR DESCRIPTION
Came up while working on #9548.

JaCoCo (`-P test-coverage`) was effectively disabled in these two modules because the simple parameter `argLine` is not automatically merged by Maven.
Solved by moving `user.language` to `systemPropertyVariables` which _is_ merged by Maven.

cc @geoand & @aloubyansky 

~PS: `rest-client` had tabs instead of spaces.~ reverted as requested