### PR TITLE
Add forwarded-host-header and forwarded-prefix-header configuration

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -703,6 +703,23 @@ java.lang.IllegalStateException: Failed to create cache dir
 
 Assuming `/tmp/` is writeable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in OpenShift by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`.
 
+== Proxy handling
+
+In case quarkus is called through a proxy and it shall behave like it is running on that proxy host, please set the properties
+
+----
+quarkus.http.proxy-address-forwarding=true <1>
+quarkus.http.forwarded-host-header=X-Forwarded-Host <2>
+quarkus.http.forwarded-prefix-header=X-Forwarded-Prefix <3>
+----
+
+<1> This settings allows the replacement of absolute URI using X-Forwarded-* headers.<2>
+<2> Defines the request header quarkus shall replace its internal host with (Disabled by default).
+<3> Defines the request header quarkus shall prefix the request's URI (Disabled by default).
+
+An example use case is the authentication handling with the quarkus OIDC extension behind a proxy.
+Without these settings, quarkus sends the wrong redirect to the authentication server.
+
 == Going further
 
 There are many other facets of Quarkus using Vert.x underneath:

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/EnvoyHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/EnvoyHeaderTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.vertx.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -12,26 +10,32 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class ForwardedForHeaderTest {
+public class EnvoyHeaderTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(ForwardedHandlerInitializer.class)
-                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"),
+                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"
+                            + "quarkus.http.forwarded-prefix-header=X-Envoy-Original-Path\n"),
                             "application.properties"));
 
     @Test
     public void test() {
-        assertThat(RestAssured.get("/forward").asString()).startsWith("http|");
-
         RestAssured.given()
-                .header("X-Forwarded-Proto", "https")
-                .header("X-Forwarded-For", "backend:4444")
-                .header("X-Forwarded-Host", "somehost")
-                .get("/forward")
+                .header("X-Envoy-Original-Path", "prefix")
+                .get("/uri")
                 .then()
-                .body(Matchers.equalTo("https|localhost|backend:4444"));
+                .body(Matchers.equalTo("/prefix/uri"));
+    }
+
+    @Test
+    public void testWithEmptyPrefix() {
+        RestAssured.given()
+                .header("X-Envoy-Original-Path", "")
+                .get("/uri")
+                .then()
+                .body(Matchers.equalTo("/uri"));
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForPrefixHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForPrefixHeaderTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.vertx.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -12,26 +10,32 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class ForwardedForHeaderTest {
+public class ForwardedForPrefixHeaderTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(ForwardedHandlerInitializer.class)
-                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"),
+                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"
+                            + "quarkus.http.forwarded-prefix-header=X-Forwarded-Prefix\n"),
                             "application.properties"));
 
     @Test
-    public void test() {
-        assertThat(RestAssured.get("/forward").asString()).startsWith("http|");
-
+    public void testWithPrefix() {
         RestAssured.given()
-                .header("X-Forwarded-Proto", "https")
-                .header("X-Forwarded-For", "backend:4444")
-                .header("X-Forwarded-Host", "somehost")
-                .get("/forward")
+                .header("X-Forwarded-Prefix", "prefix")
+                .get("/uri")
                 .then()
-                .body(Matchers.equalTo("https|localhost|backend:4444"));
+                .body(Matchers.equalTo("/prefix/uri"));
+    }
+
+    @Test
+    public void testWithEmptyPrefix() {
+        RestAssured.given()
+                .header("X-Forwarded-Prefix", "")
+                .get("/uri")
+                .then()
+                .body(Matchers.equalTo("/uri"));
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForServerHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForServerHeaderTest.java
@@ -12,13 +12,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class ForwardedForHeaderTest {
+public class ForwardedForServerHeaderTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(ForwardedHandlerInitializer.class)
-                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"),
+                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"
+                            + "quarkus.http.forwarded-host-header=X-Forwarded-Server\n"),
                             "application.properties"));
 
     @Test
@@ -28,10 +29,10 @@ public class ForwardedForHeaderTest {
         RestAssured.given()
                 .header("X-Forwarded-Proto", "https")
                 .header("X-Forwarded-For", "backend:4444")
-                .header("X-Forwarded-Host", "somehost")
+                .header("X-Forwarded-Server", "somehost")
                 .get("/forward")
                 .then()
-                .body(Matchers.equalTo("https|localhost|backend:4444"));
+                .body(Matchers.equalTo("https|somehost|backend:4444"));
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
@@ -13,6 +13,10 @@ class ForwardedHandlerInitializer {
         router.route("/forward").handler(rc -> rc.response()
                 .end(rc.request().scheme() + "|" + rc.request().getHeader(HttpHeaders.HOST) + "|"
                         + rc.request().remoteAddress().toString()));
+
+        router.route("/uri").handler(rc -> rc.response()
+                .end(rc.request().uri()));
+
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ProxyAddressForwardingDefaultSettingsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ProxyAddressForwardingDefaultSettingsTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class ForwardedForHeaderTest {
+public class ProxyAddressForwardingDefaultSettingsTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -22,16 +22,25 @@ public class ForwardedForHeaderTest {
                             "application.properties"));
 
     @Test
-    public void test() {
+    public void testWithHostHeader() {
         assertThat(RestAssured.get("/forward").asString()).startsWith("http|");
 
         RestAssured.given()
                 .header("X-Forwarded-Proto", "https")
                 .header("X-Forwarded-For", "backend:4444")
                 .header("X-Forwarded-Host", "somehost")
+                .header("X-Forwarded-Prefix", "prefix")
                 .get("/forward")
                 .then()
                 .body(Matchers.equalTo("https|localhost|backend:4444"));
     }
 
+    @Test
+    public void testWithPrefixHeader() {
+        RestAssured.given()
+                .header("X-Forwarded-Prefix", "prefix")
+                .get("/uri")
+                .then()
+                .body(Matchers.equalTo("/uri"));
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -35,9 +36,16 @@ class ForwardedServerRequestWrapper implements HttpServerRequest {
     private String uri;
     private String absoluteURI;
 
-    ForwardedServerRequestWrapper(HttpServerRequest request, boolean allowForwarded) {
+    ForwardedServerRequestWrapper(HttpServerRequest request,
+            boolean allowForwarded,
+            Optional<String> forwardedHostHeader,
+            Optional<String> forwardedPrefixHeader) {
         delegate = request;
-        forwardedParser = new ForwardedParser(delegate, allowForwarded);
+
+        forwardedParser = new ForwardedParser(delegate,
+                allowForwarded,
+                forwardedHostHeader,
+                forwardedPrefixHeader);
     }
 
     void changeTo(HttpMethod method, String uri) {
@@ -137,7 +145,7 @@ class ForwardedServerRequestWrapper implements HttpServerRequest {
     @Override
     public String uri() {
         if (!modified) {
-            return delegate.uri();
+            return forwardedParser.uri();
         }
         return uri;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -197,6 +197,18 @@ public class HttpConfiguration {
     @ConfigItem
     public Map<String, SameSiteCookieConfig> sameSiteCookie;
 
+    /**
+     * Allows replace the internal host with a header (disabled by default).
+     */
+    @ConfigItem
+    public Optional<String> forwardedHostHeader;
+
+    /**
+     * Allows use a header to prefix the request's URI (disabled by default).
+     */
+    @ConfigItem
+    public Optional<String> forwardedPrefixHeader;
+
     public int determinePort(LaunchMode launchMode) {
         return launchMode == LaunchMode.TEST ? testPort : port;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -300,7 +300,11 @@ public class VertxHttpRecorder {
             root = new Handler<HttpServerRequest>() {
                 @Override
                 public void handle(HttpServerRequest event) {
-                    delegate.handle(new ForwardedServerRequestWrapper(event, httpConfiguration.allowForwarded));
+                    delegate.handle(new ForwardedServerRequestWrapper(
+                            event,
+                            httpConfiguration.allowForwarded,
+                            httpConfiguration.forwardedHostHeader,
+                            httpConfiguration.forwardedPrefixHeader));
                 }
             };
         }


### PR DESCRIPTION
* Enables configure request header to replace quarkus' internal host with.
* Enables configure request prefix header to append as the prefix to the request's URI (supports x-envoy-original-path).

Closes #9622 