### PR TITLE
Add uber-jar to the list of default packaging in the doc

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -22,7 +22,8 @@ public class PackageConfig {
     /**
      * The requested output type.
      *
-     * The default built in types are jar and native
+     * The default built in types are 'jar', 'fast-jar' (a prototype more performant version of the default 'jar' type),
+     * 'uber-jar' and 'native'.
      */
     @ConfigItem(defaultValue = JAR)
     public String type;


### PR DESCRIPTION
Small JavaDoc improvement for the `quarkus.package.type` config property JavaDoc that didn't mention the `uber-jar` type.