### PR TITLE
Add missing dependency

### DIFF
--- a/extensions/mutiny/deployment/pom.xml
+++ b/extensions/mutiny/deployment/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
As this dependended on the runtime part of the extension the
functionality would be extivated, however the deployment
time part would not run, so it would not show up in the
feature list.