### PR TITLE
Revert "Simplify fast jar dockerfiles by only using a single copy com…

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-fast-jar.ftl
+++ b/devtools/platform-descriptor-json/src/main/resources/templates/dockerfile-fast-jar.ftl
@@ -45,7 +45,11 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
-COPY --chown=1001 ${build_dir}/quarkus-app /deployments/
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=1001 ${build_dir}/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001 ${build_dir}/quarkus-app/*.jar /deployments/
+COPY --chown=1001 ${build_dir}/quarkus-app/app/ /deployments/app/
+COPY --chown=1001 ${build_dir}/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 1001

--- a/independent-projects/tools/devtools-common/src/test/resources/templates/dockerfile-fast-jar.ftl
+++ b/independent-projects/tools/devtools-common/src/test/resources/templates/dockerfile-fast-jar.ftl
@@ -45,7 +45,10 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
-COPY ${build_dir}/quarkus-app /deployments/
+COPY ${build_dir}/quarkus-app/lib/* /deployments/lib/
+COPY ${build_dir}/quarkus-app/*.jar /deployments/
+COPY ${build_dir}/quarkus-app/app/* /deployments/app/
+COPY ${build_dir}/quarkus-app/quarkus/* /deployments/quarkus/
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
…mand."

This reverts commit cc4435c0fd2b14744a637f88e6e17a9caa3aa9de.

The multiple copy commands are deliberate, as they result in different layers being created. This means that if you only change your application code and not your libraries only the changed part of the application needs to be shipped on deployment.