### PR TITLE
Reduce log level of "objcopy" missing message

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -546,7 +546,7 @@ public class NativeImageBuildStep {
             }
         }
 
-        log.info("Cannot find executable (objcopy) to separate symbols from executable.");
+        log.debug("Cannot find executable (objcopy) to separate symbols from executable.");
         return false;
     }
 


### PR DESCRIPTION
This is a trivial change to reduce the log level of the `objcopy` command not found log message. Right now, the upstream master, keeps logging that message at `INFO` level (I'm on macOS which doesn't have objcopy) whenever any native image is built. A missing `objcopy` isn't a concerning thing (the code already handles that case), especially when native image debug option hasn't been enabled. So it's better to log this at `DEBUG`, IMO.