### PR TITLE
Don't trigger a native-image warning about using -H:+IncludeAllTimeZones explicitly

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -291,9 +291,9 @@ public class NativeImageBuildStep {
             } else {
                 command.add("-H:-AddAllCharsets");
             }
-            if (nativeConfig.includeAllTimeZones) {
-                command.add("-H:+IncludeAllTimeZones");
-            } else {
+            //if 'includeAllTimeZones' is set, don't request it explicitly as native-image will log a warning about this being now the default.
+            //(But still disable it when necessary)
+            if (!nativeConfig.includeAllTimeZones) {
                 command.add("-H:-IncludeAllTimeZones");
             }
             if (!protocols.isEmpty()) {


### PR DESCRIPTION
…nes explicitly

Rebased my previous PR #10061 - which I had closed as it would have broken compatibility on GraalVM 19.

This is a follow-up to #10838 