### PR TITLE
Log a warning for constraints on static methods and ignore them

### DIFF
--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.validator.deployment;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -10,6 +11,7 @@ import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.logging.Logger;
 
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.hibernate.validator.runtime.interceptor.MethodValidated;
@@ -19,6 +21,8 @@ import io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidated;
  * Add {@link MethodValidated} annotations to the methods requiring validation.
  */
 public class MethodValidatedAnnotationsTransformer implements AnnotationsTransformer {
+
+    private static final Logger LOGGER = Logger.getLogger(MethodValidatedAnnotationsTransformer.class.getPackage().getName());
 
     private static final DotName[] JAXRS_METHOD_ANNOTATIONS = {
             DotName.createSimple("javax.ws.rs.GET"),
@@ -56,6 +60,15 @@ public class MethodValidatedAnnotationsTransformer implements AnnotationsTransfo
         MethodInfo method = transformationContext.getTarget().asMethod();
 
         if (requiresValidation(method)) {
+            if (Modifier.isStatic(method.flags())) {
+                // We don't support validating methods on static methods yet as it used to not be supported by CDI/Weld
+                // Supporting it will require some work in Hibernate Validator so we are going back to the old behavior of ignoring them but we log a warning.
+                LOGGER.warnf(
+                        "Hibernate Validator does not support constraints on static methods yet. Constraints on %s are ignored.",
+                        method.declaringClass().name().toString() + "#" + method.toString());
+                return;
+            }
+
             if (isJaxrsMethod(method)) {
                 transformationContext.transform().add(DotName.createSimple(JaxrsEndPointValidated.class.getName())).done();
             } else {

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ConstraintOnStaticMethodTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ConstraintOnStaticMethodTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.validator.test;
+
+import javax.inject.Inject;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Pattern;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConstraintOnStaticMethodTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class).addClasses(MyUtil.class));
+
+    @Test
+    public void testStaticMethodIsIgnored() {
+        MyUtil.validateName("My name");
+    }
+
+    public static class MyUtil {
+
+        public static void validateName(@Pattern(regexp = "A.*") String name) {
+            // do nothing
+        }
+    }
+}


### PR DESCRIPTION
We go back to the previous behavior (but with a warning) as Hibernate
Validator does not support constraints on static methods.

Fixes #10579