### PR TITLE
Support FileRegions for AWS Lambda HTTP and Azure Functions HTTP

### DIFF
--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
@@ -3,6 +3,8 @@ package io.quarkus.azure.functions.resteasy.runtime;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -15,6 +17,7 @@ import com.microsoft.azure.functions.HttpStatus;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
@@ -24,6 +27,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
+import io.quarkus.netty.runtime.virtual.VirtualMessage;
 import io.quarkus.runtime.Application;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 
@@ -96,14 +100,15 @@ public class BaseFunction {
         connection.sendMessage(requestContent);
         HttpResponseMessage.Builder responseBuilder = null;
         ByteArrayOutputStream baos = null;
+        WritableByteChannel byteChannel = null;
         try {
             for (;;) {
                 // todo should we timeout? have a timeout config?
                 //log.info("waiting for message");
-                Object msg = connection.queue().poll(100, TimeUnit.MILLISECONDS);
+                VirtualMessage virtualMessage = connection.queue().poll(100, TimeUnit.MILLISECONDS);
+                if (virtualMessage == null) continue;
+                Object msg = virtualMessage.getMessage();
                 try {
-                    if (msg == null)
-                        continue;
                     //log.info("Got message: " + msg.getClass().getName());
 
                     if (msg instanceof HttpResponse) {
@@ -117,11 +122,21 @@ public class BaseFunction {
                         HttpContent content = (HttpContent) msg;
                         if (baos == null) {
                             // todo what is right size?
-                            baos = new ByteArrayOutputStream(500);
+                            baos = createByteStream();
                         }
                         int readable = content.content().readableBytes();
                         for (int i = 0; i < readable; i++) {
                             baos.write(content.content().readByte());
+                        }
+                    }
+                    if (msg instanceof FileRegion) {
+                        FileRegion file = (FileRegion) msg;
+                        if (file.count() > 0) {
+                            if (baos == null)
+                                baos = createByteStream();
+                            if (byteChannel == null)
+                                byteChannel = Channels.newChannel(baos);
+                            file.transferTo(byteChannel, 0);
                         }
                     }
                     if (msg instanceof LastHttpContent) {
@@ -129,8 +144,10 @@ public class BaseFunction {
                         return responseBuilder.build();
                     }
                 } finally {
-                    if (msg != null)
+                    if (msg != null) {
+                        virtualMessage.completed();
                         ReferenceCountUtil.release(msg);
+                    }
                 }
             }
         } finally {
@@ -138,5 +155,11 @@ public class BaseFunction {
                 baos.close();
             }
         }
+    }
+
+    private ByteArrayOutputStream createByteStream() {
+        ByteArrayOutputStream baos;
+        baos = new ByteArrayOutputStream(500);
+        return baos;
     }
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualClientConnection.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualClientConnection.java
@@ -16,7 +16,7 @@ import io.netty.util.internal.PlatformDependent;
  */
 public class VirtualClientConnection {
     protected SocketAddress clientAddress;
-    protected BlockingQueue<Object> queue = new LinkedBlockingQueue<>();
+    protected BlockingQueue<VirtualMessage> queue = new LinkedBlockingQueue<>();
     protected boolean connected = true;
     protected VirtualChannel peer;
 
@@ -33,7 +33,7 @@ public class VirtualClientConnection {
      *
      * @return
      */
-    public BlockingQueue<Object> queue() {
+    public BlockingQueue<VirtualMessage> queue() {
         return queue;
     }
 

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualMessage.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualMessage.java
@@ -1,0 +1,24 @@
+package io.quarkus.netty.runtime.virtual;
+
+import java.util.concurrent.CompletableFuture;
+
+public class VirtualMessage {
+    private Object message;
+    private CompletableFuture<Void> future = new CompletableFuture<>();
+
+    public VirtualMessage(Object message) {
+        this.message = message;
+    }
+
+    public Object getMessage() {
+        return message;
+    }
+
+    public void completed() {
+        future.complete(null);
+    }
+
+    public void awaitComplete() throws Exception {
+        future.get();
+    }
+}

--- a/integration-tests/amazon-lambda-http/pom.xml
+++ b/integration-tests/amazon-lambda-http/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
         </dependency>
         <dependency>

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -24,6 +24,16 @@ public class AmazonLambdaSimpleTestCase {
         testGetText("/hello");
     }
 
+    @Test
+    public void testSwaggerUi() throws Exception {
+        // this tests the FileRegion support in the handler
+        AwsProxyRequest request = request("/swagger-ui/");
+        AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertTrue(body(out).contains("Swagger UI"));
+
+    }
+
     private String body(AwsProxyResponse response) {
         if (!response.isBase64Encoded())
             return response.getBody();
@@ -31,20 +41,23 @@ public class AmazonLambdaSimpleTestCase {
     }
 
     private void testGetText(String path) {
-        AwsProxyRequest request = new AwsProxyRequest();
-        request.setHttpMethod("GET");
-        request.setPath(path);
+        AwsProxyRequest request = request(path);
         AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "hello");
         Assertions.assertTrue(out.getMultiValueHeaders().getFirst("Content-Type").startsWith("text/plain"));
     }
 
-    @Test
-    public void test404() throws Exception {
+    private AwsProxyRequest request(String path) {
         AwsProxyRequest request = new AwsProxyRequest();
         request.setHttpMethod("GET");
-        request.setPath("/nowhere");
+        request.setPath(path);
+        return request;
+    }
+
+    @Test
+    public void test404() throws Exception {
+        AwsProxyRequest request = request("/nowhere");
         AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 404);
     }

--- a/integration-tests/virtual-http-resteasy/pom.xml
+++ b/integration-tests/virtual-http-resteasy/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>quarkus-azure-functions-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library</artifactId>
             <scope>test</scope>

--- a/integration-tests/virtual-http-resteasy/src/test/java/io/quarkus/it/virtual/FunctionTest.java
+++ b/integration-tests/virtual-http-resteasy/src/test/java/io/quarkus/it/virtual/FunctionTest.java
@@ -27,20 +27,22 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class FunctionTest {
     @Test
-    public void testJaxrs() throws Exception {
-        String uri = "https://foo.com/hello";
-        testGET(uri);
-        testPOST(uri);
-    }
-
-    @Test
-    public void testNotFound() {
+    public void testSwagger() {
         final HttpRequestMessageMock req = new HttpRequestMessageMock();
-        req.setUri(URI.create("https://nowhere.com/badroute"));
+        req.setUri(URI.create("https://foo.com/swagger-ui/"));
         req.setHttpMethod(HttpMethod.GET);
 
         // Invoke
-        final HttpResponseMessage ret = new Function().run(req, new ExecutionContext() {
+        final HttpResponseMessage ret = new Function().run(req, createContext());
+
+        // Verify
+        Assertions.assertEquals(ret.getStatus(), HttpStatus.OK);
+        String body = new String((byte[]) ret.getBody(), StandardCharsets.UTF_8);
+        Assertions.assertTrue(body.contains("Swagger UI"));
+    }
+
+    private ExecutionContext createContext() {
+        return new ExecutionContext() {
             @Override
             public Logger getLogger() {
                 return null;
@@ -55,7 +57,24 @@ public class FunctionTest {
             public String getFunctionName() {
                 return null;
             }
-        });
+        };
+    }
+
+    @Test
+    public void testJaxrs() throws Exception {
+        String uri = "https://foo.com/hello";
+        testGET(uri);
+        testPOST(uri);
+    }
+
+    @Test
+    public void testNotFound() {
+        final HttpRequestMessageMock req = new HttpRequestMessageMock();
+        req.setUri(URI.create("https://nowhere.com/badroute"));
+        req.setHttpMethod(HttpMethod.GET);
+
+        // Invoke
+        final HttpResponseMessage ret = new Function().run(req, createContext());
 
         // Verify
         Assertions.assertEquals(ret.getStatus(), HttpStatus.NOT_FOUND);
@@ -79,22 +98,7 @@ public class FunctionTest {
         req.setHttpMethod(HttpMethod.GET);
 
         // Invoke
-        final HttpResponseMessage ret = new Function().run(req, new ExecutionContext() {
-            @Override
-            public Logger getLogger() {
-                return null;
-            }
-
-            @Override
-            public String getInvocationId() {
-                return null;
-            }
-
-            @Override
-            public String getFunctionName() {
-                return null;
-            }
-        });
+        final HttpResponseMessage ret = new Function().run(req, createContext());
 
         // Verify
         Assertions.assertEquals(ret.getStatus(), HttpStatus.OK);
@@ -112,22 +116,7 @@ public class FunctionTest {
         req.getHeaders().put("Content-Type", "text/plain");
 
         // Invoke
-        final HttpResponseMessage ret = new Function().run(req, new ExecutionContext() {
-            @Override
-            public Logger getLogger() {
-                return null;
-            }
-
-            @Override
-            public String getInvocationId() {
-                return null;
-            }
-
-            @Override
-            public String getFunctionName() {
-                return null;
-            }
-        });
+        final HttpResponseMessage ret = new Function().run(req, createContext());
 
         // Verify
         Assertions.assertEquals(ret.getStatus(), HttpStatus.OK);


### PR DESCRIPTION
quarkus-amazon-lambda-http and quarkus-azure-functions-http did not support FileRegion and things like swagger and other static endpoints were not working.

@stuartwdouglas One issue that popped up with this solution was that there was a race condition.  The FileRegion was being closed before the AWS/Azure layer was able to process the message.  Ended up having to do some ugly thread synchronization.  Not sure if this will be a performance hit or not.