### PR TITLE
Disable FormAuthCookiesTestCase#testCredentialCookieRotation

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthCookiesTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthCookiesTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -151,6 +152,7 @@ public class FormAuthCookiesTestCase {
     URL url;
 
     @Test
+    @Disabled("The logic in this test case relies too heavily on the current system time and can result in spurious failures on slow systems. See https://github.com/quarkusio/quarkus/issues/10106")
     public void testCredentialCookieRotation() throws IOException, InterruptedException {
 
         final CookieStore cookieStore = new BasicCookieStore();


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/10106

I attempted to fix the test case itself but after an initial attempt I realized it's more than a quick 5 minute job and will require a bit more work. Since I'm short of time right now and since this is affecting CI runs, I decided to just go ahead and disable it till someone can fix the test case.
