### PR TITLE
Rename credentials-provider-type into credentials-provider-name

### DIFF
--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -175,12 +175,12 @@ First, you need to name it to avoid collisions in case multiple credentials prov
 public class MyCredentialsProvider implements CredentialsProvider {
 ----
 
-It is the responsibility of the consumer to allow a `credentials-provider-type` property:
+It is the responsibility of the consumer to allow a `credentials-provider-name` property:
 
 [source, properties]
 ----
 quarkus.datasource.credentials-provider = custom
-quarkus.datasource.credentials-provider-type = my-credentials-provider
+quarkus.datasource.credentials-provider-name = my-credentials-provider
 ----
 
 The extension should allow runtime config, such as the `CredentialsProviderConfig` from the `vault` extension

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRuntimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourceRuntimeConfig.java
@@ -27,7 +27,7 @@ public class DataSourceRuntimeConfig {
     public Optional<String> credentialsProvider = Optional.empty();
 
     /**
-     * The credentials provider type.
+     * The credentials provider bean name.
      * <p>
      * It is the {@code &#64;Named} value of the credentials provider bean. It is used to discriminate if multiple
      * CredentialsProvider beans are available.
@@ -35,5 +35,5 @@ public class DataSourceRuntimeConfig {
      * For Vault it is: vault-credentials-provider. Not necessary if there is only one credentials provider available.
      */
     @ConfigItem
-    public Optional<String> credentialsProviderType = Optional.empty();
+    public Optional<String> credentialsProviderName = Optional.empty();
 }

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -98,8 +98,8 @@ public class MySQLPoolRecorder {
 
         // credentials provider
         if (dataSourceRuntimeConfig.credentialsProvider.isPresent()) {
-            String type = dataSourceRuntimeConfig.credentialsProviderType.orElse(null);
-            CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(type);
+            String beanName = dataSourceRuntimeConfig.credentialsProviderName.orElse(null);
+            CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
             String name = dataSourceRuntimeConfig.credentialsProvider.get();
             Map<String, String> credentials = credentialsProvider.getCredentials(name);
             String user = credentials.get(USER_PROPERTY_NAME);

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -100,8 +100,8 @@ public class PgPoolRecorder {
 
         // credentials provider
         if (dataSourceRuntimeConfig.credentialsProvider.isPresent()) {
-            String type = dataSourceRuntimeConfig.credentialsProviderType.orElse(null);
-            CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(type);
+            String beanName = dataSourceRuntimeConfig.credentialsProviderName.orElse(null);
+            CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
             String name = dataSourceRuntimeConfig.credentialsProvider.get();
             Map<String, String> credentials = credentialsProvider.getCredentials(name);
             String user = credentials.get(USER_PROPERTY_NAME);

--- a/integration-tests/vault-agroal/src/test/resources/application-vault-datasource.properties
+++ b/integration-tests/vault-agroal/src/test/resources/application-vault-datasource.properties
@@ -19,7 +19,7 @@ quarkus.datasource.staticDS.jdbc.url=jdbc:postgresql://localhost:6543/mydb
 quarkus.datasource.dynamicDS.db-kind=postgresql
 quarkus.datasource.dynamicDS.username=postgres
 quarkus.datasource.dynamicDS.credentials-provider=dynamic-ds
-quarkus.datasource.dynamicDS.credentials-provider-type=vault-credentials-provider
+quarkus.datasource.dynamicDS.credentials-provider-name=vault-credentials-provider
 quarkus.datasource.dynamicDS.jdbc.url=jdbc:postgresql://localhost:6543/mydb
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG


### PR DESCRIPTION
Follow up to #9552 and this specific https://github.com/quarkusio/quarkus/pull/9552#discussion_r430350205
Rename credentials-provider-type into credentials-provider-name.
Discuss whether the existing `name` should be renamed into `id`.

/cc @sberyozkin @geoand 