### PR TITLE
docs: add resteasy-mutiny extension

### DIFF
--- a/docs/src/main/asciidoc/amazon-s3.adoc
+++ b/docs/src/main/asciidoc/amazon-s3.adoc
@@ -527,6 +527,23 @@ public class S3AsyncClientResource extends CommonResource {
 }
 ----
 
+You need the RESTEasy Mutiny support for asynchronous programming. Add the dependency to the `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-resteasy-mutiny</artifactId>
+</dependency>
+----
+
+Or you can alternatively run this command in your project base directory:
+
+[source,bash]
+----
+./mvnw quarkus:add-extension -Dextensions="resteasy-mutiny"
+----
+
 And add the Netty HTTP client dependency to the `pom.xml`:
 
 [source,xml]


### PR DESCRIPTION
When I was trying `Going asynchronous` part of [amazon-s3](https://quarkus.io/guides/amazon-s3) guide, `./mvnw compile quarkus:dev` command gave me the following warning message.

> 2020-07-12 10:04:59,417 WARN  [io.qua.res.com.dep.ResteasyCommonProcessor] (build-4) Quarkus detected the need for Mutiny reactive programming support, however the quarkus-resteasy-mutiny extensionwas not present. Reactive REST endpoints in your application that return Uni or Multi will not function as you expect until you add this extension. Endpoints that need Mutiny are: com.kdnakt.quarkus.s3.S3AsyncClientResource{io.smallrye.mutiny.Uni<javax.ws.rs.core.Response> downloadFile(java.lang.String objectKey) throws java.lang.Exception}, com.kdnakt.quarkus.s3.S3AsyncClientResource{io.smallrye.mutiny.Uni<java.util.List<com.kdnakt.quarkus.s3.FileObject>> listFiles()}, com.kdnakt.quarkus.s3.S3AsyncClientResource{io.smallrye.mutiny.Uni<javax.ws.rs.core.Response> uploadFile(com.kdnakt.quarkus.s3.FormData formData) throws java.lang.Exception}

So I added an explanation about how to add `resteasy-mutiny` extension.
