### PR TITLE
Update SmallRye Reactive Messaging to version 2.1.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.13</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.1.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>2.1.1</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.27.0</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>


### PR DESCRIPTION
Micro-update of SmallRye Reactive Messaging. 

It contains a fix for the Kafka performance regression introduced in 2.1.0.
It also fixes the MQTT wildcard support and improves Avro support.

Changelog:
https://github.com/smallrye/smallrye-reactive-messaging/releases/tag/2.1.1