### PR TITLE
Dockerfile.native - write access to /work directory

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-native.ftl
@@ -16,6 +16,9 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
 COPY --chown=1001:root ${build_dir}/*-runner /work/application
 
 EXPOSE 8080

--- a/independent-projects/tools/devtools-common/src/test/resources/templates/dockerfile-native.ftl
+++ b/independent-projects/tools/devtools-common/src/test/resources/templates/dockerfile-native.ftl
@@ -16,6 +16,9 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
 COPY --chown=1001:root ${build_dir}/*-runner /work/application
 
 EXPOSE 8080


### PR DESCRIPTION
The Quarkus JTA implementation "JBoss Transactions" needs to write an object-store into the working directory and fails if the application has no write access. 

```
Caused by: com.arjuna.ats.arjuna.exceptions.ObjectStoreException: ARJUNA012225: FileSystemStore::setupStore - cannot access root of object store: /work/ObjectStore/ShadowNoFileLockStore/defaultStore/
```

This pull-request changes the privileges and owner-ship of the `/work` directory without increasing the resulting docker-image size.