### PR TITLE
Fix race condition in scheduler and quartz's ConcurrentExecutionTest

### DIFF
--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ConcurrentExecutionTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ConcurrentExecutionTest.java
@@ -44,6 +44,10 @@ public class ConcurrentExecutionTest {
 
         @Scheduled(every = "1s", concurrentExecution = SKIP)
         void nonconcurrent() throws InterruptedException {
+            if (LATCH.getCount() == 0) {
+                // we are already done with our test, don't increment the counter anymore
+                return;
+            }
             COUNTER.incrementAndGet();
             if (!LATCH.await(5, TimeUnit.SECONDS)) {
                 throw new IllegalStateException("");

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConcurrentExecutionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConcurrentExecutionTest.java
@@ -44,6 +44,10 @@ public class ConcurrentExecutionTest {
 
         @Scheduled(every = "1s", concurrentExecution = SKIP)
         void nonconcurrent() throws InterruptedException {
+            if (LATCH.getCount() == 0) {
+                // we are already done with our test, don't increment the counter anymore
+                return;
+            }
             COUNTER.incrementAndGet();
             if (!LATCH.await(5, TimeUnit.SECONDS)) {
                 throw new IllegalStateException("");


### PR DESCRIPTION
This PR[1] ran into an unrelated failure[2] which appears to be a race condition in the `ConcurrentExecutionTest`. The PR here tries to prevent that race. There were 2 `ConcurrentExecutionTest` tests, one in `quartz` extension and one in `scheduler`. I updated them both given that they both are doing the same logic.

Having said that, there might be more going on here? The reason I say that is, this exception stacktrace of the failure:
```
2020-07-03T02:58:36.5610209Z [INFO] Running io.quarkus.quartz.test.ConcurrentExecutionTest
2020-07-03T02:58:37.2370796Z 2020-07-03 02:58:37,222 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT on JVM started in 0.286s. 
2020-07-03T02:58:37.2371554Z 2020-07-03 02:58:37,230 INFO  [io.quarkus] (main) Profile test activated. 
2020-07-03T02:58:37.2372133Z 2020-07-03 02:58:37,230 INFO  [io.quarkus] (main) Installed features: [cdi, scheduler]
2020-07-03T02:58:39.2334866Z 2020-07-03 02:58:39,229 INFO  [io.quarkus] (main) Quarkus stopped in 0.003s
2020-07-03T02:58:39.2357907Z [ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.67 s <<< FAILURE! - in io.quarkus.quartz.test.ConcurrentExecutionTest
2020-07-03T02:58:39.2359910Z [ERROR] io.quarkus.quartz.test.ConcurrentExecutionTest.testNonconcurrentExecution  Time elapsed: 1.987 s  <<< FAILURE!
2020-07-03T02:58:39.2364006Z org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
2020-07-03T02:58:39.2368414Z 	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
2020-07-03T02:58:39.2373236Z 	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
2020-07-03T02:58:39.2377864Z 	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
2020-07-03T02:58:39.2382881Z 	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
2020-07-03T02:58:39.2387302Z 	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:510)
2020-07-03T02:58:39.2394124Z 	at io.quarkus.quartz.test.ConcurrentExecutionTest.testNonconcurrentExecution(ConcurrentExecutionTest.java:29)
```
Notice that it says `io.quarkus.quartz.test.ConcurrentExecutionTest.testNonconcurrentExecution  Time elapsed: 1.987 s`. I can't see how that test can take anything less than 2.x seconds (given the `LATCH` and the schedule on the `concurrent()` method). Perhaps the JUnit5 reporting is at fault or maybe there indeed is some other issue going on?




[1] https://github.com/quarkusio/quarkus/pull/10442
[2] https://github.com/quarkusio/quarkus/pull/10442/checks?check_run_id=832968580