### PR TITLE
Update smallrye reactive messaging to version 2.2.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,7 @@ updates:
       - dependency-name: io.smallrye:smallrye-opentracing
       - dependency-name: io.smallrye:smallrye-fault-tolerance
       - dependency-name: io.smallrye:smallrye-context-propagation
+      - dependency-name: io.smallrye.common:smallrye-common-annotation
       - dependency-name: io.smallrye.common:smallrye-common-io
       - dependency-name: io.smallrye.config:smallrye-config
       - dependency-name: io.smallrye.reactive:mutiny

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -32,6 +32,7 @@
         <microprofile-opentracing-api.version>1.3.3</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
+        <smallrye-common.version>1.1.0</smallrye-common.version>
         <smallrye-config.version>1.8.4</smallrye-config.version>
         <smallrye-health.version>2.2.3</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
@@ -43,7 +44,7 @@
         <smallrye-context-propagation.version>1.0.13</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-converter-api.version>1.1.0</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.2.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>2.2.1</smallrye-reactive-messaging.version>
         <swagger-ui.version>3.30.0</swagger-ui.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -2391,6 +2392,11 @@
                 <artifactId>smallrye-config-common</artifactId>
                 <!-- This is intentionally hard-coded -->
                 <version>1.5.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-annotation</artifactId>
+                <version>${smallrye-common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -44,6 +44,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <!-- Override the transitive dependency to enforce dependency convergence -->
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-health</artifactId>
             <exclusions>


### PR DESCRIPTION
This version fixes a bug when writing a failing Kafka record to the dead-queue topic.