### PR TITLE
Make Hibernate Reactive work w/o Narayana and Agroal

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -307,6 +307,7 @@ public final class HibernateOrmProcessor {
 
         final boolean enableORM = hasEntities(domainObjects, nonJpaModelBuildItems);
         final boolean hibernateReactivePresent = capabilities.isPresent(Capability.HIBERNATE_REACTIVE);
+        final boolean jtaPresent = capabilities.isPresent(Capability.TRANSACTIONS);
         //The Hibernate Reactive extension is able to handle registration of PersistenceProviders for both reactive and
         //traditional blocking Hibernate, by depending on this module and delegating to this code.
         //So when the Hibernate Reactive extension is present, trust that it will register its own PersistenceProvider
@@ -371,7 +372,7 @@ public final class HibernateOrmProcessor {
         beanContainerListener
                 .produce(new BeanContainerListenerBuildItem(
                         recorder.initMetadata(allDescriptors, scanner, integratorClasses, serviceContributorClasses,
-                                proxyDefinitions.getProxies(), strategy)));
+                                proxyDefinitions.getProxies(), strategy, jtaPresent)));
     }
 
     private MultiTenancyStrategy getMultiTenancyStrategy() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -85,12 +85,12 @@ public class HibernateOrmRecorder {
     public BeanContainerListener initMetadata(List<ParsedPersistenceXmlDescriptor> parsedPersistenceXmlDescriptors,
             Scanner scanner, Collection<Class<? extends Integrator>> additionalIntegrators,
             Collection<Class<? extends ServiceContributor>> additionalServiceContributors,
-            PreGeneratedProxies proxyDefinitions, MultiTenancyStrategy strategy) {
+            PreGeneratedProxies proxyDefinitions, MultiTenancyStrategy strategy, boolean jtaPresent) {
         return new BeanContainerListener() {
             @Override
             public void created(BeanContainer beanContainer) {
                 PersistenceUnitsHolder.initializeJpa(parsedPersistenceXmlDescriptors, scanner, additionalIntegrators,
-                        additionalServiceContributors, proxyDefinitions, strategy);
+                        additionalServiceContributors, proxyDefinitions, strategy, jtaPresent);
             }
         };
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitsHolder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/PersistenceUnitsHolder.java
@@ -41,14 +41,15 @@ public final class PersistenceUnitsHolder {
      *
      * @param parsedPersistenceXmlDescriptors
      * @param scanner
+     * @param jtaPresent
      */
     static void initializeJpa(List<ParsedPersistenceXmlDescriptor> parsedPersistenceXmlDescriptors,
             Scanner scanner, Collection<Class<? extends Integrator>> additionalIntegrators,
             Collection<Class<? extends ServiceContributor>> additionalServiceContributors,
-            PreGeneratedProxies preGeneratedProxies, MultiTenancyStrategy strategy) {
+            PreGeneratedProxies preGeneratedProxies, MultiTenancyStrategy strategy, boolean jtaPresent) {
         final List<PersistenceUnitDescriptor> units = convertPersistenceUnits(parsedPersistenceXmlDescriptors);
         final Map<String, RecordedState> metadata = constructMetadataAdvance(units, scanner, additionalIntegrators,
-                preGeneratedProxies, strategy);
+                preGeneratedProxies, strategy, jtaPresent);
 
         persistenceUnits = new PersistenceUnits(units, metadata);
     }
@@ -81,11 +82,11 @@ public final class PersistenceUnitsHolder {
             final List<PersistenceUnitDescriptor> parsedPersistenceXmlDescriptors, Scanner scanner,
             Collection<Class<? extends Integrator>> additionalIntegrators,
             PreGeneratedProxies proxyClassDefinitions,
-            MultiTenancyStrategy strategy) {
+            MultiTenancyStrategy strategy, boolean jtaPresent) {
         Map<String, RecordedState> recordedStates = new HashMap<>();
 
         for (PersistenceUnitDescriptor unit : parsedPersistenceXmlDescriptors) {
-            RecordedState m = createMetadata(unit, scanner, additionalIntegrators, proxyClassDefinitions, strategy);
+            RecordedState m = createMetadata(unit, scanner, additionalIntegrators, proxyClassDefinitions, strategy, jtaPresent);
             Object previous = recordedStates.put(unitName(unit), m);
             if (previous != null) {
                 throw new IllegalStateException("Duplicate persistence unit name: " + unit.getName());
@@ -111,9 +112,9 @@ public final class PersistenceUnitsHolder {
 
     public static RecordedState createMetadata(PersistenceUnitDescriptor unit, Scanner scanner,
             Collection<Class<? extends Integrator>> additionalIntegrators, PreGeneratedProxies proxyDefinitions,
-            MultiTenancyStrategy strategy) {
+            MultiTenancyStrategy strategy, boolean jtaPresent) {
         FastBootMetadataBuilder fastBootMetadataBuilder = new FastBootMetadataBuilder(unit, scanner, additionalIntegrators,
-                proxyDefinitions, strategy);
+                proxyDefinitions, strategy, jtaPresent);
         return fastBootMetadataBuilder.build();
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionEntityManagers.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/TransactionEntityManagers.java
@@ -10,16 +10,11 @@ import javax.persistence.EntityManager;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.runtime.entitymanager.TransactionScopedEntityManager;
 
 @ApplicationScoped
 public class TransactionEntityManagers {
-
-    @Inject
-    TransactionSynchronizationRegistry transactionSynchronizationRegistry;
-
-    @Inject
-    TransactionManager transactionManager;
 
     @Inject
     JPAConfig jpaConfig;
@@ -39,8 +34,18 @@ public class TransactionEntityManagers {
             return entityManager;
         }
         return managers.computeIfAbsent(unitName, (un) -> new TransactionScopedEntityManager(
-                transactionManager, transactionSynchronizationRegistry, jpaConfig.getEntityManagerFactory(un), un,
+                getTransactionManager(), getTransactionSynchronizationRegistry(), jpaConfig.getEntityManagerFactory(un), un,
                 requestScopedEntityManagers));
+    }
+
+    private TransactionManager getTransactionManager() {
+        return Arc.container()
+                .instance(TransactionManager.class).get();
+    }
+
+    private TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
+        return Arc.container()
+                .instance(TransactionSynchronizationRegistry.class).get();
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -197,7 +197,7 @@ public class PreconfiguredServiceRegistryBuilder {
         // Disabled: IdentifierGenerators are no longer initiated after Metadata was generated.
         // serviceInitiators.add(MutableIdentifierGeneratorFactoryInitiator.INSTANCE);
 
-        serviceInitiators.add(QuarkusJtaPlatformInitiator.INSTANCE);
+        serviceInitiators.add(new QuarkusJtaPlatformInitiator(rs.isJtaPresent()));
 
         serviceInitiators.add(SessionFactoryServiceRegistryFactoryInitiator.INSTANCE);
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusJtaPlatformInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusJtaPlatformInitiator.java
@@ -3,15 +3,32 @@ package io.quarkus.hibernate.orm.runtime.customized;
 import java.util.Map;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 public final class QuarkusJtaPlatformInitiator implements StandardServiceInitiator<JtaPlatform> {
 
-    public static final QuarkusJtaPlatformInitiator INSTANCE = new QuarkusJtaPlatformInitiator();
+    private final boolean jtaIsPresent;
+
+    public QuarkusJtaPlatformInitiator(boolean jtaIsPresent) {
+        this.jtaIsPresent = jtaIsPresent;
+    }
 
     @Override
     public JtaPlatform initiateService(Map map, ServiceRegistryImplementor serviceRegistryImplementor) {
+        return buildJtaPlatformInstance();
+    }
+
+    public JtaPlatform buildJtaPlatformInstance() {
+        return jtaIsPresent ? getJtaInstance() : getNoJtaInstance();
+    }
+
+    private NoJtaPlatform getNoJtaInstance() {
+        return NoJtaPlatform.INSTANCE;
+    }
+
+    private QuarkusJtaPlatform getJtaInstance() {
         return QuarkusJtaPlatform.INSTANCE;
     }
 
@@ -19,4 +36,5 @@ public final class QuarkusJtaPlatformInitiator implements StandardServiceInitiat
     public Class<JtaPlatform> getServiceInitiated() {
         return JtaPlatform.class;
     }
+
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/JtaIntegrationDCOHelper.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/JtaIntegrationDCOHelper.java
@@ -1,0 +1,41 @@
+package io.quarkus.hibernate.orm.runtime.graal;
+
+import java.util.function.BooleanSupplier;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.hibernate.orm.runtime.customized.QuarkusJtaPlatform;
+
+/**
+ * Technically this substitution shouldn't be needed, if only the DCO logic of the
+ * native-image compiler was a bit smarter.
+ * It doesn't seem to be able to detect that QuarkusJtaPlatformInitiator#jtaIsPresent
+ * is a constant which will always be false when the JTA platform is not available.
+ * (I had also tried to make this more obvious by adding a static final boolean,
+ * but it has to "and" this boolean with the configuration flag and it doesn't seem
+ * able to resolve that as a constant).
+ */
+@TargetClass(className = "io.quarkus.hibernate.orm.runtime.customized.QuarkusJtaPlatformInitiator", onlyWith = JtaIntegrationDCOHelper.Selector.class)
+public final class JtaIntegrationDCOHelper {
+
+    @Substitute
+    private QuarkusJtaPlatform getJtaInstance() {
+        throw new IllegalStateException(
+                "This should never be called: JTA was enabled but apparently Narayana is not on the classpath?");
+    }
+
+    static final class Selector implements BooleanSupplier {
+
+        @Override
+        public boolean getAsBoolean() {
+            try {
+                Class.forName("com.arjuna.ats.jta.TransactionManager");
+                return false;
+            } catch (ClassNotFoundException e) {
+                return true;
+            }
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedState.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/RecordedState.java
@@ -23,11 +23,12 @@ public final class RecordedState {
     private final IntegrationSettings integrationSettings;
     private final ProxyDefinitions proxyClassDefinitions;
     private final MultiTenancyStrategy multiTenancyStrategy;
+    private final boolean jtaPresent;
 
     public RecordedState(Dialect dialect, JtaPlatform jtaPlatform, PrevalidatedQuarkusMetadata metadata,
             BuildTimeSettings settings, Collection<Integrator> integrators,
             Collection<ProvidedService> providedServices, IntegrationSettings integrationSettings,
-            ProxyDefinitions classDefinitions, MultiTenancyStrategy strategy) {
+            ProxyDefinitions classDefinitions, MultiTenancyStrategy strategy, boolean jtaPresent) {
         this.dialect = dialect;
         this.jtaPlatform = jtaPlatform;
         this.metadata = metadata;
@@ -37,6 +38,7 @@ public final class RecordedState {
         this.integrationSettings = integrationSettings;
         this.proxyClassDefinitions = classDefinitions;
         this.multiTenancyStrategy = strategy;
+        this.jtaPresent = jtaPresent;
     }
 
     public Dialect getDialect() {
@@ -65,6 +67,10 @@ public final class RecordedState {
 
     public JtaPlatform getJtaPlatform() {
         return jtaPlatform;
+    }
+
+    public boolean isJtaPresent() {
+        return jtaPresent;
     }
 
     public ProxyDefinitions getProxyClassDefinitions() {

--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -20,6 +20,28 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-narayana-jta-deployment</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-narayana-jta</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal-deployment</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-reactive/runtime/pom.xml
+++ b/extensions/hibernate-reactive/runtime/pom.xml
@@ -16,6 +16,16 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-agroal</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-narayana-jta</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -192,7 +192,7 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
         // Disabled: IdentifierGenerators are no longer initiated after Metadata was generated.
         // serviceInitiators.add(MutableIdentifierGeneratorFactoryInitiator.INSTANCE);
 
-        serviceInitiators.add(QuarkusJtaPlatformInitiator.INSTANCE);
+        serviceInitiators.add(new QuarkusJtaPlatformInitiator(rs.isJtaPresent()));
 
         serviceInitiators.add(SessionFactoryServiceRegistryFactoryInitiator.INSTANCE);
 

--- a/integration-tests/hibernate-reactive-db2/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-db2/src/main/resources/application.properties
@@ -9,6 +9,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # Reactive config
 quarkus.datasource.reactive=true
 quarkus.datasource.reactive.url=${reactive-db2.url}
-
-# JDBC config
-quarkus.datasource.jdbc=false

--- a/integration-tests/hibernate-reactive-mysql/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-mysql/src/main/resources/application.properties
@@ -9,6 +9,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # Reactive config
 quarkus.datasource.reactive=true
 quarkus.datasource.reactive.url=${reactive-mysql.url}
-
-# JDBC config
-quarkus.datasource.jdbc=false

--- a/integration-tests/hibernate-reactive/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive/src/main/resources/application.properties
@@ -10,6 +10,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.reactive=true
 quarkus.datasource.reactive.url=${postgres.reactive.url}
 
-# JDBC config
-quarkus.datasource.jdbc=false
-#quarkus.datasource.jdbc.url=${postgres.url}


### PR DESCRIPTION
The Narayana and Agroal extensions are hardcoded dependencies of the Hibernate ORM extension,
which is a dependency of Hibernate Reactive.

And yet when using Hibernate Reactive these are unnecessary; this PR makes it possible to run Hibernate Reactive without actually having Narayana and Agroal running as well, and excludes the dependency from the Hibernate Reactive classpath.

The substitution is necessary as otherwise the module suffers from a broken classpath: it might be cleaner to fully separate such code in a dedicated module, but it's not a great time for large refactorings as there's several works in progress that affect this module.