### PR TITLE
Increase timeout for Windows CI run

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -223,7 +223,7 @@ jobs:
     name: Windows JDK 11 JVM Tests
     needs: build-jdk11
     runs-on: windows-latest
-    timeout-minutes: 120
+    timeout-minutes: 130
     env:
       MAVEN_OPTS: -Xmx1408m
    


### PR DESCRIPTION
I have seen a few PRs have their Windows CI run timeout,
so let's try and bump it a little in order to not have to
rerun CI when this happens