### PR TITLE
REST Data with Panache pagination

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -92,7 +92,7 @@ public class PeopleResourceImpl implements PeopleResource { // The actual class 
 
     @GET
     @Produces("application/json")
-    public List<Person> list(){
+    public Response list(){
         // ...
     }
 
@@ -132,7 +132,7 @@ It can be used in your resource interface:
 @ResourceProperties(hal = true, path = "my-people")
 public interface PeopleResource extends PanacheEntityResource<Person, Long> {
     @MethodProperties(path = "all")
-    List<Person> list();
+    Response list();
 
     @MethodProperties(exposed = false)
     void delete(Long id);
@@ -146,6 +146,10 @@ public interface PeopleResource extends PanacheEntityResource<Person, Long> {
 * `hal` - in addition to the standard `application/json` responses, generates additional methods that can return `application/hal+json` responses if requested via an `Accept` header.
 Default is `false`.
 * `path` - resource base path. Default path is a hyphenated lowercase resource name without a suffix of `resource` or `controller`.
+* `paged` - whether collection responses should be paged or not.
+First, last, previous and next page URIs are included in the response headers if they exist.
+Request page index and size are taken from the `page` and `size` query parameters that default to `0` and `20` respectively.
+Default is `true`.
 
 `@MethodProperties`
 
@@ -155,7 +159,7 @@ Default is `false`.
 == Response body examples
 
 As mentioned above REST Data with Panache supports the `application/json` and `application/hal+json` response content types.
-Here are a couple of examples of how a response body would look like for the `get` and `list` operations assuming there are two `Person` records in a database.
+Here are a couple of examples of how a response body would look like for the `get` and `list` operations assuming there are five `Person` records in a database.
 
 === GET /people/1
 
@@ -188,7 +192,7 @@ Here are a couple of examples of how a response body would look like for the `ge
 }
 ----
 
-=== GET /people
+=== GET /people?page=0&size=2
 
 `Accept: application/json`
 
@@ -206,6 +210,7 @@ Here are a couple of examples of how a response body would look like for the `ge
     "birth": "1986-11-20"
   }
 ]
+
 ----
 
 `Accept: application/hal+json`
@@ -241,7 +246,18 @@ Here are a couple of examples of how a response body would look like for the `ge
   ],
   "_links": {
     "add": "http://example.com/people",
-    "list": "http://example.com/people"
+    "list": "http://example.com/people",
+    "first": "http://example.com/people?page=0&size=2",
+    "last": "http://example.com/people?page=2&size=2",
+    "next": "http://example.com/people?page=1&size=2"
   }
 }
 ----
+
+Both responses would also contain these headers:
+
+* Link: < http://example.com/people?page=0&size=2 >; rel="first"
+* Link: < http://example.com/people?page=2&size=2 >; rel="last"
+* Link: < http://example.com/people?page=1&size=2 >; rel="next"
+
+A `previous` link header (and hal link) would not be included, because the previous page does not exist.

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/EntityDataAccessImplementor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/EntityDataAccessImplementor.java
@@ -9,7 +9,9 @@ import javax.persistence.EntityManager;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
+import io.quarkus.panache.common.Page;
 import io.quarkus.rest.data.panache.deployment.DataAccessImplementor;
 
 final class EntityDataAccessImplementor implements DataAccessImplementor {
@@ -31,6 +33,13 @@ final class EntityDataAccessImplementor implements DataAccessImplementor {
     }
 
     @Override
+    public ResultHandle findAll(BytecodeCreator creator, ResultHandle page) {
+        ResultHandle query = creator.invokeStaticMethod(ofMethod(entityClassName, "findAll", PanacheQuery.class));
+        creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "page", PanacheQuery.class, Page.class), query, page);
+        return creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "list", List.class), query);
+    }
+
+    @Override
     public ResultHandle persist(BytecodeCreator creator, ResultHandle entity) {
         creator.invokeVirtualMethod(ofMethod(entityClassName, "persist", void.class), entity);
         return entity;
@@ -47,5 +56,12 @@ final class EntityDataAccessImplementor implements DataAccessImplementor {
     @Override
     public ResultHandle deleteById(BytecodeCreator creator, ResultHandle id) {
         return creator.invokeStaticMethod(ofMethod(entityClassName, "deleteById", boolean.class, Object.class), id);
+    }
+
+    @Override
+    public ResultHandle pageCount(BytecodeCreator creator, ResultHandle page) {
+        ResultHandle query = creator.invokeStaticMethod(ofMethod(entityClassName, "findAll", PanacheQuery.class));
+        creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "page", PanacheQuery.class, Page.class), query, page);
+        return creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "pageCount", int.class), query);
     }
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/RepositoryDataAccessImplementor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/RepositoryDataAccessImplementor.java
@@ -12,8 +12,10 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
+import io.quarkus.panache.common.Page;
 import io.quarkus.rest.data.panache.deployment.DataAccessImplementor;
 
 final class RepositoryDataAccessImplementor implements DataAccessImplementor {
@@ -37,6 +39,14 @@ final class RepositoryDataAccessImplementor implements DataAccessImplementor {
     }
 
     @Override
+    public ResultHandle findAll(BytecodeCreator creator, ResultHandle page) {
+        ResultHandle query = creator.invokeInterfaceMethod(ofMethod(PanacheRepositoryBase.class, "findAll", PanacheQuery.class),
+                getRepositoryInstance(creator));
+        creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "page", PanacheQuery.class, Page.class), query, page);
+        return creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "list", List.class), query);
+    }
+
+    @Override
     public ResultHandle persist(BytecodeCreator creator, ResultHandle entity) {
         creator.invokeInterfaceMethod(ofMethod(PanacheRepositoryBase.class, "persist", void.class, Object.class),
                 getRepositoryInstance(creator), entity);
@@ -55,6 +65,14 @@ final class RepositoryDataAccessImplementor implements DataAccessImplementor {
     public ResultHandle deleteById(BytecodeCreator creator, ResultHandle id) {
         return creator.invokeInterfaceMethod(ofMethod(PanacheRepositoryBase.class, "deleteById", boolean.class, Object.class),
                 getRepositoryInstance(creator), id);
+    }
+
+    @Override
+    public ResultHandle pageCount(BytecodeCreator creator, ResultHandle page) {
+        ResultHandle query = creator.invokeInterfaceMethod(ofMethod(PanacheRepositoryBase.class, "findAll", PanacheQuery.class),
+                getRepositoryInstance(creator));
+        creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "page", PanacheQuery.class, Page.class), query, page);
+        return creator.invokeInterfaceMethod(ofMethod(PanacheQuery.class, "pageCount", int.class), query);
     }
 
     private ResultHandle getRepositoryInstance(BytecodeCreator creator) {

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HotReloadTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HotReloadTest.java
@@ -22,7 +22,7 @@ public class HotReloadTest {
     @Test
     public void shouldModifyPathAndDisableHal() {
         TEST.modifySourceFile(CollectionsController.class,
-                s -> s.replace("@ResourceProperties(hal = true)", "@ResourceProperties(path = \"col\")"));
+                s -> s.replace("@ResourceProperties(hal = true, paged = false)", "@ResourceProperties(path = \"col\")"));
         given().accept("application/json")
                 .when().get("/col")
                 .then().statusCode(200);

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/PathCustomisationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/PathCustomisationTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -72,7 +71,7 @@ class PathCustomisationTest {
     public interface CustomPathCollectionsController extends PanacheEntityResource<Collection, String> {
 
         @MethodProperties(path = "api")
-        List<Collection> list();
+        javax.ws.rs.core.Response list();
 
         @MethodProperties(path = "api")
         Collection get(String name);

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/CollectionsController.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/CollectionsController.java
@@ -3,6 +3,6 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true)
+@ResourceProperties(hal = true, paged = false)
 public interface CollectionsController extends PanacheEntityResource<Collection, String> {
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsController.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsController.java
@@ -3,6 +3,6 @@ package io.quarkus.hibernate.orm.rest.data.panache.deployment.repository;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true)
+@ResourceProperties(hal = true, paged = false)
 public interface CollectionsController extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
 }

--- a/extensions/panache/rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/rest-data-panache/deployment/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-panache-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/DataAccessImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/DataAccessImplementor.java
@@ -9,9 +9,13 @@ public interface DataAccessImplementor {
 
     ResultHandle listAll(BytecodeCreator creator);
 
+    ResultHandle findAll(BytecodeCreator creator, ResultHandle page);
+
     ResultHandle persist(BytecodeCreator creator, ResultHandle entity);
 
     ResultHandle update(BytecodeCreator creator, ResultHandle entity);
 
     ResultHandle deleteById(BytecodeCreator creator, ResultHandle id);
+
+    ResultHandle pageCount(BytecodeCreator creator, ResultHandle page);
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/PrivateFields.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/PrivateFields.java
@@ -1,0 +1,28 @@
+package io.quarkus.rest.data.panache.deployment;
+
+import javax.ws.rs.core.UriInfo;
+
+public final class PrivateFields {
+
+    public static final Field URI_INFO = new Field("uriInfo", UriInfo.class);
+
+    public static final class Field {
+
+        private final String name;
+
+        private final Class<?> type;
+
+        public Field(String name, Class<?> type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Class<?> getType() {
+            return type;
+        }
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/PrivateMethods.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/PrivateMethods.java
@@ -1,0 +1,32 @@
+package io.quarkus.rest.data.panache.deployment;
+
+public final class PrivateMethods {
+
+    public static final Method IS_PAGED = new Method("isPaged", boolean.class.getTypeName(), new String[0]);
+
+    public static final class Method {
+        private final String name;
+
+        private final String type;
+
+        private final String[] params;
+
+        public Method(String name, String type, String[] params) {
+            this.name = name;
+            this.type = type;
+            this.params = params;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String[] getParams() {
+            return params;
+        }
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataResourceImplementor.java
@@ -1,9 +1,11 @@
 package io.quarkus.rest.data.panache.deployment;
 
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 
 import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
 
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
@@ -21,6 +23,7 @@ import io.quarkus.rest.data.panache.deployment.methods.hal.AddHalMethodImplement
 import io.quarkus.rest.data.panache.deployment.methods.hal.GetHalMethodImplementor;
 import io.quarkus.rest.data.panache.deployment.methods.hal.ListHalMethodImplementor;
 import io.quarkus.rest.data.panache.deployment.methods.hal.UpdateHalMethodImplementor;
+import io.quarkus.rest.data.panache.deployment.methods.internal.IsPagedMethodImplementor;
 import io.quarkus.rest.data.panache.deployment.properties.MethodPropertiesAccessor;
 import io.quarkus.rest.data.panache.deployment.properties.ResourcePropertiesAccessor;
 
@@ -64,9 +67,18 @@ class RestDataResourceImplementor {
                 .build();
         classCreator.addAnnotation(Path.class)
                 .addValue("value", resourcePropertiesAccessor.path(resourceInfo.getClassInfo()));
+        implementPrivateFields(classCreator);
         implementMethods(classCreator, resourceInfo);
+        implementPrivateMethods(classCreator, resourceInfo);
+
         classCreator.close();
         LOGGER.tracef("Completed generation of '%s'", implementationClassName);
+    }
+
+    private void implementPrivateFields(ClassCreator classCreator) {
+        classCreator.getFieldCreator(PrivateFields.URI_INFO.getName(), PrivateFields.URI_INFO.getType())
+                .setModifiers(Modifier.PRIVATE)
+                .addAnnotation(Context.class);
     }
 
     private void implementMethods(ClassCreator classCreator, RestDataResourceInfo resourceInfo) {
@@ -78,5 +90,10 @@ class RestDataResourceImplementor {
                 methodImplementor.implement(classCreator, index, methodPropertiesAccessor, resourceInfo);
             }
         }
+    }
+
+    private void implementPrivateMethods(ClassCreator classCreator, RestDataResourceInfo resourceInfo) {
+        new IsPagedMethodImplementor(resourcePropertiesAccessor.isPaged(resourceInfo.getClassInfo()))
+                .implement(classCreator, index, methodPropertiesAccessor, resourceInfo);
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -1,14 +1,27 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
-import java.util.List;
+import static io.quarkus.gizmo.FieldDescriptor.of;
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+import static io.quarkus.rest.data.panache.deployment.PrivateFields.URI_INFO;
+import static io.quarkus.rest.data.panache.deployment.PrivateMethods.IS_PAGED;
+
+import javax.ws.rs.core.Response;
 
 import org.jboss.jandex.IndexView;
 
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.rest.data.panache.RestDataResource;
+import io.quarkus.rest.data.panache.deployment.DataAccessImplementor;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceInfo;
 import io.quarkus.rest.data.panache.deployment.properties.MethodPropertiesAccessor;
+import io.quarkus.rest.data.panache.deployment.utils.PaginationImplementor;
+import io.quarkus.rest.data.panache.deployment.utils.ResponseImplementor;
 
 public final class ListMethodImplementor extends StandardMethodImplementor {
 
@@ -29,8 +42,19 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
      *         rel = "list",
      *         entityClassName = "com.example.Entity"
      *     )
-     *     public List list() {
-     *         return Entity.listAll();
+     *     public Response list() {
+     *         if (this.isPaged()) {
+     *            Page page = ...; // Extract page index and size from a UriInfo field and create a page instance.
+     *            PanacheQuery query = Entity.findAll();
+     *            query.page(page);
+     *            // Get the page count, and build first, last, next, previous page instances
+     *            Response.ResponseBuilder responseBuilder = Response.status(200);
+     *            responseBuilder.entity(query.list());
+     *            // Add headers with first, last, next and previous page URIs if they exist
+     *            return responseBuilder.build();
+     *         } else {
+     *             return Response.ok(Entity.listAll()).build();
+     *         }
      *     }
      * }
      * </pre>
@@ -39,18 +63,40 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, IndexView index, MethodPropertiesAccessor propertiesAccessor,
             RestDataResourceInfo resourceInfo) {
         MethodMetadata methodMetadata = getMethodMetadata(resourceInfo);
-        MethodCreator methodCreator = classCreator.getMethodCreator(methodMetadata.getName(), List.class);
+        MethodCreator methodCreator = classCreator.getMethodCreator(methodMetadata.getName(), Response.class);
         addGetAnnotation(methodCreator);
         addPathAnnotation(methodCreator, propertiesAccessor.getPath(resourceInfo.getClassInfo(), methodMetadata));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceInfo.getEntityClassName(), REL);
 
-        methodCreator.returnValue(resourceInfo.getDataAccessImplementor().listAll(methodCreator));
+        FieldDescriptor uriInfoField = of(methodCreator.getMethodDescriptor().getDeclaringClass(), URI_INFO.getName(),
+                URI_INFO.getType());
+        MethodDescriptor isPagedMethod = ofMethod(methodCreator.getMethodDescriptor().getDeclaringClass(), IS_PAGED.getName(),
+                IS_PAGED.getType(), IS_PAGED.getParams());
+
+        BranchResult isPaged = methodCreator.ifTrue(methodCreator.invokeVirtualMethod(isPagedMethod, methodCreator.getThis()));
+        returnPaged(isPaged.trueBranch(), resourceInfo.getDataAccessImplementor(), uriInfoField);
+        returnNotPaged(isPaged.falseBranch(), resourceInfo.getDataAccessImplementor());
         methodCreator.close();
     }
 
     @Override
     protected MethodMetadata getMethodMetadata(RestDataResourceInfo resourceInfo) {
         return new MethodMetadata(NAME);
+    }
+
+    private void returnPaged(BytecodeCreator creator, DataAccessImplementor dataAccessImplementor,
+            FieldDescriptor uriInfoField) {
+        ResultHandle uriInfo = creator.readInstanceField(uriInfoField, creator.getThis());
+        ResultHandle page = PaginationImplementor.getRequestPage(creator, uriInfo);
+        ResultHandle pageCount = dataAccessImplementor.pageCount(creator, page);
+        ResultHandle links = PaginationImplementor.getLinks(creator, uriInfo, page, pageCount);
+        ResultHandle entities = dataAccessImplementor.findAll(creator, page);
+
+        creator.returnValue(ResponseImplementor.ok(creator, entities, links));
+    }
+
+    private void returnNotPaged(BytecodeCreator creator, DataAccessImplementor dataAccessImplementor) {
+        creator.returnValue(ResponseImplementor.ok(creator, dataAccessImplementor.listAll(creator)));
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
@@ -35,7 +35,7 @@ abstract class HalMethodImplementor implements MethodImplementor {
         return creator.newInstance(MethodDescriptor.ofConstructor(HalEntityWrapper.class, Object.class), entity);
     }
 
-    protected ResultHandle wrapEntities(BytecodeCreator creator, ResultHandle entities, RestDataResourceInfo resourceInfo) {
+    protected ResultHandle wrapHalEntities(BytecodeCreator creator, ResultHandle entities, RestDataResourceInfo resourceInfo) {
         String collectionName = ResourceName.fromClass(resourceInfo.getClassInfo().simpleName());
         return creator.newInstance(
                 MethodDescriptor.ofConstructor(HalCollectionWrapper.class, Collection.class, Class.class, String.class),

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -1,9 +1,21 @@
 package io.quarkus.rest.data.panache.deployment.methods.hal;
 
+import static io.quarkus.gizmo.FieldDescriptor.of;
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+import static io.quarkus.rest.data.panache.deployment.PrivateFields.URI_INFO;
+import static io.quarkus.rest.data.panache.deployment.PrivateMethods.IS_PAGED;
+
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+
 import org.jboss.jandex.IndexView;
 
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceInfo;
@@ -11,6 +23,8 @@ import io.quarkus.rest.data.panache.deployment.methods.ListMethodImplementor;
 import io.quarkus.rest.data.panache.deployment.methods.MethodImplementor;
 import io.quarkus.rest.data.panache.deployment.methods.MethodMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.MethodPropertiesAccessor;
+import io.quarkus.rest.data.panache.deployment.utils.PaginationImplementor;
+import io.quarkus.rest.data.panache.deployment.utils.ResponseImplementor;
 import io.quarkus.rest.data.panache.runtime.hal.HalCollectionWrapper;
 
 public final class ListHalMethodImplementor extends HalMethodImplementor {
@@ -26,9 +40,23 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
      *     &#64;GET
      *     &#64;Path("")
      *     &#64;Produces({"application/hal+json"})
-     *     public HalCollectionWrapper listHal() {
-     *         List entities = BookEntity.listAll();
-     *         return new HalCollectionWrapper(entities, Entity.class, "entities");
+     *     public Response listHal() {
+     *         if (this.isPaged()) {
+     *            Page page = ...; // Extract page index and size from a UriInfo field and create a page instance.
+     *            PanacheQuery query = Entity.findAll();
+     *            query.page(page);
+     *            List entities = query.list();
+     *            // Get the page count, and build first, last, next, previous page instances
+     *            HalCollectionWrapper wrapper = new HalCollectionWrapper(entities, Entity.class, "entities");
+     *            // Add first, last, next and previous page URIs to the wrapper if they exist
+     *            Response.ResponseBuilder responseBuilder = Response.status(200);
+     *            responseBuilder.entity(wrapper);
+     *            // Add headers with first, last, next and previous page URIs if they exist
+     *            return responseBuilder.build();
+     *         } else {
+     *             List entities = Entity.listAll();
+     *             return Response.ok(new HalCollectionWrapper(entities, Entity.class, "entities")).build();
+     *         }
      *     }
      * }
      * </pre>
@@ -36,19 +64,42 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
     @Override
     protected void implementInternal(ClassCreator classCreator, IndexView index, MethodPropertiesAccessor propertiesAccessor,
             RestDataResourceInfo resourceInfo) {
-        MethodCreator methodCreator = classCreator.getMethodCreator(NAME, HalCollectionWrapper.class);
+        MethodCreator methodCreator = classCreator.getMethodCreator(NAME, Response.class);
         addGetAnnotation(methodCreator);
         addPathAnnotation(methodCreator,
                 propertiesAccessor.getPath(resourceInfo.getClassInfo(), getStandardMethodMetadata(resourceInfo)));
         addProducesAnnotation(methodCreator, MethodImplementor.APPLICATION_HAL_JSON);
 
-        ResultHandle entities = resourceInfo.getDataAccessImplementor().listAll(methodCreator);
-        methodCreator.returnValue(wrapEntities(methodCreator, entities, resourceInfo));
+        FieldDescriptor uriInfoField = of(methodCreator.getMethodDescriptor().getDeclaringClass(), URI_INFO.getName(),
+                URI_INFO.getType());
+        MethodDescriptor isPagedMethod = ofMethod(methodCreator.getMethodDescriptor().getDeclaringClass(), IS_PAGED.getName(),
+                IS_PAGED.getType(), IS_PAGED.getParams());
+
+        BranchResult isPaged = methodCreator.ifTrue(methodCreator.invokeVirtualMethod(isPagedMethod, methodCreator.getThis()));
+        returnPaged(isPaged.trueBranch(), resourceInfo, uriInfoField);
+        returnNotPaged(isPaged.falseBranch(), resourceInfo);
         methodCreator.close();
     }
 
     @Override
     protected MethodMetadata getStandardMethodMetadata(RestDataResourceInfo resourceInfo) {
         return new MethodMetadata(ListMethodImplementor.NAME);
+    }
+
+    private void returnPaged(BytecodeCreator creator, RestDataResourceInfo resourceInfo, FieldDescriptor uriInfoField) {
+        ResultHandle uriInfo = creator.readInstanceField(uriInfoField, creator.getThis());
+        ResultHandle page = PaginationImplementor.getRequestPage(creator, uriInfo);
+        ResultHandle pageCount = resourceInfo.getDataAccessImplementor().pageCount(creator, page);
+        ResultHandle links = PaginationImplementor.getLinks(creator, uriInfo, page, pageCount);
+        ResultHandle entities = resourceInfo.getDataAccessImplementor().findAll(creator, page);
+        ResultHandle wrapper = wrapHalEntities(creator, entities, resourceInfo);
+        creator.invokeVirtualMethod(ofMethod(HalCollectionWrapper.class, "addLinks", void.class, Link[].class), wrapper, links);
+
+        creator.returnValue(ResponseImplementor.ok(creator, wrapper, links));
+    }
+
+    private void returnNotPaged(BytecodeCreator creator, RestDataResourceInfo resourceInfo) {
+        ResultHandle entities = resourceInfo.getDataAccessImplementor().listAll(creator);
+        creator.returnValue(ResponseImplementor.ok(creator, wrapHalEntities(creator, entities, resourceInfo)));
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/internal/IsPagedMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/internal/IsPagedMethodImplementor.java
@@ -1,0 +1,31 @@
+package io.quarkus.rest.data.panache.deployment.methods.internal;
+
+import java.lang.reflect.Modifier;
+
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.rest.data.panache.deployment.PrivateMethods;
+import io.quarkus.rest.data.panache.deployment.RestDataResourceInfo;
+import io.quarkus.rest.data.panache.deployment.methods.MethodImplementor;
+import io.quarkus.rest.data.panache.deployment.properties.MethodPropertiesAccessor;
+
+public class IsPagedMethodImplementor implements MethodImplementor {
+
+    private final boolean isPaged;
+
+    public IsPagedMethodImplementor(boolean isPaged) {
+        this.isPaged = isPaged;
+    }
+
+    @Override
+    public void implement(ClassCreator classCreator, IndexView index, MethodPropertiesAccessor propertiesAccessor,
+            RestDataResourceInfo resourceInfo) {
+        MethodCreator methodCreator = classCreator
+                .getMethodCreator(PrivateMethods.IS_PAGED.getName(), PrivateMethods.IS_PAGED.getType())
+                .setModifiers(Modifier.PRIVATE);
+        methodCreator.returnValue(methodCreator.load(isPaged));
+        methodCreator.close();
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesAccessor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesAccessor.java
@@ -33,6 +33,13 @@ public class ResourcePropertiesAccessor {
         return annotation.value("path").asString();
     }
 
+    public boolean isPaged(ClassInfo classInfo) {
+        AnnotationInstance annotation = getAnnotation(classInfo);
+        return annotation == null
+                || annotation.value("paged") == null
+                || annotation.value("paged").asBoolean();
+    }
+
     private AnnotationInstance getAnnotation(ClassInfo classInfo) {
         if (classInfo.classAnnotation(RESOURCE_PROPERTIES_ANNOTATION) != null) {
             return classInfo.classAnnotation(RESOURCE_PROPERTIES_ANNOTATION);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/PaginationImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/PaginationImplementor.java
@@ -1,0 +1,150 @@
+package io.quarkus.rest.data.panache.deployment.utils;
+
+import static io.quarkus.gizmo.MethodDescriptor.ofConstructor;
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
+import io.quarkus.panache.common.Page;
+
+public final class PaginationImplementor {
+
+    /**
+     * Extracts page and size query parameters from the URI and returns the {@link Page} instance.
+     * If page index or size is invalid - default value is used.
+     *
+     * @param creator a bytecode creator to be used for code generation
+     * @param uriInfo a {@link UriInfo} instance to extract the query parameters form
+     * @return a {@link Page} instance
+     */
+    public static ResultHandle getRequestPage(BytecodeCreator creator, ResultHandle uriInfo) {
+        ResultHandle queryParams = creator.invokeInterfaceMethod(
+                ofMethod(UriInfo.class, "getQueryParameters", MultivaluedMap.class), uriInfo);
+        AssignableResultHandle page = creator.createVariable(Integer.class);
+        assignIntQueryParam(creator, queryParams, "page", 0, 0, page);
+        AssignableResultHandle size = creator.createVariable(Integer.class);
+        assignIntQueryParam(creator, queryParams, "size", 1, 20, size);
+        return creator.invokeStaticMethod(ofMethod(Page.class, "of", Page.class, int.class, int.class), page, size);
+    }
+
+    private static void assignIntQueryParam(BytecodeCreator creator, ResultHandle queryParams, String key, int minValue,
+            int defaultValue, AssignableResultHandle variable) {
+        ResultHandle stringValue = creator.invokeInterfaceMethod(
+                ofMethod(MultivaluedMap.class, "getFirst", Object.class, Object.class), queryParams, creator.load(key));
+        TryBlock tryBlock = creator.tryBlock();
+
+        // Catch NumberFormatException and return default
+        CatchBlockCreator catchBlockCreator = tryBlock.addCatch(NumberFormatException.class);
+        catchBlockCreator.assign(variable, catchBlockCreator.load(defaultValue));
+
+        // Parse int and return that or default
+        ResultHandle value = tryBlock.invokeStaticMethod(
+                ofMethod(Integer.class, "parseInt", int.class, String.class), stringValue);
+        BranchResult valueIsTooSmall = tryBlock.ifIntegerLessThan(value, tryBlock.load(minValue));
+        valueIsTooSmall.trueBranch().assign(variable, tryBlock.load(defaultValue));
+        valueIsTooSmall.falseBranch().assign(variable, value);
+    }
+
+    /**
+     * Return an array with the links applicable for the provided page and page count.
+     */
+    public static ResultHandle getLinks(BytecodeCreator creator, ResultHandle uriInfo, ResultHandle page,
+            ResultHandle pageCount) {
+        ResultHandle links = creator.newInstance(ofConstructor(ArrayList.class, int.class), creator.load(4));
+
+        ResultHandle firstPage = creator.invokeVirtualMethod(ofMethod(Page.class, "first", Page.class), page);
+        ResultHandle firstPageLink = getLink(creator, uriInfo, firstPage, "first");
+        creator.invokeInterfaceMethod(ofMethod(List.class, "add", boolean.class, Object.class), links, firstPageLink);
+
+        ResultHandle lastPage = getLastPage(creator, page, pageCount);
+        ResultHandle lastPageLink = getLink(creator, uriInfo, lastPage, "last");
+        creator.invokeInterfaceMethod(ofMethod(List.class, "add", boolean.class, Object.class), links, lastPageLink);
+
+        BytecodeCreator previousPageCreator = isTheSamePage(creator, page, firstPage).falseBranch();
+        ResultHandle previousPage = previousPageCreator.invokeVirtualMethod(ofMethod(Page.class, "previous", Page.class), page);
+        ResultHandle previousPageLink = getLink(previousPageCreator, uriInfo, previousPage, "previous");
+        previousPageCreator.invokeInterfaceMethod(
+                ofMethod(List.class, "add", boolean.class, Object.class), links, previousPageLink);
+
+        BytecodeCreator nextPageCreator = isTheSamePage(creator, page, lastPage).falseBranch();
+        ResultHandle nextPage = nextPageCreator.invokeVirtualMethod(ofMethod(Page.class, "next", Page.class), page);
+        ResultHandle nextPageLink = getLink(nextPageCreator, uriInfo, nextPage, "next");
+        nextPageCreator.invokeInterfaceMethod(ofMethod(List.class, "add", boolean.class, Object.class), links, nextPageLink);
+
+        ResultHandle linksCount = creator.invokeInterfaceMethod(ofMethod(List.class, "size", int.class), links);
+        ResultHandle linksArray = creator.newArray(Link.class, linksCount);
+        return creator.invokeInterfaceMethod(
+                ofMethod(List.class, "toArray", Object[].class, Object[].class), links, linksArray);
+    }
+
+    private static ResultHandle getLink(BytecodeCreator creator, ResultHandle uriInfo, ResultHandle page, String rel) {
+        ResultHandle builder = creator.invokeStaticMethod(
+                ofMethod(Link.class, "fromUri", Link.Builder.class, URI.class), getPageUri(creator, uriInfo, page));
+        creator.invokeInterfaceMethod(ofMethod(Link.Builder.class, "rel", Link.Builder.class, String.class),
+                builder, creator.load(rel));
+        return creator.invokeInterfaceMethod(ofMethod(Link.Builder.class, "build", Link.class, Object[].class),
+                builder, creator.newArray(Object.class, 0));
+    }
+
+    /**
+     * Build a {@link URI} for the given page. Takes the absolute path from the given {@link UriInfo} and appends page and size
+     * query parameters from the given {@link Page}.
+     *
+     * @param creator a bytecode creator to be used for code generation
+     * @param uriInfo a {@link UriInfo} to be used for the absolute path extraction
+     * @param page a {@link Page} to be used for getting page number and size
+     * @return a page {@link URI}
+     */
+    private static ResultHandle getPageUri(BytecodeCreator creator, ResultHandle uriInfo, ResultHandle page) {
+        ResultHandle uriBuilder = creator.invokeInterfaceMethod(
+                ofMethod(UriInfo.class, "getAbsolutePathBuilder", UriBuilder.class), uriInfo);
+
+        // Add page query parameter
+        ResultHandle index = creator.readInstanceField(FieldDescriptor.of(Page.class, "index", int.class), page);
+        creator.invokeVirtualMethod(
+                ofMethod(UriBuilder.class, "queryParam", UriBuilder.class, String.class, Object[].class),
+                uriBuilder, creator.load("page"), creator.marshalAsArray(Object.class, index));
+
+        // Add size query parameter
+        ResultHandle size = creator.readInstanceField(FieldDescriptor.of(Page.class, "size", int.class), page);
+        creator.invokeVirtualMethod(
+                ofMethod(UriBuilder.class, "queryParam", UriBuilder.class, String.class, Object[].class),
+                uriBuilder, creator.load("size"), creator.marshalAsArray(Object.class, size));
+
+        return creator.invokeVirtualMethod(
+                ofMethod(UriBuilder.class, "build", URI.class, Object[].class), uriBuilder, creator.newArray(Object.class, 0));
+    }
+
+    /**
+     * Returns the last page with the same size as the provided page.
+     */
+    private static ResultHandle getLastPage(BytecodeCreator creator, ResultHandle page, ResultHandle pageCount) {
+        ResultHandle pageNumber = creator.invokeStaticMethod(
+                ofMethod(Integer.class, "sum", int.class, int.class, int.class), pageCount, creator.load(-1));
+        return creator.invokeVirtualMethod(
+                ofMethod(Page.class, "index", Page.class, int.class), page, pageNumber);
+    }
+
+    /**
+     * Compares indexes of two pages.
+     */
+    private static BranchResult isTheSamePage(BytecodeCreator creator, ResultHandle page, ResultHandle anotherPage) {
+        ResultHandle index = creator.readInstanceField(FieldDescriptor.of(Page.class, "index", int.class), page);
+        ResultHandle anotherIndex = creator.readInstanceField(FieldDescriptor.of(Page.class, "index", int.class), anotherPage);
+        return creator.ifIntegerEqual(index, anotherIndex);
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
@@ -1,8 +1,11 @@
 package io.quarkus.rest.data.panache.deployment.utils;
 
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+
 import java.net.URI;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
@@ -13,30 +16,39 @@ import io.quarkus.rest.data.panache.runtime.resource.ResourceLinksProvider;
 
 public final class ResponseImplementor {
 
+    public static ResultHandle ok(BytecodeCreator creator, ResultHandle entity) {
+        ResultHandle builder = creator.invokeStaticMethod(
+                ofMethod(Response.class, "ok", ResponseBuilder.class, Object.class), entity);
+        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+    }
+
+    public static ResultHandle ok(BytecodeCreator creator, ResultHandle entity, ResultHandle links) {
+        ResultHandle builder = creator.invokeStaticMethod(
+                ofMethod(Response.class, "ok", ResponseBuilder.class, Object.class), entity);
+        creator.invokeVirtualMethod(
+                ofMethod(ResponseBuilder.class, "links", ResponseBuilder.class, Link[].class), builder, links);
+        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+    }
+
     public static ResultHandle created(BytecodeCreator creator, ResultHandle entity) {
         return created(creator, entity, getEntityUrl(creator, entity));
     }
 
     public static ResultHandle created(BytecodeCreator creator, ResultHandle entity, ResultHandle location) {
         ResultHandle builder = getResponseBuilder(creator, Response.Status.CREATED.getStatusCode());
-
         creator.invokeVirtualMethod(
-                MethodDescriptor.ofMethod(ResponseBuilder.class, "entity", ResponseBuilder.class, Object.class), builder,
-                entity);
+                ofMethod(ResponseBuilder.class, "entity", ResponseBuilder.class, Object.class), builder, entity);
         creator.invokeVirtualMethod(
-                MethodDescriptor.ofMethod(ResponseBuilder.class, "location", ResponseBuilder.class, URI.class), builder,
-                location);
-
-        return creator.invokeVirtualMethod(MethodDescriptor.ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+                ofMethod(ResponseBuilder.class, "location", ResponseBuilder.class, URI.class), builder, location);
+        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
     }
 
     public static ResultHandle getEntityUrl(BytecodeCreator creator, ResultHandle entity) {
         ResultHandle linksProvider = creator.newInstance(MethodDescriptor.ofConstructor(ResourceLinksProvider.class));
         ResultHandle link = creator.invokeVirtualMethod(
-                MethodDescriptor.ofMethod(ResourceLinksProvider.class, "getSelfLink", String.class, Object.class),
-                linksProvider, entity);
+                ofMethod(ResourceLinksProvider.class, "getSelfLink", String.class, Object.class), linksProvider, entity);
         creator.ifNull(link).trueBranch().throwException(RuntimeException.class, "Could not extract a new entity URL");
-        return creator.invokeStaticMethod(MethodDescriptor.ofMethod(URI.class, "create", URI.class, String.class), link);
+        return creator.invokeStaticMethod(ofMethod(URI.class, "create", URI.class, String.class), link);
     }
 
     public static ResultHandle noContent(BytecodeCreator creator) {
@@ -50,12 +62,11 @@ public final class ResponseImplementor {
 
     private static ResultHandle status(BytecodeCreator creator, int status) {
         ResultHandle builder = getResponseBuilder(creator, status);
-
-        return creator.invokeVirtualMethod(MethodDescriptor.ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
     }
 
     private static ResultHandle getResponseBuilder(BytecodeCreator creator, int status) {
         return creator.invokeStaticMethod(
-                MethodDescriptor.ofMethod(Response.class, "status", ResponseBuilder.class, int.class), creator.load(status));
+                ofMethod(Response.class, "status", ResponseBuilder.class, int.class), creator.load(status));
     }
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ResourceProperties.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ResourceProperties.java
@@ -33,4 +33,13 @@ public @interface ResourceProperties {
      * Default: hyphenated resource name without a suffix. Ignored suffixes are `Controller` and `Resource`.
      */
     String path() default "";
+
+    /**
+     * Return a paged collection from the methods that return collections.
+     * Requested page number and size are extracted from the query parameters `page` (default 0) and `size` (default 20).
+     * These additional headers are injected to the response: first, last, prev (if exists), next (if exists).
+     * <p>
+     * Default: true.
+     */
+    boolean paged() default true;
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataResource.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataResource.java
@@ -1,7 +1,5 @@
 package io.quarkus.rest.data.panache;
 
-import java.util.List;
-
 import javax.ws.rs.core.Response;
 
 /**
@@ -16,12 +14,13 @@ import javax.ws.rs.core.Response;
 public interface RestDataResource<Entity, ID> {
 
     /**
-     * Return all entities as a JSON array.
+     * Return all entities as a JSON array.The response is paged by default, but that could be disabled with
+     * {@link ResourceProperties} annotation.
      * Response content type: application/json.
      *
      * @return A response with a JSON array of all entities.
      */
-    List<Entity> list();
+    Response list();
 
     /**
      * Return an entity as a JSON object.

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/HalCollectionWrapper.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/HalCollectionWrapper.java
@@ -1,6 +1,10 @@
 package io.quarkus.rest.data.panache.runtime.hal;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.Link;
 
 public class HalCollectionWrapper {
 
@@ -9,6 +13,8 @@ public class HalCollectionWrapper {
     private final Class<?> elementType;
 
     private final String collectionName;
+
+    private final Map<String, HalLink> links = new HashMap<>();
 
     public HalCollectionWrapper(Collection<Object> collection, Class<?> elementType, String collectionName) {
         this.collection = collection;
@@ -26,5 +32,15 @@ public class HalCollectionWrapper {
 
     public String getCollectionName() {
         return collectionName;
+    }
+
+    public Map<String, HalLink> getLinks() {
+        return links;
+    }
+
+    public void addLinks(Link... links) {
+        for (Link link : links) {
+            this.links.put(link.getRel(), new HalLink(link.getUri().toString()));
+        }
     }
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/HalCollectionWrapperJacksonSerializer.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/HalCollectionWrapperJacksonSerializer.java
@@ -45,6 +45,7 @@ public class HalCollectionWrapperJacksonSerializer extends JsonSerializer<HalCol
 
     private void writeLinks(HalCollectionWrapper wrapper, JsonGenerator generator) throws IOException {
         Map<String, HalLink> links = linksExtractor.getLinks(wrapper.getElementType());
+        links.putAll(wrapper.getLinks());
         generator.writeFieldName("_links");
         generator.writeObject(links);
     }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/HalCollectionWrapperJsonbSerializer.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/runtime/hal/HalCollectionWrapperJsonbSerializer.java
@@ -22,7 +22,7 @@ public class HalCollectionWrapperJsonbSerializer implements JsonbSerializer<HalC
     public void serialize(HalCollectionWrapper wrapper, JsonGenerator generator, SerializationContext context) {
         generator.writeStartObject();
         writeEmbedded(wrapper, generator, context);
-        writeLinks(wrapper.getElementType(), generator, context);
+        writeLinks(wrapper, generator, context);
         generator.writeEnd();
     }
 
@@ -38,8 +38,9 @@ public class HalCollectionWrapperJsonbSerializer implements JsonbSerializer<HalC
         generator.writeEnd();
     }
 
-    private void writeLinks(Class<?> type, JsonGenerator generator, SerializationContext context) {
-        Map<String, HalLink> links = linksExtractor.getLinks(type);
+    private void writeLinks(HalCollectionWrapper wrapper, JsonGenerator generator, SerializationContext context) {
+        Map<String, HalLink> links = linksExtractor.getLinks(wrapper.getElementType());
+        links.putAll(wrapper.getLinks());
         context.serialize("_links", links, generator);
     }
 }


### PR DESCRIPTION
I know we've discussed about adding a more generic JAX-RS pagination feature a couple of weeks ago. But since it seems that it would go to a Panache RESTEasy extension, which might take a while, I've decided to implement a basic pagination for the REST Data module because not having it limits the usefulness of the extension a lot.

WDYT @geoand @FroMage 