### PR TITLE
Removed support for GraalVM 19.x

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -424,11 +424,11 @@ public class NativeImageBuildStep {
 
     private void checkGraalVMVersion(String version) {
         log.info("Running Quarkus native-image plugin on " + version);
-        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.", "19.3.0", "20.0.");
+        final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.", "19.3.", "20.0.");
         final boolean vmVersionIsObsolete = obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
         if (vmVersionIsObsolete) {
             throw new IllegalStateException("Out of date version of GraalVM detected: " + version + "."
-                    + " Quarkus currently supports GraalVM 19.3.2 and 20.1.0. Please upgrade GraalVM to one of these versions.");
+                    + " Quarkus currently supports 20.1.0. Please upgrade GraalVM to this version.");
         }
     }
 

--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -591,7 +591,7 @@ For Maven, add the following to your `pom.xml`.
     </dependencies>
 ----
 
-NOTE: if you are using GraalVM earlier than 19.3, or see `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty` or similar SSL error, due to the current status of GraalVM,
+NOTE: if you see `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty` or similar SSL error, due to the current status of GraalVM,
 there is some additional work to bundle the `function.zip`, as below.  For more information, please see the link:native-and-ssl[Quarkus Native SSL Guide].
 
 == Additional requirements for client SSL
@@ -631,9 +631,9 @@ NOTE: If you are using a Docker image to build, then you must extract these file
 To extract the required ssl, you must start up a Docker container in the background, and attach to that container to copy the artifacts.
 
 First, let's start the GraalVM container, noting the container id output.
-[source, shell]
+[source, shell,subs=attributes+]
 ----
-docker run -it -d --entrypoint bash quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java8
+docker run -it -d --entrypoint bash quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}
 
 # This will output a container id, like 6304eea6179522aff69acb38eca90bedfd4b970a5475aa37ccda3585bc2abdde
 # Note this value as we will need it for the commands below

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -312,18 +312,18 @@ The `buildNative` task has been deprecated in favor of
 Native related properties can either be added in `application.properties` file, as command line arguments or in the `quarkusBuild` task.
 Configuring the `quarkusBuild` task can be done as following:
 
-[source,groovy]
+[source,groovy,subs=attributes+]
 ----
 quarkusBuild {
     nativeArgs {
         containerBuild = true <1>
-        buildImage = "quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11" <2>
+        buildImage = "quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.containerBuild` property to `true`
-<2> Set `quarkus.native.buildImage` property to `quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11`
+<2> Set `quarkus.native.buildImage` property to `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}`
 
 
 === Build a container friendly executable

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -317,13 +317,13 @@ Configuring the `quarkusBuild` task can be done as following:
 quarkusBuild {
     nativeArgs {
         containerBuild = true <1>
-        buildImage = "quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11" <2>
+        buildImage = "quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.containerBuild` property to `true`
-<2> Set `quarkus.native.buildImage` property to `quay.io/quarkus/ubi-quarkus-native-image:19.3.1-java11`
+<2> Set `quarkus.native.buildImage` property to `quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11`
 
 
 === Build a container friendly executable


### PR DESCRIPTION

This was simpler than expected, as I couldn't find any integration tests based on GraalVM 19 to disable / remove. Is that correct?

Fixes #10838 