### PR TITLE
Enable forwarded for host header configuration

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedForHeaderTest.java
@@ -18,7 +18,8 @@ public class ForwardedForHeaderTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(ForwardedHandlerInitializer.class)
-                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n"),
+                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-host=true\n"),
                             "application.properties"));
 
     @Test

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -35,9 +35,9 @@ class ForwardedServerRequestWrapper implements HttpServerRequest {
     private String uri;
     private String absoluteURI;
 
-    ForwardedServerRequestWrapper(HttpServerRequest request, boolean allowForwarded) {
+    ForwardedServerRequestWrapper(HttpServerRequest request, ForwardingProxyOptions forwardingProxyOptions) {
         delegate = request;
-        forwardedParser = new ForwardedParser(delegate, allowForwarded);
+        forwardedParser = new ForwardedParser(delegate, forwardingProxyOptions);
     }
 
     void changeTo(HttpMethod method, String uri) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -1,0 +1,32 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.netty.util.AsciiString;
+
+public class ForwardingProxyOptions {
+    boolean proxyAddressForwarding;
+    boolean allowForwarded;
+    boolean enableForwardedHost;
+    AsciiString forwardedHostHeader;
+
+    public ForwardingProxyOptions(final boolean proxyAddressForwarding,
+            final boolean allowForwarded,
+            final boolean enableForwardedHost,
+            final AsciiString forwardedHostHeader) {
+        this.proxyAddressForwarding = proxyAddressForwarding;
+        this.allowForwarded = allowForwarded;
+        this.enableForwardedHost = enableForwardedHost;
+        this.forwardedHostHeader = forwardedHostHeader;
+    }
+
+    public static ForwardingProxyOptions from(HttpConfiguration httpConfiguration) {
+        final boolean proxyAddressForwarding = httpConfiguration.proxyAddressForwarding
+                .orElse(httpConfiguration.proxy.proxyAddressForwarding);
+        final boolean allowForwarded = httpConfiguration.allowForwarded
+                .orElse(httpConfiguration.proxy.allowForwarded);
+
+        final boolean enableForwardedHost = httpConfiguration.proxy.enableForwardedHost;
+        final AsciiString forwardedHostHeader = AsciiString.cached(httpConfiguration.proxy.forwardedHostHeader);
+
+        return new ForwardingProxyOptions(proxyAddressForwarding, allowForwarded, enableForwardedHost, forwardedHostHeader);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -59,16 +59,22 @@ public class HttpConfiguration {
     /**
      * If this is true then the address, scheme etc will be set from headers forwarded by the proxy server, such as
      * {@code X-Forwarded-For}. This should only be set if you are behind a proxy that sets these headers.
+     * 
+     * @deprecated use quarkus.http.proxy.proxy-address-forwarding instead.
      */
+    @Deprecated
     @ConfigItem
-    public boolean proxyAddressForwarding;
+    public Optional<Boolean> proxyAddressForwarding;
 
     /**
      * If this is true and proxy address forwarding is enabled then the standard {@code Forwarded} header will be used,
      * rather than the more common but not standard {@code X-Forwarded-For}.
+     * 
+     * @deprecated use quarkus.http.proxy.allow-forwarded instead.
      */
+    @Deprecated
     @ConfigItem
-    public boolean allowForwarded;
+    public Optional<Boolean> allowForwarded;
 
     /**
      * If insecure (i.e. http rather than https) requests are allowed. If this is {@code enabled}
@@ -196,6 +202,8 @@ public class HttpConfiguration {
      */
     @ConfigItem
     public Map<String, SameSiteCookieConfig> sameSiteCookie;
+
+    public ProxyConfig proxy;
 
     public int determinePort(LaunchMode launchMode) {
         return launchMode == LaunchMode.TEST ? testPort : port;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -1,0 +1,37 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Holds configuration related with proxy addressing forward.
+ */
+@ConfigGroup
+public class ProxyConfig {
+    /**
+     * If this is true then the address, scheme etc will be set from headers forwarded by the proxy server, such as
+     * {@code X-Forwarded-For}. This should only be set if you are behind a proxy that sets these headers.
+     */
+    @ConfigItem
+    public boolean proxyAddressForwarding;
+
+    /**
+     * If this is true and proxy address forwarding is enabled then the standard {@code Forwarded} header will be used,
+     * rather than the more common but not standard {@code X-Forwarded-For}.
+     */
+    @ConfigItem
+    public boolean allowForwarded;
+
+    /**
+     * Enable override the received request's host through a forwarded host header.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableForwardedHost;
+
+    /**
+     * Configure the forwarded host header to be used if override enabled.
+     */
+    @ConfigItem(defaultValue = "X-Forwarded-Host")
+    public String forwardedHostHeader;
+
+}


### PR DESCRIPTION
This is the first part of #9622 that enable users to configure the header to be used to override the HTTP request's host. 

