### PR TITLE
Add defaultGoal clean install to quick-build profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Just do the following:
 git clone git@github.com:quarkusio/quarkus.git
 cd quarkus
 export MAVEN_OPTS="-Xmx1563m"
-./mvnw clean install -DskipTests -DskipITs -DskipDocs
+./mvnw -Dquickly
 ```
 
 Wait for a bit and you're done.
@@ -188,20 +188,21 @@ select the `eclipse.importorder` file as the import order config file.
 * Clone the repository: `git clone https://github.com/quarkusio/quarkus.git`
 * Navigate to the directory: `cd quarkus`
 * Set Maven heap to 1.5GB `export MAVEN_OPTS="-Xmx1563m"`
-* Invoke `./mvnw clean install -DskipTests -DskipITs -DskipDocs` from the root directory
+* Invoke `./mvnw -Dquickly` from the root directory
 
 ```bash
 git clone https://github.com/quarkusio/quarkus.git
 cd quarkus
 export MAVEN_OPTS="-Xmx1563m"
-./mvnw clean install -DskipTests -DskipITs -DskipDocs
+./mvnw -Dquickly
 # Wait... success!
 ```
 
-This build skipped all the tests, native-image builds and documentation generation. 
+This build skipped all the tests, native-image builds, documentation generation etc. and used the Maven goals `clean install` by default.
+For more details about `-Dquickly` have a look at the `quick-build` profile in `quarkus-parent` (root `pom.xml`).
 
-Removing the `-DskipTests -DskipITs` flags enables the tests. 
-It will take much longer to build but will give you more guarantees on your code. 
+Adding `-DskipTests=false -DskipITs=false` enables the tests.
+It will take much longer to build but will give you more guarantees on your code.
 
 You can build and test native images in the integration tests supporting it by using `./mvnw install -Dnative`.
 

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -303,6 +303,9 @@
                 <enforcer.skip>true</enforcer.skip>
                 <format.skip>true</format.skip>
             </properties>
+            <build>
+                <defaultGoal>clean install</defaultGoal>
+            </build>
         </profile>
         <profile>
             <id>release</id>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -484,6 +484,9 @@
                 <enforcer.skip>true</enforcer.skip>
                 <format.skip>true</format.skip>
             </properties>
+            <build>
+                <defaultGoal>clean install</defaultGoal>
+            </build>
         </profile>
         <profile>
             <id>release</id>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -247,6 +247,9 @@
                 <enforcer.skip>true</enforcer.skip>
                 <format.skip>true</format.skip>
             </properties>
+            <build>
+                <defaultGoal>clean install</defaultGoal>
+            </build>
         </profile>
         <profile>
             <id>release</id>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -312,6 +312,9 @@
                 <enforcer.skip>true</enforcer.skip>
                 <format.skip>true</format.skip>
             </properties>
+            <build>
+                <defaultGoal>clean install</defaultGoal>
+            </build>
         </profile>
         <profile>
             <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,9 @@
                 <skipExtensionValidation>true</skipExtensionValidation>
                 <skip.gradle.tests>true</skip.gradle.tests>
             </properties>
+            <build>
+                <defaultGoal>clean install</defaultGoal>
+            </build>
         </profile>
         <profile>
             <id>release</id>


### PR DESCRIPTION
As discussed here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/quick.20build.20with.20-Dquickly/near/202108542

Btw, I left out the profile in `devtools/gradle` as it auto-inherits the `defaultGoal` from `quarkus-parent` (via `build-parent`).