### PR TITLE
Update custom SecurityIdentityAugmentor to latest code

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -296,14 +296,14 @@ Internally, the identity providers create and update an istance of the `io.quark
 
 [source,java]
 ----
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import javax.enterprise.context.ApplicationScoped;
-
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.function.Supplier;
 
 @ApplicationScoped
 public class RolesAugmentor implements SecurityIdentityAugmentor {
@@ -314,26 +314,25 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
     }
 
     @Override
-    public CompletionStage<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        return context.runBlocking(build(identity));
+    }
 
-        CompletableFuture<SecurityIdentity> cs = new CompletableFuture<>();
-        if (identity.isAnonymous()) {
-            cs.complete(identity);
+    private Supplier<SecurityIdentity> build(SecurityIdentity identity) {
+        if(identity.isAnonymous()) {
+            return () -> identity;
         } else {
             // create a new builder and copy principal, attributes, credentials and roles from the original
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder()
-                .setPrincipal(identity.getPrincipal())
-                .addAttributes(identity.getAttributes())
-                .addCredentials(identity.getCredentials())
-                .addRoles(identity.getRoles());
+                    .setPrincipal(identity.getPrincipal())
+                    .addAttributes(identity.getAttributes())
+                    .addCredentials(identity.getCredentials())
+                    .addRoles(identity.getRoles());
 
             // add custom role source here
             builder.addRole("dummy");
-
-            cs.complete(builder.build());
+            return builder::build;
         }
-
-        return cs;
     }
 }
 ----


### PR DESCRIPTION
I was trying to work on adding a custom property to my identity and found this guide. The example code didn't work so I tried to rewrite it.  https://quarkus.io/guides/security#security-identity-customization

Feedback highly appreciated 😄 

One more question? How do we access the id or access token from here? I tried injecting the token in several ways but on runtime it was not available with either option and it resulted in a `ContextNotActiveException`:
```
@Inject
JsonWebToken jwt;

@IdToken
JsonWebToken idToken;
```