### PR TITLE
Error messages when jdbc.url has not been defined

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -143,27 +143,27 @@ public class DataSources {
         boolean isLegacy = matchingSupportEntry.isLegacy;
         if (!isLegacy) {
             if (!dataSourceJdbcRuntimeConfig.url.isPresent()) {
+                String errorMessage;
                 if (!legacyDataSourceRuntimeConfig.url.isPresent()) {
-                    String errorMessage;
+                    // we don't have any URL configuration so using a standard message
                     if (DataSourceUtil.isDefault(dataSourceName)) {
                         errorMessage = "quarkus.datasource.jdbc.url has not been defined";
                     } else {
                         errorMessage = "quarkus.datasource." + dataSourceName + ".jdbc.url has not been defined";
                     }
-                    throw new ConfigurationException(errorMessage);
                 } else {
-                    String errorMessage;
+                    // the user mixed legacy configuration and the new style, let's use an appropriate message
                     if (DataSourceUtil.isDefault(dataSourceName)) {
-                        errorMessage = "quarkus.datasource.url is deprecated and will be removed in a future version - it is "
-                                + "recommended to switch to quarkus.datasource.jdbc.url. See https://quarkus.io/guides/datasource";
+                        errorMessage = "Using legacy quarkus.datasource.url with a db-kind is not supported, please use "
+                                + " quarkus.datasource.jdbc.url instead. See https://quarkus.io/guides/datasource for more information.";
                     } else {
-                        errorMessage = "quarkus.datasource." + dataSourceName
-                                + ".url is deprecated and will be removed in a future version - it is " +
-                                "recommended to switch to quarkus.datasource." + dataSourceName
-                                + ".jdbc.url. See https://quarkus.io/guides/datasource";
+                        errorMessage = "Using legacy quarkus.datasource." + dataSourceName
+                                + ".url with a db-kind is not supported, please use "
+                                + "quarkus.datasource." + dataSourceName + ".jdbc.url "
+                                + "instead. See https://quarkus.io/guides/datasource for more information.";
                     }
-                    throw new ConfigurationException(errorMessage);
                 }
+                throw new ConfigurationException(errorMessage);
             }
         } else {
             if (!legacyDataSourceRuntimeConfig.url.isPresent()) {

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -143,11 +143,37 @@ public class DataSources {
         boolean isLegacy = matchingSupportEntry.isLegacy;
         if (!isLegacy) {
             if (!dataSourceJdbcRuntimeConfig.url.isPresent()) {
-                throw new ConfigurationException("URL is not defined for datasource " + dataSourceName);
+                if (!legacyDataSourceRuntimeConfig.url.isPresent()) {
+                    String errorMessage;
+                    if (DataSourceUtil.isDefault(dataSourceName)) {
+                        errorMessage = "quarkus.datasource.jdbc.url has not been defined";
+                    } else {
+                        errorMessage = "quarkus.datasource." + dataSourceName + ".jdbc.url has not been defined";
+                    }
+                    throw new ConfigurationException(errorMessage);
+                } else {
+                    String errorMessage;
+                    if (DataSourceUtil.isDefault(dataSourceName)) {
+                        errorMessage = "quarkus.datasource.url is deprecated and will be removed in a future version - it is "
+                                + "recommended to switch to quarkus.datasource.jdbc.url. See https://quarkus.io/guides/datasource";
+                    } else {
+                        errorMessage = "quarkus.datasource." + dataSourceName
+                                + ".url is deprecated and will be removed in a future version - it is " +
+                                "recommended to switch to quarkus.datasource." + dataSourceName
+                                + ".jdbc.url. See https://quarkus.io/guides/datasource";
+                    }
+                    throw new ConfigurationException(errorMessage);
+                }
             }
         } else {
             if (!legacyDataSourceRuntimeConfig.url.isPresent()) {
-                throw new ConfigurationException("URL is not defined for datasource " + dataSourceName);
+                String errorMessage;
+                if (DataSourceUtil.isDefault(dataSourceName)) {
+                    errorMessage = "quarkus.datasource.url has not been defined";
+                } else {
+                    errorMessage = "quarkus.datasource." + dataSourceName + ".url has not been defined";
+                }
+                throw new ConfigurationException(errorMessage);
             }
         }
 


### PR DESCRIPTION
As far as I understood it correctly, #10194 could be fixed by log error messages when `quarkus.datasource.jdbc.url` has not been defined, also when `quarkus.datasource.url` has been defined instead of `quarkus.datasource.jdbc.url`. 

The idea behind this PR is to log an error with an explicit message for both cases. 