### PR TITLE
Lambda core and events updated to latest libraries per #9690, adding ALB event

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -136,8 +136,8 @@
         <scala.version>2.12.9</scala.version>
         <tika.version>1.22</tika.version>
         <ooxml-schemas.version>1.4</ooxml-schemas.version>
-        <aws-lambda-java.version>1.1.0</aws-lambda-java.version>
-        <aws-lambda-java-events.version>2.2.7</aws-lambda-java-events.version>
+        <aws-lambda-java.version>1.2.1</aws-lambda-java.version>
+        <aws-lambda-java-events.version>3.1.0</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <aws-xray.version>2.4.0</aws-xray.version>
         <awssdk.version>2.11.14</awssdk.version>


### PR DESCRIPTION
Request in #9690 to update to the latest versions in the BOM of the following libraries to add support for the ALB (Application Load Balancer) event.

```
    <dependency>
        <groupId>com.amazonaws</groupId>
        <artifactId>aws-lambda-java-core</artifactId>
        <version>1.2.1</version>
    </dependency>
    <dependency>
        <groupId>com.amazonaws</groupId>
        <artifactId>aws-lambda-java-events</artifactId>
        <version>3.1.0</version>
    </dependency>
```

Validated on test projects generated from the Maven archetype. 