### PR TITLE
Gradle support - Improve logging/visibility of native image generation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/ProcessInheritIODisabled.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/ProcessInheritIODisabled.java
@@ -1,0 +1,39 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildStepBuilder;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A build item, which indicates that the {@link ProcessBuilder#inheritIO()} will not work for processes
+ * launched by build steps and instead the build step will have to explicitly stream the newly launched
+ * process' STDOUT/STDERR, if the data generated on the STDOUT/STDERR of the launched process needs to be
+ * made available
+ *
+ * @see io.quarkus.deployment.util.ProcessUtil
+ */
+public final class ProcessInheritIODisabled extends SimpleBuildItem {
+
+    /**
+     * Generates a {@link List<Consumer<BuildChainBuilder>> build chain builder} which creates a build step
+     * producing the {@link ProcessInheritIODisabled} build item
+     */
+    public static final class Factory implements Function<Map<String, Object>, List<Consumer<BuildChainBuilder>>> {
+
+        @Override
+        public List<Consumer<BuildChainBuilder>> apply(final Map<String, Object> props) {
+            return Collections.singletonList((builder) -> {
+                final BuildStepBuilder stepBuilder = builder.addBuildStep((ctx) -> {
+                    ctx.produce(new ProcessInheritIODisabled());
+                });
+                stepBuilder.produces(ProcessInheritIODisabled.class).build();
+            });
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -33,8 +33,10 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.deployment.util.GlobUtil;
+import io.quarkus.deployment.util.ProcessUtil;
 
 public class NativeImageBuildStep {
 
@@ -75,7 +77,8 @@ public class NativeImageBuildStep {
     public NativeImageBuildItem build(NativeConfig nativeConfig, NativeImageSourceJarBuildItem nativeImageSourceJarBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
             PackageConfig packageConfig,
-            List<NativeImageSystemPropertyBuildItem> nativeImageProperties) {
+            List<NativeImageSystemPropertyBuildItem> nativeImageProperties,
+            final Optional<ProcessInheritIODisabled> processInheritIODisabled) {
         Path runnerJar = nativeImageSourceJarBuildItem.getPath();
         log.info("Building native image from " + runnerJar);
         Path outputDir = nativeImageSourceJarBuildItem.getPath().getParent();
@@ -126,9 +129,9 @@ public class NativeImageBuildStep {
                 log.info("Pulling image " + nativeConfig.builderImage);
                 Process pullProcess = null;
                 try {
-                    pullProcess = new ProcessBuilder(Arrays.asList(containerRuntime, "pull", nativeConfig.builderImage))
-                            .inheritIO()
-                            .start();
+                    final ProcessBuilder pb = new ProcessBuilder(
+                            Arrays.asList(containerRuntime, "pull", nativeConfig.builderImage));
+                    pullProcess = ProcessUtil.launchProcess(pb, processInheritIODisabled);
                     pullProcess.waitFor();
                 } catch (IOException | InterruptedException e) {
                     throw new RuntimeException("Failed to pull builder image " + nativeConfig.builderImage, e);
@@ -193,12 +196,9 @@ public class NativeImageBuildStep {
             if (nativeConfig.cleanupServer) {
                 List<String> cleanup = new ArrayList<>(nativeImage);
                 cleanup.add("--server-shutdown");
-                ProcessBuilder pb = new ProcessBuilder(cleanup.toArray(new String[0]));
+                final ProcessBuilder pb = new ProcessBuilder(cleanup.toArray(new String[0]));
                 pb.directory(outputDir.toFile());
-                pb.redirectInput(ProcessBuilder.Redirect.INHERIT);
-                pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-                pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-                Process process = pb.start();
+                final Process process = ProcessUtil.launchProcess(pb, processInheritIODisabled);
                 process.waitFor();
             }
             Boolean enableSslNative = false;
@@ -335,11 +335,8 @@ public class NativeImageBuildStep {
 
             log.info(String.join(" ", command));
             CountDownLatch errorReportLatch = new CountDownLatch(1);
-
-            Process process = new ProcessBuilder(command)
-                    .directory(outputDir.toFile())
-                    .inheritIO()
-                    .start();
+            final ProcessBuilder processBuilder = new ProcessBuilder(command).directory(outputDir.toFile());
+            final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled);
             ExecutorService executor = Executors.newSingleThreadExecutor();
             executor.submit(new ErrorReplacingProcessReader(process.getErrorStream(), outputDir.resolve("reports").toFile(),
                     errorReportLatch));

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ProcessUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ProcessUtil.java
@@ -1,0 +1,138 @@
+package io.quarkus.deployment.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
+
+/**
+ * Utility for {@link Process} related operations
+ */
+public class ProcessUtil {
+
+    private static final Logger logger = Logger.getLogger(ProcessUtil.class);
+
+    /**
+     * Launches and returns a {@link Process} built from the {@link ProcessBuilder builder}.
+     * Before launching the process, this method checks if {@link ProcessInheritIODisabled inherit IO is disabled}
+     * and if so, streams both the {@code STDOUT} and {@code STDERR} of the launched process using
+     * {@link #streamToSysOutSysErr(Process)}. Else, it launches the process with {@link ProcessBuilder#inheritIO()}
+     *
+     * @param builder The process builder
+     * @param processInheritIODisabled Whether or not {@link java.lang.ProcessBuilder.Redirect#INHERIT} can be used for
+     *        launching the process
+     * @return Returns the newly launched process
+     * @throws IOException
+     */
+    public static Process launchProcess(final ProcessBuilder builder,
+            final Optional<ProcessInheritIODisabled> processInheritIODisabled) throws IOException {
+        if (!processInheritIODisabled.isPresent()) {
+            return builder.inheritIO().start();
+        }
+        final Process process = builder.redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start();
+        // stream both stdout and stderr of the process
+        ProcessUtil.streamToSysOutSysErr(process);
+        return process;
+    }
+
+    /**
+     * Launches and returns a {@link Process} built from the {@link ProcessBuilder builder}.
+     * Before launching the process, this method checks if {@link ProcessInheritIODisabled inherit IO is disabled}
+     * and if so, streams (only) the {@code STDOUT} of the launched process using {@link #streamOutputToSysOut(Process)}
+     * (Process)}. Else, it launches the process with {@link ProcessBuilder#inheritIO()}
+     *
+     * @param builder The process builder
+     * @param processInheritIODisabled Whether or not {@link java.lang.ProcessBuilder.Redirect#INHERIT} can be used for
+     *        launching the process
+     * @return Returns the newly launched process
+     * @throws IOException
+     */
+    public static Process launchProcessStreamStdOut(final ProcessBuilder builder,
+            final Optional<ProcessInheritIODisabled> processInheritIODisabled) throws IOException {
+        if (!processInheritIODisabled.isPresent()) {
+            return builder.inheritIO().start();
+        }
+        final Process process = builder.redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start();
+        // stream only stdout of the process
+        ProcessUtil.streamOutputToSysOut(process);
+        return process;
+    }
+
+    /**
+     * This is a convenience method which internally calls both the {@link #streamOutputToSysOut(Process)}
+     * and {@link #streamErrorToSysErr(Process)} methods
+     *
+     * @param process The process whose STDOUT and STDERR needs to be streamed.
+     */
+    public static void streamToSysOutSysErr(final Process process) {
+        streamOutputToSysOut(process);
+        streamErrorToSysErr(process);
+    }
+
+    /**
+     * Streams the {@link Process process'} {@code STDOUT} to the current process'
+     * {@code System.out stream}. This creates and starts a thread to stream the contents.
+     * The {@link Process} is expected to have been started in {@link java.lang.ProcessBuilder.Redirect#PIPE}
+     * mode
+     *
+     * @param process The process whose STDOUT needs to be streamed.
+     */
+    public static void streamOutputToSysOut(final Process process) {
+        final InputStream processStdOut = process.getInputStream();
+        final Thread t = new Thread(new Streamer(processStdOut, System.out));
+        t.setName("Process stdout streamer");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    /**
+     * Streams the {@link Process process'} {@code STDERR} to the current process'
+     * {@code System.err stream}. This creates and starts a thread to stream the contents.
+     * The {@link Process} is expected to have been started in {@link java.lang.ProcessBuilder.Redirect#PIPE}
+     * mode
+     *
+     * @param process The process whose STDERR needs to be streamed.
+     */
+    public static void streamErrorToSysErr(final Process process) {
+        final InputStream processStdErr = process.getErrorStream();
+        final Thread t = new Thread(new Streamer(processStdErr, System.err));
+        t.setName("Process stderr streamer");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private static final class Streamer implements Runnable {
+
+        private final InputStream processStream;
+        private final PrintStream consumer;
+
+        private Streamer(final InputStream processStream, final PrintStream consumer) {
+            this.processStream = processStream;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void run() {
+            try (final BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(processStream, StandardCharsets.UTF_8))) {
+                String line = null;
+                while ((line = reader.readLine()) != null) {
+                    consumer.println(line);
+                }
+            } catch (IOException e) {
+                logger.debug("Ignoring exception that occurred during streaming of " + processStream, e);
+            }
+        }
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/BasicJavaNativeBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/BasicJavaNativeBuildTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.gradle.nativeimage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +22,10 @@ public class BasicJavaNativeBuildTest extends QuarkusNativeGradleTestBase {
         final BuildResult build = runGradleWrapper(projectDir, "clean", "quarkusBuild", "-Dquarkus.package.type=native");
 
         assertThat(build.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        final String buildOutput = build.getOutput();
+        // make sure the output log during the build contains some expected logs from the native-image process
+        assertTrue(buildOutput.contains("(clinit):") && buildOutput.contains("(typeflow):") && buildOutput.contains("[total]:"),
+                "native-image build log is missing certain expected log messages");
         Path nativeImagePath = projectDir.toPath().resolve("build").resolve("foo-1.0.0-SNAPSHOT-runner");
         assertThat(nativeImagePath).exists();
         Process nativeImageProcess = runNativeImage(nativeImagePath.toAbsolutePath().toString());


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/9306 (and there have been similar issues filed in the past).

Right now, when using Gradle as the build tool to build a native image of a Quarkus application, there's hardly anything (literally nothing) that gets logged related to the native image generation. Being a Maven user, I had never tried Gradle before, but while investigating https://github.com/quarkusio/quarkus/issues/9306, I was surprised at the starc contrast between Maven and Gradle output/logs that get generated during this native image generation. As I noted in that issue https://github.com/quarkusio/quarkus/issues/9306#issuecomment-646451515, being used to the "timing" logs that native image process generates, not finding it in Gradle builds was like staring at the build screen for minutes, not knowing what's going on.

The root cause of this issue is that when using Gradle, if a Gradle build task (like the `QuarkusBuild`) spawns a `Process` (like the `native-image` process), then the process' `STDOUT`/`STDERR` content is lost, unless we explicitly stream it. Longer version of this issue is explained here https://github.com/gradle/gradle/issues/13522. I was initially planning to propose a fix in gradle itself but having seen the inputs on that issue, I think they have their own valid limitations around this and a fix there most likely won't be feasible or easy to achieve.

So I went ahead and introduced this workaround where the build step(s) will now have a hint via the `ProcessInheritIODisabled` build item, that they can use to decide if they want to stream the `STDOUT`/`STDERR` of processes they might launch. Not all build steps that launch a process have to stream the content (some can just continue to ignore the output), but for a build step like native image generation, having the output/error made available is extremely useful.

Here's what the Gradle build console looks like while building a native image for Quarkus, in the latest released versions and master:
```
> Task :quarkusBuild
building quarkus runner
```
(yes, literally nothing)
and here's how it will look like with this patch:

```
> Task :quarkusBuild
building quarkus runner

-H:IncludeAllTimeZones and -H:IncludeTimeZones are now deprecated. Native-image includes all timezonesby default.
[myapp-1.0.0-SNAPSHOT-runner:15146]    classlist:   4,076.37 ms,  0.96 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]        (cap):   2,416.19 ms,  0.94 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]        setup:   4,537.50 ms,  0.94 GB
11:02:05,349 INFO  [org.jbo.threads] JBoss Threads version 3.1.1.Final
[myapp-1.0.0-SNAPSHOT-runner:15146]     (clinit):     751.27 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]   (typeflow):  15,230.74 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]    (objects):  16,570.97 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]   (features):     640.82 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]     analysis:  34,543.19 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]     universe:   1,159.91 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]      (parse):   3,617.39 ms,  3.85 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]     (inline):   6,214.15 ms,  5.20 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]    (compile):  25,051.30 ms,  5.19 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]      compile:  37,606.24 ms,  5.19 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]        image:   6,257.57 ms,  5.16 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]        write:   2,376.77 ms,  5.16 GB
[myapp-1.0.0-SNAPSHOT-runner:15146]      [total]:  90,954.49 ms,  5.16 GB
```
In this patch, I intentionally decided to keep out any build tool specific details (like Gradle specific APIs from the build steps and instead keep the hooks to support this workaround minimal and just depending on standard Java API).

P.S: This is just one step towards making the Gradle build output, for Quarkus applicaitons, much more visible and informative (similar to Maven). There's still scope to improve the situation (outside of native image generation task) that I'm reviewing and working on. I plan to issue a separate PR for that once I have something useful.