### PR TITLE
Add a kotlin panache guide

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
@@ -1,0 +1,202 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
+////
+= Quarkus - Simplified Hibernate ORM with Panache and Kotlin
+
+include::./attributes.adoc[]
+:config-file: application.properties
+
+Hibernate ORM is the de facto standard JPA implementation and is well-known in the Java ecosystem.  Panache offers a
+new layer atop this familiar framework.  This guide will not dive in to the specifics of either as those are already
+covered in the link:hibernate-orm-panache.adoc[Panache guide].  In this guide, we'll cover the Kotlin specific changes
+needed to use Panache in your Kotlin-based Quarkus applications.
+
+== First: an example
+
+As we saw in the Panache guide, Panache allows us to extend the functionality in our entities and repositories (also known as DAOs) with some automatically
+provided functionality.  When using Kotlin, the approach is very similar to what we see in the Java version with a slight
+change or two.  To Panache-enable your entity, you would define it something like:
+
+[source,kotlin]
+----
+@Entity
+class Person: PanacheEntity {
+    lateinit var name: String
+    lateinit var birth: LocalDate
+    lateinit var status: Status
+}
+----
+
+As you can see our entities remain simple.  There is, however, a slight difference from the Java version.  The Kotlin
+language doesn't support the notion of static methods in quite the same way as Java does.  Instead, we must use a
+[companion object](https://kotlinlang.org/docs/tutorials/kotlin-for-py/objects-and-companion-objects.html#companion-objects):
+
+[source,kotlin]
+----
+@Entity
+class Person : PanacheEntity {
+    companion object: PanacheCompanion<Person> {  // <1>
+        fun findByName(name: String) = find("name", name).firstResult()
+        fun findAlive() = list("status", Status.Alive)
+        fun deleteStefs() = delete("name", "Stef")
+    }
+
+    lateinit var name: String  // <2>
+    lateinit var birth: LocalDate
+    lateinit var status: Status
+}
+----
+<1> The companion object holds all the methods not related to a specific instance allowing for general management and
+querying bound to a specific type.
+<2> Here there are options, but we've chosen the `lateinit` approach.  This allows us to declare these fields as non-null
+knowing they will be properly assigned either by the constructor (not shown) or by hibernate loading data from the
+database.
+
+NOTE: These types differ from the Java types mentioned in those tutorials.  For kotlin support, all the Panache
+types will be found in the `io.quarkus.hibernate.orm.panache.kotlin` package.  This subpackage allows for the distinction
+between the Java and Kotlin variants and allows for both to be used unambiguously in a single project.
+
+In the Kotlin version, we've simply moved the bulk of the link:https://www.martinfowler.com/eaaCatalog/activeRecord.html[`active record pattern`]
+functionality to the `companion object`.  Apart from this slight change, we can then work with our types in ways that map easily
+from the Java side of world.
+
+
+== Using the repository pattern
+
+
+=== Defining your entity
+
+When using the repository pattern, you can define your entities as regular JPA entities.
+[source,kotlin]
+----
+@Entity
+class Person {
+    @Id
+    @GeneratedValue
+    var id: Long? = null;
+    lateinit var name: String
+    lateinit var birth: LocalDate
+    lateinit var status: Status
+}
+----
+
+=== Defining your repository
+
+When using Repositories, you get the exact same convenient methods as with the active record pattern, injected in your Repository,
+by making them implement `PanacheRepository`:
+
+[source,kotlin]
+----
+class PersonRepository: PanacheRepository<Person> {
+     fun findByName(name: String) = find("name", name).firstResult()
+     fun findAlive() = list("status", Status.Alive)
+     fun deleteStefs() = delete("name", "Stef")
+}
+----
+
+All the operations that are defined on `PanacheEntityBase` are available on your repository, so using it
+is exactly the same as using the active record pattern, except you need to inject it:
+
+[source,kotlin]
+----
+@Inject
+lateinit var personRepository: PersonRepository
+
+@GET
+fun count() = personRepository.count()
+----
+
+=== Most useful operations
+
+Once you have written your repository, here are the most common operations you will be able to perform:
+
+[source,kotlin]
+----
+// creating a person
+var person = Person()
+person.name = "Stef"
+person.birth = LocalDate.of(1910, Month.FEBRUARY, 1)
+person.status = Status.Alive
+
+// persist it
+personRepository.persist(person)
+
+// note that once persisted, you don't need to explicitly save your entity: all
+// modifications are automatically persisted on transaction commit.
+
+// check if it's persistent
+if(personRepository.isPersistent(person)){
+    // delete it
+    personRepository.delete(person)
+}
+
+// getting a list of all Person entities
+val allPersons = personRepository.listAll()
+
+// finding a specific person by ID
+person = personRepository.findById(personId) ?: throw Exception("No person with that ID")
+
+// finding all living persons
+val livingPersons = personRepository.list("status", Status.Alive)
+
+// counting all persons
+val countAll = personRepository.count()
+
+// counting all living persons
+val countAlive = personRepository.count("status", Status.Alive)
+
+// delete all living persons
+personRepository.delete("status", Status.Alive)
+
+// delete all persons
+personRepository.deleteAll()
+
+// delete by id
+val deleted = personRepository.deleteById(personId)
+
+// set the name of all living persons to 'Mortal'
+personRepository.update("name = 'Mortal' where status = ?1", Status.Alive)
+
+----
+
+All `list` methods have equivalent `stream` versions.
+
+[source,kotlin]
+----
+val persons = personRepository.streamAll();
+val namesButEmmanuels = persons
+    .map { it.name.toLowerCase() }
+    .filter { it != "emmanuel" }
+----
+
+NOTE: The `stream` methods require a transaction to work.
+
+NOTE: The rest of the documentation show usages based on the active record pattern only,
+but keep in mind that they can be performed with the repository pattern as well.
+The repository pattern examples have been omitted for brevity.
+
+For more examples, please consult the link:hibernate-orm-panache.adoc[java version] for complete details.  Both APIs
+are the same and work identically except for some kotlin-specific tweaks to make things feel more natural to
+Kotlin developers.  These tweaks include things like better use of nullability and the lack of `Optional` on API
+methods.
+
+== Setting up and configuring Hibernate ORM with Panache
+
+To get started using Panache with Kotlin, you can, generally, follow the steps laid out in the Java tutorial.  The biggest
+change to configuring your project is the Quarkus artifact to include.  You can, of course, keep the Java version if you
+need but if all you need are the Kotlin APIs then include the following dependency instead:
+
+[source,xml]
+----
+<dependencies>
+    <!-- Hibernate ORM specific dependencies -->
+    <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-hibernate-orm-panache-kotlin</artifactId>  // <1>
+    </dependency>
+</dependencies>
+----
+<1>  Note the addition of `-kotlin` on the end.  Generally you'll only need this version but if your project will be using
+both java and kotlin code, you can safely include both artifacts.

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/kotlin/io/quarkus/hibernate/orm/panache/kotlin/PanacheCompanion.kt
@@ -11,9 +11,8 @@ import javax.persistence.LockModeType
  * Defines methods to be used via the companion objects of entities.
  *
  * @param Entity the entity type
- * @param Id the ID type
  */
-interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
+interface PanacheCompanion<Entity : PanacheEntity> {
 
     /**
      * Find an entity of this type by ID.
@@ -22,7 +21,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * @return the entity found, or `null` if not found.
      */
     @GenerateBridge(targetReturnTypeErased = true)
-    fun findById(id: Id): Entity? = injectionMissing()
+    fun findById(id: Any): Entity? = injectionMissing()
 
     /**
      * Find an entity of this type by ID and lock it.
@@ -32,7 +31,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * @return the entity found, or `null` if not found.
      */
     @GenerateBridge(targetReturnTypeErased = true)
-    fun findById(id: Id, lockModeType: LockModeType): Entity? = injectionMissing()
+    fun findById(id: Any, lockModeType: LockModeType): Entity? = injectionMissing()
 
     /**
      * Find entities using a query, with optional indexed parameters.
@@ -472,7 +471,7 @@ interface PanacheCompanion<Entity : PanacheEntity, Id: Any> {
      * @return false if the entity was not deleted (not found).
      */
     @GenerateBridge
-    fun deleteById(id: Id): Boolean = throw JpaOperations.implementationInjectionMissing()
+    fun deleteById(id: Any): Boolean = throw JpaOperations.implementationInjectionMissing()
 
     /**
      * Persist all given entities.

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Address.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Address.kt
@@ -6,7 +6,7 @@ import javax.persistence.Entity
 
 @Entity
 open class Address : PanacheEntity, Comparable<Address> {
-    companion object : PanacheCompanion<Address, Long> {
+    companion object : PanacheCompanion<Address> {
         override fun count(query: String, params: Map<String, Any>): Long {
             AddressDao.shouldBeOverridden()
         }

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Dog.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Dog.kt
@@ -7,7 +7,7 @@ import javax.persistence.ManyToOne
 
 @Entity
 open class Dog() : PanacheEntity() {
-    companion object : PanacheCompanion<Dog, Int>
+    companion object : PanacheCompanion<Dog>
 
     constructor(name: String, race: String): this() {
         this.name = name

--- a/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Person.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/main/kotlin/io/quarkus/it/panache/kotlin/Person.kt
@@ -30,7 +30,7 @@ import javax.persistence.EnumType
     Filter(name = "Person.hasName")
 )
 open class Person : PanacheEntity() {
-    companion object : PanacheCompanion<Person, Long> {
+    companion object : PanacheCompanion<Person> {
         fun findOrdered(): List<Dog>  = AddressDao.shouldBeOverridden()
     }
 


### PR DESCRIPTION
This guide is intended to be more of a supplement to the Java version so we don't duplicate and have to update multiple versions of the same information.  It's intended to focus on the Kotlin deviations specifically.

This also removes the `Id` type parameter from `PanacheEntityBase` to better align with the Java version.