### PR TITLE
Make sure --no-daemon does indeed get used when quarkus-platform-descriptor-json module is built

### DIFF
--- a/devtools/platform-descriptor-json/pom.xml
+++ b/devtools/platform-descriptor-json/pom.xml
@@ -79,6 +79,12 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <executable>${gradle-wrapper.path}/${gradle.executable}</executable>
+                            <environmentVariables>
+                                <!-- Force a higher value than the default 64m, used by
+                                 gradlew script, to make sure the no-daemon option is honoured
+                                -->
+                                <JAVA_OPTS>-Xmx512m</JAVA_OPTS>
+                            </environmentVariables>
                             <arguments>
                                 <argument>wrapper</argument>
                                 <argument>--no-daemon</argument>


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/10468 introduced the `--no-daemon` flag to help with https://github.com/quarkusio/quarkus/issues/10454. But for reasons noted here https://github.com/quarkusio/quarkus/issues/10454#issuecomment-653731422, that flag is effectively a no-op in its current state (as shown here https://github.com/quarkusio/quarkus/issues/10454#issuecomment-654569197).

The commit in this PR increases the default max heap size to something higher than `64m` to make sure the `--no-daemon` option does get honoured.
I have tested this change locally and I can confirm that with this change the Gradle daemon process isn't launched or used. Whether or not this is the cause of the hang will be known once this gets tested by @galderz. But keeping the hang aside, if we do want `--no-daemon` (which I think is the right thing) then we need to use this non-default `Xmx` value too.