### PR TITLE
Bootstrap Maven: make sure empty jar project artifacts can be resolved from the workspace

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -161,6 +161,7 @@ public class BuildMojo extends AbstractMojo {
             realProperties.putIfAbsent("quarkus.application.version", project.getVersion());
 
             MavenArtifactResolver resolver = MavenArtifactResolver.builder()
+                    .setWorkspaceDiscovery(false)
                     .setRepositorySystem(repoSystem)
                     .setRepositorySystemSession(repoSession)
                     .setRemoteRepositories(repos)
@@ -177,7 +178,6 @@ public class BuildMojo extends AbstractMojo {
                     .setMavenArtifactResolver(resolver)
                     .setBaseClassLoader(BuildMojo.class.getClassLoader())
                     .setBuildSystemProperties(realProperties)
-                    .setLocalProjectDiscovery(false)
                     .setBaseName(finalName)
                     .setTargetDirectory(buildDir.toPath())
                     .build().bootstrap();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -166,6 +166,10 @@ public class BootstrapMavenContext {
                 ModelUtils.getVersion(model));
     }
 
+    public LocalProject getCurrentProject() {
+        return currentProject;
+    }
+
     public LocalWorkspace getWorkspace() {
         return workspace;
     }
@@ -626,7 +630,6 @@ public class BootstrapMavenContext {
     }
 
     private Path resolveCurrentPom() {
-
         Path alternatePom = null;
         // explicitly set absolute path has a priority
         if (alternatePomName != null) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -92,13 +92,19 @@ public class LocalProject {
         final Model rootModel = rootProjectBaseDir == null || rootProjectBaseDir.equals(currentProjectPom.getParent())
                 ? loadRootModel(currentProjectPom)
                 : readModel(rootProjectBaseDir.resolve(POM_XML));
-        return loadWorkspace(currentProjectPom, rootModel);
+        final LocalProject lp = loadWorkspace(currentProjectPom, rootModel);
+        lp.getWorkspace().setBootstrapMavenContext(ctx);
+        return lp;
     }
 
     private static LocalProject loadWorkspace(Path currentProjectPom, Model rootModel) throws BootstrapException {
         final LocalWorkspace ws = new LocalWorkspace();
-        final LocalProject project = load(ws, null, rootModel, currentProjectPom.getParent());
-        return project == null ? load(ws, null, readModel(currentProjectPom), currentProjectPom.getParent()) : project;
+        LocalProject project = load(ws, null, rootModel, currentProjectPom.getParent());
+        if (project == null) {
+            project = load(ws, null, readModel(currentProjectPom), currentProjectPom.getParent());
+        }
+        ws.setCurrentProject(project);
+        return project;
     }
 
     private static LocalProject load(LocalWorkspace workspace, LocalProject parent, Model model, Path currentProjectDir)

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/maven/test/ResolveEmptyJarProjectArtifactTest.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/maven/test/ResolveEmptyJarProjectArtifactTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.bootstrap.resolver.maven.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContextConfig;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test makes sure that projects with packaging 'jar' that don't include any content
+ * (i.e. neither classes nor resources) are still resolvable locally.
+ * In this case, our workspace resolver will create an empty classes directory to represent
+ * the resolved artifact.
+ */
+public class ResolveEmptyJarProjectArtifactTest extends BootstrapMavenContextTestBase {
+
+    protected BootstrapMavenContextConfig<?> initBootstrapMavenContextConfig() throws Exception {
+        return BootstrapMavenContext.config();
+    }
+
+    @Test
+    public void test() throws Exception {
+        final BootstrapMavenContext ctx = bootstrapMavenContextForProject("empty-jar/root");
+        final MavenArtifactResolver resolver = new MavenArtifactResolver(ctx);
+        final Artifact emptyJar = resolver.resolve(new DefaultArtifact("org.acme", "root", "", "jar", "1.0-SNAPSHOT"))
+                .getArtifact();
+        assertEquals(ctx.getCurrentProjectBaseDir().resolve("target").resolve("classes"), emptyJar.getFile().toPath());
+    }
+}

--- a/independent-projects/bootstrap/core/src/test/resources/empty-jar/root/pom.xml
+++ b/independent-projects/bootstrap/core/src/test/resources/empty-jar/root/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+</project>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -448,7 +448,7 @@
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
-                </plugins>
+            </plugins>
         </pluginManagement>
     </build>
 


### PR DESCRIPTION
Bootstrap Maven: make sure empty jar project artifacts can be resolved from the workspace

This fixes tests under `integration-tests/devmode` when the test project hasn't been previously installed (which is what our CI does before running the tests).