### PR TITLE
Workaround some issues shading quarkus-ide-launcher

### DIFF
--- a/core/launcher/pom.xml
+++ b/core/launcher/pom.xml
@@ -48,13 +48,41 @@
                             </filters>
                             <relocations>
                                 <relocation>
-                                    <shadedPattern>io.quarkus.launcher.shaded.</shadedPattern>
+                                    <pattern>org</pattern>
+                                    <shadedPattern>io.quarkus.launcher.shaded.org</shadedPattern>
                                     <excludes>
                                         <exclude>META-INF/**</exclude>
                                         <exclude>licenses/**</exclude>
                                         <exclude>plugin.xml</exclude>
-                                        <exclude>java/**</exclude> <!-- unless this is is added, the build may fail with e.g. cannot access io.quarkus.launcher.shaded.java.lang.String -->
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com</pattern>
+                                    <shadedPattern>io.quarkus.launcher.shaded.com</shadedPattern>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>licenses/**</exclude>
+                                        <exclude>plugin.xml</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net</pattern>
+                                    <shadedPattern>io.quarkus.launcher.shaded.net</shadedPattern>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>licenses/**</exclude>
+                                        <exclude>plugin.xml</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io</pattern>
+                                    <shadedPattern>io.quarkus.launcher.shaded.io</shadedPattern>
+                                    <excludes>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>licenses/**</exclude>
+                                        <exclude>plugin.xml</exclude>
                                         <exclude>io.quarkus.launcher.*</exclude>
+                                        <exclude>io.quarkus.deployment.dev.*</exclude>
                                     </excludes>
                                 </relocation>
                             </relocations>


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/9974 .

Not sure it's enough to really solve the problem. I'm especially worried about the service files being excluded from the relocations. This looks like something that wouldn't work very well.