### PR TITLE
Make the directory containing the output fast jar a constant

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -134,6 +134,7 @@ public class JarResultBuildStep {
     public static final String TRANSFORMED_BYTECODE_JAR = "transformed-bytecode.jar";
     public static final String APP = "app";
     public static final String QUARKUS = "quarkus";
+    public static final String DEFAULT_FAST_JAR_DIRECTORY_NAME = "quarkus-app";
 
     private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
 
@@ -397,7 +398,7 @@ public class JarResultBuildStep {
         boolean rebuild = outputTargetBuildItem.isRebuild();
 
         Path buildDir = outputTargetBuildItem.getOutputDirectory()
-                .resolve(outputTargetBuildItem.getBaseName());
+                .resolve(packageConfig.outputDirectory.orElse(DEFAULT_FAST_JAR_DIRECTORY_NAME));
         //unmodified 3rd party dependencies
         Path libDir = buildDir.resolve(LIB);
         //parent first entries

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -87,7 +87,7 @@ public class JarRunnerIT extends MojoTestBase {
         Assertions.assertFalse(Files.exists(jar));
 
         jar = testDir.toPath().toAbsolutePath()
-                .resolve(Paths.get("target/acme-1.0-SNAPSHOT/quarkus-run.jar"));
+                .resolve(Paths.get("target/quarkus-app/quarkus-run.jar"));
         Assertions.assertTrue(Files.exists(jar));
         File output = new File(testDir, "target/output.log");
         output.createNewFile();
@@ -130,7 +130,7 @@ public class JarRunnerIT extends MojoTestBase {
         Assertions.assertFalse(Files.exists(jar));
 
         jar = testDir.toPath().toAbsolutePath()
-                .resolve(Paths.get("target/acme-1.0-SNAPSHOT/quarkus-run.jar"));
+                .resolve(Paths.get("target/quarkus-app/quarkus-run.jar"));
         Assertions.assertTrue(Files.exists(jar));
         File output = new File(testDir, "target/output.log");
         output.createNewFile();


### PR DESCRIPTION
This makes it easy to build a Dockerfile