### PR TITLE
Deprecate RecorderContext#classProxy method

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -77,7 +77,7 @@ import io.quarkus.runtime.StartupTask;
  * <p>
  * - primitives
  * - String
- * - Class (see {@link #classProxy(String)} to handle classes that are not loadable at generation time)
+ * - Class
  * - Objects with a no-arg constructor and getter/setters for all properties
  * - Any arbitrary object via the {@link #registerSubstitution(Class, Class, Class)} mechanism
  * - arrays, lists and maps of the above

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/RecorderContext.java
@@ -45,7 +45,10 @@ public interface RecorderContext {
      *
      * @param name The class name
      * @return A Class instance that can be passed to a recording proxy
+     * @deprecated This construct is no longer needed since directly loading deployment/application classes at
+     *             processing time in build steps is now safe
      */
+    @Deprecated
     Class<?> classProxy(String name);
 
     /**

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -52,7 +52,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -233,14 +232,15 @@ public class MessageBundleProcessor {
 
     @Record(value = STATIC_INIT)
     @BuildStep
-    void initBundleContext(RecorderContext context, MessageBundleRecorder recorder,
+    void initBundleContext(MessageBundleRecorder recorder,
             List<MessageBundleMethodBuildItem> messageBundleMethods,
             List<MessageBundleBuildItem> bundles,
-            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) throws ClassNotFoundException {
 
         Map<String, Map<String, Class<?>>> bundleInterfaces = new HashMap<>();
         for (MessageBundleBuildItem bundle : bundles) {
-            Class<?> bundleClass = context.classProxy(bundle.getDefaultBundleInterface().toString());
+            final Class<?> bundleClass = Class.forName(bundle.getDefaultBundleInterface().toString(), true,
+                    Thread.currentThread().getContextClassLoader());
             Map<String, Class<?>> localeToInterface = new HashMap<>();
             localeToInterface.put(MessageBundles.DEFAULT_LOCALE,
                     bundleClass);


### PR DESCRIPTION
As discussed in the Quarkus dev mailing list, the `RecorderContext#classProxy` is no longer needed since the build steps can now safely load the application/deployment classes without the need for this proxy construct.

This PR has 3 commits - one which does the deprecation and a couple of others which remove the usage of `classProxy` from qute and smallrye-health extensions. The updates to qute and smallrye-health are here to make sure things do actually work fine if the usage of `classProxy` method is replaced. If this shows no regressions, then as separate PRs we can move some of the remaining extensions in this repo, away from this method.