### PR TITLE
OIDC UserInfo support

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -459,6 +459,12 @@ public class OidcTenantConfig {
         @ConfigItem
         public Optional<String> roleClaimSeparator = Optional.empty();
 
+        /**
+         * Source of the principal roles.
+         */
+        @ConfigItem
+        public Optional<Source> source = Optional.empty();
+
         public Optional<String> getRoleClaimPath() {
             return roleClaimPath;
         }
@@ -473,6 +479,33 @@ public class OidcTenantConfig {
 
         public void setRoleClaimSeparator(String roleClaimSeparator) {
             this.roleClaimSeparator = Optional.of(roleClaimSeparator);
+        }
+
+        public Optional<Source> getSource() {
+            return source;
+        }
+
+        public void setSource(Source source) {
+            this.source = Optional.of(source);
+        }
+
+        // Source of the principal roles
+        public static enum Source {
+            /**
+             * ID Token - the default value for the 'web-app' applications.
+             */
+            idtoken,
+
+            /**
+             * Access Token - the default and only supported value for the 'service' applications;
+             * can also be used as the source of roles for the 'web-app' applications.
+             */
+            accesstoken,
+
+            /**
+             * User Info - only supported for the "web-app" applications
+             */
+            userinfo
         }
     }
 
@@ -508,6 +541,15 @@ public class OidcTenantConfig {
         public boolean removeRedirectParameters = true;
 
         /**
+         * Both ID and access tokens are verified as part of the authorization code flow and every time
+         * these tokens are retrieved from the user session. One should disable the access token verification if
+         * it is only meant to be propagated to the downstream services.
+         * Note the ID token will always be verified.
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean verifyAccessToken = true;
+
+        /**
          * Force 'https' as the 'redirect_uri' parameter scheme when running behind an SSL terminating reverse proxy.
          * This property, if enabled, will also affect the logout `post_logout_redirect_uri` and the local redirect requests.
          */
@@ -532,6 +574,12 @@ public class OidcTenantConfig {
          */
         @ConfigItem
         public Optional<String> cookiePath = Optional.empty();
+
+        /**
+         * If this property is set to 'true' then an OIDC UserInfo endpoint will be called
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean userInfoRequired;
 
         public Optional<String> getRedirectPath() {
             return redirectPath;
@@ -579,6 +627,30 @@ public class OidcTenantConfig {
 
         public void setCookiePath(String cookiePath) {
             this.cookiePath = Optional.of(cookiePath);
+        }
+
+        public boolean isUserInfoRequired() {
+            return userInfoRequired;
+        }
+
+        public void setUserInfoRequired(boolean userInfoRequired) {
+            this.userInfoRequired = userInfoRequired;
+        }
+
+        public boolean isRemoveRedirectParameters() {
+            return removeRedirectParameters;
+        }
+
+        public void setRemoveRedirectParameters(boolean removeRedirectParameters) {
+            this.removeRedirectParameters = removeRedirectParameters;
+        }
+
+        public boolean isVerifyAccessToken() {
+            return verifyAccessToken;
+        }
+
+        public void setVerifyAccessToken(boolean verifyAccessToken) {
+            this.verifyAccessToken = verifyAccessToken;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
@@ -1,0 +1,42 @@
+package io.quarkus.oidc;
+
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+public class UserInfo {
+
+    private JsonObject json;
+
+    public UserInfo() {
+    }
+
+    public UserInfo(String userInfoJson) {
+        json = toJsonObject(userInfoJson);
+    }
+
+    public String getString(String name) {
+        return json.getString(name);
+    }
+
+    public JsonArray getArray(String name) {
+        return json.getJsonArray(name);
+    }
+
+    public JsonObject getObject(String name) {
+        return json.getJsonObject(name);
+    }
+
+    public Object get(String name) {
+        return json.get(name);
+    }
+
+    private static JsonObject toJsonObject(String userInfoJson) {
+        try (JsonReader jsonReader = Json.createReader(new StringReader(userInfoJson))) {
+            return jsonReader.readObject();
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -86,7 +86,9 @@ public class DefaultTenantConfigResolver {
 
     boolean isBlocking(RoutingContext context) {
         TenantConfigContext resolver = resolve(context, false);
-        return resolver != null && (resolver.auth == null || resolver.oidcConfig.token.refreshExpired);
+        return resolver != null
+                && (resolver.auth == null || resolver.oidcConfig.token.refreshExpired
+                        || resolver.oidcConfig.authentication.userInfoRequired);
     }
 
     private TenantConfigContext getTenantConfigFromConfigResolver(RoutingContext context, boolean create) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcTokenCredentialProducer.java
@@ -6,7 +6,9 @@ import javax.inject.Inject;
 
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.RefreshToken;
+import io.quarkus.oidc.UserInfo;
 import io.quarkus.security.identity.SecurityIdentity;
 
 @RequestScoped
@@ -36,5 +38,20 @@ public class OidcTokenCredentialProducer {
     @RequestScoped
     RefreshToken currentRefreshToken() {
         return identity.getCredential(RefreshToken.class);
+    }
+
+    /**
+     * The producer method for the current UserInfo
+     *
+     * @return the user info
+     */
+    @Produces
+    @RequestScoped
+    UserInfo currentUserInfo() {
+        UserInfo userInfo = (UserInfo) identity.getAttribute("userinfo");
+        if (userInfo == null) {
+            throw new OIDCException("UserInfo can not be injected");
+        }
+        return userInfo;
     }
 }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -74,6 +74,7 @@ public class OidcResource {
         // This is done to test that an asynchronous JWK refresh call done by Vertx Auth is effective.
         return "{" +
                 "   \"active\": " + introspection + "," +
+                "   \"scope\": \"user\"," +
                 "   \"username\": \"alice\"" +
                 "  }";
     }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantOpaqueResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantOpaqueResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.it.keycloak;
 
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.OIDCException;
@@ -20,7 +20,8 @@ public class TenantOpaqueResource {
     AccessTokenCredential accessToken;
 
     @GET
-    public String userName(@PathParam("tenant") String tenant) {
+    @RolesAllowed("user")
+    public String userName() {
         if (!identity.getCredential(AccessTokenCredential.class).isOpaque()) {
             throw new OIDCException("Opaque token is expected");
         }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -8,15 +8,21 @@ import javax.ws.rs.PathParam;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdToken;
 import io.quarkus.oidc.OIDCException;
+import io.quarkus.oidc.UserInfo;
+import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/tenant/{tenant}/api/user")
 public class TenantResource {
 
     @Inject
     JsonWebToken accessToken;
+
+    @Inject
+    SecurityIdentity securityIdentity;
 
     @Inject
     AccessTokenCredential accessTokenCred;
@@ -27,18 +33,55 @@ public class TenantResource {
 
     @GET
     @RolesAllowed("user")
-    public String userName(@PathParam("tenant") String tenant) {
-        return tenant + ":" + (tenant.startsWith("tenant-web-app") ? getNameWebAppType() : getNameServiceType());
+    public String userNameService(@PathParam("tenant") String tenant) {
+        if (tenant.startsWith("tenant-web-app")) {
+            throw new OIDCException("Wrong tenant");
+        }
+        return tenant + ":" + getNameServiceType();
     }
 
-    private String getNameWebAppType() {
+    @GET
+    @Path("webapp")
+    @RolesAllowed("user")
+    public String userNameWebApp(@PathParam("tenant") String tenant) {
+        if (!tenant.equals("tenant-web-app")) {
+            throw new OIDCException("Wrong tenant");
+        }
+        if (!(securityIdentity.getAttribute("userinfo") instanceof UserInfo)) {
+            throw new OIDCException("userinfo attribute muset be set");
+        }
+        // Not injecting in the service field as not all tenants require it
+        UserInfo userInfo = Arc.container().instance(UserInfo.class).get();
+        if (!idToken.getGroups().contains("user")) {
+            throw new OIDCException("Groups expected");
+        }
+        return tenant + ":" + getNameWebAppType(userInfo.getString("upn"), "upn", "preferred_username");
+    }
+
+    @GET
+    @Path("webapp2")
+    @RolesAllowed("user")
+    public String userNameWebApp2(@PathParam("tenant") String tenant) {
+        if (!tenant.equals("tenant-web-app2")) {
+            throw new OIDCException("Wrong tenant");
+        }
+        if (idToken.getGroups().contains("user")) {
+            throw new OIDCException("Groups are not expected");
+        }
+        return tenant + ":" + getNameWebAppType(idToken.getName(), "preferred_username", "upn");
+    }
+
+    private String getNameWebAppType(String name,
+            String idTokenNameClaim,
+            String idTokenNameClaimNotExpected) {
         if (!"ID".equals(idToken.getClaim("typ"))) {
             throw new OIDCException("Wrong ID token type");
         }
-        String name = idToken.getName();
-        // The test is set up to use 'upn' for the 'web-app' application type
-        if (!name.equals(idToken.getClaim("upn"))) {
-            throw new OIDCException("upn claim is missing");
+        if (!name.equals(idToken.getClaim(idTokenNameClaim))) {
+            throw new OIDCException(idTokenNameClaim + " claim is missing");
+        }
+        if (idToken.getClaim(idTokenNameClaimNotExpected) != null) {
+            throw new OIDCException(idTokenNameClaimNotExpected + " claim is not expected");
         }
         // Access token must be available too
         if (!"Bearer".equals(accessToken.getClaim("typ"))) {

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -25,15 +25,17 @@ quarkus.oidc.tenant-web-app.auth-server-url=${keycloak.url}/realms/quarkus-webap
 quarkus.oidc.tenant-web-app.client-id=quarkus-app-webapp
 quarkus.oidc.tenant-web-app.credentials.secret=secret
 quarkus.oidc.tenant-web-app.application-type=web-app
+quarkus.oidc.tenant-web-app.authentication.user-info-required=true
+quarkus.oidc.tenant-web-app.roles.source=userinfo
 
 # Tenant Web App2
 quarkus.oidc.tenant-web-app2.auth-server-url=${keycloak.url}/realms/quarkus-webapp2
 quarkus.oidc.tenant-web-app2.client-id=quarkus-app-webapp2
 quarkus.oidc.tenant-web-app2.credentials.secret=secret
 quarkus.oidc.tenant-web-app2.application-type=web-app
+quarkus.oidc.tenant-web-app2.roles.source=accesstoken
 
 quarkus.oidc.tenant-public-key.client-id=test
 quarkus.oidc.tenant-public-key.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEqFyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwRTYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5eUF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYnsIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9xnQIDAQAB
 
 smallrye.jwt.sign.key-location=/privateKey.pem
-

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -38,7 +38,7 @@ public class BearerTokenAuthorizationTest {
     @Test
     public void testResolveTenantIdentifierWebApp() throws IOException {
         try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app/api/user");
+            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app/api/user/webapp");
             // State cookie is available but there must be no saved path parameter
             // as the tenant-web-app configuration does not set a redirect-path property
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app"));
@@ -55,7 +55,7 @@ public class BearerTokenAuthorizationTest {
     @Test
     public void testResolveTenantIdentifierWebApp2() throws IOException {
         try (final WebClient webClient = createWebClient()) {
-            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user");
+            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user/webapp2");
             // State cookie is available but there must be no saved path parameter
             // as the tenant-web-app configuration does not set a redirect-path property
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app2"));
@@ -73,7 +73,7 @@ public class BearerTokenAuthorizationTest {
     public void testReAuthenticateWhenSwitchingTenants() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             // tenant-web-app
-            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app/api/user");
+            HtmlPage page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app/api/user/webapp");
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app"));
             assertEquals("Log in to quarkus-webapp", page.getTitleText());
             HtmlForm loginForm = page.getForms().get(0);
@@ -82,7 +82,7 @@ public class BearerTokenAuthorizationTest {
             page = loginForm.getInputByName("login").click();
             assertEquals("tenant-web-app:alice", page.getBody().asText());
             // tenant-web-app2
-            page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user");
+            page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user/webapp2");
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app2"));
             assertEquals("Log in to quarkus-webapp2", page.getTitleText());
             loginForm = page.getForms().get(0);

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -94,6 +94,9 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         client.setDefaultRoles(new String[] { "role-" + clientId });
         if (clientId.startsWith("quarkus-app-webapp")) {
             client.setRedirectUris(Arrays.asList("*"));
+        }
+        if (clientId.equals("quarkus-app-webapp")) {
+            // This instructs Keycloak to include the roles with the ID token too
             client.setDefaultClientScopes(Arrays.asList("microprofile-jwt"));
         }
         return client;


### PR DESCRIPTION
Fixes #8719 
Fixes #8396

This PR has taken me a long time to complete, here is what it does:
- Small update to the opaque token processing (Vertx Auth checks `scope` from the introspection so it is checked in Quarkus too now)
- UserInfo is retrieved and optionally injected if required, initial `UserInfo` representation built around JSONP is done
- Access token retrieved as part of the code flow is now always verified by default - we support injecting it but we don't verify it which is not entirely safe - the docs suggest that it can be disabled if the AT is only meant for the propagation.
- For the code flow it is now possible to choose where the roles should be extracted from, id token (default), AT (it appears that quite often ID token will not have the roles but AT will), and I do recall a user having to write a custom augmentor to get the roles from UserInfo.