### PR TITLE
[WIP] add kotlin allopen transformation

### DIFF
--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/AllOpenConfig.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/AllOpenConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.kotlin.deployment;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "allopen")
+public class AllOpenConfig {
+
+    public final List<DotName> defaultAnnotations = Arrays.asList(
+            DotName.createSimple("javax.ws.rs.Path"),
+            DotName.createSimple("javax.enterprise.context.ApplicationScoped"),
+            DotName.createSimple("io.quarkus.test.junit.QuarkusTest"));
+}

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
@@ -1,15 +1,32 @@
 package io.quarkus.kotlin.deployment;
 
 import io.quarkus.deployment.Feature;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.logging.Logger;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassFinalFieldsWritablePredicateBuildItem;
+import io.quarkus.gizmo.Gizmo;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 
 public class KotlinProcessor {
 
     private static final String KOTLIN_JACKSON_MODULE = "com.fasterxml.jackson.module.kotlin.KotlinModule";
+    public static final Logger logger = Logger.getLogger(KotlinProcessor.class.getName());
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -37,5 +54,48 @@ public class KotlinProcessor {
     @BuildStep
     ReflectiveClassFinalFieldsWritablePredicateBuildItem dataClassPredicate() {
         return new ReflectiveClassFinalFieldsWritablePredicateBuildItem(new IsDataClassWithDefaultValuesPredicate());
+    }
+
+    @BuildStep
+    void transformToOpenClasses(
+            ApplicationIndexBuildItem applicationIndexBuildItem,
+            BuildProducer<BytecodeTransformerBuildItem> transformer,
+            AllOpenConfig allOpenConfig) {
+
+        Collection<ClassInfo> classes = applicationIndexBuildItem.getIndex().getKnownClasses();
+
+        ArrayList<DotName> classesToTransform = new ArrayList<>();
+        for (ClassInfo classInfo : classes) {
+            for (List<AnnotationInstance> annotationInstances : classInfo.annotations().values()) {
+                for (AnnotationInstance annotationInstance : annotationInstances) {
+                    for (DotName defaultAnnotation : allOpenConfig.defaultAnnotations) {
+                        if (annotationInstance.name().equals(defaultAnnotation)) {
+                            classesToTransform.add(classInfo.name());
+                        }
+                    }
+                }
+            }
+        }
+
+        for (DotName classToTransform : classesToTransform) {
+            logger.info("ClassToTransform : " + classToTransform);
+            transformer.produce(new BytecodeTransformerBuildItem(classToTransform.toString(),
+                    new BiFunction<String, ClassVisitor, ClassVisitor>() {
+                        @Override
+                        public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                            ClassVisitor cv = new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                                @Override
+                                public void visit(int version, int access, String name, String signature, String superName,
+                                        String[] interfaces) {
+                                    super.visit(version, access, name, signature, superName, interfaces);
+                                    access = access ^ Opcodes.ACC_FINAL;
+                                    classVisitor.visit(version, access, name, signature, superName, interfaces);
+                                }
+                            };
+                            return cv;
+                        }
+                    }));
+        }
+
     }
 }


### PR DESCRIPTION
cc @evanchooly @geoand 

Currently it is able to transform only classes with annotation
 but if a class (which is to be opened) extends a class (which also needs to be opened) than it fails

For example `class NativeImageTest : GreetingResourceTest`  then it fails 
probably because GreetingResourceTest has not been opened by transformer yet