### PR TITLE
OIDC JWK refresh support

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AccessTokenCredential.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/AccessTokenCredential.java
@@ -1,11 +1,13 @@
 package io.quarkus.oidc;
 
 import io.quarkus.oidc.runtime.ContextAwareTokenCredential;
+import io.quarkus.oidc.runtime.OidcUtils;
 import io.vertx.ext.web.RoutingContext;
 
 public class AccessTokenCredential extends ContextAwareTokenCredential {
 
     private RefreshToken refreshToken;
+    private boolean opaque;
 
     public AccessTokenCredential() {
         this(null, null);
@@ -17,7 +19,7 @@ public class AccessTokenCredential extends ContextAwareTokenCredential {
      * @param accessToken - access token
      */
     public AccessTokenCredential(String accessToken, RoutingContext context) {
-        super(accessToken, "bearer", context);
+        this(accessToken, null, context);
     }
 
     /**
@@ -27,11 +29,18 @@ public class AccessTokenCredential extends ContextAwareTokenCredential {
      * @param refreshToken - refresh token which can be used to refresh this access token, may be null
      */
     public AccessTokenCredential(String accessToken, RefreshToken refreshToken, RoutingContext context) {
-        this(accessToken, context);
+        super(accessToken, "bearer", context);
         this.refreshToken = refreshToken;
+        if (accessToken != null) {
+            this.opaque = OidcUtils.isOpaqueToken(accessToken);
+        }
     }
 
     public RefreshToken getRefreshToken() {
         return refreshToken;
+    }
+
+    public boolean isOpaque() {
+        return opaque;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -641,8 +641,8 @@ public class OidcTenantConfig {
         /**
          * Forced JWK set refresh interval in minutes.
          */
-        @ConfigItem(defaultValue = "10")
-        public long forcedJwkRefreshInterval = 10;
+        @ConfigItem(defaultValue = "10M")
+        public Duration forcedJwkRefreshInterval = Duration.ofMinutes(10);
 
         public Optional<String> getIssuer() {
             return issuer;
@@ -684,11 +684,11 @@ public class OidcTenantConfig {
             this.refreshExpired = refreshExpired;
         }
 
-        public long getForcedJwkRefreshInterval() {
+        public Duration getForcedJwkRefreshInterval() {
             return forcedJwkRefreshInterval;
         }
 
-        public void setForcedJwkRefreshInterval(long forcedJwkRefreshInterval) {
+        public void setForcedJwkRefreshInterval(Duration forcedJwkRefreshInterval) {
             this.forcedJwkRefreshInterval = forcedJwkRefreshInterval;
         }
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -638,6 +638,12 @@ public class OidcTenantConfig {
         @ConfigItem
         public boolean refreshExpired;
 
+        /**
+         * Forced JWK set refresh interval in minutes.
+         */
+        @ConfigItem(defaultValue = "10")
+        public long forcedJwkRefreshInterval = 10;
+
         public Optional<String> getIssuer() {
             return issuer;
         }
@@ -676,6 +682,14 @@ public class OidcTenantConfig {
 
         public void setRefreshExpired(boolean refreshExpired) {
             this.refreshExpired = refreshExpired;
+        }
+
+        public long getForcedJwkRefreshInterval() {
+            return forcedJwkRefreshInterval;
+        }
+
+        public void setForcedJwkRefreshInterval(long forcedJwkRefreshInterval) {
+            this.forcedJwkRefreshInterval = forcedJwkRefreshInterval;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -193,8 +193,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 LOG.debug("State parameter can not be empty or multi-valued");
                 return Uni.createFrom().failure(new AuthenticationCompletionException());
             } else if (!stateCookie.getValue().startsWith(values.get(0))) {
-                LOG.debugf("State cookie value '%s' does not match the state query parameter value '%s'",
-                        stateCookie.getValue(), values.get(0));
+                LOG.debug("State cookie value does not match the state query parameter value");
                 return Uni.createFrom().failure(new AuthenticationCompletionException());
             } else if (context.queryParam("pathChecked").isEmpty()) {
                 // This is an original redirect from IDP, check if the request path needs to be updated

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -193,7 +193,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                 LOG.debug("State parameter can not be empty or multi-valued");
                 return Uni.createFrom().failure(new AuthenticationCompletionException());
             } else if (!stateCookie.getValue().startsWith(values.get(0))) {
-                LOG.debug("State cookie does not match the state parameter");
+                LOG.debugf("State cookie value '%s' does not match the state query parameter value '%s'",
+                        stateCookie.getValue(), values.get(0));
                 return Uni.createFrom().failure(new AuthenticationCompletionException());
             } else if (context.queryParam("pathChecked").isEmpty()) {
                 // This is an original redirect from IDP, check if the request path needs to be updated

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JwkSetRefreshHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JwkSetRefreshHandler.java
@@ -1,5 +1,7 @@
 package io.quarkus.oidc.runtime;
 
+import java.time.Duration;
+
 import org.jboss.logging.Logger;
 
 import io.vertx.core.Handler;
@@ -11,9 +13,9 @@ public class JwkSetRefreshHandler implements Handler<String> {
     private volatile long lastForcedRefreshTime;
     private long forcedJwksRefreshIntervalMilliSecs;
 
-    public JwkSetRefreshHandler(OAuth2Auth auth, long forcedJwksRefreshInterval) {
+    public JwkSetRefreshHandler(OAuth2Auth auth, Duration forcedJwksRefreshInterval) {
         this.auth = auth;
-        this.forcedJwksRefreshIntervalMilliSecs = forcedJwksRefreshInterval * 60 * 1000;
+        this.forcedJwksRefreshIntervalMilliSecs = forcedJwksRefreshInterval.toMillis();
     }
 
     @SuppressWarnings("deprecation")

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java
@@ -61,6 +61,9 @@ public class OidcJsonWebTokenProducer {
         }
         TokenCredential credential = identity.getCredential(type);
         if (credential != null) {
+            if (credential instanceof AccessTokenCredential && ((AccessTokenCredential) credential).isOpaque()) {
+                throw new OIDCException("Opaque access token can not be converted to JsonWebToken");
+            }
             JwtClaims jwtClaims;
             try {
                 jwtClaims = new JwtConsumerBuilder()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -213,7 +213,7 @@ public class OidcRecorder {
                 }
             }
         }
-
+        auth.missingKeyHandler(new JwkSetRefreshHandler(auth, oidcConfig.token.forcedJwkRefreshInterval));
         return new TenantConfigContext(auth, oidcConfig);
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -1,7 +1,9 @@
 package io.quarkus.oidc.runtime;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,9 +29,23 @@ public final class OidcUtils {
      * ignoring those which are located inside a pair of the double quotes.
      */
     private static final Pattern CLAIM_PATH_PATTERN = Pattern.compile("\\/(?=(?:(?:[^\"]*\"){2})*[^\"]*$)");
+    private static final Pattern JWT_PARTS_PATTERN = Pattern.compile("\\.");
 
     private OidcUtils() {
 
+    }
+
+    public static boolean isOpaqueToken(String token) {
+        return JWT_PARTS_PATTERN.split(token).length != 3;
+    }
+
+    public static JsonObject decodeJwtContent(String jwt) {
+        String[] parts = JWT_PARTS_PATTERN.split(jwt);
+        if (parts.length != 3) {
+            return null;
+        } else {
+            return new JsonObject(new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8));
+        }
     }
 
     public static boolean validateClaims(OidcTenantConfig.Token tokenConfig, JsonObject json) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -1,6 +1,8 @@
 package io.quarkus.oidc.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -12,10 +14,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.smallrye.jwt.build.Jwt;
 import io.vertx.core.json.JsonObject;
 
 public class OidcUtilsTest {
@@ -174,6 +180,33 @@ public class OidcUtilsTest {
         } catch (Exception ex) {
             // expected
         }
+    }
+
+    @Test
+    public void testTokenIsOpaque() throws Exception {
+        assertTrue(OidcUtils.isOpaqueToken("123"));
+        assertTrue(OidcUtils.isOpaqueToken("1.23"));
+        assertFalse(OidcUtils.isOpaqueToken("1.2.3"));
+    }
+
+    @Test
+    public void testDecodeOpaqueTokenAsJwt() throws Exception {
+        assertNull(OidcUtils.decodeJwtContent("123"));
+        assertNull(OidcUtils.decodeJwtContent("1.23"));
+        assertNull(OidcUtils.decodeJwtContent("1.2.3"));
+    }
+
+    @Test
+    public void testDecodeJwt() throws Exception {
+        final byte[] keyBytes = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
+                .getBytes(StandardCharsets.UTF_8);
+        SecretKey key = new SecretKeySpec(keyBytes, 0, keyBytes.length, "HMACSHA256");
+        String jwt = Jwt.claims().sign(key);
+        assertNull(OidcUtils.decodeJwtContent(jwt + ".4"));
+        JsonObject json = OidcUtils.decodeJwtContent(jwt);
+        assertTrue(json.containsKey("iat"));
+        assertTrue(json.containsKey("exp"));
+        assertTrue(json.containsKey("jti"));
     }
 
     public static JsonObject read(InputStream input) throws IOException {

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -10,23 +10,26 @@ import io.vertx.ext.web.RoutingContext;
 public class CustomTenantConfigResolver implements TenantConfigResolver {
     @Override
     public OidcTenantConfig resolve(RoutingContext context) {
-        if ("tenant-d".equals(context.request().path().split("/")[2])) {
+        String path = context.request().path();
+        String tenantId = path.split("/")[2];
+        if ("tenant-d".equals(tenantId)) {
             OidcTenantConfig config = new OidcTenantConfig();
-            config.setTenantId("tenant-id");
+            config.setTenantId("tenant-d");
             config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-d");
             config.setClientId("quarkus-d");
-            OidcTenantConfig.Credentials credentials = new OidcTenantConfig.Credentials();
-
-            credentials.setSecret("secret");
-
-            config.setCredentials(credentials);
-
-            OidcTenantConfig.Token token = new OidcTenantConfig.Token();
-
-            token.setIssuer(getIssuerUrl() + "/realms/quarkus-d");
-
-            config.setToken(token);
-
+            config.getCredentials().setSecret("secret");
+            config.getToken().setIssuer(getIssuerUrl() + "/realms/quarkus-d");
+            return config;
+        } else if ("tenant-oidc".equals(tenantId)) {
+            OidcTenantConfig config = new OidcTenantConfig();
+            config.setTenantId("tenant-oidc");
+            String uri = context.request().absoluteURI();
+            String keycloakUri = path.contains("tenant-opaque")
+                    ? uri.replace("/tenant-opaque/tenant-oidc/api/user", "/oidc")
+                    : uri.replace("/tenant/tenant-oidc/api/user", "/oidc");
+            config.setAuthServerUrl(keycloakUri);
+            config.setClientId("client");
+            config.getCredentials().setSecret("secret");
             return config;
         }
         return null;

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -1,0 +1,136 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.PostConstruct;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import org.jose4j.jwk.JsonWebKeySet;
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.RsaJwkGenerator;
+
+import io.smallrye.jwt.build.Jwt;
+
+@Path("oidc")
+public class OidcResource {
+
+    @Context
+    UriInfo ui;
+    RsaJsonWebKey key;
+    private volatile boolean introspection;
+    private volatile boolean rotate;
+    private volatile int jwkEndpointCallCount;
+
+    @PostConstruct
+    public void init() throws Exception {
+        key = RsaJwkGenerator.generateJwk(2048);
+        key.setUse("sig");
+        key.setKeyId("1");
+        key.setAlgorithm("RS256");
+    }
+
+    @GET
+    @Produces("application/json")
+    @Path(".well-known/openid-configuration")
+    public String discovery() {
+        final String baseUri = ui.getBaseUriBuilder().path("oidc").build().toString();
+        return "{" +
+                "   \"token_endpoint\":" + "\"" + baseUri + "/token\"," +
+                "   \"token_introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
+                "   \"jwks_uri\":" + "\"" + baseUri + "/jwks\"" +
+                "  }";
+    }
+
+    @GET
+    @Produces("application/json")
+    @Path("jwks")
+    public String jwks() {
+        jwkEndpointCallCount++;
+        if (introspection) {
+            return "{\"keys\":[]}";
+        }
+        String json = new JsonWebKeySet(key).toJson();
+        if (rotate) {
+            json = json.replace("\"1\"", "\"2\"");
+        }
+        return json;
+    }
+
+    @GET
+    @Path("jwk-endpoint-call-count")
+    public int jwkEndpointCallCount() {
+        return jwkEndpointCallCount;
+    }
+
+    @POST
+    @Produces("application/json")
+    @Path("introspect")
+    public String introspect() {
+        // Introspect call will return an active token status only when the introspection is disallowed.
+        // This is done to test that an asynchronous JWK refresh call done by Vertx Auth is effective.
+        return "{" +
+                "   \"active\": " + introspection + "," +
+                "   \"username\": \"alice\"" +
+                "  }";
+    }
+
+    @POST
+    @Path("token")
+    @Produces("application/json")
+    public String token(@QueryParam("kid") String kid) {
+        return "{\"access_token\": \"" + jwt(kid) + "\"," +
+                "   \"token_type\": \"Bearer\"," +
+                "   \"refresh_token\": \"123456789\"," +
+                "   \"expires_in\": 300 }";
+    }
+
+    @POST
+    @Path("opaque-token")
+    @Produces("application/json")
+    public String opaqueToken(@QueryParam("kid") String kid) {
+        return "{\"access_token\": \"987654321\"," +
+                "   \"token_type\": \"Bearer\"," +
+                "   \"refresh_token\": \"123456789\"," +
+                "   \"expires_in\": 300 }";
+    }
+
+    @POST
+    @Path("introspection")
+    public boolean setIntrospection() {
+        introspection = true;
+        return introspection;
+    }
+
+    @GET
+    @Path("introspection-status")
+    public boolean introspectionStatus() {
+        return introspection;
+    }
+
+    @POST
+    @Path("rotate")
+    public boolean setRotate() {
+        rotate = true;
+        return rotate;
+    }
+
+    @GET
+    @Path("rotate-status")
+    public boolean rotateStatus() {
+        return rotate;
+    }
+
+    private String jwt(String kid) {
+        return Jwt.claims()
+                .claim("typ", "Bearer")
+                .upn("alice")
+                .preferredUserName("alice")
+                .groups("user")
+                .jws().signatureKeyId(kid)
+                .sign(key.getPrivateKey());
+    }
+}

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantOpaqueResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantOpaqueResource.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.OIDCException;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/tenant-opaque/tenant-oidc/api/user")
+@Authenticated
+public class TenantOpaqueResource {
+
+    @Inject
+    SecurityIdentity identity;
+    @Inject
+    AccessTokenCredential accessToken;
+
+    @GET
+    public String userName(@PathParam("tenant") String tenant) {
+        if (!identity.getCredential(AccessTokenCredential.class).isOpaque()) {
+            throw new OIDCException("Opaque token is expected");
+        }
+        return "tenant-oidc-opaque:" + identity.getPrincipal().getName();
+    }
+}

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.PathParam;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdToken;
 import io.quarkus.oidc.OIDCException;
 
@@ -16,6 +17,9 @@ public class TenantResource {
 
     @Inject
     JsonWebToken accessToken;
+
+    @Inject
+    AccessTokenCredential accessTokenCred;
 
     @Inject
     @IdToken
@@ -40,10 +44,16 @@ public class TenantResource {
         if (!"Bearer".equals(accessToken.getClaim("typ"))) {
             throw new OIDCException("Wrong access token type");
         }
+        if (accessTokenCred.isOpaque()) {
+            throw new OIDCException("JWT token is expected");
+        }
         return name;
     }
 
     private String getNameServiceType() {
+        if (accessTokenCred.isOpaque()) {
+            throw new OIDCException("JWT token is expected");
+        }
         if (!"Bearer".equals(accessToken.getClaim("typ"))) {
             throw new OIDCException("Wrong access token type");
         }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -1,10 +1,14 @@
 package io.quarkus.it.keycloak;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.AccessTokenResponse;
@@ -18,6 +22,8 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -129,6 +135,62 @@ public class BearerTokenAuthorizationTest {
                 .body(equalTo("tenant-any:alice"));
     }
 
+    @Test
+    public void testSimpleOidcJwtWithJwkRefresh() {
+        RestAssured.when().get("/oidc/introspection-status").then().body(equalTo("false"));
+        RestAssured.when().get("/oidc/rotate-status").then().body(equalTo("false"));
+        // Quarkus OIDC is initialized with JWK set with kid '1' as part of the discovery process
+        // Now enable the rotation
+        RestAssured.when().post("/oidc/rotate").then().body(equalTo("true"));
+
+        // OIDC server will have a refreshed JWK set with kid '2', 200 is expected even though the introspection fallback is disabled.
+        await().atMost(5, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofSeconds(1))
+                .until(new Callable<Boolean>() {
+                    @Override
+                    public Boolean call() throws Exception {
+                        Response r = RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("2"))
+                                .when().get("/tenant/tenant-oidc/api/user");
+                        return r.getStatusCode() == 200;
+                    }
+                });
+
+        // JWK is available now in Quarkus OIDC, confirm that no timeout is needed 
+        RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("2"))
+                .when().get("/tenant/tenant-oidc/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-oidc:alice"));
+
+        // Get a token with kid '3' - it can only be verified via the introspection fallback since OIDC returns JWL set with kid '2'
+        // 403 since the introspection is not enabled
+        RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("3"))
+                .when().get("/tenant/tenant-oidc/api/user")
+                .then()
+                .statusCode(403);
+
+        // Enable introspection
+        RestAssured.when().post("/oidc/introspection").then().body(equalTo("true"));
+        // No timeout is required
+        RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("3"))
+                .when().get("/tenant/tenant-oidc/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-oidc:alice"));
+
+        // Finally try the opaque token 
+        RestAssured.given().auth().oauth2(getOpaqueAccessTokenFromSimpleOidc())
+                .when().get("/tenant-opaque/tenant-oidc/api/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("tenant-oidc-opaque:alice"));
+
+        // OIDC JWK endpoint must've been called only twice, once as part of the Quarkus OIDC/Vertx Auth initialization
+        // and once during the 1st request with a token kid '2', follow up requests must've been blocked due to the interval
+        // restrictions
+        RestAssured.when().get("/oidc/jwk-endpoint-call-count").then().body(equalTo("2"));
+    }
+
     private String getAccessToken(String userName, String clientId) {
         return RestAssured
                 .given()
@@ -140,6 +202,26 @@ public class BearerTokenAuthorizationTest {
                 .when()
                 .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + clientId + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();
+    }
+
+    private String getAccessTokenFromSimpleOidc(String kid) {
+        String json = RestAssured
+                .given()
+                .queryParam("kid", kid)
+                .when()
+                .post("/oidc/token")
+                .body().asString();
+        JsonObject object = new JsonObject(json);
+        return object.getString("access_token");
+    }
+
+    private String getOpaqueAccessTokenFromSimpleOidc() {
+        String json = RestAssured
+                .when()
+                .post("/oidc/opaque-token")
+                .body().asString();
+        JsonObject object = new JsonObject(json);
+        return object.getString("access_token");
     }
 
     private WebClient createWebClient() {

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -162,7 +162,7 @@ public class BearerTokenAuthorizationTest {
                 .statusCode(200)
                 .body(equalTo("tenant-oidc:alice"));
 
-        // Get a token with kid '3' - it can only be verified via the introspection fallback since OIDC returns JWL set with kid '2'
+        // Get a token with kid '3' - it can only be verified via the introspection fallback since OIDC returns JWK set with kid '2'
         // 403 since the introspection is not enabled
         RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("3"))
                 .when().get("/tenant/tenant-oidc/api/user")


### PR DESCRIPTION
Fixes #5003 
Fixes #7286

This PR:
- Supports a forced JWK refresh based on a `missingKeyHandler` Vertx Auth 3.9.1 feature with a controlled refresh interval period (10 mins by default). Right now, if the rotation happens and the current token has no local JWK with a matching `kid` to verify it then 2 requests will go to OIDC server, 1 JWK refresh from our handler and one fallback introspection request - this is not really a problem for now as it will happen only once in some long enough irregular rotation interval in a long running application 
- Along the way the opaque access tokens are now also supported
- adds a test `OidcResource` server endpoint to emulate Keycloak
- adds a test that confirms that a JWK refresh alone, without the introspection, is enough to verify a token after the key rotation, plus checks the fallback introspection is effective for the opaque token 

CC @pmlopes
