### PR TITLE
Add ability to run tests with different config profiles

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -303,6 +303,61 @@ public class TestStereotypeTestCase {
 }
 ----
 
+== Testing Different Profiles
+
+So far in all our examples we only start Quarkus once for all tests. Before the first test is run Quarkus will boot,
+then all tests will run, then Quarkus will shutdown at the end. This makes for a very fast testing experience however
+it is a bit limited as you can't test different configurations.
+
+To get around this Quarkus supports the idea of a test profile. If a test has a different profile to the previously
+run test then Quarkus will be shut down and started with the new profile before running the tests. This is obviously
+a bit slower, as it adds a shutdown/startup cycle to the test time, but gives a great deal of flexibility.
+
+NOTE: In order to reduce the amount of times Quarkus needs to restart it is recommended that you place all tests
+that need a specific profile into their own package, and then run tests alphabetically.
+
+=== Writing a Profile
+
+To implement a test profile we need to implement `io.quarkus.test.junit.QuarkusTestProfile`:
+
+[source,java]
+----
+package org.acme.getting.started.testing;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class MockGreetingProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() { <1>
+        return Collections.singletonMap("quarkus.resteasy.path","/api");
+    }
+
+    @Override
+    public Set<Class<?>> getEnabledAlternatives() { <2>
+        return Collections.singleton(MockGreetingService.class);
+    }
+
+
+    @Override
+    public String getConfigProfile() { <3>
+        return "test";
+    }
+}
+----
+<1> This method allows us to override configuration properties. Here we are changing the JAX-RS root path.
+<2> This method allows us to enable CDI `@Alternative` beans. This makes it easy to mock out certain beans functionality.
+<3> This can be used to change the config profile. As this default is `test` this does nothing, but is included for completeness.
+
+Now we have defined our profile we need to include it on our test class. We do this with `@TestProfile(MockGreetingProfile.class)`.
+
+All the test profile config is stored in a single class, which makes it easy to tell if the previous test ran with the
+same configuration.
+
 
 == Mock Support
 
@@ -311,9 +366,9 @@ mock out a bean for all test classes, or use `QuarkusMock` to mock out beans on 
 
 === CDI `@Alternative` mechanism.
 
-To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean. 
+To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean.
 Alternatively, a convenient `io.quarkus.test.Mock` stereotype annotation could be used.
-This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`. 
+This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`.
 For example if I have the following service:
 
 [source,java]
@@ -596,7 +651,7 @@ public class SpyGreetingServiceTest {
 
 ==== Using `@InjectMock` with `@RestClient`
 
-The `@RegisterRestClient` registers the implementation of the rest-client at runtime, and because the bean needs to be a regular scope, you have to annotate your interface with `@ApplicationScoped`. 
+The `@RegisterRestClient` registers the implementation of the rest-client at runtime, and because the bean needs to be a regular scope, you have to annotate your interface with `@ApplicationScoped`.
 
 [source,java]
 ----
@@ -612,7 +667,7 @@ public interface GreetingService {
 }
 ----
 
-For the test class here is an example: 
+For the test class here is an example:
 
 [source,java]
 ----

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -199,6 +199,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/GreetingEndpoint.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/GreetingEndpoint.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.rest;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+@Path("/greeting")
+public class GreetingEndpoint {
+
+    @Inject
+    GreetingService greetingService;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("{name}")
+    public String greet(@PathParam String name) {
+        return greetingService.greet(name);
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/GreetingService.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/GreetingService.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.rest;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class GreetingService {
+    public String greet(String greeting) {
+        return "Hello " + greeting;
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/BonjourService.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/BonjourService.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.main;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+
+import io.quarkus.it.rest.GreetingService;
+
+@ApplicationScoped
+@Alternative
+public class BonjourService extends GreetingService {
+
+    @Override
+    public String greet(String greeting) {
+        return "Bonjour " + greeting;
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingNormalTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingNormalTestCase.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class GreetingNormalTestCase {
+
+    @Test
+    public void included() {
+        RestAssured.when()
+                .get("/greeting/Stu")
+                .then()
+                .statusCode(200)
+                .body(is("Hello Stu"));
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingProfileTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingProfileTestCase.java
@@ -1,0 +1,50 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+/**
+ * Tests that QuarkusTestProfile works as expected
+ */
+@QuarkusTest
+@TestProfile(GreetingProfileTestCase.MyProfile.class)
+public class GreetingProfileTestCase {
+
+    @Test
+    public void included() {
+        RestAssured.when()
+                .get("/greeting/Stu")
+                .then()
+                .statusCode(200)
+                .body(is("Bonjour Stu"));
+    }
+
+    @Test
+    public void testPortTakesEffect() {
+        Assertions.assertEquals(7777, RestAssured.port);
+    }
+
+    public static class MyProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Collections.singletonMap("quarkus.http.test-port", "7777");
+        }
+
+        @Override
+        public Set<Class<?>> getEnabledAlternatives() {
+            return Collections.singleton(BonjourService.class);
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
@@ -1,0 +1,42 @@
+package io.quarkus.test.junit;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Defines a 'test profile'. Tests run under a test profile
+ * will have different configuration options to other tests.
+ *
+ */
+public interface QuarkusTestProfile {
+
+    /**
+     * Returns additional config to be applied to the test. This
+     * will override any existing config (including in application.properties),
+     * however existing config will be merged with this (i.e. application.properties
+     * config will still take effect, unless a specific config key has been overridden).
+     */
+    default Map<String, String> getConfigOverrides() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Returns enabled alternatives.
+     *
+     * This has the same effect as setting the 'quarkus.arc.selected-alternatives' config key,
+     * however it may be more convenient.
+     */
+    default Set<Class<?>> getEnabledAlternatives() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Allows the default config profile to be overridden. This basically just sets the quarkus.test.profile system
+     * property before the test is run.
+     *
+     */
+    default String getConfigProfile() {
+        return null;
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestProfile.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/TestProfile.java
@@ -1,0 +1,31 @@
+package io.quarkus.test.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a 'test profile'. Tests run under a test profile
+ * will have different configuration options to other tests.
+ *
+ * Due to the global nature of Quarkus if a previous test was
+ * run under a different profile then Quarkus will need to be
+ * restarted when the profile changes. Unfortunately there
+ * is currently no way to order tests based on profile, however
+ * this can be done manually by running tests in alphabetical
+ * order and putting all tests with the same profile in the same
+ * package.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TestProfile {
+
+    /**
+     * The test profile to use. If subsequent tests use the same
+     * profile then Quarkus will not be restarted between tests,
+     * giving a faster execution.
+     */
+    Class<? extends QuarkusTestProfile> value();
+
+}


### PR DESCRIPTION
I don't know if 'profile' is the correct word, as it is not really directly related to the existing profile stuff. 

There is also lots more we can do with this, including per profile test resources, per profile TestContainer support, and probably more.