### PR TITLE
Move empty byte buffer creation direct buffer to runtime

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -23,10 +23,12 @@ import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
 import io.quarkus.netty.BossEventLoopGroup;
 import io.quarkus.netty.MainEventLoopGroup;
+import io.quarkus.netty.runtime.EmptyByteBufStub;
 import io.quarkus.netty.runtime.NettyRecorder;
 
 class NettyProcessor {
@@ -217,5 +219,11 @@ class NettyProcessor {
         return Arrays.asList(
                 new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "selectedKeys"),
                 new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "publicSelectedKeys"));
+    }
+
+    @BuildStep
+    RuntimeInitializedClassBuildItem runtimeInitBcryptUtil() {
+        // this holds a direct allocated byte buffer that needs to be initialised at run time
+        return new RuntimeInitializedClassBuildItem(EmptyByteBufStub.class.getName());
     }
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/EmptyByteBufStub.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/EmptyByteBufStub.java
@@ -1,0 +1,14 @@
+package io.quarkus.netty.runtime;
+
+import java.nio.ByteBuffer;
+
+public final class EmptyByteBufStub {
+    private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocateDirect(0);
+
+    public static ByteBuffer emptyByteBuffer() {
+        return EMPTY_BYTE_BUFFER;
+    }
+
+    private EmptyByteBufStub() {
+    }
+}

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/EmptyByteBufStub.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/EmptyByteBufStub.java
@@ -2,11 +2,30 @@ package io.quarkus.netty.runtime;
 
 import java.nio.ByteBuffer;
 
+import io.netty.util.internal.PlatformDependent;
+
 public final class EmptyByteBufStub {
     private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocateDirect(0);
+    private static final long EMPTY_BYTE_BUFFER_ADDRESS;
+
+    static {
+        long emptyByteBufferAddress = 0;
+        try {
+            if (PlatformDependent.hasUnsafe()) {
+                emptyByteBufferAddress = PlatformDependent.directBufferAddress(EMPTY_BYTE_BUFFER);
+            }
+        } catch (Throwable t) {
+            // Ignore
+        }
+        EMPTY_BYTE_BUFFER_ADDRESS = emptyByteBufferAddress;
+    }
 
     public static ByteBuffer emptyByteBuffer() {
         return EMPTY_BYTE_BUFFER;
+    }
+
+    public static long emptyByteBufferAddress() {
+        return EMPTY_BYTE_BUFFER_ADDRESS;
     }
 
     private EmptyByteBufStub() {

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -36,6 +36,7 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.JdkLoggerFactory;
+import io.quarkus.netty.runtime.EmptyByteBufStub;
 
 /**
  * This substitution avoid having loggers added to the build
@@ -403,17 +404,17 @@ final class Target_io_netty_buffer_EmptyByteBuf {
 
     @Substitute
     public ByteBuffer nioBuffer() {
-        return ByteBuffer.allocateDirect(0);
+        return EmptyByteBufStub.emptyByteBuffer();
     }
 
     @Substitute
     public ByteBuffer[] nioBuffers() {
-        return new ByteBuffer[] { ByteBuffer.allocateDirect(0) };
+        return new ByteBuffer[] { EmptyByteBufStub.emptyByteBuffer() };
     }
 
     @Substitute
     public ByteBuffer internalNioBuffer(int index, int length) {
-        return ByteBuffer.allocateDirect(0);
+        return EmptyByteBufStub.emptyByteBuffer();
     }
 
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -1,5 +1,6 @@
 package io.quarkus.netty.runtime.graal;
 
+import java.nio.ByteBuffer;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
@@ -385,6 +386,34 @@ final class Target_io_netty_util_internal_NativeLibraryLoader {
     static Class<?> tryToLoadClass(final ClassLoader loader, final Class<?> helper)
             throws ClassNotFoundException {
         return Class.forName(helper.getName(), false, loader);
+    }
+
+}
+
+@TargetClass(className = "io.netty.buffer.EmptyByteBuf")
+final class Target_io_netty_buffer_EmptyByteBuf {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    private static ByteBuffer EMPTY_BYTE_BUFFER;
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias)
+    private static long EMPTY_BYTE_BUFFER_ADDRESS = 0;
+
+    @Substitute
+    public ByteBuffer nioBuffer() {
+        return ByteBuffer.allocateDirect(0);
+    }
+
+    @Substitute
+    public ByteBuffer[] nioBuffers() {
+        return new ByteBuffer[] { ByteBuffer.allocateDirect(0) };
+    }
+
+    @Substitute
+    public ByteBuffer internalNioBuffer(int index, int length) {
+        return ByteBuffer.allocateDirect(0);
     }
 
 }

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/graal/NettySubstitutions.java
@@ -399,8 +399,8 @@ final class Target_io_netty_buffer_EmptyByteBuf {
     private static ByteBuffer EMPTY_BYTE_BUFFER;
 
     @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias)
-    private static long EMPTY_BYTE_BUFFER_ADDRESS = 0;
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    private static long EMPTY_BYTE_BUFFER_ADDRESS;
 
     @Substitute
     public ByteBuffer nioBuffer() {
@@ -415,6 +415,20 @@ final class Target_io_netty_buffer_EmptyByteBuf {
     @Substitute
     public ByteBuffer internalNioBuffer(int index, int length) {
         return EmptyByteBufStub.emptyByteBuffer();
+    }
+
+    @Substitute
+    public boolean hasMemoryAddress() {
+        return EmptyByteBufStub.emptyByteBufferAddress() != 0;
+    }
+
+    @Substitute
+    public long memoryAddress() {
+        if (hasMemoryAddress()) {
+            return EmptyByteBufStub.emptyByteBufferAddress();
+        } else {
+            throw new UnsupportedOperationException();
+        }
     }
 
 }


### PR DESCRIPTION
A better fix for https://github.com/quarkusio/quarkus/issues/9750.

The [initial PR](https://github.com/quarkusio/quarkus/pull/9751) would have caused NPEs. This PR improves that by first avoiding the NPE altogether: the static field is recomputed to the default value (`null`) and then we substitute all accesses by runtime allocated direct byte buffer.

Then, to avoid perf/GC penalty of creating an empty direct byte buffer any time, we create a stub that contains a constant direct byte buffer, but crucially this stub is initialised only at runtime.

Also, the empty byte buffer address was being calculated at build time, which would likely have caused issues at runtime if trying to access that address (any guarantees that it'd be the same?). In this initial attempt, the address has just been set to 0, but a similar trick might be possible by making the computation of the address a runtime concern.