### PR TITLE
[Qute] Allow nested content for user defined tags

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -633,12 +633,12 @@ Let's suppose we have a template called `itemDetail.html`:
 ----
 {#if showImage} <1>
   {it.image} <2>
-  {nested} <3>
+  {nested-content} <3>
 {/if}
 ----
 <1> `showImage` is a named parameter.
 <2> `it` is a special key that is replaced with the first unnamed param of the tag.
-<3> (optional) `nested` is a special key that will be replaced by the content of the tag.
+<3> (optional) `nested-content` is a special key that will be replaced by the content of the tag.
 
 Now if we register this template under the name `itemDetail.html` and if we add a `UserTagSectionHelper` to the engine:
 
@@ -660,13 +660,13 @@ We can include the tag like this:
   <li>
   {#itemDetail item showImage=true} <1>
     = <b>{item.name}</b> <2>
-  {/#itemDetail}
+  {/itemDetail}
   </li>
 {/for}
 </ul>
 ----
 <1> `item` is resolved to an iteration element and can be referenced using the `it` key in the tag template.
-<2> Tag content injected using the `nested` key in the tag template.
+<2> Tag content injected using the `nested-content` key in the tag template.
 
 === Engine Configuration
 

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -633,10 +633,12 @@ Let's suppose we have a template called `itemDetail.html`:
 ----
 {#if showImage} <1>
   {it.image} <2>
+  {nested} <3>
 {/if}
 ----
 <1> `showImage` is a named parameter.
 <2> `it` is a special key that is replaced with the first unnamed param of the tag.
+<3> (optional) `nested` is a special key that will be replaced by the content of the tag.
 
 Now if we register this template under the name `itemDetail.html` and if we add a `UserTagSectionHelper` to the engine:
 
@@ -656,12 +658,15 @@ We can include the tag like this:
 <ul>
 {#for item in items}
   <li>
-  {#itemDetail item showImage=true /} <1>
+  {#itemDetail item showImage=true} <1>
+    = <b>{item.name}</b> <2>
+  {/#itemDetail}
   </li>
 {/for}
 </ul>
 ----
 <1> `item` is resolved to an iteration element and can be referenced using the `it` key in the tag template.
+<2> Tag content injected using the `nested` key in the tag template.
 
 === Engine Configuration
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionNode.java
@@ -4,11 +4,12 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 /**
  * This node holds a single expression such as {@code foo.bar}.
  */
-class ExpressionNode implements TemplateNode {
+class ExpressionNode implements TemplateNode, Function<Object, CompletionStage<ResultNode>> {
 
     final ExpressionImpl expression;
     private final Engine engine;
@@ -22,8 +23,18 @@ class ExpressionNode implements TemplateNode {
 
     @Override
     public CompletionStage<ResultNode> resolve(ResolutionContext context) {
-        return context.evaluate(expression)
-                .thenCompose(r -> CompletableFuture.<ResultNode> completedFuture(new SingleResultNode(r, this)));
+        return context.evaluate(expression).thenCompose(this);
+    }
+
+    @Override
+    public CompletionStage<ResultNode> apply(Object result) {
+        if (result instanceof ResultNode) {
+            return CompletableFuture.completedFuture((ResultNode) result);
+        } else if (result instanceof CompletionStage) {
+            return ((CompletionStage<?>) result).thenCompose(this);
+        } else {
+            return CompletableFuture.completedFuture(new SingleResultNode(result, this));
+        }
     }
 
     public Origin getOrigin() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Futures.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Futures.java
@@ -31,6 +31,7 @@ public final class Futures {
                 result.completeExceptionally(t1);
             } else {
                 // Build a map from the params
+                // IMPL NOTE: Keep the map mutable - it can be modified in UserTagSectionHelper 
                 Map<String, Object> paramValues = new HashMap<>();
                 int j = 0;
                 try {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionBlock.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionBlock.java
@@ -39,7 +39,7 @@ public final class SectionBlock {
      */
     List<TemplateNode> nodes;
 
-    public SectionBlock(Origin origin, String id, String label, Map<String, String> parameters,
+    SectionBlock(Origin origin, String id, String label, Map<String, String> parameters,
             Map<String, Expression> expressions,
             List<TemplateNode> nodes) {
         this.origin = origin;
@@ -48,6 +48,10 @@ public final class SectionBlock {
         this.parameters = parameters;
         this.expressions = expressions;
         this.nodes = ImmutableList.copyOf(nodes);
+    }
+
+    public boolean isEmpty() {
+        return nodes.isEmpty();
     }
 
     Set<Expression> getExpressions() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -98,25 +98,25 @@ public interface SectionHelperFactory<T extends SectionHelper> {
      */
     public interface SectionInitContext extends ParserDelegate {
 
-        default Map<String, String> getParameters() {
+        default public Map<String, String> getParameters() {
             return getBlocks().get(0).parameters;
         }
 
-        default boolean hasParameter(String name) {
+        default public boolean hasParameter(String name) {
             return getParameters().containsKey(name);
         }
 
-        default String getParameter(String name) {
+        default public String getParameter(String name) {
             return getParameters().get(name);
         }
 
-        Expression getExpression(String parameterName);
+        public Expression getExpression(String parameterName);
 
-        Expression parseValue(String value);
+        public Expression parseValue(String value);
 
-        List<SectionBlock> getBlocks();
+        public List<SectionBlock> getBlocks();
 
-        Engine getEngine();
+        public Engine getEngine();
 
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
@@ -2,6 +2,7 @@ package io.quarkus.qute;
 
 import static io.quarkus.qute.Futures.evaluateParams;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -12,58 +13,44 @@ import java.util.stream.Collectors;
 public class UserTagSectionHelper implements SectionHelper {
 
     private static final String IT = "it";
-
-    private static final String NESTED = "nested";
+    private static final String NESTED_CONTENT = "nested-content";
 
     private final Supplier<Template> templateSupplier;
     private final Map<String, Expression> parameters;
+    private final boolean isEmpty;
 
-    public UserTagSectionHelper(Supplier<Template> templateSupplier, Map<String, Expression> parameters) {
+    UserTagSectionHelper(Supplier<Template> templateSupplier, Map<String, Expression> parameters, boolean isEmpty) {
         this.templateSupplier = templateSupplier;
         this.parameters = parameters;
+        this.isEmpty = isEmpty;
     }
 
     @Override
     public CompletionStage<ResultNode> resolve(SectionResolutionContext context) {
         CompletableFuture<ResultNode> result = new CompletableFuture<>();
-        evaluateParams(parameters, context.resolutionContext()).whenComplete((r1, t1) -> {
+        evaluateParams(parameters, context.resolutionContext()).whenComplete((evaluatedParams, t1) -> {
             if (t1 != null) {
                 result.completeExceptionally(t1);
             } else {
-
+                if (!isEmpty) {
+                    // Execute the nested content first and make it accessible via the "nested-content" key 
+                    evaluatedParams.put(NESTED_CONTENT,
+                            context.execute(context.resolutionContext().createChild(new HashMap<>(evaluatedParams), null)));
+                }
                 try {
-
-                    // Execute nested code for later usage in the user tag
-                    CompletableFuture<ResultNode> nestedResult = new CompletableFuture<>();
-                    context.execute(context.resolutionContext().createChild(r1, null)).whenComplete((r2, t2) -> {
-                        if (t2 != null) {
-                            result.completeExceptionally(t2);
-                        } else {
-                            nestedResult.complete(r2);
-                        }
-                    });
-                    if (result.isCompletedExceptionally()) {
-                        return;
-                    }
-
-                    StringBuilder sb = new StringBuilder();
-                    nestedResult.get().process((s) -> sb.append(s));
-                    r1.put(NESTED, sb.toString());
-
                     // Execute the template with the params as the root context object
                     TemplateImpl tagTemplate = (TemplateImpl) templateSupplier.get();
-                    tagTemplate.root.resolve(context.resolutionContext().createChild(r1, null))
-                            .whenComplete((r2, t2) -> {
+                    tagTemplate.root.resolve(context.resolutionContext().createChild(evaluatedParams, null))
+                            .whenComplete((resultNode, t2) -> {
                                 if (t2 != null) {
                                     result.completeExceptionally(t2);
                                 } else {
-                                    result.complete(r2);
+                                    result.complete(resultNode);
                                 }
                             });
                 } catch (Throwable e) {
                     result.completeExceptionally(e);
                 }
-
             }
         });
         return result;
@@ -99,6 +86,7 @@ public class UserTagSectionHelper implements SectionHelper {
 
             Map<String, Expression> params = context.getParameters().entrySet().stream()
                     .collect(Collectors.toMap(e -> e.getKey(), e -> context.parseValue(e.getValue())));
+            boolean isEmpty = context.getBlocks().size() == 1 && context.getBlocks().get(0).isEmpty();
 
             return new UserTagSectionHelper(new Supplier<Template>() {
 
@@ -110,7 +98,7 @@ public class UserTagSectionHelper implements SectionHelper {
                     }
                     return template;
                 }
-            }, params);
+            }, params, isEmpty);
         }
 
     }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
@@ -36,7 +36,7 @@ public class UserTagTest {
                 .addSectionHelper(new UserTagSectionHelper.Factory("myTag", "my-tag-id"))
                 .build();
 
-        Template tag = engine.parse("{#if showImage}<b>{nested}</b>{#else}nope{/if}");
+        Template tag = engine.parse("{#if showImage}<b>{nested-content}</b>{#else}nope{/if}");
         engine.putTemplate("my-tag-id", tag);
 
         Map<String, Object> order = new HashMap<>();
@@ -61,10 +61,10 @@ public class UserTagTest {
                 .addSectionHelper(new UserTagSectionHelper.Factory("myTag2", "my-tag-id2"))
                 .build();
 
-        Template tag = engine.parse("{#if showImage}<b>{nested}</b>{#else}nope{/if}");
+        Template tag = engine.parse("{#if showImage}<b>{nested-content}</b>{#else}nope{/if}");
         engine.putTemplate("my-tag-id", tag);
 
-        Template tag2 = engine.parse("{#if showImage2}<i>{nested}</i>{#else}nope2{/if}");
+        Template tag2 = engine.parse("{#if showImage2}<i>{nested-content}</i>{#else}nope2{/if}");
         engine.putTemplate("my-tag-id2", tag2);
 
         Map<String, Object> order = new HashMap<>();

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
@@ -30,4 +30,49 @@ public class UserTagTest {
                 engine.parse("{#each this}{#myTag it showImage=true /}{/each}").render(Collections.singletonList(order)));
     }
 
+    @Test
+    public void testUserTagWithNestedContent() {
+        Engine engine = Engine.builder().addDefaultSectionHelpers().addDefaultValueResolvers()
+                .addSectionHelper(new UserTagSectionHelper.Factory("myTag", "my-tag-id"))
+                .build();
+
+        Template tag = engine.parse("{#if showImage}<b>{nested}</b>{#else}nope{/if}");
+        engine.putTemplate("my-tag-id", tag);
+
+        Map<String, Object> order = new HashMap<>();
+        order.put("name", "Herbert");
+        assertEquals("<b>Herbert</b>",
+                engine.parse("{#myTag showImage=true}{order.name}{/}").render(Collections.singletonMap("order", order)));
+        assertEquals("nope", engine.parse("{#myTag}{order.name}{/}").render(Collections.singletonMap("order", order)));
+        assertEquals("nope",
+                engine.parse("{#myTag showImage=false}{order.name}{/}").render(Collections.singletonMap("order", order)));
+        assertEquals("nope",
+                engine.parse("{#each this}{#myTag showImage=false}{it.name}{/}{/each}")
+                        .render(Collections.singletonMap("order", order)));
+        assertEquals("<b>Herbert</b>",
+                engine.parse("{#each this}{#myTag showImage=true}{it.name}{/}{/each}")
+                        .render(Collections.singletonList(order)));
+    }
+
+    @Test
+    public void testUserTagWithRichNestedContent() {
+        Engine engine = Engine.builder().addDefaultSectionHelpers().addDefaultValueResolvers()
+                .addSectionHelper(new UserTagSectionHelper.Factory("myTag", "my-tag-id"))
+                .addSectionHelper(new UserTagSectionHelper.Factory("myTag2", "my-tag-id2"))
+                .build();
+
+        Template tag = engine.parse("{#if showImage}<b>{nested}</b>{#else}nope{/if}");
+        engine.putTemplate("my-tag-id", tag);
+
+        Template tag2 = engine.parse("{#if showImage2}<i>{nested}</i>{#else}nope2{/if}");
+        engine.putTemplate("my-tag-id2", tag2);
+
+        Map<String, Object> order = new HashMap<>();
+        order.put("name", "Herbert");
+        assertEquals("<b><i>Herbert</i></b>",
+                engine.parse("{#myTag showImage=true}{#myTag2 showImage2=true}{order.name}{/myTag2}{/myTag}")
+                        .render(Collections.singletonMap("order", order)));
+
+    }
+
 }


### PR DESCRIPTION
Hello.
Here is a first PR for a quick modification in Qute.

It will allow nested content in user defined tags. For a simple example, if I defined `tags\my-tag.html` as this : 
```html
<div class="{class}">
    {nested}
</div>
```

I can then call it this way : 
```html
{#my-tag class='large div'}
    <b>Hello !</b>
{\}
```

`nested` being a special key as `it` already is.
