### PR TITLE
Ensure that TestResourceManager is only closed once

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -675,7 +675,7 @@ public class QuarkusTestExtension
         }
     }
 
-    class ExtensionState implements ExtensionContext.Store.CloseableResource {
+    class ExtensionState {
 
         private final Closeable testResourceManager;
         private final Closeable resource;
@@ -685,7 +685,6 @@ public class QuarkusTestExtension
             this.resource = resource;
         }
 
-        @Override
         public void close() throws Throwable {
             try {
                 resource.close();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/XStreamDeepClone.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/XStreamDeepClone.java
@@ -9,13 +9,17 @@ import com.thoughtworks.xstream.XStream;
  */
 public class XStreamDeepClone implements DeepClone {
 
-    private final XStream xStream;
+    private final Supplier<XStream> xStreamSupplier;
 
     public XStreamDeepClone(ClassLoader classLoader) {
-        xStream = new XStream();
-        XStream.setupDefaultSecurity(xStream);
-        xStream.allowTypesByRegExp(new String[] { ".*" });
-        xStream.setClassLoader(classLoader);
+        // avoid doing any work eagerly since the cloner is rarely used
+        xStreamSupplier = () -> {
+            XStream result = new XStream();
+            XStream.setupDefaultSecurity(result);
+            result.allowTypesByRegExp(new String[] { ".*" });
+            result.setClassLoader(classLoader);
+            return result;
+        };
     }
 
     public Object clone(Object objectToClone) {
@@ -40,6 +44,7 @@ public class XStreamDeepClone implements DeepClone {
     }
 
     private Object doClone(Object objectToClone) {
+        XStream xStream = xStreamSupplier.get();
         final String serialized = xStream.toXML(objectToClone);
         final Object result = xStream.fromXML(serialized);
         if (result == null) {


### PR DESCRIPTION
Without this PR the TestResourceManager gets closed 3 times,
which is causing some issues with new surefire versions

Relates to: https://github.com/quarkusio/quarkus/pull/10081