### PR TITLE
Ensure that a set quarkus.log.file.path system prop is used in tests

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
@@ -8,16 +8,18 @@ import io.quarkus.runtime.logging.FileConfig;
 
 public class PropertyTestUtil {
 
+    private static final String LOG_FILE_PATH_PROPERTY = "quarkus.log.file.path";
+
     public static void setLogFileProperty() {
-        System.setProperty("quarkus.log.file.path", getLogFileLocation());
+        System.setProperty(LOG_FILE_PATH_PROPERTY, getLogFileLocation());
     }
 
     public static void setLogFileProperty(String logFileName) {
-        System.setProperty("quarkus.log.file.path", getLogFileLocation(logFileName));
+        System.setProperty(LOG_FILE_PATH_PROPERTY, getLogFileLocation(logFileName));
     }
 
     public static String getLogFileLocation() {
-        return getLogFileLocation(FileConfig.DEFAULT_LOG_FILE_NAME);
+        return getLogFileLocation(System.getProperty(LOG_FILE_PATH_PROPERTY, FileConfig.DEFAULT_LOG_FILE_NAME));
     }
 
     private static String getLogFileLocation(String logFileName) {


### PR DESCRIPTION
Fixes: #10202 