### PR TITLE
Manage kafka-streams-test-utils version in quarkus-bom

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1773,6 +1773,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams-test-utils</artifactId>
+                <version>${kafka2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.12</artifactId>
                 <version>${kafka2.version}</version>
                 <exclusions>


### PR DESCRIPTION
`org.apache.kafka:kafka-streams-test-utils` is needed when writing tests for KafkaStreams using TopologyTestDriver (which doesn't require an embedded Kafka broker) and must stay in sync with Kafka version, cf https://github.com/quarkusio/quarkus-quickstarts/pull/578