### PR TITLE
docs: multipart-provider is not a quarkus extension

### DIFF
--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -84,12 +84,22 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=amazon-s3-quickstart \
     -DclassName="org.acme.s3.S3SyncClientResource" \
     -Dpath="/s3" \
-    -Dextensions="resteasy-jsonb,multipart-provider,amazon-s3"
+    -Dextensions="resteasy-jsonb,amazon-s3"
 cd amazon-s3-quickstart
 ----
 
 This command generates a Maven structure importing the RESTEasy/JAX-RS and S3 Client extensions.
 After this, the `amazon-s3` extension has been added to your `pom.xml`.
+
+Then, we'll add the following dependency to support `multipart/form-data` requests:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.jboss.resteasy</groupId>
+    <artifactId>resteasy-multipart-provider</artifactId>
+</dependency>
+----
 
 == Setting up the model
 


### PR DESCRIPTION
```
mvn io.quarkus:quarkus-maven-plugin:1.5.2.Final:create \
    -DprojectGroupId=org.acme \
    -DprojectArtifactId=amazon-s3-quickstart \
    -DclassName="org.acme.s3.S3SyncClientResource" \
    -Dpath="/s3" \
    -Dextensions="resteasy-jsonb,multipart-provider,amazon-s3"
```

I tried the above command in the [S3 guide](https://quarkus.io/guides/amazon-s3) and got the following error.

```
❌ Cannot find a dependency matching 'multipart-provider', maybe a typo?
```

So I fixed the document according to [this  guide](https://quarkus.io/guides/rest-client-multipart).