### PR TITLE
Restore the user query after OIDC redirect

### DIFF
--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -100,5 +101,11 @@ public class ProtectedResource {
             throw new OIDCException("Refresh token values are not equal");
         }
         return refreshToken.getToken() != null && !refreshToken.getToken().isEmpty() ? "RT injected" : "no refresh";
+    }
+
+    @GET
+    @Path("refresh-query")
+    public String refresh(@QueryParam("a") String aValue) {
+        return refresh() + ":" + aValue;
     }
 }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -481,6 +481,26 @@ public class CodeFlowTest {
     }
 
     @Test
+    public void testAccessAndRefreshTokenInjectionWithoutIndexHtmlWithQuery() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/web-app/refresh-query?a=aValue");
+            assertEquals("/web-app/refresh-query?a=aValue", getStateCookieSavedPath(webClient, null));
+
+            assertEquals("Log in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("RT injected:aValue", page.getBody().asText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testNoCodeFlowUnprotected() {
         RestAssured.when().get("/public-web-app/access")
                 .then()


### PR DESCRIPTION
Fixes #9539.

This is an intermediate solution. We probably need to consider an option of encoding the user provided query parameters into the state redirect parameter since it is really one of the main purposes of it (so that the users can just get this state and extract the original query params etc instead of Quarkus doing it), and then also have it signed or encrypted inside the state cookie alongside the other content (same for the session cookie). I'd like to tweak smallrye jwt API around parsing JWT and then combine it with the builder API to convert the cookie values into the secure JWT but will do it later...