### PR TITLE
Make REST Client work whether or not SSL is enabled or not in native

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DisabledSSLContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DisabledSSLContext.java
@@ -1,0 +1,106 @@
+package io.quarkus.runtime.graal;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.Provider;
+import java.security.SecureRandom;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLContextSpi;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+public class DisabledSSLContext extends SSLContext {
+
+    public DisabledSSLContext() {
+        super(new DisabledSSLContextSpi(), new Provider("DISABLED", 1, "DISABLED") {
+        }, "DISABLED");
+    }
+
+    private static class DisabledSSLContextSpi extends SSLContextSpi {
+
+        @Override
+        protected void engineInit(KeyManager[] keyManagers, TrustManager[] trustManagers, SecureRandom secureRandom)
+                throws KeyManagementException {
+        }
+
+        @Override
+        protected SSLSocketFactory engineGetSocketFactory() {
+            return new SSLSocketFactory() {
+                @Override
+                public String[] getDefaultCipherSuites() {
+                    return new String[0];
+                }
+
+                @Override
+                public String[] getSupportedCipherSuites() {
+                    return new String[0];
+                }
+
+                @Override
+                public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(String s, int i, InetAddress inetAddress, int i1)
+                        throws IOException, UnknownHostException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+                    throw sslSupportDisabledException();
+                }
+
+                @Override
+                public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1)
+                        throws IOException {
+                    throw sslSupportDisabledException();
+                }
+            };
+        }
+
+        @Override
+        protected SSLServerSocketFactory engineGetServerSocketFactory() {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLEngine engineCreateSSLEngine() {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLEngine engineCreateSSLEngine(String s, int i) {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLSessionContext engineGetServerSessionContext() {
+            throw sslSupportDisabledException();
+        }
+
+        @Override
+        protected SSLSessionContext engineGetClientSessionContext() {
+            throw sslSupportDisabledException();
+        }
+
+        private RuntimeException sslSupportDisabledException() {
+            return new IllegalStateException(
+                    "Native SSL support is disabled: you have set quarkus.ssl.native to false in your configuration.");
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_net_ssl_SSLContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_javax_net_ssl_SSLContext.java
@@ -1,22 +1,10 @@
 package io.quarkus.runtime.graal;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.Socket;
-import java.net.UnknownHostException;
-import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
-import java.security.SecureRandom;
 
-import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLServerSocketFactory;
-import javax.net.ssl.SSLSessionContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
@@ -91,92 +79,4 @@ public final class Target_javax_net_ssl_SSLContext {
     //        return new Target_javax_net_ssl_SSLContext((SSLContextSpi) instance.impl, instance.provider,
     //                protocol);
     //    }
-
-    private static class DisabledSSLContext extends SSLContext {
-
-        protected DisabledSSLContext() {
-            super(new DisabledSSLContextSpi(), new Provider("DISABLED", 1, "DISABLED") {
-            }, "DISABLED");
-        }
-    }
-
-    private static class DisabledSSLContextSpi extends SSLContextSpi {
-
-        @Override
-        protected void engineInit(KeyManager[] keyManagers, TrustManager[] trustManagers, SecureRandom secureRandom)
-                throws KeyManagementException {
-        }
-
-        @Override
-        protected SSLSocketFactory engineGetSocketFactory() {
-            return new SSLSocketFactory() {
-                @Override
-                public String[] getDefaultCipherSuites() {
-                    return new String[0];
-                }
-
-                @Override
-                public String[] getSupportedCipherSuites() {
-                    return new String[0];
-                }
-
-                @Override
-                public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
-                    throw sslSupportDisabledException();
-                }
-
-                @Override
-                public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
-                    throw sslSupportDisabledException();
-                }
-
-                @Override
-                public Socket createSocket(String s, int i, InetAddress inetAddress, int i1)
-                        throws IOException, UnknownHostException {
-                    throw sslSupportDisabledException();
-                }
-
-                @Override
-                public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
-                    throw sslSupportDisabledException();
-                }
-
-                @Override
-                public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1)
-                        throws IOException {
-                    throw sslSupportDisabledException();
-                }
-            };
-        }
-
-        @Override
-        protected SSLServerSocketFactory engineGetServerSocketFactory() {
-            throw sslSupportDisabledException();
-        }
-
-        @Override
-        protected SSLEngine engineCreateSSLEngine() {
-            throw sslSupportDisabledException();
-        }
-
-        @Override
-        protected SSLEngine engineCreateSSLEngine(String s, int i) {
-            throw sslSupportDisabledException();
-        }
-
-        @Override
-        protected SSLSessionContext engineGetServerSessionContext() {
-            throw sslSupportDisabledException();
-        }
-
-        @Override
-        protected SSLSessionContext engineGetClientSessionContext() {
-            throw sslSupportDisabledException();
-        }
-
-        private RuntimeException sslSupportDisabledException() {
-            return new IllegalStateException(
-                    "Native SSL support is disabled: you have set quarkus.ssl.native to false in your configuration.");
-        }
-    }
 }

--- a/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
+++ b/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
@@ -59,7 +59,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -138,9 +137,7 @@ class RestClientProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
     void processInterfaces(CombinedIndexBuildItem combinedIndexBuildItem,
-            SslNativeConfigBuildItem sslNativeConfig,
             Capabilities capabilities,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxyDefinition,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -148,8 +145,7 @@ class RestClientProcessor {
             BuildProducer<BeanRegistrarBuildItem> beanRegistrars,
             BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             BuildProducer<ServiceProviderBuildItem> serviceProvider,
-            BuildProducer<RestClientBuildItem> restClient,
-            RestClientRecorder restClientRecorder) {
+            BuildProducer<RestClientBuildItem> restClient) {
 
         // According to the spec only rest client interfaces annotated with RegisterRestClient are registered as beans
         Map<DotName, ClassInfo> interfaces = new HashMap<>();
@@ -222,8 +218,6 @@ class RestClientProcessor {
 
         // Indicates that this extension would like the SSL support to be enabled
         extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.REST_CLIENT));
-
-        restClientRecorder.setSslEnabled(sslNativeConfig.isEnabled());
     }
 
     private void findInterfaces(IndexView index, Map<DotName, ClassInfo> interfaces, Set<Type> returnTypes,

--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientRecorder.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientRecorder.java
@@ -23,7 +23,6 @@ import io.quarkus.runtime.annotations.Recorder;
 public class RestClientRecorder {
 
     public static ResteasyProviderFactory providerFactory;
-    public static boolean SSL_ENABLED;
 
     public BeanContainerListener hackAroundExtension() {
         return new BeanContainerListener() {
@@ -42,11 +41,6 @@ public class RestClientRecorder {
 
     public void setRestClientBuilderResolver() {
         RestClientBuilderResolver.setInstance(new BuilderResolver());
-    }
-
-    public void setSslEnabled(boolean sslEnabled) {
-        SSL_ENABLED = sslEnabled;
-        RestClientBuilderImpl.setSslEnabled(sslEnabled);
     }
 
     public void initializeResteasyProviderFactory(RuntimeValue<InjectorFactory> ifc, boolean useBuiltIn,

--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/graal/ClientBuilderReplacement.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/graal/ClientBuilderReplacement.java
@@ -3,7 +3,6 @@ package io.quarkus.restclient.runtime.graal;
 import javax.ws.rs.client.ClientBuilder;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.engines.URLConnectionClientEngineBuilder;
 import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 
@@ -19,12 +18,6 @@ final class ClientBuilderReplacement {
     public static ClientBuilder newBuilder() {
         ResteasyClientBuilder client = new ResteasyClientBuilderImpl();
         client.providerFactory(new LocalResteasyProviderFactory(RestClientRecorder.providerFactory));
-        if (!RestClientRecorder.SSL_ENABLED) {
-            client.httpEngine(new URLConnectionClientEngineBuilder().resteasyClientBuilder(client).build());
-            client.sslContext(null);
-            client.trustStore(null);
-            client.keyStore(null, "");
-        }
         return client;
     }
 }

--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/graal/ClientHttpEngineBuilder43Replacement.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/graal/ClientHttpEngineBuilder43Replacement.java
@@ -1,0 +1,36 @@
+package io.quarkus.restclient.runtime.graal;
+
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * This class is used to make sure that only the default SSLContext is requested when no SSLContext has been provided.
+ * The reason this is necessary is because by default, the code requests
+ * {@code SSLContext.getInstance(SSLConnectionSocketFactory.TLS)} which will fail in native when the SSL has been disabled
+ */
+@TargetClass(className = "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43")
+public final class ClientHttpEngineBuilder43Replacement {
+
+    @Alias
+    private ResteasyClientBuilder that;
+
+    @Substitute
+    public ClientHttpEngineBuilder43Replacement resteasyClientBuilder(ResteasyClientBuilder resteasyClientBuilder) {
+        that = resteasyClientBuilder;
+        if (that.getSSLContext() == null) {
+            try {
+                that.sslContext(SSLContext.getDefault());
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return this;
+    }
+}

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -45,6 +45,9 @@
                         <!-- We have our own version of these tests which set up a config environment -->
                         <exclude>org.eclipse.microprofile.rest.client.tck.InvokeWithJsonBProviderTest</exclude>
                         <exclude>org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest</exclude>
+
+                        <!-- The connection timeout is too small -->
+                        <exclude>org/eclipse/microprofile/rest/client/tck/timeout/*.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This is done in order to enable the use of Apache HTTP Client in all
cases where the REST Client is used.
This enables us to drop the fallback to URLConnection which is rather limited

Fixes: #9342

~~Requires: https://github.com/resteasy/Resteasy/pull/2431~~

~~PR is a draft because without the RESTEasy fix this doesn't make sense.~~ (after talking with @gsmet it became clear to me that the fix in RESTEasy is not necessary)