### PR TITLE
Fix duplicate surefire plugin build warning

### DIFF
--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -126,13 +126,6 @@
                             <skipTests>${native.surefire.skip}</skipTests>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-integration-test-maven:jar:999-SNAPSHOT
[WARNING] 'profiles.profile[native-image].plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-surefire-plugin @ line 129, column 29
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```