### PR TITLE
Improved getting started reactive

### DIFF
--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -594,6 +594,25 @@ This resource returns `Uni` and `Multi` instances based on the result produced b
 
 The previous example uses a _service_ provided by Quarkus.
 Also, you can use Vert.x clients directly.
+
+First of all, make sure the `quarkus-vertx` extension is present. If not, activate the extension by executing the following command:
+
+[source,shell,subs=attributes+]
+----
+mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:add-extensions \
+    -Dextensions=vertx
+----
+
+Or add `quarkus-vertx` into your dependencies manually.
+
+[source, xml]
+----
+<dependency>
+	<groupId>io.quarkus</groupId>
+	<artifactId>quarkus-vertx</artifactId>
+</dependency>
+----
+
 There is a Mutiny version of the Vert.x APIs.
 This API is divided into several artifacts you can import independently:
 


### PR DESCRIPTION
For the first time came to this doc, I was confused about the description of [Using Vertx clients ](https://quarkus.io/guides/getting-started-reactive#using-vert-x-clients) section. 

Check [the original question I posted on Stackoverflow](https://stackoverflow.com/questions/62151570/vertx-is-not-available-in-quarkus-vertx-munity-web-client-extesions).

Added a small fragment to describe adding `vertx` extension.