### PR TITLE
ResteasyServerCommonProcessor - fix resource method reflective scanning

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -32,9 +32,9 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
 
     private final Type type;
-    private IndexView index;
+    private final IndexView index;
     private final Predicate<DotName> ignorePredicate;
-    private String source;
+    private final String source;
 
     public ReflectiveHierarchyBuildItem(Type type) {
         this(type, DefaultIgnorePredicate.INSTANCE);


### PR DESCRIPTION
- do not register the ReflectiveHierarchyBuildItem twice for most
resource methods; first try the BeanArchiveIndexBuildItem and then add
methods only found in the CombinedIndexBuildItem
- resolves #10742