### PR TITLE
Upgrade to Hibernate ORM 5.4.17.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -83,7 +83,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
-        <hibernate-orm.version>5.4.16.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.17.Final</hibernate-orm.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta7</hibernate-search.version>
         <narayana.version>5.10.5.Final</narayana.version>


### PR DESCRIPTION

There's not much of interest in this version, but it's a required step for Hibernate Reactive.

Changelog:
 - https://hibernate.atlassian.net/projects/HHH/versions/31858/tab/release-report-all-issues