### PR TITLE
Remove useless output from CI logs

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
-        run: find . -name '*-reports' -type d | tar -czvf test-reports.tgz -T - 
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v1
         if: failure()
@@ -258,7 +258,7 @@ jobs:
         shell: bash
         run: |
           # Disambiguate windows find from cygwin find
-          /usr/bin/find . -name '*-reports' -type d | tar -czvf test-reports.tgz -T - 
+          /usr/bin/find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v1
         if: failure()
@@ -296,7 +296,7 @@ jobs:
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
-        run: find . -name '*-reports' -type d | tar -czvf test-reports.tgz -T - 
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v1
         if: failure()
@@ -562,7 +562,7 @@ jobs:
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
-        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar -czvf test-reports.tgz -T -
+        run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v1
         if: failure()


### PR DESCRIPTION
Make the report generation silent