### PR TITLE
Experimental support for Avro in native mode.

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -200,6 +200,7 @@
         <gson.version>2.8.6</gson.version>
         <webjars-locator-core.version>0.46</webjars-locator-core.version>
         <log4j2-jboss-logmanager.version>1.0.0.Beta1</log4j2-jboss-logmanager.version>
+        <avro.version>1.10.0</avro.version>
     </properties>
 
     <dependencyManagement>
@@ -802,6 +803,16 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-kafka-streams-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-avro</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-avro-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -2650,6 +2661,11 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${avro.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>

--- a/extensions/avro/deployment/pom.xml
+++ b/extensions/avro/deployment/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-avro-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-avro-deployment</artifactId>
+    <name>Quarkus - Avro - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
@@ -1,0 +1,43 @@
+package io.quarkus.avro.deployment;
+
+import java.util.Collection;
+
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.specific.AvroGenerated;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+
+public class AvroProcessor {
+
+    @BuildStep
+    public void build(CombinedIndexBuildItem indexBuildItem,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<NativeImageSystemPropertyBuildItem> sys,
+            BuildProducer<NativeImageConfigBuildItem> conf) {
+
+        NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();
+        builder.addRuntimeInitializedClass(GenericDatumReader.class.getName());
+
+        Collection<AnnotationInstance> annotations = indexBuildItem.getIndex()
+                .getAnnotations(DotName.createSimple(AvroGenerated.class.getName()));
+        for (AnnotationInstance annotation : annotations) {
+            if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
+                String className = annotation.target().asClass().name().toString();
+                builder.addRuntimeInitializedClass(className);
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, className));
+            }
+        }
+
+        builder.addRuntimeInitializedClass("org.apache.avro.reflect.ReflectData");
+        conf.produce(builder.build());
+        sys.produce(new NativeImageSystemPropertyBuildItem("avro.disable.unsafe", "true"));
+    }
+}

--- a/extensions/avro/pom.xml
+++ b/extensions/avro/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <parent>
+      <artifactId>quarkus-build-parent</artifactId>
+      <groupId>io.quarkus</groupId>
+      <version>999-SNAPSHOT</version>
+      <relativePath>../../build-parent/pom.xml</relativePath>
+   </parent>
+
+   <modelVersion>4.0.0</modelVersion>
+   <artifactId>quarkus-avro-parent</artifactId>
+   <name>Quarkus - Avro</name>
+   <packaging>pom</packaging>
+
+   <modules>
+      <module>deployment</module>
+      <module>runtime</module>
+   </modules>
+</project>

--- a/extensions/avro/runtime/pom.xml
+++ b/extensions/avro/runtime/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-avro-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-avro</artifactId>
+    <name>Quarkus - Avro - Runtime</name>
+    <description>Provide support for the Avro data serialization system</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Mark this as a runtime dependency, so to make sure it's included on the final classpath during native-image -->
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/extensions/avro/runtime/src/main/java/io/quarkus/avro/graal/AvroSubstitutions.java
+++ b/extensions/avro/runtime/src/main/java/io/quarkus/avro/graal/AvroSubstitutions.java
@@ -1,0 +1,83 @@
+package io.quarkus.avro.graal;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.avro.generic.IndexedRecord;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Inject;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.apache.avro.reflect.ReflectionUtil")
+final class Target_org_apache_avro_reflect_ReflectionUtil {
+
+    /**
+     * Use reflection instead of method handles
+     */
+    @Substitute
+    public static <V, R> Function<V, R> getConstructorAsFunction(Class<V> parameterClass, Class<R> clazz) {
+        try {
+            Constructor<R> constructor = clazz.getConstructor(parameterClass);
+            return new Function<V, R>() {
+                @Override
+                public R apply(V v) {
+                    try {
+                        return constructor.newInstance(v);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+        } catch (Throwable t) {
+            // if something goes wrong, do not provide a Function instance
+            return null;
+        }
+    }
+
+}
+
+@TargetClass(className = "org.apache.avro.reflect.ReflectData")
+final class Target_org_apache_avro_reflect_ReflectData {
+
+    @Inject
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.None)
+    Map<Class<?>, Target_org_apache_avro_reflect_ReflectData_ClassAccessorData> ACCESSORS;
+
+    @Substitute
+    private Target_org_apache_avro_reflect_ReflectData_ClassAccessorData getClassAccessorData(Class<?> c) {
+        if (ACCESSORS == null) {
+            ACCESSORS = new HashMap<>();
+        }
+
+        Map<Class<?>, Target_org_apache_avro_reflect_ReflectData_ClassAccessorData> map = ACCESSORS;
+        Target_org_apache_avro_reflect_ReflectData_ClassAccessorData o = map.get(c);
+        if (o == null) {
+            if (!IndexedRecord.class.isAssignableFrom(c)) {
+                Target_org_apache_avro_reflect_ReflectData_ClassAccessorData d = new Target_org_apache_avro_reflect_ReflectData_ClassAccessorData(
+                        c);
+                map.put(c, d);
+            }
+            return null;
+        }
+        return o;
+    }
+}
+
+@TargetClass(className = "org.apache.avro.reflect.ReflectData", innerClass = "ClassAccessorData")
+final class Target_org_apache_avro_reflect_ReflectData_ClassAccessorData<T> {
+    // Just provide access to "ReflectData.ClassAccessorData"
+
+    @Alias
+    public Target_org_apache_avro_reflect_ReflectData_ClassAccessorData(Class<?> c) {
+
+    }
+
+}
+
+class AvroSubstitutions {
+}

--- a/extensions/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,9 @@
+---
+name: "Apache Avro"
+metadata:
+  keywords:
+  - "avro"
+  guide: "https://quarkus.io/guides/kafka"
+  categories:
+  - "serialization"
+  status: "experimental"

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -100,6 +100,7 @@
         <module>mongodb-client</module>
         <module>artemis-core</module>
         <module>artemis-jms</module>
+        <module>avro</module>
 
         <!-- Spring -->
         <module>spring-di</module>

--- a/integration-tests/kafka-avro/pom.xml
+++ b/integration-tests/kafka-avro/pom.xml
@@ -51,10 +51,16 @@
 
         <!-- Avro -->
         <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>1.9.2</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-avro</artifactId>
         </dependency>
+
+        <!-- Apicurio needs the rest client -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+
         <!-- Confluent (Not in Maven Central) -->
         <dependency>
             <groupId>io.confluent</groupId>
@@ -204,6 +210,54 @@
                         <configuration>
                             <skip>false</skip>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>native-image-it-main</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <enableAllSecurityServices>true</enableAllSecurityServices>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/kafka-avro/src/main/resources/application.properties
+++ b/integration-tests/kafka-avro/src/main/resources/application.properties
@@ -6,6 +6,3 @@ quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 quarkus.kafka.health.enabled=true
 kafka.bootstrap.servers=localhost:19092
 
-
-# Native - Avro is not supported in native mode.
-quarkus.native.additional-build-args=--initialize-at-run-time=io.quarkus.it.kafka.avro.Pet

--- a/integration-tests/kafka-avro/src/test/java/io/quarkus/it/kafka/KafkaAvroIT.java
+++ b/integration-tests/kafka-avro/src/test/java/io/quarkus/it/kafka/KafkaAvroIT.java
@@ -1,0 +1,11 @@
+package io.quarkus.it.kafka;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+@QuarkusTestResource(KafkaTestResource.class)
+@QuarkusTestResource(SchemaRegistryTestResource.class)
+public class KafkaAvroIT extends KafkaAvroTest {
+
+}


### PR DESCRIPTION
This PR adds experimental support for Avro in native mode.

I consider this support experimental as I based my experiments on the few tests we have. So most probably something might be missing, or need to be tuned.

The PR introduced a new `quarkus-avro` extension with a few substitutions and native configuration.
It also extends the Kafka Processor to register the Avro serde and related classes for the Confluent Avro serde and the Apicurio Avro serde.

This might also enable Avro for Kafka Streams (CC @gunnarmorling)