### PR TITLE
Explain which config property is failing to load

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigRecorder.java
@@ -37,7 +37,8 @@ public class ConfigRecorder {
                                 "No config value of type " + entry.getValue() + " exists for: " + entry.getKey());
                     }
                 } catch (IllegalArgumentException e) {
-                    throw new DeploymentException(e);
+                    throw new DeploymentException(
+                            "Failed to load config value of type " + entry.getValue() + " for: " + entry.getKey(), e);
                 }
             }
         }


### PR DESCRIPTION
This PR adds an explanation to which configuration key is causing failure within the Configuration system when Quarkus verifies the configuration environment.

Previously a stack trace for a Quarkus application failing to start due to a configuration system error did not mention which configuration key was causing the error.

```
Caused by: java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:641)
	....
Caused by: javax.enterprise.inject.spi.DeploymentException: java.lang.IllegalArgumentException: SRCFG00013: No Converter registered for class java.util.UUID
	at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:40)
	at io.quarkus.deployment.steps.ConfigBuildStep$validateConfigProperties1249763973.deploy_0(ConfigBuildStep$validateConfigProperties1249763973.zig:460)
	at io.quarkus.deployment.steps.ConfigBuildStep$validateConfigProperties1249763973.deploy(ConfigBuildStep$validateConfigProperties1249763973.zig:36)
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:532)
	... 12 more
Caused by: java.lang.IllegalArgumentException: SRCFG00013: No Converter registered for class java.util.UUID
	at io.smallrye.config.SmallRyeConfig.lambda$getConverter$3(SmallRyeConfig.java:266)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.smallrye.config.SmallRyeConfig.getConverter(SmallRyeConfig.java:263)
	at io.smallrye.config.SmallRyeConfig.lambda$getOptionalConverter$2(SmallRyeConfig.java:252)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.smallrye.config.SmallRyeConfig.getOptionalConverter(SmallRyeConfig.java:251)
	at io.smallrye.config.SmallRyeConfig.getOptionalValue(SmallRyeConfig.java:197)
	at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:35)
	... 15 more
```

This pull request enhances the exception thrown by ConfigRecorder by adding a message to the Exception with details of the type and key of the configuration causing the error.

```
Caused by: java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:641)
	...
Caused by: javax.enterprise.inject.spi.DeploymentException: Failed to load config value of type [java.util.UUID] for: demo.configuration.unsupported
	at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:41)
	at io.quarkus.deployment.steps.ConfigBuildStep$validateConfigProperties1249763973.deploy_0(ConfigBuildStep$validateConfigProperties1249763973.zig:460)
	at io.quarkus.deployment.steps.ConfigBuildStep$validateConfigProperties1249763973.deploy(ConfigBuildStep$validateConfigProperties1249763973.zig:36)
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:532)
	... 12 more
Caused by: java.lang.IllegalArgumentException: SRCFG00013: No Converter registered for class java.util.UUID
	at io.smallrye.config.SmallRyeConfig.lambda$getConverter$3(SmallRyeConfig.java:266)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1740)
	at io.smallrye.config.SmallRyeConfig.getConverter(SmallRyeConfig.java:263)
	at io.smallrye.config.SmallRyeConfig.lambda$getOptionalConverter$2(SmallRyeConfig.java:252)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.smallrye.config.SmallRyeConfig.getOptionalConverter(SmallRyeConfig.java:251)
	at io.smallrye.config.SmallRyeConfig.getOptionalValue(SmallRyeConfig.java:197)
	at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:35)
	... 15 more
```

I came across this issue in an attempt to use UUID as a configuration type (unsupported in the current version of SmallRye Config):
```java
import io.quarkus.arc.config.ConfigProperties;
import java.util.UUID;

@ConfigProperties(prefix = "demo.configuration")
public interface DemoConfigurationProperties {
    UUID getUnsupported();
}
```

Future note - SmallRye Config will include a UUID converter by default going forwards: smallrye/smallrye-config#356
