### PR TITLE
Update surefire from 2.22.0 to 3.0.0-M5 in independent-projects

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -45,6 +45,8 @@
         <version.jakarta-annotation>1.3.5</version.jakarta-annotation>
         <version.gizmo>1.0.3.Final</version.gizmo>
         <version.jpa>2.2.3</version.jpa>
+
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
 
@@ -247,6 +249,13 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                    <configuration>
+                        <argLine>${jacoco.agent.argLine}</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -45,6 +45,7 @@
         <jboss-logmanager-embedded.version>1.0.4</jboss-logmanager-embedded.version>
         <graal-sdk.version>20.1.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
     </properties>
     <modules>
         <module>app-model</module>
@@ -428,6 +429,13 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                    <configuration>
+                        <argLine>${jacoco.agent.argLine}</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>

--- a/independent-projects/ide-config/pom.xml
+++ b/independent-projects/ide-config/pom.xml
@@ -34,6 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     </properties>
 
@@ -47,6 +48,20 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                    <configuration>
+                        <argLine>${jacoco.agent.argLine}</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <profiles>
         <profile>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -40,6 +40,7 @@
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
         <version.reactivestreams>1.0.3</version.reactivestreams>
         <version.mutiny>0.5.3</version.mutiny>
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     </properties>
 
@@ -191,6 +192,13 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                    <configuration>
+                        <argLine>${jacoco.agent.argLine}</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code.formatter</groupId>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -48,6 +48,7 @@
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <maven-core.version>3.6.3</maven-core.version>
         <mockito.version>3.3.3</mockito.version>
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <quarkus.version>999-SNAPSHOT</quarkus.version>
         <quarkus-http.version>3.0.11.Final</quarkus-http.version>
@@ -268,6 +269,13 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
+                <configuration>
+                    <argLine>${jacoco.agent.argLine}</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
A "leftover" from #10081

I did _not_ add
```xml
<systemPropertyVariables>
    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
    <maven.home>${maven.home}</maven.home>
</systemPropertyVariables>
```
like in `build-parent` because all those projects don't seem to have `jboss-logging` on the classpath and probably don't have anything to do with the Quarkus Maven home lookup.

cc @geoand

