### PR TITLE
Qute - replace the map-based html escaper with simplified impl

### DIFF
--- a/extensions/qute/runtime/pom.xml
+++ b/extensions/qute/runtime/pom.xml
@@ -31,6 +31,11 @@
             <groupId>io.quarkus.qute</groupId>
             <artifactId>qute-mutiny</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/HtmlEscaper.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/HtmlEscaper.java
@@ -1,0 +1,82 @@
+package io.quarkus.qute.runtime;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.quarkus.qute.Expression;
+import io.quarkus.qute.RawString;
+import io.quarkus.qute.ResultMapper;
+import io.quarkus.qute.TemplateNode.Origin;
+import io.quarkus.qute.Variant;
+
+class HtmlEscaper implements ResultMapper {
+
+    @Override
+    public boolean appliesTo(Origin origin, Object result) {
+        if (result instanceof RawString) {
+            return false;
+        }
+        Optional<Variant> variant = origin.getVariant();
+        if (variant.isPresent()) {
+            return requiresDefaultEscaping(variant.get());
+        }
+        return false;
+    }
+
+    @Override
+    public String map(Object result, Expression expression) {
+        return escape(result.toString());
+    }
+
+    String escape(CharSequence value) {
+        if (Objects.requireNonNull(value).length() == 0) {
+            return value.toString();
+        }
+        for (int i = 0; i < value.length(); i++) {
+            String replacement = replacementFor(value.charAt(i));
+            if (replacement != null) {
+                // In most cases we will not need to escape the value at all
+                return doEscape(value, i, new StringBuilder(value.subSequence(0, i)).append(replacement));
+            }
+        }
+        return value.toString();
+    }
+
+    static boolean requiresDefaultEscaping(Variant variant) {
+        return variant.mediaType != null
+                ? (Variant.TEXT_HTML.equals(variant.mediaType) || Variant.TEXT_XML.equals(variant.mediaType))
+                : false;
+    }
+
+    private String doEscape(CharSequence value, int index, StringBuilder builder) {
+        int length = value.length();
+        while (++index < length) {
+            char c = value.charAt(index);
+            String replacement = replacementFor(c);
+            if (replacement != null) {
+                builder.append(replacement);
+            } else {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+    private String replacementFor(char c) {
+        switch (c) {
+            case '"':
+                return "&quot;";
+            case '\'':
+                return "&#39;";
+            case '&':
+                return "&amp;";
+            case '<':
+                return "&lt;";
+            case '>':
+                return "&gt;";
+            default:
+                return null;
+        }
+    }
+
+}

--- a/extensions/qute/runtime/src/test/java/io/quarkus/qute/runtime/HtmlEscaperTest.java
+++ b/extensions/qute/runtime/src/test/java/io/quarkus/qute/runtime/HtmlEscaperTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.qute.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.qute.RawString;
+import io.quarkus.qute.TemplateNode.Origin;
+import io.quarkus.qute.Variant;
+
+public class HtmlEscaperTest {
+
+    @Test
+    public void testAppliesTo() {
+        HtmlEscaper html = new HtmlEscaper();
+        Origin htmlOrigin = new Origin() {
+
+            @Override
+            public Optional<Variant> getVariant() {
+                return Optional.of(new Variant(Locale.getDefault(), Variant.TEXT_HTML, null));
+            }
+
+            @Override
+            public String getTemplateId() {
+                return null;
+            }
+
+            @Override
+            public String getTemplateGeneratedId() {
+                return null;
+            }
+
+            @Override
+            public int getLineCharacter() {
+                return 0;
+            }
+
+            @Override
+            public int getLine() {
+                return 0;
+            }
+        };
+        assertFalse(html.appliesTo(htmlOrigin, new RawString("foo")));
+        assertTrue(html.appliesTo(htmlOrigin, "foo"));
+    }
+
+    @Test
+    public void testEscaping() throws IOException {
+        HtmlEscaper html = new HtmlEscaper();
+        assertEquals("Čolek", html.escape("Čolek"));
+        assertEquals("&lt;strong&gt;Čolek&lt;/strong&gt;", html.escape("<strong>Čolek</strong>"));
+        assertEquals("&lt;a&gt;&amp;link&quot;&#39;&lt;/a&gt;", html.escape("<a>&link\"'</a>"));
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
@@ -44,6 +44,10 @@ public interface TemplateNode {
 
         String getTemplateGeneratedId();
 
+        /**
+         * 
+         * @return the template variant
+         */
         Optional<Variant> getVariant();
 
     }


### PR DESCRIPTION
- this result mapper is used to replace some characters for HTML/XML
templates