### PR TITLE
Build google-cloud-functions-http module with Java 8.

### DIFF
--- a/integration-tests/google-cloud-functions-http/pom.xml
+++ b/integration-tests/google-cloud-functions-http/pom.xml
@@ -9,11 +9,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <properties>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
-    </properties>
-
     <artifactId>quarkus-integration-test-google-cloud-functions-http</artifactId>
     <name>Quarkus - Integration Tests - Google Cloud Functions HTTP</name>
 


### PR DESCRIPTION
Alternative to #9908 (which does what I originally proposed doing / had also done but not raised yet) for discussion.

Fix for #9904.  