### PR TITLE
Prevent a NPE and report the actual cause of boot failure in QuarkusTestExtension

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -258,13 +258,8 @@ public class QuarkusTestExtension
                 setCCL(original);
             }
         } else {
-            if (firstException != null) {
-                Throwable throwable = firstException;
-                firstException = null;
-                throw new RuntimeException(throwable);
-            } else {
-                throw new TestAbortedException("Boot failed");
-            }
+            throwBootFailureException();
+            return;
         }
     }
 
@@ -331,6 +326,16 @@ public class QuarkusTestExtension
         return original;
     }
 
+    private void throwBootFailureException() throws Exception {
+        if (firstException != null) {
+            Throwable throwable = firstException;
+            firstException = null;
+            throw new RuntimeException(throwable);
+        } else {
+            throw new TestAbortedException("Boot failed");
+        }
+    }
+
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         if (isNativeTest(context)) {
@@ -376,6 +381,10 @@ public class QuarkusTestExtension
             return;
         }
         ensureStarted(extensionContext);
+        if (failedBoot) {
+            throwBootFailureException();
+            return;
+        }
         runExtensionMethod(invocationContext, extensionContext);
         invocation.skip();
     }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/9971

The commit in this PR, now checks for a boot failure during the `@BeforeAll` interception and throws the original boot failure cause, instead of running into an `NullPointerException`