### PR TITLE
Provide a proper error message when a Kubernetes token is invalid

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
@@ -70,6 +70,12 @@ public class KubernetesDeploy {
             masterURL = client.getConfiguration().getMasterUrl();
             //Let's check if we can connect.
             VersionInfo version = client.getVersion();
+            if (version == null) {
+                return Result.exceptional(new RuntimeException(
+                        "Although a Kubernetes deployment was requested, it however cannot take place because the version of the API Server at '"
+                                + masterURL + "' could not be determined. Please ensure that a valid token is being used."));
+            }
+
             log.info("Kubernetes API Server at '" + masterURL + "' successfully contacted.");
             log.debugf("Kubernetes Version: %s.%s", version.getMajor(), version.getMinor());
             serverFound = true;


### PR DESCRIPTION
The k8s client returns null when the token is invalid which
resulted in a NPE being thrown.

This was originally reported here: https://groups.google.com/d/msg/quarkus-dev/LPG1NlvRGUw/8agNrnKpAQAJ