### PR TITLE
enable gradle grpc devmode test

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -138,9 +138,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
                     Task classesTask = tasks.getByName(JavaPlugin.CLASSES_TASK_NAME);
                     Task resourcesTask = tasks.getByName(JavaPlugin.PROCESS_RESOURCES_TASK_NAME);
-                    // TODO quarkusDev needs to depend on quarkusPrepare for code gen reload #10631
-                    // TODO but it causes strange failures on other gradle tests
-                    quarkusDev.dependsOn(classesTask, resourcesTask);
+                    quarkusDev.dependsOn(classesTask, resourcesTask, quarkusPrepare);
                     quarkusRemoteDev.dependsOn(classesTask, resourcesTask);
                     quarkusBuild.dependsOn(classesTask, resourcesTask, tasks.getByName(JavaPlugin.JAR_TASK_NAME));
 

--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPrepare.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusPrepare.java
@@ -44,7 +44,6 @@ public class QuarkusPrepare extends QuarkusTask {
         appArtifact.setPaths(QuarkusGradleUtils.getOutputPaths(getProject()));
 
         final AppModelResolver modelResolver = extension().getAppModelResolver();
-
         final Properties realProperties = getBuildSystemProperties(appArtifact);
 
         Path buildDir = getProject().getBuildDir().toPath();

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/GrpcDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/GrpcDevModeTest.java
@@ -1,24 +1,24 @@
-//package io.quarkus.gradle.devmode;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//import com.google.common.collect.ImmutableMap;
-// // TODO: to be uncommented with #10631
-//public class GrpcDevModeTest extends QuarkusDevGradleTestBase {
-//    @Override
-//    protected String projectDirectoryName() {
-//        return "grpc-multi-module-project";
-//    }
-//
-//    @Override
-//    protected void testDevMode() throws Exception {
-//        assertThat(getHttpResponse("/hello")).isEqualTo("hello 2");
-//
-//        replace("application/src/main/proto/devmodetest.proto",
-//                ImmutableMap.of("TEST_ONE = 2;", "TEST_ONE = 15;"));
-//
-//        Thread.sleep(1000);
-//
-//        assertThat(getHttpResponse("/hello")).isEqualTo("hello 15");
-//    }
-//}
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+
+public class GrpcDevModeTest extends QuarkusDevGradleTestBase {
+    @Override
+    protected String projectDirectoryName() {
+        return "grpc-multi-module-project";
+    }
+
+    @Override
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).isEqualTo("hello 2");
+
+        replace("application/src/main/proto/devmodetest.proto",
+                ImmutableMap.of("TEST_ONE = 2;", "TEST_ONE = 15;"));
+
+        Thread.sleep(1000);
+
+        assertThat(getHttpResponse("/hello")).isEqualTo("hello 15");
+    }
+}

--- a/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/application/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-resources-in-build-steps/application/build.gradle
@@ -19,7 +19,7 @@ test {
     forkEvery 1
 }
 
-quarkusDev {
+quarkusPrepare {
     dependsOn 'publishAcmeExt'
 }
 


### PR DESCRIPTION
This branch enable `quarkusPrepare` task as a dependency of `quarkusDev`. The only error was due to a missing dependency in a test. 
Making `quarkusPrepare` instead of `quarkusDev` depends on the task in charge of publishing that dependency locally, fix the test. 

close #10631 