### PR TITLE
Updated smallrye-open-api to 1.2.4

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -35,7 +35,7 @@
         <smallrye-config.version>1.7.0</smallrye-config.version>
         <smallrye-health.version>2.2.1</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
-        <smallrye-open-api.version>1.2.3</smallrye-open-api.version>
+        <smallrye-open-api.version>1.2.4</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.3</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.2.0</smallrye-fault-tolerance.version>


### PR DESCRIPTION
This update to smallrye-open-api [1.2.4](https://github.com/smallrye/smallrye-open-api/releases/tag/1.2.4)

This should fix #8810 and #9538