### PR TITLE
Qute - fix incorrect behavior of Evaluator in loop sections

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -73,14 +73,9 @@ class EvaluatorImpl implements Evaluator {
             // The last part - no need to compose
             return resolve(evalContext, resolvers.iterator());
         } else {
+            // Next part - no need to try the parent context/outer scope
             return resolve(evalContext, resolvers.iterator())
-                    .thenCompose(r -> {
-                        if (parts.hasNext()) {
-                            return resolveReference(tryParent, r, parts, resolutionContext);
-                        } else {
-                            return CompletableFuture.completedFuture(r);
-                        }
-                    });
+                    .thenCompose(r -> resolveReference(false, r, parts, resolutionContext));
         }
     }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -145,6 +146,28 @@ public class LoopSectionTest {
         } catch (TemplateException expected) {
             assertTrue(expected.getMessage().contains("[items] resolved to [java.lang.Boolean]"), expected.getMessage());
         }
+    }
+
+    @Test
+    void testScope() {
+        final HashMap<String, Object> dep1 = new HashMap<>();
+        dep1.put("version", "1.0");
+        final HashMap<String, Object> data = new HashMap<>();
+        data.put("dependencies", Arrays.asList(dep1, new HashMap<>()));
+        data.put("version", "hellllllo");
+        Engine engine = Engine.builder().addDefaults().build();
+        String result = engine.parse("{#for dep in dependencies}{#if dep.version}<version>{dep.version}</version>{/if}{/for}")
+                .render(data);
+        assertFalse(result.contains("hellllllo"), result);
+        result = engine.parse("{#for dep in dependencies}{#if dep.version}<version>{version}</version>{/if}{/for}")
+                .render(data);
+        assertTrue(result.contains("hellllllo"), result);
+        result = engine.parse("{#each dependencies}{#if it.version}<version>{it.version}</version>{/if}{/each}")
+                .render(data);
+        assertFalse(result.contains("hellllllo"), result);
+        result = engine.parse("{#each dependencies}{#if it.version}<version>{version}</version>{/if}{/each}")
+                .render(data);
+        assertTrue(result.contains("hellllllo"), result);
     }
 
 }


### PR DESCRIPTION
- only try the parent context/outer scope for the first part of an
expression
- resolves #10572