### PR TITLE
fix missing quarkus gradle dependency

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -58,7 +58,6 @@ import io.quarkus.bootstrap.resolver.AppModelResolver;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.DevModeMain;
-import io.quarkus.gradle.QuarkusPlugin;
 import io.quarkus.gradle.QuarkusPluginExtension;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.utilities.JavaBinFinder;
@@ -482,20 +481,19 @@ public class QuarkusDev extends QuarkusTask {
         boolean foundQuarkusPlugin = false;
         Project prj = getProject();
         while (prj != null && !foundQuarkusPlugin) {
-            if (prj.getPlugins().hasPlugin(QuarkusPlugin.ID)) {
-                final Set<ResolvedDependency> firstLevelDeps = prj.getBuildscript().getConfigurations().getByName("classpath")
-                        .getResolvedConfiguration().getFirstLevelModuleDependencies();
-                if (firstLevelDeps.isEmpty()) {
-                    // TODO this looks weird
-                } else {
-                    for (ResolvedDependency rd : firstLevelDeps) {
-                        if ("io.quarkus.gradle.plugin".equals(rd.getModuleName())) {
-                            rd.getAllModuleArtifacts().stream()
-                                    .map(ResolvedArtifact::getFile)
-                                    .forEach(f -> addToClassPaths(classPathManifest, f));
-                            foundQuarkusPlugin = true;
-                            break;
-                        }
+            final Set<ResolvedDependency> firstLevelDeps = prj.getBuildscript().getConfigurations().getByName("classpath")
+                    .getResolvedConfiguration().getFirstLevelModuleDependencies();
+
+            if (firstLevelDeps.isEmpty()) {
+                // TODO this looks weird
+            } else {
+                for (ResolvedDependency rd : firstLevelDeps) {
+                    if ("io.quarkus.gradle.plugin".equals(rd.getModuleName())) {
+                        rd.getAllModuleArtifacts().stream()
+                                .map(ResolvedArtifact::getFile)
+                                .forEach(f -> addToClassPaths(classPathManifest, f));
+                        foundQuarkusPlugin = true;
+                        break;
                     }
                 }
             }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/ModuleWithParentDependencyDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/ModuleWithParentDependencyDevModeTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleWithParentDependencyDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "multi-module-parent-dependency";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("hello");
+    }
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/main/java/io/quarkus/reproducer/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/main/java/io/quarkus/reproducer/ExampleResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.reproducer;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>io.quarkus.reproducer - 1.0.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: io.quarkus</li>
+                <li>ArtifactId: io.quarkus.reproducer</li>
+                <li>Version: 1.0.0-SNAPSHOT</li>
+                <li>Quarkus Version: 1.3.1.Final</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# Configuration file
+# key = value

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/native-test/java/io/quarkus/reproducer/NativeExampleResourceIT.java
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/native-test/java/io/quarkus/reproducer/NativeExampleResourceIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.reproducer;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeExampleResourceIT extends ExampleResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/test/java/io/quarkus/reproducer/ExampleResourceTest.java
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/app/src/test/java/io/quarkus/reproducer/ExampleResourceTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.reproducer;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class ExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello"));
+    }
+
+}

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/build.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/build.gradle
@@ -1,0 +1,15 @@
+
+plugins {
+    id 'io.quarkus' apply false
+}
+
+subprojects {
+    group = 'io.quarkus.reproducer'
+    version = '1.0.0-SNAPSHOT'
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/gradle.properties
@@ -1,0 +1,4 @@
+#Quarkus Gradle TS
+#Sat May 23 23:11:14 CEST 2020
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/multi-module-parent-dependency/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name='io.quarkus.reproducer'
+
+include 'app'


### PR DESCRIPTION
this branch closes #9842 by looking to all buildscript dependency not only buildscript declaring quarkus as parent.

