### PR TITLE
Set LogManager for all failsafe executions

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -28,6 +28,7 @@
         <scala-plugin.version>4.1.1</scala-plugin.version>
 
         <version.surefire.plugin>2.22.1</version.surefire.plugin>
+        <failsafe-plugin.version>${version.surefire.plugin}</failsafe-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's
@@ -221,6 +222,15 @@
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         </systemPropertyVariables>
                         <argLine>${jacoco.agent.argLine}</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${failsafe-plugin.version}</version>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/integration-tests/picocli/pom.xml
+++ b/integration-tests/picocli/pom.xml
@@ -62,9 +62,6 @@
                                 <configuration>
                                     <skip>false</skip>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <systemPropertyVariables>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/vault-agroal/pom.xml
+++ b/integration-tests/vault-agroal/pom.xml
@@ -74,10 +74,6 @@
                                 <configuration>
                                     <skip>false</skip>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <systemPropertyVariables>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager
-                                        </java.util.logging.manager>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -69,9 +69,6 @@
                                 <configuration>
                                     <skip>false</skip>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <systemPropertyVariables>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This is my last PR before the introduction of the system property `maven.home` in #9523.
I thought it would make sense to have a consistent state of surefire and failsafe.

I almost went as far as pulling out
```xml
<native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
```
from all the `integration-tests` modules (moving it to `build-parent`) but I wasn't sure whether you guys would like that.
Maybe the two goals could also be "pulled up", later.

cc @geoand @aloubyansky 