### PR TITLE
Properly fix issue with primitive id types in Spring Data JPA.

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/StockMethodsAdder.java
@@ -156,7 +156,10 @@ public class StockMethodsAdder {
                             throw new IllegalArgumentException("Id type of '" + entityDotName + "' is invalid.");
                         }
                         if (idType.name().equals(DotNames.PRIMITIVE_LONG)) {
-                            idValue = save.checkCast(idValue, int.class);
+                            ResultHandle longObject = save.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(Long.class, "valueOf", Long.class, long.class), idValue);
+                            idValue = save.invokeVirtualMethod(MethodDescriptor.ofMethod(Long.class, "intValue", int.class),
+                                    longObject);
                         }
                         BranchResult idValueNonZeroBranch = save.ifNonZero(idValue);
                         idValueSet = idValueNonZeroBranch.trueBranch();

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/Person.java
@@ -28,7 +28,7 @@ public class Person {
     @Id
     @SequenceGenerator(name = "personSeqGen", sequenceName = "personSeq", initialValue = 100, allocationSize = 1)
     @GeneratedValue(generator = "personSeqGen")
-    private Long id;
+    private long id;
 
     @JsonbProperty(nillable = true)
     private String name;
@@ -56,7 +56,7 @@ public class Person {
     public Person() {
     }
 
-    public Long getId() {
+    public long getId() {
         return id;
     }
 


### PR DESCRIPTION
It seems like checkcast doesn't do a straight cast, but also does
implicit conversions we don't want here

Follow up to #10208.

This was uncovered by this conversation: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/quarkus-dev/Qfmx6ftUdgo/HPYrbQkhCgAJ