### PR TITLE
Provide infrastructure to index additional classes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalIndexedClassesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalIndexedClassesBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class AdditionalIndexedClassesBuildItem extends MultiBuildItem {
+
+    private final Set<String> classesToIndex = new HashSet<>();
+
+    public AdditionalIndexedClassesBuildItem(String... classesToIndex) {
+        this.classesToIndex.addAll(Arrays.asList(classesToIndex));
+    }
+
+    public Set<String> getClassesToIndex() {
+        return classesToIndex;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -71,7 +71,7 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         public static final DefaultIgnorePredicate INSTANCE = new DefaultIgnorePredicate();
 
         private static final List<String> DEFAULT_IGNORED_PACKAGES = Arrays.asList("java.", "io.reactivex.",
-                "org.reactivestreams.");
+                "org.reactivestreams.", "org.slf4j.");
         // if this gets more complicated we will need to move to some tree like structure
         static final Set<String> WHITELISTED_FROM_IGNORED_PACKAGES = new HashSet<>(
                 Arrays.asList("java.math.BigDecimal", "java.math.BigInteger"));

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -34,6 +34,7 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
     private final Type type;
     private IndexView index;
     private final Predicate<DotName> ignorePredicate;
+    private String source;
 
     public ReflectiveHierarchyBuildItem(Type type) {
         this(type, DefaultIgnorePredicate.INSTANCE);
@@ -44,14 +45,30 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
     }
 
     public ReflectiveHierarchyBuildItem(Type type, Predicate<DotName> ignorePredicate) {
-        this.type = type;
-        this.ignorePredicate = ignorePredicate;
+        this(type, ignorePredicate, null);
     }
 
     public ReflectiveHierarchyBuildItem(Type type, IndexView index, Predicate<DotName> ignorePredicate) {
+        this(type, index, ignorePredicate, null);
+    }
+
+    public ReflectiveHierarchyBuildItem(Type type, String source) {
+        this(type, DefaultIgnorePredicate.INSTANCE, source);
+    }
+
+    public ReflectiveHierarchyBuildItem(Type type, IndexView index, String source) {
+        this(type, index, DefaultIgnorePredicate.INSTANCE, source);
+    }
+
+    public ReflectiveHierarchyBuildItem(Type type, Predicate<DotName> ignorePredicate, String source) {
+        this(type, null, ignorePredicate, source);
+    }
+
+    public ReflectiveHierarchyBuildItem(Type type, IndexView index, Predicate<DotName> ignorePredicate, String source) {
         this.type = type;
         this.index = index;
         this.ignorePredicate = ignorePredicate;
+        this.source = source;
     }
 
     public Type getType() {
@@ -64,6 +81,14 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
 
     public Predicate<DotName> getIgnorePredicate() {
         return ignorePredicate;
+    }
+
+    public boolean hasSource() {
+        return source != null;
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public static class DefaultIgnorePredicate implements Predicate<DotName> {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CombinedIndexBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CombinedIndexBuildStep.java
@@ -1,25 +1,46 @@
 package io.quarkus.deployment.steps;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.jandex.CompositeIndex;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
 
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.index.IndexingUtil;
 
 public class CombinedIndexBuildStep {
 
     @BuildStep
-    CombinedIndexBuildItem build(ApplicationArchivesBuildItem archives) {
-        List<IndexView> allIndexes = new ArrayList<>();
+    CombinedIndexBuildItem build(ApplicationArchivesBuildItem archives,
+            List<AdditionalIndexedClassesBuildItem> additionalIndexedClassesItems) {
+        List<IndexView> archiveIndexes = new ArrayList<>();
+
         for (ApplicationArchive i : archives.getAllApplicationArchives()) {
-            allIndexes.add(i.getIndex());
+            archiveIndexes.add(i.getIndex());
         }
-        return new CombinedIndexBuildItem(CompositeIndex.create(allIndexes));
+
+        CompositeIndex archivesIndex = CompositeIndex.create(archiveIndexes);
+
+        Indexer indexer = new Indexer();
+        Set<DotName> additionalIndex = new HashSet<>();
+
+        for (AdditionalIndexedClassesBuildItem additionalIndexedClasses : additionalIndexedClassesItems) {
+            for (String classToIndex : additionalIndexedClasses.getClassesToIndex()) {
+                IndexingUtil.indexClass(classToIndex, indexer, archivesIndex, additionalIndex,
+                        Thread.currentThread().getContextClassLoader());
+            }
+        }
+
+        return new CombinedIndexBuildItem(CompositeIndex.create(archivesIndex, indexer.complete()));
     }
 
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -45,6 +45,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -81,6 +82,20 @@ public class KafkaProcessor {
             StringDeserializer.class,
             FloatDeserializer.class
     };
+
+    @BuildStep
+    void contributeClassesToIndex(BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClasses,
+            BuildProducer<IndexDependencyBuildItem> indexDependency) {
+        // This is needed for SASL authentication
+
+        additionalIndexedClasses.produce(new AdditionalIndexedClassesBuildItem(
+                LoginModule.class.getName(),
+                javax.security.auth.Subject.class.getName(),
+                javax.security.auth.login.AppConfigurationEntry.class.getName(),
+                javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.class.getName()));
+
+        indexDependency.produce(new IndexDependencyBuildItem("org.apache.kafka", "kafka-clients"));
+    }
 
     @BuildStep
     public void build(CombinedIndexBuildItem indexBuildItem, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -132,18 +147,15 @@ public class KafkaProcessor {
     }
 
     @BuildStep
-    public void withSasl(BuildProducer<IndexDependencyBuildItem> indexDependency,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+    public void withSasl(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy) {
-
-        indexDependency.produce(new IndexDependencyBuildItem("org.apache.kafka", "kafka-clients"));
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, AbstractLogin.DefaultLoginCallbackHandler.class));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, SaslClientCallbackHandler.class));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, DefaultLogin.class));
 
         final Type loginModuleType = Type
-                .create(DotName.createSimple(LoginModule.class.getCanonicalName()), Kind.CLASS);
+                .create(DotName.createSimple(LoginModule.class.getName()), Kind.CLASS);
 
         reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(loginModuleType));
     }

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -751,15 +751,18 @@ public class ResteasyServerCommonProcessor {
             if (instance.target().kind() != Kind.METHOD) {
                 continue;
             }
+
             MethodInfo method = instance.target().asMethod();
+            String source = method.declaringClass() + "[" + method + "]";
+
             reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(method.returnType(), index,
-                    ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
+                    ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE, source));
 
             for (short i = 0; i < method.parameters().size(); i++) {
                 Type parameterType = method.parameters().get(i);
                 if (!hasAnnotation(method, i, ResteasyDotNames.CONTEXT)) {
                     reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem(parameterType, index,
-                            ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE));
+                            ResteasyDotNames.IGNORE_FOR_REFLECTION_PREDICATE, source));
                 }
             }
         }


### PR DESCRIPTION
Several of our extensions need to index additional classes and it makes no sense to create a separate index each time, especially since these classes might be useful for other extensions.

This PR introduces a new build item to be able to push additional classes once and for all to the shared `CombinedIndexBuildItem`.

Also the idea was to fix https://github.com/quarkusio/quarkus/issues/9954 .

Better reviewed commit per commit.

Created as draft to see what CI has to say.