### PR TITLE
Support Charset in Quarkus Config - Use it in Hibernate

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/CharsetConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/CharsetConverter.java
@@ -1,0 +1,28 @@
+package io.quarkus.runtime.configuration;
+
+import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
+
+import java.io.Serializable;
+import java.nio.charset.Charset;
+
+import javax.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * A converter which converts a Charset string into an instance of {@link java.nio.charset.Charset}.
+ */
+@Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
+public class CharsetConverter implements Converter<Charset>, Serializable {
+
+    private static final long serialVersionUID = 2320905063828247874L;
+
+    @Override
+    public Charset convert(String value) {
+        try {
+            return Charset.forName(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to create Charset from: '" + value + "'", e);
+        }
+    }
+}

--- a/core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/core/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,4 +1,5 @@
 io.quarkus.runtime.configuration.InetSocketAddressConverter
+io.quarkus.runtime.configuration.CharsetConverter
 io.quarkus.runtime.configuration.CidrAddressConverter
 io.quarkus.runtime.configuration.InetAddressConverter
 io.quarkus.runtime.configuration.RegexConverter

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/CharsetConverterTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/CharsetConverterTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.runtime.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CharsetConverterTestCase {
+
+    private CharsetConverter charsetConverter;
+
+    @BeforeEach
+    public void setup() {
+        charsetConverter = new CharsetConverter();
+    }
+
+    @Test
+    public void testUTF8Uppercase() {
+        assertEquals(charsetConverter.convert("UTF-8"), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testUTF8Lowercase() {
+        assertEquals(charsetConverter.convert("utf-8"), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testOther() {
+        assertEquals(charsetConverter.convert("US-ASCII"), StandardCharsets.US_ASCII);
+    }
+
+    @Test
+    public void testInvalidCharset() {
+        assertThrows(IllegalArgumentException.class, () -> charsetConverter.convert("whatever"));
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.orm.deployment;
 
+import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -219,6 +220,8 @@ public class HibernateOrmConfig {
     @ConfigGroup
     public static class HibernateOrmConfigDatabase {
 
+        private static final String DEFAULT_CHARSET = "UTF-8";
+
         /**
          * Select whether the database schema is generated or not.
          *
@@ -249,9 +252,11 @@ public class HibernateOrmConfig {
 
         /**
          * The charset of the database.
+         * <p>
+         * Used for DDL generation and also for the SQL import scripts.
          */
-        @ConfigItem
-        public Optional<String> charset;
+        @ConfigItem(defaultValue = "UTF-8")
+        public Charset charset;
 
         /**
          * Whether Hibernate should quote all identifiers.
@@ -262,7 +267,7 @@ public class HibernateOrmConfig {
         public boolean isAnyPropertySet() {
             return !"none".equals(generation) || defaultCatalog.isPresent() || defaultSchema.isPresent()
                     || generationHaltOnError
-                    || charset.isPresent()
+                    || !DEFAULT_CHARSET.equals(charset.name())
                     || globallyQuotedIdentifiers;
         }
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -784,8 +784,9 @@ public final class HibernateOrmProcessor {
                     desc.getProperties().setProperty(AvailableSettings.HBM2DDL_HALT_ON_ERROR, "true");
                 }
 
-                hibernateConfig.database.charset.ifPresent(
-                        charset -> desc.getProperties().setProperty(AvailableSettings.HBM2DDL_CHARSET_NAME, charset));
+                //charset
+                desc.getProperties().setProperty(AvailableSettings.HBM2DDL_CHARSET_NAME,
+                        hibernateConfig.database.charset.name());
 
                 hibernateConfig.database.defaultCatalog.ifPresent(
                         catalog -> desc.getProperties().setProperty(AvailableSettings.DEFAULT_CATALOG, catalog));


### PR DESCRIPTION
Relates to: #9542

Also set the default charset for Hibernate to `UTF-8`