### PR TITLE
Fix typo in max header size value

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -209,7 +209,7 @@ The following properties are supported.
 |===
 |Property Name|Default|Description
 |quarkus.http.limits.max-body-size| `10240K` |The maximum size of request body.
-|quarkus.http.limits.max-header-size|`2OK`|The maximum length of all headers.
+|quarkus.http.limits.max-header-size|`20K`|The maximum length of all headers.
 |===
 
 [NOTE]


### PR DESCRIPTION
Fixes the typo in the value of default max header size.