### PR TITLE
Ensure that QuarkusClassLoader returns the same URL format as URLClassLoader

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -12,6 +12,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ class FlywayProcessor {
 
         Collection<String> dataSourceNames = getDataSourceNames(jdbcDataSourceBuildItems);
 
-        Set<String> applicationMigrations = discoverApplicationMigrations(getMigrationLocations(dataSourceNames));
+        List<String> applicationMigrations = discoverApplicationMigrations(getMigrationLocations(dataSourceNames));
         recorder.setApplicationMigrationFiles(applicationMigrations);
 
         Set<Class<?>> javaMigrationClasses = new HashSet<>();
@@ -195,9 +196,9 @@ class FlywayProcessor {
         return migrationLocations;
     }
 
-    private Set<String> discoverApplicationMigrations(Collection<String> locations) throws IOException, URISyntaxException {
+    private List<String> discoverApplicationMigrations(Collection<String> locations) throws IOException, URISyntaxException {
         try {
-            Set<String> applicationMigrationResources = new HashSet<>();
+            List<String> applicationMigrationResources = new ArrayList<>();
             // Locations can be a comma separated list
             for (String location : locations) {
                 // Strip any 'classpath:' protocol prefixes because they are assumed

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
@@ -72,7 +72,15 @@ public class DirectoryClassPathElement extends AbstractClassPathElement {
                 @Override
                 public URL getUrl() {
                     try {
-                        return file.toUri().toURL();
+                        URI uri = file.toUri();
+                        // the URLClassLoader doesn't add trailing slashes to directories, so we make sure we return
+                        // the same URL as it would to avoid having QuarkusClassLoader return different URLs
+                        // (one with a trailing slash and one without) for same resource
+                        if (uri.getPath().endsWith("/")) {
+                            String uriStr = uri.toString();
+                            return new URL(uriStr.substring(0, uriStr.length() - 1));
+                        }
+                        return uri.toURL();
                     } catch (MalformedURLException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
The URLClassLoader adds a trailing slash when resolving a directory so we
should do the same to prevent the QuarkusClassLoader from returning
multiple entries for the same directory.

This should properly fix the Flyway issue that was fixed in #10219 (the fix introduced there was reverted here).
Thanks to @gsmet for inquiring about this.

@stuartwdouglas if there is a better way to remove the trailing slash than the manual thing I did, I'd love to hear it :)

~~PR is in draft so CI will run on my fork since this has the potential to fail and I obviously didn't run all tests~~