### PR TITLE
Allow Arc to deal with final methods of beans that need to be proxied

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -647,7 +647,15 @@ class Services {
 * Private static methods are never intercepted
 * `InvocationContext#getTarget()` returns `null` for obvious reasons; therefore not all existing interceptors may behave correctly when intercepting static methods
 +
-NOTE: Interceptors can use `InvocationContext.getMethod()` to detect static methods and adjust the behavior accordingly. 
+NOTE: Interceptors can use `InvocationContext.getMethod()` to detect static methods and adjust the behavior accordingly.
+
+=== Ability to handle 'final' classes and methods
+
+In normal CDI, classes that are marked as `final` and / or have `final` methods are not eligible for proxy creation,
+which in turn means that interceptors and normal scoped beans don't work properly.
+This situation is very common when trying to use CDI with alternative JVM languages like Kotlin where classes and methods are `final` by default.
+
+Quarkus however, can overcome these limitations when `quarkus.arc.transform-unproxyable-classes` is set to `true` (which is the default value).
 
 == Build Time Extension Points
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -59,6 +59,13 @@ public class ArcConfig {
      * If set to true, the bytecode of unproxyable beans will be transformed. This ensures that a proxy/subclass
      * can be created properly. If the value is set to false, then an exception is thrown at build time indicating that a
      * subclass/proxy could not be created.
+     *
+     * Quarkus performs the following transformations when this setting is enabled:
+     * <ul>
+     * <li>Remove 'final' modifier from classes and methods when a proxy is required.
+     * <li>Create a no-args constructor if needed.
+     * <li>Makes private no-args constructors package-private if necessary.
+     * </ul
      */
     @ConfigItem(defaultValue = "true")
     public boolean transformUnproxyableClasses;

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unproxyable/RequestScopedFinalMethodsTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unproxyable/RequestScopedFinalMethodsTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.arc.test.unproxyable;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RequestScopedFinalMethodsTest {
+
+    @RegisterExtension
+    public static QuarkusUnitTest container = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RequestScopedBean.class));
+
+    @Test
+    public void testRequestScopedBeanWorksProperly() {
+        ArcContainer container = Arc.container();
+        ManagedContext requestContext = container.requestContext();
+        requestContext.activate();
+
+        InstanceHandle<RequestScopedBean> handle = container.instance(RequestScopedBean.class);
+        Assertions.assertTrue(handle.isAvailable());
+
+        RequestScopedBean bean = handle.get();
+        Assertions.assertNull(bean.getProp());
+        bean.setProp(100);
+        Assertions.assertEquals(100, bean.getProp());
+
+        requestContext.terminate();
+        requestContext.activate();
+
+        handle = container.instance(RequestScopedBean.class);
+        bean = handle.get();
+        Assertions.assertTrue(handle.isAvailable());
+        Assertions.assertNull(bean.getProp());
+    }
+
+    @RequestScoped
+    static class RequestScopedBean {
+        private Integer prop = null;
+
+        public final Integer getProp() {
+            return prop;
+        }
+
+        public final void setProp(Integer prop) {
+            this.prop = prop;
+        }
+    }
+
+    @Dependent
+    static class StringProducer {
+
+        @Inject
+        Event<String> event;
+
+        void fire(String value) {
+            event.fire(value);
+        }
+
+    }
+
+    @Singleton
+    static class StringObserver {
+
+        private List<Integer> events;
+
+        @Inject
+        RequestScopedBean requestScopedBean;
+
+        @PostConstruct
+        void init() {
+            events = new CopyOnWriteArrayList<>();
+        }
+
+        void observeSync(@Observes Integer value) {
+            Integer oldValue = requestScopedBean.getProp();
+            Integer newValue = oldValue == null ? value : value + oldValue;
+            requestScopedBean.setProp(newValue);
+            events.add(newValue);
+        }
+
+        List<Integer> getEvents() {
+            return events;
+        }
+
+    }
+}


### PR DESCRIPTION
This is done in the same manner that is already present for
interceptors and is very useful for Kotlin code where methods
are final by default

Fixes: #10290