### PR TITLE
Patch Funqy Amazon Lambda HTTP test contentType to json

### DIFF
--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingTest.java
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingTest.java
@@ -33,8 +33,8 @@ public class GreetingTest
     @Test
     public void testFunqy() {
         RestAssured.when().get("/funqyHello").then()
-                .contentType("text/plain")
-                .body(equalTo("hello funqy"));
+                .contentType("application/json")
+                .body(equalTo("\"hello funqy\""));
     }
 
 }


### PR DESCRIPTION
Maven archetype project generated as below generates test errors as the contentType is `application/json', yet the test is expecting `text/plain`.

```
mvn archetype:generate \
  -DarchetypeGroupId=io.quarkus \
  -DarchetypeArtifactId=quarkus-amazon-lambda-http-archetype \
  -DarchetypeVersion=999-SNAPSHOT
```

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.tjpower.GreetingTest
2020-06-13 08:40:24,190 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT on JVM started in 2.010s. Listening on: http://0.0.0.0:8081
2020-06-13 08:40:24,192 INFO  [io.quarkus] (main) Profile test activated. 
2020-06-13 08:40:24,192 INFO  [io.quarkus] (main) Installed features: [amazon-lambda, cdi, funqy-http, mutiny, resteasy, servlet, vertx, vertx-web]
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.724 s <<< FAILURE! - in org.tjpower.GreetingTest
[ERROR] testFunqy  Time elapsed: 1.138 s  <<< FAILURE!
java.lang.AssertionError: 
1 expectation failed.
Expected content-type "text/plain" doesn't match actual content-type "application/json".

        at org.tjpower.GreetingTest.testFunqy(GreetingTest.java:36)

2020-06-13 08:40:25,540 INFO  [io.quarkus] (main) Quarkus stopped in 0.040s
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   GreetingTest.testFunqy:36 1 expectation failed.
Expected content-type "text/plain" doesn't match actual content-type "application/json".

[INFO] 
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

After the patch to `application/json` is applied:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.tjpower.GreetingTest
2020-06-13 08:49:05,051 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT on JVM started in 1.946s. Listening on: http://0.0.0.0:8081
2020-06-13 08:49:05,053 INFO  [io.quarkus] (main) Profile test activated. 
2020-06-13 08:49:05,053 INFO  [io.quarkus] (main) Installed features: [amazon-lambda, cdi, funqy-http, mutiny, resteasy, servlet, vertx, vertx-web]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.826 s - in org.tjpower.GreetingTest
2020-06-13 08:49:06,236 INFO  [io.quarkus] (main) Quarkus stopped in 0.037s
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ post1 ---
[INFO] Building jar: /var/tmp/post1/target/post1-1.0-SNAPSHOT.jar
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:build (default) @ post1 ---
[INFO] [org.jboss.threads] JBoss Threads version 3.1.1.Final
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building fat jar: /var/tmp/post1/target/post1-1.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 6833ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

/cc @patriot1burke 