### PR TITLE
[WIP] Move VaultRuntimeConfig to BOOTSTRAP phase

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
@@ -1,10 +1,16 @@
 package io.quarkus.vault.runtime;
 
+import java.util.Collections;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
+import io.quarkus.vault.runtime.config.VaultConfigSourceProvider;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 
 @Recorder
@@ -12,13 +18,28 @@ public class VaultRecorder {
 
     private static final Logger log = Logger.getLogger(VaultRecorder.class);
 
-    public void configureRuntimeProperties(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig vaultRuntimeConfig) {
+    public RuntimeValue<ConfigSourceProvider> configureRuntimeProperties(VaultBuildTimeConfig vaultBuildTimeConfig,
+            VaultRuntimeConfig vaultRuntimeConfig) {
 
         if (vaultRuntimeConfig.url.isPresent()) {
             VaultServiceProducer producer = Arc.container().instance(VaultServiceProducer.class).get();
             producer.setVaultConfigs(vaultBuildTimeConfig, vaultRuntimeConfig);
+            return new RuntimeValue<>(new VaultConfigSourceProvider(vaultBuildTimeConfig, vaultRuntimeConfig));
+        } else {
+            return emptyRuntimeValue();
         }
+    }
 
+    private RuntimeValue<ConfigSourceProvider> emptyRuntimeValue() {
+        return new RuntimeValue<>(new EmptyConfigSourceProvider());
+    }
+
+    private static class EmptyConfigSourceProvider implements ConfigSourceProvider {
+
+        @Override
+        public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
+            return Collections.emptyList();
+        }
     }
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/HealthConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/HealthConfig.java
@@ -25,4 +25,12 @@ public class HealthConfig {
     @ConfigItem
     public boolean performanceStandByOk;
 
+    @Override
+    public String toString() {
+        return "HealthConfig{" +
+                "enabled=" + enabled +
+                ", standByOk=" + standByOk +
+                ", performanceStandByOk=" + performanceStandByOk +
+                '}';
+    }
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBuildTimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBuildTimeConfig.java
@@ -15,4 +15,10 @@ public class VaultBuildTimeConfig {
     @ConfigDocSection
     public HealthConfig health;
 
+    @Override
+    public String toString() {
+        return "VaultBuildTimeConfig{" +
+                "health=" + health +
+                '}';
+    }
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -1,61 +1,23 @@
 package io.quarkus.vault.runtime.config;
 
-import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
-import static io.quarkus.vault.runtime.LogConfidentialityLevel.MEDIUM;
 import static io.quarkus.vault.runtime.config.VaultCacheEntry.tryReturnLastKnownValue;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_CONNECT_TIMEOUT;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KUBERNETES_JWT_TOKEN_PATH;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_READ_TIMEOUT;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_RENEW_GRACE_PERIOD;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_SECRET_CONFIG_CACHE_PERIOD;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_TLS_SKIP_VERIFY;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_TLS_USE_KUBERNETES_CACERT;
-import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.KV_SECRET_ENGINE_VERSION_V2;
-import static java.lang.Boolean.parseBoolean;
-import static java.lang.Integer.parseInt;
 import static java.util.Collections.emptyMap;
-import static java.util.Optional.empty;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.Duration;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.logging.Logger;
 
-import io.quarkus.runtime.configuration.DurationConverter;
-import io.quarkus.vault.VaultException;
-import io.quarkus.vault.runtime.LogConfidentialityLevel;
 import io.quarkus.vault.runtime.VaultManager;
 
-public class VaultConfigSource implements ConfigSource {
+class VaultConfigSource implements ConfigSource {
 
     private static final Logger log = Logger.getLogger(VaultConfigSource.class);
-
-    private static final String PROPERTY_PREFIX = "quarkus.vault.";
-    public static final Pattern CREDENTIALS_PATTERN = Pattern.compile("^quarkus\\.vault\\.credentials-provider\\.([^.]+)\\.");
-    public static final Pattern TRANSIT_KEY_PATTERN = Pattern.compile("^quarkus\\.vault\\.transit.key\\.([^.]+)\\.");
-    public static final Pattern SECRET_CONFIG_KV_PATH_PATTERN = Pattern
-            .compile("^quarkus\\.vault\\.secret-config-kv-path\\.([^.]+)$");
 
     private AtomicReference<VaultCacheEntry<Map<String, String>>> cache = new AtomicReference<>(null);
     private AtomicReference<VaultRuntimeConfig> serverConfig = new AtomicReference<>(null);
@@ -63,15 +25,25 @@ public class VaultConfigSource implements ConfigSource {
 
     private AtomicBoolean init = new AtomicBoolean(false);
     private int ordinal;
-    private DurationConverter durationConverter = new DurationConverter();
 
-    public VaultConfigSource(int ordinal) {
+    public VaultConfigSource(int ordinal, VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig vaultRuntimeConfig) {
         this.ordinal = ordinal;
+        this.buildServerConfig.set(vaultBuildTimeConfig);
+        this.serverConfig.set(vaultRuntimeConfig);
+
+        System.out.println("DEBUG VAULT ===> stringListMap = " + vaultRuntimeConfig.stringListMap);
+        System.out.println("DEBUG VAULT ===> stringMap = " + vaultRuntimeConfig.stringMap);
+        System.out.println("DEBUG VAULT ===> stringList = " + vaultRuntimeConfig.stringList);
+
+        System.out.println("DEBUG VAULT ===> secretConfigKvPath = " + vaultRuntimeConfig.secretConfigKvPath);
+        System.out.println("DEBUG VAULT ===> secretConfigKvPrefixPath = " + vaultRuntimeConfig.secretConfigKvPrefixPath);
+        System.out.println("DEBUG VAULT ===> credentialsProvider = " + vaultRuntimeConfig.credentialsProvider);
+
     }
 
     @Override
     public String getName() {
-        return "vault";
+        return VaultRuntimeConfig.NAME;
     }
 
     @Override
@@ -92,7 +64,7 @@ public class VaultConfigSource implements ConfigSource {
     @Override
     public String getValue(String propertyName) {
 
-        VaultRuntimeConfig serverConfig = getRuntimeConfig();
+        VaultRuntimeConfig serverConfig = this.serverConfig.get();
 
         if (!serverConfig.url.isPresent()) {
             return null;
@@ -103,7 +75,7 @@ public class VaultConfigSource implements ConfigSource {
 
     private Map<String, String> getSecretConfig() {
 
-        VaultRuntimeConfig serverConfig = getRuntimeConfig();
+        VaultRuntimeConfig serverConfig = this.serverConfig.get();
 
         VaultCacheEntry<Map<String, String>> cacheEntry = cache.get();
         if (cacheEntry != null && cacheEntry.youngerThan(serverConfig.secretConfigCachePeriod)) {
@@ -151,8 +123,8 @@ public class VaultConfigSource implements ConfigSource {
 
     private VaultManager getVaultManager() {
 
-        VaultBuildTimeConfig buildTimeConfig = getBuildtimeConfig();
-        VaultRuntimeConfig serverConfig = getRuntimeConfig();
+        VaultBuildTimeConfig buildTimeConfig = this.buildServerConfig.get();
+        VaultRuntimeConfig serverConfig = this.serverConfig.get();
 
         // init at most once
         if (init.compareAndSet(false, true)) {
@@ -160,202 +132,6 @@ public class VaultConfigSource implements ConfigSource {
         }
 
         return VaultManager.getInstance();
-    }
-
-    private VaultRuntimeConfig getRuntimeConfig() {
-        return getConfig(this.serverConfig, () -> loadRuntimeConfig(), "runtime");
-    }
-
-    private VaultBuildTimeConfig getBuildtimeConfig() {
-        return getConfig(this.buildServerConfig, () -> loadBuildtimeConfig(), "buildtime");
-    }
-
-    private <T> T getConfig(AtomicReference<T> ref, Supplier<T> supplier, String name) {
-        T config = ref.get();
-        if (config != null) {
-            return config;
-        } else {
-            config = supplier.get();
-            log.debug("loaded vault " + name + " config " + config);
-            ref.set(config);
-            return ref.get();
-        }
-    }
-
-    // need to recode config loading since we are at the config source level
-    private VaultBuildTimeConfig loadBuildtimeConfig() {
-        VaultBuildTimeConfig vaultBuildTimeConfig = new VaultBuildTimeConfig();
-        vaultBuildTimeConfig.health = new HealthConfig();
-
-        vaultBuildTimeConfig.health.enabled = parseBoolean(
-                getVaultProperty("health.enabled", "false"));
-
-        vaultBuildTimeConfig.health.standByOk = parseBoolean(
-                getVaultProperty("health.stand-by-ok", "false"));
-        vaultBuildTimeConfig.health.performanceStandByOk = parseBoolean(
-                getVaultProperty("health.performance-stand-by-ok", "false"));
-
-        return vaultBuildTimeConfig;
-    }
-
-    // need to recode config loading since we are at the config source level
-    private VaultRuntimeConfig loadRuntimeConfig() {
-
-        VaultRuntimeConfig serverConfig = new VaultRuntimeConfig();
-        serverConfig.tls = new VaultTlsConfig();
-        serverConfig.transit = new VaultTransitConfig();
-        serverConfig.authentication = new VaultAuthenticationConfig();
-        serverConfig.authentication.userpass = new VaultUserpassAuthenticationConfig();
-        serverConfig.authentication.appRole = new VaultAppRoleAuthenticationConfig();
-        serverConfig.authentication.kubernetes = new VaultKubernetesAuthenticationConfig();
-        serverConfig.url = newURL(getOptionalVaultProperty("url"));
-        serverConfig.authentication.clientToken = getOptionalVaultProperty("authentication.client-token");
-        serverConfig.authentication.clientTokenWrappingToken = getOptionalVaultProperty(
-                "authentication.client-token-wrapping-token");
-        serverConfig.authentication.kubernetes.role = getOptionalVaultProperty("authentication.kubernetes.role");
-        serverConfig.authentication.kubernetes.jwtTokenPath = getVaultProperty("authentication.kubernetes.jwt-token-path",
-                DEFAULT_KUBERNETES_JWT_TOKEN_PATH);
-        serverConfig.authentication.userpass.username = getOptionalVaultProperty("authentication.userpass.username");
-        serverConfig.authentication.userpass.password = getOptionalVaultProperty("authentication.userpass.password");
-        serverConfig.authentication.userpass.passwordWrappingToken = getOptionalVaultProperty(
-                "authentication.userpass.password-wrapping-token");
-        serverConfig.authentication.appRole.roleId = getOptionalVaultProperty("authentication.app-role.role-id");
-        serverConfig.authentication.appRole.secretId = getOptionalVaultProperty("authentication.app-role.secret-id");
-        serverConfig.authentication.appRole.secretIdWrappingToken = getOptionalVaultProperty(
-                "authentication.app-role.secret-id-wrapping-token");
-        serverConfig.renewGracePeriod = getVaultDuration("renew-grace-period", DEFAULT_RENEW_GRACE_PERIOD);
-        serverConfig.secretConfigCachePeriod = getVaultDuration("secret-config-cache-period",
-                DEFAULT_SECRET_CONFIG_CACHE_PERIOD);
-        serverConfig.logConfidentialityLevel = LogConfidentialityLevel
-                .valueOf(getVaultProperty("log-confidentiality-level", MEDIUM.name()).toUpperCase());
-        serverConfig.kvSecretEngineVersion = parseInt(
-                getVaultProperty("kv-secret-engine-version", KV_SECRET_ENGINE_VERSION_V2));
-        serverConfig.kvSecretEngineMountPath = getVaultProperty("kv-secret-engine-mount-path",
-                DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH);
-        serverConfig.secretConfigKvPath = getOptionalListProperty("secret-config-kv-path");
-        serverConfig.tls.skipVerify = parseBoolean(getVaultProperty("tls.skip-verify", DEFAULT_TLS_SKIP_VERIFY));
-        serverConfig.tls.useKubernetesCaCert = parseBoolean(
-                getVaultProperty("tls.use-kubernetes-ca-cert", DEFAULT_TLS_USE_KUBERNETES_CACERT));
-        serverConfig.tls.caCert = getOptionalVaultProperty("tls.ca-cert");
-        serverConfig.connectTimeout = getVaultDuration("connect-timeout", DEFAULT_CONNECT_TIMEOUT);
-        serverConfig.readTimeout = getVaultDuration("read-timeout", DEFAULT_READ_TIMEOUT);
-
-        serverConfig.credentialsProvider = createCredentialProviderConfigParser().getConfig();
-        serverConfig.transit.key = createTransitKeyConfigParser().getConfig();
-        serverConfig.secretConfigKvPrefixPath = getSecretConfigKvPrefixPaths();
-
-        return serverConfig;
-    }
-
-    private VaultMapConfigParser<CredentialsProviderConfig> createCredentialProviderConfigParser() {
-        return new VaultMapConfigParser<>(CREDENTIALS_PATTERN, this::getCredentialsProviderConfig, getConfigSourceStream());
-    }
-
-    private CredentialsProviderConfig getCredentialsProviderConfig(String name) {
-        String prefix = "credentials-provider." + name;
-        CredentialsProviderConfig config = new CredentialsProviderConfig();
-        config.databaseCredentialsRole = getOptionalVaultProperty(prefix + ".database-credentials-role");
-        config.kvPath = getOptionalVaultProperty(prefix + ".kv-path");
-        config.kvKey = getVaultProperty(prefix + ".kv-key", PASSWORD_PROPERTY_NAME);
-        return config;
-    }
-
-    private VaultMapConfigParser<TransitKeyConfig> createTransitKeyConfigParser() {
-        return new VaultMapConfigParser<>(TRANSIT_KEY_PATTERN, this::getTransitKeyConfig, getConfigSourceStream());
-    }
-
-    private TransitKeyConfig getTransitKeyConfig(String name) {
-        String prefix = "transit.key." + name;
-        TransitKeyConfig config = new TransitKeyConfig();
-        config.name = getOptionalVaultProperty(prefix + ".name");
-        config.hashAlgorithm = getOptionalVaultProperty(prefix + ".hash-algorithm");
-        config.signatureAlgorithm = getOptionalVaultProperty(prefix + ".signature-algorithm");
-        config.type = getOptionalVaultProperty(prefix + ".type");
-        config.convergentEncryption = getOptionalVaultProperty(prefix + ".convergent-encryption");
-        Optional<String> prehashed = getOptionalVaultProperty(prefix + ".prehashed");
-        config.prehashed = Optional.ofNullable(prehashed.isPresent() ? Boolean.parseBoolean(prehashed.get()) : null);
-        return config;
-    }
-
-    private Optional<List<String>> getOptionalListProperty(String name) {
-
-        Optional<String> optionalVaultProperty = getOptionalVaultProperty(name);
-        if (!optionalVaultProperty.isPresent()) {
-            return empty();
-        }
-
-        String[] split = optionalVaultProperty.get().split(",");
-        return Optional.of(Arrays.stream(split)
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(toList()));
-    }
-
-    private Optional<URL> newURL(Optional<String> url) {
-        try {
-            return Optional.ofNullable(url.isPresent() ? new URL(url.get()) : null);
-        } catch (MalformedURLException e) {
-            throw new VaultException(e);
-        }
-    }
-
-    private Optional<String> getOptionalVaultProperty(String key) {
-        return Optional.ofNullable(getVaultProperty(key, null));
-    }
-
-    private Duration getVaultDuration(String key, String defaultValue) {
-        return durationConverter.convert(getVaultProperty(key, defaultValue));
-    }
-
-    private String getVaultProperty(String key, String defaultValue) {
-        String propertyName = PROPERTY_PREFIX + key;
-
-        return getConfigSourceStream()
-                .map(configSource -> configSource.getValue(propertyName))
-                .filter(value -> value != null && value.length() != 0)
-                .map(String::trim)
-                .findFirst()
-                .orElse(defaultValue);
-    }
-
-    private Map<String, List<String>> getSecretConfigKvPrefixPaths() {
-
-        return getConfigSourceStream()
-                .flatMap(configSource -> configSource.getPropertyNames().stream())
-                .map(this::getSecretConfigKvPrefixPathName)
-                .filter(Objects::nonNull)
-                .distinct()
-                .map(this::createNameSecretConfigKvPrefixPathPair)
-                .collect(toMap(SimpleEntry::getKey, SimpleEntry::getValue));
-    }
-
-    private Stream<ConfigSource> getConfigSourceStream() {
-        Config config = ConfigProviderResolver.instance().getConfig();
-        return StreamSupport.stream(config.getConfigSources().spliterator(), false).filter(this::retain);
-    }
-
-    private boolean retain(ConfigSource configSource) {
-        String other;
-        try {
-            other = configSource.getName();
-        } catch (NullPointerException e) {
-            // FIXME at org.jboss.resteasy.microprofile.config.BaseServletConfigSource.getName(BaseServletConfigSource.java:51)
-            other = null;
-        }
-        return !getName().equals(other);
-    }
-
-    private SimpleEntry<String, List<String>> createNameSecretConfigKvPrefixPathPair(String name) {
-        return new SimpleEntry<>(name, getSecretConfigKvPrefixPath(name));
-    }
-
-    private String getSecretConfigKvPrefixPathName(String propertyName) {
-        Matcher matcher = SECRET_CONFIG_KV_PATH_PATTERN.matcher(propertyName);
-        return matcher.find() ? matcher.group(1) : null;
-    }
-
-    private List<String> getSecretConfigKvPrefixPath(String prefixName) {
-        return getOptionalListProperty("secret-config-kv-path." + prefixName).get();
     }
 
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSourceProvider.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSourceProvider.java
@@ -1,0 +1,23 @@
+package io.quarkus.vault.runtime.config;
+
+import java.util.Arrays;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+public class VaultConfigSourceProvider implements ConfigSourceProvider {
+
+    private VaultRuntimeConfig vaultRuntimeConfig;
+    private VaultBuildTimeConfig vaultBuildTimeConfig;
+
+    public VaultConfigSourceProvider(VaultBuildTimeConfig vaultBuildTimeConfig, VaultRuntimeConfig vaultRuntimeConfig) {
+        this.vaultRuntimeConfig = vaultRuntimeConfig;
+        this.vaultBuildTimeConfig = vaultBuildTimeConfig;
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
+        return Arrays.asList(new VaultConfigSource(150, vaultBuildTimeConfig, vaultRuntimeConfig));
+    }
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -5,6 +5,7 @@ import static io.quarkus.vault.runtime.LogConfidentialityLevel.MEDIUM;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.APPROLE;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.KUBERNETES;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
+import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.NAME;
 
 import java.net.URL;
 import java.time.Duration;
@@ -12,14 +13,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.vault.runtime.LogConfidentialityLevel;
 
-@ConfigRoot(name = "vault", phase = ConfigPhase.RUN_TIME)
+@ConfigRoot(name = NAME, phase = ConfigPhase.BOOTSTRAP)
 public class VaultRuntimeConfig {
+
+    public static final String NAME = "vault";
 
     public static final String DEFAULT_KUBERNETES_JWT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
     public static final String DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH = "secret";
@@ -133,6 +137,23 @@ public class VaultRuntimeConfig {
     // @formatter:on
     @ConfigItem(name = "secret-config-kv-path.\"prefix\"")
     public Map<String, List<String>> secretConfigKvPrefixPath;
+
+    // FIXME DEBUG
+    /** A map of property lists */
+    @ConfigItem
+    @ConfigDocMapKey("list-of-strings")
+    public Map<String, List<String>> stringListMap;
+
+    // FIXME DEBUG
+    /** A map of properties */
+    @ConfigItem
+    @ConfigDocMapKey("string-property")
+    public Map<String, String> stringMap;
+
+    // FIXME DEBUG
+    /** A List of string values */
+    @ConfigItem
+    public List<String> stringList;
 
     /**
      * Used to hide confidential infos, for logging in particular.

--- a/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-path.properties
@@ -4,6 +4,15 @@ quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
 quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
 
+# FIXME DEBUG
+quarkus.vault.string-list-map.key1=value1,value2,value3
+quarkus.vault.string-list-map.key2=value4,value5
+quarkus.vault.string-list-map.key3=value6
+quarkus.vault.string-map.key1=value1
+quarkus.vault.string-map.key2=value2
+quarkus.vault.string-map.key3=value3
+quarkus.vault.string-list=value1,value2
+
 quarkus.vault.tls.skip-verify=true
 
 # CI can sometimes be slow, there is no need to fail a test if Vault doesn't respond in 1 second which is the default


### PR DESCRIPTION
Use the `BOOTSTRAP` phase in the vault config, and remove all the logic in the vault config source that was required to recode the property loading mechanism.

See this https://github.com/quarkusio/quarkus/issues/4848#issuecomment-635302504