### PR TITLE
Fix use-parent-handlers case in logging doc

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -37,7 +37,7 @@ These can also be overridden by attaching a one or more named handlers to a cate
 |===
 |Property Name|Default|Description
 |quarkus.log.category."<category-name>".level|INFO footnote:[Some extensions may define customized default log levels for certain categories, in order to reduce log noise by default.  Setting the log level in configuration will override any extension-defined log levels.]|The level to use to configure the category named `<category-name>`.  The quotes are necessary.
-|quarkus.log.category."<category-name>".useParentHandlers|true|Specify whether or not this logger should send its output to its parent logger.
+|quarkus.log.category."<category-name>".use-parent-handlers|true|Specify whether or not this logger should send its output to its parent logger.
 |quarkus.log.category."<category-name>".handlers=[<handler>]|empty footnote:[By default the configured category gets the same handlers attached as the one on the root logger.]|The names of the handlers that you want to attach to a specific category.
 |===
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/62635955/quarkus-logging-useparenthandler-does-not-work/62638694