### PR TITLE
Add global quarkus.tls.trust-all configuration property

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/TlsConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/TlsConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Configuration class allowing to globally set TLS properties.
+ */
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class TlsConfig {
+
+    /**
+     * Enable trusting all certificates. Disable by default.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean trustAll;
+
+}

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -15,6 +15,7 @@ import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerRecorder;
 import io.quarkus.oidc.runtime.OidcBuildTimeConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
@@ -71,11 +72,11 @@ public class KeycloakPolicyEnforcerBuildStep {
 
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    public void setup(OidcBuildTimeConfig oidcBuildTimeConfig, OidcConfig oidcRunTimeConfig,
+    public void setup(OidcBuildTimeConfig oidcBuildTimeConfig, OidcConfig oidcRunTimeConfig, TlsConfig tlsConfig,
             KeycloakPolicyEnforcerConfig keycloakConfig, KeycloakPolicyEnforcerRecorder recorder, BeanContainerBuildItem bc,
             HttpConfiguration httpConfiguration) {
         if (oidcBuildTimeConfig.enabled && keycloakConfig.policyEnforcer.enable) {
-            recorder.setup(oidcRunTimeConfig, keycloakConfig, bc.getValue(), httpConfiguration);
+            recorder.setup(oidcRunTimeConfig, keycloakConfig, tlsConfig, bc.getValue(), httpConfiguration);
         }
     }
 }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerAuthorizer.java
@@ -20,6 +20,7 @@ import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.Tls.Verification;
 import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
@@ -90,7 +91,8 @@ public class KeycloakPolicyEnforcerAuthorizer
                 }).build();
     }
 
-    public void init(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config, HttpConfiguration httpConfiguration) {
+    public void init(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config, TlsConfig tlsConfig,
+            HttpConfiguration httpConfiguration) {
         AdapterConfig adapterConfig = new AdapterConfig();
         String authServerUrl = oidcConfig.defaultTenant.getAuthServerUrl().get();
 
@@ -104,7 +106,10 @@ public class KeycloakPolicyEnforcerAuthorizer
         adapterConfig.setResource(oidcConfig.defaultTenant.getClientId().get());
         adapterConfig.setCredentials(getCredentials(oidcConfig.defaultTenant));
 
-        if (oidcConfig.defaultTenant.tls.getVerification() == Verification.NONE) {
+        boolean trustAll = oidcConfig.defaultTenant.tls.getVerification().isPresent()
+                ? oidcConfig.defaultTenant.tls.getVerification().get() == Verification.NONE
+                : tlsConfig.trustAll;
+        if (trustAll) {
             adapterConfig.setDisableTrustManager(true);
             adapterConfig.setAllowAnyHostname(true);
         }

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -4,17 +4,19 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
 @Recorder
 public class KeycloakPolicyEnforcerRecorder {
 
-    public void setup(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config, BeanContainer beanContainer,
+    public void setup(OidcConfig oidcConfig, KeycloakPolicyEnforcerConfig config, TlsConfig tlsConfig,
+            BeanContainer beanContainer,
             HttpConfiguration httpConfiguration) {
         if (oidcConfig.defaultTenant.applicationType == OidcTenantConfig.ApplicationType.WEB_APP) {
             throw new OIDCException("Application type [" + oidcConfig.defaultTenant.applicationType + "] is not supported");
         }
-        beanContainer.instance(KeycloakPolicyEnforcerAuthorizer.class).init(oidcConfig, config, httpConfiguration);
+        beanContainer.instance(KeycloakPolicyEnforcerAuthorizer.class).init(oidcConfig, config, tlsConfig, httpConfiguration);
     }
 }

--- a/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientBuildStep.java
+++ b/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientBuildStep.java
@@ -5,13 +5,14 @@ import static io.quarkus.kubernetes.client.runtime.KubernetesClientUtils.*;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientBuildConfig;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
+import io.quarkus.runtime.TlsConfig;
 
 public class KubernetesClientBuildStep {
 
     private KubernetesClientBuildConfig buildConfig;
 
     @BuildStep
-    public KubernetesClientBuildItem process() {
-        return new KubernetesClientBuildItem(createClient(buildConfig));
+    public KubernetesClientBuildItem process(TlsConfig tlsConfig) {
+        return new KubernetesClientBuildItem(createClient(buildConfig, tlsConfig));
     }
 }

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientBuildConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientBuildConfig.java
@@ -14,7 +14,7 @@ public class KubernetesClientBuildConfig {
      * Whether or not the client should trust a self signed certificate if so presented by the API server
      */
     @ConfigItem
-    public boolean trustCerts;
+    public Optional<Boolean> trustCerts = Optional.empty();
 
     /**
      * URL of the Kubernetes API server

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.runtime.TlsConfig;
 
 @Singleton
 public class KubernetesClientProducer {
@@ -17,8 +18,8 @@ public class KubernetesClientProducer {
     @DefaultBean
     @Singleton
     @Produces
-    public Config config(KubernetesClientBuildConfig buildConfig) {
-        return KubernetesClientUtils.createConfig(buildConfig);
+    public Config config(KubernetesClientBuildConfig buildConfig, TlsConfig tlsConfig) {
+        return KubernetesClientUtils.createConfig(buildConfig, tlsConfig);
     }
 
     @DefaultBean

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
@@ -8,15 +8,17 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.runtime.TlsConfig;
 
 public class KubernetesClientUtils {
 
     private static final String PREFIX = "quarkus.kubernetes-client.";
 
-    public static Config createConfig(KubernetesClientBuildConfig buildConfig) {
+    public static Config createConfig(KubernetesClientBuildConfig buildConfig, TlsConfig tlsConfig) {
         Config base = Config.autoConfigure(null);
+        boolean trustAll = buildConfig.trustCerts.isPresent() ? buildConfig.trustCerts.get() : tlsConfig.trustAll;
         return new ConfigBuilder()
-                .withTrustCerts(buildConfig.trustCerts)
+                .withTrustCerts(trustAll)
                 .withWatchReconnectInterval((int) buildConfig.watchReconnectInterval.toMillis())
                 .withWatchReconnectLimit(buildConfig.watchReconnectLimit)
                 .withConnectionTimeout((int) buildConfig.connectionTimeout.toMillis())
@@ -43,8 +45,8 @@ public class KubernetesClientUtils {
                 .build();
     }
 
-    public static KubernetesClient createClient(KubernetesClientBuildConfig buildConfig) {
-        return new DefaultKubernetesClient(createConfig(buildConfig));
+    public static KubernetesClient createClient(KubernetesClientBuildConfig buildConfig, TlsConfig tlsConfig) {
+        return new DefaultKubernetesClient(createConfig(buildConfig, tlsConfig));
     }
 
     public static KubernetesClient createClient() {

--- a/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
+++ b/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
@@ -17,6 +17,7 @@ import io.quarkus.kubernetes.client.runtime.KubernetesConfigRecorder;
 import io.quarkus.kubernetes.client.runtime.KubernetesConfigSourceConfig;
 import io.quarkus.kubernetes.spi.KubernetesRoleBindingBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
+import io.quarkus.runtime.TlsConfig;
 
 public class KubernetesConfigProcessor {
 
@@ -24,9 +25,10 @@ public class KubernetesConfigProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public RunTimeConfigurationSourceValueBuildItem configure(KubernetesConfigRecorder recorder,
             KubernetesConfigSourceConfig config, KubernetesConfigBuildTimeConfig buildTimeConfig,
-            KubernetesClientBuildConfig clientConfig) {
+            KubernetesClientBuildConfig clientConfig,
+            TlsConfig tlsConfig) {
         return new RunTimeConfigurationSourceValueBuildItem(
-                recorder.configSources(config, buildTimeConfig, clientConfig));
+                recorder.configSources(config, buildTimeConfig, clientConfig, tlsConfig));
     }
 
     @BuildStep

--- a/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesConfigRecorder.java
+++ b/extensions/kubernetes-config/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesConfigRecorder.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.AbstractRawDefaultConfigSource;
 
@@ -21,7 +22,8 @@ public class KubernetesConfigRecorder {
 
     public RuntimeValue<ConfigSourceProvider> configSources(KubernetesConfigSourceConfig kubernetesConfigSourceConfig,
             KubernetesConfigBuildTimeConfig buildTimeConfig,
-            KubernetesClientBuildConfig clientConfig) {
+            KubernetesClientBuildConfig clientConfig,
+            TlsConfig tlsConfig) {
         if ((!kubernetesConfigSourceConfig.enabled && !buildTimeConfig.secretsEnabled) || isExplicitlyDisabled()) {
             log.debug(
                     "No attempt will be made to obtain configuration from the Kubernetes API server because the functionality has been disabled via configuration");
@@ -29,7 +31,7 @@ public class KubernetesConfigRecorder {
         }
 
         return new RuntimeValue<>(new KubernetesConfigSourceProvider(kubernetesConfigSourceConfig, buildTimeConfig,
-                KubernetesClientUtils.createClient(clientConfig)));
+                KubernetesClientUtils.createClient(clientConfig, tlsConfig)));
     }
 
     // We don't want to enable the reading of anything if 'quarkus.kubernetes-config.enabled' is EXPLICITLY set to false

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailConfig.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailConfig.java
@@ -65,10 +65,10 @@ public class MailConfig {
 
     /**
      * Set whether to trust all certificates on ssl connect the option is also
-     * applied to {@code STARTTLS} operation. {@code false} by default.
+     * applied to {@code STARTTLS} operation. Disabled by default.
      */
     @ConfigItem
-    public boolean trustAll;
+    public Optional<Boolean> trustAll = Optional.empty();
 
     /**
      * Configures the maximum allowed number of open connections to the mail server

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MutinyMailerImpl.java
@@ -51,7 +51,7 @@ public class MutinyMailerImpl implements ReactiveMailer {
         public Void apply(List<?> results) {
             return null;
         }
-    };;
+    };
 
     @Override
     public Uni<Void> send(Mail... mails) {

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -35,6 +35,7 @@ import io.quarkus.oidc.runtime.OidcJsonWebTokenProducer;
 import io.quarkus.oidc.runtime.OidcRecorder;
 import io.quarkus.oidc.runtime.OidcTokenCredentialProducer;
 import io.quarkus.oidc.runtime.TenantConfigBean;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.smallrye.jwt.auth.cdi.ClaimValueProducer;
 import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
@@ -92,9 +93,10 @@ public class OidcBuildStep {
     public SyntheticBeanBuildItem setup(
             OidcConfig config,
             OidcRecorder recorder,
-            CoreVertxBuildItem vertxBuildItem) {
+            CoreVertxBuildItem vertxBuildItem,
+            TlsConfig tlsConfig) {
         return SyntheticBeanBuildItem.configure(TenantConfigBean.class).unremovable().types(TenantConfigBean.class)
-                .supplier(recorder.setup(config, vertxBuildItem.getVertx()))
+                .supplier(recorder.setup(config, vertxBuildItem.getVertx(), tlsConfig))
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .done();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -187,15 +187,14 @@ public class OidcTenantConfig {
          * Certificate validation and hostname verification, which can be one of the following values from enum
          * {@link Verification}. Default is required.
          */
-        @ConfigItem(defaultValue = "REQUIRED")
-        public Verification verification;
+        public Optional<Verification> verification = Optional.empty();
 
-        public Verification getVerification() {
+        public Optional<Verification> getVerification() {
             return verification;
         }
 
         public void setVerification(Verification verification) {
-            this.verification = verification;
+            this.verification = Optional.ofNullable(verification);
         }
 
     }

--- a/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -44,6 +44,8 @@ public class RestClientBase {
     public static final String REST_KEY_STORE_PASSWORD = "%s/" + MP_REST + "/keyStorePassword";
     public static final String REST_KEY_STORE_TYPE = "%s/" + MP_REST + "/keyStoreType";
     public static final String REST_HOSTNAME_VERIFIER = "%s/" + MP_REST + "/hostnameVerifier";
+    public static final String REST_NOOP_HOSTNAME_VERIFIER = "io.quarkus.restclient.NoopHostnameVerifier";
+    public static final String TLS_TRUST_ALL = "quarkus.tls.trust-all";
 
     private final Class<?> proxyType;
     private final String baseUriFromAnnotation;
@@ -72,17 +74,23 @@ public class RestClientBase {
     }
 
     private void configureSsl(RestClientBuilder builder) {
-        Optional<String> maybeTrustStore = getOptionalProperty(REST_TRUST_STORE, String.class);
+
+        Optional<Boolean> trustAll = getOptionalProperty(TLS_TRUST_ALL, Boolean.class);
+        if (trustAll.isPresent() && trustAll.get()) {
+            registerHostnameVerifier(REST_NOOP_HOSTNAME_VERIFIER, builder);
+        }
+
+        Optional<String> maybeTrustStore = getOptionalDynamicProperty(REST_TRUST_STORE, String.class);
         if (maybeTrustStore.isPresent()) {
             registerTrustStore(maybeTrustStore.get(), builder);
         }
 
-        Optional<String> maybeKeyStore = getOptionalProperty(REST_KEY_STORE, String.class);
+        Optional<String> maybeKeyStore = getOptionalDynamicProperty(REST_KEY_STORE, String.class);
         if (maybeKeyStore.isPresent()) {
             registerKeyStore(maybeKeyStore.get(), builder);
         }
 
-        Optional<String> maybeHostnameVerifier = getOptionalProperty(REST_HOSTNAME_VERIFIER, String.class);
+        Optional<String> maybeHostnameVerifier = getOptionalDynamicProperty(REST_HOSTNAME_VERIFIER, String.class);
         if (maybeHostnameVerifier.isPresent()) {
             registerHostnameVerifier(maybeHostnameVerifier.get(), builder);
         }
@@ -115,8 +123,8 @@ public class RestClientBase {
     }
 
     private void registerKeyStore(String keyStorePath, RestClientBuilder builder) {
-        Optional<String> keyStorePassword = getOptionalProperty(REST_KEY_STORE_PASSWORD, String.class);
-        Optional<String> keyStoreType = getOptionalProperty(REST_KEY_STORE_TYPE, String.class);
+        Optional<String> keyStorePassword = getOptionalDynamicProperty(REST_KEY_STORE_PASSWORD, String.class);
+        Optional<String> keyStoreType = getOptionalDynamicProperty(REST_KEY_STORE_TYPE, String.class);
 
         try {
             KeyStore keyStore = KeyStore.getInstance(keyStoreType.orElse("JKS"));
@@ -139,8 +147,8 @@ public class RestClientBase {
     }
 
     private void registerTrustStore(String trustStorePath, RestClientBuilder builder) {
-        Optional<String> maybeTrustStorePassword = getOptionalProperty(REST_TRUST_STORE_PASSWORD, String.class);
-        Optional<String> maybeTrustStoreType = getOptionalProperty(REST_TRUST_STORE_TYPE, String.class);
+        Optional<String> maybeTrustStorePassword = getOptionalDynamicProperty(REST_TRUST_STORE_PASSWORD, String.class);
+        Optional<String> maybeTrustStoreType = getOptionalDynamicProperty(REST_TRUST_STORE_TYPE, String.class);
 
         try {
             KeyStore trustStore = KeyStore.getInstance(maybeTrustStoreType.orElse("JKS"));
@@ -188,7 +196,7 @@ public class RestClientBase {
     }
 
     private void configureProviders(RestClientBuilder builder) {
-        Optional<String> maybeProviders = getOptionalProperty(REST_PROVIDERS, String.class);
+        Optional<String> maybeProviders = getOptionalDynamicProperty(REST_PROVIDERS, String.class);
         if (maybeProviders.isPresent()) {
             registerProviders(builder, maybeProviders.get());
         }
@@ -209,21 +217,21 @@ public class RestClientBase {
     }
 
     private void configureTimeouts(RestClientBuilder builder) {
-        Optional<Long> connectTimeout = getOptionalProperty(REST_CONNECT_TIMEOUT_FORMAT, Long.class);
+        Optional<Long> connectTimeout = getOptionalDynamicProperty(REST_CONNECT_TIMEOUT_FORMAT, Long.class);
         if (connectTimeout.isPresent()) {
             builder.connectTimeout(connectTimeout.get(), TimeUnit.MILLISECONDS);
         }
 
-        Optional<Long> readTimeout = getOptionalProperty(REST_READ_TIMEOUT_FORMAT, Long.class);
+        Optional<Long> readTimeout = getOptionalDynamicProperty(REST_READ_TIMEOUT_FORMAT, Long.class);
         if (readTimeout.isPresent()) {
             builder.readTimeout(readTimeout.get(), TimeUnit.MILLISECONDS);
         }
     }
 
     private void configureBaseUrl(RestClientBuilder builder) {
-        Optional<String> propertyOptional = getOptionalProperty(REST_URI_FORMAT, String.class);
+        Optional<String> propertyOptional = getOptionalDynamicProperty(REST_URI_FORMAT, String.class);
         if (!propertyOptional.isPresent()) {
-            propertyOptional = getOptionalProperty(REST_URL_FORMAT, String.class);
+            propertyOptional = getOptionalDynamicProperty(REST_URL_FORMAT, String.class);
         }
         if (((baseUriFromAnnotation == null) || baseUriFromAnnotation.isEmpty())
                 && !propertyOptional.isPresent()) {
@@ -250,10 +258,16 @@ public class RestClientBase {
         }
     }
 
-    private <T> Optional<T> getOptionalProperty(String propertyFormat, Class<T> type) {
+    private <T> Optional<T> getOptionalDynamicProperty(String propertyFormat, Class<T> type) {
         final Config config = ConfigProvider.getConfig();
         Optional<T> interfaceNameValue = config.getOptionalValue(String.format(propertyFormat, proxyType.getName()), type);
         return interfaceNameValue.isPresent() ? interfaceNameValue
                 : config.getOptionalValue(String.format(propertyFormat, propertyPrefix), type);
     }
+
+    private <T> Optional<T> getOptionalProperty(String propertyName, Class<T> type) {
+        final Config config = ConfigProvider.getConfig();
+        return config.getOptionalValue(propertyName, type);
+    }
+
 }

--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
@@ -17,6 +17,7 @@ import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationSourceBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vault.runtime.Base64StringDeserializer;
 import io.quarkus.vault.runtime.Base64StringSerializer;
@@ -73,8 +74,9 @@ public class VaultProcessor {
 
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    void configure(VaultRecorder recorder, VaultBuildTimeConfig buildTimeConfig, VaultRuntimeConfig serverConfig) {
-        recorder.configureRuntimeProperties(buildTimeConfig, serverConfig);
+    void configure(VaultRecorder recorder, VaultBuildTimeConfig buildTimeConfig, VaultRuntimeConfig serverConfig,
+            TlsConfig tlsConfig) {
+        recorder.configureRuntimeProperties(buildTimeConfig, serverConfig, tlsConfig);
     }
 
     @BuildStep

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultManager.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultManager.java
@@ -1,5 +1,6 @@
 package io.quarkus.vault.runtime;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.runtime.client.OkHttpVaultClient;
 import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
@@ -11,6 +12,7 @@ public class VaultManager {
 
     private VaultRuntimeConfig serverConfig;
     private VaultBuildTimeConfig buildTimeConfig;
+    private TlsConfig tlsConfig;
 
     private VaultClient vaultClient;
     private VaultAuthManager vaultAuthManager;
@@ -26,9 +28,9 @@ public class VaultManager {
         return instance;
     }
 
-    public static void init(VaultBuildTimeConfig buildTimeConfig, VaultRuntimeConfig serverConfig) {
+    public static void init(VaultBuildTimeConfig buildTimeConfig, VaultRuntimeConfig serverConfig, TlsConfig tlsConfig) {
         if (instance == null) {
-            instance = new VaultManager(buildTimeConfig, serverConfig);
+            instance = new VaultManager(buildTimeConfig, serverConfig, tlsConfig);
         }
     }
 
@@ -36,14 +38,16 @@ public class VaultManager {
         instance = null;
     }
 
-    public VaultManager(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig serverConfig) {
-        this(vaultBuildTimeConfig, serverConfig, new OkHttpVaultClient(serverConfig));
+    public VaultManager(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig serverConfig, TlsConfig tlsConfig) {
+        this(vaultBuildTimeConfig, serverConfig, new OkHttpVaultClient(serverConfig, tlsConfig), tlsConfig);
     }
 
-    public VaultManager(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig serverConfig, VaultClient vaultClient) {
+    public VaultManager(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig serverConfig, VaultClient vaultClient,
+            TlsConfig tlsConfig) {
         this.serverConfig = serverConfig;
         this.vaultClient = vaultClient;
         this.buildTimeConfig = vaultBuildTimeConfig;
+        this.tlsConfig = tlsConfig;
         this.vaultAuthManager = new VaultAuthManager(this.vaultClient, serverConfig);
         this.vaultKvManager = new VaultKvManager(this.vaultAuthManager, this.vaultClient, serverConfig);
         this.vaultDbManager = new VaultDbManager(this.vaultAuthManager, this.vaultClient, serverConfig);
@@ -89,6 +93,10 @@ public class VaultManager {
 
     public VaultBuildTimeConfig getBuildTimeConfig() {
         return buildTimeConfig;
+    }
+
+    public TlsConfig getTlsConfig() {
+        return tlsConfig;
     }
 
     public VaultSystemBackendManager getVaultSystemBackendManager() {

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
@@ -3,6 +3,7 @@ package io.quarkus.vault.runtime;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
@@ -12,11 +13,12 @@ public class VaultRecorder {
 
     private static final Logger log = Logger.getLogger(VaultRecorder.class);
 
-    public void configureRuntimeProperties(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig vaultRuntimeConfig) {
+    public void configureRuntimeProperties(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig vaultRuntimeConfig,
+            TlsConfig tlsConfig) {
 
         if (vaultRuntimeConfig.url.isPresent()) {
             VaultServiceProducer producer = Arc.container().instance(VaultServiceProducer.class).get();
-            producer.setVaultConfigs(vaultBuildTimeConfig, vaultRuntimeConfig);
+            producer.setVaultConfigs(vaultBuildTimeConfig, vaultRuntimeConfig, tlsConfig);
         }
 
     }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultServiceProducer.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultServiceProducer.java
@@ -6,6 +6,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 
 import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.VaultKVSecretEngine;
 import io.quarkus.vault.VaultSystemBackendEngine;
 import io.quarkus.vault.VaultTOTPSecretEngine;
@@ -58,7 +59,7 @@ public class VaultServiceProducer {
         VaultManager.reset();
     }
 
-    public void setVaultConfigs(VaultBuildTimeConfig buildTimeConfig, VaultRuntimeConfig serverConfig) {
-        VaultManager.init(buildTimeConfig, serverConfig);
+    public void setVaultConfigs(VaultBuildTimeConfig buildTimeConfig, VaultRuntimeConfig serverConfig, TlsConfig tlsConfig) {
+        VaultManager.init(buildTimeConfig, serverConfig, tlsConfig);
     }
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpClientFactory.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpClientFactory.java
@@ -17,6 +17,7 @@ import javax.net.ssl.X509TrustManager;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.util.JavaVersionUtil;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
@@ -27,7 +28,7 @@ public class OkHttpClientFactory {
 
     private static final Logger log = Logger.getLogger(OkHttpClientFactory.class.getName());
 
-    public static OkHttpClient createHttpClient(VaultRuntimeConfig serverConfig) {
+    public static OkHttpClient createHttpClient(VaultRuntimeConfig serverConfig, TlsConfig tlsConfig) {
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder()
                 .connectTimeout(serverConfig.connectTimeout)
@@ -40,7 +41,8 @@ public class OkHttpClientFactory {
         }
 
         try {
-            if (serverConfig.tls.skipVerify) {
+            boolean trustAll = serverConfig.tls.skipVerify.isPresent() ? serverConfig.tls.skipVerify.get() : tlsConfig.trustAll;
+            if (trustAll) {
                 skipVerify(builder);
             } else if (serverConfig.tls.caCert.isPresent()) {
                 cacert(builder, serverConfig.tls.caCert.get());

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuthBody;
@@ -83,8 +84,8 @@ public class OkHttpVaultClient implements VaultClient {
     private String kubernetesAuthMountPath;
     private ObjectMapper mapper = new ObjectMapper();
 
-    public OkHttpVaultClient(VaultRuntimeConfig serverConfig) {
-        this.client = createHttpClient(serverConfig);
+    public OkHttpVaultClient(VaultRuntimeConfig serverConfig, TlsConfig tlsConfig) {
+        this.client = createHttpClient(serverConfig, tlsConfig);
         this.url = serverConfig.url.get();
         this.mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
         this.mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -30,7 +30,6 @@ public class VaultRuntimeConfig {
     public static final String KUBERNETES_CACERT = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
     public static final String DEFAULT_CONNECT_TIMEOUT = "5S";
     public static final String DEFAULT_READ_TIMEOUT = "1S";
-    public static final String DEFAULT_TLS_SKIP_VERIFY = "false";
     public static final String DEFAULT_TLS_USE_KUBERNETES_CACERT = "true";
     public static final String DEFAULT_KUBERNETES_AUTH_MOUNT_PATH = "auth/kubernetes";
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultTlsConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultTlsConfig.java
@@ -1,6 +1,5 @@
 package io.quarkus.vault.runtime.config;
 
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_TLS_SKIP_VERIFY;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_TLS_USE_KUBERNETES_CACERT;
 
 import java.util.Optional;
@@ -18,8 +17,8 @@ public class VaultTlsConfig {
      * certificate presented by Vault. This is discouraged in production because it allows man in the middle
      * type of attacks.
      */
-    @ConfigItem(defaultValue = DEFAULT_TLS_SKIP_VERIFY)
-    public boolean skipVerify;
+    @ConfigItem
+    public Optional<Boolean> skipVerify = Optional.empty();
 
     /**
      * Certificate bundle used to validate TLS communications with Vault.

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultAuthManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultAuthManagerTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.runtime.client.OkHttpVaultClient;
 import io.quarkus.vault.runtime.client.VaultClientException;
 import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
@@ -28,6 +29,7 @@ import io.quarkus.vault.runtime.config.VaultUserpassAuthenticationConfig;
 public class VaultAuthManagerTest {
 
     VaultRuntimeConfig config = createConfig();
+    TlsConfig tlsConfig = new TlsConfig();
     AtomicBoolean lookupSelfShouldReturn403 = new AtomicBoolean(false);
     OkHttpVaultClient vaultClient = createVaultClient();
     VaultAuthManager vaultAuthManager = new VaultAuthManager(vaultClient, config);
@@ -107,7 +109,7 @@ public class VaultAuthManagerTest {
             config.authentication.userpass.passwordWrappingToken = Optional.empty();
             config.connectTimeout = Duration.ofSeconds(1);
             config.readTimeout = Duration.ofSeconds(1);
-            config.tls.skipVerify = true;
+            config.tls.skipVerify = Optional.of(true);
             config.logConfidentialityLevel = LogConfidentialityLevel.LOW;
             config.renewGracePeriod = Duration.ofSeconds(3);
             return config;
@@ -117,7 +119,7 @@ public class VaultAuthManagerTest {
     }
 
     private OkHttpVaultClient createVaultClient() {
-        return new OkHttpVaultClient(config) {
+        return new OkHttpVaultClient(config, tlsConfig) {
             @Override
             public VaultUserPassAuth loginUserPass(String user, String password) {
                 return vaultUserPassAuth;

--- a/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
+++ b/extensions/vault/runtime/src/test/java/io/quarkus/vault/runtime/VaultDbManagerTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.runtime.client.OkHttpVaultClient;
 import io.quarkus.vault.runtime.client.VaultClientException;
 import io.quarkus.vault.runtime.client.dto.database.VaultDatabaseCredentials;
@@ -30,6 +31,7 @@ import io.quarkus.vault.runtime.config.VaultUserpassAuthenticationConfig;
 public class VaultDbManagerTest {
 
     VaultRuntimeConfig config = createConfig();
+    TlsConfig tlsConfig = new TlsConfig();
     VaultDatabaseCredentials credentials = new VaultDatabaseCredentials();
     VaultLeasesLookup vaultLeasesLookup = new VaultLeasesLookup();
     AtomicBoolean lookupLeaseShouldReturn400 = new AtomicBoolean(false);
@@ -113,7 +115,7 @@ public class VaultDbManagerTest {
             config.authentication.userpass.passwordWrappingToken = Optional.empty();
             config.connectTimeout = Duration.ofSeconds(1);
             config.readTimeout = Duration.ofSeconds(1);
-            config.tls.skipVerify = true;
+            config.tls.skipVerify = Optional.of(true);
             config.logConfidentialityLevel = LogConfidentialityLevel.LOW;
             config.renewGracePeriod = Duration.ofSeconds(3);
             return config;
@@ -123,7 +125,7 @@ public class VaultDbManagerTest {
     }
 
     private OkHttpVaultClient createVaultClient() {
-        return new OkHttpVaultClient(config) {
+        return new OkHttpVaultClient(config, tlsConfig) {
             @Override
             public VaultDatabaseCredentials generateDatabaseCredentials(String token, String databaseCredentialsRole) {
                 return credentials;

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllIT.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.rest.client.trustall;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class ExternalTlsTrustAllIT extends ExternalTlsTrustAllTestCase {
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.rest.client.trustall;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(ExternalTlsTrustAllTestResource.class)
+public class ExternalTlsTrustAllTestCase {
+
+    @Test
+    public void restClient() {
+        when()
+                .get("/wrong-host")
+                .then()
+                .statusCode(200)
+                .body(is("200"));
+    }
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestResource.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.rest.client.trustall;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class ExternalTlsTrustAllTestResource implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> result = new HashMap<>();
+        result.put("wrong-host/mp-rest/trustStore", System.getProperty("rest-client.trustStore"));
+        result.put("wrong-host/mp-rest/trustStorePassword", System.getProperty("rest-client.trustStorePassword"));
+        result.put("quarkus.tls.trust-all", "true");
+        return result;
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
@@ -4,7 +4,7 @@ quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
 quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
 
-quarkus.vault.tls.skip-verify=true
+quarkus.tls.trust-all=true
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
 quarkus.vault.read-timeout=5S

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -46,6 +46,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.OutputFrame;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.VaultKVSecretEngine;
 import io.quarkus.vault.runtime.VaultManager;
@@ -168,7 +169,7 @@ public class VaultTestExtension {
         VaultRuntimeConfig serverConfig = new VaultRuntimeConfig();
         serverConfig.tls = new VaultTlsConfig();
         serverConfig.url = getVaultUrl();
-        serverConfig.tls.skipVerify = true;
+        serverConfig.tls.skipVerify = Optional.of(true);
         serverConfig.tls.caCert = Optional.empty();
         serverConfig.connectTimeout = Duration.ofSeconds(5);
         serverConfig.readTimeout = Duration.ofSeconds(1);
@@ -177,8 +178,9 @@ public class VaultTestExtension {
 
         VaultBuildTimeConfig buildTimeConfig = new VaultBuildTimeConfig();
         buildTimeConfig.health = new HealthConfig();
+        TlsConfig tlsConfig = new TlsConfig();
 
-        return new VaultManager(buildTimeConfig, serverConfig, new TestVaultClient(serverConfig));
+        return new VaultManager(buildTimeConfig, serverConfig, new TestVaultClient(serverConfig, tlsConfig), tlsConfig);
     }
 
     private static Optional<URL> getVaultUrl() {

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/client/TestVaultClient.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/client/TestVaultClient.java
@@ -1,5 +1,6 @@
 package io.quarkus.vault.test.client;
 
+import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.runtime.VaultManager;
 import io.quarkus.vault.runtime.client.OkHttpVaultClient;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitRandomBody;
@@ -13,11 +14,11 @@ import io.quarkus.vault.test.client.dto.VaultTransitRandom;
 public class TestVaultClient extends OkHttpVaultClient {
 
     public TestVaultClient() {
-        this(VaultManager.getInstance().getServerConfig());
+        this(VaultManager.getInstance().getServerConfig(), VaultManager.getInstance().getTlsConfig());
     }
 
-    public TestVaultClient(VaultRuntimeConfig serverConfig) {
-        super(serverConfig);
+    public TestVaultClient(VaultRuntimeConfig serverConfig, TlsConfig tlsConfig) {
+        super(serverConfig, tlsConfig);
     }
 
     public VaultAppRoleSecretId generateAppRoleSecretId(String token, String roleName) {


### PR DESCRIPTION
This branch adds a global config property `quarkus.tls.trust-all`. Thus, extensions which needs a property to enable/disable tls verification could use it. 

There are some failed tests. 
Here is the problem: 
The `quarkus.tls.trust-all` property has a default value to `false`. 
When configuring an other property (`quarkus.vault.tls.skip-verify`) as: 

    @ConfigItem(defaultValue = "${quarkus.tls.trust-all}")

This will end with an error resolving the property. But when setting `quarkus.tls.trust-all` property in `application.properties`, the resolution will be ok. 
I think using `Optional` could fix it but it means handling default value in each extension.

close #8975 
close #12266