### PR TITLE
Fixing the GraalVM with macOS Catalina workaround

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -119,7 +119,7 @@ Use the following command to recursively delete the `com.apple.quarantine` exten
 
 [source,shell]
 -----
-xattr -r -d com.apple.quarantine ${GRAALVM_HOME}
+xattr -r -d com.apple.quarantine ${GRAALVM_HOME}/../..
 -----
 ====
 


### PR DESCRIPTION
Updated the command to ensure the whole GraalVM distribution is modified. Otherwise, the workaround didnt work for me, and I got the same error that the workaround was intending to remove.

