### PR TITLE
Introduce ArcContainer.select() methods

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import javax.enterprise.context.ContextNotActiveException;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.util.TypeLiteral;
 
@@ -96,6 +97,34 @@ public interface ArcContainer {
      * @return a new bean instance handle
      */
     <T> InstanceHandle<T> instance(InjectableBean<T> bean);
+
+    /**
+     * Instances of dependent scoped beans obtained with the returned injectable instance must be explicitly destroyed, either
+     * via the {@link Instance#destroy(Object)} method invoked upon the same injectable instance or with
+     * {@link InstanceHandle#destroy()}.
+     * 
+     * If no qualifier is passed, the <tt>@Default</tt> qualifier is assumed.
+     * 
+     * @param <T>
+     * @param type
+     * @param qualifiers
+     * @return a new injectable instance that could be used for programmatic lookup
+     */
+    <T> InjectableInstance<T> select(Class<T> type, Annotation... qualifiers);
+
+    /**
+     * Instances of dependent scoped beans obtained with the returned injectable instance must be explicitly destroyed, either
+     * via the {@link Instance#destroy(Object)} method invoked upon the same injectable instance or with
+     * {@link InstanceHandle#destroy()}.
+     * 
+     * If no qualifier is passed, the <tt>@Default</tt> qualifier is assumed.
+     * 
+     * @param <T>
+     * @param type
+     * @param qualifiers
+     * @return a new injectable instance that could be used for programmatic lookup
+     */
+    <T> InjectableInstance<T> select(TypeLiteral<T> type, Annotation... qualifiers);
 
     /**
      * Returns true if Arc container is running.

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -6,6 +6,7 @@ import io.quarkus.arc.Components;
 import io.quarkus.arc.ComponentsProvider;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableObserverMethod;
 import io.quarkus.arc.InstanceHandle;
@@ -86,6 +87,8 @@ public class ArcContainerImpl implements ArcContainer {
 
     private final List<ResourceReferenceProvider> resourceProviders;
 
+    final InstanceImpl<Object> instance;
+
     private volatile ExecutorService executorService;
 
     public ArcContainerImpl() {
@@ -141,6 +144,8 @@ public class ArcContainerImpl implements ArcContainer {
         for (ResourceReferenceProvider resourceProvider : ServiceLoader.load(ResourceReferenceProvider.class)) {
             resourceProviders.add(resourceProvider);
         }
+
+        instance = InstanceImpl.of(Object.class, Collections.emptySet());
     }
 
     private void addBuiltInBeans() {
@@ -251,6 +256,16 @@ public class ArcContainerImpl implements ArcContainer {
         Objects.requireNonNull(bean);
         requireRunning();
         return (InstanceHandle<T>) beanInstanceHandle(bean, null);
+    }
+
+    @Override
+    public <T> InjectableInstance<T> select(Class<T> type, Annotation... qualifiers) {
+        return instance.select(type, qualifiers);
+    }
+
+    @Override
+    public <T> InjectableInstance<T> select(TypeLiteral<T> type, Annotation... qualifiers) {
+        return instance.select(type, qualifiers);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -38,7 +38,6 @@ import javax.enterprise.inject.spi.InterceptionType;
 import javax.enterprise.inject.spi.Interceptor;
 import javax.enterprise.inject.spi.ObserverMethod;
 import javax.enterprise.inject.spi.ProducerFactory;
-import javax.enterprise.util.TypeLiteral;
 import javax.inject.Qualifier;
 import javax.interceptor.InterceptorBinding;
 
@@ -46,10 +45,6 @@ import javax.interceptor.InterceptorBinding;
  * @author Martin Kouba
  */
 public class BeanManagerImpl implements BeanManager {
-
-    @SuppressWarnings("serial")
-    static final TypeLiteral<Instance<Object>> INSTANCE_LITERAL = new TypeLiteral<Instance<Object>>() {
-    };
 
     static final LazyValue<BeanManagerImpl> INSTANCE = new LazyValue<>(BeanManagerImpl::new);
 
@@ -302,8 +297,7 @@ public class BeanManagerImpl implements BeanManager {
 
     @Override
     public Instance<Object> createInstance() {
-        return new InstanceImpl<>(null, INSTANCE_LITERAL.getType(), Collections.emptySet(), new CreationalContextImpl<>(null),
-                Collections.emptySet(), null, -1);
+        return ArcContainerImpl.instance().instance;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
@@ -74,8 +74,10 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
             if (javaMember instanceof Executable) {
                 this.annotated = new AnnotatedParameterImpl<>(injectionPointType, annotations, position,
                         (Executable) javaMember);
-            } else {
+            } else if (javaMember instanceof Field) {
                 this.annotated = new AnnotatedFieldImpl<>(injectionPointType, annotations, (Field) javaMember);
+            } else {
+                this.annotated = null;
             }
             this.member = javaMember;
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceImpl.java
@@ -30,6 +30,12 @@ import javax.inject.Provider;
  */
 public class InstanceImpl<T> implements InjectableInstance<T> {
 
+    static <T> InstanceImpl<T> of(Type requiredType, Set<Annotation> requiredQualifiers) {
+        return new InstanceImpl<>(null, null, requiredType, requiredQualifiers,
+                new CreationalContextImpl<>(null),
+                Collections.emptySet(), null, -1);
+    }
+
     private static final Annotation[] EMPTY_ANNOTATION_ARRAY = new Annotation[] {};
 
     private final CreationalContextImpl<?> creationalContext;
@@ -50,7 +56,7 @@ public class InstanceImpl<T> implements InjectableInstance<T> {
         this(targetBean, type, getRequiredType(type), qualifiers, creationalContext, annotations, javaMember, position);
     }
 
-    InstanceImpl(InstanceImpl<?> parent, Type requiredType, Set<Annotation> requiredQualifiers) {
+    private InstanceImpl(InstanceImpl<?> parent, Type requiredType, Set<Annotation> requiredQualifiers) {
         this(parent.targetBean, parent.injectionPointType, requiredType, requiredQualifiers, parent.creationalContext,
                 parent.annotations, parent.javaMember, parent.position);
     }
@@ -135,15 +141,27 @@ public class InstanceImpl<T> implements InjectableInstance<T> {
         return getHandle(bean());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Iterable<InstanceHandle<T>> handles() {
-        return (Iterable<InstanceHandle<T>>) beans().stream().map(this::getHandle).iterator();
+        return new Iterable<InstanceHandle<T>>() {
+            @Override
+            public Iterator<InstanceHandle<T>> iterator() {
+                return new InstanceHandlesIterator<T>(beans());
+            }
+        };
     }
 
     @SuppressWarnings("unchecked")
     private <H> InstanceHandle<H> getHandle(InjectableBean<H> bean) {
-        return ArcContainerImpl.beanInstanceHandle(bean, (CreationalContextImpl<H>) creationalContext, true, this::destroy);
+        InjectionPoint prev = InjectionPointProvider
+                .set(new InjectionPointImpl(injectionPointType, requiredType, requiredQualifiers, targetBean, annotations,
+                        javaMember, position));
+        try {
+            return ArcContainerImpl.beanInstanceHandle(bean, (CreationalContextImpl<H>) creationalContext, false,
+                    this::destroy);
+        } finally {
+            InjectionPointProvider.set(prev);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -210,6 +228,27 @@ public class InstanceImpl<T> implements InjectableInstance<T> {
         @Override
         public T next() {
             return getBeanInstance((InjectableBean<T>) delegate.next());
+        }
+
+    }
+
+    private class InstanceHandlesIterator<H> implements Iterator<InstanceHandle<H>> {
+
+        final Iterator<InjectableBean<?>> delegate;
+
+        InstanceHandlesIterator(Collection<InjectableBean<?>> beans) {
+            this.delegate = beans.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public InstanceHandle<H> next() {
+            return getHandle((InjectableBean<H>) delegate.next());
         }
 
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/ArcContainerSelectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/ArcContainerSelectTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.arc.test.instance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.util.TypeLiteral;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ArcContainerSelectTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Alpha.class, Washcloth.class);
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testSelect() {
+        assertTrue(Arc.container().select(BeanManager.class).isResolvable());
+        InjectableInstance<Supplier<String>> instance = Arc.container().select(new TypeLiteral<Supplier<String>>() {
+        });
+        Set<String> strings = new HashSet<>();
+        for (InstanceHandle<Supplier<String>> handle : instance.handles()) {
+            strings.add(handle.get().get());
+            handle.close();
+        }
+        assertEquals(2, strings.size());
+        assertTrue(strings.contains("alpha"));
+        assertTrue(strings.contains("washcloth"));
+        assertTrue(Washcloth.INIT.get());
+        assertTrue(Washcloth.DESTROYED.get());
+    }
+
+    @Singleton
+    static class Alpha implements Supplier<String> {
+
+        @Override
+        public String get() {
+            return "alpha";
+        }
+
+    }
+
+    @Dependent
+    static class Washcloth implements Supplier<String> {
+
+        static final AtomicBoolean INIT = new AtomicBoolean(false);
+        static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+
+        @Inject
+        InjectionPoint injectionPoint;
+
+        @PostConstruct
+        void init() {
+            assertNotNull(injectionPoint);
+            assertEquals(0, injectionPoint.getQualifiers().size());
+            Type requiredType = injectionPoint.getType();
+            assertTrue(requiredType instanceof ParameterizedType);
+            assertEquals(Supplier.class, ((ParameterizedType) requiredType).getRawType());
+            INIT.set(true);
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+
+        @Override
+        public String get() {
+            return "washcloth";
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Arc.container().select() is a slightly more effective quarkus-specific
alternative to CDI.current().select()
- returns quarkus-specific InjectableInstance that leverages
InstanceHandle