### PR TITLE
Cut off path to Class serialization

### DIFF
--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/JavaIOSubstitutions.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/graal/JavaIOSubstitutions.java
@@ -1,0 +1,25 @@
+package io.quarkus.kafka.client.runtime.graal;
+
+import java.io.ObjectStreamClass;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(java.io.ObjectStreamClass.class)
+@SuppressWarnings({ "unused" })
+final class Target_java_io_ObjectStreamClass {
+
+    @Substitute
+    private static ObjectStreamClass lookup(Class<?> cl, boolean all) {
+        throw new UnsupportedOperationException("Serialization of class definitions not supported");
+    }
+
+    private Target_java_io_ObjectStreamClass(final Class<?> cl) {
+        throw new UnsupportedOperationException("Serialization of class definitions not supported");
+    }
+
+    private Target_java_io_ObjectStreamClass() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+}


### PR DESCRIPTION
This is a draft PR to solve https://github.com/quarkusio/quarkus/issues/9633.

It solves the problem because even though the analysis detects a path through ObjectStreamClass, this is actually not used.

It's likely we'd want this substitution not only for Kafka, but all other extensions, hence why it's a draft PR. What would be the best place to add such substitution?