### PR TITLE
Usability improvements around Panache annotation processors

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -950,3 +950,29 @@ by the presence of the marker file `META-INF/panache-archive.marker`. Panache in
 annotation processor that will automatically create this file in archives that depend on
 Panache (even indirectly). If you have disabled annotation processors you may need to create
 this file manually in some cases.
+
+WARNING: If you include the jpa-modelgen annotation processor this will exclude the Panache
+annotation processor by default. If you do this you should either create the marker file
+yourself, or add the `quarkus-panache-common` as well, as shown below:
+
+[source,xml]
+----
+<plugin>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <version>${compiler-plugin.version}</version>
+    <configuration>
+      <annotationProcessorPaths>
+        <annotationProcessorPath>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-jpamodelgen</artifactId>
+          <version>${hibernate.version}</version>
+        </annotationProcessorPath>
+        <annotationProcessorPath>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-panache-common</artifactId>
+          <version>${quarkus.platform.version}</version>
+        </annotationProcessorPath>
+      </annotationProcessorPaths>
+    </configuration>
+</plugin>
+----

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityEnhancer.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheEntityEnhancer.java
@@ -91,10 +91,19 @@ public abstract class PanacheEntityEnhancer<MetamodelType extends MetamodelInfo<
 
         @Override
         public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
-            FieldVisitor superVisitor = super.visitField(access, name, descriptor, signature, value);
             EntityField ef = fields.get(name);
             if (ef == null) {
-                return superVisitor;
+                return super.visitField(access, name, descriptor, signature, value);
+            }
+            //we make the fields protected
+            //so any errors are visible immediately, rather than data just being lost
+
+            FieldVisitor superVisitor;
+            if (name.equals("id")) {
+                superVisitor = super.visitField(access, name, descriptor, signature, value);
+            } else {
+                superVisitor = super.visitField((access | Modifier.PROTECTED) & ~(Modifier.PRIVATE | Modifier.PUBLIC),
+                        name, descriptor, signature, value);
             }
             ef.signature = signature;
             // if we have a mapped field, let's add some annotations

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1214,7 +1214,7 @@ public class TestEndpoint {
     }
 
     private void ensureFieldSanitized(String fieldName) throws Exception {
-        Field f = JAXBEntity.class.getField(fieldName);
+        Field f = JAXBEntity.class.getDeclaredField(fieldName);
         assertNull(f.getAnnotation(XmlAttribute.class));
         assertNotNull(f.getAnnotation(XmlTransient.class));
     }


### PR DESCRIPTION
- Document that the jpa-modelgen processor may cause issues
- Always transform the application
- Make fields protected to avoid silent failures if there is a problem

Fixes #9961