### PR TITLE
Make YAML configuration work for Bootstrap Config

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalBootstrapConfigSourceProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AdditionalBootstrapConfigSourceProviderBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.deployment.builditem;
+
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Build item to use when an additional {@link ConfigSourceProvider} needs to be
+ * registered to the Bootstrap Config setup.
+ * This is needed because during Bootstrap Config setup, we don't auto-discover providers
+ * but we do want for example the YAML provider to be enabled.
+ */
+public final class AdditionalBootstrapConfigSourceProviderBuildItem extends MultiBuildItem {
+
+    private final String providerClassName;
+
+    public AdditionalBootstrapConfigSourceProviderBuildItem(String providerClassName) {
+        this.providerClassName = providerClassName;
+    }
+
+    public String getProviderClassName() {
+        return providerClassName;
+    }
+}

--- a/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
+++ b/extensions/config-yaml/deployment/src/main/java/io/quarkus/config/yaml/deployment/ConfigYamlProcessor.java
@@ -4,6 +4,7 @@ import io.quarkus.config.yaml.runtime.ApplicationYamlProvider;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalBootstrapConfigSourceProviderBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 
@@ -12,6 +13,11 @@ public final class ConfigYamlProcessor {
     @BuildStep
     public FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.CONFIG_YAML);
+    }
+
+    @BuildStep
+    public AdditionalBootstrapConfigSourceProviderBuildItem bootstrap() {
+        return new AdditionalBootstrapConfigSourceProviderBuildItem(ApplicationYamlProvider.class.getName());
     }
 
     @BuildStep

--- a/integration-tests/spring-cloud-config-client/pom.xml
+++ b/integration-tests/spring-cloud-config-client/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/spring-cloud-config-client/src/main/resources/application.properties
+++ b/integration-tests/spring-cloud-config-client/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-quarkus.application.name=a-bootiful-client
-%prod.quarkus.spring-cloud-config.url=http://localhost:8089
-%prod.quarkus.spring-cloud-config.username=user
-%prod.quarkus.spring-cloud-config.password=pass
-%prod.quarkus.spring-cloud-config.enabled=true
-
-greeting.message=hello from application.properties

--- a/integration-tests/spring-cloud-config-client/src/main/resources/application.yaml
+++ b/integration-tests/spring-cloud-config-client/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+'%prod':
+   quarkus:
+     spring-cloud-config:
+       url: http://localhost:8089
+       username: user
+       password: pass
+       enabled: true     
+quarkus:
+  application:
+    name: a-bootiful-client
+
+greeting:
+    message: hello from application.properties


### PR DESCRIPTION
Fixes: #9973

The idea here to allow an extension to register which `ConfigSourceProvider` can work in Bootstrap Config, because we (correctly) don't do auto-discovery when building the Bootstrap Config