### PR TITLE
Bump RESTEasy version to 4.5.5.Final, added test for #8795

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <aesh.version>2.5</aesh.version>
         <jandex.version>2.1.3.Final</jandex.version>
-        <resteasy.version>4.5.3.Final</resteasy.version>
+        <resteasy.version>4.5.5.Final</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>
         <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>
         <opentracing-web-servlet-filter.version>0.2.3</opentracing-web-servlet-filter.version>

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ClientResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ClientResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.rest;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
@@ -19,6 +20,7 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.quarkus.arc.Arc;
+import io.smallrye.mutiny.Multi;
 
 @Path("/client")
 public class ClientResource {
@@ -178,5 +180,31 @@ public class ClientResource {
             e.printStackTrace();
             return -1;
         }
+    }
+
+    @Inject
+    @RestClient
+    GouvFrGeoApiClient api;
+
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @GET
+    @Path("publisher-client")
+    public Multi<String> publisherClient() {
+        Set<Commune> communes = api.getCommunes("75007");
+        return Multi.createFrom().emitter(emitter -> {
+            try {
+                communes.forEach((commune) -> {
+                    commune.codesPostaux.forEach((postalCode) -> {
+                        int level = org.jboss.resteasy.core.ResteasyContext.getContextDataLevelCount();
+                        api.getCommunes(postalCode).forEach(c -> emitter.emit(c.code + "-" + level));
+                    });
+                });
+            } catch (Exception e) {
+                e.printStackTrace();
+                emitter.fail(e);
+            } finally {
+                emitter.complete();
+            }
+        });
     }
 }

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/Commune.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/Commune.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.rest;
+
+import java.util.Set;
+
+public class Commune {
+    public String code;
+    public String nom;
+    public Set<String> codesPostaux;
+    public String codeDepartement;
+    public String codeRegion;
+    // departement
+    // region
+    public Integer population;
+    public Float surface;
+
+    public Commune() {
+    }
+
+    public Commune(String nom, String code, String codeDepartement, String codeRegion, Set<String> codePostaux,
+            int population) {
+        this.nom = nom;
+        this.code = code;
+        this.codeDepartement = codeDepartement;
+        this.codeRegion = codeRegion;
+        this.codesPostaux = codePostaux;
+        this.population = population;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/GouvFrGeoApiClient.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/GouvFrGeoApiClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.rest;
+
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@Path("gouv-geo-api")
+public interface GouvFrGeoApiClient {
+
+    @GET
+    @Path("/communes")
+    public Set<Commune> getCommunes(
+            @QueryParam("codePostal") String postalCode);
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/GouvFrGeoApiClientImpl.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/GouvFrGeoApiClientImpl.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.rest;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("gouv-geo-api")
+public class GouvFrGeoApiClientImpl {
+
+    @GET
+    @Path("/communes")
+    public Set<Commune> getCommunes(
+            @QueryParam("codePostal") String postalCode) {
+        Set<Commune> ret = new HashSet<>();
+        Set<String> cp = new HashSet<>(Arrays.asList("75001", "75002", "75003", "75004", "75005", "75006", "75007", "75008",
+                "75009", "75010", "75011", "75012", "75013", "75014", "75015", "75016", "75017", "75018", "75019", "75020"));
+        ret.add(new Commune("Paris", "75056", "75", "11", cp, 2190327));
+        return ret;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ServerSentEventResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ServerSentEventResource.java
@@ -62,7 +62,8 @@ public class ServerSentEventResource {
 
     @GET
     @Path("/stream-xml")
-    @Produces("text/event-stream;element-type=text/xml")
+    @SseElementType(MediaType.TEXT_XML)
+    @Produces(MediaType.SERVER_SENT_EVENTS)
     public void sendXmlData(@Context SseEventSink sink) {
         // send a stream of few events
         try {

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceForConstructorProperties.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/TestResourceForConstructorProperties.java
@@ -13,6 +13,8 @@ import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 
+import org.jboss.resteasy.annotations.SseElementType;
+
 @Path("/constructorproperties")
 public class TestResourceForConstructorProperties {
 
@@ -44,7 +46,8 @@ public class TestResourceForConstructorProperties {
 
     @GET
     @Path("/sse")
-    @Produces(MediaType.SERVER_SENT_EVENTS + ";element-type=" + MediaType.APPLICATION_JSON)
+    @SseElementType(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.SERVER_SENT_EVENTS)
     public void serverSentEvents(@Context SseEventSink sink) {
         VanillaJavaImmutableData data = new VanillaJavaImmutableData("sse", "ssevalue");
         try {

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+io.quarkus.it.rest.GouvFrGeoApiClient/mp-rest/url=${test.url}
 io.quarkus.it.rest.RestInterface/mp-rest/url=${test.url}
 io.quarkus.it.rest.RestInterface/mp-rest/scope=javax.inject.Singleton
 io.quarkus.it.rest.RestClientInterface/mp-rest/url=${test.url}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
@@ -2,7 +2,8 @@ package io.quarkus.it.main;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Map;
@@ -136,5 +137,30 @@ public class RestClientTestCase {
         RestAssured.when().get("/ssl").then()
                 .statusCode(500)
                 .body(containsString("SSL support"), containsString("disabled"));
+    }
+
+    @Test
+    public void testIssue8795() {
+        RestAssured.when().get("/client/publisher-client").then()
+                .body(is("\n\ndata: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"
+                        + "data: 75056-2\n\n"));
     }
 }


### PR DESCRIPTION
Had to bump to 4.5.5.Final because 4.5.4.Final did not have the fixes that were supposed to be in there, due to some release mishap.