### PR TITLE
Fix panache/kotlin test that breaks build

### DIFF
--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/TestEndpointRunner.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/TestEndpointRunner.kt
@@ -62,7 +62,7 @@ class TestEndpointRunner {
         invokeNonOverload { addressDao.count() }
 
         invokeNonOverload { addressDao.findById(12) }
-        invokeNonOverload { Address.findById(12) }
+        invokeNonOverload { Address.findById(12L) }
     }
 
     private fun invokeOverload(function: () -> Any?) {


### PR DESCRIPTION
I don't know if kotlin or Panache is supposed to autocast a int to a long or not.  Also not sure how this test got into master.  Is somebody merging without passing a build?