### PR TITLE
Align buffer size for Azure and AWS functions

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -40,6 +40,8 @@ import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
 public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
     private static final Logger log = Logger.getLogger("quarkus.amazon.lambda.http");
 
+    private static final int BUFFER_SIZE = 8096;
+
     private static Headers errorHeaders = new Headers();
     static {
         errorHeaders.putSingle("Content-Type", "application/json");
@@ -122,7 +124,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
                             responseBuilder.setBase64Encoded(true);
                             responseBuilder.setBody(Base64.getMimeEncoder().encodeToString(baos.toByteArray()));
                         } else {
-                            responseBuilder.setBody(new String(baos.toByteArray(), "UTF-8"));
+                            responseBuilder.setBody(new String(baos.toByteArray(), StandardCharsets.UTF_8));
                         }
                     }
                     future.complete(responseBuilder);
@@ -205,8 +207,8 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
     }
 
     private ByteArrayOutputStream createByteStream() {
-        ByteArrayOutputStream baos;// todo what is right size?
-        baos = new ByteArrayOutputStream(1000);
+        ByteArrayOutputStream baos;
+        baos = new ByteArrayOutputStream(BUFFER_SIZE);
         return baos;
     }
 

--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
@@ -37,6 +37,8 @@ public class BaseFunction {
     protected static final String deploymentStatus;
     protected static boolean started = false;
 
+    private static final int BUFFER_SIZE = 8096;
+
     static {
         StringWriter error = new StringWriter();
         PrintWriter errorWriter = new PrintWriter(error, true);
@@ -106,7 +108,7 @@ public class BaseFunction {
 
     private ByteArrayOutputStream createByteStream() {
         ByteArrayOutputStream baos;
-        baos = new ByteArrayOutputStream(500);
+        baos = new ByteArrayOutputStream(BUFFER_SIZE);
         return baos;
     }
 
@@ -136,7 +138,6 @@ public class BaseFunction {
                 if (msg instanceof HttpContent) {
                     HttpContent content = (HttpContent) msg;
                     if (baos == null) {
-                        // todo what is right size?
                         baos = createByteStream();
                     }
                     int readable = content.content().readableBytes();


### PR DESCRIPTION
Some small implementation improvements for Azure function HTTP and Amazon lambda HTTP.
This align the implementation with Google Cloud Functin HTTP.

- Use a `ByteArrayOutputStream` of 8k as it's the admitted default ideal size (this is the size used inside the JDK by default)
- Close the `ByteArrayOutputStream` gracefully