### PR TITLE
Update non-native base image to ubi8/openjdk-11

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift-s2i.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift-s2i.adoc
@@ -126,7 +126,7 @@ We are going to create an OpenShift `build` executing it:
 [source,shell, subs="attributes"]
 ----
 # To build the image on OpenShift
-oc new-app registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift~{quickstarts-clone-url} --context-dir=getting-started --name=quarkus-quickstart
+oc new-app registry.access.redhat.com/ubi8/openjdk-11:latest~{quickstarts-clone-url} --context-dir=getting-started --name=quarkus-quickstart
 oc logs -f bc/quarkus-quickstart
 
 # To create the route


### PR DESCRIPTION
The ubi8/openjdk-8 image, based upon RHEL 8 UBI, is available legitimately without a Red Hat subscription under the terms of the UBI EULA. The older (RHEL7-based) image, although it can be pulled unauthenticated from the Red Hat registry, is not intended to be a publically available image.

I tested the quickstart with the ubi8/openjdk-8 image and it works.