### PR TITLE
Properly integrate log4j2 inside Quarkus

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -199,6 +199,7 @@
         <commons-compress.version>1.20</commons-compress.version>
         <gson.version>2.8.6</gson.version>
         <webjars-locator-core.version>0.46</webjars-locator-core.version>
+        <log4j2-jboss-logmanager.version>1.0.0.Beta1</log4j2-jboss-logmanager.version>
     </properties>
 
     <dependencyManagement>
@@ -1932,6 +1933,11 @@
                         <artifactId>javax.json</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logmanager</groupId>
+                <artifactId>log4j2-jboss-logmanager</artifactId>
+                <version>${log4j2-jboss-logmanager.version}</version>
             </dependency>
 
             <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -357,7 +357,6 @@
                                             <exclude>io.netty:netty-all</exclude>
                                             <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
                                             <exclude>log4j:log4j</exclude>
-                                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
                                             <exclude>org.apache.logging.log4j:log4j-core</exclude>
                                             <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
                                             <!-- Ban commons-logging (use org.jboss.logging:commons-logging-jboss-logging instead) -->


### PR DESCRIPTION
Extracted from https://github.com/quarkusio/quarkus/pull/8290 .