### PR TITLE
Upgrade to Hibernate Search 6.0.0.Beta8

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -91,7 +91,7 @@
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.8</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.6.2</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.7.0</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <rxjava.version>2.2.19</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -86,7 +86,7 @@
         <hibernate-orm.version>5.4.17.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha5</hibernate-reactive.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.Beta7</hibernate-search.version>
+        <hibernate-search.version>6.0.0.Beta8</hibernate-search.version>
         <narayana.version>5.10.5.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.8</agroal.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Maven plugin versions -->
         <elasticsearch-maven-plugin.version>6.15</elasticsearch-maven-plugin.version>
-        <elasticsearch-server.version>7.6.2</elasticsearch-server.version>
+        <elasticsearch-server.version>7.7.0</elasticsearch-server.version>
         <scala-maven-plugin.version>4.1.1</scala-maven-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->

--- a/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-elasticsearch.adoc
@@ -620,7 +620,7 @@ Let's use Docker to start one of each:
 
 [source, shell]
 ----
-docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.7.0
 ----
 
 [source, shell]

--- a/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
+++ b/extensions/hibernate-search-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/elasticsearch/HibernateSearchClasses.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.T
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenizerDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.AbstractTypeMapping;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplate;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplateJsonAdapterFactory;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicType;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.FormatJsonAdapter;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplate;
@@ -43,10 +44,6 @@ class HibernateSearchClasses {
 
     static final List<DotName> GSON_CLASSES = new ArrayList<>();
     static {
-        // TODO this type should be public; see https://hibernate.atlassian.net/browse/HSEARCH-3916
-        GSON_CLASSES.add(DotName.createSimple(
-                "org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplateJsonAdapterFactory"));
-
         List<Class<?>> publicGsonClasses = Arrays.asList(
                 AbstractTypeMapping.class,
                 DynamicType.class,
@@ -71,6 +68,7 @@ class HibernateSearchClasses {
                 IndexAliasDefinition.class,
                 IndexAliasDefinitionJsonAdapterFactory.class,
                 DynamicTemplate.class,
+                DynamicTemplateJsonAdapterFactory.class,
                 NamedDynamicTemplate.class,
                 NamedDynamicTemplateJsonAdapterFactory.class);
         for (Class<?> publicGsonClass : publicGsonClasses) {

--- a/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -374,7 +374,7 @@ public class HibernateSearchElasticsearchRuntimeConfig {
          * which may lead to higher indexing throughput,
          * but incurs a risk of overloading Elasticsearch,
          * i.e. of overflowing its HTTP request buffers and tripping
-         * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.6/circuit-breaker.html">circuit breakers</a>,
+         * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.7/circuit-breaker.html">circuit breakers</a>,
          * leading to Elasticsearch giving up on some request and resulting in indexing failures.
          */
         // We can't set an actual default value here: see comment on this class.
@@ -400,7 +400,7 @@ public class HibernateSearchElasticsearchRuntimeConfig {
          * which may lead to higher indexing throughput,
          * but incurs a risk of overloading Elasticsearch,
          * i.e. of overflowing its HTTP request buffers and tripping
-         * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.6/circuit-breaker.html">circuit breakers</a>,
+         * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.7/circuit-breaker.html">circuit breakers</a>,
          * leading to Elasticsearch giving up on some request and resulting in indexing failures.
          * <p>
          * Note that raising this number above the queue size has no effect,


### PR DESCRIPTION
Release announcement: https://in.relation.to/2020/06/03/hibernate-search-6-0-0-Beta8/