### PR TITLE
 Devmode .env: fall back to mklink /H on Windows

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.IoUtils;
@@ -237,7 +238,5 @@ public class AppCDSBuildStep {
     // copied from Java 9
     // TODO remove when we move to Java 11
 
-    private static final File NULL_FILE = new File(
-            (System.getProperty("os.name")
-                    .startsWith("Windows") ? "NUL" : "/dev/null"));
+    private static final File NULL_FILE = new File(SystemUtils.IS_OS_WINDOWS ? "NUL" : "/dev/null");
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -23,7 +23,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,6 +37,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.BootstrapDependencyProcessingException;
@@ -130,8 +130,6 @@ public class JarResultBuildStep {
     public static final String APP = "app";
     public static final String QUARKUS = "quarkus";
     public static final String DEFAULT_FAST_JAR_DIRECTORY_NAME = "quarkus-app";
-
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
 
     @BuildStep
     OutputTargetBuildItem outputTarget(BuildSystemTargetBuildItem bst, PackageConfig packageConfig) {
@@ -669,7 +667,7 @@ public class JarResultBuildStep {
                 .map((s) -> new GeneratedClassBuildItem(true, s.getName(), s.getClassData()))
                 .collect(Collectors.toList()));
 
-        if (IS_WINDOWS) {
+        if (SystemUtils.IS_OS_WINDOWS) {
             log.warn("Uber JAR strategy is used for native image source JAR generation on Windows. This is done " +
                     "for the time being to work around a current GraalVM limitation on Windows concerning the " +
                     "maximum command length (see https://github.com/oracle/graal/issues/2387).");

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ProcessUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ProcessUtil.java
@@ -105,8 +105,20 @@ public class ProcessUtil {
      * @param process The process whose STDERR needs to be streamed.
      */
     public static void streamErrorToSysErr(final Process process) {
+        streamErrorTo(System.err, process);
+    }
+
+    /**
+     * Streams the {@link Process process'} {@code STDERR} to the given
+     * {@code printStream}. This creates and starts a thread to stream the contents.
+     * The {@link Process} is expected to have been started in {@link java.lang.ProcessBuilder.Redirect#PIPE}
+     * mode
+     *
+     * @param process The process whose STDERR needs to be streamed.
+     */
+    public static void streamErrorTo(final PrintStream printStream, final Process process) {
         final InputStream processStdErr = process.getErrorStream();
-        final Thread t = new Thread(new Streamer(processStdErr, System.err));
+        final Thread t = new Thread(new Streamer(processStdErr, printStream));
         t.setName("Process stderr streamer");
         t.setDaemon(true);
         t.start();


### PR DESCRIPTION
Fixes #8297 at least for NTFS partitions (which should be the default case for everyone these days).
Theoretically, this will most likely fail for cross disk operations but I don't think that's realistic here.

I tested this on my Win10 Home machine. `DevMojoIT.testThatTheApplicationIsReloadedOnDotEnvConfigChange` now passes for the first time.

The second commit switches from home-grown OS-detection code to `org.apache.commons.lang3.SystemUtils`.
It felt like a good oportunity to "clean that up". But I can also create a separate PR for that (or drop it entirely), just let me know.

cc @geoand 