### PR TITLE
Debug symbols improvements

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -270,6 +270,8 @@ public class NativeImageBuildStep {
                 command.add("-H:GenerateDebugInfo=1");
                 final Path sourcePath = Paths.get("..", "..", "src", "main", "java");
                 command.add("-H:DebugInfoSourceSearchPath=" + sourcePath.toString());
+                final Path sourcesCachePath = outputDir.getParent().resolve("sources-cache");
+                command.add("-H:DebugInfoSourceCacheRoot=" + sourcesCachePath.toString());
             }
             if (nativeConfig.debugBuildProcess) {
                 command.add("-J-Xrunjdwp:transport=dt_socket,address=" + DEBUG_BUILD_PROCESS_PORT + ",server=y,suspend=y");

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -401,12 +401,14 @@ public class NativeImageBuildStep {
                         // Do we need to handle transformed classes?
                         // Their bytecode might have been modified but is there source for such modification?
                         final Path jarSourceDep = toJarSource(resolvedDep);
-                        final String fileName = depArtifact.getGroupId() + "." + jarSourceDep.getFileName();
-                        final Path targetPath = libDir.resolve(fileName);
-                        try {
-                            Files.copy(jarSourceDep, targetPath, StandardCopyOption.REPLACE_EXISTING);
-                        } catch (IOException e) {
-                            throw new RuntimeException("Unable to copy from " + resolvedDep + " to " + targetPath);
+                        if (jarSourceDep.toFile().exists()) {
+                            final String fileName = depArtifact.getGroupId() + "." + jarSourceDep.getFileName();
+                            final Path targetPath = libDir.resolve(fileName);
+                            try {
+                                Files.copy(jarSourceDep, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                            } catch (IOException e) {
+                                throw new RuntimeException("Unable to copy from " + jarSourceDep + " to " + targetPath, e);
+                            }
                         }
                     }
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -268,6 +268,8 @@ public class NativeImageBuildStep {
             }
             if (nativeConfig.debug.enabled) {
                 command.add("-H:GenerateDebugInfo=1");
+                final Path sourcePath = Paths.get("..", "..", "src", "main", "java");
+                command.add("-H:DebugInfoSourceSearchPath=" + sourcePath.toString());
             }
             if (nativeConfig.debugBuildProcess) {
                 command.add("-J-Xrunjdwp:transport=dt_socket,address=" + DEBUG_BUILD_PROCESS_PORT + ",server=y,suspend=y");


### PR DESCRIPTION
This is a draft follow up PR for #9792. Do let me know if I need to open a separate issue for it.

The changes here were partially discussed in [this quarkus-dev discussion](https://groups.google.com/g/quarkus-dev/c/jEJsKmHQzcw/m/XjiVWF9hCgAJ).

Let me address each improvement individually:

### Third party sources

When native debug is enabled, the build step has been enhanced to temporarily copy the `-sources.jar` for each dependency to the ` target/<...>-native-image-source-jar/lib` directory. By doing that, when GraalVM builds the source cache, it'd automatically find the sources for those dependencies and add them to the sources cache. Once native image build completes, these `-sources.jar` in the lib directory are deleted.

In terms of the quarkus-dev discussion above, it uses a solution based on option 1.

There is one detail that still needs to be decided: By default third party sources are not downloaded. Could the native image build step (or any other build step) trigger `mvn dependency:sources` so that those third party sources get downloaded? It'd be nice to achieve that, only when native image debug is enabled? 

The alternative would for the user to invoke `mvn dependency:sources` or the Quarkus sample project generation to add that plugin to the pom.xml of the projects. This is currently required by this draft PR.

### Application sources added to the sources cache

Before this PR, the sources for the user code in the Quarkus application were not included in the sources cache. Fixes in this PR make sure this code also gets added to the sources cache.

### Move the sources cache folder to be under `target/sources-cache`

When using `gdb` with an existing Quarkus application, the existing sources cache folders were very long and not very user friendly to type in gdb. Using one of the debug info options in GraalVM, I've moved the folder to be under `target/sources-cache`.

Note that this change might not make that much sense any more, since @zakkak has improved GraalVM so that `gdb` automatically finds the sources directories, so you no longer have to type those in `gdb` (see https://github.com/oracle/graal/pull/2661).

### Warning

One final warning note. The changes here won't work with any existing official GraalVM releases. If you want to try them out, you'd need to checkout [Mandrel 20.1 branch](https://github.com/graalvm/mandrel/tree/mandrel/20.1) locally, apply fix for https://github.com/oracle/graal/issues/2637, and then use that. Two reasons:

* Adding third party sources that were created 2/3 years before today would trigger https://github.com/oracle/graal/issues/2637. A [PR](https://github.com/oracle/graal/issues/2637) is available but has not yet been integrated.
* The latest official GraalVM 20.1 release does not include all the debug info patches that @adinn created. In particular, that release does not include support for `-H:DebugInfoSourceCacheRoot`


