### PR TITLE
The smallrye reactive streams operators project is in maintenance mode.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,7 +63,6 @@ updates:
       - dependency-name: io.smallrye.config:smallrye-config
       - dependency-name: io.smallrye.reactive:mutiny
       - dependency-name: io.smallrye.reactive:smallrye-reactive-messaging
-      - dependency-name: io.smallrye.reactive:smallrye-reactive-streams-operators
       # Swagger-UI
       - dependency-name: org.webjars:swagger-ui
       # Tika

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -148,9 +148,7 @@ The injected `ManagedExecutor` uses the Quarkus thread pool.
 
 == Adding support for RxJava2
 
-If you use Reactive Streams Operators (the `quarkus-smallrye-reactive-streams-operators` module),
-you get support for link:https://github.com/ReactiveX/RxJava[RxJava2] context propagation automatically, but if you don't, you
-may want to include the following modules to get RxJava2 support:
+You need to include the following modules to get RxJava2 support:
 
 [source,xml]
 ----

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/pom.xml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-smallrye-reactive-streams-operators-parent</artifactId>
-    <name>Quarkus - SmallRye Reactive Streams Operators</name>
+    <name>Quarkus - SmallRye Reactive Streams Operators (deprecated)</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/reactive-streams-operators/smallrye-reactive-streams-operators/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,9 @@
 ---
+#  This extension is deprecated and the upstream project is now in maintenance-only mode
+#  It is recommended to use the quarkus-mutiny-reactive-streams-operators extension instead
 name: "SmallRye Reactive Streams Operators"
 metadata:
+  unlisted: true
   keywords:
   - "smallrye-reactive-streams-operators"
   - "smallrye-reactive-streams"
@@ -9,3 +12,4 @@ metadata:
   categories:
   - "reactive"
   status: "stable"
+


### PR DESCRIPTION
This PR removes the dependency from dependabot, rephrase a paragraph in context propagation, and add deprecated to the project name.