### PR TITLE
Increase native CI timeout for grpc

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -452,7 +452,7 @@ jobs:
               spring-boot-properties
               spring-cloud-config-client
           - category: gRPC
-            timeout: 50
+            timeout: 55
             test-modules: >
               grpc-health
               grpc-interceptors


### PR DESCRIPTION
Done because I saw a few PRs have their grpc run cancelled (for example #9597)