### PR TITLE
Fix NullPointerException(s) when dealing with remote and local address returned by HTTP request

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/LocalIPAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/LocalIPAttribute.java
@@ -20,6 +20,9 @@ public class LocalIPAttribute implements ExchangeAttribute {
     @Override
     public String readAttribute(final RoutingContext exchange) {
         SocketAddress localAddress = exchange.request().localAddress();
+        if (localAddress == null) {
+            return null;
+        }
         return localAddress.host();
     }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/LocalPortAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/LocalPortAttribute.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -19,7 +20,11 @@ public class LocalPortAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        return Integer.toString(exchange.request().localAddress().port());
+        final SocketAddress localAddr = exchange.request().localAddress();
+        if (localAddr == null) {
+            return null;
+        }
+        return Integer.toString(localAddr.port());
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteHostAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteHostAttribute.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime.attribute;
 
+import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -19,7 +20,11 @@ public class RemoteHostAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(final RoutingContext exchange) {
-        return exchange.request().remoteAddress().host();
+        final SocketAddress remoteAddr = exchange.request().remoteAddress();
+        if (remoteAddr == null) {
+            return null;
+        }
+        return remoteAddr.host();
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteIPAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RemoteIPAttribute.java
@@ -21,6 +21,9 @@ public class RemoteIPAttribute implements ExchangeAttribute {
     @Override
     public String readAttribute(final RoutingContext exchange) {
         final SocketAddress sourceAddress = exchange.request().remoteAddress();
+        if (sourceAddress == null) {
+            return null;
+        }
         return sourceAddress.host();
     }
 


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/9882

Both `localAddress` and `remoteAddress` of `io.vertx.core.http.HttpServerRequest` as per the javadoc can return null in certain cases. The commit here adds a check to make sure we don't run into `NullPointerException` when using these attribute values in access logging