### PR TITLE
Add configuration for http max initial line length

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -203,23 +203,7 @@ quarkus.http.cors.access-control-max-age=24H
 
 == HTTP Limits Configuration
 
-The following properties are supported.
-
-[cols="<m,<m,<2",options="header"]
-|===
-|Property Name|Default|Description
-|quarkus.http.limits.max-body-size| `10240K` |The maximum size of request body.
-|quarkus.http.limits.max-header-size|`20K`|The maximum length of all headers.
-|===
-
-[NOTE]
-====
-The following config options will recognize sizes expressed as strings in this format (shown as a regular expression): `[0-9]+[KkMmGgTtPpEeZzYy]?`.
-If no unit suffix is given, bytes are assumed.
-
-* `quarkus.http.limits.max-body-size`,
-* `quarkus.http.limits.max-header-size`
-====
+include::{generated-dir}/config/quarkus-vertx-http-config-group-server-limits-config.adoc[leveloffset=+1, opts=optional]
 
 == Configuring HTTP Access Logs
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -25,4 +25,11 @@ public class ServerLimitsConfig {
      */
     @ConfigItem
     public Optional<MemorySize> maxChunkSize;
+
+    /**
+     * The maximum length of the initial line (e.g. {@code "GET / HTTP/1.0"}).
+     */
+    @ConfigItem(defaultValue = "4096")
+    public int maxInitialLineLength;
+
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -607,6 +607,7 @@ public class VertxHttpRecorder {
         serverOptions.setTcpQuickAck(httpConfiguration.tcpQuickAck);
         serverOptions.setTcpCork(httpConfiguration.tcpCork);
         serverOptions.setTcpFastOpen(httpConfiguration.tcpFastOpen);
+        serverOptions.setMaxInitialLineLength(httpConfiguration.limits.maxInitialLineLength);
 
         return serverOptions;
     }
@@ -700,6 +701,7 @@ public class VertxHttpRecorder {
         options.setTcpQuickAck(httpConfiguration.tcpQuickAck);
         options.setTcpCork(httpConfiguration.tcpCork);
         options.setTcpFastOpen(httpConfiguration.tcpFastOpen);
+        options.setMaxInitialLineLength(httpConfiguration.limits.maxInitialLineLength);
         return options;
     }
 


### PR DESCRIPTION
Netty lets us configure tha maximum length of the initial length of an HTTP request. By default it's 4096.

https://netty.io/4.0/api/io/netty/handler/codec/http/HttpRequestDecoder.html