### PR TITLE
Reduce level of a log message in Gradle QuarkusDev task

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -531,7 +531,7 @@ public class QuarkusDev extends QuarkusTask {
 
     private void addToClassPaths(StringBuilder classPathManifest, File file) {
         if (filesIncludedInClasspath.add(file)) {
-            getProject().getLogger().info("Adding dependency {}", file);
+            getProject().getLogger().debug("Adding dependency {}", file);
 
             final URI uri = file.toPath().toAbsolutePath().toUri();
             classPathManifest.append(uri).append(" ");


### PR DESCRIPTION
A trivial change which prevents spamming of the logs when `INFO` level logging is enabled for Gradle `quarkusDev` task. Right now, these logs are getting logged at `INFO` level which ends up with far too many messages like:
```
...
Adding dependency maven/repository/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar
Adding dependency maven/repository/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar
Adding dependency maven/repository/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar
Adding dependency maven/repository/org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar
Adding dependency maven/repository/org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11.jar
Adding dependency maven/repository/commons-codec/commons-codec/1.11/commons-codec-1.11.jar
Adding dependency maven/repository/jakarta/ejb/jakarta.ejb-api/3.2.6/jakarta.ejb-api-3.2.6.jar
Adding dependency maven/repository/jakarta/transaction/jakarta.transaction-api/1.3.2/jakarta.transaction-api-1.3.2.jar
...
```