### PR TITLE
Fixes #9339 document log workaround in IDEs

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -239,8 +239,6 @@ In particular, you need to set the appropriate `LogManager` using the `java.util
 <1> Make sure the `org.jboss.logmanager.LogManager` is used.
 <2> Enable debug logging for all logging categories.
 
-WARNING: Eclipse IDE will not automatically read Maven surefire configuration, see https://github.com/quarkusio/quarkus/issues/9339
-
 If you are using Gradle, add this to your `build.gradle`:
 
 [source, groovy]
@@ -249,6 +247,33 @@ test {
 	systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
 }
 ----
+== Running `@QuarkusTest` from an IDE
+
+Most IDEs offer the possibility to run a selected class as JUnit test directly, in which case the above workaround will not be applied. You will need to apply it in the settings of your chosen IDE.
+
+=== Eclipse separate JRE definition
+
+Copy your current "Installed JRE" definition into a new one, where you will add the workaround as a new VM argument 
+`-Djava.util.logging.manager=org.jboss.logmanager.LogManager`. Use this JRE definition as your Quarkus project targeted runtime and the workaround will be applied to any "Run as JUnit" configuration.
+
+=== VSCode "run with" configuration
+
+The `settings.json` placed in the root of your project directory or in the workspace will need the workaround in your test configuration:
+[source, json]
+----
+"java.test.config": [
+    {
+        "name": "quarkusConfiguration",
+        "vmargs": [ "-Djava.util.logging.manager=org.jboss.logmanager.LogManager ..." ],
+        ...
+    },
+  ...
+]
+----
+
+=== IntelliJ JUnit template
+
+In the same screen where you edit your run configuration you can edit the JUnit template to add the workaround Java VM argument `-Djava.util.logging.manager=org.jboss.logmanager.LogManager`.
 
 [[loggingConfigurationReference]]
 == Logging configuration reference

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -273,7 +273,7 @@ The `settings.json` placed in the root of your project directory or in the works
 
 === IntelliJ JUnit template
 
-In the same screen where you edit your run configuration you can edit the JUnit template to add the workaround Java VM argument `-Djava.util.logging.manager=org.jboss.logmanager.LogManager`.
+Nothing needed in IntelliJ because the IDE will pick the `systemPropertyVariables` from the surefire plugin configuration in `pom.xml`.
 
 [[loggingConfigurationReference]]
 == Logging configuration reference


### PR DESCRIPTION
Fixes #9339 as discussed, mentions the ways of adding the workaround JVM LogManager argument to Eclipse, VSCode and IntelliJ