### PR TITLE
Re-enable WebsocketTestCase.testSendMessageOnOpen

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/WebsocketTestCase.java
@@ -14,7 +14,6 @@ import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.websocket.WebSocketOpenEndpoint;
@@ -105,7 +104,6 @@ public class WebsocketTestCase {
     }
 
     @Test
-    @Disabled("test disabled as the message handler may be registered after the messages being sent.")
     public void testSendMessageOnOpen() throws Exception {
 
         LinkedBlockingDeque<String> message = new LinkedBlockingDeque<>();


### PR DESCRIPTION
This should have been fixed by https://github.com/quarkusio/quarkus-http/commit/a06b3acac0bb6703530be1f1ed97d75ae28a5fba