### PR TITLE
Fix IDE launcher by replacing shading with alternate solution

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -97,6 +97,7 @@
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <protoc.version>3.11.4</protoc.version>
         <grpc.version>1.29.0</grpc.version>
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -234,6 +235,11 @@
                             <maven.home>${maven.home}</maven.home>
                         </systemPropertyVariables>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>

--- a/core/launcher/pom.xml
+++ b/core/launcher/pom.xml
@@ -17,47 +17,32 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>unpack-dependencies</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <createSourcesJar>true</createSourcesJar>
-                            <filters>
-                                <filter>
-                                    <artifact>org.eclipse.sisu:org.eclipse.sisu.inject</artifact>
-                                    <excludes>
-                                        <!-- exclude the annotation processor service -->
-                                        <exclude>META-INF/services/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                </filter>
-                            </filters>
-                            <relocations>
-                                <relocation>
-                                    <shadedPattern>io.quarkus.launcher.shaded.</shadedPattern>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
-                                        <exclude>licenses/**</exclude>
-                                        <exclude>plugin.xml</exclude>
-                                        <exclude>java/**</exclude> <!-- unless this is is added, the build may fail with e.g. cannot access io.quarkus.launcher.shaded.java.lang.String -->
-                                        <exclude>io.quarkus.launcher.*</exclude>
-                                    </excludes>
-                                </relocation>
-                            </relocations>
+                            <fileMappers>
+                                <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    <pattern>$</pattern>
+                                    <replacement>.ide-launcher-res</replacement>
+                                </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                            </fileMappers>
+                            <outputDirectory>${project.build.directory}/classes/META-INF/ide-deps</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>

--- a/core/launcher/src/main/java/io/quarkus/launcher/QuarkusLauncher.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/QuarkusLauncher.java
@@ -1,14 +1,15 @@
 package io.quarkus.launcher;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-
-import io.quarkus.bootstrap.app.CuratedApplication;
-import io.quarkus.bootstrap.app.QuarkusBootstrap;
 
 /**
  * IDE entry point.
@@ -40,18 +41,100 @@ public class QuarkusLauncher {
             context.put("app-classes", appClasses);
             context.put("args", args);
 
-            //todo : proper support for everything
-            CuratedApplication app = QuarkusBootstrap.builder(appClasses)
-                    .setBaseClassLoader(QuarkusLauncher.class.getClassLoader())
-                    .setProjectRoot(appClasses)
-                    .setIsolateDeployment(true)
-                    .setMode(QuarkusBootstrap.Mode.DEV)
-                    .build().bootstrap();
-            app.runInAugmentClassLoader("io.quarkus.deployment.dev.IDEDevModeMain", context);
+            IDEClassLoader loader = new IDEClassLoader(QuarkusLauncher.class.getClassLoader());
+            Thread.currentThread().setContextClassLoader(loader);
+            Class<?> launcher = loader.loadClass("io.quarkus.bootstrap.IDELauncherImpl");
+            launcher.getDeclaredMethod("launch", Path.class, Map.class).invoke(null, appClasses, context);
 
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
+    public static class IDEClassLoader extends ClassLoader {
+
+        static {
+            registerAsParallelCapable();
+        }
+
+        public IDEClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            String resourceName = name.replace(".", "/") + ".class";
+            try {
+                try (InputStream is = getResourceAsStream(resourceName)) {
+                    if (is == null) {
+                        throw new ClassNotFoundException(name);
+                    }
+                    definePackage(name);
+                    byte[] buf = new byte[1024];
+                    int r;
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    while ((r = is.read(buf)) > 0) {
+                        out.write(buf, 0, r);
+                    }
+                    byte[] bytes = out.toByteArray();
+
+                    return defineClass(name, bytes, 0, bytes.length);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+        }
+
+        private void definePackage(String name) {
+            final String pkgName = getPackageNameFromClassName(name);
+            if ((pkgName != null) && getPackage(pkgName) == null) {
+                synchronized (getClassLoadingLock(pkgName)) {
+                    if (getPackage(pkgName) == null) {
+                        // this could certainly be improved to use the actual manifest
+                        definePackage(pkgName, null, null, null, null, null, null, null);
+                    }
+                }
+            }
+        }
+
+        private String getPackageNameFromClassName(String className) {
+            final int index = className.lastIndexOf('.');
+            if (index == -1) {
+                // we return null here since in this case no package is defined
+                // this is same behavior as Package.getPackage(clazz) exhibits
+                // when the class is in the default package
+                return null;
+            }
+            return className.substring(0, index);
+        }
+
+        protected Class<?> findClass(String moduleName, String name) {
+            try {
+                return findClass(name);
+            } catch (ClassNotFoundException e) {
+                return null;
+            }
+        }
+
+        protected URL findResource(String moduleName, String name) throws IOException {
+            return findResource(name);
+        }
+
+        @Override
+        protected URL findResource(String name) {
+            if (!name.startsWith("/")) {
+                name = "/" + name;
+            }
+            return getParent().getResource("META-INF/ide-deps" + name + ".ide-launcher-res");
+        }
+
+        @Override
+        protected Enumeration<URL> findResources(String name) throws IOException {
+            if (!name.startsWith("/")) {
+                name = "/" + name;
+            }
+            return getParent().getResources("META-INF/ide-deps" + name + ".ide-launcher-res");
+        }
+    }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
@@ -1,0 +1,34 @@
+package io.quarkus.bootstrap;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * IDE entry point.
+ * 
+ * This is launched from the core/launcher module. To avoid any shading issues core/launcher unpacks all its dependencies
+ * into the jar file, then uses a custom class loader load them.
+ * 
+ */
+@SuppressWarnings("unused")
+public class IDELauncherImpl {
+
+    public static void launch(Path projectRoot, Map<String, Object> context) {
+
+        try {
+            //todo : proper support for everything
+            CuratedApplication app = QuarkusBootstrap.builder(projectRoot)
+                    .setBaseClassLoader(IDELauncherImpl.class.getClassLoader())
+                    .setProjectRoot(projectRoot)
+                    .setIsolateDeployment(true)
+                    .setMode(QuarkusBootstrap.Mode.DEV)
+                    .build().bootstrap();
+            app.runInAugmentClassLoader("io.quarkus.deployment.dev.IDEDevModeMain", context);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/integration-tests/ide-launcher/pom.xml
+++ b/integration-tests/ide-launcher/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-ide-launcher</artifactId>
+
+    <name>Quarkus - Integration Tests - IDE Launcher</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/integration-tests/ide-launcher/src/main/java/io/quarkus/it/ide/launcher/HelloResource.java
+++ b/integration-tests/ide-launcher/src/main/java/io/quarkus/it/ide/launcher/HelloResource.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.ide.launcher;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/ide-launcher/src/main/java/io/quarkus/it/ide/launcher/Main.java
+++ b/integration-tests/ide-launcher/src/main/java/io/quarkus/it/ide/launcher/Main.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.ide.launcher;
+
+import io.quarkus.runtime.Quarkus;
+
+public class Main {
+
+    public static void main(String... args) {
+        Quarkus.run(args);
+    }
+
+}

--- a/integration-tests/ide-launcher/src/test/java/io/quarkus/it/launcher/IDELauncherTestCase.java
+++ b/integration-tests/ide-launcher/src/test/java/io/quarkus/it/launcher/IDELauncherTestCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.launcher;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.dev.appstate.ApplicationStateNotification;
+import io.quarkus.it.ide.launcher.Main;
+import io.quarkus.runtime.Quarkus;
+import io.restassured.RestAssured;
+
+/**
+ * Tests doing an IDE style launch.
+ *
+ * Note that this is not a @QuarkusTest, the launch is done via the IDE launcher components.
+ */
+public class IDELauncherTestCase {
+
+    @Test
+    public void testIdeLauncher() {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Main.main();
+            }
+        }).start();
+        try {
+            ApplicationStateNotification.waitForApplicationStart();
+            RestAssured.get("/hello")
+                    .then().body(Matchers.equalTo("hello"));
+        } finally {
+            Quarkus.blockingExit();
+        }
+
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -121,6 +121,7 @@
         <module>picocli-native</module>
         <module>webjars-locator</module>
         <module>devmode</module>
+        <module>ide-launcher</module>
 
         <!-- gRPC tests -->
         <module>grpc-plain-text</module>


### PR DESCRIPTION
All dependencies are not unpacked, but with a modified file
name, and a custom ClassLoader is used to load them.

As these are no longer stored as .class files IDE's and
other tools will not see them as being part of the class
path.

Fixes #9974