### PR TITLE
Return null from DirectoryClassPathElement#getResource if it can't resolve the Path

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/runner/classloading/DirectoryClassPathElementTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/runner/classloading/DirectoryClassPathElementTestCase.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterAll;
@@ -48,5 +49,18 @@ public class DirectoryClassPathElementTestCase {
         ClassPathResource res = f.getResource("foo/sub.txt");
         Assertions.assertNotNull(res);
         Assertions.assertEquals("subdir file", new String(res.getData(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testInvalidPath() {
+        final String invalidPath;
+        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")) {
+            invalidPath = "D:\\*";
+        } else {
+            invalidPath = "hello\u0000world";
+        }
+        final DirectoryClassPathElement classPathElement = new DirectoryClassPathElement(root);
+        final ClassPathResource resource = classPathElement.getResource(invalidPath);
+        Assertions.assertNull(resource, "DirectoryClassPathElement wasn't expected to return a resource for an invalid path");
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.CodeSource;
@@ -36,7 +37,13 @@ public class DirectoryClassPathElement extends AbstractClassPathElement {
 
     @Override
     public ClassPathResource getResource(String name) {
-        Path file = root.resolve(name);
+        final Path file;
+        try {
+            file = root.resolve(name);
+        } catch (InvalidPathException ipe) {
+            // can't resolve the resource
+            return null;
+        }
         Path normal = file.normalize();
         String cn = name;
         if (File.separatorChar == '\\') {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/10750

The `DirectoryClassPathElement` is just one of the many types of classpath elements that are given a chance to resolve a (ClassLoader) resource, by the resource name. If the `DirectoryClassPathElement` can't resolve the passed resource name into a valid directory `java.nio.file.Path`, then instead of throwing an exception (like it does now), it should instead return `null` indicating that it cannot resolve that resource. The commit here fixes the current issue where it throws an exception. A test case has been added to reproduce this issue and verify the fix.