### PR TITLE
Optimize ArcContextProvider

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc;
 
-import io.quarkus.arc.InjectableContext.ContextState;
 import java.util.Map;
 import javax.enterprise.context.NormalScope;
 import javax.enterprise.context.spi.AlterableContext;


### PR DESCRIPTION
- reuse snapshot instances if possible

This should save quite a few allocations per each capture.