### PR TITLE
GraphQL: Adding the guide in the metadata

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,5 @@ metadata:
   - "web"
   categories:
   - "web"
+  guide: "https://quarkus.io/guides/microprofile-graphql"
   status: "preview"


### PR DESCRIPTION
Adding the guide in the metadata so that it's available in code.quarkus