### PR TITLE
Use '/' as the path element separator creating a relative resource path

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -220,7 +219,7 @@ public class CreateProjectMojo extends AbstractMojo {
             Files.createDirectories(projectDirPath.resolve("gradle/wrapper"));
 
             for (String filename : CreateUtils.GRADLE_WRAPPER_FILES) {
-                byte[] fileContent = platform.loadResource(Paths.get(CreateUtils.GRADLE_WRAPPER_PATH, filename).toString(),
+                byte[] fileContent = platform.loadResource(CreateUtils.GRADLE_WRAPPER_PATH + '/' + filename,
                         is -> {
                             byte[] buffer = new byte[is.available()];
                             is.read(buffer);


### PR DESCRIPTION
When looking for Gradle wrapper resources on the classpath we should be using `/` as the path element separator instead of the OS-specific one. This path may be used by looking for resources on the classpath in which case it should always be `/`.
And `java.nio.file.Path` also support `/` even on Windows, in case the path is used for look ups in a directory.

Fixes #10003 