### PR TITLE
Returns long instead of int

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -435,7 +435,7 @@ List<Person> page7 = livingPersons.page(Page.of(7, 25)).list();
 int numberOfPages = livingPersons.pageCount();
 
 // get the total number of entities returned by this query without paging
-int count = livingPersons.count();
+long count = livingPersons.count();
 
 // and you can chain methods of course
 return Person.find("status", Status.Alive)


### PR DESCRIPTION
`livingPersons.pageCount()` returns an `int`, but `livingPersons.count()` returns a `long`