### PR TITLE
Exposing the reactive MongoDatabase

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/impl/ReactiveMongoDatabaseImpl.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/impl/ReactiveMongoDatabaseImpl.java
@@ -333,4 +333,9 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
             AggregateOptions options) {
         return Wrappers.toMulti(apply(options, database.aggregate(clientSession, pipeline, clazz)));
     }
+
+    @Override
+    public MongoDatabase unwrap() {
+        return database;
+    }
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/reactive/ReactiveMongoDatabase.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/reactive/ReactiveMongoDatabase.java
@@ -1,5 +1,6 @@
 package io.quarkus.mongodb.reactive;
 
+import com.mongodb.reactivestreams.client.MongoDatabase;
 import java.util.List;
 
 import org.bson.Document;
@@ -564,4 +565,10 @@ public interface ReactiveMongoDatabase {
      */
     <T> Multi<T> aggregate(ClientSession clientSession, List<? extends Bson> pipeline, Class<T> clazz,
             AggregateOptions options);
+
+
+    /**
+     * @return the underlying database.
+     */
+    MongoDatabase unwrap();
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/reactive/ReactiveMongoDatabase.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/reactive/ReactiveMongoDatabase.java
@@ -1,6 +1,5 @@
 package io.quarkus.mongodb.reactive;
 
-import com.mongodb.reactivestreams.client.MongoDatabase;
 import java.util.List;
 
 import org.bson.Document;
@@ -11,6 +10,7 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.reactivestreams.client.ClientSession;
+import com.mongodb.reactivestreams.client.MongoDatabase;
 
 import io.quarkus.mongodb.AggregateOptions;
 import io.quarkus.mongodb.ChangeStreamOptions;
@@ -565,7 +565,6 @@ public interface ReactiveMongoDatabase {
      */
     <T> Multi<T> aggregate(ClientSession clientSession, List<? extends Bson> pipeline, Class<T> clazz,
             AggregateOptions options);
-
 
     /**
      * @return the underlying database.


### PR DESCRIPTION
Exposing the reactive MongoDatabase provides the ability to use MongoDB features not yet wrapped in quarkus like the GridFS feature.

Added the unwrap method.