### PR TITLE
Avoid version issues by using an extended name option to decode base64

### DIFF
--- a/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/manage.sh
+++ b/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/manage.sh
@@ -30,7 +30,7 @@ function cmd_invoke() {
     --payload file://payload.json \
     --log-type Tail \
     --query 'LogResult' \
-    --output text |  base64 -d
+    --output text |  base64 --decode
   { set +x; } 2>/dev/null
   cat response.txt && rm -f response.txt
 }


### PR DESCRIPTION
Suggested by @jaikiran  in #10386