### PR TITLE
Change default thread pool size to max of 200 & 8*CPU

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -162,7 +162,7 @@ public class ExecutorRecorder {
         final int cpus = ProcessorInfo.availableProcessors();
         // run time config variables
         builder.setCorePoolSize(threadPoolConfig.coreThreads);
-        builder.setMaximumPoolSize(threadPoolConfig.maxThreads.orElse(8 * cpus));
+        builder.setMaximumPoolSize(threadPoolConfig.maxThreads.orElse(Math.max(8 * cpus, 200)));
         if (threadPoolConfig.queueSize.isPresent()) {
             if (threadPoolConfig.queueSize.getAsInt() < 0) {
                 builder.setMaximumQueueSize(Integer.MAX_VALUE);

--- a/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
@@ -30,7 +30,9 @@ public class ThreadPoolConfig {
 
     /**
      * The maximum number of threads. If this is not specified then
-     * it will be automatically sized to 8 * the number of available processors
+     * it will be automatically sized to the greater of 8 * the number of available processors and 200.
+     * For example if there are 4 processors the max threads will be 200.
+     * If there are 48 processors it will be 384.
      */
     @ConfigItem
     public OptionalInt maxThreads;


### PR DESCRIPTION
Currently the executor thread pool size as per quarkus.thread-pool.max-threads defaults to 8 X Processor count.

We had some performance/throughput issues recently on an AWS ECS environment and it came down to this being far too low as a default. In typical cloud-native microservice deployments you have multiple small containers running with 1 VCPU being commonplace. This results in max 8 execution threads. If a completely non-blocking scenario this is fine but for blocking API's that call other external services or databases, 8 threads becomes a major bottleneck.

As a comparison, here are the defaults max thread pool sizes on other web/app server environment:
Tomat = 200
TomEE = 200
Payara = 250
Open liberty = unlimited
Helidon = 32
Thorntail = cpuCount * 16

This PR changes the default to the greater of 8XCpu's and 200. If the threads are never needed then there is no impact on existing deployments, but if they are it will greatly improve throughput for blocking calls.