### PR TITLE
Upgrade to Hibernate ORM 5.4.18.Final

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -83,7 +83,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
-        <hibernate-orm.version>5.4.17.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.4.18.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Alpha5</hibernate-reactive.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.0.Beta8</hibernate-search.version>


### PR DESCRIPTION
Highlights:
 - CVE-2019-14900
 - we'll need this upgrade for Hibernate Reactive.

Full changelog:
 - https://hibernate.atlassian.net/secure/ReleaseNote.jspa?version=31861&styleName=Html&projectId=10031
