### PR TITLE
Enable kubernetes authentication path configuration in Vault extension

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
@@ -72,6 +72,7 @@ public class OkHttpVaultClient implements VaultClient {
 
     private OkHttpClient client;
     private URL url;
+    private String kubernetesAuthMountPath;
     private ObjectMapper mapper = new ObjectMapper();
 
     public OkHttpVaultClient(VaultRuntimeConfig serverConfig) {
@@ -79,6 +80,8 @@ public class OkHttpVaultClient implements VaultClient {
         this.url = serverConfig.url.get();
         this.mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
         this.mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        this.kubernetesAuthMountPath = serverConfig.authentication.kubernetes.authMountPath;
     }
 
     @Override
@@ -90,7 +93,7 @@ public class OkHttpVaultClient implements VaultClient {
     @Override
     public VaultKubernetesAuth loginKubernetes(String role, String jwt) {
         VaultKubernetesAuthBody body = new VaultKubernetesAuthBody(role, jwt);
-        return post("auth/kubernetes/login", null, body, VaultKubernetesAuth.class);
+        return post(kubernetesAuthMountPath + "/login", null, body, VaultKubernetesAuth.class);
     }
 
     @Override

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -4,6 +4,7 @@ import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.vault.runtime.LogConfidentialityLevel.MEDIUM;
 import static io.quarkus.vault.runtime.config.VaultCacheEntry.tryReturnLastKnownValue;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_CONNECT_TIMEOUT;
+import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KUBERNETES_AUTH_MOUNT_PATH;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KUBERNETES_JWT_TOKEN_PATH;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_READ_TIMEOUT;
@@ -215,6 +216,8 @@ public class VaultConfigSource implements ConfigSource {
         serverConfig.authentication.kubernetes.role = getOptionalVaultProperty("authentication.kubernetes.role");
         serverConfig.authentication.kubernetes.jwtTokenPath = getVaultProperty("authentication.kubernetes.jwt-token-path",
                 DEFAULT_KUBERNETES_JWT_TOKEN_PATH);
+        serverConfig.authentication.kubernetes.authMountPath = getVaultProperty("authentication.kubernetes.auth-mount-path",
+                DEFAULT_KUBERNETES_AUTH_MOUNT_PATH);
         serverConfig.authentication.userpass.username = getOptionalVaultProperty("authentication.userpass.username");
         serverConfig.authentication.userpass.password = getOptionalVaultProperty("authentication.userpass.password");
         serverConfig.authentication.userpass.passwordWrappingToken = getOptionalVaultProperty(

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultKubernetesAuthenticationConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultKubernetesAuthenticationConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.vault.runtime.config;
 
+import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KUBERNETES_AUTH_MOUNT_PATH;
 import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KUBERNETES_JWT_TOKEN_PATH;
 
 import java.util.Optional;
@@ -24,4 +25,10 @@ public class VaultKubernetesAuthenticationConfig {
      */
     @ConfigItem(defaultValue = DEFAULT_KUBERNETES_JWT_TOKEN_PATH)
     public String jwtTokenPath;
+
+    /**
+     * Allows configure Kubernetes authentication mount path.
+     */
+    @ConfigItem(defaultValue = DEFAULT_KUBERNETES_AUTH_MOUNT_PATH)
+    public String authMountPath;
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -32,6 +32,7 @@ public class VaultRuntimeConfig {
     public static final String DEFAULT_READ_TIMEOUT = "1S";
     public static final String DEFAULT_TLS_SKIP_VERIFY = "false";
     public static final String DEFAULT_TLS_USE_KUBERNETES_CACERT = "true";
+    public static final String DEFAULT_KUBERNETES_AUTH_MOUNT_PATH = "auth/kubernetes";
 
     /**
      * Vault server url.
@@ -239,6 +240,7 @@ public class VaultRuntimeConfig {
     public String toString() {
         return "VaultRuntimeConfig{" +
                 "url=" + url +
+                ", kubernetesAuthenticationMountPath=" + authentication.kubernetes.authMountPath +
                 ", kubernetesAuthenticationRole="
                 + logConfidentialityLevel.maskWithTolerance(authentication.kubernetes.role.orElse(""), MEDIUM) +
                 ", kubernetesJwtTokenPath='" + authentication.kubernetes.jwtTokenPath + '\'' +

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKubernetesITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKubernetesITCase.java
@@ -1,0 +1,49 @@
+package io.quarkus.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.runtime.config.VaultAuthenticationType;
+import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultKubernetesITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault-kubernetes.properties", "application.properties"));
+
+    @Inject
+    VaultRuntimeConfig runtimeConfig;
+
+    @Test
+    public void testGetAuthenticationType() {
+        assertEquals(VaultAuthenticationType.KUBERNETES, runtimeConfig.getAuthenticationType());
+    }
+
+    @Test
+    public void testRole() {
+        assertEquals(Optional.of("test"), runtimeConfig.authentication.kubernetes.role);
+    }
+
+    @Test
+    public void testAuthMountPath() {
+        assertEquals("auth/test", runtimeConfig.authentication.kubernetes.authMountPath);
+    }
+
+}

--- a/integration-tests/vault/src/test/resources/application-vault-kubernetes.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-kubernetes.properties
@@ -1,0 +1,20 @@
+quarkus.vault.url=https://localhost:8200
+
+# vault-test.client-token-wrapping-token provided by VaultTestLifecycleManager
+quarkus.vault.authentication.kubernetes.auth-mount-path=auth/test
+quarkus.vault.authentication.kubernetes.role=test
+
+#quarkus.vault.tls.skip-verify=true
+quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
+
+quarkus.vault.log-confidentiality-level=low
+quarkus.vault.renew-grace-period=10
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG
+
+# CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default
+quarkus.vault.read-timeout=5S
+
+#quarkus.log.min-level=DEBUG
+#quarkus.log.level=DEBUG
+#quarkus.log.console.level=DEBUG

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -51,7 +51,9 @@ import io.quarkus.vault.runtime.client.VaultClientException;
 import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
 import io.quarkus.vault.runtime.config.HealthConfig;
+import io.quarkus.vault.runtime.config.VaultAuthenticationConfig;
 import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
+import io.quarkus.vault.runtime.config.VaultKubernetesAuthenticationConfig;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 import io.quarkus.vault.runtime.config.VaultTlsConfig;
 import io.quarkus.vault.test.client.TestVaultClient;
@@ -168,6 +170,8 @@ public class VaultTestExtension {
         serverConfig.tls.caCert = Optional.empty();
         serverConfig.connectTimeout = Duration.ofSeconds(5);
         serverConfig.readTimeout = Duration.ofSeconds(1);
+        serverConfig.authentication = new VaultAuthenticationConfig();
+        serverConfig.authentication.kubernetes = new VaultKubernetesAuthenticationConfig();
 
         VaultBuildTimeConfig buildTimeConfig = new VaultBuildTimeConfig();
         buildTimeConfig.health = new HealthConfig();


### PR DESCRIPTION
* Allows kubernetes authentication path configuration through the "kubernetes.auth-endpoint-path" config property

Closes #9871