### PR TITLE
Typo in cdi-reference.adoc

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -746,7 +746,7 @@ AnnotationsTransformerBuildItem transform() {
         }
 
         public void transform(TransformationContext context) {
-            if (contex.getTarget().asClass().name().toString().equals("com.foo.Bar")) {
+            if (context.getTarget().asClass().name().toString().equals("com.foo.Bar")) {
                 context.transform().add(MyInterceptorBinding.class).done();
             }
         }


### PR DESCRIPTION
Fixed typo in Guides cdi-reference#annotation-transformations