### PR TITLE
Replace com.sun.activation dependencies to standardize on jakarta

### DIFF
--- a/core/test-extension/runtime/pom.xml
+++ b/core/test-extension/runtime/pom.xml
@@ -68,8 +68,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/mailer/runtime/pom.xml
+++ b/extensions/mailer/runtime/pom.xml
@@ -52,8 +52,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -79,8 +79,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/extensions/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-common/runtime/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Relates to issue https://github.com/quarkusio/quarkus/issues/9834
and to discussion https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Duplicate.20classes.20in.20quarkus