### PR TITLE
Added missing docker port flag for AWS SQS guide

### DIFF
--- a/docs/src/main/asciidoc/amazon-sqs.adoc
+++ b/docs/src/main/asciidoc/amazon-sqs.adoc
@@ -44,7 +44,7 @@ The easiest way to start working with SQS is to run a local instance as a contai
 
 [source,shell,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-sqs 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-sqs -p 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1
 ----
 This starts a SQS instance that is accessible on port `8010`.
 


### PR DESCRIPTION
Without `-p`:
```
docker run --rm --name local-sqs 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1
Unable to find image '8010:4576' locally
```
With fix:
```
 docker run --rm --name local-sqs -p 8010:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1
Unable to find image 'localstack/localstack:0.11.1' locally
0.11.1: Pulling from localstack/localstack
309cae7bf612: Downloading [>                                                  ]  2.685MB/468MB
```