### PR TITLE
Default file.encoding system property to UTF-8 during native image build

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -223,7 +223,11 @@ public class NativeImageBuildStep {
                 }
             }
             command.add("-J-Duser.language=" + System.getProperty("user.language"));
-            command.add("-J-Dfile.encoding=" + System.getProperty("file.encoding"));
+            // Native image runtime uses the host's (i.e. build time) value of file.encoding
+            // system property. We intentionally default this to UTF-8 to avoid platform specific
+            // defaults to be picked up which can then result in inconsistent behaviour in the
+            // generated native application
+            command.add("-J-Dfile.encoding=UTF-8");
 
             if (enableSslNative) {
                 nativeConfig.enableHttpsUrlHandler = true;


### PR DESCRIPTION
As discussed here https://github.com/quarkusio/quarkus/issues/1971 and in the linked graal repo issue, I think making UTF-8 the default `file.encoding` should help prevent platform specific inconsistencies in the generated native image.