### PR TITLE
Fix issue with running Hibernate Reactive MySQL tests with docker

### DIFF
--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -200,16 +200,12 @@
 <!--                                         Speed things up a bit by not actually flushing writes to disk -->
 <!--                                         <tmpfs>/var/lib/mysql</tmpfs> -->
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
-<!--                                             <tcp> -->
-<!--                                                 <mode>direct</mode> -->
-<!--                                                 <ports> -->
-<!--                                                     <port>3306</port> -->
-<!--                                                 </ports> -->
-<!--                                             </tcp> -->
-											<log>.*mysqld: ready for connections.*</log>
-                                            <!-- Unfortunately booting MariaDB is slow, needs to set a generous timeout: -->
-                                            <time>40000</time>
+                                            <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                            <time>20000</time>
+                                            <!-- wait until MySQL is actually up by checking if mysqladmin can ping the server with specified username/password -->
+                                            <exec>
+                                                <postStart>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test</postStart>
+                                            </exec>
                                         </wait>
 <!--                                         <volumes> -->
 <!--                                             <bind> -->


### PR DESCRIPTION
When starting MariaDB with docker, we need to make sure we haven't
caught the temporary server startup logs

When I ran the test locally, I got something like:

```
12:16:18.800 MariaDB:2020-06-14 09:16:18+00:00 [Note] [Entrypoint]: Database files initialized
12:16:18.801 MariaDB:2020-06-14 09:16:18+00:00 [Note] [Entrypoint]: Starting temporary server
12:16:18.802 MariaDB:2020-06-14 09:16:18+00:00 [Note] [Entrypoint]: Waiting for server startup
12:16:18.911 MariaDB:2020-06-14  9:16:18 0 [Note] mysqld (mysqld 10.4.12-MariaDB-1:10.4.12+maria~bionic) starting as process 123 ...
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Using Linux native AIO
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Uses event mutexes
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Number of pools: 1
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Using SSE2 crc32 instructions
12:16:18.922 MariaDB:2020-06-14  9:16:18 0 [Note] mysqld: O_TMPFILE is not supported on /tmp (disabling future attempts)
12:16:18.976 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Initializing buffer pool, total size = 256M, instances = 1, chunk size = 128M
12:16:18.983 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Completed initialization of buffer pool
12:16:18.983 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
12:16:18.999 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: 128 out of 128 rollback segments are active.
12:16:18.999 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Creating shared tablespace for temporary tables
12:16:18.999 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
12:16:18.999 MariaDB:2020-06-14  9:16:18 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
12:16:19.001 MariaDB:2020-06-14  9:16:19 0 [Note] InnoDB: 10.4.12 started; log sequence number 60972; transaction id 21
12:16:19.001 MariaDB:2020-06-14  9:16:19 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
12:16:19.001 MariaDB:2020-06-14  9:16:19 0 [Note] Plugin 'FEEDBACK' is disabled.
12:16:19.003 MariaDB:2020-06-14  9:16:19 0 [Warning] 'user' entry 'root@36043844a23c' ignored in --skip-name-resolve mode.
12:16:19.003 MariaDB:2020-06-14  9:16:19 0 [Warning] 'user' entry '@36043844a23c' ignored in --skip-name-resolve mode.
12:16:19.003 MariaDB:2020-06-14  9:16:19 0 [Warning] 'proxies_priv' entry '@% root@36043844a23c' ignored in --skip-name-resolve mode.
12:16:19.004 MariaDB:2020-06-14  9:16:19 0 [Note] InnoDB: Buffer pool(s) load completed at 200614  9:16:18
12:16:19.077 MariaDB:2020-06-14  9:16:19 0 [Note] Reading of all Master_info entries succeeded
12:16:19.077 MariaDB:2020-06-14  9:16:19 0 [Note] Added new Master_info '' to hash table
12:16:19.077 MariaDB:2020-06-14  9:16:19 0 [Note] mysqld: ready for connections.
12:16:19.077 MariaDB:Version: '10.4.12-MariaDB-1:10.4.12+maria~bionic'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  mariadb.org binary distribution
12:16:19.820 MariaDB:2020-06-14 09:16:19+00:00 [Note] [Entrypoint]: Temporary server started.
12:16:21.706 MariaDB:Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
12:16:26.381 MariaDB:2020-06-14 09:16:26+00:00 [Note] [Entrypoint]: GENERATED ROOT PASSWORD: sohxaefiexae4Pe6Ge0Osh1ziewee0ha
12:16:26.392 MariaDB:2020-06-14  9:16:26 10 [Warning] 'proxies_priv' entry '@% root@36043844a23c' ignored in --skip-name-resolve mode.
12:16:26.396 MariaDB:2020-06-14 09:16:26+00:00 [Note] [Entrypoint]: Creating database hibernate_orm_test
12:16:26.403 MariaDB:2020-06-14 09:16:26+00:00 [Note] [Entrypoint]: Creating user hibernate_orm_test
12:16:26.411 MariaDB:2020-06-14 09:16:26+00:00 [Note] [Entrypoint]: Giving user hibernate_orm_test access to schema hibernate_orm_test
12:16:26.424 MariaDB:2020-06-14  9:16:26 14 [Warning] 'proxies_priv' entry '@% root@36043844a23c' ignored in --skip-name-resolve mode.
12:16:26.424 MariaDB:
12:16:26.425 MariaDB:2020-06-14 09:16:26+00:00 [Note] [Entrypoint]: Stopping temporary server
12:16:26.429 MariaDB:2020-06-14  9:16:26 0 [Note] mysqld (initiated by: root[root] @ localhost []): Normal shutdown
12:16:26.429 MariaDB:2020-06-14  9:16:26 0 [Note] Event Scheduler: Purging the queue. 0 events
12:16:26.429 MariaDB:2020-06-14  9:16:26 0 [Note] InnoDB: FTS optimize thread exiting.
12:16:26.458 MariaDB:2020-06-14  9:16:26 0 [Note] InnoDB: Starting shutdown...
12:16:26.458 MariaDB:2020-06-14  9:16:26 0 [Note] InnoDB: Dumping buffer pool(s) to /var/lib/mysql/ib_buffer_pool
12:16:26.458 MariaDB:2020-06-14  9:16:26 0 [Note] InnoDB: Buffer pool(s) dump completed at 200614  9:16:26
12:16:28.211 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Shutdown completed; log sequence number 60981; transaction id 24
12:16:28.211 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Removed temporary tablespace data file: "ibtmp1"
12:16:28.221 MariaDB:2020-06-14  9:16:28 0 [Note] mysqld: Shutdown complete
12:16:28.221 MariaDB:
12:16:28.432 MariaDB:2020-06-14 09:16:28+00:00 [Note] [Entrypoint]: Temporary server stopped
12:16:28.432 MariaDB:
12:16:28.433 MariaDB:2020-06-14 09:16:28+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
12:16:28.433 MariaDB:
12:16:28.543 MariaDB:2020-06-14  9:16:28 0 [Note] mysqld (mysqld 10.4.12-MariaDB-1:10.4.12+maria~bionic) starting as process 1 ...
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Using Linux native AIO
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Uses event mutexes
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Number of pools: 1
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Using SSE2 crc32 instructions
12:16:28.554 MariaDB:2020-06-14  9:16:28 0 [Note] mysqld: O_TMPFILE is not supported on /tmp (disabling future attempts)
12:16:28.636 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Initializing buffer pool, total size = 256M, instances = 1, chunk size = 128M
12:16:28.644 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Completed initialization of buffer pool
12:16:28.644 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
12:16:28.663 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: 128 out of 128 rollback segments are active.
12:16:28.664 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Creating shared tablespace for temporary tables
12:16:28.664 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
12:16:28.664 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
12:16:28.665 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Waiting for purge to start
12:16:28.715 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: 10.4.12 started; log sequence number 60981; transaction id 21
12:16:28.715 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
12:16:28.715 MariaDB:2020-06-14  9:16:28 0 [Note] Plugin 'FEEDBACK' is disabled.
12:16:28.716 MariaDB:2020-06-14  9:16:28 0 [Note] Server socket created on IP: '::'.
[INFO] DOCKER> Pattern '.*Server socket created on IP.*' matched for container 36043844a23c
12:16:28.718 MariaDB:2020-06-14  9:16:28 0 [Warning] 'proxies_priv' entry '@% root@36043844a23c' ignored in --skip-name-resolve mode.
12:16:28.718 MariaDB:2020-06-14  9:16:28 0 [Note] InnoDB: Buffer pool(s) load completed at 200614  9:16:28
12:16:28.720 MariaDB:2020-06-14  9:16:28 0 [Note] Reading of all Master_info entries succeeded
12:16:28.720 MariaDB:2020-06-14  9:16:28 0 [Note] Added new Master_info '' to hash table
12:16:28.720 MariaDB:2020-06-14  9:16:28 0 [Note] mysqld: ready for connections.
12:16:28.720 MariaDB:Version: '10.4.12-MariaDB-1:10.4.12+maria~bionic'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
```

(note that `ready for connections` appears twice, once for the temporary server and once for the actual one) 

Which meant that there was a race condition where the tests could start before the actual MariaDB server has started