### PR TITLE
Better support for OIDC without the discovery endpoint

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -33,15 +33,8 @@ public class OidcTenantConfig {
     public ApplicationType applicationType;
 
     /**
-     * The maximum amount of time the adapter will try connecting to the currently unavailable OIDC server for.
-     * For example, setting it to '20S' will let the adapter keep requesting the connection for up to 20 seconds.
-     */
-    @ConfigItem
-    public Optional<Duration> connectionDelay = Optional.empty();
-
-    /**
      * The base URL of the OpenID Connect (OIDC) server, for example, 'https://host:port/auth'.
-     * OIDC discovery endpoint will be called by appending a '/.well-known/openid-configuration' path segment to this URL.
+     * OIDC discovery endpoint will be called by default by appending a '.well-known/openid-configuration' path to this URL.
      * Note if you work with Keycloak OIDC server, make sure the base URL is in the following format:
      * 'https://host:port/auth/realms/{realm}' where '{realm}' has to be replaced by the name of the Keycloak realm.
      */
@@ -49,25 +42,77 @@ public class OidcTenantConfig {
     public Optional<String> authServerUrl = Optional.empty();
 
     /**
-     * Relative path of the RFC7662 introspection service.
+     * Enables OIDC discovery.
+     * If the discovery is disabled then the following properties must be configured:
+     * - 'authorization-path' and 'token-path' for the 'web-app' applications
+     * - 'jwks-path' or 'introspection-path' for both the 'web-app' and 'service' applications
+     * <p>
+     * 'web-app' applications may also have 'user-info-path' and 'end-session-path' properties configured.
      */
+    @ConfigItem(defaultValue = "true")
+    public boolean discoveryEnabled = true;
 
+    /**
+     * Relative path of the OIDC authorization endpoint which authenticates the users.
+     * This property must be set for the 'web-app' applications if OIDC discovery is disabled.
+     * This property will be ignored if the discovery is enabled.
+     */
+    @ConfigItem
+    public Optional<String> authorizationPath = Optional.empty();
+
+    /**
+     * Relative path of the OIDC token endpoint which issues ID, access and refresh tokens.
+     * This property must be set for the 'web-app' applications if OIDC discovery is disabled.
+     * This property will be ignored if the discovery is enabled.
+     */
+    @ConfigItem
+    public Optional<String> tokenPath = Optional.empty();
+
+    /**
+     * Relative path of the OIDC userinfo endpoint.
+     * This property must only be set for the 'web-app' applications if OIDC discovery is disabled
+     * and 'authentication.user-info-required' property is enabled.
+     * This property will be ignored if the discovery is enabled.
+     */
+    @ConfigItem
+    public Optional<String> userInfoPath = Optional.empty();
+
+    /**
+     * Relative path of the OIDC RFC7662 introspection endpoint which can introspect both opaque and JWT tokens.
+     * This property must be set if OIDC discovery is disabled and 1) the opaque bearer access tokens have to be verified
+     * or 2) JWT tokens have to be verified while the cached JWK verification set with no matching JWK is being refreshed.
+     * This property will be ignored if the discovery is enabled.
+     */
     @ConfigItem
     public Optional<String> introspectionPath = Optional.empty();
 
     /**
-     * Relative path of the OIDC service returning a JWK set.
+     * Relative path of the OIDC JWKS endpoint which returns a JSON Web Key Verification Set.
+     * This property should be set if OIDC discovery is disabled and the local JWT verification is required.
+     * This property will be ignored if the discovery is enabled.
      */
     @ConfigItem
     public Optional<String> jwksPath = Optional.empty();
 
     /**
      * Relative path of the OIDC end_session_endpoint.
+     * This property must be set if OIDC discovery is disabled and RP Initiated Logout support for the 'web-app' applications is
+     * required.
+     * This property will be ignored if the discovery is enabled.
      */
     @ConfigItem
     public Optional<String> endSessionPath = Optional.empty();
+
+    /**
+     * The maximum amount of time the adapter will try connecting to the currently unavailable OIDC server for.
+     * For example, setting it to '20S' will let the adapter keep requesting the connection for up to 20 seconds.
+     */
+    @ConfigItem
+    public Optional<Duration> connectionDelay = Optional.empty();
+
     /**
      * Public key for the local JWT token verification.
+     * OIDC server connection will not be created when this property is set.
      */
     @ConfigItem
     public Optional<String> publicKey = Optional.empty();
@@ -200,6 +245,30 @@ public class OidcTenantConfig {
         this.authServerUrl = Optional.of(authServerUrl);
     }
 
+    public Optional<String> getAuthorizationPath() {
+        return authorizationPath;
+    }
+
+    public void setAuthorizationPath(String authorizationPath) {
+        this.authorizationPath = Optional.of(authorizationPath);
+    }
+
+    public Optional<String> getTokenPath() {
+        return tokenPath;
+    }
+
+    public void setTokenPath(String tokenPath) {
+        this.tokenPath = Optional.of(tokenPath);
+    }
+
+    public Optional<String> getUserInfoPath() {
+        return userInfoPath;
+    }
+
+    public void setUserInfoPath(String userInfoPath) {
+        this.userInfoPath = Optional.of(userInfoPath);
+    }
+
     public Optional<String> getIntrospectionPath() {
         return introspectionPath;
     }
@@ -278,6 +347,22 @@ public class OidcTenantConfig {
 
     public void setTenantId(String tenantId) {
         this.tenantId = Optional.of(tenantId);
+    }
+
+    public boolean isTenantEnabled() {
+        return tenantEnabled;
+    }
+
+    public void setTenantEnabled(boolean enabled) {
+        this.tenantEnabled = enabled;
+    }
+
+    public boolean isDiscoveryEnabled() {
+        return discoveryEnabled;
+    }
+
+    public void setDiscoveryEnabled(boolean enabled) {
+        this.discoveryEnabled = enabled;
     }
 
     public Proxy getProxy() {

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -24,12 +24,21 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             OidcTenantConfig config = new OidcTenantConfig();
             config.setTenantId("tenant-oidc");
             String uri = context.request().absoluteURI();
-            String keycloakUri = path.contains("tenant-opaque")
+            String authServerUri = path.contains("tenant-opaque")
                     ? uri.replace("/tenant-opaque/tenant-oidc/api/user", "/oidc")
                     : uri.replace("/tenant/tenant-oidc/api/user", "/oidc");
-            config.setAuthServerUrl(keycloakUri);
+            config.setAuthServerUrl(authServerUri);
             config.setClientId("client");
-            config.getCredentials().setSecret("secret");
+            return config;
+        } else if ("tenant-oidc-no-discovery".equals(tenantId)) {
+            OidcTenantConfig config = new OidcTenantConfig();
+            config.setTenantId("tenant-oidc-no-discovery");
+            String uri = context.request().absoluteURI();
+            String authServerUri = uri.replace("/tenant/tenant-oidc-no-discovery/api/user", "/oidc");
+            config.setAuthServerUrl(authServerUri);
+            config.setDiscoveryEnabled(false);
+            config.setJwksPath("jwks");
+            config.setClientId("client");
             return config;
         }
         return null;

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -67,6 +67,13 @@ public class OidcResource {
     }
 
     @POST
+    @Path("jwk-endpoint-call-count")
+    public int resetJwkEndpointCallCount() {
+        jwkEndpointCallCount = 0;
+        return jwkEndpointCallCount;
+    }
+
+    @POST
     @Produces("application/json")
     @Path("introspect")
     public String introspect() {


### PR DESCRIPTION
We've had `jwksPath` and `instrospectionPath` properties since the very beginning but they've never worked and have only confused the users, due to the fact we have always relied on the auto-discovery

This PR:
- introduces a `discovery-enabled` property (enabled by default)
- if it is disabled - makes sure the minimum set of OIDC endpoint properties is set for `web-app`/`service` and initializes `OAuth2Auth` correctly
- adds a test (relies on the test `OidcResource` which has a jwk endpoint)

CC @MarcusBiel