### PR TITLE
Add native args configuration in quarkusBuild task

### DIFF
--- a/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/BasicJavaNativeBuildTest.java
+++ b/devtools/gradle/src/functionalTest/java/io/quarkus/gradle/BasicJavaNativeBuildTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BasicJavaNativeBuildTest extends QuarkusGradleTestBase  {
+
+    @Test
+    public void shouldIgnoreNativeArgs() throws Exception{
+        final File projectDir = getProjectDir("basic-java-native-module");
+
+        BuildResult build = GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments(arguments("clean", "quarkusBuild"))
+                .withProjectDir(projectDir)
+                .build();
+
+        assertThat(build.task(":quarkusBuild").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.toPath().resolve("build").resolve("foo-1.0.0-SNAPSHOT-runner.jar")).exists();
+        assertThat(projectDir.toPath().resolve("build").resolve("foo-1.0.0-SNAPSHOT-runner")).doesNotExist();
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-native-module/build.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-native-module/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+quarkusBuild {
+    nativeArgs {
+        graalvmHome="/foo/bar"
+        containerBuild=true
+    }
+}

--- a/devtools/gradle/src/functionalTest/resources/basic-java-native-module/gradle.properties
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-native-module/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/devtools/gradle/src/functionalTest/resources/basic-java-native-module/settings.gradle
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-native-module/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='foo'

--- a/devtools/gradle/src/functionalTest/resources/basic-java-native-module/src/main/java/org/acme/HelloResource.java
+++ b/devtools/gradle/src/functionalTest/resources/basic-java-native-module/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -302,8 +302,24 @@ A native executable will be present in `build/`.
 ====
 The `buildNative` task has been deprecated in favor of
 `build -Dquarkus.package.type=native`.
-Native related properties can either be added in `application.properties` file or as command line arguments.
 ====
+
+Native related properties can either be added in `application.properties` file, as command line arguments or in the `quarkusBuild` task.
+Configuring the `quarkusBuild` task can be done as following:
+
+[source,groovy]
+----
+quarkusBuild {
+    nativeArgs {
+        containerBuild = true <1>
+        buildImage = "quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11" <2>
+    }
+}
+----
+
+<1> Set `quarkus.native.containerBuild` property to `true`
+<2> Set `quarkus.native.buildImage` property to `quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11`
+
 
 === Build a container friendly executable
 


### PR DESCRIPTION
This introduce a way to set native argument to the `quarkusBuild` task. 

@aloubyansky could you have a look? I wanted to add some native test but the CI fails with `native-image not installed` error. As you said, we maybe should take care of this in an other branch? 

close #8958 