### PR TITLE
add quarkusDev tips on compilerArgs

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -192,6 +192,11 @@ quarkusDev {
 }
 ----
 
+[TIP]
+====
+By default, the `quarkusDev` task uses `compileJava` compiler options. These can be overridden by setting the `compilerArgs` property in the task.
+====
+
 === Remote Development Mode
 
 It is possible to use development mode remotely, so that you can run Quarkus in a container environment (such as OpenShift)


### PR DESCRIPTION
Regarding issue #10472 I added a small tips in the docs to specify how to set  java compiler options. 