### PR TITLE
Fix #9684: Allow CDI bean creation from picocli args parsing

### DIFF
--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -77,6 +77,24 @@ class GreetingService {
 <1> If there is only one class annotated with `picocli.CommandLine.Command` it will be used as entry point to Picocli CommandLine.
 <2> All classes annotated with `picocli.CommandLine.Command` are registered as CDI beans.
 
+IMPORTANT: Beans with `@CommandLine.Command` should not use proxied scopes (e.g. do not use `@ApplicationScope`)
+because Picocli will not be able set field values in such beans. This extension will register classes with `@CommandLine.Command` annotation
+using `@Depended` scope. If you need to use proxied scope, then annotate setter and not field, for example:
+[source,java]
+----
+@CommandLine.Command
+@ApplicationScoped
+public class EntryCommand {
+    private String name;
+
+    @CommandLine.Option(names = "-n")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}
+----
+
 == Command line application with multiple Commands
 
 When multiple classes have the `picocli.CommandLine.Command` annotation, then one of them needs to be also annotated with `io.quarkus.picocli.runtime.annotations.TopCommand`.
@@ -177,6 +195,46 @@ public class Config {
 }
 ----
 <1> You can return instance of `java.lang.Class` here. In such case `CommandLine` will try to instantiate this class using `CommandLine.IFactory`.
+
+== Configure CDI Beans with parsed arguments
+
+You can use `Event<CommandLine.ParseResult>` or just `CommandLine.ParseResult` to configure CDI beans based on arguments parsed by Picocli.
+This event will be generated in `QuarkusApplication` class created by this extension. If you are providing your own `@QuarkusMain` this event will not be raised.
+`CommandLine.ParseResult` is created from default `CommandLine` bean.
+
+[source,java]
+----
+@CommandLine.Command
+public class EntryCommand implements Runnable {
+@CommandLine.Option(names = "-c", description = "JDBC connection string")
+String connectionString;
+
+    @Inject
+    DataSource dataSource;
+
+    @Override
+    public void run() {
+        try (Connection c = dataSource.getConnection()) {
+            // Do something
+        } catch (SQLException throwables) {
+            // Handle error
+        }
+    }
+}
+
+@ApplicationScoped
+class DatasourceConfiguration {
+
+    @Produces
+    @ApplicationScoped // <1>
+    DataSource dataSource(CommandLine.ParseResult parseResult) {
+        PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setURL(parseResult.matchedOption("c").getValue().toString());
+        return ds;
+    }
+}
+----
+<1> `@ApplicationScoped` used for lazy initialization
 
 == Providing own QuarkusMain
 

--- a/extensions/picocli/runtime/src/main/java/io/quarkus/picocli/runtime/PicocliCommandLineProducer.java
+++ b/extensions/picocli/runtime/src/main/java/io/quarkus/picocli/runtime/PicocliCommandLineProducer.java
@@ -5,6 +5,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.runtime.annotations.CommandLineArguments;
 import picocli.CommandLine;
 
 @ApplicationScoped
@@ -22,4 +23,8 @@ public class PicocliCommandLineProducer {
         return picocliCommandLineFactory.create();
     }
 
+    @Produces
+    public CommandLine.ParseResult picocliParseResult(CommandLine commandLine, @CommandLineArguments String[] args) {
+        return commandLine.parseArgs(args);
+    }
 }

--- a/extensions/picocli/runtime/src/main/java/io/quarkus/picocli/runtime/PicocliRunner.java
+++ b/extensions/picocli/runtime/src/main/java/io/quarkus/picocli/runtime/PicocliRunner.java
@@ -1,6 +1,7 @@
 package io.quarkus.picocli.runtime;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 
 import io.quarkus.runtime.QuarkusApplication;
 import picocli.CommandLine;
@@ -8,10 +9,29 @@ import picocli.CommandLine;
 @Dependent
 public class PicocliRunner implements QuarkusApplication {
 
+    private static final class EventExecutionStrategy implements CommandLine.IExecutionStrategy {
+        private final CommandLine.IExecutionStrategy executionStrategy;
+        private final Event<CommandLine.ParseResult> parseResultEvent;
+
+        private EventExecutionStrategy(CommandLine.IExecutionStrategy executionStrategy,
+                Event<CommandLine.ParseResult> parseResultEvent) {
+            this.executionStrategy = executionStrategy;
+            this.parseResultEvent = parseResultEvent;
+        }
+
+        @Override
+        public int execute(CommandLine.ParseResult parseResult)
+                throws CommandLine.ExecutionException, CommandLine.ParameterException {
+            parseResultEvent.fire(parseResult);
+            return executionStrategy.execute(parseResult);
+        }
+    }
+
     private final CommandLine commandLine;
 
-    public PicocliRunner(CommandLine commandLine) {
-        this.commandLine = commandLine;
+    public PicocliRunner(CommandLine commandLine, Event<CommandLine.ParseResult> parseResultEvent) {
+        this.commandLine = commandLine
+                .setExecutionStrategy(new EventExecutionStrategy(commandLine.getExecutionStrategy(), parseResultEvent));
     }
 
     @Override

--- a/integration-tests/picocli/src/main/java/io/quarkus/it/picocli/ConfigFromParseResult.java
+++ b/integration-tests/picocli/src/main/java/io/quarkus/it/picocli/ConfigFromParseResult.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.picocli;
+
+public class ConfigFromParseResult {
+    private final String parsedName;
+
+    public ConfigFromParseResult(String parsedName) {
+        this.parsedName = parsedName;
+    }
+
+    public String getParsedName() {
+        return parsedName;
+    }
+}

--- a/integration-tests/picocli/src/main/java/io/quarkus/it/picocli/ParsedCommand.java
+++ b/integration-tests/picocli/src/main/java/io/quarkus/it/picocli/ParsedCommand.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.picocli;
+
+import javax.inject.Inject;
+
+import picocli.CommandLine;
+
+@CommandLine.Command
+public class ParsedCommand implements Runnable {
+
+    @CommandLine.Option(names = { "-p", "--parsed" }, description = "Will be parsed before run.")
+    String name;
+
+    @Inject
+    ConfigFromParseResult configFromParseResult;
+
+    @Override
+    public void run() {
+        System.out.println("Set value: " + name);
+        System.out.println("Parsed value: " + configFromParseResult.getParsedName());
+    }
+}

--- a/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestOneCommand.java
+++ b/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestOneCommand.java
@@ -2,22 +2,34 @@ package io.quarkus.it.picocli;
 
 import static io.quarkus.it.picocli.TestUtils.createConfig;
 
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusProdModeTest;
+import picocli.CommandLine;
 
 public class TestOneCommand {
 
     @RegisterExtension
-    static final QuarkusProdModeTest config = createConfig("hello-app", HelloCommand.class)
+    static final QuarkusProdModeTest config = createConfig("hello-app", HelloCommand.class, EventListener.class)
             .setCommandLineParameters("--name=Tester");
 
     @Test
     public void simpleTest() {
+        Assertions.assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("ParseResult Event: Tester");
         Assertions.assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Hello Tester!");
         Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @Dependent
+    static class EventListener {
+        void onParseEvent(@Observes CommandLine.ParseResult result) {
+            System.out.println("ParseResult Event: " + result.matchedOption("name").getValue());
+        }
     }
 
 }

--- a/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestParsedCommand.java
+++ b/integration-tests/picocli/src/test/java/io/quarkus/it/picocli/TestParsedCommand.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.picocli;
+
+import static io.quarkus.it.picocli.TestUtils.createConfig;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+import picocli.CommandLine;
+
+public class TestParsedCommand {
+    @RegisterExtension
+    static final QuarkusProdModeTest config = createConfig("hello-app", ParsedCommand.class,
+            ConfigFromParseResult.class, ConfigProducer.class)
+                    .setCommandLineParameters("-p", "FromConfig");
+
+    @Test
+    public void simpleTest() {
+        Assertions.assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Set value: FromConfig");
+        Assertions.assertThat(config.getStartupConsoleOutput()).containsOnlyOnce("Parsed value: FromConfig");
+        Assertions.assertThat(config.getExitCode()).isZero();
+    }
+
+    @ApplicationScoped
+    static class ConfigProducer {
+
+        @Produces
+        @ApplicationScoped
+        ConfigFromParseResult configFromParseResult(CommandLine.ParseResult parseResult) {
+            return new ConfigFromParseResult(parseResult.matchedOption("p").getValue());
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #9684. As @danielpetisme suggested, we will fire event with `CommandLine.ParseResult` before command itself is executed. 
I've also added `CommandLine.ParseResult` as bean:

```java
    @Produces
    public CommandLine.ParseResult picocliParseResult(CommandLine commandLine, @CommandLineArguments String[] args) {
        return commandLine.parseArgs(args);
    }
```
But I'm not sure if this is good approach. 
@remkop @geoand @danielpetisme  Could you please review?

- [x] Guide updated
