### PR TITLE
forkMode is deprecated since Surefire 2.14

### DIFF
--- a/integration-tests/funqy-amazon-lambda/pom.xml
+++ b/integration-tests/funqy-amazon-lambda/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-		            <forkMode>always</forkMode>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/google-cloud-functions/pom.xml
+++ b/integration-tests/google-cloud-functions/pom.xml
@@ -37,7 +37,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkMode>always</forkMode>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
See "Migrating the Deprecated forkMode Parameter to forkCount and reuseForks" in https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html