### PR TITLE
Qute - fix parser

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -403,6 +403,9 @@ class Parser implements Function<String, Expression>, ParserHelper {
                 ignoreContent = true;
             } else {
                 // Section end
+                if (section.helperName.equals(ROOT_HELPER_NAME)) {
+                    throw parserError("no section start tag found for " + tag);
+                }
                 if (!name.isEmpty() && !section.helperName.equals(name)) {
                     throw parserError(
                             "section end tag [" + name + "] does not match the start tag [" + section.helperName + "]");

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -32,6 +32,14 @@ public class ParserTest {
     }
 
     @Test
+    public void testSectionEndWithoutStart() {
+        assertParserError("Hello {/}",
+                "Parser error on line 1: no section start tag found for {/}", 1);
+        assertParserError("{#if true}Bye...{/if} Hello {/if}",
+                "Parser error on line 1: no section start tag found for {/if}", 1);
+    }
+
+    @Test
     public void testNonexistentHelper() {
         assertParserError("Hello!\n {#foo test/}",
                 "Parser error on line 2: no section helper found for {#foo test/}", 2);


### PR DESCRIPTION
- handle the error case where a section end tag has no relevant section
start tag and is not placed inside another section