### PR TITLE
Take into account the RESTEasy path in SmallRye OpenAPI

### DIFF
--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -207,22 +207,26 @@ public class ResteasyServerCommonProcessor {
             return;
         }
 
+        final String rootPath;
         final String path;
         final String appClass;
         if (!applicationPaths.isEmpty()) {
             AnnotationInstance applicationPath = applicationPaths.iterator().next();
+            rootPath = "/";
             path = applicationPath.value().asString();
             appClass = applicationPath.target().asClass().name().toString();
         } else {
             if (resteasyServletMappingBuildItem.isPresent()) {
                 if (resteasyServletMappingBuildItem.get().getPath().endsWith("/*")) {
-                    path = resteasyServletMappingBuildItem.get().getPath().substring(0,
+                    rootPath = resteasyServletMappingBuildItem.get().getPath().substring(0,
                             resteasyServletMappingBuildItem.get().getPath().length() - 1);
                 } else {
-                    path = resteasyServletMappingBuildItem.get().getPath();
+                    rootPath = resteasyServletMappingBuildItem.get().getPath();
                 }
+                path = rootPath;
                 appClass = null;
             } else {
+                rootPath = resteasyConfig.path;
                 path = resteasyConfig.path;
                 appClass = null;
             }
@@ -324,7 +328,7 @@ public class ResteasyServerCommonProcessor {
         resteasyInitParameters.put(ResteasyContextParameters.RESTEASY_UNWRAPPED_EXCEPTIONS,
                 ArcUndeclaredThrowableException.class.getName());
 
-        resteasyServerConfig.produce(new ResteasyServerConfigBuildItem(path, resteasyInitParameters));
+        resteasyServerConfig.produce(new ResteasyServerConfigBuildItem(rootPath, path, resteasyInitParameters));
 
         Set<DotName> autoInjectAnnotationNames = autoInjectAnnotations.stream().flatMap(a -> a.getAnnotationNames().stream())
                 .collect(Collectors.toSet());

--- a/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerConfigBuildItem.java
+++ b/extensions/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerConfigBuildItem.java
@@ -9,13 +9,24 @@ import io.quarkus.builder.item.SimpleBuildItem;
  */
 public final class ResteasyServerConfigBuildItem extends SimpleBuildItem {
 
+    private final String rootPath;
+
     private final String path;
 
     private final Map<String, String> initParameters;
 
-    public ResteasyServerConfigBuildItem(String path, Map<String, String> initParameters) {
+    /**
+     * rootPath can be different from the path if {@code @ApplicationPath} is used.
+     * rootPath will not contain the {@code @ApplicationPath} while path will contain it.
+     */
+    public ResteasyServerConfigBuildItem(String rootPath, String path, Map<String, String> initParameters) {
+        this.rootPath = rootPath;
         this.path = path;
         this.initParameters = initParameters;
+    }
+
+    public String getRootPath() {
+        return rootPath;
     }
 
     public String getPath() {

--- a/extensions/resteasy-server-common/spi/src/main/java/io/quarkus/resteasy/server/common/spi/ResteasyJaxrsConfigBuildItem.java
+++ b/extensions/resteasy-server-common/spi/src/main/java/io/quarkus/resteasy/server/common/spi/ResteasyJaxrsConfigBuildItem.java
@@ -1,0 +1,30 @@
+package io.quarkus.resteasy.server.common.spi;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A build item that represents a JAX-RS config.
+ */
+public final class ResteasyJaxrsConfigBuildItem extends SimpleBuildItem {
+
+    private final String rootPath;
+
+    private final String defaultPath;
+
+    /**
+     * rootPath can be different from the defaultPath if {@code @ApplicationPath} is used.
+     * rootPath will not contain the {@code @ApplicationPath} while defaultPath will contain it.
+     */
+    public ResteasyJaxrsConfigBuildItem(String rootPath, String defaultPath) {
+        this.rootPath = rootPath;
+        this.defaultPath = defaultPath;
+    }
+
+    public String getRootPath() {
+        return rootPath;
+    }
+
+    public String getDefaultPath() {
+        return defaultPath;
+    }
+}

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyJaxrsConfigBuildItem.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyJaxrsConfigBuildItem.java
@@ -4,7 +4,10 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 /**
  * A build item that represents a JAX-RS config.
+ *
+ * @deprecated use {@link io.quarkus.resteasy.server.common.spi.ResteasyJaxrsConfigBuildItem} instead.
  */
+@Deprecated
 public final class ResteasyJaxrsConfigBuildItem extends SimpleBuildItem {
 
     public final String defaultPath;

--- a/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
+++ b/extensions/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
@@ -49,11 +49,18 @@ public class ResteasyServletProcessor {
     private static final String JAX_RS_SERVLET_NAME = JAVAX_WS_RS_APPLICATION;
 
     @BuildStep
-    public void jaxrsConfig(Optional<ResteasyServerConfigBuildItem> resteasyServerConfig,
-            BuildProducer<ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig, HttpRootPathBuildItem httpRootPathBuildItem) {
+    public void jaxrsConfig(
+            Optional<ResteasyServerConfigBuildItem> resteasyServerConfig,
+            BuildProducer<ResteasyJaxrsConfigBuildItem> deprecatedResteasyJaxrsConfig,
+            BuildProducer<io.quarkus.resteasy.server.common.spi.ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig,
+            HttpRootPathBuildItem httpRootPathBuildItem) {
         if (resteasyServerConfig.isPresent()) {
-            resteasyJaxrsConfig.produce(
-                    new ResteasyJaxrsConfigBuildItem(httpRootPathBuildItem.adjustPath(resteasyServerConfig.get().getPath())));
+            String rootPath = httpRootPathBuildItem.adjustPath(resteasyServerConfig.get().getRootPath());
+            String defaultPath = httpRootPathBuildItem.adjustPath(resteasyServerConfig.get().getPath());
+
+            deprecatedResteasyJaxrsConfig.produce(new ResteasyJaxrsConfigBuildItem(defaultPath));
+            resteasyJaxrsConfig
+                    .produce(new io.quarkus.resteasy.server.common.spi.ResteasyJaxrsConfigBuildItem(rootPath, defaultPath));
         }
     }
 

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-server-common-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc-deployment</artifactId>
     </dependency>
     <dependency>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -56,6 +56,7 @@ import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentProducer;
 import io.quarkus.smallrye.openapi.runtime.OpenApiHandler;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRecorder;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
@@ -257,6 +258,7 @@ public class SmallRyeOpenApiProcessor {
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
             OpenApiFilteredIndexViewBuildItem openApiFilteredIndexViewBuildItem,
             Capabilities capabilities,
+            HttpRootPathBuildItem httpRootPathBuildItem,
             Optional<ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig) throws Exception {
         FilteredIndexView index = openApiFilteredIndexViewBuildItem.getIndex();
 
@@ -266,7 +268,7 @@ public class SmallRyeOpenApiProcessor {
         OpenAPI annotationModel;
 
         if (shouldScanAnnotations(capabilities)) {
-            annotationModel = generateAnnotationModel(index, capabilities, resteasyJaxrsConfig);
+            annotationModel = generateAnnotationModel(index, capabilities, httpRootPathBuildItem, resteasyJaxrsConfig);
         } else {
             annotationModel = null;
         }
@@ -311,6 +313,7 @@ public class SmallRyeOpenApiProcessor {
     }
 
     private OpenAPI generateAnnotationModel(IndexView indexView, Capabilities capabilities,
+            HttpRootPathBuildItem httpRootPathBuildItem,
             Optional<ResteasyJaxrsConfigBuildItem> resteasyJaxrsConfig) {
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
@@ -325,7 +328,7 @@ public class SmallRyeOpenApiProcessor {
         if (resteasyJaxrsConfig.isPresent()) {
             defaultPath = resteasyJaxrsConfig.get().getRootPath();
         } else {
-            defaultPath = config.getValue("quarkus.http.root-path", String.class);
+            defaultPath = httpRootPathBuildItem.getRootPath();
         }
         if (defaultPath != null && !"/".equals(defaultPath)) {
             extensions.add(new CustomPathExtension(defaultPath));

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -33,6 +33,7 @@ import org.jboss.jandex.Type;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -296,8 +297,8 @@ public class SmallRyeOpenApiProcessor {
         }
 
         // Only scan if either JaxRS or Spring is used
-        boolean isJaxrs = capabilities.isCapabilityPresent(Capabilities.RESTEASY);
-        boolean isSpring = capabilities.isCapabilityPresent(Capabilities.SPRING_WEB);
+        boolean isJaxrs = capabilities.isPresent(Capability.RESTEASY);
+        boolean isSpring = capabilities.isPresent(Capability.SPRING_WEB);
         return isJaxrs || isSpring;
     }
 
@@ -319,8 +320,8 @@ public class SmallRyeOpenApiProcessor {
         OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
 
         List<AnnotationScannerExtension> extensions = new ArrayList<>();
-        // Add RestEasy if jaxrs
-        if (capabilities.isCapabilityPresent(Capabilities.RESTEASY)) {
+        // Add the RESTEasy extension if the capability is present
+        if (capabilities.isPresent(Capability.RESTEASY)) {
             extensions.add(new RESTEasyExtension(indexView));
         }
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiWithResteasyPathHttpRootDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class)
+                    .addAsResource(new StringAsset("quarkus.http.root-path=/http-root-path\n" +
+                            "quarkus.resteasy.path=/resteasy-path"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiResteasyPathHttpRootDefaultPath() {
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/http-root-path/resteasy-path/resource"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
@@ -1,0 +1,33 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiWithResteasyPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiResource.class)
+                    .addAsResource(new StringAsset("quarkus.resteasy.path=/foo/bar"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiResteasyPath() {
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/foo/bar/resource"));
+    }
+}


### PR DESCRIPTION
This is another version of what was proposed here: https://github.com/quarkusio/quarkus/pull/10636 .

It's based on build items which is cleaner and (hopefully) takes all the cases into account.

Also I added some tests.