### PR TITLE
Quartz - improve the error message when scheduler is disabled and org.quartz.Scheduler is injected

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -207,6 +207,8 @@ class MyJobs {
 }
 ----
 
+NOTE: By default, the scheduler is not started unless a `@Scheduled` business method is found. You may need to force the start of the scheduler for "pure" programmatic scheduling. See also <<quartz.adoc#quartz-configuration-reference,Quartz Configuration Reference>>.
+
 == Scheduled Methods and Testing
 
 It is often desirable to disable the scheduler when running the tests.

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DisabledSchedulerTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DisabledSchedulerTest.java
@@ -1,7 +1,10 @@
 package io.quarkus.quartz.test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -17,7 +20,10 @@ import io.quarkus.test.QuarkusUnitTest;
 public class DisabledSchedulerTest {
 
     @Inject
-    Scheduler quartzScheduler;
+    Scheduler scheduler;
+
+    @Inject
+    Instance<org.quartz.Scheduler> quartzScheduler;
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
@@ -28,7 +34,13 @@ public class DisabledSchedulerTest {
 
     @Test
     public void testNoSchedulerInvocations() throws InterruptedException {
-        assertFalse(quartzScheduler.isRunning());
+        assertFalse(scheduler.isRunning());
+        assertTrue(quartzScheduler.isResolvable());
+        try {
+            quartzScheduler.get();
+            fail();
+        } catch (IllegalStateException expected) {
+        }
     }
 
     static class Jobs {

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -71,7 +71,7 @@ public class QuartzScheduler implements Scheduler {
     org.quartz.Scheduler produceQuartzScheduler() {
         if (scheduler == null) {
             throw new IllegalStateException(
-                    "Cannot produce org.quartz.Scheduler - Quartz scheduler is disabled or no schedules were found");
+                    "Quartz scheduler is either explicitly disabled through quarkus.scheduler.enabled=false or no @Scheduled methods were found. If you only need to schedule a job programmatically you can force the start of the scheduler via quarkus.quartz.force-start=true");
         }
         return scheduler;
     }


### PR DESCRIPTION
... and org.quartz.Scheduler is injected
- resolve #10633

The error message is: `java.lang.IllegalStateException: Quartz scheduler is either explicitly disabled through quarkus.scheduler.enabled=false or no @Scheduled methods were found. If you only need to schedule a job programmatically you can force the start of the scheduler via quarkus.quartz.force-start=true`.