### PR TITLE
Uses quick-build profile for build-jdk11

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -85,7 +85,7 @@ jobs:
           restore-only: ${{ github.event_name == 'pull_request' }}
       - name: Build
         run: |
-          mvn -e -B -DskipTests -DskipITs -Dno-format -Ddocumentation-pdf clean install
+          mvn -e -B -Dquickly
       - name: Tar Maven Repo
         shell: bash
         run: tar -czf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
Since all jobs in `ci-actions.yml` depend on the `build-jdk11` making it as fast as possible should be of high priority.