### PR TITLE
docs: small fixes in amazon-kms.adoc file

### DIFF
--- a/docs/src/main/asciidoc/amazon-kms.adoc
+++ b/docs/src/main/asciidoc/amazon-kms.adoc
@@ -8,10 +8,10 @@ https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-Amazon Key Management Service (KMS) is a service that allows you to create and control the keys used to encrypt or digitally sign your data.
+AWS Key Management Service (KMS) is a service that allows you to create and control the keys used to encrypt or digitally sign your data.
 Using KMS, you can create and manage cryptographic keys and control their use across a wide range of AWS services and in your application.
 
-You can find more information about KMS at https://aws.amazon.com/kms/[the Amazon KMS website].
+You can find more information about KMS at https://aws.amazon.com/kms/[the AWS KMS website].
 
 NOTE: The KMS extension is based on https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/welcome.html[AWS Java SDK 2.x].
 It's a major rewrite of the 1.x code base that offers two programming models (Blocking & Async).
@@ -63,7 +63,7 @@ Create a KMS master key queue using AWS CLI and store in `MASTER_KEY_ARN` enviro
 ----
 MASTER_KEY_ARN=`aws kms create-key --profile localstack --endpoint-url=http://localhost:8011 | cut -f3`
 ----
-Generate a key data as 256-bit symnmetric key (AES 256)
+Generate a key data as 256-bit symmetric key (AES 256)
 [source,shell,subs="verbatim,attributes"]
 ----
 aws kms generate-data-key --key-id $MASTER_KEY_ARN --key-spec AES_256 --profile localstack --endpoint-url=http://localhost:8011
@@ -109,7 +109,7 @@ After this, the `amazon-kms` extension has been added to your `pom.xml` as well 
 In this example, we will create an application that allows to encrypt and decrypt text message provided in the request.
 The example application will demonstrate the two programming models supported by the extension.
 
-Lets create a `org.acme.kms.QuarkusKmsSyncResource` that will provide an API to encrypt and decrypt message using the synchronous client.
+Let's create a `org.acme.kms.QuarkusKmsSyncResource` that will provide an API to encrypt and decrypt message using the synchronous client.
 
 [source,java]
 ----
@@ -206,10 +206,11 @@ quarkus.kms.aws.credentials.static-provider.secret-access-key=test-secret
 
 If you want to work with an AWS account, you can simply remove or comment out all Amazon KMS related properties. By default, the KMS client extension
 will use the `default` credentials provider chain that looks for credentials in this order:
-- Java System Properties - `aws.accessKeyId` and `aws.secretKey`
+
+* Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
 * Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
 * Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-* Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
+* Credentials delivered through the Amazon ECS if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
 * Instance profile credentials delivered through the Amazon EC2 metadata service
 
 And the region from your AWS CLI profile will be used.


### PR DESCRIPTION
- Changed to correct AWS service name, AWS Key Management Service
- Fixed some typos
- Fixed AWS credentials info according to the official document: https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html
