### PR TITLE
Set context class loader to the system one when loading the default filesystem providers

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/CustomFileSystemProviderTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/CustomFileSystemProviderTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.gradle;
+
+import java.io.File;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+
+
+public class CustomFileSystemProviderTest extends QuarkusGradleTestBase {
+
+    @Test
+    public void test() throws Exception {
+
+        final File projectDir = getProjectDir("custom-filesystem-provider");
+
+        GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments(arguments("clean", ":application:test"))
+                .withProjectDir(projectDir)
+                .build();
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'io.quarkus'
+}
+
+dependencies {
+    testImplementation project(":common")
+    testImplementation project(":custom-filesystem-provider")
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,18 @@
+package org.acme.quarkus.sample;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/main/resources/application.properties
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/test/java/org/acme/ExampleResourceTest.java
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/test/java/org/acme/ExampleResourceTest.java
@@ -1,0 +1,23 @@
+package org.acme;
+
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+@QuarkusTestResource(TestResource.class)
+public class ExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello"));
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/test/java/org/acme/TestResource.java
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/application/src/test/java/org/acme/TestResource.java
@@ -1,0 +1,22 @@
+package org.acme;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.acme.common.CommonBean;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class TestResource implements QuarkusTestResourceLifecycleManager {
+
+	@Override
+	public Map<String, String> start() {
+		final CommonBean bean = new CommonBean();
+		System.out.println("TestResource start " + bean.getClass().getName());
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public void stop() {
+	}
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/build.gradle
@@ -1,0 +1,44 @@
+buildscript {
+
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+}
+
+apply plugin: 'java'
+
+group = 'io.quarkus.gradle.test'
+version = '1.0'
+
+
+subprojects {
+
+    apply plugin: 'java'
+
+    test {
+        dependsOn 'cleanTest'
+        useJUnitPlatform()
+        forkEvery 1
+    }
+
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+
+        implementation 'io.quarkus:quarkus-resteasy'
+
+        testImplementation 'io.quarkus:quarkus-junit5'
+        testImplementation 'io.rest-assured:rest-assured'
+
+        implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/common/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/common/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'io.quarkus'
+    id 'java-library'
+}
+
+dependencies {
+
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/common/src/main/java/org/acme/common/CommonBean.java
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/common/src/main/java/org/acme/common/CommonBean.java
@@ -1,0 +1,11 @@
+package org.acme.common;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class CommonBean {
+
+   public String getName() {
+       return "common";
+   }
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/common/src/main/resources/META-INF/beans.xml
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/common/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+                      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+        bean-discovery-mode="all">
+
+</beans>

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/custom-filesystem-provider/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/custom-filesystem-provider/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation project(":common")
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/custom-filesystem-provider/src/main/java/org/acme/fs/AcmeFileSystemProvider.java
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/custom-filesystem-provider/src/main/java/org/acme/fs/AcmeFileSystemProvider.java
@@ -1,0 +1,121 @@
+package org.acme.fs;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.DirectoryStream.Filter;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Map;
+import java.util.Set;
+
+import org.acme.common.CommonBean;
+
+public class AcmeFileSystemProvider extends FileSystemProvider {
+
+	final CommonBean bean;
+
+	public AcmeFileSystemProvider() {
+		try {
+			bean = (CommonBean) Thread.currentThread().getContextClassLoader().loadClass(CommonBean.class.getName()).getDeclaredConstructor().newInstance();
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to create an instance of " + CommonBean.class.getName() + " loaded from " + Thread.currentThread().getContextClassLoader(), e);
+		}
+	}
+	
+	@Override
+	public String getScheme() {
+		return "acme";
+	}
+
+	@Override
+	public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+		return null;
+	}
+
+	@Override
+	public FileSystem getFileSystem(URI uri) {
+		return null;
+	}
+
+	@Override
+	public Path getPath(URI uri) {
+		return null;
+	}
+
+	@Override
+	public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
+			throws IOException {
+		return null;
+	}
+
+	@Override
+	public DirectoryStream<Path> newDirectoryStream(Path dir, Filter<? super Path> filter) throws IOException {
+		return null;
+	}
+
+	@Override
+	public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+	}
+
+	@Override
+	public void delete(Path path) throws IOException {
+	}
+
+	@Override
+	public void copy(Path source, Path target, CopyOption... options) throws IOException {
+	}
+
+	@Override
+	public void move(Path source, Path target, CopyOption... options) throws IOException {
+	}
+
+	@Override
+	public boolean isSameFile(Path path, Path path2) throws IOException {
+		return false;
+	}
+
+	@Override
+	public boolean isHidden(Path path) throws IOException {
+		return false;
+	}
+
+	@Override
+	public FileStore getFileStore(Path path) throws IOException {
+		return null;
+	}
+
+	@Override
+	public void checkAccess(Path path, AccessMode... modes) throws IOException {
+	}
+
+	@Override
+	public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
+		return null;
+	}
+
+	@Override
+	public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options)
+			throws IOException {
+		return null;
+	}
+
+	@Override
+	public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) throws IOException {
+		return null;
+	}
+
+	@Override
+	public void setAttribute(Path path, String attribute, Object value, LinkOption... options) throws IOException {
+	}
+}

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/custom-filesystem-provider/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/custom-filesystem-provider/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+org.acme.fs.AcmeFileSystemProvider

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/gradle.properties
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/settings.gradle
+++ b/devtools/gradle/src/functionalTest/resources/custom-filesystem-provider/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name = 'quarkus-custom-filesystem-provider'
+
+include ':common'
+include ':custom-filesystem-provider'
+include ':application'
+


### PR DESCRIPTION
Fixes #9017 
Fixes #7424

These two issues were reported by the same user. They are different but both reproducers are affected by #9017