### PR TITLE
Use the AWS SDK BOM to avoid inconsistent versions and upgrade to 2.13.46 - Fix various other version alignments

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -3345,6 +3345,11 @@
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>net.sourceforge.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
                 <version>${htmlunit.version}</version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2727,6 +2727,11 @@
                 <artifactId>mongodb-driver-sync</artifactId>
                 <version>${mongo-client.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-core</artifactId>
+                <version>${mongo-client.version}</version>
+            </dependency>
             <!-- mongodb-driver-legacy is not needed for Quarkus but we add the dependency for backward compatibility -->
             <dependency>
                 <groupId>org.mongodb</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -140,7 +140,7 @@
         <aws-lambda-java-events.version>3.1.0</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
         <aws-xray.version>2.4.0</aws-xray.version>
-        <awssdk.version>2.13.26</awssdk.version>
+        <awssdk.version>2.13.46</awssdk.version>
         <aws-alexa-sdk.version>2.30.0</aws-alexa-sdk.version>
         <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
         <kotlin.version>1.3.72</kotlin.version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2656,6 +2656,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-resolver-provider</artifactId>
                 <version>${maven-core.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -2590,6 +2590,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient-cache</artifactId>
+                <version>${httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpasyncclient</artifactId>
                 <version>${httpasync.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -268,6 +268,15 @@
                 <type>pom</type>
             </dependency>
 
+            <!-- AWS SDK dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Quarkus core -->
 
             <dependency>
@@ -3797,71 +3806,6 @@
                 </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>sdk-core</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>aws-core</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>regions</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>auth</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>http-client-spi</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>dynamodb</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>s3</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>sns</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>sqs</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>ses</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>kms</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>netty-nio-client</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>url-connection-client</artifactId>
-                <version>${awssdk.version}</version>
-            </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>apache-client</artifactId>


### PR DESCRIPTION
In the platform, we have inconsistent versions of various artifacts from
the AWS SDK, better fix it once and for all.

I tested the platform with this forced and it worked OK.

/cc @quarkusio/camel FYI. I also think you should drop the override of the AWS SDK version in your Camel Quarkus project as they are not properly enforced fully in the platform and will be ignored starting with this commit.

I plan to backport this for 1.6.0.Final except if there is a significant issue.