### PR TITLE
Increase read timeout for Vault tests

### DIFF
--- a/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle-wrap.properties
@@ -12,6 +12,9 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-approle.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-approle.properties
@@ -12,6 +12,9 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-client-token-wrap.properties
@@ -11,6 +11,9 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
@@ -5,3 +5,6 @@ quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
 quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
 
 quarkus.vault.tls.skip-verify=true
+
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S

--- a/integration-tests/vault/src/test/resources/application-vault-totp.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-totp.properties
@@ -3,3 +3,6 @@ quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 
 quarkus.vault.tls.skip-verify=true
+
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv1-wrap.properties
@@ -15,6 +15,9 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-userpass-kvv2-wrap.properties
@@ -12,6 +12,9 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -19,6 +19,9 @@ quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
 
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
 #quarkus.log.min-level=DEBUG
 #quarkus.log.level=DEBUG
 #quarkus.log.console.level=DEBUG


### PR DESCRIPTION
Done because I saw:

```
2020-05-26T09:47:16.0904938Z [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.269 s <<< FAILURE! - in io.quarkus.vault.VaultAppRoleWrapITCase
2020-05-26T09:47:16.0911426Z [ERROR] secretV2  Time elapsed: 1.105 s  <<< ERROR!
2020-05-26T09:47:16.0917129Z io.quarkus.vault.VaultException: java.net.SocketTimeoutException: timeout
```

in the CI run of #9577