### PR TITLE
set info log level on gradle

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -325,8 +325,7 @@ jobs:
     name: Windows JDK 11 JVM Gradle Tests
     needs: build-jdk11
     runs-on: windows-latest
-    timeout-minutes: 60
-
+    timeout-minutes: 80
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -344,6 +343,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Gradle
         uses: eskatos/gradle-command-action@v1
+        timeout-minutes: 60
         env:
           GRADLE_OPTS: -Xmx1408m
         with:

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/java/gradle.properties-template.ftl
@@ -2,3 +2,4 @@ quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
 quarkusPluginVersion = ${plugin_version}
+org.gradle.logging.level=INFO

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/kotlin/gradle.properties-template.ftl
@@ -2,3 +2,4 @@ quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
 quarkusPluginVersion = ${plugin_version}
+org.gradle.logging.level=INFO

--- a/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/gradle.properties-template.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/basic-rest/scala/gradle.properties-template.ftl
@@ -2,3 +2,4 @@ quarkusPlatformGroupId = ${bom_groupId}
 quarkusPlatformArtifactId = ${bom_artifactId}
 quarkusPlatformVersion = ${bom_version}
 quarkusPluginVersion = ${plugin_version}
+org.gradle.logging.level=INFO

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/CreateProjectMojoIT.java
@@ -238,7 +238,14 @@ public class CreateProjectMojoIT extends QuarkusPlatformAwareMojoTestBase {
         testDir = new File(testDir, "acme");
 
         assertThat(new File(testDir, "build.gradle")).isFile();
+        assertThat(new File(testDir, "gradlew.bat")).isFile();
+        assertThat(new File(testDir, "gradlew")).isFile();
+        assertThat(new File(testDir, "gradle/wrapper")).isDirectory();
         assertThat(new File(testDir, "src/main/kotlin")).isDirectory();
+
+        File gradleProperties = new File(testDir, "gradle.properties");
+        assertThat(gradleProperties).isFile();
+        check(gradleProperties, "org.gradle.logging.level=INFO");
 
         check(new File(testDir, "src/main/kotlin/org/acme/MyResource.kt"), "package org.acme");
 


### PR DESCRIPTION
As discussed in this thread: https://groups.google.com/forum/#!msg/quarkus-dev/Gp5UwLRaItA/SJd3iCdTBQAJ
This branch set the gradle log level to INFO for newly generated project. 
I also add some assertions in the test. 

@geoand, @jaikiran what do you think?