### PR TITLE
Bump to Jackson 2.11.1

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -178,6 +178,10 @@ update_configs:
       # Caffeine
       - match:
           dependency_name: "com.github.ben-manes.caffeine:caffeine"
+      # Jackson
+      - match:
+          dependency_name: "com.fasterxml.jackson:jackson-bom"
+
   - package_manager: "java:gradle"
     directory: "/devtools/gradle"
     update_schedule: "daily"

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -78,7 +78,7 @@
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
         <graal-sdk.version>20.1.0</graal-sdk.version>
         <gizmo.version>1.0.3.Final</gizmo.version>
-        <jackson.version>2.11.0</jackson.version>
+        <jackson.version>2.11.1</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -35,7 +35,7 @@
         <plexus-cypher.version>1.7</plexus-cypher.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson.version>2.11.0</jackson.version>
+        <jackson.version>2.11.1</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <jakarta.inject-api.version>1.0</jakarta.inject-api.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -39,7 +39,7 @@
         <!-- Versions -->
         <assertj.version>3.16.1</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
-        <jackson.version>2.11.0</jackson.version>
+        <jackson.version>2.11.1</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
         <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>


### PR DESCRIPTION
This also adds Jackson to Dependabot (which should be reviewed by @cescoffier to make sure it doesn't break Vert.x)