### PR TITLE
Netty's shaded JC Tools need Unsafe access in native mode

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -218,7 +218,24 @@ class NettyProcessor {
     public List<UnsafeAccessedFieldBuildItem> unsafeAccessedFields() {
         return Arrays.asList(
                 new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "selectedKeys"),
-                new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "publicSelectedKeys"));
+                new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "publicSelectedKeys"),
+
+                new UnsafeAccessedFieldBuildItem(
+                        "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField", "producerIndex"),
+                new UnsafeAccessedFieldBuildItem(
+                        "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField", "producerLimit"),
+                new UnsafeAccessedFieldBuildItem(
+                        "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField", "consumerIndex"),
+
+                new UnsafeAccessedFieldBuildItem(
+                        "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+                        "producerIndex"),
+                new UnsafeAccessedFieldBuildItem(
+                        "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+                        "producerLimit"),
+                new UnsafeAccessedFieldBuildItem(
+                        "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+                        "consumerIndex"));
     }
 
     @BuildStep


### PR DESCRIPTION
Netty's shaded JC Tools 3.0 changes queue behavior when compiled natively and the unsafe configuration must be adjusted.

Follow up of the discussion from https://github.com/netty/netty/issues/10376