### PR TITLE
Move google-cloud-functions-http tests into profile activated on JDK 11+

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -103,13 +103,12 @@ jobs:
         java :
           - { name: Java8,
               java-version: 8,
-              maven_args: "-pl !integration-tests/vault-app,!integration-tests/vault-agroal,!integration-tests/vault,!integration-tests/google-cloud-functions-http"
+              maven_args: "-pl !integration-tests/vault-app,!integration-tests/vault-agroal,!integration-tests/vault"
           }
           - {
             name: "Java 8 - 242",
             java-version: 8,
-            release: "jdk8u242-b08",
-            maven_args: "-pl !integration-tests/google-cloud-functions-http"
+            release: "jdk8u242-b08"
           }
           - {
             name: Java 11,

--- a/.github/workflows/native-cron-build.yml
+++ b/.github/workflows/native-cron-build.yml
@@ -54,7 +54,7 @@ jobs:
         run: mvn -B install -DskipTests -DskipITs -Dformat.skip
 
       - name: Run integration tests in native
-        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-db2 -Dtest-amazon-services -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dtest-kafka -Dtest-mssql -Dtest-mariadb -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test" -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http'
+        run: mvn -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Ddocker -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java${{ matrix.java }} -Dtest-postgresql -Dtest-elasticsearch -Dtest-mysql -Dtest-db2 -Dtest-amazon-services -Dtest-vault -Dtest-neo4j -Dtest-keycloak -Dtest-kafka -Dtest-mssql -Dtest-mariadb -Dmariadb.url="jdbc:mariadb://localhost:3308/hibernate_orm_test"
 
       - name: Report
         if: always()

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -129,7 +129,6 @@
         <module>grpc-interceptors</module>
         <module>grpc-proto-v2</module>
         <module>grpc-health</module>
-        <module>google-cloud-functions-http</module>
     </modules>
 
     <build>
@@ -196,4 +195,16 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>jdk11plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <modules>
+                <module>google-cloud-functions-http</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Move google-cloud-functions-http tests into profile activated on JDK 11+

Currently there are several workarounds on CI level and users can't build Quarkus master on JDK8 using simple `mvn clean install` approach.

Fixes: #9904 