### PR TITLE
Fix issue with primitive id types in Spring Data JPA

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
@@ -134,6 +134,13 @@ public class StockMethodsAdder {
                     BytecodeCreator idValueUnset;
                     BytecodeCreator idValueSet;
                     if (idType instanceof PrimitiveType) {
+                        if (!idType.name().equals(DotNames.PRIMITIVE_LONG)
+                                && !idType.name().equals(DotNames.PRIMITIVE_INTEGER)) {
+                            throw new IllegalArgumentException("Id type of '" + entityDotName + "' is invalid.");
+                        }
+                        if (idType.name().equals(DotNames.PRIMITIVE_LONG)) {
+                            idValue = save.checkCast(idValue, int.class);
+                        }
                         BranchResult idValueNonZeroBranch = save.ifNonZero(idValue);
                         idValueSet = idValueNonZeroBranch.trueBranch();
                         idValueUnset = idValueNonZeroBranch.falseBranch();

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Book.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Book.java
@@ -6,7 +6,7 @@ import javax.persistence.Id;
 @Entity
 public class Book extends NamedEntity {
 
-    private Integer bid;
+    private int bid;
 
     private Integer publicationYear;
 
@@ -20,11 +20,11 @@ public class Book extends NamedEntity {
     }
 
     @Id
-    public Integer getBid() {
+    public int getBid() {
         return bid;
     }
 
-    public void setBid(Integer bid) {
+    public void setBid(int bid) {
         this.bid = bid;
     }
 

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Cat.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Cat.java
@@ -9,7 +9,7 @@ public class Cat {
 
     @Id
     @GeneratedValue
-    public Long id;
+    public long id;
 
     private String breed;
 
@@ -25,7 +25,7 @@ public class Cat {
         this.color = color;
     }
 
-    public Long getId() {
+    public long getId() {
         return id;
     }
 


### PR DESCRIPTION
This mainly comes up code in Kotlin where kotlin.Long is converted
to primitive long.

Relates to: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/quarkus-dev/Qfmx6ftUdgo/HPYrbQkhCgAJ