### PR TITLE
Adding AWS Secrets Manager

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1483,6 +1483,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-secretsmanager</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-amazon-secretsmanager-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-amazon-alexa</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Feature.java
@@ -17,6 +17,7 @@ public enum Feature {
     AMAZON_SQS,
     AMAZON_SES,
     AMAZON_KMS,
+    AMAZON_SECRETS_MANAGER,
     ARTEMIS_CORE,
     ARTEMIS_JMS,
     CACHE,

--- a/extensions/amazon-services/pom.xml
+++ b/extensions/amazon-services/pom.xml
@@ -22,5 +22,6 @@
         <module>sqs</module>
         <module>ses</module>
         <module>kms</module>
+        <module>secretsmanager</module>
     </modules>
 </project>

--- a/extensions/amazon-services/secretsmanager/deployment/pom.xml
+++ b/extensions/amazon-services/secretsmanager/deployment/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-secretsmanager-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-secretsmanager-deployment</artifactId>
+    <name>Quarkus - Amazon Services - Secrets Manager - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-secretsmanager</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -65,6 +65,7 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> buildProducer) {
         buildProducer.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClass(AWSSecretsManagerProcessor.class)
+                .addBeanClass(AWSSecretsManagerReader.class)
                 .build());
     }
 

--- a/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -65,6 +65,13 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     }
 
     @BuildStep
+    void registerBeans(BuildProducer<AdditionalBeanBuildItem> buildProducer) {
+        buildProducer.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClass(SecretsManagerProcessor.class)
+                .build());
+    }
+
+    @BuildStep
     void setup(BeanRegistrationPhaseBuildItem beanRegistrationPhase,
             BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             BuildProducer<FeatureBuildItem> feature,

--- a/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -12,10 +12,7 @@ import io.quarkus.amazon.common.deployment.AmazonClientInterceptorsPathBuildItem
 import io.quarkus.amazon.common.deployment.AmazonClientTransportsBuildItem;
 import io.quarkus.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientTransportRecorder;
-import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerBuildTimeConfig;
-import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerClientProducer;
-import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerConfig;
-import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerRecorder;
+import io.quarkus.amazon.secretsmanager.runtime.*;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
@@ -67,7 +64,7 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> buildProducer) {
         buildProducer.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClass(SecretsManagerProcessor.class)
+                .addBeanClass(AWSSecretsManagerProcessor.class)
                 .build());
     }
 

--- a/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -1,0 +1,123 @@
+package io.quarkus.amazon.secretsmanager.deployment;
+
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.amazon.common.deployment.AbstractAmazonServiceProcessor;
+import io.quarkus.amazon.common.deployment.AmazonClientBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientBuilderBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientBuilderConfiguredBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientInterceptorsPathBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientTransportsBuildItem;
+import io.quarkus.amazon.common.runtime.AmazonClientRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientTransportRecorder;
+import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerBuildTimeConfig;
+import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerClientProducer;
+import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerConfig;
+import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerRecorder;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
+
+    SecretsManagerBuildTimeConfig buildTimeConfig;
+
+    @Override
+    protected Feature amazonServiceClientName() {
+        return Feature.AMAZON_SECRETS_MANAGER;
+    }
+
+    @Override
+    protected String configName() {
+        return "secretsmanager";
+    }
+
+    @Override
+    protected DotName syncClientName() {
+        return DotName.createSimple(SecretsManagerClient.class.getName());
+    }
+
+    @Override
+    protected DotName asyncClientName() {
+        return DotName.createSimple(SecretsManagerAsyncClient.class.getName());
+    }
+
+    @Override
+    protected String builtinInterceptorsPath() {
+        return "software/amazon/awssdk/services/secretsmanager/execution.interceptors";
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem producer() {
+        return AdditionalBeanBuildItem.unremovableOf(SecretsManagerClientProducer.class);
+    }
+
+    @BuildStep
+    void setup(BeanRegistrationPhaseBuildItem beanRegistrationPhase,
+            BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
+            BuildProducer<FeatureBuildItem> feature,
+            BuildProducer<AmazonClientInterceptorsPathBuildItem> interceptors,
+            BuildProducer<AmazonClientBuildItem> clientProducer) {
+
+        setupExtension(beanRegistrationPhase, extensionSslNativeSupport, feature, interceptors, clientProducer,
+                buildTimeConfig.sdk, buildTimeConfig.syncClient);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupTransport(List<AmazonClientBuildItem> amazonClients, SecretsManagerRecorder recorder,
+            AmazonClientTransportRecorder transportRecorder,
+            SecretsManagerConfig runtimeConfig, BuildProducer<AmazonClientTransportsBuildItem> clientTransportBuildProducer) {
+
+        createTransportBuilders(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient,
+                recorder.getSyncConfig(runtimeConfig),
+                recorder.getAsyncConfig(runtimeConfig),
+                clientTransportBuildProducer);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void createClientBuilders(List<AmazonClientTransportsBuildItem> transportBuildItems, SecretsManagerRecorder recorder,
+            SecretsManagerConfig runtimeConfig, BuildProducer<AmazonClientBuilderBuildItem> builderProducer) {
+
+        createClientBuilders(transportBuildItems, builderProducer,
+                (syncTransport) -> recorder.createSyncBuilder(runtimeConfig, syncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(runtimeConfig, asyncTransport));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void configureClient(List<AmazonClientBuilderBuildItem> clients, SecretsManagerRecorder recorder,
+            AmazonClientRecorder commonRecorder,
+            SecretsManagerConfig runtimeConfig,
+            BuildProducer<AmazonClientBuilderConfiguredBuildItem> producer) {
+
+        initClientBuilders(clients, commonRecorder, recorder.getAwsConfig(runtimeConfig), recorder.getSdkConfig(runtimeConfig),
+                buildTimeConfig.sdk, producer);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void buildClients(List<AmazonClientBuilderConfiguredBuildItem> configuredClients, SecretsManagerRecorder recorder,
+            BeanContainerBuildItem beanContainer,
+            ShutdownContextBuildItem shutdown) {
+
+        buildClients(configuredClients,
+                (syncBuilder) -> recorder.buildClient(syncBuilder, beanContainer.getValue(), shutdown),
+                (asyncBuilder) -> recorder.buildAsyncClient(asyncBuilder, beanContainer.getValue(), shutdown));
+    }
+}

--- a/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
@@ -24,7 +24,6 @@ public class SecretsManagerSyncClientFullConfigTest {
 
     final static String SECRET_ID = "someSecretId";
     @AWSSecretsManager(SECRET_ID)
-    @Inject
     String secretId;
 
     @RegisterExtension

--- a/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
@@ -7,6 +7,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.amazon.secretsmanager.runtime.AWSSecretsManager;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.secretsmanager.*;
 
@@ -16,7 +17,11 @@ public class SecretsManagerSyncClientFullConfigTest {
     SecretsManagerClient client;
 
     @Inject
-    SecretsManagerAsyncClient async;
+    SecretsManagerAsyncClient asyncClient;
+
+    @AWSSecretsManager("someSecretId")
+    @Inject
+    String secretId;
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
@@ -4,9 +4,13 @@ import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.amazon.secretsmanager.runtime.AWSSecretsManager;
+import io.quarkus.amazon.secretsmanager.runtime.AWSSecretsManagerReader;
+import io.quarkus.test.Mock;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.secretsmanager.*;
 
@@ -18,9 +22,10 @@ public class SecretsManagerSyncClientFullConfigTest {
     @Inject
     SecretsManagerAsyncClient asyncClient;
 
-    //    @AWSSecretsManager("someSecretId")
-    //    @Inject
-    //    String secretId;
+    final static String SECRET_ID = "someSecretId";
+    @AWSSecretsManager(SECRET_ID)
+    @Inject
+    String secretId;
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -29,6 +34,13 @@ public class SecretsManagerSyncClientFullConfigTest {
 
     @Test
     public void test() {
-        // should finish with success
+        Assertions.assertEquals(SECRET_ID, secretId);
+    }
+
+    @Mock
+    public static class MockAWSSecretsManagerReader extends AWSSecretsManagerReader {
+        public String getSecret(final String key) {
+            return key;
+        }
     }
 }

--- a/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.amazon.secretsmanager.deployment;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import software.amazon.awssdk.services.secretsmanager.*;
+
+public class SecretsManagerSyncClientFullConfigTest {
+
+    @Inject
+    SecretsManagerClient client;
+
+    @Inject
+    SecretsManagerAsyncClient async;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("sync-urlconn-full-config.properties", "application.properties"));
+
+    @Test
+    public void test() {
+        // should finish with success
+    }
+}

--- a/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
+++ b/extensions/amazon-services/secretsmanager/deployment/src/test/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerSyncClientFullConfigTest.java
@@ -7,7 +7,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.amazon.secretsmanager.runtime.AWSSecretsManager;
 import io.quarkus.test.QuarkusUnitTest;
 import software.amazon.awssdk.services.secretsmanager.*;
 
@@ -19,9 +18,9 @@ public class SecretsManagerSyncClientFullConfigTest {
     @Inject
     SecretsManagerAsyncClient asyncClient;
 
-    @AWSSecretsManager("someSecretId")
-    @Inject
-    String secretId;
+    //    @AWSSecretsManager("someSecretId")
+    //    @Inject
+    //    String secretId;
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/extensions/amazon-services/secretsmanager/deployment/src/test/resources/sync-urlconn-full-config.properties
+++ b/extensions/amazon-services/secretsmanager/deployment/src/test/resources/sync-urlconn-full-config.properties
@@ -1,0 +1,7 @@
+quarkus.secretsmanager.endpoint-override=http://localhost:9090
+
+quarkus.secretsmanager.aws.region=us-east-1
+
+quarkus.secretsmanager.sync-client.type = url
+quarkus.secretsmanager.sync-client.connection-timeout = 0.100S
+quarkus.secretsmanager.sync-client.socket-timeout = 0.100S

--- a/extensions/amazon-services/secretsmanager/pom.xml
+++ b/extensions/amazon-services/secretsmanager/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-services-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-secretsmanager-parent</artifactId>
+    <name>Quarkus - Amazon Services - Secrets Manager</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/extensions/amazon-services/secretsmanager/runtime/pom.xml
+++ b/extensions/amazon-services/secretsmanager/runtime/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-amazon-secretsmanager-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-secretsmanager</artifactId>
+    <name>Quarkus - Amazon Services - Secrets Manager - Runtime</name>
+    <description>Connect to Amazon Secrets Manager</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManager.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManager.java
@@ -1,0 +1,17 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+public @interface AWSSecretsManager {
+    @Nonbinding
+    String value();
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
@@ -13,7 +13,7 @@ public class AWSSecretsManagerProcessor {
 
     @Produces
     @AWSSecretsManager("")
-    String getStringValue(InjectionPoint ip) {
+    String getStringValue(InjectionPoint ip) throws Exception {
         final String secretId = ip.getAnnotated().getAnnotation(AWSSecretsManager.class).value();
         return reader.getSecret(secretId);
     }

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
@@ -1,0 +1,42 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+@ApplicationScoped
+public class AWSSecretsManagerProcessor {
+
+    @Inject
+    SecretsManagerClient client;
+
+    @Produces
+    @AWSSecretsManager("")
+    String getStringValue(InjectionPoint ip) {
+        return ip.getAnnotated().getAnnotation(AWSSecretsManager.class).value();
+    }
+
+    //    private String getSecret(final String key) {
+    //        final GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest
+    //                .builder()
+    //                .secretId(key)
+    //                .build();
+    //        GetSecretValueResponse secretValueResponse;
+    //        try {
+    //            secretValueResponse = client.getSecretValue(getSecretValueRequest);
+    //        } catch (DecryptionFailureException e) {
+    //            throw new RuntimeException("Secrets Manager can't decrypt.");
+    //        } catch (InternalServiceErrorException e) {
+    //            throw new RuntimeException("An error occurred on the server side.");
+    //        } catch (InvalidRequestException e) {
+    //            throw new RuntimeException(
+    //                    "You provided a parameter value that is not valid for the current state of the resource.");
+    //        } catch (ResourceNotFoundException e) {
+    //            throw new RuntimeException("We can't find the resource that you asked for: " + key);
+    //        }
+    //        return secretValueResponse.secretString();
+    //    }
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
@@ -5,40 +5,17 @@ import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
 
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.*;
-
 @ApplicationScoped
 public class AWSSecretsManagerProcessor {
 
     @Inject
-    SecretsManagerClient client;
+    AWSSecretsManagerReader reader;
 
     @Produces
     @AWSSecretsManager("")
     String getStringValue(InjectionPoint ip) {
         final String secretId = ip.getAnnotated().getAnnotation(AWSSecretsManager.class).value();
-        return getSecret(secretId);
+        return reader.getSecret(secretId);
     }
 
-    private String getSecret(final String key) {
-        final GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest
-                .builder()
-                .secretId(key)
-                .build();
-        GetSecretValueResponse secretValueResponse;
-        try {
-            secretValueResponse = client.getSecretValue(getSecretValueRequest);
-        } catch (DecryptionFailureException e) {
-            throw new RuntimeException("Secrets Manager can't decrypt.");
-        } catch (InternalServiceErrorException e) {
-            throw new RuntimeException("An error occurred on the server side.");
-        } catch (InvalidRequestException e) {
-            throw new RuntimeException(
-                    "You provided a parameter value that is not valid for the current state of the resource.");
-        } catch (ResourceNotFoundException e) {
-            throw new RuntimeException("We can't find the resource that you asked for: " + key);
-        }
-        return secretValueResponse.secretString();
-    }
 }

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerProcessor.java
@@ -6,6 +6,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Inject;
 
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.*;
 
 @ApplicationScoped
 public class AWSSecretsManagerProcessor {
@@ -16,27 +17,28 @@ public class AWSSecretsManagerProcessor {
     @Produces
     @AWSSecretsManager("")
     String getStringValue(InjectionPoint ip) {
-        return ip.getAnnotated().getAnnotation(AWSSecretsManager.class).value();
+        final String secretId = ip.getAnnotated().getAnnotation(AWSSecretsManager.class).value();
+        return getSecret(secretId);
     }
 
-    //    private String getSecret(final String key) {
-    //        final GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest
-    //                .builder()
-    //                .secretId(key)
-    //                .build();
-    //        GetSecretValueResponse secretValueResponse;
-    //        try {
-    //            secretValueResponse = client.getSecretValue(getSecretValueRequest);
-    //        } catch (DecryptionFailureException e) {
-    //            throw new RuntimeException("Secrets Manager can't decrypt.");
-    //        } catch (InternalServiceErrorException e) {
-    //            throw new RuntimeException("An error occurred on the server side.");
-    //        } catch (InvalidRequestException e) {
-    //            throw new RuntimeException(
-    //                    "You provided a parameter value that is not valid for the current state of the resource.");
-    //        } catch (ResourceNotFoundException e) {
-    //            throw new RuntimeException("We can't find the resource that you asked for: " + key);
-    //        }
-    //        return secretValueResponse.secretString();
-    //    }
+    private String getSecret(final String key) {
+        final GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest
+                .builder()
+                .secretId(key)
+                .build();
+        GetSecretValueResponse secretValueResponse;
+        try {
+            secretValueResponse = client.getSecretValue(getSecretValueRequest);
+        } catch (DecryptionFailureException e) {
+            throw new RuntimeException("Secrets Manager can't decrypt.");
+        } catch (InternalServiceErrorException e) {
+            throw new RuntimeException("An error occurred on the server side.");
+        } catch (InvalidRequestException e) {
+            throw new RuntimeException(
+                    "You provided a parameter value that is not valid for the current state of the resource.");
+        } catch (ResourceNotFoundException e) {
+            throw new RuntimeException("We can't find the resource that you asked for: " + key);
+        }
+        return secretValueResponse.secretString();
+    }
 }

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerReader.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/AWSSecretsManagerReader.java
@@ -1,0 +1,35 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.*;
+
+@ApplicationScoped
+public class AWSSecretsManagerReader {
+
+    @Inject
+    SecretsManagerClient client;
+
+    public String getSecret(final String key) {
+        final GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest
+                .builder()
+                .secretId(key)
+                .build();
+        GetSecretValueResponse secretValueResponse;
+        try {
+            secretValueResponse = client.getSecretValue(getSecretValueRequest);
+        } catch (DecryptionFailureException e) {
+            throw new RuntimeException("Secrets Manager can't decrypt.");
+        } catch (InternalServiceErrorException e) {
+            throw new RuntimeException("An error occurred on the server side.");
+        } catch (InvalidRequestException e) {
+            throw new RuntimeException(
+                    "You provided a parameter value that is not valid for the current state of the resource.");
+        } catch (ResourceNotFoundException e) {
+            throw new RuntimeException("We can't find the resource that you asked for: " + key);
+        }
+        return secretValueResponse.secretString();
+    }
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerBuildTimeConfig.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerBuildTimeConfig.java
@@ -1,0 +1,26 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import io.quarkus.amazon.common.runtime.SdkBuildTimeConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientBuildTimeConfig;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Amazon Secrets Manager build time configuration
+ */
+@ConfigRoot(name = "secretsmanager", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class SecretsManagerBuildTimeConfig {
+
+    /**
+     * SDK client configurations for AWS Secrets Manager client
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public SdkBuildTimeConfig sdk;
+
+    /**
+     * Sync HTTP transport configuration for Amazon Secrets Manager client
+     */
+    @ConfigItem
+    public SyncHttpClientBuildTimeConfig syncClient;
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerClientProducer.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerClientProducer.java
@@ -1,0 +1,52 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClientBuilder;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+
+@ApplicationScoped
+public class SecretsManagerClientProducer {
+
+    private volatile SecretsManagerClientBuilder syncConfiguredBuilder;
+    private volatile SecretsManagerAsyncClientBuilder asyncConfiguredBuilder;
+
+    private SecretsManagerClient client;
+    private SecretsManagerAsyncClient asyncClient;
+
+    @Produces
+    @ApplicationScoped
+    public SecretsManagerClient client() {
+        client = syncConfiguredBuilder.build();
+        return client;
+    }
+
+    @Produces
+    @ApplicationScoped
+    public SecretsManagerAsyncClient asyncClient() {
+        asyncClient = asyncConfiguredBuilder.build();
+        return asyncClient;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (client != null) {
+            client.close();
+        }
+        if (asyncClient != null) {
+            asyncClient.close();
+        }
+    }
+
+    public void setSyncConfiguredBuilder(SecretsManagerClientBuilder syncConfiguredBuilder) {
+        this.syncConfiguredBuilder = syncConfiguredBuilder;
+    }
+
+    public void setAsyncConfiguredBuilder(SecretsManagerAsyncClientBuilder asyncConfiguredBuilder) {
+        this.asyncConfiguredBuilder = asyncConfiguredBuilder;
+    }
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerConfig.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerConfig.java
@@ -1,0 +1,42 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import io.quarkus.amazon.common.runtime.AwsConfig;
+import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
+import io.quarkus.amazon.common.runtime.SdkConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "secretsmanager", phase = ConfigPhase.RUN_TIME)
+public class SecretsManagerConfig {
+
+    /**
+     * AWS SDK client configurations
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigDocSection
+    public SdkConfig sdk;
+
+    /**
+     * AWS services configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public AwsConfig aws;
+
+    /**
+     * Sync HTTP transport configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public SyncHttpClientConfig syncClient;
+
+    /**
+     * Netty HTTP transport configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public NettyHttpClientConfig asyncClient;
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerRecorder.java
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerRecorder.java
@@ -1,0 +1,74 @@
+package io.quarkus.amazon.secretsmanager.runtime;
+
+import io.quarkus.amazon.common.runtime.AwsConfig;
+import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
+import io.quarkus.amazon.common.runtime.SdkConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClientBuilder;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+
+@Recorder
+public class SecretsManagerRecorder {
+
+    public RuntimeValue<SyncHttpClientConfig> getSyncConfig(SecretsManagerConfig config) {
+        return new RuntimeValue<>(config.syncClient);
+    }
+
+    public RuntimeValue<NettyHttpClientConfig> getAsyncConfig(SecretsManagerConfig config) {
+        return new RuntimeValue<>(config.asyncClient);
+    }
+
+    public RuntimeValue<AwsConfig> getAwsConfig(SecretsManagerConfig config) {
+        return new RuntimeValue<>(config.aws);
+    }
+
+    public RuntimeValue<SdkConfig> getSdkConfig(SecretsManagerConfig config) {
+        return new RuntimeValue<>(config.sdk);
+    }
+
+    public RuntimeValue<AwsClientBuilder> createSyncBuilder(SecretsManagerConfig config,
+            RuntimeValue<SdkHttpClient.Builder> transport) {
+        SecretsManagerClientBuilder builder = SecretsManagerClient.builder();
+        if (transport != null) {
+            builder.httpClientBuilder(transport.getValue());
+        }
+        return new RuntimeValue<>(builder);
+    }
+
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(SecretsManagerConfig config,
+            RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+
+        SecretsManagerAsyncClientBuilder builder = SecretsManagerAsyncClient.builder();
+        if (transport != null) {
+            builder.httpClientBuilder(transport.getValue());
+        }
+        return new RuntimeValue<>(builder);
+    }
+
+    public RuntimeValue<SecretsManagerClient> buildClient(RuntimeValue<? extends AwsClientBuilder> builder,
+            BeanContainer beanContainer,
+            ShutdownContext shutdown) {
+        SecretsManagerClientProducer producer = beanContainer.instance(SecretsManagerClientProducer.class);
+        producer.setSyncConfiguredBuilder((SecretsManagerClientBuilder) builder.getValue());
+        shutdown.addShutdownTask(producer::destroy);
+        return new RuntimeValue<>(producer.client());
+    }
+
+    public RuntimeValue<SecretsManagerAsyncClient> buildAsyncClient(RuntimeValue<? extends AwsClientBuilder> builder,
+            BeanContainer beanContainer,
+            ShutdownContext shutdown) {
+        SecretsManagerClientProducer producer = beanContainer.instance(SecretsManagerClientProducer.class);
+        producer.setAsyncConfiguredBuilder((SecretsManagerAsyncClientBuilder) builder.getValue());
+        shutdown.addShutdownTask(producer::destroy);
+        return new RuntimeValue<>(producer.asyncClient());
+    }
+}

--- a/extensions/amazon-services/secretsmanager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/amazon-services/secretsmanager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "Amazon Secrets Manager"
+metadata:
+  keywords:
+    - "secretsmanager"
+    - "aws"
+    - "amazon"
+  guide: "https://quarkus.io/guides/amazon-secretsmanager"
+  categories:
+    - "data"
+  status: "preview"


### PR DESCRIPTION
# AWS Secrets Manager Extension
## Description
The goal of this extension is to make easy then integration with AWS Secrets Manager. The extension provides an annotation to inject the secret into a variable. Also, it is possible to inject the client and use it directly.

## Tasks
- [x] AWS Secrets Manager Client
- [x] AWS Secrets Manager Async Client
- [x] AWS Secrets Manager Annotation
- [ ] AWS Secrets Manager integration with DB Config [#6896](https://github.com/quarkusio/quarkus/issues/6896)

## AWS Secrets Manager Clients
### Sync Client
```
    @Inject
    SecretsManagerClient client;
```
### Async Client
```
    @Inject
    SecretsManagerAsyncClient asyncClient;
```
## AWS Secrets Manager Annotation
Allows injecting a secret from AWS Secrets Manager directly to a variable. It supports plaintext and binary secrets.
```
    @AWSSecretsManager("a-secret-id")
    String secretId;
```