### PR TITLE
Adding Spring Web support in OpenAPI

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -35,7 +35,7 @@
         <smallrye-config.version>1.8.1</smallrye-config.version>
         <smallrye-health.version>2.2.1</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
-        <smallrye-open-api.version>1.2.4</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.2</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.3</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.0</smallrye-fault-tolerance.version>
@@ -1561,7 +1561,29 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-open-api</artifactId>
+                <artifactId>smallrye-open-api-core</artifactId>
+                <version>${smallrye-open-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.osgi</groupId>
+                        <artifactId>org.osgi.annotation.versioning</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-open-api-jaxrs</artifactId>
+                <version>${smallrye-open-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.osgi</groupId>
+                        <artifactId>org.osgi.annotation.versioning</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-open-api-spring</artifactId>
                 <version>${smallrye-open-api.version}</version>
                 <exclusions>
                     <exclusion>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capabilities.java
@@ -69,6 +69,8 @@ public final class Capabilities extends SimpleBuildItem {
     public static final String HIBERNATE_ORM = Capability.HIBERNATE_ORM.getName();
     @Deprecated
     public static final String SMALLRYE_OPENTRACING = Capability.SMALLRYE_OPENTRACING.getName();
+    @Deprecated
+    public static final String SPRING_WEB = Capability.SPRING_WEB.getName();
 
     private final Set<String> capabilities;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -46,7 +46,7 @@ public enum Capability {
     HIBERNATE_ORM,
     HIBERNATE_REACTIVE,
     SMALLRYE_OPENTRACING,
-    ;
+    SPRING_WEB;
 
     /**
      * 

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -24,10 +24,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc-deployment</artifactId>
     </dependency>
     <dependency>
@@ -41,6 +37,24 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-spring-web-deployment</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/CustomPathExtension.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/CustomPathExtension.java
@@ -1,0 +1,25 @@
+package io.quarkus.smallrye.openapi.deployment;
+
+import java.util.Collection;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
+
+/**
+ * This adds support for the quarkus.http.root-path config option
+ */
+public class CustomPathExtension implements AnnotationScannerExtension {
+
+    private final String defaultPath;
+
+    public CustomPathExtension(String defaultPath) {
+        this.defaultPath = defaultPath;
+    }
+
+    @Override
+    public void processScannerApplications(AnnotationScanner scanner, Collection<ClassInfo> applications) {
+        scanner.setContextRoot(defaultPath);
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/IgnoreDotNames.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/IgnoreDotNames.java
@@ -1,0 +1,52 @@
+package io.quarkus.smallrye.openapi.deployment;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+
+/**
+ * Copied from resteasy-common, but changed to not depend on JAX-RS. This is so
+ * that when open-api is used without scanning (so no JAX-RS) we do not pull in
+ * the jax-rs dep
+ */
+public final class IgnoreDotNames {
+
+    public static final IgnoreForReflectionPredicate IGNORE_FOR_REFLECTION_PREDICATE = new IgnoreForReflectionPredicate();
+
+    private static class IgnoreForReflectionPredicate implements Predicate<DotName> {
+
+        @Override
+        public boolean test(DotName name) {
+            return IgnoreDotNames.TYPES_IGNORED_FOR_REFLECTION.contains(name)
+                    || ReflectiveHierarchyBuildItem.DefaultIgnorePredicate.INSTANCE.test(name);
+        }
+    }
+
+    // Types ignored for reflection used by the RESTEasy and SmallRye REST client extensions.
+    private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(Arrays.asList(
+            // javax.json
+            DotName.createSimple("javax.json.JsonObject"),
+            DotName.createSimple("javax.json.JsonArray"),
+            DotName.createSimple("javax.json.JsonValue"),
+            // Jackson
+            DotName.createSimple("com.fasterxml.jackson.databind.JsonNode"),
+            // JAX-RS
+            DotName.createSimple("javax.ws.rs.core.Response"),
+            DotName.createSimple("javax.ws.rs.container.AsyncResponse"),
+            DotName.createSimple("javax.ws.rs.core.StreamingOutput"),
+            DotName.createSimple("javax.ws.rs.core.Form"),
+            DotName.createSimple("javax.ws.rs.core.MultivaluedMap"),
+            // RESTEasy
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartInput"),
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput"),
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartOutput"),
+            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput"),
+            // Vert-x
+            DotName.createSimple("io.vertx.core.json.JsonArray"),
+            DotName.createSimple("io.vertx.core.json.JsonObject")));
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/RESTEasyExtension.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/RESTEasyExtension.java
@@ -2,7 +2,6 @@ package io.quarkus.smallrye.openapi.deployment;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -13,9 +12,7 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import io.quarkus.deployment.util.ServiceUtil;
-import io.quarkus.resteasy.deployment.ResteasyJaxrsConfigBuildItem;
 import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
-import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
 
 public class RESTEasyExtension implements AnnotationScannerExtension {
 
@@ -23,11 +20,9 @@ public class RESTEasyExtension implements AnnotationScannerExtension {
     private static final DotName DOTNAME_ASYNC_RESPONSE_PROVIDER = DotName
             .createSimple("org.jboss.resteasy.spi.AsyncResponseProvider");
 
-    private List<DotName> asyncTypes = new ArrayList<>();
-    private String defaultPath;
+    private final List<DotName> asyncTypes = new ArrayList<>();
 
-    public RESTEasyExtension(ResteasyJaxrsConfigBuildItem jaxrsConfig, IndexView index) {
-        this.defaultPath = jaxrsConfig.defaultPath;
+    public RESTEasyExtension(IndexView index) {
         // the index is not enough to scan for providers because it does not contain
         // dependencies, so we have to rely on scanning the declared providers via services
         scanAsyncResponseProvidersFromServices();
@@ -103,12 +98,5 @@ public class RESTEasyExtension implements AnnotationScannerExtension {
             }
         }
         return null;
-    }
-
-    @Override
-    public void processJaxRsApplications(OpenApiAnnotationScanner scanner, Collection<ClassInfo> applications) {
-        if (applications.isEmpty()) {
-            scanner.setCurrentAppPath(defaultPath);
-        }
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -5,13 +5,12 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -35,6 +34,7 @@ import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -42,7 +42,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
-import io.quarkus.deployment.builditem.DeploymentClassLoaderBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
@@ -53,8 +52,6 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
-import io.quarkus.resteasy.common.deployment.ResteasyDotNames;
-import io.quarkus.resteasy.deployment.ResteasyJaxrsConfigBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentProducer;
@@ -68,7 +65,9 @@ import io.smallrye.openapi.api.OpenApiConfigImpl;
 import io.smallrye.openapi.api.OpenApiDocument;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
 import io.smallrye.openapi.runtime.OpenApiStaticFile;
+import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+import io.smallrye.openapi.runtime.scanner.AnnotationScannerExtension;
 import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
 import io.smallrye.openapi.runtime.scanner.OpenApiAnnotationScanner;
 
@@ -108,7 +107,7 @@ public class SmallRyeOpenApiProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    RouteBuildItem handler(DeploymentClassLoaderBuildItem deploymentClassLoaderBuildItem, LaunchModeBuildItem launch,
+    RouteBuildItem handler(LaunchModeBuildItem launch,
             BuildProducer<NotFoundPageDisplayableEndpointBuildItem> displayableEndpoints, OpenApiRecorder recorder,
             ShutdownContextBuildItem shutdownContext) {
         /*
@@ -148,38 +147,41 @@ public class SmallRyeOpenApiProcessor {
     @BuildStep
     public void registerOpenApiSchemaClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
-            OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem) {
+            OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem,
+            Capabilities capabilities) {
 
-        FilteredIndexView index = openApiFilteredIndexViewBuildItem.getIndex();
-        // Generate reflection declaration from MP OpenAPI Schema definition
-        // They are needed for serialization.
-        Collection<AnnotationInstance> schemaAnnotationInstances = index.getAnnotations(OPENAPI_SCHEMA);
-        for (AnnotationInstance schemaAnnotationInstance : schemaAnnotationInstances) {
-            AnnotationTarget typeTarget = schemaAnnotationInstance.target();
-            if (typeTarget.kind() != AnnotationTarget.Kind.CLASS) {
-                continue;
+        if (shouldScanAnnotations(capabilities)) {
+            FilteredIndexView index = openApiFilteredIndexViewBuildItem.getIndex();
+            // Generate reflection declaration from MP OpenAPI Schema definition
+            // They are needed for serialization.
+            Collection<AnnotationInstance> schemaAnnotationInstances = index.getAnnotations(OPENAPI_SCHEMA);
+            for (AnnotationInstance schemaAnnotationInstance : schemaAnnotationInstances) {
+                AnnotationTarget typeTarget = schemaAnnotationInstance.target();
+                if (typeTarget.kind() != AnnotationTarget.Kind.CLASS) {
+                    continue;
+                }
+                reflectiveHierarchy
+                        .produce(new ReflectiveHierarchyBuildItem(Type.create(typeTarget.asClass().name(), Type.Kind.CLASS),
+                                IgnoreDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
             }
-            reflectiveHierarchy
-                    .produce(new ReflectiveHierarchyBuildItem(Type.create(typeTarget.asClass().name(), Type.Kind.CLASS),
-                            ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
-        }
 
-        // Generate reflection declaration from MP OpenAPI APIResponse schema definition
-        // They are needed for serialization
-        Collection<AnnotationInstance> apiResponseAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSE);
-        registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
-                apiResponseAnnotationInstances);
-
-        // Generate reflection declaration from MP OpenAPI APIResponses schema definition
-        // They are needed for serialization
-        Collection<AnnotationInstance> apiResponsesAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSES);
-        for (AnnotationInstance apiResponsesAnnotationInstance : apiResponsesAnnotationInstances) {
-            AnnotationValue apiResponsesAnnotationValue = apiResponsesAnnotationInstance.value();
-            if (apiResponsesAnnotationValue == null) {
-                continue;
-            }
+            // Generate reflection declaration from MP OpenAPI APIResponse schema definition
+            // They are needed for serialization
+            Collection<AnnotationInstance> apiResponseAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSE);
             registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
-                    Arrays.asList(apiResponsesAnnotationValue.asNestedArray()));
+                    apiResponseAnnotationInstances);
+
+            // Generate reflection declaration from MP OpenAPI APIResponses schema definition
+            // They are needed for serialization
+            Collection<AnnotationInstance> apiResponsesAnnotationInstances = index.getAnnotations(OPENAPI_RESPONSES);
+            for (AnnotationInstance apiResponsesAnnotationInstance : apiResponsesAnnotationInstances) {
+                AnnotationValue apiResponsesAnnotationValue = apiResponsesAnnotationInstance.value();
+                if (apiResponsesAnnotationValue == null) {
+                    continue;
+                }
+                registerReflectionForApiResponseSchemaSerialization(reflectiveClass, reflectiveHierarchy,
+                        Arrays.asList(apiResponsesAnnotationValue.asNestedArray()));
+            }
         }
     }
 
@@ -202,7 +204,7 @@ public class SmallRyeOpenApiProcessor {
                 AnnotationValue schemaImplementationClass = schema.value(OPENAPI_SCHEMA_IMPLEMENTATION);
                 if (schemaImplementationClass != null) {
                     reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaImplementationClass.asClass(),
-                            ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
+                            IgnoreDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
                 }
 
                 AnnotationValue schemaNotClass = schema.value(OPENAPI_SCHEMA_NOT);
@@ -214,7 +216,7 @@ public class SmallRyeOpenApiProcessor {
                 if (schemaOneOfClasses != null) {
                     for (Type schemaOneOfClass : schemaOneOfClasses.asClassArray()) {
                         reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaOneOfClass,
-                                ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
+                                IgnoreDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
                     }
                 }
 
@@ -222,7 +224,7 @@ public class SmallRyeOpenApiProcessor {
                 if (schemaAnyOfClasses != null) {
                     for (Type schemaAnyOfClass : schemaAnyOfClasses.asClassArray()) {
                         reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaAnyOfClass,
-                                ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
+                                IgnoreDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
                     }
                 }
 
@@ -230,7 +232,7 @@ public class SmallRyeOpenApiProcessor {
                 if (schemaAllOfClasses != null) {
                     for (Type schemaAllOfClass : schemaAllOfClasses.asClassArray()) {
                         reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(schemaAllOfClass,
-                                ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
+                                IgnoreDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
                     }
                 }
             }
@@ -240,25 +242,24 @@ public class SmallRyeOpenApiProcessor {
     @BuildStep
     public void build(ApplicationArchivesBuildItem archivesBuildItem,
             BuildProducer<FeatureBuildItem> feature,
-            Optional<ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig,
             BuildProducer<GeneratedResourceBuildItem> resourceBuildItemBuildProducer,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
-            OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem) throws Exception {
+            OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem,
+            Capabilities capabilities) throws Exception {
         FilteredIndexView index = openApiFilteredIndexViewBuildItem.getIndex();
 
         feature.produce(new FeatureBuildItem(Feature.SMALLRYE_OPENAPI));
         OpenAPI staticModel = generateStaticModel(archivesBuildItem);
 
         OpenAPI annotationModel;
-        Config config = ConfigProvider.getConfig();
-        boolean scanDisable = config.getOptionalValue(OASConfig.SCAN_DISABLE, Boolean.class).orElse(false);
-        if (resteasyJaxrsConfig.isPresent() && !scanDisable) {
-            annotationModel = generateAnnotationModel(index, resteasyJaxrsConfig.get());
+
+        if (shouldScanAnnotations(capabilities)) {
+            annotationModel = generateAnnotationModel(index, capabilities);
         } else {
             annotationModel = null;
         }
         OpenApiDocument finalDocument = loadDocument(staticModel, annotationModel);
-        for (OpenApiSerializer.Format format : OpenApiSerializer.Format.values()) {
+        for (Format format : Format.values()) {
             String name = OpenApiHandler.BASE_NAME + format;
             resourceBuildItemBuildProducer.produce(new GeneratedResourceBuildItem(name,
                     OpenApiSerializer.serialize(finalDocument.get(), format).getBytes(StandardCharsets.UTF_8)));
@@ -272,6 +273,20 @@ public class SmallRyeOpenApiProcessor {
                 "OpenAPI document initialized:");
     }
 
+    private boolean shouldScanAnnotations(Capabilities capabilities) {
+        // Disabled via config
+        Config config = ConfigProvider.getConfig();
+        boolean scanDisable = config.getOptionalValue(OASConfig.SCAN_DISABLE, Boolean.class).orElse(false);
+        if (scanDisable) {
+            return false;
+        }
+
+        // Only scan if either JaxRS or Spring is used
+        boolean isJaxrs = capabilities.isCapabilityPresent(Capabilities.RESTEASY);
+        boolean isSpring = capabilities.isCapabilityPresent(Capabilities.SPRING_WEB);
+        return isJaxrs || isSpring;
+    }
+
     private OpenAPI generateStaticModel(ApplicationArchivesBuildItem archivesBuildItem) throws IOException {
         Result result = findStaticModel(archivesBuildItem);
         if (result != null) {
@@ -283,7 +298,7 @@ public class SmallRyeOpenApiProcessor {
         return null;
     }
 
-    private OpenAPI generateAnnotationModel(IndexView indexView, ResteasyJaxrsConfigBuildItem jaxrsConfig) {
+    private OpenAPI generateAnnotationModel(IndexView indexView, Capabilities capabilities) {
         // build a composite index with additional JDK classes, because SmallRye-OpenAPI will check if some
         // app types implement Map and Collection and will go through super classes until Object is reached,
         // and yes, it even checks Object
@@ -301,13 +316,24 @@ public class SmallRyeOpenApiProcessor {
 
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
-        return new OpenApiAnnotationScanner(openApiConfig, compositeIndex,
-                Collections.singletonList(new RESTEasyExtension(jaxrsConfig, compositeIndex))).scan();
+
+        String defaultPath = config.getValue("quarkus.http.root-path", String.class);
+
+        List<AnnotationScannerExtension> extensions = new ArrayList<>();
+        // Add RestEasy if jaxrs
+        if (capabilities.isCapabilityPresent(Capabilities.RESTEASY)) {
+            extensions.add(new RESTEasyExtension(compositeIndex));
+        }
+        // Add path if not null
+        if (defaultPath != null) {
+            extensions.add(new CustomPathExtension(defaultPath));
+        }
+        return new OpenApiAnnotationScanner(openApiConfig, compositeIndex, extensions).scan();
     }
 
     private Result findStaticModel(ApplicationArchivesBuildItem archivesBuildItem) {
         // Check for the file in both META-INF and WEB-INF/classes/META-INF
-        OpenApiSerializer.Format format = OpenApiSerializer.Format.YAML;
+        Format format = Format.YAML;
         Path resourcePath = archivesBuildItem.getRootArchive().getChildPath(META_INF_OPENAPI_YAML);
         if (resourcePath == null) {
             resourcePath = archivesBuildItem.getRootArchive().getChildPath(WEB_INF_CLASSES_META_INF_OPENAPI_YAML);
@@ -320,11 +346,11 @@ public class SmallRyeOpenApiProcessor {
         }
         if (resourcePath == null) {
             resourcePath = archivesBuildItem.getRootArchive().getChildPath(META_INF_OPENAPI_JSON);
-            format = OpenApiSerializer.Format.JSON;
+            format = Format.JSON;
         }
         if (resourcePath == null) {
             resourcePath = archivesBuildItem.getRootArchive().getChildPath(WEB_INF_CLASSES_META_INF_OPENAPI_JSON);
-            format = OpenApiSerializer.Format.JSON;
+            format = Format.JSON;
         }
 
         if (resourcePath == null) {
@@ -335,10 +361,10 @@ public class SmallRyeOpenApiProcessor {
     }
 
     static class Result {
-        final OpenApiSerializer.Format format;
+        final Format format;
         final Path path;
 
-        Result(OpenApiSerializer.Format format, Path path) {
+        Result(Format format, Path path) {
             this.format = format;
             this.path = path;
         }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
@@ -1,7 +1,7 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.jaxrs;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -9,15 +9,13 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class OpenApiPathWithSegmentsTestCase {
-    private static final String OPEN_API_PATH = "/path/with/segments";
+public class OpenApiDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
-                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
-                            "application.properties"));
+                    .addClasses(OpenApiResource.class));
 
     @Test
     public void testOpenApiPathAccessResource() {
@@ -32,6 +30,10 @@ public class OpenApiPathWithSegmentsTestCase {
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
                 .when().get(OPEN_API_PATH)
-                .then().header("Content-Type", "application/json;charset=UTF-8");
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiHttpRootDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class)
+                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/foo/resource"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithSegmentsTestCase.java
@@ -1,7 +1,7 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.jaxrs;
 
-import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -9,13 +9,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class OpenApiDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+public class OpenApiPathWithSegmentsTestCase {
+    private static final String OPEN_API_PATH = "/path/with/segments";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class));
+                    .addClasses(OpenApiResource.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
+                            "application.properties"));
 
     @Test
     public void testOpenApiPathAccessResource() {
@@ -30,10 +32,6 @@ public class OpenApiDefaultPathTestCase {
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
                 .when().get(OPEN_API_PATH)
-                .then()
-                .header("Content-Type", "application/json;charset=UTF-8")
-                .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
-                .body("paths", Matchers.hasKey("/resource"));
+                .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiPathWithoutSegmentsTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiPathWithoutSegmentsTestCase {
+    private static final String OPEN_API_PATH = "/path-without-segments";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResource.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResource.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.jaxrs;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.jaxrs;
 
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.jaxrs;
 
 import static org.hamcrest.Matchers.containsString;
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiController.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiController.java
@@ -1,0 +1,26 @@
+package io.quarkus.smallrye.openapi.test.spring;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/resource")
+public class OpenApiController {
+
+    @GetMapping
+    public String root() {
+        return "resource";
+    }
+
+    @GetMapping("/test-enums")
+    public Query testEnums(@RequestParam(name = "query") Query query) {
+        return query;
+    }
+
+    public enum Query {
+        QUERY_PARAM_1,
+        QUERY_PARAM_2;
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiDefaultPathTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.openapi.test.spring;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiController.class));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/resource"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiHttpRootDefaultPathTestCase.java
@@ -1,5 +1,6 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.spring;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -9,15 +10,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class OpenApiPathWithoutSegmentsTestCase {
-    private static final String OPEN_API_PATH = "/path-without-segments";
+public class OpenApiHttpRootDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
-                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
-                            "application.properties"));
+                    .addClasses(OpenApiController.class)
+                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
 
     @Test
     public void testOpenApiPathAccessResource() {
@@ -32,6 +32,10 @@ public class OpenApiPathWithoutSegmentsTestCase {
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
                 .when().get(OPEN_API_PATH)
-                .then().header("Content-Type", "application/json;charset=UTF-8");
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/foo/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithSegmentsTestCase.java
@@ -1,6 +1,5 @@
-package io.quarkus.smallrye.openapi.test;
+package io.quarkus.smallrye.openapi.test.spring;
 
-import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -10,14 +9,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class OpenApiHttpRootDefaultPathTestCase {
-    private static final String OPEN_API_PATH = "/openapi";
+public class OpenApiPathWithSegmentsTestCase {
+    private static final String OPEN_API_PATH = "/path/with/segments";
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(OpenApiResource.class)
-                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
+                    .addClasses(OpenApiController.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
+                            "application.properties"));
 
     @Test
     public void testOpenApiPathAccessResource() {
@@ -32,10 +32,6 @@ public class OpenApiHttpRootDefaultPathTestCase {
                 .then().header("Content-Type", "application/json;charset=UTF-8");
         RestAssured.given().queryParam("format", "JSON")
                 .when().get(OPEN_API_PATH)
-                .then()
-                .header("Content-Type", "application/json;charset=UTF-8")
-                .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
-                .body("paths", Matchers.hasKey("/foo/resource"));
+                .then().header("Content-Type", "application/json;charset=UTF-8");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiPathWithoutSegmentsTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.spring;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiPathWithoutSegmentsTestCase {
+    private static final String OPEN_API_PATH = "/path-without-segments";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiController.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/OpenApiWithConfigTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.openapi.test.spring;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiWithConfigTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiController.class)
+                    .addAsManifestResource("test-openapi.yaml", "openapi.yaml")
+                    .addAsResource(new StringAsset("mp.openapi.scan.disable=true\nmp.openapi.servers=https://api.acme.org/"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenAPI() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Test OpenAPI"))
+                .body("info.description", Matchers.equalTo("Some description"))
+                .body("info.version", Matchers.equalTo("4.2"))
+                .body("servers[0].url", Matchers.equalTo("https://api.acme.org/"))
+                .body("paths", Matchers.hasKey("/openapi"))
+                .body("paths", Matchers.not(Matchers.hasKey("/resource")));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/spring/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.openapi.test.spring;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * This test is a reproducer for https://github.com/quarkusio/quarkus/issues/4613.
+ */
+public class SwaggerAndOpenAPIWithCommonPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(OpenApiController.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=/swagger"), "application.properties"));
+
+    @Test
+    public void shouldWorkEvenWithCommonPrefix() {
+        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
+        RestAssured.when().get("/swagger").then().statusCode(200)
+                .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
+    }
+}

--- a/extensions/smallrye-openapi/runtime/pom.xml
+++ b/extensions/smallrye-openapi/runtime/pom.xml
@@ -17,13 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>io.smallrye</groupId>
-      <artifactId>smallrye-open-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>smallrye-open-api-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentProducer.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentProducer.java
@@ -17,7 +17,7 @@ import io.smallrye.openapi.api.OpenApiConfigImpl;
 import io.smallrye.openapi.api.OpenApiDocument;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
 import io.smallrye.openapi.runtime.OpenApiStaticFile;
-import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+import io.smallrye.openapi.runtime.io.Format;
 
 /**
  * @author Ken Finnigan
@@ -36,9 +36,9 @@ public class OpenApiDocumentProducer {
     @PostConstruct
     void create() throws IOException {
         try (InputStream is = getClass().getClassLoader()
-                .getResourceAsStream(OpenApiHandler.BASE_NAME + OpenApiSerializer.Format.JSON)) {
+                .getResourceAsStream(OpenApiHandler.BASE_NAME + Format.JSON)) {
             if (is != null) {
-                try (OpenApiStaticFile staticFile = new OpenApiStaticFile(is, OpenApiSerializer.Format.JSON)) {
+                try (OpenApiStaticFile staticFile = new OpenApiStaticFile(is, Format.JSON)) {
                     Config config = ConfigProvider.getConfig();
                     OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
 

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -62,12 +62,12 @@ public class OpenApiHandler implements Handler<RoutingContext> {
             String formatParam = formatParams.isEmpty() ? null : formatParams.get(0);
 
             // Default content type is YAML
-            OpenApiSerializer.Format format = OpenApiSerializer.Format.YAML;
+            Format format = Format.YAML;
 
             // Check Accept, then query parameter "format" for JSON; else use YAML.
-            if ((accept != null && accept.contains(OpenApiSerializer.Format.JSON.getMimeType())) ||
+            if ((accept != null && accept.contains(Format.JSON.getMimeType())) ||
                     ("JSON".equalsIgnoreCase(formatParam))) {
-                format = OpenApiSerializer.Format.JSON;
+                format = Format.JSON;
             }
 
             addCorsResponseHeaders(resp);

--- a/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -35,12 +35,14 @@ import org.jboss.resteasy.spring.web.ResponseStatusFeature;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -101,6 +103,11 @@ public class SpringWebProcessor {
     @BuildStep
     FeatureBuildItem registerFeature() {
         return new FeatureBuildItem(Feature.SPRING_WEB);
+    }
+
+    @BuildStep
+    CapabilityBuildItem capability() {
+        return new CapabilityBuildItem(Capabilities.SPRING_WEB);
     }
 
     @BuildStep


### PR DESCRIPTION
The main purpose of this PR is to pull in smallrye-open-api version 2 that added support for Spring Web. (fixing the already closed #4693)

This will also:

Fix #7095 - Corrent path when using `@ApplicationPath` and config `quarkus.http.root-path`
Fix #8499 - Openapi doesn't treat CompletableFuture as CompletionStage 
Fix #8407 - Openapi should not be Resteasy dependent

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>