### PR TITLE
Attempt to fix more Mongo test failures

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -47,7 +47,7 @@ public class MongoTestBase {
                     .version(version)
                     .net(new Net(port, Network.localhostIsIPv6()))
                     .build();
-            MONGO = MongodStarter.getDefaultInstance().prepare(config);
+            MONGO = getMongodExecutable(config);
             try {
                 MONGO.start();
             } catch (Exception e) {
@@ -63,6 +63,24 @@ public class MongoTestBase {
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }
+    }
+
+    private static MongodExecutable getMongodExecutable(IMongodConfig config) {
+        try {
+            return doGetExecutable(config);
+        } catch (Exception e) {
+            // sometimes the download process can timeout so just sleep and try again
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+
+            }
+            return doGetExecutable(config);
+        }
+    }
+
+    private static MongodExecutable doGetExecutable(IMongodConfig config) {
+        return MongodStarter.getDefaultInstance().prepare(config);
     }
 
     @AfterAll

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -45,7 +45,7 @@ public class MongoWithReplicasTestBase {
                 configs.add(buildMongodConfiguration("localhost", port, true));
             }
             configs.forEach(config -> {
-                MongodExecutable exec = MongodStarter.getDefaultInstance().prepare(config);
+                MongodExecutable exec = getMongodExecutable(config);
                 MONGOS.add(exec);
                 try {
                     try {
@@ -68,6 +68,24 @@ public class MongoWithReplicasTestBase {
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }
+    }
+
+    private static MongodExecutable getMongodExecutable(IMongodConfig config) {
+        try {
+            return doGetExecutable(config);
+        } catch (Exception e) {
+            // sometimes the download process can timeout so just sleep and try again
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+
+            }
+            return doGetExecutable(config);
+        }
+    }
+
+    private static MongodExecutable doGetExecutable(IMongodConfig config) {
+        return MongodStarter.getDefaultInstance().prepare(config);
     }
 
     @AfterAll

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
@@ -60,7 +60,7 @@ public class MongoTestBase {
                     .version(version)
                     .net(new Net(port, Network.localhostIsIPv6()))
                     .build();
-            MONGO = MongodStarter.getDefaultInstance().prepare(config);
+            MONGO = getMongodExecutable(config);
             try {
                 MONGO.start();
             } catch (Exception e) {
@@ -75,6 +75,24 @@ public class MongoTestBase {
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }
+    }
+
+    private static MongodExecutable getMongodExecutable(IMongodConfig config) {
+        try {
+            return doGetExecutable(config);
+        } catch (Exception e) {
+            // sometimes the download process can timeout so just sleep and try again
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+
+            }
+            return doGetExecutable(config);
+        }
+    }
+
+    private static MongodExecutable doGetExecutable(IMongodConfig config) {
+        return MongodStarter.getDefaultInstance().prepare(config);
     }
 
     @AfterAll

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
@@ -45,7 +45,7 @@ public class MongoWithReplicasTestBase {
                 configs.add(buildMongodConfiguration("localhost", port, true));
             }
             configs.forEach(config -> {
-                MongodExecutable exec = MongodStarter.getDefaultInstance().prepare(config);
+                MongodExecutable exec = getMongodExecutable(config);
                 MONGOS.add(exec);
                 try {
                     try {
@@ -68,6 +68,24 @@ public class MongoWithReplicasTestBase {
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }
+    }
+
+    private static MongodExecutable getMongodExecutable(IMongodConfig config) {
+        try {
+            return doGetExecutable(config);
+        } catch (Exception e) {
+            // sometimes the download process can timeout so just sleep and try again
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+
+            }
+            return doGetExecutable(config);
+        }
+    }
+
+    private static MongodExecutable doGetExecutable(IMongodConfig config) {
+        return MongodStarter.getDefaultInstance().prepare(config);
     }
 
     @AfterAll

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/MongoTestResource.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/MongoTestResource.java
@@ -30,7 +30,7 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
                     .version(version)
                     .net(new Net(port, Network.localhostIsIPv6()))
                     .build();
-            MONGO = MongodStarter.getDefaultInstance().prepare(config);
+            MONGO = getMongodExecutable(config);
             try {
                 MONGO.start();
             } catch (Exception e) {
@@ -43,6 +43,24 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
             throw new RuntimeException(e);
         }
         return Collections.emptyMap();
+    }
+
+    private MongodExecutable getMongodExecutable(IMongodConfig config) {
+        try {
+            return doGetExecutable(config);
+        } catch (Exception e) {
+            // sometimes the download process can timeout so just sleep and try again
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+
+            }
+            return doGetExecutable(config);
+        }
+    }
+
+    private MongodExecutable doGetExecutable(IMongodConfig config) {
+        return MongodStarter.getDefaultInstance().prepare(config);
     }
 
     @Override

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResource.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResource.java
@@ -29,7 +29,7 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
                     .version(version)
                     .net(new Net(port, Network.localhostIsIPv6()))
                     .build();
-            MONGO = MongodStarter.getDefaultInstance().prepare(config);
+            MONGO = getMongodExecutable(config);
             try {
                 MONGO.start();
             } catch (Exception e) {
@@ -42,6 +42,24 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private MongodExecutable getMongodExecutable(IMongodConfig config) {
+        try {
+            return doGetExecutable(config);
+        } catch (Exception e) {
+            // sometimes the download process can timeout so just sleep and try again
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+
+            }
+            return doGetExecutable(config);
+        }
+    }
+
+    private MongodExecutable doGetExecutable(IMongodConfig config) {
+        return MongodStarter.getDefaultInstance().prepare(config);
     }
 
     @Override


### PR DESCRIPTION
Similar idea to #9524

This one attempts to get over an `IOException` that can occur
when `de.flapdoodle.embed.process.store.Downloader.downloadInputStream`
is called.
An example of such an error was seen in https://github.com/quarkusio/quarkus/pull/9576.

Part of that stacktrace is:

```
Caused by: java.io.IOException: Could not open inputStream for https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.2.tgz
	at de.flapdoodle.embed.process.store.Downloader.downloadInputStream(Downloader.java:131)
	at de.flapdoodle.embed.process.store.Downloader.download(Downloader.java:69)
	at de.flapdoodle.embed.process.store.ArtifactStore.checkDistribution(ArtifactStore.java:66)
	at de.flapdoodle.embed.process.store.ExtractedArtifactStore.checkDistribution(ExtractedArtifactStore.java:60)
	at de.flapdoodle.embed.process.runtime.Starter.prepare(Starter.java:52)
```