### PR TITLE
Use example.com

### DIFF
--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-custom.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-custom.properties
@@ -1,4 +1,4 @@
 quarkus.log.sentry=true
-quarkus.log.sentry.dsn=https://123@test.io/22222
+quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-default.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-default.properties
@@ -1,3 +1,3 @@
 quarkus.log.sentry=true
-quarkus.log.sentry.dsn=https://123@test.io/22222
+quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.in-app-packages=*

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-environment-option.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-environment-option.properties
@@ -1,5 +1,5 @@
 quarkus.log.sentry=true
-quarkus.log.sentry.dsn=https://123@test.io/22222
+quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
 quarkus.log.sentry.environment=test-environment

--- a/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-release-option.properties
+++ b/extensions/logging-sentry/deployment/src/test/resources/application-sentry-logger-release-option.properties
@@ -1,5 +1,5 @@
 quarkus.log.sentry=true
-quarkus.log.sentry.dsn=https://123@test.io/22222
+quarkus.log.sentry.dsn=https://123@example.com/22222
 quarkus.log.sentry.level=TRACE
 quarkus.log.sentry.in-app-packages=io.quarkus.logging.sentry,org.test
 quarkus.log.sentry.release=releaseABC


### PR DESCRIPTION
test.io is a real domain, and was sending back HTML pages that
were generating a lot of log noise.

This may help with the JDK14 hangs.