### PR TITLE
Update Mutiny version to 0.5.4 and fix CompositeException unwrapping in the security handling

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -127,7 +127,7 @@
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
-        <mutiny.version>0.5.3</mutiny.version>
+        <mutiny.version>0.5.4</mutiny.version>
         <axle-client.version>0.0.16</axle-client.version>
         <mutiny-client.version>0.1.1</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>


### PR DESCRIPTION
Update to Mutiny 0.5.4.

Mutiny does not provide the CompletionException anymore as it was a leak of the CompletionStage API.

In this case, it gets a CompositeException (because multiple exceptions have been caught) and we should iterate on it to retrieve the cause.