### PR TITLE
Upgrade SmallRye OpenAPI to 2.0.3 version

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -35,7 +35,7 @@
         <smallrye-config.version>1.8.4</smallrye-config.version>
         <smallrye-health.version>2.2.2</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.2</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.3</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.4</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.0</smallrye-fault-tolerance.version>


### PR DESCRIPTION
You can see the full list of fixes here: 
https://github.com/smallrye/smallrye-open-api/releases/tag/2.0.3


Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>