### PR TITLE
Add helpful message for QuarkusDevModeTest logging

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -70,7 +70,12 @@ public class QuarkusDevModeTest
 
     static {
         System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
-        rootLogger = (Logger) LogManager.getLogManager().getLogger("");
+        java.util.logging.Logger logger = LogManager.getLogManager().getLogger("");
+        if (!(logger instanceof org.jboss.logmanager.Logger)) {
+            throw new IllegalStateException(
+                    "QuarkusDevModeTest must be used with the the JBoss LogManager. See https://quarkus.io/guides/logging#how-to-configure-logging-for-quarkustest for an example of how to configure it in Maven.");
+        }
+        rootLogger = (org.jboss.logmanager.Logger) logger;
     }
 
     private DevModeMain devModeMain;


### PR DESCRIPTION
Done because Kogito encountered a CCE the cause of which
would have been immediately evident had this message existed.

Mentioned by @evacchi [here](https://github.com/quarkusio/quarkus/issues/8694#issuecomment-652849090)

