### PR TITLE
Update manage.sh for updated aws cli for issue 10480

### DIFF
--- a/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/manage.sh
+++ b/extensions/amazon-lambda/common-deployment/src/main/resources/lambda/manage.sh
@@ -24,8 +24,14 @@ function cmd_delete() {
 
 function cmd_invoke() {
   echo Invoking function
+
+  inputFormat=""
+  if [ $(aws --version | awk '{print substr($1,9)}' | cut -c1-1) -ge 2 ]; then inputFormat="--cli-binary-format raw-in-base64-out"; fi
+
   set -x
+
   aws lambda invoke response.txt \
+    ${inputFormat} \
     --function-name ${FUNCTION_NAME} \
     --payload file://payload.json \
     --log-type Tail \


### PR DESCRIPTION
This is a recreation of an old pull request that I broke with a bad merge.

Old PR: https://github.com/quarkusio/quarkus/pull/10481

This resolves an issue where the aws cli expects the input format of the json to be base64. This change allows the input to be raw json so that the manage script works.The current script results in:

/projects/quarkus/lamda-test$ target/manage.sh invoke
Invoking function
++ aws lambda invoke response.txt --function-name LamdaTest --payload file://payload.json --log-type Tail --query LogResult --output text
++ base64 -D

An error occurred (InvalidRequestContentException) when calling the Invoke operation: Could not parse request body into json: Unexpected character ((CTRL-CHAR, code 157)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')
 at [Source: (byte[])"���&����y"; line: 1, column: 2]