### PR TITLE
Use JBoss Commons Logging Implementation - Amazon Alexa

### DIFF
--- a/extensions/amazon-alexa/runtime/pom.xml
+++ b/extensions/amazon-alexa/runtime/pom.xml
@@ -52,6 +52,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logging</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Enforce the use of the JBoss Apache Commons Logging Implementation by default for use with native image compilation of Amazon Alexa #10589, as explained in the documentation update #10474 

The Amazon ASK SDK v2 uses Commons Logging, and an SL4J implementation, which is excluded by the Quarkus Amazon Alexa extension. 
