### PR TITLE
Default quarkus.kafka-streams.application-id to quarkus.application.name

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -455,7 +455,6 @@ Create the file `aggregator/src/main/resources/application.properties` with the 
 [source]
 ----
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
-quarkus.kafka-streams.application-id=temperature-aggregator
 quarkus.kafka-streams.application-server=${hostname}:8080
 quarkus.kafka-streams.topics=weather-stations,temperature-values
 
@@ -469,7 +468,7 @@ kafka-streams.metrics.recording.level=DEBUG
 
 The options with the `quarkus.kafka-streams` prefix can be changed dynamically at application startup,
 e.g. via environment variables or system properties.
-`bootstrap-servers`, `application-id` and `application-server` are mapped to the Kafka Streams properties `bootstrap.servers`, `application.id` and `application.server`, respectively.
+`bootstrap-servers` and `application-server` are mapped to the Kafka Streams properties `bootstrap.servers`, `application.id` and `application.server`, respectively.
 `topics` is specific to Quarkus: the application will wait for all the given topics to exist before launching the Kafka Streams engine.
 This is to done to gracefully await the creation of topics that don't yet exist at application startup time.
 

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -468,7 +468,7 @@ kafka-streams.metrics.recording.level=DEBUG
 
 The options with the `quarkus.kafka-streams` prefix can be changed dynamically at application startup,
 e.g. via environment variables or system properties.
-`bootstrap-servers` and `application-server` are mapped to the Kafka Streams properties `bootstrap.servers`, `application.id` and `application.server`, respectively.
+`bootstrap-servers` and `application-server` are mapped to the Kafka Streams properties `bootstrap.servers` and `application.server`, respectively.
 `topics` is specific to Quarkus: the application will wait for all the given topics to exist before launching the Kafka Streams engine.
 This is to done to gracefully await the creation of topics that don't yet exist at application startup time.
 

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
@@ -14,8 +14,9 @@ public class KafkaStreamsRuntimeConfig {
 
     /**
      * A unique identifier for this Kafka Streams application.
+     * If not set, defaults to quarkus.application.name.
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "${quarkus.application.name}")
     public String applicationId;
 
     /**

--- a/integration-tests/kafka-streams/src/main/resources/application.properties
+++ b/integration-tests/kafka-streams/src/main/resources/application.properties
@@ -3,7 +3,6 @@ quarkus.log.category.\"org.apache.kafka\".level=WARN
 quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 
 quarkus.kafka-streams.bootstrap-servers=localhost:19092
-quarkus.kafka-streams.application-id=streams-test-pipeline
 quarkus.kafka-streams.topics=streams-test-categories,streams-test-customers
 
 # streams options
@@ -11,3 +10,6 @@ kafka-streams.cache.max.bytes.buffering=10240
 kafka-streams.commit.interval.ms=1000
 kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest
+
+# Set explicitly as for tests the quarkus.application.name does not default to the name of the project
+%test.quarkus.application.name=streams-test-pipeline


### PR DESCRIPTION
As part of issue #[3500](https://github.com/quarkusio/quarkus/issues/3500) : Default quarkus.kafka-streams.application-id to quarkus.application.name.

Purpose of this PR is to simplify configuration for the kafka-streams extension by providing a default value for the [application-id](https://quarkus.io/guides/all-config#quarkus-kafka-streams_quarkus.kafka-streams.application-id) parameter that would be quarkus' [application.name](https://quarkus.io/guides/all-config#quarkus-core_quarkus.application.name).


