### PR TITLE
Changed the maximum size of request body allowed in HTTP request

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -208,7 +208,7 @@ The following properties are supported.
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.http.limits.max-body-size| `unlimited` |The maximum size of request body.
+|quarkus.http.limits.max-body-size| `2048K` |The maximum size of request body.
 |quarkus.http.limits.max-header-size|`2OK`|The maximum length of all headers.
 |===
 

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -208,7 +208,7 @@ The following properties are supported.
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|quarkus.http.limits.max-body-size| `2048K` |The maximum size of request body.
+|quarkus.http.limits.max-body-size| `10240K` |The maximum size of request body.
 |quarkus.http.limits.max-header-size|`2OK`|The maximum length of all headers.
 |===
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -16,9 +16,9 @@ public class ServerLimitsConfig {
 
     /**
      * The maximum size of a request body.
-     * Default: 2048K.
+     * Default: 10240K.
      */
-    @ConfigItem(defaultValue = "2048K")
+    @ConfigItem(defaultValue = "10240K")
     public Optional<MemorySize> maxBodySize;
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -16,9 +16,9 @@ public class ServerLimitsConfig {
 
     /**
      * The maximum size of a request body.
-     * Default: no limit.
+     * Default: 2048K.
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "2048K")
     public Optional<MemorySize> maxBodySize;
 
     /**


### PR DESCRIPTION
I have made changes to the maximum size allowed for a HTTP request body by default from unlimited to 2 MB. This is to resolve the #10079 issue