### PR TITLE
If the rotate-on-boot is defined and there is a file-suffix use the PeriodicSizeRotatingFileHandler

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -74,6 +74,8 @@ public class FileConfig {
 
         /**
          * Indicates whether to rotate log files on server initialization.
+         * <p>
+         * You need to either set a {@code max-file-size} or configure a {@code file-suffix} for it to work.
          */
         @ConfigItem(defaultValue = "true")
         boolean rotateOnBoot;

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogConfig.java
@@ -37,6 +37,30 @@ public final class LogConfig {
     public Level minLevel;
 
     /**
+     * Console logging.
+     * <p>
+     * Console logging is enabled by default.
+     */
+    @ConfigDocSection
+    public ConsoleConfig console;
+
+    /**
+     * File logging.
+     * <p>
+     * Logging to a file is also supported but not enabled by default.
+     */
+    @ConfigDocSection
+    public FileConfig file;
+
+    /**
+     * Syslog logging.
+     * <p>
+     * Logging to a syslog is also supported but not enabled by default.
+     */
+    @ConfigDocSection
+    public SyslogConfig syslog;
+
+    /**
      * Logging categories.
      * <p>
      * Logging is done on a per-category basis. Each category can be independently configured.
@@ -73,30 +97,6 @@ public final class LogConfig {
     @ConfigItem(name = "handler.syslog")
     @ConfigDocSection
     public Map<String, SyslogConfig> syslogHandlers;
-
-    /**
-     * Console logging.
-     * <p>
-     * Console logging is enabled by default.
-     */
-    @ConfigDocSection
-    public ConsoleConfig console;
-
-    /**
-     * File logging.
-     * <p>
-     * Logging to a file is also supported but not enabled by default.
-     */
-    @ConfigDocSection
-    public FileConfig file;
-
-    /**
-     * Syslog logging.
-     * <p>
-     * Logging to a syslog is also supported but not enabled by default.
-     */
-    @ConfigDocSection
-    public SyslogConfig syslog;
 
     /**
      * Log cleanup filters - internal use.

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -284,10 +284,12 @@ public class LoggingSetupRecorder {
             final List<LogCleanupFilterElement> filterElements) {
         FileHandler handler = new FileHandler();
         FileConfig.RotationConfig rotationConfig = config.rotation;
-        if (rotationConfig.maxFileSize.isPresent() && rotationConfig.fileSuffix.isPresent()) {
+        if ((rotationConfig.maxFileSize.isPresent() || rotationConfig.rotateOnBoot)
+                && rotationConfig.fileSuffix.isPresent()) {
             PeriodicSizeRotatingFileHandler periodicSizeRotatingFileHandler = new PeriodicSizeRotatingFileHandler();
             periodicSizeRotatingFileHandler.setSuffix(rotationConfig.fileSuffix.get());
-            periodicSizeRotatingFileHandler.setRotateSize(rotationConfig.maxFileSize.get().asLongValue());
+            rotationConfig.maxFileSize
+                    .ifPresent(memorySize -> periodicSizeRotatingFileHandler.setRotateSize(memorySize.asLongValue()));
             periodicSizeRotatingFileHandler.setRotateOnBoot(rotationConfig.rotateOnBoot);
             periodicSizeRotatingFileHandler.setMaxBackupIndex(rotationConfig.maxBackupIndex);
             handler = periodicSizeRotatingFileHandler;

--- a/core/test-extension/deployment/src/main/resources/application-periodic-size-file-log-rotating-rotate-on-boot.properties
+++ b/core/test-extension/deployment/src/main/resources/application-periodic-size-file-log-rotating-rotate-on-boot.properties
@@ -1,0 +1,7 @@
+quarkus.log.level=INFO
+quarkus.log.file.enable=true
+quarkus.log.file.level=INFO
+quarkus.log.file.format=%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n
+quarkus.log.file.rotation.file-suffix=.yyyy-MM-dd
+quarkus.log.file.rotation.rotate-on-boot=true
+quarkus.root.dsa-key-location=/DSAPublicKey.encoded

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/LoggingTestsHelper.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/LoggingTestsHelper.java
@@ -3,12 +3,14 @@ package io.quarkus.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import org.jboss.logmanager.handlers.DelayedHandler;
+import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 
@@ -22,9 +24,10 @@ public class LoggingTestsHelper {
         assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
         assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
 
-        Handler handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (clazz.isInstance(h)))
-                .findFirst().get();
-        assertThat(handler).isNotNull();
-        return handler;
+        Optional<Handler> handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (clazz.isInstance(h)))
+                .findFirst();
+        Assertions.assertTrue(handler.isPresent(), () -> String.format("Could not find handler of type %s: %s", clazz,
+                Arrays.asList(delayedHandler.getHandlers())));
+        return handler.get();
     }
 }

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingRotateOnBootTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/PeriodicSizeRotatingLoggingRotateOnBootTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.logging;
+
+import static io.quarkus.logging.LoggingTestsHelper.getHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PeriodicSizeRotatingLoggingRotateOnBootTest {
+
+    private static final String FILE_NAME = PeriodicSizeRotatingLoggingRotateOnBootTest.class.getSimpleName() + ".log";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-periodic-size-file-log-rotating-rotate-on-boot.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(LoggingTestsHelper.class)
+                    .addAsManifestResource("application.properties", "microprofile-config.properties"))
+            .setLogFileName(FILE_NAME);
+
+    @Test
+    public void periodicSizeRotatingConfigurationTest() {
+        Handler handler = getHandler(PeriodicSizeRotatingFileHandler.class);
+        assertThat(handler.getLevel()).isEqualTo(Level.INFO);
+
+        Formatter formatter = handler.getFormatter();
+        assertThat(formatter).isInstanceOf(PatternFormatter.class);
+        PatternFormatter patternFormatter = (PatternFormatter) formatter;
+        assertThat(patternFormatter.getPattern()).isEqualTo("%d{HH:mm:ss} %-5p [%c{2.}]] (%t) %s%e%n");
+
+        PeriodicSizeRotatingFileHandler periodicSizeRotatingFileHandler = (PeriodicSizeRotatingFileHandler) handler;
+        assertThat(periodicSizeRotatingFileHandler.isRotateOnBoot()).isTrue();
+    }
+}


### PR DESCRIPTION
…e the PeriodicSizeRotatingFileHandler.

Note it was a conscious decision not to allow the `SizeRotatingFileHandler` if the `rotate-on-boot` was defined, but `max-file-size` was not. That seems like an odd use case as we'd have to assume some kind of maximum size. This could be `Long.MAX_VALUE`, but again that seems odd.

Also if this needs to be ported to the other branches let me know and I'm happy to do it.

Fixes #9259