### PR TITLE
Do not build integration tests with '-Dquickly'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,6 @@
         <!-- relying on the fact that the extension descriptor, generated as part of an extension build, is available -->
         <module>devtools</module>
 
-        <!-- Integration Tests -->
-        <module>integration-tests</module>
-
         <!-- Misc. -->
         <module>docs</module>
     </modules>
@@ -114,6 +111,19 @@
             <build>
                 <defaultGoal>clean install</defaultGoal>
             </build>
+        </profile>
+        <profile>
+            <id>it</id>
+            <activation>
+                <property>
+                    <name>quickly</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <!-- Integration Tests -->
+                <module>integration-tests</module>
+            </modules>
         </profile>
         <profile>
             <id>release</id>


### PR DESCRIPTION
This cuts the build time from 4:07 to 02:56 (in my laptop)