### PR TITLE
Don't generate JdbcDataSourceBuildItem twice

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -260,22 +260,6 @@ class AgroalProcessor {
         }
     }
 
-    @BuildStep
-    void configureDataSources(BuildProducer<JdbcDataSourceBuildItem> jdbcDataSource,
-            List<AggregatedDataSourceBuildTimeConfigBuildItem> aggregatedBuildTimeConfigBuildItems,
-            SslNativeConfigBuildItem sslNativeConfig) {
-        if (aggregatedBuildTimeConfigBuildItems.isEmpty()) {
-            // No datasource has been configured so bail out
-            return;
-        }
-
-        for (AggregatedDataSourceBuildTimeConfigBuildItem aggregatedBuildTimeConfigBuildItem : aggregatedBuildTimeConfigBuildItems) {
-            jdbcDataSource.produce(new JdbcDataSourceBuildItem(aggregatedBuildTimeConfigBuildItem.getName(),
-                    aggregatedBuildTimeConfigBuildItem.getResolvedDbKind(),
-                    DataSourceUtil.isDefault(aggregatedBuildTimeConfigBuildItem.getName())));
-        }
-    }
-
     private List<AggregatedDataSourceBuildTimeConfigBuildItem> getAggregatedConfigBuildItems(
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
             DataSourcesJdbcBuildTimeConfig dataSourcesJdbcBuildTimeConfig,


### PR DESCRIPTION
They are already generated here: https://github.com/quarkusio/quarkus/blob/master/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java#L257 .

I think this is a leftover and we got it wrong when we worked on the synthetic build thing.

Noticed while debugging something else :).