### PR TITLE
quick-build profile that sets various system props to skip tests and validation steps

### DIFF
--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -185,5 +185,16 @@
                 <gradle.task>assemble</gradle.task>
             </properties>
         </profile>
+        <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <gradle.task>assemble</gradle.task>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -21,7 +21,6 @@
         <quarkus-home-url>https://quarkus.io</quarkus-home-url>
         <quarkus-base-url>https://github.com/quarkusio/quarkus</quarkus-base-url>
         <quickstarts-base-url>https://github.com/quarkusio/quarkus-quickstarts</quickstarts-base-url>
-        <skipDocs>false</skipDocs>
     </properties>
 
     <name>Quarkus - Documentation</name>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -291,6 +291,20 @@
 
     <profiles>
         <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+                <enforcer.skip>true</enforcer.skip>
+                <format.skip>true</format.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -472,6 +472,20 @@
 
     <profiles>
         <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+                <enforcer.skip>true</enforcer.skip>
+                <format.skip>true</format.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -235,6 +235,20 @@
 
     <profiles>
         <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+                <enforcer.skip>true</enforcer.skip>
+                <format.skip>true</format.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -300,6 +300,20 @@
 
     <profiles>
         <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+                <enforcer.skip>true</enforcer.skip>
+                <format.skip>true</format.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -22,6 +22,18 @@
 
     <profiles>
         <profile>
+            <id>skip-gradle-build</id>
+            <activation>
+                <property>
+                    <name>skip.gradle.build</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.gradle.tests>true</skip.gradle.tests>
+            </properties>
+        </profile>
+        <profile>
             <id>Gradle-IT</id>
             <activation>
                 <property>
@@ -52,7 +64,7 @@
                                         <MAVEN_LOCAL_REPO>${settings.localRepository}</MAVEN_LOCAL_REPO>
                                         <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
                                     </environmentVariables>
-                                    <skip>${skip.gradle.build}</skip>
+                                    <skip>${skip.gradle.tests}</skip>
                                 </configuration>
                                 <goals>
                                     <goal>exec</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+
+        <skipDocs>false</skipDocs>
+        <skip.gradle.tests>false</skip.gradle.tests>
     </properties>
 
     <modules>
@@ -92,6 +95,23 @@
     </distributionManagement>
 
     <profiles>
+        <profile>
+            <id>quick-build</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+                <skipDocs>true</skipDocs>
+                <enforcer.skip>true</enforcer.skip>
+                <format.skip>true</format.skip>
+                <skipExtensionValidation>true</skipExtensionValidation>
+                <skip.gradle.tests>true</skip.gradle.tests>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
This PR introduces a Maven profile that when activated sets various system properties that skip test execution, all sorts of validation steps and docs generation.