### PR TITLE
ArC - ignore abstract classes annotated with a bean defining annotation

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -49,6 +49,8 @@ public class BeanDeployment {
 
     private static final Logger LOGGER = Logger.getLogger(BeanDeployment.class);
 
+    private static final int ANNOTATION = 0x00002000;
+
     static final EnumSet<Type.Kind> CLASS_TYPES = EnumSet.of(Type.Kind.CLASS, Type.Kind.PARAMETERIZED_TYPE);
 
     private final BuildContextImpl buildContext;
@@ -635,8 +637,11 @@ public class BeanDeployment {
 
         for (ClassInfo beanClass : index.getKnownClasses()) {
 
-            if (Modifier.isInterface(beanClass.flags()) || DotNames.ENUM.equals(beanClass.superName())) {
-                // Skip interfaces, annotations and enums
+            if (Modifier.isInterface(beanClass.flags()) || Modifier.isAbstract(beanClass.flags())
+            // Replace with ClassInfo#isAnnotation() and ClassInfo#isEnum() when using Jandex 2.1.4+
+                    || (beanClass.flags() & ANNOTATION) != 0
+                    || DotNames.ENUM.equals(beanClass.superName())) {
+                // Skip interfaces, abstract classes, annotations and enums
                 continue;
             }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/discovery/AbstractClassIgnoredTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/discovery/AbstractClassIgnoredTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.discovery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AbstractClassIgnoredTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Foo.class, Bar.class);
+
+    @Test
+    public void testBeans() {
+        assertEquals(1, Arc.container().beanManager().getBeans(Foo.class).size());
+        assertEquals("bar", Arc.container().instance(Foo.class).get().ping());
+
+    }
+
+    @ApplicationScoped
+    static abstract class Foo {
+
+        protected String ping() {
+            return "foo";
+        }
+
+    }
+
+    @ApplicationScoped
+    static class Bar extends Foo {
+
+        @Override
+        protected String ping() {
+            return "bar";
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/discovery/ParameterizedBeanTypeWithVariableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/discovery/ParameterizedBeanTypeWithVariableTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.test.discovery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ParameterizedBeanTypeWithVariableTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Foo.class);
+
+    @Test
+    public void testBeans() {
+        assertEquals(1, Arc.container().beanManager().getBeans(Foo.class).size());
+        assertEquals("foo", Arc.container().instance(Foo.class).get().ping());
+
+    }
+
+    @ApplicationScoped
+    static class Foo<T> {
+
+        protected String ping() {
+            return "foo";
+        }
+
+    }
+}


### PR DESCRIPTION
- also ignore annotation types
- resolves #9674