### PR TITLE
Add the missing space in the error message.

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -183,7 +183,7 @@ public class ResteasyCommonProcessor {
             String needsMutinyClasses = mutinySupportNeeded(indexBuildItem);
             if (needsMutinyClasses != null) {
                 LOGGER.warn(
-                        "Quarkus detected the need for Mutiny reactive programming support, however the quarkus-resteasy-mutiny extension"
+                        "Quarkus detected the need for Mutiny reactive programming support, however the quarkus-resteasy-mutiny extension "
                                 + "was not present. Reactive REST endpoints in your application that return Uni or Multi " +
                                 "will not function as you expect until you add this extension. Endpoints that need Mutiny are: "
                                 + needsMutinyClasses);


### PR DESCRIPTION
**Problem:**
Currently the error message for a missing extension is  "Quarkus detected the need for Mutiny reactive programming support, however the quarkus-resteasy-mutiny *extensionwas* not present."

**Changes:**
Add a space into the raw string.