### PR TITLE
Properly use password instead of user for MySQL reactive

### DIFF
--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -108,7 +108,7 @@ public class MySQLPoolRecorder {
                 mysqlConnectOptions.setUser(user);
             }
             if (password != null) {
-                mysqlConnectOptions.setPassword(user);
+                mysqlConnectOptions.setPassword(password);
             }
         }
 


### PR DESCRIPTION
Fixes #9849 for the MySQL reactive client.

This is a follow-up of https://github.com/quarkusio/quarkus/pull/9850 .