### PR TITLE
Simplify fast jar dockerfiles by only using a single copy command.

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-fast-jar.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-fast-jar.ftl
@@ -45,10 +45,7 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
-COPY --chown=1001 ${build_dir}/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001 ${build_dir}/quarkus-app/*.jar /deployments/
-COPY --chown=1001 ${build_dir}/quarkus-app/app/ /deployments/app/
-COPY --chown=1001 ${build_dir}/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --chown=1001 ${build_dir}/quarkus-app /deployments/
 
 EXPOSE 8080
 USER 1001

--- a/independent-projects/tools/devtools-common/src/test/resources/templates/dockerfile-fast-jar.ftl
+++ b/independent-projects/tools/devtools-common/src/test/resources/templates/dockerfile-fast-jar.ftl
@@ -45,10 +45,7 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
-COPY ${build_dir}/quarkus-app/lib/* /deployments/lib/
-COPY ${build_dir}/quarkus-app/*.jar /deployments/
-COPY ${build_dir}/quarkus-app/app/* /deployments/app/
-COPY ${build_dir}/quarkus-app/quarkus/* /deployments/quarkus/
+COPY ${build_dir}/quarkus-app /deployments/
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
Use only a single COPY command in the fast jar dockerfile templates.