### PR TITLE
Bootstrap Maven: replace the met runtime extensions but not their child deps

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -264,7 +264,8 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             }
         }
 
-        List<AppDependency> fullDeploymentDeps = new ArrayList<>(userDeps);
+        List<AppDependency> fullDeploymentDeps = new ArrayList<>(userDeps.size() + deploymentDeps.size());
+        fullDeploymentDeps.addAll(userDeps);
         fullDeploymentDeps.addAll(deploymentDeps);
         //we need these to have a type of 'jar'
         //type is blank when loaded


### PR DESCRIPTION
The current implementation is actually replacing way too many runtime dependencies with their corresponding deployment ones than necessary, i.e. for nothing.
It is based on the assumption that if extension E1 depends on extension E2 then
* the runtime artifact of E1 depends on the runtime artifact of E2
* the deployment artifact of E1 depends on the deployment artifact of E2
This assumption allows us to resolve the complete deployment dependency tree of a given extension with a single Maven request.

The way the resolver works is it resolves the graph of the application dependencies and then navigates all the nodes collecting all the runtime artifacts of Quarkus extensions. Once all of the extensions have been collected, it replaces branches starting with the each found runtime extension artifact with its corresponding deployment artifact dependency branch. (And then re-runs the Maven's version convergence over the new graph)

It would however be enough to only replace the first met runtime extension node with its corresponding deployment node. Replacing the children of the already replaced runtime node is actually a wast of time, given that the branch starting with the original runtime node has already been cut off from the full graph.