### PR TITLE
DevMojoIT: Remove superfluous first mvn install to avoid race condition

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -816,10 +816,10 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         RunningInvoker invoker = new RunningInvoker(testDir, false);
 
         // to properly surface the problem of multiple classpath entries, we need to install the project to the local m2
-        invoker.execute(Collections.singletonList("install"), Collections.emptyMap());
         MavenProcessInvocationResult installInvocation = invoker.execute(Arrays.asList("clean", "install", "-DskipTests"),
                 Collections.emptyMap());
         assertThat(installInvocation.getProcess().waitFor(2, TimeUnit.MINUTES)).isTrue();
+        assertThat(installInvocation.getExecutionException()).isNull();
         assertThat(installInvocation.getExitCode()).isEqualTo(0);
 
         // run dev mode from the runner module


### PR DESCRIPTION
As already mentioned on zulip, I think the first `mvn install` call was a c&p mistake or something. But I might be wrong.

One can clearly see the two "racy" executions in `integration-tests/maven/target/test-classes/projects/multimodule-resources-classpath/build-multimodule-resources-classpath.log`:
```
[INFO] Scanning for projects...
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] multimodule-cp-resources                                           [pom]
[INFO] multimodule-cp-resources-rest                                      [jar]
[INFO] multimodule-cp-resources-html                                      [jar]
[INFO] multimodule-cp-resources-main                                      [jar]
[INFO] 
[INFO] ------------------< cp.acme:multimodule-cp-resources >------------------
[INFO] Building multimodule-cp-resources 1.0-SNAPSHOT                     [1/4]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] multimodule-cp-resources                                           [pom]
[INFO] multimodule-cp-resources-rest                                      [jar]
[INFO] multimodule-cp-resources-html                                      [jar]
[INFO] multimodule-cp-resources-main                                      [jar]
[INFO] 
[INFO] ------------------< cp.acme:multimodule-cp-resources >------------------
[INFO] Building multimodule-cp-resources 1.0-SNAPSHOT                     [1/4]
[INFO] --------------------------------[ pom ]---------------------------------
```

I added another assert _before_ the existing return code assert as we might see more helpful output in case the test is still flaky.