### PR TITLE
Bump jaeger version, to eliminate vulnerabilities

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -23,7 +23,7 @@
         <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
-        <jaeger.version>0.34.0</jaeger.version>
+        <jaeger.version>0.34.3</jaeger.version>
         <quarkus-http.version>3.0.11.Final</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <microprofile-config-api.version>1.4</microprofile-config-api.version>

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -25,6 +25,13 @@
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-thrift</artifactId>
+            <exclusions>
+                <!-- jaeger-thrift 3.43.3 pulls in a banned version of annotation-api. Remove once we move to jaeger 1.x-->
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>


### PR DESCRIPTION
Exclude annotation-api 1.3.2, which has been banned, but is pulled in through thrift 0.13.

Exclude and fixme about annotation-api might not be the best approach. Any thoughts? 