### PR TITLE
Add retrieval of persistence unit names to `JPAConfig`

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.runtime;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,6 +93,15 @@ public class JPAConfig {
 
     boolean isJtaEnabled() {
         return jtaEnabled.get();
+    }
+
+    /**
+     * Returns the registered persistence units.
+     *
+     * @return Set containing the names of all registered persistence units.
+     */
+    public Set<String> getPersistenceUnits() {
+        return persistenceUnits.keySet();
     }
 
     /**


### PR DESCRIPTION
Helpful for other extensions that need to iterate over persistence units