### PR TITLE
HealthBuildItem - remove the useless configRootName property

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1336,7 +1336,7 @@ Following is an example from the Agroal extension that provides a `DataSourceHea
 @BuildStep
 HealthBuildItem addHealthCheck(AgroalBuildTimeConfig agroalBuildTimeConfig) {
     return new HealthBuildItem("io.quarkus.agroal.runtime.health.DataSourceHealthCheck",
-            agroalBuildTimeConfig.healthEnabled, "datasource");
+            agroalBuildTimeConfig.healthEnabled);
 }
 ----
 

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -441,7 +441,7 @@ class AgroalProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
         return new HealthBuildItem("io.quarkus.agroal.runtime.health.DataSourceHealthCheck",
-                dataSourcesBuildTimeConfig.healthEnabled, "datasource");
+                dataSourcesBuildTimeConfig.healthEnabled);
     }
 
     @BuildStep

--- a/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
+++ b/extensions/artemis-core/deployment/src/main/java/io/quarkus/artemis/core/deployment/ArtemisCoreProcessor.java
@@ -87,7 +87,7 @@ public class ArtemisCoreProcessor {
 
         return new HealthBuildItem(
                 "io.quarkus.artemis.core.runtime.health.ServerLocatorHealthCheck",
-                buildConfig.healthEnabled, "artemis");
+                buildConfig.healthEnabled);
     }
 
     @BuildStep

--- a/extensions/artemis-jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
+++ b/extensions/artemis-jms/deployment/src/main/java/io/quarkus/artemis/jms/deployment/ArtemisJmsProcessor.java
@@ -29,7 +29,7 @@ public class ArtemisJmsProcessor {
     HealthBuildItem health(ArtemisBuildTimeConfig buildConfig) {
         return new HealthBuildItem(
                 "io.quarkus.artemis.jms.runtime.health.ConnectionFactoryHealthCheck",
-                buildConfig.healthEnabled, "artemis");
+                buildConfig.healthEnabled);
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -142,7 +142,7 @@ public class GrpcServerProcessor {
                 beans.produce(AdditionalBeanBuildItem.unremovableOf(GrpcHealthStorage.class));
             }
             return new HealthBuildItem("io.quarkus.grpc.runtime.health.GrpcHealthCheck",
-                    config.mpHealthEnabled, GRPC_SERVER);
+                    config.mpHealthEnabled);
         } else {
             return null;
         }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -206,10 +206,10 @@ class KafkaStreamsProcessor {
         healthChecks.produce(
                 new HealthBuildItem(
                         "io.quarkus.kafka.streams.runtime.health.KafkaStreamsTopicsHealthCheck",
-                        buildTimeConfig.healthEnabled, "kafka-streams"));
+                        buildTimeConfig.healthEnabled));
         healthChecks.produce(
                 new HealthBuildItem(
                         "io.quarkus.kafka.streams.runtime.health.KafkaStreamsStateHealthCheck",
-                        buildTimeConfig.healthEnabled, "kafka-streams"));
+                        buildTimeConfig.healthEnabled));
     }
 }

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -251,7 +251,7 @@ public class MongoClientProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(MongoClientBuildTimeConfig buildTimeConfig) {
         return new HealthBuildItem("io.quarkus.mongodb.health.MongoHealthCheck",
-                buildTimeConfig.healthEnabled, "mongodb");
+                buildTimeConfig.healthEnabled);
     }
 
     @BuildStep

--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverProcessor.java
@@ -42,6 +42,6 @@ class Neo4jDriverProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(Neo4jBuildTimeConfig buildTimeConfig) {
         return new HealthBuildItem("io.quarkus.neo4j.runtime.health.Neo4jHealthCheck",
-                buildTimeConfig.healthEnabled, "neo4j");
+                buildTimeConfig.healthEnabled);
     }
 }

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -68,6 +68,6 @@ class ReactiveMySQLClientProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
         return new HealthBuildItem("io.quarkus.reactive.mysql.client.runtime.health.ReactiveMySQLDataSourceHealthCheck",
-                dataSourcesBuildTimeConfig.healthEnabled, "datasource");
+                dataSourcesBuildTimeConfig.healthEnabled);
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/ReactivePgClientProcessor.java
@@ -74,6 +74,6 @@ class ReactivePgClientProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig) {
         return new HealthBuildItem("io.quarkus.reactive.pg.client.runtime.health.ReactivePgDataSourceHealthCheck",
-                dataSourcesBuildTimeConfig.healthEnabled, "datasource");
+                dataSourcesBuildTimeConfig.healthEnabled);
     }
 }

--- a/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
+++ b/extensions/smallrye-health/spi/src/main/java/io/quarkus/smallrye/health/deployment/spi/HealthBuildItem.java
@@ -3,21 +3,31 @@ package io.quarkus.smallrye.health.deployment.spi;
 import io.quarkus.builder.item.MultiBuildItem;
 
 public final class HealthBuildItem extends MultiBuildItem {
-    private String healthCheckClass;
-    private boolean enabled;
-    private String configRootName;
+
+    private final String healthCheckClass;
+
+    private final boolean enabled;
+
+    /**
+     * 
+     * @param healthCheckClass
+     * @param enabled
+     * @param configRootName This parameter is not used
+     * @deprecated Use {@link #HealthBuildItem(String, boolean)} instead.
+     */
+    @Deprecated
+    public HealthBuildItem(String healthCheckClass, boolean enabled, String configRootName) {
+        this(healthCheckClass, enabled);
+    }
 
     /**
      * @param healthCheckClass the name of the health check class, needs to implements
      *        org.eclipse.microprofile.health.HealthCheck
      * @param enabled whether or not the check is enabled
-     * @param configRootName the name of the root configuration of the extension as defined by the <code>@ConfigRoot</code>
-     *        annotation.
      */
-    public HealthBuildItem(String healthCheckClass, boolean enabled, String configRootName) {
+    public HealthBuildItem(String healthCheckClass, boolean enabled) {
         this.healthCheckClass = healthCheckClass;
         this.enabled = enabled;
-        this.configRootName = configRootName;
     }
 
     public String getHealthCheckClass() {
@@ -28,7 +38,4 @@ public final class HealthBuildItem extends MultiBuildItem {
         return enabled;
     }
 
-    public String getConfigRootName() {
-        return configRootName;
-    }
 }

--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
@@ -73,7 +73,7 @@ public class VaultProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(VaultBuildTimeConfig config) {
         return new HealthBuildItem("io.quarkus.vault.runtime.health.VaultHealthCheck",
-                config.health.enabled, "vault");
+                config.health.enabled);
     }
 
 }


### PR DESCRIPTION
- the property is not used by SmallRyeHealthProcessor
- keep the old version of constructor for backwards compatibility