### PR TITLE
Devmode: introduce quarkus.live-reload.watched-resources

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/DevModeBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/DevModeBuildStep.java
@@ -1,18 +1,23 @@
 package io.quarkus.deployment.steps;
 
 import java.nio.file.Paths;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.runtime.LiveReloadConfig;
 
 class DevModeBuildStep {
 
     @BuildStep
-    List<HotDeploymentWatchedFileBuildItem> config() {
-        return Arrays.asList(new HotDeploymentWatchedFileBuildItem("META-INF/microprofile-config.properties"),
-                new HotDeploymentWatchedFileBuildItem("application.properties"), new HotDeploymentWatchedFileBuildItem(
-                        Paths.get(".env").toAbsolutePath().toAbsolutePath().toString()));
+    List<HotDeploymentWatchedFileBuildItem> watchChanges(LiveReloadConfig config) {
+        List<String> names = new ArrayList<>();
+        names.add("META-INF/microprofile-config.properties");
+        names.add("application.properties");
+        names.add(Paths.get(".env").toAbsolutePath().toString());
+        config.watchedResources.ifPresent(names::addAll);
+        return names.stream().map(HotDeploymentWatchedFileBuildItem::new).collect(Collectors.toList());
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LiveReloadConfig.java
@@ -1,19 +1,21 @@
 package io.quarkus.runtime;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-/**
- * This is used currently only to suppress warnings about unknown properties
- * when the user supplies something like: -Dquarkus.live-reload.password=secret
- *
- * TODO refactor code to actually use these values
- */
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class LiveReloadConfig {
+
+    /**
+     * The names of additional resource files to watch for changes, triggering a reload on change. Directories are <em>not</em>
+     * supported.
+     */
+    @ConfigItem
+    public Optional<List<String>> watchedResources;
 
     /**
      * Password used to use to connect to the remote dev-mode application

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/reload/AdditionalWatchedResourcesDevModeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/reload/AdditionalWatchedResourcesDevModeTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.test.reload;
+
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class AdditionalWatchedResourcesDevModeTest {
+
+    private static final String RES_WATCHED = "watched.txt";
+    private static final String RES_WATCHED_SUBPATH = "sub/watched.txt";
+    private static final String RES_NOT_WATCHED = "not-watched.txt";
+
+    private static final String PROPERTY = "quarkus.live-reload.watched-resources="
+            + RES_WATCHED + "," + RES_WATCHED_SUBPATH;
+
+    private static final String MODIFIED = "modified";
+    private static final String INITIAL = "initial";
+
+    @RegisterExtension
+    static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(AdditionalWatchedResourcesResource.class)
+                    .addAsResource(new StringAsset(INITIAL), RES_WATCHED)
+                    .addAsResource(new StringAsset(INITIAL), RES_WATCHED_SUBPATH)
+                    .addAsResource(new StringAsset(INITIAL), RES_NOT_WATCHED)
+                    .addAsResource(new StringAsset(PROPERTY), "application.properties"));
+
+    @Test
+    public void watched() {
+        RestAssured.get("/content/{name}", RES_WATCHED).then().body(is(INITIAL));
+
+        TEST.modifyResourceFile(RES_WATCHED, oldSource -> MODIFIED);
+
+        RestAssured.get("/content/{name}", RES_WATCHED).then().body(is(MODIFIED));
+    }
+
+    @Test
+    public void watchedInSubPath() {
+        RestAssured.get("/content/{name}", RES_WATCHED_SUBPATH).then().body(is(INITIAL));
+
+        TEST.modifyResourceFile(RES_WATCHED_SUBPATH, oldSource -> MODIFIED);
+
+        RestAssured.get("/content/{name}", RES_WATCHED_SUBPATH).then().body(is(MODIFIED));
+    }
+
+    @Test
+    public void notWatched() {
+        RestAssured.get("/content/{name}", RES_NOT_WATCHED).then().body(is(INITIAL));
+
+        TEST.modifyResourceFile(RES_WATCHED_SUBPATH, oldSource -> MODIFIED);
+
+        RestAssured.get("/content/{name}", RES_NOT_WATCHED).then().body(is(INITIAL));
+    }
+}

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/reload/AdditionalWatchedResourcesResource.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/reload/AdditionalWatchedResourcesResource.java
@@ -1,0 +1,38 @@
+package io.quarkus.test.reload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.io.IOUtils;
+
+@Path("/")
+@ApplicationScoped // see contents map
+public class AdditionalWatchedResourcesResource {
+
+    // make sure to load content only once to check whether app was reloaded or not
+    // (TCCL.getResourceAsStream(name) will always provide the latest data, regardless of being reloaded or not)
+    private final Map<String, String> contents = new HashMap<>();
+
+    @Path("content/{name}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getContentOfAdditionallyWatchedResource(@PathParam("name") String name) {
+        return contents.computeIfAbsent(name, k -> {
+            try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(name)) {
+                return in != null ? IOUtils.toString(in, StandardCharsets.UTF_8) : "";
+            } catch (IOException e) {
+                throw new IllegalStateException("Error reading " + name, e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Resolves #10234

This is WIP because there are some things left to clarify and to implement:
- Test is missing. I'd extend `DevMojoIT`. Is this ok?
- Not sure about the `devmode` `ConfigRoot` as there is also `LiveReloadConfig` (which seems like a workaround judging from its JavaDoc)
- `additional-watched-resources` could be shortened to `extra-watched-resources` or ...? In case more "watched" aspects should be configurable in the future (e.g. #10298?) then maybe `watched.additional-resources` or similar would be better.
- JavaDoc for the new item is missing
- Not sure about the `ConfigPhase`.

PS: I remove the duplicate `toAbsolutePath()` from `Paths.get(".env").toAbsolutePath().toAbsolutePath().toString()`.