### PR TITLE
Add x86_64 to the architecture detection

### DIFF
--- a/independent-projects/tools/utilities/src/main/java/io/quarkus/utilities/OS.java
+++ b/independent-projects/tools/utilities/src/main/java/io/quarkus/utilities/OS.java
@@ -34,7 +34,7 @@ public enum OS {
     // by Trustin Heuiseung Lee (ASL 2.0)
     public static String getArchitecture() {
         String arch = System.getProperty("os.arch");
-        if (arch.matches("^(x8664|amd64|ia32e|em64t|x64)$")) {
+        if (arch.matches("^(x8664|amd64|ia32e|em64t|x64|x86_64)$")) {
             return "x86_64";
         }
         if (arch.matches("^(x8632|x86|i[3-6]86|ia32|x32)$")) {


### PR DESCRIPTION
The architecture detection missed the x86_64 case which broke the build on Mac OS X.