### PR TITLE
Use proxy activation status in maven settings.xml

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -334,7 +334,9 @@ public class BootstrapMavenContext {
 
         final DefaultProxySelector proxySelector = new DefaultProxySelector();
         for (org.apache.maven.settings.Proxy p : decrypted.getProxies()) {
-            proxySelector.add(toAetherProxy(p), p.getNonProxyHosts());
+            if (p.isActive()) {
+                proxySelector.add(toAetherProxy(p), p.getNonProxyHosts());
+            }
         }
         session.setProxySelector(proxySelector);
 


### PR DESCRIPTION
Proxy activation status in maven settings.xml is not being honored. With this patch only activated proxies in configuration are applied.