### PR TITLE
Add webjars-locator-core version to the BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -197,6 +197,8 @@
         <google-cloud-functions.version>1.0.1</google-cloud-functions.version>
         <commons-compress.version>1.20</commons-compress.version>
         <gson.version>2.8.6</gson.version>
+        <webjars-locator.version>0.40</webjars-locator.version>
+        <webjars-locator-core.version>0.44</webjars-locator-core.version>
     </properties>
 
     <dependencyManagement>
@@ -4219,7 +4221,12 @@
             <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>webjars-locator</artifactId>
-                <version>0.39</version>
+                <version>${webjars-locator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars</groupId>
+                <artifactId>webjars-locator-core</artifactId>
+                <version>${webjars-locator-core.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>webjars-locator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>webjars-locator-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
@@ -30,7 +34,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-webjars-locator</artifactId>
         </dependency>
-        
+
         <!-- Tests -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -42,7 +46,7 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- Using setForcedDependencies only works if the dependency is in the pom's test scope. -->
         <dependency>
           <groupId>org.webjars</groupId>
@@ -56,7 +60,7 @@
           <version>2.24.0</version>
           <scope>test</scope>
         </dependency>
-        
+
         <!-- DevMode has no setForcedDependencies, so need to add resteasy extension here -->
         <dependency>
           <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Potentially could fix the CI when quarkus-webjars-locator-deployment fails to compile.