### PR TITLE
Static method interception

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -572,6 +572,36 @@ class Producers {
 }
 ----
 
+=== Interception of Static Methods 
+
+The Interceptors specification is clear that _around-invoke_ methods must not be declared static.
+However, this restriction was driven mostly by technical limitations.
+And since Quarkus is a build-time oriented stack that allows for additional class transformations, those limitations don't apply anymore. 
+It's possible to annotate a non-private static method with an interceptor binding:
+
+[source,java]
+----
+class Services {
+
+  @Logged <1>
+  static BigDecimal computePrice(long amout) { <2>
+    BigDecimal price;
+    // Perform computations...
+    return price;
+  }
+}
+----
+<1> `Logged` is an interceptor binding.
+<2> Each method invocation is intercepted if there is an interceptor associated with `Logged`. 
+
+==== Limitations
+
+* Only *method-level bindings* are considered for backward compatibility reasons (otherwise static methods of bean classes that declare class-level bindings would be suddenly intercepted)
+* Private static methods are never intercepted
+* `InvocationContext#getTarget()` returns `null` for obvious reasons; therefore not all existing interceptors may behave correctly when intercepting static methods
++
+NOTE: Interceptors can use `InvocationContext.getMethod()` to detect static methods and adjust the behavior accordingly. 
+
 == Build Time Extension Points
 
 [[portable_extensions]]

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -312,7 +312,7 @@ public class ArcProcessor {
     // PHASE 2 - register all beans
     @BuildStep
     public BeanRegistrationPhaseBuildItem registerBeans(ContextRegistrationPhaseBuildItem contextRegistrationPhase,
-            List<ContextConfiguratorBuildItem> contextConfigurators) {
+            List<ContextConfiguratorBuildItem> contextConfigurators, BuildProducer<InterceptorResolverBuildItem> resolver) {
 
         for (ContextConfiguratorBuildItem contextConfigurator : contextConfigurators) {
             for (ContextConfigurator value : contextConfigurator.getValues()) {
@@ -320,6 +320,8 @@ public class ArcProcessor {
                 value.done();
             }
         }
+
+        resolver.produce(new InterceptorResolverBuildItem(contextRegistrationPhase.getBeanProcessor().getBeanDeployment()));
 
         return new BeanRegistrationPhaseBuildItem(contextRegistrationPhase.getBeanProcessor().registerBeans(),
                 contextRegistrationPhase.getBeanProcessor());

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanRegistrationPhaseBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanRegistrationPhaseBuildItem.java
@@ -36,7 +36,7 @@ public final class BeanRegistrationPhaseBuildItem extends SimpleBuildItem {
         return context;
     }
 
-    BeanProcessor getBeanProcessor() {
+    public BeanProcessor getBeanProcessor() {
         return beanProcessor;
     }
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/InterceptorResolverBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/InterceptorResolverBuildItem.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.deployment;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.processor.BeanDeployment;
+import io.quarkus.arc.processor.InterceptorResolver;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Holds a reference to the interceptor resolver.
+ */
+public final class InterceptorResolverBuildItem extends SimpleBuildItem {
+
+    private final InterceptorResolver resolver;
+
+    private final Set<DotName> interceptorBindings;
+
+    InterceptorResolverBuildItem(BeanDeployment beanDeployment) {
+        this.resolver = beanDeployment.getInterceptorResolver();
+        this.interceptorBindings = Collections.unmodifiableSet(
+                beanDeployment.getInterceptorBindings().stream().map(ClassInfo::name).collect(Collectors.toSet()));
+    }
+
+    public InterceptorResolver get() {
+        return resolver;
+    }
+
+    /**
+     * 
+     * @return the set of all known interceptor bindings
+     */
+    public Set<DotName> getInterceptorBindings() {
+        return interceptorBindings;
+    }
+
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodBuildItem.java
@@ -1,0 +1,63 @@
+package io.quarkus.arc.deployment.staticmethods;
+
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.arc.processor.InterceptorInfo;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.util.HashUtil;
+
+/**
+ * Represents an intercepted static method.
+ */
+public final class InterceptedStaticMethodBuildItem extends MultiBuildItem {
+
+    private final MethodInfo method;
+    private final List<InterceptorInfo> interceptors;
+    private final Set<AnnotationInstance> bindings;
+    private final String hash;
+
+    InterceptedStaticMethodBuildItem(MethodInfo method, Set<AnnotationInstance> bindings, List<InterceptorInfo> interceptors) {
+        this.method = method;
+        this.interceptors = interceptors;
+        this.bindings = bindings;
+        this.hash = HashUtil.sha1(method.declaringClass().name().toString() + method.toString());
+    }
+
+    public ClassInfo getTarget() {
+        return method.declaringClass();
+    }
+
+    public MethodInfo getMethod() {
+        return method;
+    }
+
+    /**
+     * 
+     * @return the list of interceptors that should be applied
+     */
+    public List<InterceptorInfo> getInterceptors() {
+        return interceptors;
+    }
+
+    /**
+     * 
+     * @return the set of interceptor bindings
+     */
+    public Set<AnnotationInstance> getBindings() {
+        return bindings;
+    }
+
+    /**
+     * 
+     * @return the unique hash that could be used to indentify the method
+     */
+    public String getHash() {
+        return hash;
+    }
+
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
@@ -1,0 +1,505 @@
+package io.quarkus.arc.deployment.staticmethods;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.inject.spi.InterceptionType;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.arc.InjectableInterceptor;
+import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.arc.deployment.InterceptorResolverBuildItem;
+import io.quarkus.arc.impl.CreationalContextImpl;
+import io.quarkus.arc.impl.InterceptedMethodMetadata;
+import io.quarkus.arc.impl.InterceptedStaticMethods;
+import io.quarkus.arc.impl.InterceptedStaticMethods.InterceptedStaticMethod;
+import io.quarkus.arc.processor.AnnotationLiteralProcessor;
+import io.quarkus.arc.processor.BeanProcessor;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.arc.processor.InterceptorInfo;
+import io.quarkus.arc.processor.MethodDescriptors;
+import io.quarkus.arc.runtime.InterceptedStaticMethodsRecorder;
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
+import io.quarkus.deployment.util.AsmUtil;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.DescriptorUtils;
+import io.quarkus.gizmo.FunctionCreator;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+public class InterceptedStaticMethodsProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(InterceptedStaticMethodsProcessor.class);
+
+    static final MethodDescriptor INTERCEPTED_STATIC_METHODS_REGISTER = MethodDescriptor
+            .ofMethod(InterceptedStaticMethods.class, "register", void.class, String.class, InterceptedStaticMethod.class);
+    static final MethodDescriptor INTERCEPTED_STATIC_METHODS_AROUND_INVOKE = MethodDescriptor
+            .ofMethod(InterceptedStaticMethods.class, "aroundInvoke", Object.class, String.class, Object[].class);
+
+    private static final String ORGINAL_METHOD_COPY_SUFFIX = "_orig";
+    private static final String INITIALIZER_CLASS_SUFFIX = "_InterceptorInitializer";
+
+    @BuildStep
+    void collectInterceptedStaticMethodsCandidates(BeanArchiveIndexBuildItem beanArchiveIndex,
+            BuildProducer<InterceptedStaticMethodBuildItem> interceptedStaticMethods,
+            InterceptorResolverBuildItem interceptorResolver) {
+
+        // In this step we collect all intercepted static methods, ie. static methods annotated with interceptor bindings  
+        IndexView index = beanArchiveIndex.getIndex();
+        Set<MethodInfo> processedMethods = new HashSet<>();
+
+        for (DotName interceptorBinding : interceptorResolver.getInterceptorBindings()) {
+            // Find all occurrences of each binding annotation
+            for (AnnotationInstance bindingInstance : index.getAnnotations(interceptorBinding)) {
+                if (bindingInstance.target().kind() != Kind.METHOD) {
+                    // Only consider annotation instances declared on methods
+                    continue;
+                }
+                MethodInfo method = bindingInstance.target().asMethod();
+
+                if (Modifier.isStatic(method.flags()) && !"clinit".equals(method.name())
+                        && processedMethods.add(method)) {
+                    // Found static method (except for static initializer) that was not processed yet
+                    Collection<AnnotationInstance> annotations = method.annotations();
+                    if (!annotations.isEmpty()) {
+                        // Only method-level bindings are considered due to backwards compatibility
+                        Set<AnnotationInstance> methodLevelBindings = new HashSet<>();
+                        for (AnnotationInstance annotationInstance : annotations) {
+                            if (annotationInstance.target().kind() == Kind.METHOD
+                                    && interceptorResolver.getInterceptorBindings().contains(annotationInstance.name())) {
+                                methodLevelBindings.add(annotationInstance);
+                            }
+                        }
+                        if (!methodLevelBindings.isEmpty()) {
+                            if (Modifier.isPrivate(method.flags())) {
+                                LOGGER.warnf(
+                                        "Interception of private static methods is not supported; bindings found on %s: %s",
+                                        method.declaringClass().name(),
+                                        method);
+                            } else {
+                                List<InterceptorInfo> interceptors = interceptorResolver.get().resolve(
+                                        InterceptionType.AROUND_INVOKE,
+                                        methodLevelBindings);
+                                if (!interceptors.isEmpty()) {
+                                    LOGGER.debugf("Intercepted static method found on %s: %s", method.declaringClass().name(),
+                                            method);
+                                    interceptedStaticMethods.produce(
+                                            new InterceptedStaticMethodBuildItem(method, methodLevelBindings, interceptors));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Produce(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
+    @BuildStep
+    void processInterceptedStaticMethods(BeanArchiveIndexBuildItem beanArchiveIndex,
+            BeanRegistrationPhaseBuildItem phase,
+            List<InterceptedStaticMethodBuildItem> interceptedStaticMethods,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            BuildProducer<BytecodeTransformerBuildItem> transformers,
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods) {
+
+        if (interceptedStaticMethods.isEmpty()) {
+            return;
+        }
+
+        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, true);
+
+        // declaring class -> intercepted static methods
+        Map<DotName, List<InterceptedStaticMethodBuildItem>> interceptedStaticMethodsMap = new HashMap<>();
+        for (InterceptedStaticMethodBuildItem interceptedStaticMethod : interceptedStaticMethods) {
+            List<InterceptedStaticMethodBuildItem> list = interceptedStaticMethodsMap
+                    .get(interceptedStaticMethod.getTarget().name());
+            if (list == null) {
+                list = new ArrayList<>();
+                interceptedStaticMethodsMap.put(interceptedStaticMethod.getTarget().name(), list);
+            }
+            list.add(interceptedStaticMethod);
+        }
+
+        // For each declaring class create an initializer class that: 
+        // 1. registers all interceptor chains inside an "init_static_intercepted_methods" method
+        // 2. adds static methods to invoke the interceptor chain and delegate to the copy of the original static method
+        // declaring class -> initializer class
+        Map<DotName, String> initializers = new HashMap<>();
+        String initAllMethodName = "init_static_intercepted_methods";
+        for (Entry<DotName, List<InterceptedStaticMethodBuildItem>> entry : interceptedStaticMethodsMap.entrySet()) {
+
+            String packageName = DotNames.packageName(entry.getKey());
+            String intializerName = packageName + "." + entry.getKey().withoutPackagePrefix() + INITIALIZER_CLASS_SUFFIX;
+            initializers.put(entry.getKey(), intializerName);
+
+            ClassCreator initializer = ClassCreator.builder().classOutput(classOutput)
+                    .className(intializerName.replace('.', '/')).setFinal(true).build();
+
+            List<String> initMethods = new ArrayList<>();
+            for (InterceptedStaticMethodBuildItem interceptedStaticMethod : entry.getValue()) {
+                initMethods.add(implementInit(beanArchiveIndex.getIndex(), classOutput, initializer, interceptedStaticMethod,
+                        reflectiveMethods, phase.getBeanProcessor()));
+                implementForward(initializer, interceptedStaticMethod);
+            }
+
+            MethodCreator init = initializer.getMethodCreator(initAllMethodName, void.class)
+                    .setModifiers(ACC_PUBLIC | ACC_STATIC);
+            for (String initMethod : initMethods) {
+                init.invokeStaticMethod(
+                        MethodDescriptor.ofMethod(initializer.getClassName(), initMethod, void.class));
+
+            }
+            init.returnValue(null);
+            initializer.close();
+        }
+
+        // Transform all declaring classes
+        // For each intercepted static methods create a copy and modify the original method to delegate to the relevant initializer
+        for (Entry<DotName, List<InterceptedStaticMethodBuildItem>> entry : interceptedStaticMethodsMap.entrySet()) {
+            transformers.produce(new BytecodeTransformerBuildItem(entry.getKey().toString(),
+                    new InterceptedStaticMethodsEnhancer(initializers.get(entry.getKey()), entry.getValue())));
+        }
+
+        // Generate a global initializer that calls all other initializers
+        ClassCreator globalInitializer = ClassCreator.builder().classOutput(classOutput)
+                .className(InterceptedStaticMethodsRecorder.INTIALIZER_CLASS_NAME.replace('.', '/')).setFinal(true).build();
+
+        MethodCreator staticInit = globalInitializer.getMethodCreator("<clinit>", void.class)
+                .setModifiers(ACC_STATIC);
+        for (String initializerClass : initializers.values()) {
+            staticInit.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(initializerClass, initAllMethodName, void.class));
+        }
+        staticInit.returnValue(null);
+        globalInitializer.close();
+    }
+
+    @Record(STATIC_INIT)
+    @BuildStep
+    void callInitializer(BeanContainerBuildItem beanContainer, List<InterceptedStaticMethodBuildItem> interceptedStaticMethods,
+            InterceptedStaticMethodsRecorder recorder) {
+        if (interceptedStaticMethods.isEmpty()) {
+            return;
+        }
+        recorder.callInitializer();
+    }
+
+    private void implementForward(ClassCreator initializer,
+            InterceptedStaticMethodBuildItem interceptedStaticMethod) {
+        MethodInfo method = interceptedStaticMethod.getMethod();
+        List<Type> params = method.parameters();
+        Object[] paramTypes = new String[params.size()];
+        for (int i = 0; i < paramTypes.length; ++i) {
+            paramTypes[i] = DescriptorUtils.typeToString(params.get(i));
+        }
+        MethodCreator forward = initializer
+                .getMethodCreator(interceptedStaticMethod.getHash(), DescriptorUtils.typeToString(method.returnType()),
+                        paramTypes)
+                .setModifiers(ACC_PUBLIC | ACC_FINAL | ACC_STATIC);
+        ResultHandle argArray = forward.newArray(Object.class, params.size());
+        for (int i = 0; i < params.size(); i++) {
+            forward.writeArrayValue(argArray, i, forward.getMethodParam(i));
+        }
+        ResultHandle ret = forward.invokeStaticMethod(INTERCEPTED_STATIC_METHODS_AROUND_INVOKE,
+                forward.load(interceptedStaticMethod.getHash()), argArray);
+        forward.returnValue(ret);
+    }
+
+    private String implementInit(IndexView index, ClassOutput classOutput, ClassCreator initializer,
+            InterceptedStaticMethodBuildItem interceptedStaticMethod,
+            BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods, BeanProcessor beanProcessor) {
+
+        MethodInfo method = interceptedStaticMethod.getMethod();
+        List<InterceptorInfo> interceptors = interceptedStaticMethod.getInterceptors();
+        Set<AnnotationInstance> bindings = interceptedStaticMethod.getBindings();
+
+        // init_interceptMe_hash()
+        String name = new StringBuilder("init")
+                .append("_")
+                .append(method.name())
+                .append("_")
+                .append(interceptedStaticMethod.getHash()).toString();
+
+        MethodCreator init = initializer.getMethodCreator(name, void.class)
+                .setModifiers(ACC_PRIVATE | ACC_FINAL | ACC_STATIC);
+        ResultHandle creationalContext = init.newInstance(
+                MethodDescriptor.ofConstructor(CreationalContextImpl.class, Contextual.class), init.loadNull());
+
+        // 1. Interceptor chain
+        ResultHandle chainHandle;
+        if (interceptors.size() == 1) {
+            // List<InvocationContextImpl.InterceptorInvocation> m1Chain = Collections.singletonList(...);
+            chainHandle = init.invokeStaticMethod(MethodDescriptors.COLLECTIONS_SINGLETON_LIST,
+                    createInterceptorInvocation(interceptors.get(0), init, creationalContext));
+        } else {
+            // List<InvocationContextImpl.InterceptorInvocation> m1Chain = new ArrayList<>();
+            chainHandle = init.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
+            for (InterceptorInfo interceptor : interceptors) {
+                // m1Chain.add(InvocationContextImpl.InterceptorInvocation.aroundInvoke(p3,interceptorInstanceMap.get(InjectableInterceptor.getIdentifier())))
+                init.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, chainHandle,
+                        createInterceptorInvocation(interceptor, init, creationalContext));
+            }
+        }
+
+        // 2. Method method = Reflections.findMethod(...)
+        ResultHandle[] paramsHandles = new ResultHandle[3];
+        paramsHandles[0] = init.loadClass(method.declaringClass().name().toString());
+        paramsHandles[1] = init.load(method.name());
+        if (!method.parameters().isEmpty()) {
+            ResultHandle paramsArray = init.newArray(Class.class, init.load(method.parameters().size()));
+            for (ListIterator<Type> iterator = method.parameters().listIterator(); iterator.hasNext();) {
+                init.writeArrayValue(paramsArray, iterator.nextIndex(),
+                        init.loadClass(iterator.next().name().toString()));
+            }
+            paramsHandles[2] = paramsArray;
+        } else {
+            paramsHandles[2] = init.newArray(Class.class, init.load(0));
+        }
+        ResultHandle methodHandle = init.invokeStaticMethod(MethodDescriptors.REFLECTIONS_FIND_METHOD,
+                paramsHandles);
+
+        // 3. Interceptor bindings
+        ResultHandle bindingsHandle;
+        if (bindings.size() == 1) {
+            bindingsHandle = init.invokeStaticMethod(MethodDescriptors.COLLECTIONS_SINGLETON,
+                    createBindingLiteral(index, classOutput, init, bindings.iterator().next(),
+                            beanProcessor.getAnnotationLiteralProcessor()));
+        } else {
+            bindingsHandle = init.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+            for (AnnotationInstance binding : bindings) {
+                init.invokeInterfaceMethod(MethodDescriptors.SET_ADD, bindingsHandle,
+                        createBindingLiteral(index, classOutput, init, binding, beanProcessor.getAnnotationLiteralProcessor()));
+            }
+        }
+
+        // Now create metadata for the given intercepted method
+        ResultHandle metadataHandle = init.newInstance(MethodDescriptors.INTERCEPTED_METHOD_METADATA_CONSTRUCTOR,
+                chainHandle, methodHandle, bindingsHandle);
+
+        // Needed when running on native image
+        reflectiveMethods.produce(new ReflectiveMethodBuildItem(method));
+
+        // Create forwarding function
+        ResultHandle forwardingFunc = createForwardingFunction(init, interceptedStaticMethod.getTarget(), method);
+
+        ResultHandle staticMethodHandle = init.newInstance(
+                MethodDescriptor.ofConstructor(InterceptedStaticMethod.class, Function.class, InterceptedMethodMetadata.class),
+                forwardingFunc, metadataHandle);
+
+        // Call InterceptedStaticMethods.register()
+        init.invokeStaticMethod(INTERCEPTED_STATIC_METHODS_REGISTER, init.load(interceptedStaticMethod.getHash()),
+                staticMethodHandle);
+        init.returnValue(null);
+        return name;
+    }
+
+    private ResultHandle createBindingLiteral(IndexView index, ClassOutput classOutput, BytecodeCreator init,
+            AnnotationInstance binding, AnnotationLiteralProcessor annotationLiteralProcessor) {
+        ClassInfo bindingClass = index.getClassByName(binding.name());
+        return annotationLiteralProcessor.process(init, classOutput, bindingClass, binding,
+                "io.quarkus.arc.runtime");
+    }
+
+    private ResultHandle createInterceptorInvocation(InterceptorInfo interceptor, BytecodeCreator init,
+            ResultHandle creationalContext) {
+        ResultHandle interceptorBean = getInterceptorBean(interceptor, init);
+        ResultHandle interceptorInstane = createInterceptor(interceptorBean, init, creationalContext);
+        return init.invokeStaticMethod(
+                MethodDescriptors.INTERCEPTOR_INVOCATION_AROUND_INVOKE,
+                interceptorBean, interceptorInstane);
+    }
+
+    private ResultHandle getInterceptorBean(InterceptorInfo interceptor, BytecodeCreator creator) {
+        ResultHandle containerHandle = creator
+                .invokeStaticMethod(MethodDescriptors.ARC_CONTAINER);
+        return creator.checkCast(creator.invokeInterfaceMethod(
+                MethodDescriptors.ARC_CONTAINER_BEAN,
+                containerHandle, creator.load(interceptor.getIdentifier())), InjectableInterceptor.class);
+    }
+
+    private ResultHandle createInterceptor(ResultHandle interceptorBean, BytecodeCreator creator,
+            ResultHandle parentCreationalContext) {
+        ResultHandle creationalContext = creator.invokeStaticMethod(MethodDescriptors.CREATIONAL_CTX_CHILD,
+                parentCreationalContext);
+        return creator.invokeInterfaceMethod(
+                MethodDescriptors.INJECTABLE_REF_PROVIDER_GET, interceptorBean, creationalContext);
+    }
+
+    private ResultHandle createForwardingFunction(MethodCreator init, ClassInfo target, MethodInfo method) {
+        // Forwarding function
+        // Function<InvocationContext, Object> forward = ctx -> Foo.interceptMe_original((java.lang.String)ctx.getParameters()[0])
+        FunctionCreator func = init.createFunction(Function.class);
+        BytecodeCreator funcBytecode = func.getBytecode();
+        List<Type> paramTypes = method.parameters();
+        ResultHandle[] paramHandles;
+        String[] params;
+        if (paramTypes.isEmpty()) {
+            paramHandles = new ResultHandle[0];
+            params = new String[0];
+        } else {
+            paramHandles = new ResultHandle[paramTypes.size()];
+            ResultHandle ctxHandle = funcBytecode.getMethodParam(0);
+            ResultHandle ctxParamsHandle = funcBytecode.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(InvocationContext.class, "getParameters", Object[].class),
+                    ctxHandle);
+            // autoboxing is handled inside Gizmo
+            for (int i = 0; i < paramHandles.length; i++) {
+                paramHandles[i] = funcBytecode.readArrayValue(ctxParamsHandle, i);
+            }
+            params = new String[paramTypes.size()];
+            for (int i = 0; i < paramTypes.size(); i++) {
+                params[i] = paramTypes.get(i).name().toString();
+            }
+        }
+        ResultHandle ret = funcBytecode.invokeStaticMethod(
+                MethodDescriptor.ofMethod(target.name().toString(), method.name() + ORGINAL_METHOD_COPY_SUFFIX,
+                        method.returnType().name().toString(),
+                        params),
+                paramHandles);
+        if (ret == null) {
+            funcBytecode.returnValue(funcBytecode.loadNull());
+        } else {
+            funcBytecode.returnValue(ret);
+        }
+        return func.getInstance();
+    }
+
+    static class InterceptedStaticMethodsEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+        private final String initializerClassName;
+        private final List<InterceptedStaticMethodBuildItem> methods;
+
+        public InterceptedStaticMethodsEnhancer(String initializerClassName, List<InterceptedStaticMethodBuildItem> methods) {
+            this.methods = methods;
+            this.initializerClassName = initializerClassName;
+        }
+
+        @Override
+        public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+            return new InterceptedStaticMethodsClassVisitor(initializerClassName, outputClassVisitor, methods);
+        }
+
+    }
+
+    static class InterceptedStaticMethodsClassVisitor extends ClassVisitor {
+
+        private final String initializerClassName;
+        private final List<InterceptedStaticMethodBuildItem> methods;
+
+        public InterceptedStaticMethodsClassVisitor(String initializerClassName, ClassVisitor outputClassVisitor,
+                List<InterceptedStaticMethodBuildItem> methods) {
+            super(Gizmo.ASM_API_VERSION, outputClassVisitor);
+            this.methods = methods;
+            this.initializerClassName = initializerClassName;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            InterceptedStaticMethodBuildItem method = findMatchingMethod(access, name, descriptor);
+            if (method != null) {
+                MethodVisitor copy = super.visitMethod(access,
+                        name + ORGINAL_METHOD_COPY_SUFFIX,
+                        descriptor,
+                        signature,
+                        exceptions);
+                MethodVisitor superVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+                return new InterceptedStaticMethodsMethodVisitor(superVisitor, copy, initializerClassName, method);
+            } else {
+                return super.visitMethod(access, name, descriptor, signature, exceptions);
+            }
+        }
+
+        private InterceptedStaticMethodBuildItem findMatchingMethod(int access, String name, String descriptor) {
+            if (Modifier.isStatic(access)) {
+                for (InterceptedStaticMethodBuildItem method : methods) {
+                    if (method.getMethod().name().equals(name)
+                            && MethodDescriptor.of(method.getMethod()).getDescriptor().equals(descriptor)) {
+                        return method;
+                    }
+                }
+            }
+            return null;
+        }
+
+    }
+
+    static class InterceptedStaticMethodsMethodVisitor extends MethodVisitor {
+
+        private final String initializerClassName;
+        private final InterceptedStaticMethodBuildItem interceptedStaticMethod;
+        private final MethodVisitor superVisitor;
+
+        public InterceptedStaticMethodsMethodVisitor(MethodVisitor superVisitor, MethodVisitor copyVisitor,
+                String initializerClassName, InterceptedStaticMethodBuildItem interceptedStaticMethod) {
+            super(Gizmo.ASM_API_VERSION, copyVisitor);
+            this.superVisitor = superVisitor;
+            this.initializerClassName = initializerClassName;
+            this.interceptedStaticMethod = interceptedStaticMethod;
+        }
+
+        @Override
+        public void visitEnd() {
+            // Invoke the initializer, i.e. Foo_InterceptorInitializer.hash("ping")
+            MethodDescriptor descriptor = MethodDescriptor.of(interceptedStaticMethod.getMethod());
+            int paramSlot = 0;
+            for (Type paramType : interceptedStaticMethod.getMethod().parameters()) {
+                superVisitor.visitIntInsn(AsmUtil.getLoadOpcode(paramType), paramSlot);
+                paramSlot += AsmUtil.getParameterSize(paramType);
+            }
+            superVisitor.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    initializerClassName.replace('.', '/'), interceptedStaticMethod.getHash(),
+                    descriptor.getDescriptor().toString(),
+                    false);
+            superVisitor.visitInsn(AsmUtil.getReturnInstruction(interceptedStaticMethod.getMethod().returnType()));
+            superVisitor.visitMaxs(0, 0);
+            superVisitor.visitEnd();
+
+            super.visitEnd();
+        }
+
+    }
+
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsTransformersRegisteredBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsTransformersRegisteredBuildItem.java
@@ -1,0 +1,13 @@
+package io.quarkus.arc.deployment.staticmethods;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+
+/**
+ * Marker build item to signal that bytecode transformers used for static method interception were registered.
+ * <p>
+ * ASM class visitors produced by transformers registered by consumers of this build item will be run before visitors used for
+ * static method interception.
+ */
+public class InterceptedStaticMethodsTransformersRegisteredBuildItem extends EmptyBuildItem {
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodTest.java
@@ -1,0 +1,98 @@
+package io.quarkus.arc.test.interceptor.staticmethods;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.AssertionFailedError;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InterceptedStaticMethodTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(InterceptMe.class, Simple.class, SimpleInterceptor.class));
+
+    @Test
+    public void testInterceptor() {
+        assertEquals("OK:PONG", Simple.ping("pong"));
+        Simple.pong();
+        assertEquals(42.0, Simple.testDouble(2.0, "foo", 5, null));
+        assertEquals(1, SimpleInterceptor.VOID_INTERCEPTIONS.get());
+    }
+
+    public static class Simple {
+
+        @InterceptMe
+        public static String ping(String val) {
+            return val.toUpperCase();
+        }
+
+        @InterceptMe
+        static void pong() {
+        }
+
+        @InterceptMe
+        protected static Double testDouble(double val, String str, int num, Simple parent) {
+            return val;
+        }
+
+    }
+
+    @Priority(1)
+    @Interceptor
+    @InterceptMe
+    static class SimpleInterceptor {
+
+        static final AtomicInteger VOID_INTERCEPTIONS = new AtomicInteger();
+
+        @AroundInvoke
+        Object aroundInvoke(InvocationContext ctx) throws Exception {
+            if (!Modifier.isStatic(ctx.getMethod().getModifiers())) {
+                throw new AssertionFailedError("Not a static method!");
+            }
+            assertNull(ctx.getTarget());
+            Object ret = ctx.proceed();
+            if (ret != null) {
+                if (ret instanceof String) {
+                    return "OK:" + ctx.proceed();
+                } else if (ret instanceof Double) {
+                    return 42.0;
+                } else {
+                    throw new AssertionFailedError("Unsupported return type: " + ret.getClass());
+                }
+            } else {
+                VOID_INTERCEPTIONS.incrementAndGet();
+                return ret;
+            }
+        }
+
+    }
+
+    @InterceptorBinding
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @interface InterceptMe {
+
+    }
+
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/InterceptedStaticMethodsRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/InterceptedStaticMethodsRecorder.java
@@ -1,0 +1,22 @@
+package io.quarkus.arc.runtime;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class InterceptedStaticMethodsRecorder {
+
+    public static final String INTIALIZER_CLASS_NAME = "io.quarkus.arc.runtime.InterceptedStaticMethodsInitializer";
+
+    public void callInitializer() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = InterceptedStaticMethodsRecorder.class.getClassLoader();
+        }
+        try {
+            Class.forName(INTIALIZER_CLASS_NAME, true, cl);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -69,10 +69,12 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
 import io.quarkus.arc.deployment.ResourceAnnotationBuildItem;
+import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
@@ -512,6 +514,7 @@ public final class HibernateOrmProcessor {
         }
     }
 
+    @Consume(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
     @BuildStep
     public HibernateEnhancersRegisteredBuildItem enhancerDomainObjects(JpaEntitiesBuildItem domainObjects,
             BuildProducer<BytecodeTransformerBuildItem> transformers,

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/interceptor/TransactionalInterceptorBase.java
@@ -83,7 +83,15 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     private TransactionConfiguration getTransactionConfiguration(InvocationContext ic) {
         TransactionConfiguration configuration = ic.getMethod().getAnnotation(TransactionConfiguration.class);
         if (configuration == null) {
-            return ic.getTarget().getClass().getAnnotation(TransactionConfiguration.class);
+            Class<?> clazz;
+            Object target = ic.getTarget();
+            if (target != null) {
+                clazz = target.getClass();
+            } else {
+                // Very likely an intercepted static method
+                clazz = ic.getMethod().getDeclaringClass();
+            }
+            return clazz.getAnnotation(TransactionConfiguration.class);
         }
         return configuration;
     }

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheEntityClassBuildItem.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheEntityClassBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.hibernate.orm.panache.deployment;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Represents a regular Panache entity class.
+ */
+public final class PanacheEntityClassBuildItem extends MultiBuildItem {
+
+    private final ClassInfo entityClass;
+
+    public PanacheEntityClassBuildItem(ClassInfo entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    public ClassInfo get() {
+        return entityClass;
+    }
+
+}

--- a/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheMongoEntityClassBuildItem.java
+++ b/extensions/panache/mongodb-panache/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/PanacheMongoEntityClassBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.mongodb.panache.deployment;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Represents a regular Panache entity class.
+ */
+public final class PanacheMongoEntityClassBuildItem extends MultiBuildItem {
+
+    private final ClassInfo entityClass;
+
+    public PanacheMongoEntityClassBuildItem(ClassInfo entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    public ClassInfo get() {
+        return entityClass;
+    }
+
+}

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityClassesBuildItem.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityClassesBuildItem.java
@@ -9,7 +9,8 @@ import io.quarkus.builder.item.MultiBuildItem;
  * getters/setters generated for public fields, even if they're not visible in the index.
  */
 public final class PanacheEntityClassesBuildItem extends MultiBuildItem {
-    private Set<String> entityClasses;
+
+    private final Set<String> entityClasses;
 
     public PanacheEntityClassesBuildItem(Set<String> entityClasses) {
         this.entityClasses = entityClasses;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
@@ -19,10 +19,11 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 
 /**
- *
- * @author Martin Kouba
+ * Generates shared annotation literal classes that can be used to represent annotation instances at runtime.
+ * <p>
+ * This construct is thread-safe.
  */
-class AnnotationLiteralProcessor {
+public class AnnotationLiteralProcessor {
 
     private final ComputingCache<Key, Literal> cache;
 
@@ -54,7 +55,7 @@ class AnnotationLiteralProcessor {
      * @param targetPackage Target package is only used if annotation literals are not shared
      * @return an annotation literal result handle
      */
-    ResultHandle process(BytecodeCreator bytecode, ClassOutput classOutput, ClassInfo annotationClass,
+    public ResultHandle process(BytecodeCreator bytecode, ClassOutput classOutput, ClassInfo annotationClass,
             AnnotationInstance annotationInstance,
             String targetPackage) {
         Objects.requireNonNull(annotationClass, "Annotation class not available: " + annotationInstance);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
@@ -20,7 +20,7 @@ import org.jboss.jandex.DotName;
  * @author Martin Kouba
  * @see AnnotationsTransformer
  */
-public class AnnotationStore {
+public final class AnnotationStore {
 
     private final ConcurrentMap<AnnotationTarget, Collection<AnnotationInstance>> transformed;
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -352,6 +352,10 @@ public class BeanDeployment {
         return Collections.unmodifiableCollection(qualifiers.values());
     }
 
+    public Collection<ClassInfo> getInterceptorBindings() {
+        return Collections.unmodifiableCollection(interceptorBindings.values());
+    }
+
     public Collection<ObserverInfo> getObservers() {
         return observers;
     }
@@ -368,7 +372,7 @@ public class BeanDeployment {
         return beanResolver;
     }
 
-    InterceptorResolver getInterceptorResolver() {
+    public InterceptorResolver getInterceptorResolver() {
         return interceptorResolver;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -52,7 +52,7 @@ public class BeanProcessor {
 
     private final String name;
     private final ResourceOutput output;
-    private final boolean sharedAnnotationLiterals;
+    private final AnnotationLiteralProcessor annotationLiterals;
     private final ReflectionRegistration reflectionRegistration;
     private final List<BeanRegistrar> beanRegistrars;
     private final List<ContextRegistrar> contextRegistrars;
@@ -95,7 +95,7 @@ public class BeanProcessor {
         this.applicationClassPredicate = applicationClassPredicate;
         this.name = name;
         this.output = output;
-        this.sharedAnnotationLiterals = sharedAnnotationLiterals;
+        this.annotationLiterals = new AnnotationLiteralProcessor(sharedAnnotationLiterals, applicationClassPredicate);
         this.generateSources = generateSources;
         this.allowMocking = allowMocking;
 
@@ -168,8 +168,6 @@ public class BeanProcessor {
         Map<BeanInfo, String> beanToGeneratedName = new HashMap<>();
         Map<ObserverInfo, String> observerToGeneratedName = new HashMap<>();
 
-        AnnotationLiteralProcessor annotationLiterals = new AnnotationLiteralProcessor(sharedAnnotationLiterals,
-                applicationClassPredicate);
         BeanGenerator beanGenerator = new BeanGenerator(annotationLiterals, applicationClassPredicate, privateMembers,
                 generateSources, reflectionRegistration, existingClasses, beanToGeneratedName,
                 injectionPointAnnotationsPredicate);
@@ -243,6 +241,10 @@ public class BeanProcessor {
 
     public BeanDeployment getBeanDeployment() {
         return beanDeployment;
+    }
+
+    public AnnotationLiteralProcessor getAnnotationLiteralProcessor() {
+        return annotationLiterals;
     }
 
     public BeanDeployment process() throws IOException {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
@@ -14,10 +14,16 @@ public class InterceptorResolver {
 
     private final BeanDeployment beanDeployment;
 
-    public InterceptorResolver(BeanDeployment beanDeployment) {
+    InterceptorResolver(BeanDeployment beanDeployment) {
         this.beanDeployment = beanDeployment;
     }
 
+    /**
+     * 
+     * @param interceptionType
+     * @param bindings
+     * @return the list of interceptors for a set of interceptor bindings and a type of interception
+     */
     public List<InterceptorInfo> resolve(InterceptionType interceptionType, Set<AnnotationInstance> bindings) {
         if (bindings.isEmpty()) {
             return Collections.emptyList();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -9,11 +9,11 @@ import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableReferenceProvider;
 import io.quarkus.arc.impl.CreationalContextImpl;
 import io.quarkus.arc.impl.FixedValueSupplier;
+import io.quarkus.arc.impl.InterceptedMethodMetadata;
 import io.quarkus.arc.impl.InterceptorInvocation;
 import io.quarkus.arc.impl.InvocationContexts;
 import io.quarkus.arc.impl.MapValueSupplier;
 import io.quarkus.arc.impl.Reflections;
-import io.quarkus.arc.impl.SubclassMethodMetadata;
 import io.quarkus.gizmo.MethodDescriptor;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -35,177 +35,195 @@ import javax.interceptor.InvocationContext;
  *
  * @author Martin Kouba
  */
-final class MethodDescriptors {
+public final class MethodDescriptors {
 
-    static final MethodDescriptor FIXED_VALUE_SUPPLIER_CONSTRUCTOR = MethodDescriptor.ofConstructor(FixedValueSupplier.class,
+    public static final MethodDescriptor FIXED_VALUE_SUPPLIER_CONSTRUCTOR = MethodDescriptor.ofConstructor(
+            FixedValueSupplier.class,
             Object.class);
 
-    static final MethodDescriptor MAP_VALUE_SUPPLIER_CONSTRUCTOR = MethodDescriptor.ofConstructor(MapValueSupplier.class,
+    public static final MethodDescriptor MAP_VALUE_SUPPLIER_CONSTRUCTOR = MethodDescriptor.ofConstructor(MapValueSupplier.class,
             Map.class, String.class);
 
-    static final MethodDescriptor SUPPLIER_GET = MethodDescriptor.ofMethod(Supplier.class, "get", Object.class);
+    public static final MethodDescriptor SUPPLIER_GET = MethodDescriptor.ofMethod(Supplier.class, "get", Object.class);
 
-    static final MethodDescriptor CREATIONAL_CTX_CHILD = MethodDescriptor.ofMethod(CreationalContextImpl.class, "child",
+    public static final MethodDescriptor CREATIONAL_CTX_CHILD = MethodDescriptor.ofMethod(CreationalContextImpl.class, "child",
             CreationalContextImpl.class,
             CreationalContext.class);
 
-    static final MethodDescriptor CREATIONAL_CTX_CHILD_CONTEXTUAL = MethodDescriptor.ofMethod(CreationalContextImpl.class,
+    public static final MethodDescriptor CREATIONAL_CTX_CHILD_CONTEXTUAL = MethodDescriptor.ofMethod(
+            CreationalContextImpl.class,
             "child",
             CreationalContextImpl.class,
             InjectableReferenceProvider.class,
             CreationalContext.class);
 
-    static final MethodDescriptor MAP_GET = MethodDescriptor.ofMethod(Map.class, "get", Object.class, Object.class);
+    public static final MethodDescriptor MAP_GET = MethodDescriptor.ofMethod(Map.class, "get", Object.class, Object.class);
 
-    static final MethodDescriptor MAP_PUT = MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class,
+    public static final MethodDescriptor MAP_PUT = MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class,
             Object.class);
 
-    static final MethodDescriptor INJECTABLE_REF_PROVIDER_GET = MethodDescriptor.ofMethod(InjectableReferenceProvider.class,
+    public static final MethodDescriptor INJECTABLE_REF_PROVIDER_GET = MethodDescriptor.ofMethod(
+            InjectableReferenceProvider.class,
             "get", Object.class,
             CreationalContext.class);
 
-    static final MethodDescriptor SET_ADD = MethodDescriptor.ofMethod(Set.class, "add", boolean.class, Object.class);
+    public static final MethodDescriptor SET_ADD = MethodDescriptor.ofMethod(Set.class, "add", boolean.class, Object.class);
 
-    static final MethodDescriptor LIST_ADD = MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class);
+    public static final MethodDescriptor LIST_ADD = MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class);
 
-    static final MethodDescriptor OBJECT_EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
+    public static final MethodDescriptor OBJECT_EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
             Object.class);
 
-    static final MethodDescriptor OBJECT_TO_STRING = MethodDescriptor.ofMethod(Object.class, "toString", String.class);
+    public static final MethodDescriptor OBJECT_TO_STRING = MethodDescriptor.ofMethod(Object.class, "toString", String.class);
 
-    static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
+    public static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
 
-    static final MethodDescriptor INTERCEPTOR_INVOCATION_POST_CONSTRUCT = MethodDescriptor.ofMethod(InterceptorInvocation.class,
+    public static final MethodDescriptor INTERCEPTOR_INVOCATION_POST_CONSTRUCT = MethodDescriptor.ofMethod(
+            InterceptorInvocation.class,
             "postConstruct",
             InterceptorInvocation.class, InjectableInterceptor.class, Object.class);
 
-    static final MethodDescriptor INTERCEPTOR_INVOCATION_PRE_DESTROY = MethodDescriptor.ofMethod(InterceptorInvocation.class,
+    public static final MethodDescriptor INTERCEPTOR_INVOCATION_PRE_DESTROY = MethodDescriptor.ofMethod(
+            InterceptorInvocation.class,
             "preDestroy",
             InterceptorInvocation.class, InjectableInterceptor.class, Object.class);
 
-    static final MethodDescriptor INTERCEPTOR_INVOCATION_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
+    public static final MethodDescriptor INTERCEPTOR_INVOCATION_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
             InterceptorInvocation.class, "aroundConstruct",
             InterceptorInvocation.class, InjectableInterceptor.class, Object.class);
 
-    static final MethodDescriptor INTERCEPTOR_INVOCATION_AROUND_INVOKE = MethodDescriptor.ofMethod(InterceptorInvocation.class,
+    public static final MethodDescriptor INTERCEPTOR_INVOCATION_AROUND_INVOKE = MethodDescriptor.ofMethod(
+            InterceptorInvocation.class,
             "aroundInvoke",
             InterceptorInvocation.class, InjectableInterceptor.class, Object.class);
 
-    static final MethodDescriptor REFLECTIONS_FIND_CONSTRUCTOR = MethodDescriptor.ofMethod(Reflections.class, "findConstructor",
+    public static final MethodDescriptor REFLECTIONS_FIND_CONSTRUCTOR = MethodDescriptor.ofMethod(Reflections.class,
+            "findConstructor",
             Constructor.class, Class.class,
             Class[].class);
 
-    static final MethodDescriptor REFLECTIONS_FIND_METHOD = MethodDescriptor.ofMethod(Reflections.class, "findMethod",
+    public static final MethodDescriptor REFLECTIONS_FIND_METHOD = MethodDescriptor.ofMethod(Reflections.class, "findMethod",
             Method.class, Class.class, String.class,
             Class[].class);
 
-    static final MethodDescriptor REFLECTIONS_FIND_FIELD = MethodDescriptor.ofMethod(Reflections.class, "findField",
+    public static final MethodDescriptor REFLECTIONS_FIND_FIELD = MethodDescriptor.ofMethod(Reflections.class, "findField",
             Field.class, Class.class, String.class);
 
-    static final MethodDescriptor REFLECTIONS_WRITE_FIELD = MethodDescriptor.ofMethod(Reflections.class, "writeField",
+    public static final MethodDescriptor REFLECTIONS_WRITE_FIELD = MethodDescriptor.ofMethod(Reflections.class, "writeField",
             void.class, Class.class, String.class,
             Object.class, Object.class);
 
-    static final MethodDescriptor REFLECTIONS_READ_FIELD = MethodDescriptor.ofMethod(Reflections.class, "readField",
+    public static final MethodDescriptor REFLECTIONS_READ_FIELD = MethodDescriptor.ofMethod(Reflections.class, "readField",
             Object.class, Class.class, String.class,
             Object.class);
 
-    static final MethodDescriptor REFLECTIONS_INVOKE_METHOD = MethodDescriptor.ofMethod(Reflections.class, "invokeMethod",
+    public static final MethodDescriptor REFLECTIONS_INVOKE_METHOD = MethodDescriptor.ofMethod(Reflections.class,
+            "invokeMethod",
             Object.class, Class.class,
             String.class, Class[].class, Object.class, Object[].class);
 
-    static final MethodDescriptor REFLECTIONS_NEW_INSTANCE = MethodDescriptor.ofMethod(Reflections.class, "newInstance",
+    public static final MethodDescriptor REFLECTIONS_NEW_INSTANCE = MethodDescriptor.ofMethod(Reflections.class, "newInstance",
             Object.class, Class.class,
             Class[].class, Object[].class);
 
-    static final MethodDescriptor CLIENT_PROXY_GET_CONTEXTUAL_INSTANCE = MethodDescriptor.ofMethod(ClientProxy.class,
+    public static final MethodDescriptor CLIENT_PROXY_GET_CONTEXTUAL_INSTANCE = MethodDescriptor.ofMethod(ClientProxy.class,
             ClientProxyGenerator.GET_CONTEXTUAL_INSTANCE_METHOD_NAME, Object.class);
 
-    static final MethodDescriptor INJECTABLE_BEAN_DESTROY = MethodDescriptor.ofMethod(InjectableBean.class, "destroy",
+    public static final MethodDescriptor INJECTABLE_BEAN_DESTROY = MethodDescriptor.ofMethod(InjectableBean.class, "destroy",
             void.class, Object.class,
             CreationalContext.class);
 
-    static final MethodDescriptor CREATIONAL_CTX_RELEASE = MethodDescriptor.ofMethod(CreationalContext.class, "release",
+    public static final MethodDescriptor CREATIONAL_CTX_RELEASE = MethodDescriptor.ofMethod(CreationalContext.class, "release",
             void.class);
 
-    static final MethodDescriptor EVENT_CONTEXT_GET_EVENT = MethodDescriptor.ofMethod(EventContext.class, "getEvent",
+    public static final MethodDescriptor EVENT_CONTEXT_GET_EVENT = MethodDescriptor.ofMethod(EventContext.class, "getEvent",
             Object.class);
 
-    static final MethodDescriptor EVENT_CONTEXT_GET_METADATA = MethodDescriptor.ofMethod(EventContext.class, "getMetadata",
+    public static final MethodDescriptor EVENT_CONTEXT_GET_METADATA = MethodDescriptor.ofMethod(EventContext.class,
+            "getMetadata",
             EventMetadata.class);
 
-    static final MethodDescriptor INVOCATION_CONTEXTS_PERFORM_AROUND_INVOKE = MethodDescriptor.ofMethod(
+    public static final MethodDescriptor INVOCATION_CONTEXTS_PERFORM_AROUND_INVOKE = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "performAroundInvoke",
             Object.class, Object.class, Method.class, Function.class, Object[].class, List.class,
             Set.class);
 
-    static final MethodDescriptor INVOCATION_CONTEXTS_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
+    public static final MethodDescriptor INVOCATION_CONTEXTS_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "aroundConstruct",
             InvocationContext.class, Constructor.class, List.class, Supplier.class, Set.class);
 
-    static final MethodDescriptor INVOCATION_CONTEXTS_POST_CONSTRUCT = MethodDescriptor.ofMethod(
+    public static final MethodDescriptor INVOCATION_CONTEXTS_POST_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "postConstruct",
             InvocationContext.class, Object.class, List.class, Set.class);
 
-    static final MethodDescriptor INVOCATION_CONTEXTS_PRE_DESTROY = MethodDescriptor.ofMethod(InvocationContexts.class,
+    public static final MethodDescriptor INVOCATION_CONTEXTS_PRE_DESTROY = MethodDescriptor.ofMethod(InvocationContexts.class,
             "preDestroy",
             InvocationContext.class, Object.class, List.class, Set.class);
 
-    static final MethodDescriptor INVOCATION_CONTEXT_PROCEED = MethodDescriptor.ofMethod(InvocationContext.class, "proceed",
+    public static final MethodDescriptor INVOCATION_CONTEXT_PROCEED = MethodDescriptor.ofMethod(InvocationContext.class,
+            "proceed",
             Object.class);
 
-    static final MethodDescriptor INVOCATION_CONTEXT_GET_TARGET = MethodDescriptor.ofMethod(InvocationContext.class,
+    public static final MethodDescriptor INVOCATION_CONTEXT_GET_TARGET = MethodDescriptor.ofMethod(InvocationContext.class,
             "getTarget",
             Object.class);
 
-    static final MethodDescriptor CREATIONAL_CTX_ADD_DEP_TO_PARENT = MethodDescriptor.ofMethod(CreationalContextImpl.class,
+    public static final MethodDescriptor CREATIONAL_CTX_ADD_DEP_TO_PARENT = MethodDescriptor.ofMethod(
+            CreationalContextImpl.class,
             "addDependencyToParent", void.class,
             InjectableBean.class, Object.class, CreationalContext.class);
 
-    static final MethodDescriptor COLLECTIONS_UNMODIFIABLE_SET = MethodDescriptor.ofMethod(Collections.class, "unmodifiableSet",
+    public static final MethodDescriptor COLLECTIONS_UNMODIFIABLE_SET = MethodDescriptor.ofMethod(Collections.class,
+            "unmodifiableSet",
             Set.class, Set.class);
 
-    static final MethodDescriptor COLLECTIONS_SINGLETON = MethodDescriptor.ofMethod(Collections.class, "singleton",
+    public static final MethodDescriptor COLLECTIONS_SINGLETON = MethodDescriptor.ofMethod(Collections.class, "singleton",
             Set.class, Object.class);
 
-    static final MethodDescriptor COLLECTIONS_SINGLETON_LIST = MethodDescriptor.ofMethod(Collections.class, "singletonList",
+    public static final MethodDescriptor COLLECTIONS_SINGLETON_LIST = MethodDescriptor.ofMethod(Collections.class,
+            "singletonList",
             List.class, Object.class);
 
-    static final MethodDescriptor COLLECTIONS_EMPTY_MAP = MethodDescriptor.ofMethod(Collections.class, "emptyMap",
+    public static final MethodDescriptor COLLECTIONS_EMPTY_MAP = MethodDescriptor.ofMethod(Collections.class, "emptyMap",
             Map.class);
 
-    static final MethodDescriptor ARC_CONTAINER = MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class);
+    public static final MethodDescriptor ARC_CONTAINER = MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class);
 
-    static final MethodDescriptor ARC_CONTAINER_GET_ACTIVE_CONTEXT = MethodDescriptor.ofMethod(ArcContainer.class,
+    public static final MethodDescriptor ARC_CONTAINER_BEAN = MethodDescriptor.ofMethod(ArcContainer.class, "bean",
+            InjectableBean.class, String.class);
+
+    public static final MethodDescriptor ARC_CONTAINER_GET_ACTIVE_CONTEXT = MethodDescriptor.ofMethod(ArcContainer.class,
             "getActiveContext", InjectableContext.class, Class.class);
 
-    static final MethodDescriptor CONTEXT_GET = MethodDescriptor.ofMethod(Context.class, "get", Object.class, Contextual.class,
+    public static final MethodDescriptor CONTEXT_GET = MethodDescriptor.ofMethod(Context.class, "get", Object.class,
+            Contextual.class,
             CreationalContext.class);
 
-    static final MethodDescriptor CONTEXT_GET_IF_PRESENT = MethodDescriptor.ofMethod(Context.class, "get", Object.class,
+    public static final MethodDescriptor CONTEXT_GET_IF_PRESENT = MethodDescriptor.ofMethod(Context.class, "get", Object.class,
             Contextual.class);
 
-    static final MethodDescriptor GET_IDENTIFIER = MethodDescriptor.ofMethod(InjectableBean.class, "getIdentifier",
+    public static final MethodDescriptor GET_IDENTIFIER = MethodDescriptor.ofMethod(InjectableBean.class, "getIdentifier",
             String.class);
 
-    static final MethodDescriptor SUBCLASS_METHOD_METADATA_CONSTRUCTOR = MethodDescriptor.ofConstructor(
-            SubclassMethodMetadata.class,
+    public static final MethodDescriptor INTERCEPTED_METHOD_METADATA_CONSTRUCTOR = MethodDescriptor.ofConstructor(
+            InterceptedMethodMetadata.class,
             List.class, Method.class, Set.class);
 
-    static final MethodDescriptor CREATIONAL_CTX_HAS_DEPENDENT_INSTANCES = MethodDescriptor.ofMethod(
+    public static final MethodDescriptor CREATIONAL_CTX_HAS_DEPENDENT_INSTANCES = MethodDescriptor.ofMethod(
             CreationalContextImpl.class,
             "hasDependentInstances", boolean.class);
 
-    static final MethodDescriptor THREAD_CURRENT_THREAD = MethodDescriptor.ofMethod(Thread.class, "currentThread",
+    public static final MethodDescriptor THREAD_CURRENT_THREAD = MethodDescriptor.ofMethod(Thread.class, "currentThread",
             Thread.class);
 
-    static final MethodDescriptor THREAD_GET_TCCL = MethodDescriptor.ofMethod(Thread.class, "getContextClassLoader",
+    public static final MethodDescriptor THREAD_GET_TCCL = MethodDescriptor.ofMethod(Thread.class, "getContextClassLoader",
             ClassLoader.class);
 
-    static final MethodDescriptor CL_FOR_NAME = MethodDescriptor.ofMethod(Class.class, "forName", Class.class, String.class,
+    public static final MethodDescriptor CL_FOR_NAME = MethodDescriptor.ofMethod(Class.class, "forName", Class.class,
+            String.class,
             boolean.class, ClassLoader.class);
 
     private MethodDescriptors() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -7,7 +7,7 @@ import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.Subclass;
-import io.quarkus.arc.impl.SubclassMethodMetadata;
+import io.quarkus.arc.impl.InterceptedMethodMetadata;
 import io.quarkus.arc.processor.BeanInfo.InterceptionInfo;
 import io.quarkus.arc.processor.ResourceOutput.Resource;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -63,11 +63,11 @@ public class SubclassGenerator extends AbstractGenerator {
 
     protected static final String FIELD_NAME_PREDESTROYS = "preDestroys";
     protected static final String FIELD_NAME_METADATA = "metadata";
-    protected static final FieldDescriptor FIELD_METADATA_METHOD = FieldDescriptor.of(SubclassMethodMetadata.class, "method",
+    protected static final FieldDescriptor FIELD_METADATA_METHOD = FieldDescriptor.of(InterceptedMethodMetadata.class, "method",
             Method.class);
-    protected static final FieldDescriptor FIELD_METADATA_CHAIN = FieldDescriptor.of(SubclassMethodMetadata.class, "chain",
+    protected static final FieldDescriptor FIELD_METADATA_CHAIN = FieldDescriptor.of(InterceptedMethodMetadata.class, "chain",
             List.class);
-    protected static final FieldDescriptor FIELD_METADATA_BINDINGS = FieldDescriptor.of(SubclassMethodMetadata.class,
+    protected static final FieldDescriptor FIELD_METADATA_BINDINGS = FieldDescriptor.of(InterceptedMethodMetadata.class,
             "bindings", Set.class);
 
     private final Predicate<DotName> applicationClassPredicate;
@@ -308,8 +308,9 @@ public class SubclassGenerator extends AbstractGenerator {
             ResultHandle bindingsHandle = bindings.computeIfAbsent(
                     interceptedMethod.bindings.stream().map(BindingKey::new).collect(Collectors.toList()), bindingsFun);
 
-            //Now create SubclassMethodMetadata for the given intercepted method
-            ResultHandle methodMetadataHandle = constructor.newInstance(MethodDescriptors.SUBCLASS_METHOD_METADATA_CONSTRUCTOR,
+            // Now create metadata for the given intercepted method
+            ResultHandle methodMetadataHandle = constructor.newInstance(
+                    MethodDescriptors.INTERCEPTED_METHOD_METADATA_CONSTRUCTOR,
                     chainHandle, methodHandle, bindingsHandle);
             // metadata.put("m1", new SubclassMethodMetadata(...))
             constructor.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, metadataHandle, methodIdHandle, methodMetadataHandle);

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -359,6 +359,7 @@ public class ArcContainerImpl implements ArcContainer {
             resolved.clear();
             observers.clear();
             running.set(false);
+            InterceptedStaticMethods.clear();
 
             LOGGER.debugf("ArC DI container shut down");
         }
@@ -480,6 +481,11 @@ public class ArcContainerImpl implements ArcContainer {
         for (InjectableBean<?> bean : beans) {
             if (bean.getIdentifier().equals(identifier)) {
                 return bean;
+            }
+        }
+        for (InjectableInterceptor<?> interceptorBean : interceptors) {
+            if (interceptorBean.getIdentifier().equals(identifier)) {
+                return interceptorBean;
             }
         }
         return null;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
@@ -5,13 +5,13 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
 
-public class SubclassMethodMetadata {
+public class InterceptedMethodMetadata {
 
     public final List<InterceptorInvocation> chain;
     public final Method method;
     public final Set<Annotation> bindings;
 
-    public SubclassMethodMetadata(List<InterceptorInvocation> chain, Method method, Set<Annotation> bindings) {
+    public InterceptedMethodMetadata(List<InterceptorInvocation> chain, Method method, Set<Annotation> bindings) {
         this.chain = chain;
         this.method = method;
         this.bindings = bindings;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedStaticMethods.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedStaticMethods.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.impl;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import javax.interceptor.InvocationContext;
+
+public final class InterceptedStaticMethods {
+
+    private static final ConcurrentMap<String, InterceptedStaticMethod> METHODS = new ConcurrentHashMap<>();
+
+    private InterceptedStaticMethods() {
+    }
+
+    public static void register(String key, InterceptedStaticMethod method) {
+        METHODS.putIfAbsent(key, method);
+    }
+
+    public static Object aroundInvoke(String key, Object[] args) throws Exception {
+        InterceptedStaticMethod method = METHODS.get(key);
+        if (method == null) {
+            throw new IllegalArgumentException("Intercepted method metadata not found for key: " + key);
+        }
+        return InvocationContexts.performAroundInvoke(null, method.metadata.method, method.forward, args, method.metadata.chain,
+                method.metadata.bindings);
+    }
+
+    public static final class InterceptedStaticMethod {
+
+        final Function<InvocationContext, Object> forward;
+        final InterceptedMethodMetadata metadata;
+
+        public InterceptedStaticMethod(Function<InvocationContext, Object> forward, InterceptedMethodMetadata metadata) {
+            this.forward = forward;
+            this.metadata = metadata;
+        }
+
+    }
+
+    static void clear() {
+        METHODS.clear();
+    }
+
+}

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Beer.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/Beer.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.panache;
 
 import javax.persistence.Entity;
+import javax.transaction.Transactional;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
@@ -8,4 +9,11 @@ import io.quarkus.hibernate.orm.panache.PanacheEntity;
 public class Beer extends PanacheEntity {
 
     public String name;
+
+    @Transactional
+    public static void deleteAllAndPersist(Beer beer) {
+        deleteAll();
+        persist(beer);
+    }
+
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TransactionalPanacheEntityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TransactionalPanacheEntityTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.panache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TransactionalPanacheEntityTest {
+
+    @Test
+    public void testTransactionalPanacheEntity() {
+        Beer b = new Beer();
+        b.name = "IPA";
+        // Method is annotated with @Transactional and should be intercepted
+        Beer.deleteAllAndPersist(b);
+        assertEquals(1, Beer.count());
+    }
+
+}

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TransactionalRepositoryTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/TransactionalRepositoryTest.java
@@ -15,6 +15,9 @@ public class TransactionalRepositoryTest {
 
     @Test
     public void testTransactionalRepository() {
+        // Make sure there are no beers stored
+        beerRepository.deleteAll();
+
         Beer b = new Beer();
         b.name = "IPA";
         beerRepository.persist(b);


### PR DESCRIPTION
This is a non-standard feature.

### Use cases
Makes it possible to apply interceptors to static methods. CDI does support static producers and observers so the reason why CDI does not support this is very likely a technical "obstacle". It could be useful for things like metrics and transactions.

### Limitations
- only method-level bindings are considered for backward compatibility
reasons (otherwise static methods of bean classes that declare class-level bindings would be suddenly intercepted -> behavior change)
- private static methods are never intercepted
- `InvocationContext#getTarget()` returns null for obvious reasons; interceptors can use `InvocationContext.getMethod()` to detect static methods
- annotation transformers are not taken into account (bindings must be declared on the class)

### Impl. Notes
Suppose we have a class with a static method that declares an interceptor binding:
```java
class Foo {
  
   @Transactional
   static String ping() {
       return "pong";
   }
}
```
We generate a `Foo_InterceptorInitializer` class. This class registers an inteceptor chain for each intercepted static method via `io.quarkus.arc.impl.InterceptedStaticMethods#register()` (only for `ping()` in this particular case) and also provides a forwarding static method, i.e. `Foo_InterceptorInitializer.hashForPingMethod()` that can invoke the chain and eventually delegate to the original method. 

However, we also transform the `Foo.class` in a way that:
- the original method body is copied to a new method that has the same signature but the name has `_orig` suffix
- the original method body is modified to invoke `Foo_InterceptorInitializer.hashForPingMethod()`

```java
class Foo {
     static String ping() {
      return Foo_InterceptorInitializer.hashForPingMethod();
   }
   @Transactional
   static String ping_orig() {
       return "pong";
   }
}
```

Therefore, `Foo_InterceptorInitializer.hashForPingMethod()` does not delegate to `Foo.ping()` but  `Foo.ping_orig()`.

This way we don't have to transform the call sites which would be much more expensive in terms of resources.