### PR TITLE
Hot reload logging fixes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -41,7 +41,7 @@ import io.quarkus.runtime.logging.LoggingSetupRecorder;
 
 public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<String, Object>>, Closeable {
 
-    private static final Logger log = Logger.getLogger(DevModeMain.class);
+    private static final Logger log = Logger.getLogger(IsolatedDevModeMain.class);
     public static final String APP_ROOT = "app-root";
 
     private volatile DevModeContext context;
@@ -101,7 +101,6 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                 } else {
                     //we need to set this here, while we still have the correct TCCL
                     //this is so the config is still valid, and we can read HTTP config from application.properties
-                    log.error("Failed to start Quarkus", t);
                     log.info("Attempting to start hot replacement endpoint to recover from previous Quarkus startup failure");
                     if (runtimeUpdatesProcessor != null) {
                         Thread.currentThread().setContextClassLoader(curatedApplication.getBaseRuntimeClassLoader());
@@ -142,6 +141,8 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
             } catch (Throwable t) {
                 deploymentProblem = t;
                 log.error("Failed to start quarkus", t);
+                Thread.currentThread().setContextClassLoader(curatedApplication.getAugmentClassLoader());
+                LoggingSetupRecorder.handleFailedStart();
             }
         } finally {
             restarting = false;

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.vertx.core.Vertx;
 
 public class VertxProducerTest {
 
@@ -27,24 +28,23 @@ public class VertxProducerTest {
 
     @Test
     public void shouldNotFailWithoutConfig() {
-        producer.vertx = VertxCoreRecorder.initialize(null, null);
-        verifyProducer();
+        verifyProducer(VertxCoreRecorder.initialize(null, null));
     }
 
-    private void verifyProducer() {
-        assertThat(producer.eventbus()).isNotNull();
+    private void verifyProducer(Vertx v) {
+        assertThat(producer.eventbus(v)).isNotNull();
 
-        assertThat(producer.axle()).isNotNull();
-        assertFalse(producer.axle().isClustered());
-        assertThat(producer.axleEventBus(producer.axle())).isNotNull();
+        assertThat(producer.axle(v)).isNotNull();
+        assertFalse(producer.axle(v).isClustered());
+        assertThat(producer.axleEventBus(producer.axle(v))).isNotNull();
 
-        assertThat(producer.rx()).isNotNull();
-        assertFalse(producer.rx().isClustered());
-        assertThat(producer.rxEventBus(producer.rx())).isNotNull();
+        assertThat(producer.rx(v)).isNotNull();
+        assertFalse(producer.rx(v).isClustered());
+        assertThat(producer.rxEventBus(producer.rx(v))).isNotNull();
 
-        assertThat(producer.mutiny()).isNotNull();
-        assertFalse(producer.mutiny().isClustered());
-        assertThat(producer.mutinyEventBus(producer.mutiny())).isNotNull();
+        assertThat(producer.mutiny(v)).isNotNull();
+        assertFalse(producer.mutiny(v).isClustered());
+        assertThat(producer.mutinyEventBus(producer.mutiny(v))).isNotNull();
 
     }
 }


### PR DESCRIPTION
Fixes various logging problems on failed starts, including:
- Vert.x error about undeploying verticles before vert.x was initialized
- No logging if restart fails until issue is fixed
- Startup failure reason being logged twice

Fixes #6209