### PR TITLE
Remove Sundrio dependency from bom

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -169,7 +169,6 @@
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
         <kubernetes-client.version>4.10.2</kubernetes-client.version>
-        <sundr.version>0.19.1</sundr.version> <!-- this is to avoid annoying pop-up in eclipse about failure to init Velocity logging -->
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP1</quarkus-spring-data-api.version>
@@ -1667,11 +1666,6 @@
                         <artifactId>javaee-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.sundr</groupId>
-                <artifactId>builder-annotations</artifactId>
-                <version>${sundr.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.activation</groupId>

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -42,6 +42,10 @@
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>io.sundr</groupId>
+                  <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Sundrio is used only as compile time tooling for generating stuff, is not needed on runtime.

Quarkus don't use Sundrio directly on its code, this dependency is removed since its only used by kubernetes-client on compile time.