### PR TITLE
fix from pattern in CommonPanacheQueryImpl class

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -29,11 +29,11 @@ public class CommonPanacheQueryImpl<Entity> {
     // match SELECT DISTINCT? id (AS id)? (, id (AS id)?)*
     static final Pattern SELECT_PATTERN = Pattern.compile(
             "^\\s*SELECT\\s+((?:DISTINCT\\s+)?\\w+(?:\\.\\w+)*)(?:\\s+AS\\s+\\w+)?(\\s*,\\s*\\w+(?:\\.\\w+)*(?:\\s+AS\\s+\\w+)?)*\\s+(.*)",
-            Pattern.CASE_INSENSITIVE);
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     // match FROM
     static final Pattern FROM_PATTERN = Pattern.compile("^\\s*FROM\\s+.*",
-            Pattern.CASE_INSENSITIVE);
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private interface NonThrowingCloseable extends AutoCloseable {
         @Override

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/test/java/io/quarkus/hibernate/orm/panache/common/runtime/QueryMatcherTest.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/test/java/io/quarkus/hibernate/orm/panache/common/runtime/QueryMatcherTest.java
@@ -9,22 +9,28 @@ public class QueryMatcherTest {
 
     @Test
     public void testSelectMatcher() {
-        testMatch("from bar", null);
-        testMatch("select foo from bar", "from bar");
-        testMatch("  select   foo   from   bar  ", "from   bar  ");
-        testMatch("select foo as fff from bar", "from bar");
-        testMatch("select foo,bar from bar", "from bar");
-        testMatch("select foo , bar from bar", "from bar");
-        testMatch("select foo as f,bar as b from bar", "from bar");
-        testMatch("select foo as f , bar as b from bar", "from bar");
-
-        testMatch("select foo.bar.gee as f , bar.sup as b from bar", "from bar");
-
-        testMatch("select distinct foo from bar", "from bar");
-        testMatch("select distinct foo,bar from bar", "from bar");
+        testSelectMatch("from bar", null);
+        testSelectMatch("select foo from bar", "from bar");
+        testSelectMatch("  select   foo   from   bar  ", "from   bar  ");
+        testSelectMatch("select foo as fff from bar", "from bar");
+        testSelectMatch("select foo,bar from bar", "from bar");
+        testSelectMatch("select foo , bar from bar", "from bar");
+        testSelectMatch("select foo as f,bar as b from bar", "from bar");
+        testSelectMatch("select foo as f , bar as b from bar", "from bar");
+        testSelectMatch("select foo.bar.gee as f , bar.sup as b from bar", "from bar");
+        testSelectMatch("select distinct foo from bar \n where field = :value",
+                "from bar \n where field = :value");
+        testSelectMatch("select distinct foo from bar", "from bar");
+        testSelectMatch("select distinct foo,bar from bar", "from bar");
+        testSelectMatch("select foo from bar where field = :value", "from bar where field = :value");
+        testSelectMatch("select foo from bar \n where field = :value",
+                "from bar \n where field = :value");
+        testSelectMatch("select foo from bar \n where field = :value " +
+                "\n\r and fieldTwo :valueTwo \r\n :fieldThree = :valueThree",
+                "from bar \n where field = :value \n\r and fieldTwo :valueTwo \r\n :fieldThree = :valueThree");
     }
 
-    private void testMatch(String select, String result) {
+    private void testSelectMatch(String select, String result) {
         Matcher matcher = CommonPanacheQueryImpl.SELECT_PATTERN.matcher(select);
         if (result != null) {
             Assertions.assertTrue(matcher.matches());
@@ -33,4 +39,25 @@ public class QueryMatcherTest {
             Assertions.assertFalse(matcher.matches());
         }
     }
+
+    @Test
+    public void testFromMatcher() {
+        testFromMatch("from bar");
+        testFromMatch("   from   bar  ");
+        testFromMatch("from bar where field = :value");
+        testFromMatch("from bar where fieldOne = :valueOne and fieldTwo :valueTwo");
+        testFromMatch("from bar where fieldOne = :valueOne \n and fieldTwo :valueTwo");
+        testFromMatch("from bar where fieldOne = :valueOne \n\r and fieldTwo :valueTwo");
+        testFromMatch("from bar where fieldOne = :valueOne \r\n and fieldTwo :valueTwo \n" +
+                "\n :fieldThree = :valueThree");
+        testFromMatch("from \n bar where field = :value");
+        testFromMatch("from \n bar \n\r where \r\n field = :value");
+        testFromMatch("from \n bar b \n\r where \r\n b.field = :value");
+    }
+
+    private void testFromMatch(String query) {
+        Matcher matcher = CommonPanacheQueryImpl.FROM_PATTERN.matcher(query);
+        Assertions.assertTrue(matcher.matches());
+    }
+
 }


### PR DESCRIPTION
replace CommonPanacheQueryImpl.FROM_PATTERN in CommonPanacheQueryImpl.class because pattern not matches string if it is contains line break characters.
Add test for check CommonPanacheQueryImpl.FROM_PATTERN

Fixes #10617