### PR TITLE
Avoid very unlikely NPE

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -407,21 +407,25 @@ public class DevMojo extends AbstractMojo {
      */
     private void handleResources() throws MojoExecutionException {
         List<Resource> resources = project.getResources();
-        if (!resources.isEmpty()) {
-            Plugin resourcesPlugin = project.getPlugin(ORG_APACHE_MAVEN_PLUGINS + ":" + MAVEN_RESOURCES_PLUGIN);
-            MojoExecutor.executeMojo(
-                    MojoExecutor.plugin(
-                            MojoExecutor.groupId(ORG_APACHE_MAVEN_PLUGINS),
-                            MojoExecutor.artifactId(MAVEN_RESOURCES_PLUGIN),
-                            MojoExecutor.version(resourcesPlugin.getVersion()),
-                            resourcesPlugin.getDependencies()),
-                    MojoExecutor.goal("resources"),
-                    getPluginConfig(resourcesPlugin),
-                    MojoExecutor.executionEnvironment(
-                            project,
-                            session,
-                            pluginManager));
+        if (resources.isEmpty()) {
+            return;
         }
+        Plugin resourcesPlugin = project.getPlugin(ORG_APACHE_MAVEN_PLUGINS + ":" + MAVEN_RESOURCES_PLUGIN);
+        if (resourcesPlugin == null) {
+            return;
+        }
+        MojoExecutor.executeMojo(
+                MojoExecutor.plugin(
+                        MojoExecutor.groupId(ORG_APACHE_MAVEN_PLUGINS),
+                        MojoExecutor.artifactId(MAVEN_RESOURCES_PLUGIN),
+                        MojoExecutor.version(resourcesPlugin.getVersion()),
+                        resourcesPlugin.getDependencies()),
+                MojoExecutor.goal("resources"),
+                getPluginConfig(resourcesPlugin),
+                MojoExecutor.executionEnvironment(
+                        project,
+                        session,
+                        pluginManager));
     }
 
     private void executeCompileGoal(Plugin plugin, String groupId, String artifactId) throws MojoExecutionException {


### PR DESCRIPTION
I was able to reproduce the NPE initially
when adding the test for https://github.com/quarkusio/quarkus/pull/10421.
The way I got around it in that test was to
make sure the compile phase was invoked