### PR TITLE
Re-subscription must re-trigger the operation

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -422,6 +422,25 @@ public class CountriesResource {
 The previous snippet uses Mutiny reactive types, if you're not familiar with them, read the link:getting-started-reactive#mutiny[Getting Started with Reactive guide] first.
 ====
 
+When returning a `Uni`, every _subscription_ invokes the remote service.
+It means you can re-send the request by re-subscribing on the `Uni`, or use a `retry` as follow:
+
+[source, java]
+----
+
+@Inject @RestClient CountriesResource service;
+
+// ...
+
+service.nameAsync("Greece")
+   .onFailure().retry().atMost(10);
+
+----
+
+If you use a `CompletionStage`, you would need to call the service's method to retry.
+This difference comes from the laziness aspect of Mutiny and its subscription protocol.
+More details about this can be found in https://smallrye.io/smallrye-mutiny/#_uni_and_multi[the Mutiny documentation].
+
 == Package and run the application
 
 Run the application with: `./mvnw compile quarkus:dev`.

--- a/extensions/resteasy-mutiny/runtime/pom.xml
+++ b/extensions/resteasy-mutiny/runtime/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy-mutiny/runtime/src/main/java/io/quarkus/resteasy/mutiny/runtime/UniRxInvokerImpl.java
+++ b/extensions/resteasy-mutiny/runtime/src/main/java/io/quarkus/resteasy/mutiny/runtime/UniRxInvokerImpl.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.mutiny.runtime;
 
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
 import javax.ws.rs.client.CompletionStageRxInvoker;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
@@ -7,6 +10,7 @@ import javax.ws.rs.core.Response;
 
 import io.smallrye.mutiny.Uni;
 
+@SuppressWarnings("unchecked")
 public class UniRxInvokerImpl implements UniRxInvoker {
     private final CompletionStageRxInvoker completionStageRxInvoker;
     private final UniProvider UniProvider;
@@ -18,126 +22,251 @@ public class UniRxInvokerImpl implements UniRxInvoker {
 
     @Override
     public Uni<Response> get() {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.get());
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.get();
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> get(Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.get(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.get(responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> get(GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.get(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.get(responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> put(Entity<?> entity) {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.put(entity));
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.put(entity);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> put(Entity<?> entity, Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.put(entity, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.put(entity, responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> put(Entity<?> entity, GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.put(entity, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.put(entity, responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> post(Entity<?> entity) {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.post(entity));
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.post(entity);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> post(Entity<?> entity, Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.post(entity, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.post(entity, responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> post(Entity<?> entity, GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.post(entity, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.post(entity, responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> delete() {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.delete());
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.delete();
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> delete(Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.delete(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.delete(responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> delete(GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.delete(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.delete(responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> head() {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.head());
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.head();
+            }
+        });
     }
 
     @Override
     public Uni<Response> options() {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.options());
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.options();
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> options(Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.options(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.options(responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> options(GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.options(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.options(responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> trace() {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.trace());
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.trace();
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> trace(Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.trace(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.trace(responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> trace(GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.trace(responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.trace(responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> method(String name) {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.method(name));
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.method(name);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> method(String name, Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.method(name, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.method(name, responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> method(String name, GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.method(name, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.method(name, responseType);
+            }
+        });
     }
 
     @Override
     public Uni<Response> method(String name, Entity<?> entity) {
-        return (Uni<Response>) UniProvider.fromCompletionStage(completionStageRxInvoker.method(name, entity));
+        return (Uni<Response>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.method(name, entity);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> method(String name, Entity<?> entity, Class<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.method(name, entity, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.method(name, entity, responseType);
+            }
+        });
     }
 
     @Override
     public <T> Uni<T> method(String name, Entity<?> entity, GenericType<T> responseType) {
-        return (Uni<T>) UniProvider.fromCompletionStage(completionStageRxInvoker.method(name, entity, responseType));
+        return (Uni<T>) UniProvider.fromCompletionStage(new Supplier<CompletionStage<?>>() {
+            @Override
+            public CompletionStage<?> get() {
+                return completionStageRxInvoker.method(name, entity, responseType);
+            }
+        });
     }
 }

--- a/extensions/resteasy-mutiny/runtime/src/test/java/io/quarkus/resteasy/mutiny/test/UniRxInvokerImplTest.java
+++ b/extensions/resteasy-mutiny/runtime/src/test/java/io/quarkus/resteasy/mutiny/test/UniRxInvokerImplTest.java
@@ -1,0 +1,147 @@
+package io.quarkus.resteasy.mutiny.test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.client.CompletionStageRxInvoker;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.resteasy.mutiny.runtime.UniRxInvokerImpl;
+import io.smallrye.mutiny.Uni;
+
+@SuppressWarnings("unchecked")
+public class UniRxInvokerImplTest {
+
+    @Test
+    public void testGetEntity() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+        when(csInvoker.get(Integer.class)).thenReturn(
+                CompletableFuture.completedFuture(counter.incrementAndGet()), // First call
+                CompletableFuture.completedFuture(counter.incrementAndGet()) // Second call
+        );
+
+        Uni<Integer> uni = invoker.get(Integer.class);
+        Assertions.assertEquals(1, uni.await().indefinitely());
+        Assertions.assertEquals(2, uni.await().indefinitely());
+    }
+
+    @Test
+    public void testGet() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+
+        CompletionStage<Response> resp1 = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        CompletionStage<Response> resp2 = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        when(csInvoker.get()).thenReturn(
+                resp1, resp2);
+
+        Uni<Integer> uni = invoker.get()
+                .onItem().transform(r -> r.readEntity(Integer.class));
+        Assertions.assertEquals(1, uni.await().indefinitely());
+        Assertions.assertEquals(2, uni.await().indefinitely());
+    }
+
+    @Test
+    public void testGetWithRetry() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+
+        CompletableFuture<Response> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new IOException("boom"));
+        CompletionStage<Response> ok = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        when(csInvoker.get()).thenReturn(failed, ok);
+
+        Uni<Integer> uni = invoker.get()
+                .onItem().transform(r -> r.readEntity(Integer.class))
+                .onFailure().retry().atMost(1);
+        Assertions.assertEquals(1, uni.await().indefinitely());
+    }
+
+    @Test
+    public void testPut() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+
+        CompletionStage<Response> resp1 = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        CompletionStage<Response> resp2 = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        Entity<String> entity = Entity.entity("hello", MediaType.TEXT_PLAIN_TYPE);
+        when(csInvoker.put(entity)).thenReturn(
+                resp1, resp2);
+
+        Uni<Integer> uni = invoker.put(entity)
+                .onItem().transform(r -> r.readEntity(Integer.class));
+        Assertions.assertEquals(1, uni.await().indefinitely());
+        Assertions.assertEquals(2, uni.await().indefinitely());
+    }
+
+    @Test
+    public void testPostEntity() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+        Entity<String> entity = Entity.entity("hello", MediaType.TEXT_PLAIN_TYPE);
+        when(csInvoker.post(entity, Integer.class)).thenReturn(
+                CompletableFuture.completedFuture(counter.incrementAndGet()), // First call
+                CompletableFuture.completedFuture(counter.incrementAndGet()) // Second call
+        );
+
+        Uni<Integer> uni = invoker.post(entity, Integer.class);
+        Assertions.assertEquals(1, uni.await().indefinitely());
+        Assertions.assertEquals(2, uni.await().indefinitely());
+    }
+
+    @Test
+    public void testDeleteEntity() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+        when(csInvoker.delete(Integer.class)).thenReturn(
+                CompletableFuture.completedFuture(counter.incrementAndGet()), // First call
+                CompletableFuture.completedFuture(counter.incrementAndGet()) // Second call
+        );
+
+        Uni<Integer> uni = invoker.delete(Integer.class);
+        Assertions.assertEquals(1, uni.await().indefinitely());
+        Assertions.assertEquals(2, uni.await().indefinitely());
+    }
+
+    @Test
+    public void testHead() {
+        AtomicInteger counter = new AtomicInteger();
+        CompletionStageRxInvoker csInvoker = mock(CompletionStageRxInvoker.class);
+        UniRxInvokerImpl invoker = new UniRxInvokerImpl(csInvoker);
+
+        CompletionStage<Response> resp1 = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        CompletionStage<Response> resp2 = CompletableFuture
+                .completedFuture(Response.ok(counter.incrementAndGet()).build());
+        when(csInvoker.head()).thenReturn(
+                resp1, resp2);
+
+        Uni<Integer> uni = invoker.head()
+                .onItem().transform(r -> r.readEntity(Integer.class));
+        Assertions.assertEquals(1, uni.await().indefinitely());
+        Assertions.assertEquals(2, uni.await().indefinitely());
+    }
+
+}


### PR DESCRIPTION
When an operation returns a Uni, resubscribing to this Uni must re-execute the underlying operation (except if the user explicitly uses cache()).
As RestEasy uses CompletionStage behind the scene, this behavior was not working and was always returning the same CompletionStage (the initial one). As a consequence, resubscriptions and retries were not working.

This PR changes how the Unis are created to re-execute the operation on every subscription. Note that it also delays the initial execution until the first subscription.