### PR TITLE
docs: fix description for credentials provider

### DIFF
--- a/docs/src/main/asciidoc/amazon-credentials.adoc
+++ b/docs/src/main/asciidoc/amazon-credentials.adoc
@@ -1,0 +1,5 @@
+* Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
+* Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+* Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
+* Credentials delivered through the Amazon ECS if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
+* Instance profile credentials delivered through the Amazon EC2 metadata service

--- a/docs/src/main/asciidoc/amazon-dynamodb.adoc
+++ b/docs/src/main/asciidoc/amazon-dynamodb.adoc
@@ -372,11 +372,8 @@ quarkus.dynamodb.aws.credentials.type=default
 
 - `quarkus.dynamodb.aws.region` you should set it to the region where you provisioned the DynamoDB table,
 - `quarkus.dynamodb.aws.credentials.type` - use the `default` credentials provider chain that looks for credentials in this order:
-- Java System Properties - `aws.accessKeyId` and `aws.secretKey`
-* Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-* Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
-* Instance profile credentials delivered through the Amazon EC2 metadata service
+
+include::./amazon-credentials.adoc[]
 
 == Next steps
 

--- a/docs/src/main/asciidoc/amazon-kms.adoc
+++ b/docs/src/main/asciidoc/amazon-kms.adoc
@@ -207,11 +207,7 @@ quarkus.kms.aws.credentials.static-provider.secret-access-key=test-secret
 If you want to work with an AWS account, you can simply remove or comment out all Amazon KMS related properties. By default, the KMS client extension
 will use the `default` credentials provider chain that looks for credentials in this order:
 
-* Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
-* Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-* Credentials delivered through the Amazon ECS if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
-* Instance profile credentials delivered through the Amazon EC2 metadata service
+include::./amazon-credentials.adoc[]
 
 And the region from your AWS CLI profile will be used.
 

--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -129,6 +129,7 @@ public class FormData {
 ----
 
 The class defines three fields:
+
 * `data` that fill capture stream of uploaded bytes from the client
 * `fileName` that captures a filename as provided by the submited form
 * `mimeType` content type of the uploaded file
@@ -393,11 +394,8 @@ quarkus.s3.aws.credentials.type=default
 - `bucket.name` - name of the S3 bucket on your AWS account.
 - `quarkus.s3.aws.region` you should set it to the region where your S3 bucket was created,
 - `quarkus.s3.aws.credentials.type` - use the `default` credentials provider chain that looks for credentials in this order:
-    * Java System Properties - `aws.accessKeyId` and `aws.secretKey`
-    * Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-    * Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-    * Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
-    * Instance profile credentials delivered through the Amazon EC2 metadata service
+
+include::./amazon-credentials.adoc[]
 
 == Creating a frontend
 

--- a/docs/src/main/asciidoc/amazon-ses.adoc
+++ b/docs/src/main/asciidoc/amazon-ses.adoc
@@ -169,11 +169,8 @@ quarkus.ses.aws.credentials.static-provider.secret-access-key=test-secret
 
 If you want to work with an AWS account, you can simply remove or comment out all Amazon SES related properties. By default, the SES client extension
 will use the `default` credentials provider chain that looks for credentials in this order:
-- Java System Properties - `aws.accessKeyId` and `aws.secretKey`
-* Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-* Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
-* Instance profile credentials delivered through the Amazon EC2 metadata service
+
+include::./amazon-credentials.adoc[]
 
 And the region from your AWS CLI profile will be used.
 

--- a/docs/src/main/asciidoc/amazon-sns.adoc
+++ b/docs/src/main/asciidoc/amazon-sns.adoc
@@ -638,11 +638,8 @@ quarkus.sns.aws.credentials.type=default
 
 - `quarkus.sns.aws.region` you should set it to the region where you provisioned the SNS table,
 - `quarkus.sns.aws.credentials.type` - use the `default` credentials provider chain that looks for credentials in this order:
-- Java System Properties - `aws.accessKeyId` and `aws.secretKey`
-* Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-* Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
-* Instance profile credentials delivered through the Amazon EC2 metadata service
+
+include::./amazon-credentials.adoc[]
 
 == Next steps
 

--- a/docs/src/main/asciidoc/amazon-sqs.adoc
+++ b/docs/src/main/asciidoc/amazon-sqs.adoc
@@ -315,11 +315,8 @@ quarkus.sqs.aws.credentials.static-provider.secret-access-key=test-secret
 
 If you want to work with an AWS account, you can simply remove or comment out all SQS related properties. By default, the SQS client extension
 will use the `default` credentials provider chain that looks for credentials in this order:
-- Java System Properties - `aws.accessKeyId` and `aws.secretKey`
-* Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-* Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable,
-* Instance profile credentials delivered through the Amazon EC2 metadata service
+
+include::./amazon-credentials.adoc[]
 
 And the region from your AWS CLI profile will be used.
 


### PR DESCRIPTION
Fixed AWS credentials info according to the official document:
https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html