### PR TITLE
Switch liquibase dependency to 3.10.1 version

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -155,7 +155,7 @@
         <jgit.version>5.8.0.202006091008-r</jgit.version>
         <flyway.version>6.5.0</flyway.version>
         <yasson.version>1.0.7</yasson.version>
-        <liquibase.version>3.10.0</liquibase.version>
+        <liquibase.version>3.10.1</liquibase.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <neo4j-java-driver.version>4.0.1</neo4j-java-driver.version>

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/LiquibaseProcessor.java
@@ -110,6 +110,7 @@ class LiquibaseProcessor {
             Index index = reader.read();
             Map<String, List<String>> services = new HashMap<>();
             for (Class<?> c : Arrays.asList(liquibase.diff.compare.DatabaseObjectComparator.class,
+                    liquibase.command.LiquibaseCommand.class,
                     liquibase.parser.NamespaceDetails.class,
                     liquibase.precondition.Precondition.class,
                     liquibase.database.Database.class,
@@ -120,8 +121,7 @@ class LiquibaseProcessor {
                     liquibase.datatype.LiquibaseDataType.class,
                     liquibase.executor.Executor.class,
                     liquibase.lockservice.LockService.class,
-                    liquibase.sqlgenerator.SqlGenerator.class,
-                    liquibase.license.LicenseService.class)) {
+                    liquibase.sqlgenerator.SqlGenerator.class)) {
                 List<String> impls = new ArrayList<>();
                 services.put(c.getName(), impls);
                 Set<ClassInfo> classes = new HashSet<>();
@@ -143,6 +143,11 @@ class LiquibaseProcessor {
                     }
                 }
             }
+            // add license service manually. Index file for windows/jdk11 does not contain
+            // implementation 'liquibase.pro.packaged.kp' class for interface 'liquibase.license.LicenseService'
+            services.put(liquibase.license.LicenseService.class.getName(),
+                    Collections.singletonList("liquibase.pro.packaged.kp"));
+
             //if we know what DB types are in use we limit them
             //this gives a huge startup time boost
             //otherwise it generates SQL for every DB
@@ -236,8 +241,11 @@ class LiquibaseProcessor {
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.7.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd",
+                "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd",
+                "www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd",
+                "www.liquibase.org/xml/ns/pro/liquibase-pro-3.10.xsd",
                 "liquibase.build.properties"));
 
         // liquibase resource bundles


### PR DESCRIPTION
Issue: `failed to find pre-indexed service interface liquibase.command.LiquibaseCommand, 
falling back to slow classpath scanning`
Fix: Search for the implementation classes of the interface `liquibase.command.LiquibaseCommand`  in the index

Issue: NPE
Fix: On Windows + jdk11 the class `liquibase.pro.packaged.kp` is not in the index (Could be index issue)
Fix: Add the implementation for license service `liquibase.license.LicenseService` interface manually.
```
// add license service manually. Index file for windows/jdk11 does not contain
// implementation 'liquibase.pro.packaged.kp' class for interface 'liquibase.license.LicenseService'
services.put(liquibase.license.LicenseService.class.getName(),
         Collections.singletonList("liquibase.pro.packaged.kp"));
```

Issue: XSD for native image
Fix: Currently we need to manually add the `xsd` for the native image for each version of the Liquibase.
```
"www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.7.xsd",
"www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd",
"www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd",
"www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd",
"www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd",
"www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd",
"www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd",
"www.liquibase.org/xml/ns/pro/liquibase-pro-3.10.xsd",
"liquibase.build.properties"));
```
For this I created an issue https://github.com/quarkusio/quarkus/issues/7033