### PR TITLE
Enable forwarded for prefix header configuration

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -703,6 +703,50 @@ java.lang.IllegalStateException: Failed to create cache dir
 
 Assuming `/tmp/` is writeable this can be fixed by setting the `vertx.cacheDirBase` property to point to a directory in `/tmp/` for instance in OpenShift by creating an environment variable `JAVA_OPTS` with the value `-Dvertx.cacheDirBase=/tmp/vertx`.
 
+== Running behind a reverse proxy
+
+Quarkus could be accessed through proxies that additionally generate headers (e.g. `X-Forwarded-Host`) to keep
+information from the client-facing side of the proxy servers that is altered or lost when they are involved.
+In those scenarios, Quarkus can be configured to automatically update information like protocol, host, port and URI
+reflecting the values in these headers.
+
+IMPORTANT: Activating this feature makes the server exposed to several security issues (i.e. information spoofing).
+Consider activate it only when running behind a reverse proxy.
+
+To setup this feature, please include the following lines in `src/main/resources/application.properties`:
+[source]
+----
+quarkus.http.proxy-address-forwarding=true
+----
+
+To consider only de-facto standard header (`Forwarded` header), please include the following lines in `src/main/resources/application.properties`:
+[source]
+----
+quarkus.http.allow-forwarded=true
+----
+
+To consider only non-standard headers, please include the following lines instead in `src/main/resources/application.properties`:
+
+[source]
+----
+quarkus.http.proxy-address-forwarding=true
+quarkus.http.proxy.enable-forwarded-host=true
+quarkus.http.proxy.enable-forwarded-prefix=true
+----
+
+Both configurations related with standard and non-standard headers can be combine.
+In this case, the `Forwarded` header will have precedence in presence of both set of headers.
+
+Supported forwarding address headers are:
+
+* `Forwarded`
+* `X-Forwarded-Proto`
+* `X-Forwarded-Host`
+* `X-Forwarded-Port`
+* `X-Forwarded-Ssl`
+* `X-Forwarded-Prefix`
+
+
 == Going further
 
 There are many other facets of Quarkus using Vert.x underneath:

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ConfigureForwardedHeadersTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ConfigureForwardedHeadersTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.vertx.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ConfigureForwardedHeadersTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-host=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-prefix=true\n" +
+                            "quarkus.http.proxy.forwarded-host-header=X-Forwarded-Server\n" +
+                            "quarkus.http.proxy.forwarded-prefix-header=X-Envoy-Path\n"),
+                            "application.properties"));
+
+    @Test
+    public void test() {
+        assertThat(RestAssured.get("/path").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Server", "somehost")
+                .header("X-Envoy-Path", "/prefix")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("https|somehost|backend:4444|/prefix/path|https://somehost/prefix/path"));
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
@@ -13,6 +13,12 @@ class ForwardedHandlerInitializer {
         router.route("/forward").handler(rc -> rc.response()
                 .end(rc.request().scheme() + "|" + rc.request().getHeader(HttpHeaders.HOST) + "|"
                         + rc.request().remoteAddress().toString()));
+        router.route("/path").handler(rc -> rc.response()
+                .end(rc.request().scheme()
+                        + "|" + rc.request().getHeader(HttpHeaders.HOST)
+                        + "|" + rc.request().remoteAddress().toString()
+                        + "|" + rc.request().uri()
+                        + "|" + rc.request().absoluteURI()));
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedPrefixHeaderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedPrefixHeaderTest.java
@@ -1,0 +1,90 @@
+package io.quarkus.vertx.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ForwardedPrefixHeaderTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset("quarkus.http.proxy-address-forwarding=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-prefix=true\n"),
+                            "application.properties"));
+
+    @Test
+    public void test() {
+        assertThat(RestAssured.get("/path").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Prefix", "/prefix")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("https|localhost|backend:4444|/prefix/path|https://localhost/prefix/path"));
+    }
+
+    @Test
+    public void testWithASlashAtEnding() {
+        assertThat(RestAssured.get("/path").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Prefix", "/prefix/")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("https|localhost|backend:4444|/prefix/path|https://localhost/prefix/path"));
+    }
+
+    @Test
+    public void testWhenPrefixIsEmpty() {
+        assertThat(RestAssured.get("/path").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Prefix", "")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("https|localhost|backend:4444|/path|https://localhost/path"));
+    }
+
+    @Test
+    public void testWhenPrefixIsASlash() {
+        assertThat(RestAssured.get("/path").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Prefix", "/")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("https|localhost|backend:4444|/path|https://localhost/path"));
+    }
+
+    @Test
+    public void testWhenPrefixIsADoubleSlash() {
+        assertThat(RestAssured.get("/path").asString()).startsWith("http|");
+
+        RestAssured.given()
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Prefix", "//")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("https|localhost|backend:4444|/path|https://localhost/path"));
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -137,7 +137,7 @@ class ForwardedServerRequestWrapper implements HttpServerRequest {
     @Override
     public String uri() {
         if (!modified) {
-            return delegate.uri();
+            return forwardedParser.uri();
         }
         return uri;
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardingProxyOptions.java
@@ -6,16 +6,22 @@ public class ForwardingProxyOptions {
     boolean proxyAddressForwarding;
     boolean allowForwarded;
     boolean enableForwardedHost;
+    boolean enableForwardedPrefix;
     AsciiString forwardedHostHeader;
+    AsciiString forwardedPrefixHeader;
 
     public ForwardingProxyOptions(final boolean proxyAddressForwarding,
             final boolean allowForwarded,
             final boolean enableForwardedHost,
-            final AsciiString forwardedHostHeader) {
+            final AsciiString forwardedHostHeader,
+            final boolean enableForwardedPrefix,
+            final AsciiString forwardedPrefixHeader) {
         this.proxyAddressForwarding = proxyAddressForwarding;
         this.allowForwarded = allowForwarded;
         this.enableForwardedHost = enableForwardedHost;
+        this.enableForwardedPrefix = enableForwardedPrefix;
         this.forwardedHostHeader = forwardedHostHeader;
+        this.forwardedPrefixHeader = forwardedPrefixHeader;
     }
 
     public static ForwardingProxyOptions from(HttpConfiguration httpConfiguration) {
@@ -25,8 +31,11 @@ public class ForwardingProxyOptions {
                 .orElse(httpConfiguration.proxy.allowForwarded);
 
         final boolean enableForwardedHost = httpConfiguration.proxy.enableForwardedHost;
+        final boolean enableForwardedPrefix = httpConfiguration.proxy.enableForwardedPrefix;
+        final AsciiString forwardedPrefixHeader = AsciiString.cached(httpConfiguration.proxy.forwardedPrefixHeader);
         final AsciiString forwardedHostHeader = AsciiString.cached(httpConfiguration.proxy.forwardedHostHeader);
 
-        return new ForwardingProxyOptions(proxyAddressForwarding, allowForwarded, enableForwardedHost, forwardedHostHeader);
+        return new ForwardingProxyOptions(proxyAddressForwarding, allowForwarded, enableForwardedHost, forwardedHostHeader,
+                enableForwardedPrefix, forwardedPrefixHeader);
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -34,4 +34,15 @@ public class ProxyConfig {
     @ConfigItem(defaultValue = "X-Forwarded-Host")
     public String forwardedHostHeader;
 
+    /**
+     * Enable prefix the received request's path with a forwarded prefix header.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableForwardedPrefix;
+
+    /**
+     * Configure the forwarded prefix header to be used if prefixing enabled.
+     */
+    @ConfigItem(defaultValue = "X-Forwarded-Prefix")
+    public String forwardedPrefixHeader;
 }


### PR DESCRIPTION
This is the last part of #9622 that enable users to configure the header to be used to prefix the HTTP request's URI. It includes also documentation how to setup it.

Fixes: #9622 