### PR TITLE
Exit in dev mode if port is in use

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -114,8 +114,12 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                             }
                             runtimeUpdatesProcessor.startupFailed();
                         } catch (Exception e) {
-                            t.addSuppressed(new RuntimeException("Failed to recover after failed start", e));
-                            throw new RuntimeException(t);
+                            close();
+                            log.error("Failed to recover after failed start", e);
+                            //this is the end of the road, we just exit
+                            //generally we only hit this if something is already listening on the HTTP port
+                            //or the system config is so broken we can't start HTTP
+                            System.exit(1);
                         }
                     }
                 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -333,6 +333,9 @@ public class DevMojo extends AbstractMojo {
                 if (System.currentTimeMillis() > nextCheck) {
                     nextCheck = System.currentTimeMillis() + 100;
                     if (!runner.process.isAlive()) {
+                        if (runner.process.exitValue() != 0) {
+                            throw new MojoExecutionException("Dev mode process did not complete successfully");
+                        }
                         return;
                     }
                     final Set<Path> changed = new HashSet<>();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -152,9 +152,15 @@ public class VertxHttpRecorder {
             // the server start to fail
             hotReplacementHandler = prevHotReplacementHandler;
         }
-        VertxConfiguration vertxConfiguration = new VertxConfiguration();
-        ConfigInstantiator.handleObject(vertxConfiguration);
-        Vertx vertx = VertxCoreRecorder.initialize(vertxConfiguration, null);
+        Supplier<Vertx> supplier = VertxCoreRecorder.getVertx();
+        Vertx vertx;
+        if (supplier == null) {
+            VertxConfiguration vertxConfiguration = new VertxConfiguration();
+            ConfigInstantiator.handleObject(vertxConfiguration);
+            vertx = VertxCoreRecorder.initialize(vertxConfiguration, null);
+        } else {
+            vertx = supplier.get();
+        }
 
         try {
             HttpBuildTimeConfig buildConfig = new HttpBuildTimeConfig();


### PR DESCRIPTION
If it is not possible to start a HTTP endpoint to listen
for changes we just immediatly exit with a non-zero exit
code.

Fixes #8416