### PR TITLE
Display HTTP request contents in the log

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
@@ -12,6 +12,7 @@ import io.vertx.ext.web.RoutingContext;
 public final class FilterBuildItem extends MultiBuildItem {
 
     //predefined system priorities
+    public static final int LOGGER = 400;
     public static final int CORS = 300;
     public static final int AUTHENTICATION = 200;
     public static final int AUTHORIZATION = 100;

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/logging/RequestLoggerProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/logging/RequestLoggerProcessor.java
@@ -1,0 +1,24 @@
+package io.quarkus.vertx.http.deployment.logging;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.vertx.http.deployment.FilterBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.logging.RequestLoggerRecorder;
+
+public class RequestLoggerProcessor {
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void setupRequestLoggerHandler(
+            RequestLoggerRecorder recorder,
+            BuildProducer<FilterBuildItem> filterBuildItemBuildProducer,
+            HttpBuildTimeConfig buildTimeConfig) {
+        if (buildTimeConfig.requestLogger.enabled) {
+            filterBuildItemBuildProducer.produce(
+                    new FilterBuildItem(recorder.handler(buildTimeConfig.requestLogger.format), FilterBuildItem.LOGGER));
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/logging/CustomFormatRequestLoggingHandlerTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/logging/CustomFormatRequestLoggingHandlerTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.vertx.http.logging;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+class CustomFormatRequestLoggingHandlerTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.request-logger.enabled=true\n" +
+            "quarkus.http.request-logger.format=long";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties")
+                    .addClasses(MyBean.class));
+
+    @Test
+    void handle() {
+        RestAssured.given().get("/api").then().statusCode(200);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/api").handler(rc -> rc.response().end());
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.vertx.http.runtime;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.vertx.http.runtime.logging.RequestLoggerConfig;
 import io.vertx.core.http.ClientAuth;
 
 @ConfigRoot(name = "http", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
@@ -35,4 +36,6 @@ public class HttpBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "/quarkus")
     public String consolePath;
+
+    public RequestLoggerConfig requestLogger;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/CustomFormatRequestLoggingHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/CustomFormatRequestLoggingHandler.java
@@ -1,0 +1,43 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import java.text.MessageFormat;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class CustomFormatRequestLoggingHandler implements Handler<RoutingContext> {
+
+    private static final Logger LOGGER = Logger.getLogger(CustomFormatRequestLoggingHandler.class.getName());
+
+    private final RequestLogMessageFormatter requestLogMessageFormatter;
+
+    public CustomFormatRequestLoggingHandler(RequestLogMessageFormatter requestLogMessageFormatter) {
+        this.requestLogMessageFormatter = requestLogMessageFormatter;
+    }
+
+    @Override
+    public void handle(RoutingContext event) {
+        final RequestLogMessage requestLogMessage = RequestLogMessage.builder()
+                .headers(
+                        event.request()
+                                .headers()
+                                .entries()
+                                .stream()
+                                .collect(Collectors
+                                        .toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .method(event.request().method().name())
+                .path(event.request().path())
+                .version(event.request().version())
+                .build();
+
+        LOGGER.info(MessageFormat.format("Request{0}{1}", System.lineSeparator(),
+                this.requestLogMessageFormatter.format(requestLogMessage)));
+
+        event.next();
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLogMessage.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLogMessage.java
@@ -1,0 +1,80 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.vertx.core.http.HttpVersion;
+
+public final class RequestLogMessage {
+
+    private final Map<String, String> headers;
+
+    private final String method;
+
+    private final String path;
+
+    private final HttpVersion version;
+
+    public RequestLogMessage(Builder builder) {
+        this.headers = Collections.unmodifiableMap(builder.headers);
+        this.method = builder.method;
+        this.path = builder.path;
+        this.version = builder.version;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public HttpVersion getVersion() {
+        return version;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private Map<String, String> headers;
+
+        private String method;
+
+        private String path;
+
+        private HttpVersion version;
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder method(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public RequestLogMessage build() {
+            return new RequestLogMessage(this);
+        }
+
+        public Builder version(HttpVersion version) {
+            this.version = version;
+            return this;
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLogMessageFormatter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLogMessageFormatter.java
@@ -1,0 +1,30 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import io.vertx.core.http.HttpVersion;
+
+public class RequestLogMessageFormatter {
+
+    public String format(RequestLogMessage requestLogMessage) {
+        return requestLogMessage.getMethod() + " " + requestLogMessage.getPath() + " " + format(requestLogMessage.getVersion())
+                + System.lineSeparator()
+                + requestLogMessage.getHeaders().entrySet()
+                        .stream()
+                        .map(entry -> entry.getKey() + ": " + entry.getValue())
+                        .reduce((h1, h2) -> String.join(System.lineSeparator(), h1, h2))
+                        .orElse("");
+    }
+
+    private String format(HttpVersion version) {
+        switch (version) {
+            case HTTP_1_0:
+                return "HTTP/1.0";
+            case HTTP_1_1:
+                return "HTTP/1.1";
+            case HTTP_2:
+                return "HTTP/2";
+            default:
+                return version.toString();
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLoggerConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLoggerConfig.java
@@ -1,0 +1,22 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class RequestLoggerConfig {
+
+    /**
+     * Enable logging for all HTTP requests.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enabled;
+
+    /**
+     * The HTTP Request log format.
+     * The possible values are: LONG, DEFAULT, SHORT and TINY.
+     */
+    @ConfigItem(defaultValue = "DEFAULT")
+    public RequestLoggerFormat format;
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLoggerFormat.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLoggerFormat.java
@@ -1,0 +1,14 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+public enum RequestLoggerFormat {
+
+    LONG,
+    DEFAULT,
+    SHORT,
+    TINY;
+
+    public static RequestLoggerFormat parse(String s) {
+        return RequestLoggerFormat.valueOf(s.toUpperCase());
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLoggerRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/RequestLoggerRecorder.java
@@ -1,0 +1,20 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerHandler;
+
+@Recorder
+public class RequestLoggerRecorder {
+
+    private static final RequestLogMessageFormatter REQUEST_LOG_MESSAGE_FORMATTER = new RequestLogMessageFormatter();
+
+    public static final VertxLoggerFormatMapper VERTX_LOGGER_FORMAT_MAPPER = new VertxLoggerFormatMapper();
+
+    public Handler<RoutingContext> handler(RequestLoggerFormat format) {
+        return VERTX_LOGGER_FORMAT_MAPPER.map(format).<Handler<RoutingContext>> map(LoggerHandler::create)
+                .orElseGet(() -> new CustomFormatRequestLoggingHandler(REQUEST_LOG_MESSAGE_FORMATTER));
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/VertxLoggerFormatMapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logging/VertxLoggerFormatMapper.java
@@ -1,0 +1,22 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import java.util.Optional;
+
+import io.vertx.ext.web.handler.LoggerFormat;
+
+public class VertxLoggerFormatMapper {
+
+    public Optional<LoggerFormat> map(RequestLoggerFormat requestLoggerFormat) {
+        switch (requestLoggerFormat) {
+            case DEFAULT:
+                return Optional.of(LoggerFormat.DEFAULT);
+            case SHORT:
+                return Optional.of(LoggerFormat.SHORT);
+            case TINY:
+                return Optional.of(LoggerFormat.TINY);
+            default:
+                return Optional.empty();
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/logging/RequestLogMessageFormatterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/logging/RequestLogMessageFormatterTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.vertx.http.runtime.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.http.HttpVersion;
+
+class RequestLogMessageFormatterTest {
+
+    @Test
+    void format() {
+        final RequestLogMessageFormatter formatter = new RequestLogMessageFormatter();
+
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("Cookie", "any-cookie");
+        headers.put("Accept", "application/json, text/plain, */*");
+        headers.put("Connection", "keep-alive");
+
+        final RequestLogMessage requestLogMessage = RequestLogMessage.builder()
+                .headers(headers)
+                .method("GET")
+                .path("/quarkus")
+                .version(HttpVersion.HTTP_1_1)
+                .build();
+
+        final String expectedFormat = "GET /quarkus HTTP/1.1" + System.lineSeparator()
+                + "Cookie: any-cookie" + System.lineSeparator()
+                + "Accept: application/json, text/plain, */*" + System.lineSeparator()
+                + "Connection: keep-alive";
+
+        assertEquals(expectedFormat, formatter.format(requestLogMessage));
+    }
+}


### PR DESCRIPTION
I couldn't find a way to test the log messages. Is there any similar test case that I can use as an example?
I created two new configurations:

```
# Enables the request logger. The default value is "false"
quarkus.http.request-logger.enabled=true

# Defines the logger format. The possible values are: "long", "default", "short" and "tiny". The default value is "default"
quarkus.http.request-logger.format=long
```