### PR TITLE
[WIP] Fast-jar not recognizing additional archives produced during the build

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/SerializedApplication.java
@@ -49,7 +49,7 @@ public class SerializedApplication {
     }
 
     public static void write(OutputStream outputStream, String mainClass, Path applicationRoot, List<Path> classPath,
-            List<Path> parentFirst)
+            List<Path> parentFirst, List<Path> additionalArchives)
             throws IOException {
         try (DataOutputStream data = new DataOutputStream(outputStream)) {
             data.writeInt(MAGIC);
@@ -57,8 +57,12 @@ public class SerializedApplication {
             data.writeUTF(mainClass);
             data.writeInt(classPath.size());
             for (Path jar : classPath) {
-                String relativePath = relativize(applicationRoot, jar).replace("\\", "/");
-                data.writeUTF(relativePath);
+                if (additionalArchives.contains(jar)) {
+                    data.writeUTF(jar.toString().replace("\\", "/"));
+                } else {
+                    String relativePath = relativize(applicationRoot, jar).replace("\\", "/");
+                    data.writeUTF(relativePath);
+                }
                 writeJar(data, jar);
             }
             Set<String> parentFirstPackages = new HashSet<>();


### PR DESCRIPTION
Trying to fix two issues:

* The `quarkus-application.dat` file does not have references to `AdditionalApplicationArchiveBuildItem` produced by extensions, mainly when the archive comes from some external source, not necessarily from the application classpath

* The `hibernate-orm` extension fails to run re-augmentation when generating proxies for entity classes from additional archives

The use case I'm trying to solve is to allow users to drop additional jars in a specific directory so that during re-augmentation we treat that file as any other in the application original classpath.

Not sure if it is the best fix, please let me know what you think.