### PR TITLE
Make the HTTP protocol version value, printed in access logs, conform to the Common Log Format

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestLineAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/RequestLineAttribute.java
@@ -23,8 +23,27 @@ public class RequestLineAttribute implements ExchangeAttribute {
                 .append(exchange.request().method())
                 .append(' ')
                 .append(exchange.request().uri());
-        sb.append(' ')
-                .append(exchange.request().version());
+        sb.append(' ');
+        String httpVersion = "-";
+        switch (exchange.request().version()) {
+            case HTTP_1_0:
+                httpVersion = "HTTP/1.0";
+                break;
+            case HTTP_1_1:
+                httpVersion = "HTTP/1.1";
+                break;
+            case HTTP_2:
+                httpVersion = "HTTP/2";
+                break;
+            default:
+                // best effort to try and infer the HTTP version from
+                // any "unknown" enum value
+                httpVersion = exchange.request().version().name()
+                        .replace("HTTP_", "HTTP/")
+                        .replace("_", ".");
+                break;
+        }
+        sb.append(httpVersion);
         return sb.toString();
     }
 


### PR DESCRIPTION
Right now, the HTTP protocol value printed in the access log looks like this:

```
"GET /_health HTTP_1_1" 200 2 - "-" "curl/7.58.0"
```
Notice the `HTTP_1_1` in there. That's the internal enum representation for the HTTP protocol version. We should instead print the value in a manner that's recognized by the Common Log Format[1].

The commit here fixes that and also includes a test case to verify the change. With this change, it should now look like:
```
"GET /_health HTTP/1.1" 200 2 - "-" "curl/7.58.0"
```

[1] https://en.wikipedia.org/wiki/Common_Log_Format