### PR TITLE
Skip gpg signing for integration tests modules

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
     </properties>
 


### PR DESCRIPTION
We don't deploy them so no need to sign them.

(already pushed to the 1.6 branch as I got some issues)