### PR TITLE
Asterisk and other special characters not escaped in Quarkus config docs

### DIFF
--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -44,6 +44,18 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <scope>test</scope>
+            <version>2.3.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/JavaDocParser.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/JavaDocParser.java
@@ -51,8 +51,6 @@ final class JavaDocParser {
     private static final String SUPER_SCRIPT_NODE = "sup";
     private static final String UN_ORDERED_LIST_NODE = "ul";
 
-    private static final String INLINE_JAVA_DOC_TAG_FORMAT = "`%s`";
-
     private static final String BIG_ASCIDOC_STYLE = "[.big]";
     private static final String LINK_ATTRIBUTE_FORMAT = "[%s]";
     private static final String SUB_SCRIPT_ASCIDOC_STYLE = "~";
@@ -153,14 +151,18 @@ final class JavaDocParser {
                     case VALUE:
                     case LITERAL:
                     case SYSTEM_PROPERTY:
-                        sb.append(String.format(INLINE_JAVA_DOC_TAG_FORMAT, content));
+                        sb.append('`');
+                        appendEscapedAsciiDoc(sb, content);
+                        sb.append('`');
                         break;
                     case LINK:
                     case LINKPLAIN:
                         if (content.startsWith(HASH)) {
                             content = hyphenate(content.substring(1));
                         }
-                        sb.append(String.format(INLINE_JAVA_DOC_TAG_FORMAT, content));
+                        sb.append('`');
+                        appendEscapedAsciiDoc(sb, content);
+                        sb.append('`');
                         break;
                     default:
                         sb.append(content);
@@ -257,14 +259,52 @@ final class JavaDocParser {
                     sb.append(NEW_LINE);
                     break;
                 case TEXT_NODE:
-                    final TextNode textNode = (TextNode) childNode;
-                    sb.append(textNode.text());
+                    appendEscapedAsciiDoc(sb, ((TextNode) childNode).text());
                     break;
                 default:
                     appendHtml(sb, childNode);
                     break;
             }
         }
+    }
+
+    static StringBuilder appendEscapedAsciiDoc(StringBuilder sb, String text) {
+        boolean escaping = false;
+        for (int i = 0; i < text.length(); i++) {
+            final char ch = text.charAt(i);
+            switch (ch) {
+                case '#':
+                case '*':
+                case '\\':
+                case '{':
+                case '}':
+                case '[':
+                case ']':
+                    if (!escaping) {
+                        sb.append("++");
+                        escaping = true;
+                    }
+                    sb.append(ch);
+                    break;
+                case '+':
+                    if (escaping) {
+                        sb.append("++");
+                        escaping = false;
+                    }
+                    sb.append("{plus}");
+                    break;
+                default:
+                    if (escaping) {
+                        sb.append("++");
+                        escaping = false;
+                    }
+                    sb.append(ch);
+            }
+        }
+        if (escaping) {
+            sb.append("++");
+        }
+        return sb;
     }
 
     static class SectionHolder {

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
@@ -2,8 +2,13 @@ package io.quarkus.annotation.processor.generate_doc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+
+import org.asciidoctor.Asciidoctor.Factory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class JavaDocConfigDescriptionParserTest {
 
@@ -238,4 +243,41 @@ public class JavaDocConfigDescriptionParserTest {
 
         assertEquals(asciidoc, parser.parseConfigDescription(asciidoc + "\n" + "@asciidoclet"));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "#", "*", "\\", "[", "]" })
+    public void escape(String ch) {
+        final String javaDoc = "Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch + " " + ch + ch
+                + "</code>, {@code JavaDoc tag " + ch + " " + ch + ch + "}";
+        final String expected = "<div class=\"paragraph\">\n<p>Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch
+                + " " + ch + ch + "</code>, <code>JavaDoc tag " + ch + " " + ch + ch + "</code></p>\n</div>";
+
+        final String asciiDoc = parser.parseConfigDescription(javaDoc);
+        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void escapePlus() {
+        final String javaDoc = "Inline + ++, <code>HTML tag glob + ++</code>, {@code JavaDoc tag + ++}";
+        final String expected = "<div class=\"paragraph\">\n<p>Inline &#43; &#43;&#43;, <code>HTML tag glob &#43; &#43;&#43;</code>, <code>JavaDoc tag &#43; &#43;&#43;</code></p>\n</div>";
+
+        final String asciiDoc = parser.parseConfigDescription(javaDoc);
+        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "{", "}" })
+    public void escapeBrackets(String ch) {
+        final String javaDoc = "Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch + " " + ch + ch
+                + "</code>";
+        final String expected = "<div class=\"paragraph\">\n<p>Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch
+                + " " + ch + ch + "</code></p>\n</div>";
+
+        final String asciiDoc = parser.parseConfigDescription(javaDoc);
+        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        assertEquals(expected, actual);
+    }
+
 }


### PR DESCRIPTION
Fix #10153 