### PR TITLE
Upgrade axle-client version to the one matching the mutiny-client version

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -128,7 +128,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.3.2.Final</jboss-logging.version>
         <mutiny.version>0.5.4</mutiny.version>
-        <axle-client.version>0.0.16</axle-client.version>
+        <axle-client.version>0.1.1</axle-client.version>
         <mutiny-client.version>0.1.1</mutiny-client.version>
         <kafka2.version>2.5.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>


### PR DESCRIPTION
axle-client and mutiny-client belong to the same project and are released together.