### PR TITLE
Change inner class modifier in quartz docs

### DIFF
--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -179,7 +179,7 @@ public class TaskBean {
     }
     
     // A new instance of MyJob is created by Quartz for every job execution
-    static class MyJob implements Job {
+    public static class MyJob implements Job {
     
        public void execute(JobExecutionContext context) throws JobExecutionException {
           Arc.container().instance(TaskBean.class).get(). performTask(); <3>


### PR DESCRIPTION
Change inner class modifier, if not a `[See nested exception: java.lang.IllegalAccessException: class org.quartz.simpl.SimpleJobFactory cannot access a member of class org.acme.PeriodicTask$MyJob with modifiers ""]` exception is thrown.