### PR TITLE
Fix test dependency filtering in DevMojo

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -871,16 +871,12 @@ public class DevMojo extends AbstractMojo {
 
         for (LocalProject project : localProject.getSelfWithLocalDeps()) {
             inProject.add(project.getKey());
-            final Artifact projectDep = this.project.getArtifactMap().get(project.getGroupId() + ':' + project.getArtifactId());
-            if (project.getClassesDir() != null
-                    && (
-                    // if it is not found among project.getArtifacts() it shouldn't be included (e.g. a local test dependency)
-                    (localProject != project && projectDep == null)
-                            //if this project also contains Quarkus extensions we do no want to include these in the discovery
-                            //a bit of an edge case, but if you try and include a sample project with your extension you will
-                            //run into problems without this
-                            || (Files.exists(project.getClassesDir().resolve("META-INF/quarkus-extension.properties")) ||
-                                    Files.exists(project.getClassesDir().resolve("META-INF/quarkus-build-steps.list"))))) {
+            if (project.getClassesDir() != null &&
+            //if this project also contains Quarkus extensions we do no want to include these in the discovery
+            //a bit of an edge case, but if you try and include a sample project with your extension you will
+            //run into problems without this
+                    (Files.exists(project.getClassesDir().resolve("META-INF/quarkus-extension.properties")) ||
+                            Files.exists(project.getClassesDir().resolve("META-INF/quarkus-build-steps.list")))) {
                 toRemove.add(project);
                 extensionsAndDeps.add(project.getKey());
             } else {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -294,6 +294,9 @@ public class LocalProject {
             }
         }
         for (Dependency dep : project.getRawModel().getDependencies()) {
+            if ("test".equals(dep.getScope())) {
+                continue;
+            }
             final AppArtifactKey depKey = project.getKey(dep);
             final LocalProject localDep = project.workspace.getProject(depKey);
             if (localDep == null || addedDeps.contains(depKey)) {

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -294,7 +294,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         run(true, "-Dquarkus.platform.version=" + projectVersion,
                 "-Dquarkus-plugin.version=" + projectVersion);
 
-        assertEquals("class not found", DevModeTestUtils.getHttpResponse("/hello"));
+        assertEquals("Test class is not visible", DevModeTestUtils.getHttpResponse("/hello"));
     }
 
     @Test

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/pom.xml
@@ -11,6 +11,10 @@
   <dependencies>
     <dependency>
       <groupId>org.acme</groupId>
+      <artifactId>quarkus-app-lib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.acme</groupId>
       <artifactId>quarkus-app-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/src/main/java/org/acme/quarkus/HelloResource.java
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/src/main/java/org/acme/quarkus/HelloResource.java
@@ -11,13 +11,14 @@ public class HelloResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() throws ClassNotFoundException {
-        String result = "class not found";
         try {
-            Class.forName("org.acme.quarkus.test.SomeTestSupport");
-            result = "class found";
+            Class.forName("org.acme.SomeTestSupport");
+            return "Test class loaded";
         } catch (ClassNotFoundException e) {
-            // ignored
+            // expected
         }
-        return result;
+        Class.forName("org.acme.AcmeUtil");
+        Class.forName("org.acme.AcmeCommon");
+        return "Test class is not visible";
     }
 }

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/common/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/common/pom.xml
@@ -7,11 +7,5 @@
     <artifactId>quarkus-app-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <artifactId>quarkus-app-test</artifactId>
-  <dependencies>
-    <dependency>
-      <groupId>org.acme</groupId>
-      <artifactId>quarkus-app-common</artifactId>
-    </dependency>
-  </dependencies>
+  <artifactId>quarkus-app-common</artifactId>
 </project>

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/common/src/main/java/org/acme/AcmeCommon.java
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/common/src/main/java/org/acme/AcmeCommon.java
@@ -1,0 +1,5 @@
+package org.acme;
+
+public class AcmeCommon {
+
+}

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/library/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/library/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>quarkus-app-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <artifactId>quarkus-app-test</artifactId>
+  <artifactId>quarkus-app-lib</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.acme</groupId>

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/library/src/main/java/org/acme/AcmeUtil.java
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/library/src/main/java/org/acme/AcmeUtil.java
@@ -1,0 +1,5 @@
+package org.acme;
+
+public class AcmeUtil {
+
+}

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/pom.xml
@@ -20,6 +20,8 @@
     <modules>
         <module>app</module>
         <module>test</module>
+        <module>common</module>
+        <module>library</module>
     </modules>
 
     <build>
@@ -43,7 +45,17 @@
             </dependency>
             <dependency>
                 <groupId>org.acme</groupId>
+                <artifactId>quarkus-app-common</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.acme</groupId>
                 <artifactId>quarkus-app</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.acme</groupId>
+                <artifactId>quarkus-app-lib</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/test/src/main/java/org/acme/SomeTestSupport.java
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/test/src/main/java/org/acme/SomeTestSupport.java
@@ -1,4 +1,4 @@
-package org.acme.quarkus.test;
+package org.acme;
 
 public class SomeTestSupport {
 


### PR DESCRIPTION
Filter out test dependencies in LocalProject.getSelfWithLocalDeps() instead of DevMojo

Fixes #10143 