### PR TITLE
Add Vault System Backend Engine Policy and Kubernetes Auth method provisioning services

### DIFF
--- a/docs/src/main/asciidoc/vault.adoc
+++ b/docs/src/main/asciidoc/vault.adoc
@@ -443,6 +443,63 @@ The last relevant property is `quarkus.vault.tls.skip-verify`, which allows to c
 but without checking the certificate authenticity. This may be convenient in development, but is strongly
 discouraged in production as it is not more secure than talking to Vault in plain HTTP.
 
+== Vault Provisioning
+
+Beside the typical client use cases, the Quarkus extension can be used to provision Vault as well, 
+for instance as part of a CD pipeline. Specific CDI beans support this scenario:
+
+* `VaultSystemBackendEngine`: create Vault Policies. See the https://www.vaultproject.io/api-docs/system/policy[Vault documentation].
+* `VaultKubernetesAuthService`. See the https://www.vaultproject.io/api-docs/auth/kubernetes[Vault documentation].
+** Configure the Kubernetes Auth Method (Kubernetes host, certificates, keys, ...)
+** Create Kubernetes Auth Roles (association between Kubernetes service accounts, Kubernetes namespaces and Vault policies)
+
+For instance:
+
+[source, java]
+----
+@Inject
+VaultSystemBackendEngine vaultSystemBackendEngine;
+
+@Inject
+VaultKubernetesAuthService vaultKubernetesAuthService;
+
+...
+
+  String rules = "path \"transit/*\" {\n" +
+          "  capabilities = [ \"create\", \"read\", \"update\" ]\n" +
+          "}";
+  String policyName = "sys-test-policy";
+  vaultSystemBackendEngine.createUpdatePolicy(policyName, rules);
+
+  String roleName = "test-auth-k8s";
+  List<String> boundServiceAccountNames = asList("vault-auth");
+  List<String> boundServiceAccountNamespaces = asList("default");
+  List<String> tokenPolicies = asList(policyName);
+
+  vaultKubernetesAuthService.createRole(roleName, new VaultKubernetesAuthRole()
+          .setBoundServiceAccountNames(boundServiceAccountNames)
+          .setBoundServiceAccountNamespaces(boundServiceAccountNamespaces)
+          .setTokenPolicies(tokenPolicies));
+
+----
+
+Like any client, a provisioning program would have to authenticate using one of the supported Auth methods, and get the appropriate grants through one or more policies. Example:
+
+[source]
+----
+# create Policies
+path "sys/policy/*" {
+  capabilities = ["read", "create", "update", "delete"]
+}
+
+# create Kubernetes Auth Roles
+path "auth/kubernetes/role/*" {
+  capabilities = ["read", "create", "update", "delete"]
+}
+----
+
+You should adjust to the minimal set of access rights depending on your specific use case.
+
 == Conclusion
 
 As a general matter, you should consider reading the extensive https://www.vaultproject.io/docs/[Vault documentation]

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultKubernetesAuthService.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultKubernetesAuthService.java
@@ -1,0 +1,58 @@
+package io.quarkus.vault;
+
+import java.util.List;
+
+import io.quarkus.vault.auth.VaultKubernetesAuthConfig;
+import io.quarkus.vault.auth.VaultKubernetesAuthRole;
+
+/**
+ * This service provides programmatic access to the Kubernetes auth method.
+ * This may be used by admin clients that provision Vault for use from Kubernetes.
+ */
+public interface VaultKubernetesAuthService {
+
+    /**
+     * Configure the Kubernetes auth method.
+     *
+     * @param config configuration detail
+     */
+    void configure(VaultKubernetesAuthConfig config);
+
+    /**
+     * Gives access to the currently configured Kubernetes auth method.
+     *
+     * @return the configuration
+     */
+    VaultKubernetesAuthConfig getConfig();
+
+    /**
+     * Returns the definition of a Kubernetes vault role.
+     *
+     * @param name role name
+     * @return the Kubernetes vault role
+     */
+    VaultKubernetesAuthRole getRole(String name);
+
+    /**
+     * Create or update a Kubernetes vault role.
+     *
+     * @param name role name
+     * @param role role attributes
+     */
+    void createRole(String name, VaultKubernetesAuthRole role);
+
+    /**
+     * Delete a Kubernetes vault role through its name.
+     *
+     * @param name role name to delete
+     */
+    void deleteRole(String name);
+
+    /**
+     * Get the names of the existing Kubernetes vault roles.
+     *
+     * @return the role names
+     */
+    List<String> getRoles();
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendEngine.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendEngine.java
@@ -1,5 +1,7 @@
 package io.quarkus.vault;
 
+import java.util.List;
+
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 import io.quarkus.vault.sys.VaultHealth;
 import io.quarkus.vault.sys.VaultHealthStatus;
@@ -47,4 +49,34 @@ public interface VaultSystemBackendEngine {
      * @return Vault Seal Status.
      */
     VaultSealStatus sealStatus();
+
+    /**
+     * Get the rules for the named policy.
+     * 
+     * @param name of the policy
+     * @return rules of named policy
+     */
+    String getPolicyRules(String name);
+
+    /**
+     * Create or update a policy.
+     *
+     * @param name policy name
+     * @param rules policy content
+     */
+    void createUpdatePolicy(String name, String rules);
+
+    /**
+     * Delete a policy by its name.
+     *
+     * @param name policy name
+     */
+    void deletePolicy(String name);
+
+    /**
+     * List existing policies.
+     * 
+     * @return a list of all policy names
+     */
+    List<String> getPolicies();
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/auth/VaultKubernetesAuthConfig.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/auth/VaultKubernetesAuthConfig.java
@@ -1,0 +1,57 @@
+package io.quarkus.vault.auth;
+
+import java.util.List;
+
+public class VaultKubernetesAuthConfig {
+
+    public String kubernetesHost;
+    public String kubernetesCaCert;
+    public String tokenReviewerJwt;
+    public List<String> pemKeys;
+    public String issuer;
+
+    public String getKubernetesHost() {
+        return kubernetesHost;
+    }
+
+    public VaultKubernetesAuthConfig setKubernetesHost(String kubernetesHost) {
+        this.kubernetesHost = kubernetesHost;
+        return this;
+    }
+
+    public String getKubernetesCaCert() {
+        return kubernetesCaCert;
+    }
+
+    public VaultKubernetesAuthConfig setKubernetesCaCert(String kubernetesCaCert) {
+        this.kubernetesCaCert = kubernetesCaCert;
+        return this;
+    }
+
+    public String getTokenReviewerJwt() {
+        return tokenReviewerJwt;
+    }
+
+    public VaultKubernetesAuthConfig setTokenReviewerJwt(String tokenReviewerJwt) {
+        this.tokenReviewerJwt = tokenReviewerJwt;
+        return this;
+    }
+
+    public List<String> getPemKeys() {
+        return pemKeys;
+    }
+
+    public VaultKubernetesAuthConfig setPemKeys(List<String> pemKeys) {
+        this.pemKeys = pemKeys;
+        return this;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public VaultKubernetesAuthConfig setIssuer(String issuer) {
+        this.issuer = issuer;
+        return this;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/auth/VaultKubernetesAuthRole.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/auth/VaultKubernetesAuthRole.java
@@ -1,0 +1,127 @@
+package io.quarkus.vault.auth;
+
+import java.util.List;
+
+public class VaultKubernetesAuthRole {
+
+    public List<String> boundServiceAccountNames;
+    public List<String> boundServiceAccountNamespaces;
+    public String audience;
+    public Integer tokenTtl;
+    public List<String> tokenPolicies;
+    public List<String> tokenBoundCidrs;
+    public Integer tokenMaxTtl;
+    public Integer tokenExplicitMaxTtl;
+    public Boolean tokenNoDefaultPolicy;
+    public Integer tokenNumUses;
+    public Integer tokenPeriod;
+    public String tokenType;
+
+    public List<String> getBoundServiceAccountNames() {
+        return boundServiceAccountNames;
+    }
+
+    public List<String> getBoundServiceAccountNamespaces() {
+        return boundServiceAccountNamespaces;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public Integer getTokenTtl() {
+        return tokenTtl;
+    }
+
+    public List<String> getTokenPolicies() {
+        return tokenPolicies;
+    }
+
+    public List<String> getTokenBoundCidrs() {
+        return tokenBoundCidrs;
+    }
+
+    public Integer getTokenMaxTtl() {
+        return tokenMaxTtl;
+    }
+
+    public Integer getTokenExplicitMaxTtl() {
+        return tokenExplicitMaxTtl;
+    }
+
+    public Boolean getTokenNoDefaultPolicy() {
+        return tokenNoDefaultPolicy;
+    }
+
+    public Integer getTokenNumUses() {
+        return tokenNumUses;
+    }
+
+    public Integer getTokenPeriod() {
+        return tokenPeriod;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public VaultKubernetesAuthRole setBoundServiceAccountNames(List<String> boundServiceAccountNames) {
+        this.boundServiceAccountNames = boundServiceAccountNames;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setBoundServiceAccountNamespaces(List<String> boundServiceAccountNamespaces) {
+        this.boundServiceAccountNamespaces = boundServiceAccountNamespaces;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setAudience(String audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenTtl(Integer tokenTtl) {
+        this.tokenTtl = tokenTtl;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenPolicies(List<String> tokenPolicies) {
+        this.tokenPolicies = tokenPolicies;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenBoundCidrs(List<String> tokenBoundCidrs) {
+        this.tokenBoundCidrs = tokenBoundCidrs;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenMaxTtl(Integer tokenMaxTtl) {
+        this.tokenMaxTtl = tokenMaxTtl;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenExplicitMaxTtl(Integer tokenExplicitMaxTtl) {
+        this.tokenExplicitMaxTtl = tokenExplicitMaxTtl;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenNoDefaultPolicy(Boolean tokenNoDefaultPolicy) {
+        this.tokenNoDefaultPolicy = tokenNoDefaultPolicy;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenNumUses(Integer tokenNumUses) {
+        this.tokenNumUses = tokenNumUses;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenPeriod(Integer tokenPeriod) {
+        this.tokenPeriod = tokenPeriod;
+        return this;
+    }
+
+    public VaultKubernetesAuthRole setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+        return this;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultKubernetesAuthManager.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultKubernetesAuthManager.java
@@ -1,0 +1,103 @@
+package io.quarkus.vault.runtime;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.quarkus.vault.VaultKubernetesAuthService;
+import io.quarkus.vault.auth.VaultKubernetesAuthConfig;
+import io.quarkus.vault.auth.VaultKubernetesAuthRole;
+import io.quarkus.vault.runtime.client.VaultClient;
+import io.quarkus.vault.runtime.client.VaultClientException;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigData;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthRoleData;
+
+public class VaultKubernetesAuthManager implements VaultKubernetesAuthService {
+
+    private final VaultAuthManager vaultAuthManager;
+    private final VaultClient vaultClient;
+
+    public VaultKubernetesAuthManager(VaultAuthManager vaultAuthManager, VaultClient vaultClient) {
+        this.vaultAuthManager = vaultAuthManager;
+        this.vaultClient = vaultClient;
+    }
+
+    @Override
+    public void configure(VaultKubernetesAuthConfig config) {
+        String token = vaultAuthManager.getClientToken();
+        vaultClient.configureKubernetesAuth(token, new VaultKubernetesAuthConfigData()
+                .setIssuer(config.issuer)
+                .setKubernetesCaCert(config.kubernetesCaCert)
+                .setKubernetesHost(config.kubernetesHost)
+                .setPemKeys(config.pemKeys)
+                .setTokenReviewerJwt(config.tokenReviewerJwt));
+    }
+
+    @Override
+    public VaultKubernetesAuthConfig getConfig() {
+        String token = vaultAuthManager.getClientToken();
+        VaultKubernetesAuthConfigData data = vaultClient.readKubernetesAuthConfig(token).data;
+        return new VaultKubernetesAuthConfig()
+                .setKubernetesCaCert(data.kubernetesCaCert)
+                .setKubernetesHost(data.kubernetesHost)
+                .setIssuer(data.issuer)
+                .setPemKeys(data.pemKeys)
+                .setTokenReviewerJwt(data.tokenReviewerJwt);
+    }
+
+    public VaultKubernetesAuthRole getRole(String name) {
+        String token = vaultAuthManager.getClientToken();
+        VaultKubernetesAuthRoleData role = vaultClient.getVaultKubernetesAuthRole(token, name).data;
+        return new VaultKubernetesAuthRole()
+                .setBoundServiceAccountNames(role.boundServiceAccountNames)
+                .setBoundServiceAccountNamespaces(role.boundServiceAccountNamespaces)
+                .setAudience(role.audience)
+                .setTokenTtl(role.tokenTtl)
+                .setTokenMaxTtl(role.tokenMaxTtl)
+                .setTokenPolicies(role.tokenPolicies)
+                .setTokenBoundCidrs(role.tokenBoundCidrs)
+                .setTokenExplicitMaxTtl(role.tokenExplicitMaxTtl)
+                .setTokenNoDefaultPolicy(role.tokenNoDefaultPolicy)
+                .setTokenNumUses(role.tokenNumUses)
+                .setTokenPeriod(role.tokenPeriod)
+                .setTokenType(role.tokenType);
+    }
+
+    public void createRole(String name, VaultKubernetesAuthRole role) {
+        String token = vaultAuthManager.getClientToken();
+        VaultKubernetesAuthRoleData body = new VaultKubernetesAuthRoleData()
+                .setBoundServiceAccountNames(role.boundServiceAccountNames)
+                .setBoundServiceAccountNamespaces(role.boundServiceAccountNamespaces)
+                .setAudience(role.audience)
+                .setTokenTtl(role.tokenTtl)
+                .setTokenMaxTtl(role.tokenMaxTtl)
+                .setTokenPolicies(role.tokenPolicies)
+                .setTokenBoundCidrs(role.tokenBoundCidrs)
+                .setTokenExplicitMaxTtl(role.tokenExplicitMaxTtl)
+                .setTokenNoDefaultPolicy(role.tokenNoDefaultPolicy)
+                .setTokenNumUses(role.tokenNumUses)
+                .setTokenPeriod(role.tokenPeriod)
+                .setTokenType(role.tokenType);
+        vaultClient.createKubernetesAuthRole(token, name, body);
+    }
+
+    @Override
+    public List<String> getRoles() {
+        try {
+            String token = vaultAuthManager.getClientToken();
+            return vaultClient.listKubernetesAuthRoles(token).data.keys;
+        } catch (VaultClientException e) {
+            if (e.getStatus() == 404) {
+                return Collections.emptyList();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void deleteRole(String name) {
+        String token = vaultAuthManager.getClientToken();
+        vaultClient.deleteKubernetesAuthRoles(token, name);
+    }
+
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultManager.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultManager.java
@@ -20,6 +20,7 @@ public class VaultManager {
     private VaultCredentialsProvider vaultCredentialsProvider;
     private VaultTOTPManager vaultTOTPManager;
     private VaultSystemBackendManager vaultSystemBackendManager;
+    private VaultKubernetesAuthManager vaultKubernetesAuthManager;
 
     public static VaultManager getInstance() {
         return instance;
@@ -49,7 +50,9 @@ public class VaultManager {
         this.vaultTransitManager = new VaultTransitManager(this.vaultAuthManager, this.vaultClient, serverConfig);
         this.vaultCredentialsProvider = new VaultCredentialsProvider(serverConfig, this.vaultKvManager, this.vaultDbManager);
         this.vaultTOTPManager = new VaultTOTPManager(this.vaultAuthManager, this.vaultClient);
-        this.vaultSystemBackendManager = new VaultSystemBackendManager(this.buildTimeConfig, this.vaultClient);
+        this.vaultSystemBackendManager = new VaultSystemBackendManager(this.buildTimeConfig, this.vaultAuthManager,
+                this.vaultClient);
+        this.vaultKubernetesAuthManager = new VaultKubernetesAuthManager(this.vaultAuthManager, this.vaultClient);
     }
 
     public VaultClient getVaultClient() {
@@ -90,5 +93,9 @@ public class VaultManager {
 
     public VaultSystemBackendManager getVaultSystemBackendManager() {
         return vaultSystemBackendManager;
+    }
+
+    public VaultKubernetesAuthManager getVaultKubernetesAuthManager() {
+        return vaultKubernetesAuthManager;
     }
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultServiceProducer.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultServiceProducer.java
@@ -42,6 +42,12 @@ public class VaultServiceProducer {
 
     @Produces
     @ApplicationScoped
+    public VaultKubernetesAuthManager createVaultKubernetesAuthManager() {
+        return VaultManager.getInstance().getVaultKubernetesAuthManager();
+    }
+
+    @Produces
+    @ApplicationScoped
     @Named("vault-credentials-provider")
     public CredentialsProvider createCredentialsProvider() {
         return VaultManager.getInstance().getVaultCredentialsProvider();

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/OkHttpVaultClient.java
@@ -21,6 +21,11 @@ import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuthBody;
 import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthBody;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigData;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthListRolesResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthReadRoleResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthRoleData;
 import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelfBody;
@@ -36,6 +41,9 @@ import io.quarkus.vault.runtime.client.dto.sys.VaultInitBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
+import io.quarkus.vault.runtime.client.dto.sys.VaultListPolicyResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
+import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapBody;
@@ -94,6 +102,36 @@ public class OkHttpVaultClient implements VaultClient {
     public VaultKubernetesAuth loginKubernetes(String role, String jwt) {
         VaultKubernetesAuthBody body = new VaultKubernetesAuthBody(role, jwt);
         return post(kubernetesAuthMountPath + "/login", null, body, VaultKubernetesAuth.class);
+    }
+
+    @Override
+    public void createKubernetesAuthRole(String token, String name, VaultKubernetesAuthRoleData body) {
+        post(kubernetesAuthMountPath + "/role/" + name, token, body, 204);
+    }
+
+    @Override
+    public VaultKubernetesAuthReadRoleResult getVaultKubernetesAuthRole(String token, String name) {
+        return get(kubernetesAuthMountPath + "/role/" + name, token, VaultKubernetesAuthReadRoleResult.class);
+    }
+
+    @Override
+    public VaultKubernetesAuthListRolesResult listKubernetesAuthRoles(String token) {
+        return list(kubernetesAuthMountPath + "/role", token, VaultKubernetesAuthListRolesResult.class);
+    }
+
+    @Override
+    public void deleteKubernetesAuthRoles(String token, String name) {
+        delete(kubernetesAuthMountPath + "/role/" + name, token, 204);
+    }
+
+    @Override
+    public void configureKubernetesAuth(String token, VaultKubernetesAuthConfigData config) {
+        post(kubernetesAuthMountPath + "/config", token, config, 204);
+    }
+
+    @Override
+    public VaultKubernetesAuthConfigResult readKubernetesAuthConfig(String token) {
+        return get(kubernetesAuthMountPath + "/config", token, VaultKubernetesAuthConfigResult.class);
     }
 
     @Override
@@ -268,6 +306,26 @@ public class OkHttpVaultClient implements VaultClient {
         return post("sys/wrapping/unwrap", wrappingToken, VaultUnwrapBody.EMPTY, resultClass);
     }
 
+    @Override
+    public VaultPolicyResult getPolicy(String token, String name) {
+        return get("sys/policy/" + name, token, VaultPolicyResult.class);
+    }
+
+    @Override
+    public void createUpdatePolicy(String token, String name, VaultPolicyBody body) {
+        put("sys/policy/" + name, token, body, 204);
+    }
+
+    @Override
+    public VaultListPolicyResult listPolicies(String token) {
+        return get("sys/policy", token, VaultListPolicyResult.class);
+    }
+
+    @Override
+    public void deletePolicy(String token, String name) {
+        delete("sys/policy/" + name, token, 204);
+    }
+
     // ---
 
     protected <T> T list(String path, String token, Class<T> resultClass) {
@@ -298,6 +356,11 @@ public class OkHttpVaultClient implements VaultClient {
 
     protected <T> T post(String path, String token, Object body, int expectedCode) {
         Request request = builder(path, token).post(requestBody(body)).build();
+        return exec(request, expectedCode);
+    }
+
+    protected <T> T put(String path, String token, Object body, int expectedCode) {
+        Request request = builder(path, token).put(requestBody(body)).build();
         return exec(request, expectedCode);
     }
 

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
@@ -4,6 +4,11 @@ import java.util.Map;
 
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigData;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthConfigResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthListRolesResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthReadRoleResult;
+import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthRoleData;
 import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuth;
@@ -14,6 +19,9 @@ import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2WriteBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultHealthResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultInitResponse;
 import io.quarkus.vault.runtime.client.dto.sys.VaultLeasesLookup;
+import io.quarkus.vault.runtime.client.dto.sys.VaultListPolicyResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
+import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultWrapResult;
@@ -41,6 +49,18 @@ public interface VaultClient {
     VaultUserPassAuth loginUserPass(String user, String password);
 
     VaultKubernetesAuth loginKubernetes(String role, String jwt);
+
+    void createKubernetesAuthRole(String token, String name, VaultKubernetesAuthRoleData body);
+
+    VaultKubernetesAuthReadRoleResult getVaultKubernetesAuthRole(String token, String name);
+
+    VaultKubernetesAuthListRolesResult listKubernetesAuthRoles(String token);
+
+    void deleteKubernetesAuthRoles(String token, String name);
+
+    void configureKubernetesAuth(String token, VaultKubernetesAuthConfigData config);
+
+    VaultKubernetesAuthConfigResult readKubernetesAuthConfig(String token);
 
     VaultAppRoleAuth loginAppRole(String roleId, String secretId);
 
@@ -101,4 +121,13 @@ public interface VaultClient {
     VaultWrapResult wrap(String token, long ttl, Object object);
 
     <T> T unwrap(String wrappingToken, Class<T> resultClass);
+
+    VaultPolicyResult getPolicy(String token, String name);
+
+    void createUpdatePolicy(String token, String name, VaultPolicyBody body);
+
+    VaultListPolicyResult listPolicies(String token);
+
+    void deletePolicy(String token, String name);
+
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthConfigData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthConfigData.java
@@ -1,0 +1,65 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultKubernetesAuthConfigData implements VaultModel {
+
+    @JsonProperty("kubernetes_host")
+    public String kubernetesHost;
+    @JsonProperty("kubernetes_ca_cert")
+    public String kubernetesCaCert;
+    @JsonProperty("token_reviewer_jwt")
+    public String tokenReviewerJwt;
+    @JsonProperty("pem_keys")
+    public List<String> pemKeys;
+    public String issuer;
+
+    public String getKubernetesHost() {
+        return kubernetesHost;
+    }
+
+    public VaultKubernetesAuthConfigData setKubernetesHost(String kubernetesHost) {
+        this.kubernetesHost = kubernetesHost;
+        return this;
+    }
+
+    public String getKubernetesCaCert() {
+        return kubernetesCaCert;
+    }
+
+    public VaultKubernetesAuthConfigData setKubernetesCaCert(String kubernetesCaCert) {
+        this.kubernetesCaCert = kubernetesCaCert;
+        return this;
+    }
+
+    public String getTokenReviewerJwt() {
+        return tokenReviewerJwt;
+    }
+
+    public VaultKubernetesAuthConfigData setTokenReviewerJwt(String tokenReviewerJwt) {
+        this.tokenReviewerJwt = tokenReviewerJwt;
+        return this;
+    }
+
+    public List<String> getPemKeys() {
+        return pemKeys;
+    }
+
+    public VaultKubernetesAuthConfigData setPemKeys(List<String> pemKeys) {
+        this.pemKeys = pemKeys;
+        return this;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public VaultKubernetesAuthConfigData setIssuer(String issuer) {
+        this.issuer = issuer;
+        return this;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthConfigResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthConfigResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultKubernetesAuthConfigResult extends AbstractVaultDTO<VaultKubernetesAuthConfigData, Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthListRolesData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthListRolesData.java
@@ -1,0 +1,10 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import java.util.List;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultKubernetesAuthListRolesData implements VaultModel {
+
+    public List<String> keys;
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthListRolesResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthListRolesResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultKubernetesAuthListRolesResult extends AbstractVaultDTO<VaultKubernetesAuthListRolesData, Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthReadRoleResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthReadRoleResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultKubernetesAuthReadRoleResult extends AbstractVaultDTO<VaultKubernetesAuthRoleData, Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthRoleData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultKubernetesAuthRoleData.java
@@ -1,0 +1,142 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultKubernetesAuthRoleData implements VaultModel {
+
+    @JsonProperty("bound_service_account_names")
+    public List<String> boundServiceAccountNames;
+    @JsonProperty("bound_service_account_namespaces")
+    public List<String> boundServiceAccountNamespaces;
+    public String audience;
+    @JsonProperty("token_ttl")
+    public Integer tokenTtl;
+    @JsonProperty("token_policies")
+    public List<String> tokenPolicies;
+    @JsonProperty("token_bound_cidrs")
+    public List<String> tokenBoundCidrs;
+    @JsonProperty("token_max_ttl")
+    public Integer tokenMaxTtl;
+    @JsonProperty("token_explicit_max_ttl")
+    public Integer tokenExplicitMaxTtl;
+    @JsonProperty("token_no_default_policy")
+    public Boolean tokenNoDefaultPolicy;
+    @JsonProperty("token_num_uses")
+    public Integer tokenNumUses;
+    @JsonProperty("token_period")
+    public Integer tokenPeriod;
+    @JsonProperty("token_type")
+    public String tokenType;
+
+    public List<String> getBoundServiceAccountNames() {
+        return boundServiceAccountNames;
+    }
+
+    public VaultKubernetesAuthRoleData setBoundServiceAccountNames(List<String> boundServiceAccountNames) {
+        this.boundServiceAccountNames = boundServiceAccountNames;
+        return this;
+    }
+
+    public List<String> getBoundServiceAccountNamespaces() {
+        return boundServiceAccountNamespaces;
+    }
+
+    public VaultKubernetesAuthRoleData setBoundServiceAccountNamespaces(List<String> boundServiceAccountNamespaces) {
+        this.boundServiceAccountNamespaces = boundServiceAccountNamespaces;
+        return this;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public VaultKubernetesAuthRoleData setAudience(String audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    public Integer getTokenTtl() {
+        return tokenTtl;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenTtl(Integer tokenTtl) {
+        this.tokenTtl = tokenTtl;
+        return this;
+    }
+
+    public List<String> getTokenPolicies() {
+        return tokenPolicies;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenPolicies(List<String> tokenPolicies) {
+        this.tokenPolicies = tokenPolicies;
+        return this;
+    }
+
+    public List<String> getTokenBoundCidrs() {
+        return tokenBoundCidrs;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenBoundCidrs(List<String> tokenBoundCidrs) {
+        this.tokenBoundCidrs = tokenBoundCidrs;
+        return this;
+    }
+
+    public Integer getTokenMaxTtl() {
+        return tokenMaxTtl;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenMaxTtl(Integer tokenMaxTtl) {
+        this.tokenMaxTtl = tokenMaxTtl;
+        return this;
+    }
+
+    public Integer getTokenExplicitMaxTtl() {
+        return tokenExplicitMaxTtl;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenExplicitMaxTtl(Integer tokenExplicitMaxTtl) {
+        this.tokenExplicitMaxTtl = tokenExplicitMaxTtl;
+        return this;
+    }
+
+    public Boolean getTokenNoDefaultPolicy() {
+        return tokenNoDefaultPolicy;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenNoDefaultPolicy(Boolean tokenNoDefaultPolicy) {
+        this.tokenNoDefaultPolicy = tokenNoDefaultPolicy;
+        return this;
+    }
+
+    public Integer getTokenNumUses() {
+        return tokenNumUses;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenNumUses(Integer tokenNumUses) {
+        this.tokenNumUses = tokenNumUses;
+        return this;
+    }
+
+    public Integer getTokenPeriod() {
+        return tokenPeriod;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenPeriod(Integer tokenPeriod) {
+        this.tokenPeriod = tokenPeriod;
+        return this;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public VaultKubernetesAuthRoleData setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+        return this;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultListPolicyData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultListPolicyData.java
@@ -1,0 +1,10 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import java.util.List;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultListPolicyData implements VaultModel {
+
+    public List<String> policies;
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultListPolicyResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultListPolicyResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultListPolicyResult extends AbstractVaultDTO<VaultListPolicyData, Object> {
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultPolicyBody.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultPolicyBody.java
@@ -1,0 +1,12 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultPolicyBody implements VaultModel {
+
+    public String policy;
+
+    public VaultPolicyBody(String policy) {
+        this.policy = policy;
+    }
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultPolicyData.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultPolicyData.java
@@ -1,0 +1,9 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultPolicyData implements VaultModel {
+
+    public String name;
+    public String rules;
+}

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultPolicyResult.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultPolicyResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultPolicyResult extends AbstractVaultDTO<VaultPolicyData, Object> {
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAuthITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAuthITCase.java
@@ -1,0 +1,95 @@
+package io.quarkus.vault;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.auth.VaultKubernetesAuthConfig;
+import io.quarkus.vault.auth.VaultKubernetesAuthRole;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultAuthITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application-vault.properties", "application.properties"));
+
+    @Inject
+    VaultKubernetesAuthService vaultKubernetesAuthService;
+
+    @Test
+    public void role() {
+        String name = "test-auth-k8s";
+        List<String> boundServiceAccountNames = asList("vault-auth");
+        List<String> boundServiceAccountNamespaces = asList("default");
+        List<String> tokenPolicies = asList("dev", "prod");
+        vaultKubernetesAuthService.createRole(name, new VaultKubernetesAuthRole()
+                .setBoundServiceAccountNames(boundServiceAccountNames)
+                .setBoundServiceAccountNamespaces(boundServiceAccountNamespaces)
+                .setTokenPolicies(tokenPolicies));
+
+        List<String> roles = vaultKubernetesAuthService.getRoles();
+        assertTrue(roles.contains(name));
+
+        VaultKubernetesAuthRole role = vaultKubernetesAuthService.getRole(name);
+        assertEquals(boundServiceAccountNames, role.boundServiceAccountNames);
+        assertEquals(boundServiceAccountNamespaces, role.boundServiceAccountNamespaces);
+        assertEquals(tokenPolicies, role.tokenPolicies);
+
+        vaultKubernetesAuthService.deleteRole(name);
+
+        roles = vaultKubernetesAuthService.getRoles();
+        assertFalse(roles.contains(name));
+    }
+
+    @Test
+    public void config() {
+
+        String caCert = "-----BEGIN CERTIFICATE-----\n" +
+                "MIIDMTCCAhmgAwIBAgIJAM9e7Tsk0nLvMA0GCSqGSIb3DQEBCwUAMEcxCzAJBgNV\n" +
+                "BAYTAkZSMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAlBY21lIENvcnAx\n" +
+                "DzANBgNVBAMMBnRlc3RjYTAeFw0yMDA0MDQxMjEyNTlaFw0zMDA0MDIxMjEyNTla\n" +
+                "MEcxCzAJBgNVBAYTAkZSMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQKDAlB\n" +
+                "Y21lIENvcnAxDzANBgNVBAMMBnRlc3RjYTCCASIwDQYJKoZIhvcNAQEBBQADggEP\n" +
+                "ADCCAQoCggEBANGaRFI/mUr94qKSdOvev/bL8CYx2rw4VmrqMytzH78s+3cSpOYw\n" +
+                "ovKY9Ua5+F//5XSuY2oQEf1GUg7a+66awGdzKcqX1+BWU68S2YUKKER5jGrfEvvR\n" +
+                "AVQeqMf6U12EG89JHWYlgSsNFNKGp0sckH4PZyZchkQSU7VTQ0o7ZzimVOxhVzmP\n" +
+                "7ZuYtRGmFRGCmROlIzzdUJF8/ntygaexxyCq51UZ5ntT22RfenP/NAGReS+1R54x\n" +
+                "y6GPu5opxXZ4m7vnJ3B6z/C6nJ/xoZvzd/SdtV6k2u7f4FuBL8c63AhFp8WL5x7b\n" +
+                "Ce3weNLmq8uZF2hPYDIp8yIF1M8p53dgCVkCAwEAAaMgMB4wDAYDVR0TBAUwAwEB\n" +
+                "/zAOBgNVHQ8BAf8EBAMCAgQwDQYJKoZIhvcNAQELBQADggEBAIfk2XRUBLptRHMI\n" +
+                "S7fhUgRFsPbv7audIw2Lg/OaLBGpKuitTe3BJ6dgiSpQGBSaw9cKs0ixolGVOTmU\n" +
+                "WrMqVCtxOTzT4Fnoa8VoBDEAP/nvk61gS4tJNz1Xj6/TUHb/Gne6bNWE7uol9C7U\n" +
+                "R971oiC1IR6BA5su27R2AcpUNuU5ql4XVgmso2NMxQ7ayKMmo4Mzy8V3rN0KoqdK\n" +
+                "vugY1vmMjqdD1aMz2ANUVfhvyQ1UCI2XPEE0R5GJ2EE5dv/YuuDvXrmtqnTEVWoB\n" +
+                "4vgsrpPCXiDwzPTogeT09m/fsXealSfNcTN7VcGap7aqtZfepPcyxBwDddQsNjyx\n" +
+                "CaRgMW4=\n" +
+                "-----END CERTIFICATE-----";
+
+        String kubernetesHost = "https://192.168.99.100:8443";
+        vaultKubernetesAuthService.configure(new VaultKubernetesAuthConfig()
+                .setKubernetesHost(kubernetesHost)
+                .setKubernetesCaCert(caCert));
+
+        VaultKubernetesAuthConfig config = vaultKubernetesAuthService.getConfig();
+        assertEquals(kubernetesHost, config.kubernetesHost);
+        assertEquals(caCert, config.kubernetesCaCert);
+    }
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultSysITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultSysITCase.java
@@ -1,6 +1,11 @@
 package io.quarkus.vault;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -35,4 +40,19 @@ public class VaultSysITCase {
         assertThat(vaultSealStatus).returns(false, VaultSealStatus::isSealed);
     }
 
+    @Test
+    public void policy() {
+        String rules = "path \"transit/*\" {\n" +
+                "  capabilities = [ \"create\", \"read\", \"update\" ]\n" +
+                "}";
+        String name = "sys-test-policy";
+        vaultSystemBackendEngine.createUpdatePolicy(name, rules);
+        List<String> policies = vaultSystemBackendEngine.getPolicies();
+        assertTrue(policies.contains(name));
+        String policyRules = vaultSystemBackendEngine.getPolicyRules(name);
+        assertEquals(rules, policyRules);
+        vaultSystemBackendEngine.deletePolicy(name);
+        policies = vaultSystemBackendEngine.getPolicies();
+        assertFalse(policies.contains(name));
+    }
 }

--- a/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/vault/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -1,6 +1,7 @@
 package io.quarkus.vault.test;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +31,7 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
 
         try {
             vaultTestExtension.start();
-        } catch (InterruptedException | IOException e) {
+        } catch (InterruptedException | IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
 

--- a/test-framework/vault/src/main/resources/vault.policy
+++ b/test-framework/vault/src/main/resources/vault.policy
@@ -53,3 +53,11 @@ path "secret-v1/crud" {
 path "totp/*" {
   capabilities = ["read", "create", "update", "delete", "list"]
 }
+
+path "sys/*" {
+  capabilities = ["read", "create", "update", "delete", "list"]
+}
+
+path "auth/kubernetes/*" {
+  capabilities = ["read", "create", "update", "delete", "list"]
+}


### PR DESCRIPTION
This provides provisioning services to create and configure:
 - vault policies
 - kubernetes auth method
 - kubernetes auth role

this may be used by clients that provision vault programmatically.
in my company we have developed a java program that is deploying a kubernetes application into the cluster, including the vault objects, such as the app kubernetes auth role and policy.

I have implemented all methods on https://www.vaultproject.io/api-docs/auth/kubernetes and https://www.vaultproject.io/api-docs/system/policy for the sake of completeness.