### PR TITLE
Adds smallrye cloud events

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -44,6 +44,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.0.13</smallrye-converter-api.version>
         <smallrye-reactive-messaging.version>2.1.1</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging-cloud-events.version>2.1.1</smallrye-reactive-messaging-cloud-events.version>
         <swagger-ui.version>3.28.0</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -3620,7 +3621,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-reactive-messaging-cloud-events</artifactId>
+                <version>${smallrye-reactive-messaging-cloud-events.version}</version>
+            </dependency>            
+            
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>

--- a/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-amqp/runtime/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>smallrye-reactive-messaging-amqp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-cloud-events</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
         </dependency>

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>smallrye-reactive-messaging-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-cloud-events</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>


### PR DESCRIPTION
Adds the smallrye-reactive-messaging-cloud-events package to the quarkus-smallrye-reactive-messaging-amqp and quarkus-smallrye-reactive-messaging-kafka. 

Todo #1515