### PR TITLE
Add test to ensure that .env works in Gradle

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/devmode/DotEnvQuarkusDevModeConfigurationTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/devmode/DotEnvQuarkusDevModeConfigurationTest.java
@@ -1,0 +1,15 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DotEnvQuarkusDevModeConfigurationTest extends QuarkusDevGradleTestBase {
+    @Override
+    protected String projectDirectoryName() {
+        return "dotenv-config-java-module";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("hey");
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/.env
+++ b/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/.env
@@ -1,0 +1,1 @@
+GREETING_MESSAGE=hey

--- a/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+quarkusDev {
+    workingDir = System.getProperty("java.io.tmpdir")
+}

--- a/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/gradle.properties
+++ b/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/settings.gradle
+++ b/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/src/main/java/org/acme/GreetingResource.java
+++ b/devtools/gradle/src/functionalTest/resources/dotenv-config-java-module/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @ConfigProperty(name = "greeting.message")
+    String message;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return message;
+    }
+}


### PR DESCRIPTION
Relates to: #9752

The issue mentioned in #9752 has already been fixed in Quarkus `1.5.0.Final` (I confirmed it failed in `1.4.2.Final` and works in `1.5.0.Final` by creating a reproducer of my own), but this is a good opportunity to increase the Gradle test coverage