### PR TITLE
Check OIDC token type and return 401 for invalid bearer tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -769,6 +769,12 @@ public class OidcTenantConfig {
         public Optional<List<String>> audience = Optional.empty();
 
         /**
+         * Expected token type
+         */
+        @ConfigItem
+        public Optional<String> tokenType = Optional.empty();
+
+        /**
          * Life span grace period in seconds.
          * When checking token expiry, current time is allowed to be later than token expiration time by at most the configured
          * number of seconds.
@@ -848,6 +854,14 @@ public class OidcTenantConfig {
 
         public void setForcedJwkRefreshInterval(Duration forcedJwkRefreshInterval) {
             this.forcedJwkRefreshInterval = forcedJwkRefreshInterval;
+        }
+
+        public Optional<String> getTokenType() {
+            return tokenType;
+        }
+
+        public void setTokenType(String tokenType) {
+            this.tokenType = Optional.of(tokenType);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BearerAuthenticationMechanism.java
@@ -15,8 +15,6 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
     private static final String BEARER = "Bearer";
     protected static final ChallengeData UNAUTHORIZED_CHALLENGE = new ChallengeData(HttpResponseStatus.UNAUTHORIZED.code(),
             null, null);
-    protected static final ChallengeData FORBIDDEN_CHALLENGE = new ChallengeData(HttpResponseStatus.FORBIDDEN.code(), null,
-            null);
 
     public Uni<SecurityIdentity> authenticate(RoutingContext context,
             IdentityProviderManager identityProviderManager,
@@ -31,13 +29,7 @@ public class BearerAuthenticationMechanism extends AbstractOidcAuthenticationMec
     }
 
     public Uni<ChallengeData> getChallenge(RoutingContext context, DefaultTenantConfigResolver resolver) {
-        String bearerToken = extractBearerToken(context);
-
-        if (bearerToken == null) {
-            return Uni.createFrom().item(UNAUTHORIZED_CHALLENGE);
-        }
-
-        return Uni.createFrom().item(FORBIDDEN_CHALLENGE);
+        return Uni.createFrom().item(UNAUTHORIZED_CHALLENGE);
     }
 
     private String extractBearerToken(RoutingContext context) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -114,6 +114,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                     userInfo = getUserInfo(event.result(), (String) vertxContext.get("access_token"));
                                 }
                                 if (tokenJson != null) {
+                                    OidcUtils.validatePrimaryJwtTokenType(resolvedContext.oidcConfig.token, tokenJson);
                                     JsonObject rolesJson = getRolesJson(vertxContext, resolvedContext, tokenCred, tokenJson,
                                             userInfo);
                                     try {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -191,4 +191,16 @@ public final class OidcUtils {
             builder.addAttribute("userinfo", new UserInfo(userInfo.encode()));
         }
     }
+
+    public static void validatePrimaryJwtTokenType(OidcTenantConfig.Token tokenConfig, JsonObject tokenJson) {
+        if (tokenJson.containsKey("typ")) {
+            String type = tokenJson.getString("typ");
+            if (tokenConfig.getTokenType().isPresent() && !tokenConfig.getTokenType().get().equals(type)) {
+                throw new OIDCException("Invalid token type");
+            } else if ("Refresh".equals(type)) {
+                // At least check it is not a refresh token issued by Keycloak
+                throw new OIDCException("Refresh token can only be used with the refresh token grant");
+            }
+        }
+    }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -27,6 +27,41 @@ import io.vertx.core.json.JsonObject;
 public class OidcUtilsTest {
 
     @Test
+    public void testCorrectTokenType() throws Exception {
+        OidcTenantConfig.Token tokenClaims = new OidcTenantConfig.Token();
+        tokenClaims.setTokenType("access_token");
+        JsonObject json = new JsonObject();
+        json.put("typ", "access_token");
+        OidcUtils.validatePrimaryJwtTokenType(tokenClaims, json);
+    }
+
+    @Test
+    public void testWrongTokenType() throws Exception {
+        OidcTenantConfig.Token tokenClaims = new OidcTenantConfig.Token();
+        tokenClaims.setTokenType("access_token");
+        JsonObject json = new JsonObject();
+        json.put("typ", "refresh_token");
+        try {
+            OidcUtils.validatePrimaryJwtTokenType(tokenClaims, json);
+            fail("Exception expected: wrong token type");
+        } catch (OIDCException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testKeycloakRefreshTokenType() throws Exception {
+        JsonObject json = new JsonObject();
+        json.put("typ", "Refresh");
+        try {
+            OidcUtils.validatePrimaryJwtTokenType(new OidcTenantConfig.Token(), json);
+            fail("Exception expected: wrong token type");
+        } catch (OIDCException ex) {
+            // expected
+        }
+    }
+
+    @Test
     public void testTokenWithCorrectIssuer() throws Exception {
         OidcTenantConfig.Token tokenClaims = OidcTenantConfig.Token.fromIssuer("https://server.example.com");
         InputStream is = getClass().getResourceAsStream("/tokenIssuer.json");

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -103,11 +103,11 @@ public class BearerTokenAuthorizationTest {
                 .statusCode(200)
                 .body(equalTo("tenant-b:alice"));
 
-        // should give a 403 given that access token from issuer b can not access tenant c
+        // should give a 401 given that access token from issuer b can not access tenant c
         RestAssured.given().auth().oauth2(getAccessToken("alice", "b"))
                 .when().get("/tenant/tenant-c/api/user")
                 .then()
-                .statusCode(403);
+                .statusCode(401);
     }
 
     @Test
@@ -118,11 +118,11 @@ public class BearerTokenAuthorizationTest {
                 .statusCode(200)
                 .body(equalTo("tenant-d:alice"));
 
-        // should give a 403 given that access token from issuer b can not access tenant c
+        // should give a 401 given that access token from issuer b can not access tenant c
         RestAssured.given().auth().oauth2(getAccessToken("alice", "b"))
                 .when().get("/tenant/tenant-d/api/user")
                 .then()
-                .statusCode(403);
+                .statusCode(401);
     }
 
     @Test
@@ -164,11 +164,11 @@ public class BearerTokenAuthorizationTest {
                 .body(equalTo("tenant-oidc:alice"));
 
         // Get a token with kid '3' - it can only be verified via the introspection fallback since OIDC returns JWK set with kid '2'
-        // 403 since the introspection is not enabled
+        // 401 since the introspection is not enabled
         RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("3"))
                 .when().get("/tenant/tenant-oidc/api/user")
                 .then()
-                .statusCode(403);
+                .statusCode(401);
 
         // Enable introspection
         RestAssured.when().post("/oidc/introspection").then().body(equalTo("true"));

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java
@@ -28,6 +28,6 @@ public class ServicePublicKeyTestCase {
         Response r = RestAssured.given().auth()
                 .oauth2(jwt + "1")
                 .get("/service/tenant-public-key");
-        Assertions.assertEquals(403, r.getStatusCode());
+        Assertions.assertEquals(401, r.getStatusCode());
     }
 }

--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # Configuration file
 quarkus.oidc.auth-server-url=${keycloak.ssl.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.secret=secret
 quarkus.oidc.token.principal-claim=email
 quarkus.http.cors=true
 quarkus.oidc.tls.verification=none

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.keycloak;
 
 import static io.quarkus.it.keycloak.KeycloakRealmResourceManager.getAccessToken;
+import static io.quarkus.it.keycloak.KeycloakRealmResourceManager.getRefreshToken;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -78,6 +79,14 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testAccessAdminResourceWithRefreshToken() {
+        RestAssured.given().auth().oauth2(getRefreshToken("admin"))
+                .when().get("/api/admin")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
     public void testPermissionHttpInformationProvider() {
         RestAssured.given().auth().oauth2(getAccessToken("alice"))
                 .when().get("/api/permission/http-cip")
@@ -119,6 +128,6 @@ public class BearerTokenAuthorizationTest {
                 .pollDelay(3, TimeUnit.SECONDS)
                 .atMost(5, TimeUnit.SECONDS).until(
                         () -> RestAssured.given().auth().oauth2(token).when()
-                                .get("/api/users/me").thenReturn().statusCode() == 403);
+                                .get("/api/users/me").thenReturn().statusCode() == 401);
     }
 }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -141,4 +141,17 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                 .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();
     }
+
+    public static String getRefreshToken(String userName) {
+        return RestAssured
+                .given()
+                .param("grant_type", "password")
+                .param("username", userName)
+                .param("password", userName)
+                .param("client_id", "quarkus-app")
+                .param("client_secret", "secret")
+                .when()
+                .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token")
+                .as(AccessTokenResponse.class).getRefreshToken();
+    }
 }


### PR DESCRIPTION
Fixes #10717

This PR:
- adds an optional token type check, and if the property is not set, does check as the last try, that Keycloak issued valid refresh tokens can not be used to get an access. if a RT is sent and is valid, it can be verified successfully. 
In fact, even without this PR, the test would get `403` because RT would have no expected roles (403 in this case is not issued by `quarkus-oidc` but by the follow up roles checker), but the correct response is not even get the RBAC layer exercised and return 401 immediately since the token is invalid. 
- so I had to fix `BearerAuthenticationMechanism`, the challenge should really be `401` all the time, `403` implies that the actual token is valid (signature, different verification constraints), only roles are not matching but RBAC is not even enforced yet by the time Challenge is made so it should be `401`