### PR TITLE
Add debug symbols support #9792

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -74,12 +74,6 @@ public class NativeConfig {
     public Optional<String> nativeImageXmx;
 
     /**
-     * If debug symbols should be included. Only applicable to GraalVM EE.
-     */
-    @ConfigItem
-    public boolean debugSymbols;
-
-    /**
      * If the native image build should wait for a debugger to be attached before running. This is an advanced option
      * and is generally only intended for those familiar with GraalVM internals
      */

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -74,7 +74,7 @@ public class NativeConfig {
     public Optional<String> nativeImageXmx;
 
     /**
-     * If debug symbols should be included
+     * If debug symbols should be included. Only applicable to GraalVM EE.
      */
     @ConfigItem
     public boolean debugSymbols;
@@ -275,5 +275,21 @@ public class NativeConfig {
         @ConfigItem
         public Optional<List<String>> includes;
 
+    }
+
+    /**
+     * Debugging options.
+     */
+    @ConfigItem
+    public Debug debug;
+
+    @ConfigGroup
+    public static class Debug {
+        /**
+         * If debug is enabled and debug symbols are generated.
+         * The symbols will be generated in a separate .debug file.
+         */
+        @ConfigItem
+        public boolean enabled;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -362,8 +362,12 @@ public class NativeImageBuildStep {
             Files.delete(generatedImage);
             System.setProperty("native.image.path", finalPath.toAbsolutePath().toString());
 
-            if (nativeConfig.debug.enabled && objcopyExists(env)) {
-                splitDebugSymbols(finalPath);
+            if (objcopyExists(env)) {
+                if (nativeConfig.debug.enabled) {
+                    splitDebugSymbols(finalPath);
+                }
+                // Strip debug symbols regardless, because the underlying JDK might contain them
+                objcopy("--strip-debug", finalPath.toString());
             }
 
             return new NativeImageBuildItem(finalPath);
@@ -558,7 +562,6 @@ public class NativeImageBuildStep {
     private void splitDebugSymbols(Path executable) {
         Path symbols = Paths.get(String.format("%s.debug", executable.toString()));
         objcopy("--only-keep-debug", executable.toString(), symbols.toString());
-        objcopy("--strip-debug", executable.toString());
         objcopy(String.format("--add-gnu-debuglink=%s", symbols.toString()), executable.toString());
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -258,9 +258,6 @@ public class NativeImageBuildStep {
             if (nativeConfig.reportExceptionStackTraces) {
                 command.add("-H:+ReportExceptionStackTraces");
             }
-            if (nativeConfig.debugSymbols) {
-                command.add("-g");
-            }
             if (nativeConfig.debug.enabled) {
                 command.add("-H:GenerateDebugInfo=1");
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -261,6 +261,9 @@ public class NativeImageBuildStep {
             if (nativeConfig.debugSymbols) {
                 command.add("-g");
             }
+            if (nativeConfig.debug.enabled) {
+                command.add("-H:GenerateDebugInfo=1");
+            }
             if (nativeConfig.debugBuildProcess) {
                 command.add("-J-Xrunjdwp:transport=dt_socket,address=" + DEBUG_BUILD_PROCESS_PORT + ",server=y,suspend=y");
             }
@@ -358,6 +361,10 @@ public class NativeImageBuildStep {
             IoUtils.copy(generatedImage, finalPath);
             Files.delete(generatedImage);
             System.setProperty("native.image.path", finalPath.toAbsolutePath().toString());
+
+            if (nativeConfig.debug.enabled && objcopyExists(env)) {
+                splitDebugSymbols(finalPath);
+            }
 
             return new NativeImageBuildItem(finalPath);
         } catch (Exception e) {
@@ -528,4 +535,48 @@ public class NativeImageBuildStep {
         return "";
     }
 
+    private boolean objcopyExists(Map<String, String> env) {
+        // System path
+        String systemPath = env.get(PATH);
+        if (systemPath != null) {
+            String[] pathDirs = systemPath.split(File.pathSeparator);
+            for (String pathDir : pathDirs) {
+                File dir = new File(pathDir);
+                if (dir.isDirectory()) {
+                    File file = new File(dir, "objcopy");
+                    if (file.exists()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        log.info("Cannot find executable (objcopy) to separate symbols from executable.");
+        return false;
+    }
+
+    private void splitDebugSymbols(Path executable) {
+        Path symbols = Paths.get(String.format("%s.debug", executable.toString()));
+        objcopy("--only-keep-debug", executable.toString(), symbols.toString());
+        objcopy("--strip-debug", executable.toString());
+        objcopy(String.format("--add-gnu-debuglink=%s", symbols.toString()), executable.toString());
+    }
+
+    private static void objcopy(String... args) {
+        final List<String> command = new ArrayList<>(args.length + 1);
+        command.add("objcopy");
+        command.addAll(Arrays.asList(args));
+        log.infof("Execute %s", command);
+        Process process = null;
+        try {
+            process = new ProcessBuilder(command).start();
+            process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Unable to invoke objcopy", e);
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #9792. 

This PR adds:
* A new debug symbol enable option called `quarkus.native.debug.enabled`.
* A new option has been added instead of breaking existing users that might rely on `quarkus.native.debugSymbols` flag. This flag adds `-g` to the `native-image` invocation which is a GraalVM EE only flag. Should it eventually deprecated? 
* After creating the native image, if `objcopy` is found, it uses it to split the debug symbols from the binary executable. The debug symbols are put in a file called `<executable>.debug` at the same level as the binary.
* This new option is disabled by default. See [quarkus-dev](https://groups.google.com/forum/#!topic/quarkus-dev/VOSQ6zhy_vI) discussion for details.

Q. What can I debug with this?
* User code in Quarkus project.
* JDK code.
* Some of the `com.oracle.svm` code.

Q. What can't I debug?
* Library dependencies. Further work on Quarkus build code needs to be done to enable source jars to be found. ~I'll create a follow up issue for this~. See #10094.
* `org.graalvm` code. Some sources are missing from latest GraalVM CE downloads. @adinn already spotted this and reported it in https://github.com/oracle/graal/issues/2551.

Q. What I do need to do native debugging?
* `gdb` version 8.x or 9.x. I tried with 7.6 but gdb itself gave me a segmentation fault (working with @adinn to figure out what's wrong there).
* (optional) emacs so that you can have nice integration between gdb and source navigation.

Q. Can I give this a try? 
Sure! 

I've been using [this sample project called `debug-info`](https://github.com/galderz/debug-info) to test things out. This is how it works:

1. Build this Quarkus branch locally.
2. Go into debug-info project and call (assumes you're using GraalVM CE 20.1.0 as `JAVA_HOME`):
```
./mvnw clean package -DskipTests \
	-Pnative \
	-Dquarkus.platform.version=999-SNAPSHOT \
	-Dquarkus-plugin.version=999-SNAPSHOT \
	-Dquarkus.platform.artifact-id=quarkus-bom \
	-Dquarkus.native.debug.enabled=true
```
3. Fire up `emacs` (or any other tool that has gdb integration) from the root of the project.
4. Call `M-x gud-gdb`
5. Set directories for source lookup: `set directories ../src/main/java:debug-info-1.0.0-SNAPSHOT-native-image-source-jar/sources/graal:debug-info-1.0.0-SNAPSHOT-native-image-source-jar/sources/jdk`
6. Invoke `gdb`: `gdb --fullname target/debug-info-1.0.0-SNAPSHOT-runner`
7. Verify that debug symbols are present, e.g. `info func greeting`
8. Put a breakpoint in the code, e.g. `break debug.info.GreetingService::greeting`
9. Make `gdb` execute the program, e.g. `run`
10. From a separate shell exercise the app, e.g. `curl localhost:8080/hello/greeting/quarkus`. The debugger should stop in the breakpoint.
11. Type `s` or `n` to jump around the code.