### PR TITLE
Upgrade SmallRye GraphQL to 1.0.5

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -36,7 +36,7 @@
         <smallrye-health.version>2.2.2</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
         <smallrye-open-api.version>2.0.3</smallrye-open-api.version>
-        <smallrye-graphql.version>1.0.4</smallrye-graphql.version>
+        <smallrye-graphql.version>1.0.5</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>2.1.2</smallrye-jwt.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -71,6 +72,7 @@ import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.graphql.spi.LookupService;
+import io.smallrye.graphql.spi.SchemaBuildingExtensionService;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -129,6 +131,15 @@ public class SmallRyeGraphQLProcessor {
                 lookupService);
         serviceProvider.produce(
                 new ServiceProviderBuildItem(LookupService.class.getName(), lookupImplementations.toArray(new String[0])));
+
+        // Schema Extension Service (We use the one from the CDI Module)
+        String schemaExtensionService = SPI_PATH + SchemaBuildingExtensionService.class.getName();
+        Set<String> schemaExtensionImplementations = ServiceUtil.classNamesNamedIn(
+                Thread.currentThread().getContextClassLoader(),
+                schemaExtensionService);
+        serviceProvider.produce(
+                new ServiceProviderBuildItem(SchemaBuildingExtensionService.class.getName(),
+                        schemaExtensionImplementations.toArray(new String[0])));
     }
 
     @Record(ExecutionTime.STATIC_INIT)
@@ -307,9 +318,9 @@ public class SmallRyeGraphQLProcessor {
         return classes;
     }
 
-    private Set<String> getFieldClassNames(Set<Field> fields) {
+    private Set<String> getFieldClassNames(Map<String, Field> fields) {
         Set<String> classes = new HashSet<>();
-        for (Field field : fields) {
+        for (Field field : fields.values()) {
             classes.add(field.getReference().getClassName());
         }
         return classes;

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.smallrye.graphql.deployment;
 
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
+
 import org.hamcrest.CoreMatchers;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,6 +44,7 @@ public class GraphQLTest extends AbstractGraphQLTest {
         Assertions.assertTrue(body.contains("\"Query root\""));
         Assertions.assertTrue(body.contains("type Query {"));
         Assertions.assertTrue(body.contains("ping: TestPojo"));
+        Assertions.assertTrue(body.contains("enum SomeEnum {"));
     }
 
     @Test
@@ -120,5 +123,20 @@ public class GraphQLTest extends AbstractGraphQLTest {
                 .body(CoreMatchers.containsString(
                         "{\"data\":{\"foos\":[{\"message\":\"bar\",\"randomNumber\":{\"value\":123.0},\"list\":[\"a\",\"b\",\"c\"]}]}}"));
 
+    }
+
+    @Test
+    public void testContext() {
+        String query = getPayload("{context}");
+
+        RestAssured.given()
+                .body(query)
+                .contentType(MEDIATYPE_JSON)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("{\"data\":{\"context\":\"/context\"}}"));
     }
 }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestResource.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestResource.java
@@ -1,15 +1,25 @@
 package io.quarkus.smallrye.graphql.deployment;
 
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
+
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.api.Context;
 
 /**
  * Just a test endpoint
  */
 @GraphQLApi
 public class TestResource {
+
+    @Inject
+    Context context;
 
     @Query
     public TestPojo ping() {
@@ -26,6 +36,11 @@ public class TestResource {
         return new TestPojo[] { foo() };
     }
 
+    @Query("context")
+    public String getPathFromContext() {
+        return context.getPath();
+    }
+
     @Mutation
     public TestPojo moo(String name) {
         return new TestPojo(name);
@@ -35,5 +50,16 @@ public class TestResource {
 
     public TestRandom getRandomNumber(@Source TestPojo testPojo) {
         return new TestRandom(123);
+    }
+
+    public GraphQLSchema.Builder addMyOwnEnum(@Observes GraphQLSchema.Builder builder) {
+
+        GraphQLEnumType myOwnEnum = GraphQLEnumType.newEnum()
+                .name("SomeEnum")
+                .description("Adding some enum type")
+                .value("value1")
+                .value("value2").build();
+
+        return builder.additionalType(myOwnEnum);
     }
 }


### PR DESCRIPTION
This upgrades SmallRye GraphQL to 1.0.5.

The main new feature is the `@Context` Object that is now available.

For a full list list fixes and enhancements see:
https://github.com/smallrye/smallrye-graphql/releases/tag/1.0.5

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>