### PR TITLE
add remove extension test

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGradleBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/AbstractGradleBuildFile.java
@@ -46,7 +46,7 @@ public abstract class AbstractGradleBuildFile extends BuildFile {
             try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
                 getModel().getRootPropertiesContent().store(out, "Gradle properties");
                 Files.write(rootProjectPath.get().resolve(GRADLE_PROPERTIES_PATH),
-                        getModel().getRootSettingsContent().getBytes());
+                        out.toByteArray());
             }
         } else {
             writeToProjectFile(SETTINGS_GRADLE_PATH, getModel().getSettingsContent().getBytes());

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToModuleInMultiModuleProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToModuleInMultiModuleProjectTest.java
@@ -28,6 +28,9 @@ public class AddExtensionToModuleInMultiModuleProjectTest extends QuarkusGradleW
         final Path appBuild = projectDir.toPath().resolve("application").resolve("build.gradle");
         assertThat(appBuild).exists();
         assertThat(readFile(appBuild)).contains("implementation 'io.quarkus:quarkus-hibernate-orm'");
+
+        runGradleWrapper(projectDir, ":application:removeExtension", "--extensions=hibernate-orm");
+        assertThat(readFile(appBuild)).doesNotContain("implementation 'io.quarkus:quarkus-hibernate-orm'");
     }
 
     private static String readFile(Path file) throws IOException {


### PR DESCRIPTION
As discussed in zulip thread (https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/gradle.20test.20command)
In multi module project, there were an issue on properties writing. 
The `gradle.properties` file where written with the content of the `settings.gradle` file. 
This branch fix this and add a test on `removeExtension` task (which made this issue visible)
 