### PR TITLE
Bootstrap Maven workspace: local parent and support locally configured build dirs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -506,13 +506,11 @@ public class DevMojo extends AbstractMojo {
 
         String projectDirectory = null;
         Set<String> sourcePaths = null;
-        Set<String> sourceGenPaths = null;
         String classesPath = null;
         String resourcePath = null;
 
         final MavenProject mavenProject = session.getProjectMap().get(
                 String.format("%s:%s:%s", localProject.getGroupId(), localProject.getArtifactId(), localProject.getVersion()));
-
         if (mavenProject == null) {
             projectDirectory = localProject.getDir().toAbsolutePath().toString();
             Path sourcePath = localProject.getSourcesSourcesDir().toAbsolutePath();
@@ -530,7 +528,6 @@ public class DevMojo extends AbstractMojo {
                     .map(src -> src.toAbsolutePath().toString())
                     .collect(Collectors.toSet());
         }
-
         Path sourceParent = localProject.getSourcesDir().toAbsolutePath();
 
         Path classesDir = localProject.getClassesDir();
@@ -542,7 +539,8 @@ public class DevMojo extends AbstractMojo {
             resourcePath = resourcesSourcesDir.toAbsolutePath().toString();
         }
 
-        Path targetDir = Paths.get(project.getBuild().getOutputDirectory()).getParent();
+        Path targetDir = Paths.get(project.getBuild().getDirectory());
+
         DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo(localProject.getKey(),
                 localProject.getArtifactId(),
                 projectDirectory,
@@ -674,15 +672,14 @@ public class DevMojo extends AbstractMojo {
             }
 
             setKotlinSpecificFlags(devModeContext);
-            final LocalProject localProject;
             if (noDeps) {
-                localProject = LocalProject.load(project.getModel().getPomFile().toPath());
+                final LocalProject localProject = LocalProject.load(project.getModel().getPomFile().toPath());
                 addProject(devModeContext, localProject, true);
                 pomFiles.add(localProject.getRawModel().getPomFile().toPath());
                 devModeContext.getLocalArtifacts()
                         .add(new AppArtifactKey(localProject.getGroupId(), localProject.getArtifactId(), null, "jar"));
             } else {
-                localProject = LocalProject.loadWorkspace(project.getModel().getPomFile().toPath());
+                final LocalProject localProject = LocalProject.loadWorkspace(project.getModel().getPomFile().toPath());
                 for (LocalProject project : filterExtensionDependencies(localProject)) {
                     addProject(devModeContext, project, project == localProject);
                     pomFiles.add(project.getRawModel().getPomFile().toPath());

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/build-directories/multimodule/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/build-directories/multimodule/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>multimodule-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+    </properties>
+
+    <modules>
+        <module>runner</module>
+    </modules>
+
+    <build>
+        <directory>custom-target</directory>
+        <outputDirectory>${project.build.directory}/custom-classes</outputDirectory>
+        <sourceDirectory>src/main/other</sourceDirectory>
+        <testSourceDirectory>src/test/other</testSourceDirectory>
+    </build>
+
+    <dependencyManagement>
+    </dependencyManagement>
+
+</project>

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/build-directories/multimodule/runner/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/build-directories/multimodule/runner/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>multimodule-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <artifactId>multimodule-main</artifactId>
+
+    <dependencies>
+    </dependencies>
+
+    <build>
+        <outputDirectory>${project.build.directory}/other-classes</outputDirectory>
+    </build>
+</project>


### PR DESCRIPTION
Fixes #10677
This is a quick fix for projects with custom build directories. This change is taking into account build dir configurations in the scope of the current workspace. However, this change does not support build dirs that are configured in parent POMs that aren't present in the current workspace.