### PR TITLE
ArC - introduce CacheGet annotation

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.util.TypeLiteral;
 
@@ -23,5 +24,13 @@ public interface InjectableInstance<T> extends Instance<T> {
 
     @Override
     <U extends T> InjectableInstance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
+
+    /**
+     * Removes the cached result of the {@link #get()} operation. If the cached result was a contextual reference of
+     * a {@link Dependent} bean, destroy the reference as well.
+     * 
+     * @see WithCaching
+     */
+    void clearCache();
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/WithCaching.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/WithCaching.java
@@ -1,0 +1,95 @@
+package io.quarkus.arc;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+
+/**
+ * An injected {@link Instance} annotated with this annotation will cache the result of the {@link Instance#get()} operation.
+ * 
+ * <p>
+ * The result is "computed" on the first call to {@link Instance#get()} and the same value is returned for all subsequent calls,
+ * even for {@link Dependent} beans.
+ * </p>
+ * 
+ * <h2>Example</h2>
+ * 
+ * <pre>
+ * <code>
+ *  class Producer {
+ *     
+ *     long nextLong = 0;
+ *     int nextInt = 0;
+ *  
+ *     {@literal @Dependent}
+ *     {@literal @Produces} 
+ *     Integer produceInt() {
+ *       return nextInt++;
+ *     }
+ *     
+ *     {@literal @Dependent}
+ *     {@literal @Produces} 
+ *     Long produceLong() {
+ *       return nextLong++;
+ *     }
+ *  }
+ *  
+ *  class Consumer {
+ *  
+ *     {@literal @Inject}
+ *     Instance&lt;Long&gt; longInstance;
+ *  
+ *     {@literal @WithCaching}
+ *     {@literal @Inject}
+ *     Instance&lt;Integer&gt; intInstance;
+ *     
+ *     // this method should always return true and Producer#produceInt() is only called once 
+ *     boolean pingInt() {
+ *        return intInstance.get().equals(intInstance.get());
+ *     }
+ *     
+ *     // this method should always return false and Producer#produceLong() is always called twice 
+ *     boolean pingLong() {
+ *        return longInstance.get().equals(longInstance.get());
+ *     }
+ *  }
+ *  </code>
+ * </pre>
+ * 
+ * <h2>Cache Invalidation</h2>
+ * 
+ * <p>
+ * It is possible to invalidate the cache via the {@link InjectableInstance#clearCache()} method.
+ * </p>
+ * 
+ * <pre>
+ * <code>
+ *  class Consumer {
+  *  
+ *     {@literal @WithCaching}
+ *     {@literal @Inject}
+ *     InjectableInstance&lt;Integer&gt; instance;
+ *     
+ *     int ping(boolean clearCache) {
+ *        if (clearCache) {
+ *          instance.clearCache();
+ *        }
+ *        return instance.get();
+ *     }
+ *  }
+ *  </code>
+ * </pre>
+ * 
+ * @see Instance
+ * @see InjectableInstance#clearCache()
+ */
+@Target({ PARAMETER, FIELD })
+@Retention(RUNTIME)
+public @interface WithCaching {
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/cacheget/InstanceWithCachingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/cacheget/InstanceWithCachingTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.arc.test.instance.cacheget;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.WithCaching;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InstanceWithCachingTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Client.class, Washcloth.class);
+
+    @Test
+    public void testDestroy() {
+        Client client = Arc.container().instance(Client.class).get();
+        assertEquals(client.nextId(), client.nextId());
+        client.clear();
+        assertTrue(Washcloth.DESTROYED.get());
+    }
+
+    @ApplicationScoped
+    static class Client {
+
+        @WithCaching
+        @Inject
+        Instance<Washcloth> instance;
+
+        String nextId() {
+            return instance.get().id;
+        }
+
+        void clear() {
+            ((InjectableInstance<Washcloth>) instance).clearCache();
+        }
+
+    }
+
+    @Dependent
+    static class Washcloth {
+
+        static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+
+        String id;
+
+        @PostConstruct
+        void init() {
+            this.id = UUID.randomUUID().toString();
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+
+    }
+
+}


### PR DESCRIPTION
- that instructs an injected Instance<> to cache the result of the get()
method
- makes it possible to use Instance<> to lazily fetch a dependent bean
and reuse the instance for subsequent get() invocations


The main motivation is to simplify workarounds for use cases like this: https://github.com/quarkusio/quarkus/issues/10159#issuecomment-651728624

NOTE: It's basically a CDI alternative of Dagger's [Lazy](https://dagger.dev/api/2.11/dagger/Lazy.html).