### PR TITLE
Make sure to use normalised paths

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
@@ -26,7 +26,7 @@ public class DirectoryClassPathElement extends AbstractClassPathElement {
 
     public DirectoryClassPathElement(Path root) {
         assert root != null : "root is null";
-        this.root = root;
+        this.root = root.normalize();
     }
 
     @Override


### PR DESCRIPTION
Non-heiracial maven project layouts may
result in paths with ../ path seperators,
which causes problems with directory escape
detection.

Fixes #9515