### PR TITLE
Amazon Lambda HTTP resolve native test issues from #7362

### DIFF
--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -30,6 +30,18 @@ under the License.
       <directory>src/test/java</directory>
     </fileSet>
     <fileSet>
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>src/test/resources</directory>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
       <directory>src/assembly</directory>
       <includes>
         <include>*</include>

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-amazon-lambda</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/main/application.properties
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/main/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingTest.java
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingTest.java
@@ -1,5 +1,11 @@
 package ${package};
 
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
+import io.quarkus.amazon.lambda.http.model.Headers;
+import io.quarkus.amazon.lambda.test.LambdaClient;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.Assertions;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -7,8 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
-public class GreetingTest
-{
+public class GreetingTest {
     @Test
     public void testJaxrs() {
         RestAssured.when().get("/hello").then()
@@ -33,8 +38,44 @@ public class GreetingTest
     @Test
     public void testFunqy() {
         RestAssured.when().get("/funqyHello").then()
-                .contentType("text/plain")
-                .body(equalTo("hello funqy"));
+                .contentType("application/json")
+                .body(equalTo("\"hello funqy\""));
+    }
+
+    @Test
+    public void testGetTextJaxrs() throws Exception {
+        testGetText("/hello", "text/plain","hello jaxrs");
+    }
+
+    @Test
+    public void testGetTextServelet() throws Exception {
+        testGetText("/servlet/hello","text/plain", "hello servlet");
+    }
+
+    @Test
+    public void testGetTextVertx() throws Exception {
+        testGetText("/vertx/hello","text/plain", "hello vertx");
+    }
+
+    @Test
+    public void testGetTextFunqy() throws Exception {
+        testGetText("/funqyHello","application/json", "\"hello funqy\"");
+    }
+
+    private void testGetText(String path, String contentType, String bodyText) {
+        AwsProxyRequest request = new AwsProxyRequest();
+        request.setHttpMethod("GET");
+        request.setPath(path);
+        AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertEquals(body(out), bodyText);
+        Assertions.assertTrue(out.getMultiValueHeaders().getFirst("Content-Type").startsWith(contentType));
+    }
+
+    private String body(AwsProxyResponse response) {
+        if (!response.isBase64Encoded())
+            return response.getBody();
+        return new String(Base64.decodeBase64(response.getBody()));
     }
 
 }

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/resources/application.properties
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.lambda.enable-polling-jvm-mode=true
+quarkus.http.virtual=true
+
+


### PR DESCRIPTION
Issue #7362 identified a couple of problems, first that the undertow host `localhost:5387` was not being set for native tests, and second some ugly shutdown exceptions.

Addressed the shutdown issues for the Amazon Lambda HTTP in `AbstractLambdaPollLoop` where the requestId was being read on a closed socket (thread no longer running).

Also identified an issue in the maven-archetype where the Funqy tests were returning application/json. \cc @patriot1burke. Added the AwsProxy versions of the unit tests, which is used in the quarkus integration tests. The AwsProxy tests also work on native (RestAssured does not), yet left the RestAssured version in the maven-archetype as it works with the JVM. 

Shutdown exceptions per #7362 Native Tests pre the change:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.quarkus.qe.NativeMyResourceIT
Executing [/private/var/tmp/barFoo/target/barFoo-1.0.0-SNAPSHOT-runner, -Dquarkus.http.port=8081, -Dquarkus.http.ssl-port=8444, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=target/quarkus.log, -Dquarkus-internal.aws-lambda.test-api=localhost:5387]
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2020-05-31 15:55:42,424 INFO  [io.quarkus] (main) barFoo 1.0.0-SNAPSHOT native (powered by Quarkus 999-SNAPSHOT) started in 0.018s. 
2020-05-31 15:55:42,424 INFO  [io.quarkus] (main) Profile prod activated. 
2020-05-31 15:55:42,424 INFO  [io.quarkus] (main) Installed features: [amazon-lambda, cdi, resteasy]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.513 s - in io.quarkus.qe.NativeMyResourceIT
2020-05-31 15:55:43,629 ERROR [io.qua.ama.lam.run.AbstractLambdaPollLoop] (Lambda Thread) Failed to run lambda: java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:186)
	at java.net.SocketInputStream.read(SocketInputStream.java:140)
	at java.io.BufferedInputStream.fill(BufferedInputStream.java:252)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:292)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:351)
	at sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:754)
	at sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:689)
	at sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:863)
	at sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:689)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1610)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1515)
	at sun.net.www.protocol.http.HttpURLConnection.getHeaderField(HttpURLConnection.java:3094)
	at io.quarkus.amazon.lambda.runtime.AbstractLambdaPollLoop$1.run(AbstractLambdaPollLoop.java:50)
	at java.lang.Thread.run(Thread.java:834)
	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:517)
	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:193)

May 31, 2020 3:55:43 PM io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor forceClose
WARN: Failed to register an accepted channel: [id: 0x24df1aca, L:0.0.0.0/0.0.0.0:5387]
java.lang.IllegalStateException
	at io.vertx.core.net.impl.VertxEventLoopGroup.next(VertxEventLoopGroup.java:37)
	at io.vertx.core.net.impl.VertxEventLoopGroup.register(VertxEventLoopGroup.java:53)
	at io.netty.bootstrap.ServerBootstrap$ServerBootstrapAcceptor.channelRead(ServerBootstrap.java:218)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioMessageChannel$NioMessageUnsafe.read(AbstractNioMessageChannel.java:93)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:714)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:576)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:484)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:834)

[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
```
Post the changes to `AbstractLambdaPollLoop` Native Tests on #7362:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.quarkus.qe.NativeMyResourceIT
Executing [/private/var/tmp/barFoo/target/barFoo-1.0.0-SNAPSHOT-runner, -Dquarkus.http.port=8081, -Dquarkus.http.ssl-port=8444, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=target/quarkus.log, -Dquarkus-internal.aws-lambda.test-api=localhost:5387]
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2020-05-31 16:04:16,350 INFO  [io.quarkus] (main) barFoo 1.0.0-SNAPSHOT native (powered by Quarkus 999-SNAPSHOT) started in 0.018s. 
2020-05-31 16:04:16,351 INFO  [io.quarkus] (main) Profile prod activated. 
2020-05-31 16:04:16,351 INFO  [io.quarkus] (main) Installed features: [amazon-lambda, cdi, resteasy]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.391 s - in io.quarkus.qe.NativeMyResourceIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
```
  

Archetype tested by:

```
mvn archetype:generate \
       -DarchetypeGroupId=io.quarkus \
       -DarchetypeArtifactId=quarkus-amazon-lambda-http-archetype \
       -DarchetypeVersion=999-SNAPSHOT

mvn verify # all tests now work - Funqy was failing with content type = application\json
```

