### PR TITLE
Update asciidoctor-maven-plugin to latest stable v2.0.0

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -15,8 +15,8 @@
 
     <packaging>jar</packaging>
     <properties>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <asciidoctor-maven-plugin.version>2.0.0-RC.1</asciidoctor-maven-plugin.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
         <asciidoctorj-pdf.version>1.5.0-beta.8</asciidoctorj-pdf.version>
         <quarkus-home-url>https://quarkus.io</quarkus-home-url>
         <quarkus-base-url>https://github.com/quarkusio/quarkus</quarkus-base-url>


### PR DESCRIPTION
Even though main Quarkus site is build in another repo, asciidoctor-maven-plugin plugin released stable version, no need to keep the RC ([release notes](https://github.com/asciidoctor/asciidoctor-maven-plugin/releases/tag/asciidoctor-maven-plugin-2.0.0)).
Also updates to latests Asciidoctorj, reviewed config, made a build of the docs, and everything is fine.
