### PR TITLE
Swagger and static resource support AWS Lambda HTTP, Azure HTTP

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -3,11 +3,15 @@ package io.quarkus.amazon.lambda.http;
 import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
+
+import org.jboss.logging.Logger;
 
 import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.services.lambda.runtime.Context;
@@ -15,6 +19,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
@@ -28,10 +33,12 @@ import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 import io.quarkus.amazon.lambda.http.model.AwsProxyResponse;
 import io.quarkus.amazon.lambda.http.model.Headers;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
+import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 
 @SuppressWarnings("unused")
 public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
+    private static final Logger log = Logger.getLogger("quarkus.amazon.lambda.http");
 
     private static Headers errorHeaders = new Headers();
     static {
@@ -46,19 +53,99 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
             }
         }
 
-        VirtualClientConnection connection = VirtualClientConnection.connect(VertxHttpRecorder.VIRTUAL_HTTP, clientAddress);
         try {
-            return nettyDispatch(connection, request);
+            return nettyDispatch(clientAddress, request);
         } catch (Exception e) {
+            log.error("Request Failure", e);
             return new AwsProxyResponse(500, errorHeaders, "{ \"message\": \"Internal Server Error\" }");
-        } finally {
-            connection.close();
         }
 
     }
 
-    private AwsProxyResponse nettyDispatch(VirtualClientConnection connection, AwsProxyRequest request) throws Exception {
+    private class NettyResponseHandler implements VirtualResponseHandler {
+        AwsProxyResponse responseBuilder = new AwsProxyResponse();
+        ByteArrayOutputStream baos;
+        WritableByteChannel byteChannel;
+        final AwsProxyRequest request;
+        CompletableFuture<AwsProxyResponse> future = new CompletableFuture<>();
+
+        public NettyResponseHandler(AwsProxyRequest request) {
+            this.request = request;
+        }
+
+        public CompletableFuture<AwsProxyResponse> getFuture() {
+            return future;
+        }
+
+        @Override
+        public void handleMessage(Object msg) {
+            try {
+                //log.info("Got message: " + msg.getClass().getName());
+
+                if (msg instanceof HttpResponse) {
+                    HttpResponse res = (HttpResponse) msg;
+                    responseBuilder.setStatusCode(res.status().code());
+
+                    if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
+                        responseBuilder.setStatusDescription(res.status().reasonPhrase());
+                    }
+                    responseBuilder.setMultiValueHeaders(new Headers());
+                    for (String name : res.headers().names()) {
+                        for (String v : res.headers().getAll(name)) {
+                            responseBuilder.getMultiValueHeaders().add(name, v);
+                        }
+                    }
+                }
+                if (msg instanceof HttpContent) {
+                    HttpContent content = (HttpContent) msg;
+                    int readable = content.content().readableBytes();
+                    if (baos == null && readable > 0) {
+                        baos = createByteStream();
+                    }
+                    for (int i = 0; i < readable; i++) {
+                        baos.write(content.content().readByte());
+                    }
+                }
+                if (msg instanceof FileRegion) {
+                    FileRegion file = (FileRegion) msg;
+                    if (file.count() > 0 && file.transferred() < file.count()) {
+                        if (baos == null)
+                            baos = createByteStream();
+                        if (byteChannel == null)
+                            byteChannel = Channels.newChannel(baos);
+                        file.transferTo(byteChannel, file.transferred());
+                    }
+                }
+                if (msg instanceof LastHttpContent) {
+                    if (baos != null) {
+                        if (isBinary(responseBuilder.getMultiValueHeaders().getFirst("Content-Type"))) {
+                            responseBuilder.setBase64Encoded(true);
+                            responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
+                        } else {
+                            responseBuilder.setBody(new String(baos.toByteArray(), "UTF-8"));
+                        }
+                    }
+                    future.complete(responseBuilder);
+                }
+            } catch (Throwable ex) {
+                future.completeExceptionally(ex);
+            } finally {
+                if (msg != null) {
+                    ReferenceCountUtil.release(msg);
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            if (!future.isDone())
+                future.completeExceptionally(new RuntimeException("Connection closed"));
+        }
+    }
+
+    private AwsProxyResponse nettyDispatch(InetSocketAddress clientAddress, AwsProxyRequest request) throws Exception {
         String path = request.getPath();
+        //log.info("---- Got lambda request: " + path);
         if (request.getMultiValueQueryStringParameters() != null && !request.getMultiValueQueryStringParameters().isEmpty()) {
             StringBuilder sb = new StringBuilder(path);
             sb.append("?");
@@ -104,67 +191,23 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
                 requestContent = new DefaultLastHttpContent(body);
             }
         }
+        NettyResponseHandler handler = new NettyResponseHandler(request);
+        VirtualClientConnection connection = VirtualClientConnection.connect(handler, VertxHttpRecorder.VIRTUAL_HTTP,
+                clientAddress);
 
         connection.sendMessage(nettyRequest);
         connection.sendMessage(requestContent);
-        AwsProxyResponse responseBuilder = new AwsProxyResponse();
-        ByteArrayOutputStream baos = null;
         try {
-            for (;;) {
-                // todo should we timeout? have a timeout config?
-                //log.info("waiting for message");
-                Object msg = connection.queue().poll(100, TimeUnit.MILLISECONDS);
-                try {
-                    if (msg == null)
-                        continue;
-                    //log.info("Got message: " + msg.getClass().getName());
-
-                    if (msg instanceof HttpResponse) {
-                        HttpResponse res = (HttpResponse) msg;
-                        responseBuilder.setStatusCode(res.status().code());
-
-                        if (request.getRequestSource() == AwsProxyRequest.RequestSource.ALB) {
-                            responseBuilder.setStatusDescription(res.status().reasonPhrase());
-                        }
-                        responseBuilder.setMultiValueHeaders(new Headers());
-                        for (String name : res.headers().names()) {
-                            for (String v : res.headers().getAll(name)) {
-                                responseBuilder.getMultiValueHeaders().add(name, v);
-                            }
-                        }
-                    }
-                    if (msg instanceof HttpContent) {
-                        HttpContent content = (HttpContent) msg;
-                        int readable = content.content().readableBytes();
-                        if (baos == null && readable > 0) {
-                            // todo what is right size?
-                            baos = new ByteArrayOutputStream(500);
-                        }
-                        for (int i = 0; i < readable; i++) {
-                            baos.write(content.content().readByte());
-                        }
-                    }
-                    if (msg instanceof LastHttpContent) {
-                        if (baos != null) {
-                            if (isBinary(responseBuilder.getMultiValueHeaders().getFirst("Content-Type"))) {
-                                responseBuilder.setBase64Encoded(true);
-                                responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
-                            } else {
-                                responseBuilder.setBody(new String(baos.toByteArray(), "UTF-8"));
-                            }
-                        }
-                        return responseBuilder;
-                    }
-                } finally {
-                    if (msg != null)
-                        ReferenceCountUtil.release(msg);
-                }
-            }
+            return handler.getFuture().get();
         } finally {
-            if (baos != null) {
-                baos.close();
-            }
+            connection.close();
         }
+    }
+
+    private ByteArrayOutputStream createByteStream() {
+        ByteArrayOutputStream baos;// todo what is right size?
+        baos = new ByteArrayOutputStream(1000);
+        return baos;
     }
 
     private boolean isBinary(String contentType) {

--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
@@ -3,9 +3,11 @@ package io.quarkus.azure.functions.resteasy.runtime;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
 
 import org.jboss.logging.Logger;
 
@@ -15,6 +17,7 @@ import com.microsoft.azure.functions.HttpStatus;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
@@ -24,6 +27,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
+import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 import io.quarkus.runtime.Application;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 
@@ -56,20 +60,16 @@ public class BaseFunction {
     }
 
     protected HttpResponseMessage dispatch(HttpRequestMessage<Optional<byte[]>> request) {
-        VirtualClientConnection connection = VirtualClientConnection.connect(VertxHttpRecorder.VIRTUAL_HTTP);
         try {
-            return nettyDispatch(connection, request);
+            return nettyDispatch(request);
         } catch (Exception e) {
             e.printStackTrace();
             return request
                     .createResponseBuilder(HttpStatus.valueOf(500)).build();
-        } finally {
-            connection.close();
         }
     }
 
-    protected HttpResponseMessage nettyDispatch(VirtualClientConnection connection,
-            HttpRequestMessage<Optional<byte[]>> request)
+    protected HttpResponseMessage nettyDispatch(HttpRequestMessage<Optional<byte[]>> request)
             throws Exception {
         String path = request.getUri().getRawPath();
         String query = request.getUri().getRawQuery();
@@ -92,51 +92,83 @@ public class BaseFunction {
             requestContent = new DefaultLastHttpContent(body);
         }
 
+        ResponseHandler handler = new ResponseHandler(request);
+        VirtualClientConnection connection = VirtualClientConnection.connect(handler, VertxHttpRecorder.VIRTUAL_HTTP);
+
         connection.sendMessage(nettyRequest);
         connection.sendMessage(requestContent);
-        HttpResponseMessage.Builder responseBuilder = null;
-        ByteArrayOutputStream baos = null;
         try {
-            for (;;) {
-                // todo should we timeout? have a timeout config?
-                //log.info("waiting for message");
-                Object msg = connection.queue().poll(100, TimeUnit.MILLISECONDS);
-                try {
-                    if (msg == null)
-                        continue;
-                    //log.info("Got message: " + msg.getClass().getName());
-
-                    if (msg instanceof HttpResponse) {
-                        HttpResponse res = (HttpResponse) msg;
-                        responseBuilder = request.createResponseBuilder(HttpStatus.valueOf(res.status().code()));
-                        for (Map.Entry<String, String> entry : res.headers()) {
-                            responseBuilder.header(entry.getKey(), entry.getValue());
-                        }
-                    }
-                    if (msg instanceof HttpContent) {
-                        HttpContent content = (HttpContent) msg;
-                        if (baos == null) {
-                            // todo what is right size?
-                            baos = new ByteArrayOutputStream(500);
-                        }
-                        int readable = content.content().readableBytes();
-                        for (int i = 0; i < readable; i++) {
-                            baos.write(content.content().readByte());
-                        }
-                    }
-                    if (msg instanceof LastHttpContent) {
-                        responseBuilder.body(baos.toByteArray());
-                        return responseBuilder.build();
-                    }
-                } finally {
-                    if (msg != null)
-                        ReferenceCountUtil.release(msg);
-                }
-            }
+            return handler.future.get();
         } finally {
-            if (baos != null) {
-                baos.close();
+            connection.close();
+        }
+    }
+
+    private ByteArrayOutputStream createByteStream() {
+        ByteArrayOutputStream baos;
+        baos = new ByteArrayOutputStream(500);
+        return baos;
+    }
+
+    private class ResponseHandler implements VirtualResponseHandler {
+        HttpResponseMessage.Builder responseBuilder;
+        ByteArrayOutputStream baos;
+        WritableByteChannel byteChannel;
+        CompletableFuture<HttpResponseMessage> future = new CompletableFuture<>();
+        final HttpRequestMessage<Optional<byte[]>> request;
+
+        public ResponseHandler(HttpRequestMessage<Optional<byte[]>> request) {
+            this.request = request;
+        }
+
+        @Override
+        public void handleMessage(Object msg) {
+            try {
+                //log.info("Got message: " + msg.getClass().getName());
+
+                if (msg instanceof HttpResponse) {
+                    HttpResponse res = (HttpResponse) msg;
+                    responseBuilder = request.createResponseBuilder(HttpStatus.valueOf(res.status().code()));
+                    for (Map.Entry<String, String> entry : res.headers()) {
+                        responseBuilder.header(entry.getKey(), entry.getValue());
+                    }
+                }
+                if (msg instanceof HttpContent) {
+                    HttpContent content = (HttpContent) msg;
+                    if (baos == null) {
+                        // todo what is right size?
+                        baos = createByteStream();
+                    }
+                    int readable = content.content().readableBytes();
+                    for (int i = 0; i < readable; i++) {
+                        baos.write(content.content().readByte());
+                    }
+                }
+                if (msg instanceof FileRegion) {
+                    FileRegion file = (FileRegion) msg;
+                    if (file.count() > 0 && file.transferred() < file.count()) {
+                        if (baos == null)
+                            baos = createByteStream();
+                        if (byteChannel == null)
+                            byteChannel = Channels.newChannel(baos);
+                        file.transferTo(byteChannel, file.transferred());
+                    }
+                }
+                if (msg instanceof LastHttpContent) {
+                    responseBuilder.body(baos.toByteArray());
+                    future.complete(responseBuilder.build());
+                }
+            } catch (Throwable ex) {
+                future.completeExceptionally(ex);
+            } finally {
+                ReferenceCountUtil.release(msg);
             }
+        }
+
+        @Override
+        public void close() {
+            if (!future.isDone())
+                future.completeExceptionally(new RuntimeException("Connection closed"));
         }
     }
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualChannel.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualChannel.java
@@ -313,7 +313,8 @@ public class VirtualChannel extends AbstractChannel {
                     // It is possible the peer could have closed while we are writing, and in this case we should
                     // simulate real socket behavior and ensure the sendMessage operation is failed.
                     if (peer.isConnected()) {
-                        peer.queue().add(ReferenceCountUtil.retain(msg));
+                        ReferenceCountUtil.retain(msg);
+                        peer.handler.handleMessage(msg);
                         in.remove();
                     } else {
                         if (exception == null) {

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualResponseHandler.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualResponseHandler.java
@@ -1,0 +1,7 @@
+package io.quarkus.netty.runtime.virtual;
+
+public interface VirtualResponseHandler {
+    void handleMessage(Object msg);
+
+    void close();
+}

--- a/integration-tests/amazon-lambda-http/pom.xml
+++ b/integration-tests/amazon-lambda-http/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
         </dependency>
         <dependency>

--- a/integration-tests/amazon-lambda-http/src/main/resources/application.properties
+++ b/integration-tests/amazon-lambda-http/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.lambda.enable-polling-jvm-mode=true
 quarkus.http.virtual=true
+quarkus.swagger-ui.always-include=true

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -24,6 +24,16 @@ public class AmazonLambdaSimpleTestCase {
         testGetText("/hello");
     }
 
+    @Test
+    public void testSwaggerUi() throws Exception {
+        // this tests the FileRegion support in the handler
+        AwsProxyRequest request = request("/swagger-ui/");
+        AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
+        Assertions.assertEquals(out.getStatusCode(), 200);
+        Assertions.assertTrue(body(out).contains("Swagger UI"));
+
+    }
+
     private String body(AwsProxyResponse response) {
         if (!response.isBase64Encoded())
             return response.getBody();
@@ -31,20 +41,23 @@ public class AmazonLambdaSimpleTestCase {
     }
 
     private void testGetText(String path) {
-        AwsProxyRequest request = new AwsProxyRequest();
-        request.setHttpMethod("GET");
-        request.setPath(path);
+        AwsProxyRequest request = request(path);
         AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 200);
         Assertions.assertEquals(body(out), "hello");
         Assertions.assertTrue(out.getMultiValueHeaders().getFirst("Content-Type").startsWith("text/plain"));
     }
 
-    @Test
-    public void test404() throws Exception {
+    private AwsProxyRequest request(String path) {
         AwsProxyRequest request = new AwsProxyRequest();
         request.setHttpMethod("GET");
-        request.setPath("/nowhere");
+        request.setPath(path);
+        return request;
+    }
+
+    @Test
+    public void test404() throws Exception {
+        AwsProxyRequest request = request("/nowhere");
         AwsProxyResponse out = LambdaClient.invoke(AwsProxyResponse.class, request);
         Assertions.assertEquals(out.getStatusCode(), 404);
     }

--- a/integration-tests/virtual-http-resteasy/pom.xml
+++ b/integration-tests/virtual-http-resteasy/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>quarkus-azure-functions-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library</artifactId>
             <scope>test</scope>

--- a/integration-tests/virtual-http-resteasy/src/main/resources/application.properties
+++ b/integration-tests/virtual-http-resteasy/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 quarkus.http.virtual=true
+quarkus.swagger-ui.always-include=true
+

--- a/integration-tests/virtual-http-resteasy/src/test/java/io/quarkus/it/virtual/FunctionTest.java
+++ b/integration-tests/virtual-http-resteasy/src/test/java/io/quarkus/it/virtual/FunctionTest.java
@@ -27,20 +27,22 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class FunctionTest {
     @Test
-    public void testJaxrs() throws Exception {
-        String uri = "https://foo.com/hello";
-        testGET(uri);
-        testPOST(uri);
-    }
-
-    @Test
-    public void testNotFound() {
+    public void testSwagger() {
         final HttpRequestMessageMock req = new HttpRequestMessageMock();
-        req.setUri(URI.create("https://nowhere.com/badroute"));
+        req.setUri(URI.create("https://foo.com/swagger-ui/"));
         req.setHttpMethod(HttpMethod.GET);
 
         // Invoke
-        final HttpResponseMessage ret = new Function().run(req, new ExecutionContext() {
+        final HttpResponseMessage ret = new Function().run(req, createContext());
+
+        // Verify
+        Assertions.assertEquals(ret.getStatus(), HttpStatus.OK);
+        String body = new String((byte[]) ret.getBody(), StandardCharsets.UTF_8);
+        Assertions.assertTrue(body.contains("Swagger UI"));
+    }
+
+    private ExecutionContext createContext() {
+        return new ExecutionContext() {
             @Override
             public Logger getLogger() {
                 return null;
@@ -55,7 +57,24 @@ public class FunctionTest {
             public String getFunctionName() {
                 return null;
             }
-        });
+        };
+    }
+
+    @Test
+    public void testJaxrs() throws Exception {
+        String uri = "https://foo.com/hello";
+        testGET(uri);
+        testPOST(uri);
+    }
+
+    @Test
+    public void testNotFound() {
+        final HttpRequestMessageMock req = new HttpRequestMessageMock();
+        req.setUri(URI.create("https://nowhere.com/badroute"));
+        req.setHttpMethod(HttpMethod.GET);
+
+        // Invoke
+        final HttpResponseMessage ret = new Function().run(req, createContext());
 
         // Verify
         Assertions.assertEquals(ret.getStatus(), HttpStatus.NOT_FOUND);
@@ -79,22 +98,7 @@ public class FunctionTest {
         req.setHttpMethod(HttpMethod.GET);
 
         // Invoke
-        final HttpResponseMessage ret = new Function().run(req, new ExecutionContext() {
-            @Override
-            public Logger getLogger() {
-                return null;
-            }
-
-            @Override
-            public String getInvocationId() {
-                return null;
-            }
-
-            @Override
-            public String getFunctionName() {
-                return null;
-            }
-        });
+        final HttpResponseMessage ret = new Function().run(req, createContext());
 
         // Verify
         Assertions.assertEquals(ret.getStatus(), HttpStatus.OK);
@@ -112,22 +116,7 @@ public class FunctionTest {
         req.getHeaders().put("Content-Type", "text/plain");
 
         // Invoke
-        final HttpResponseMessage ret = new Function().run(req, new ExecutionContext() {
-            @Override
-            public Logger getLogger() {
-                return null;
-            }
-
-            @Override
-            public String getInvocationId() {
-                return null;
-            }
-
-            @Override
-            public String getFunctionName() {
-                return null;
-            }
-        });
+        final HttpResponseMessage ret = new Function().run(req, createContext());
 
         // Verify
         Assertions.assertEquals(ret.getStatus(), HttpStatus.OK);


### PR DESCRIPTION
I was not handling static resource correctly in the virtual HTTP layer.  This fix will allow swagger support to work with AWS and Azure HTTP extensions as well as any static resource that emits FileRegion's internally.

I also redid the VirtualChannel stuff a bit to avoid context switching.  I was having trouble with FileRegions as the VirtualChannel was closing the file before the azure/aws layer could read from the region.  Since I was doing too much context switching anyways, I decided to just move message processing to the io loop.  This aws/azure message processing is all non-blocking so it should be fine.

@stuartwdouglas Not sure if I handled FileRegions correctly.  Can you take a look?  They are in a spin loop.  It looks like the NioChannel is handling them in the same way.