### PR TITLE
Initial OpenAPI support for Vert.x

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -35,7 +35,7 @@
         <smallrye-config.version>1.8.4</smallrye-config.version>
         <smallrye-health.version>2.2.3</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.3</smallrye-open-api.version>
+        <smallrye-open-api.version>2.0.4</smallrye-open-api.version>
         <smallrye-graphql.version>1.0.5</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.4</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.0</smallrye-fault-tolerance.version>
@@ -2468,6 +2468,17 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-spring</artifactId>
+                <version>${smallrye-open-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.osgi</groupId>
+                        <artifactId>org.osgi.annotation.versioning</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-open-api-vertx</artifactId>
                 <version>${smallrye-open-api.version}</version>
                 <exclusions>
                     <exclusion>

--- a/extensions/smallrye-openapi/deployment/pom.xml
+++ b/extensions/smallrye-openapi/deployment/pom.xml
@@ -51,6 +51,10 @@
       <artifactId>smallrye-open-api-spring</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-vertx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-deployment</artifactId>
       <scope>test</scope>
@@ -58,6 +62,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-spring-web-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-web-deployment</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiRoute.class));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/resource"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
@@ -1,0 +1,41 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiHttpRootDefaultPathTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiRoute.class)
+                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("paths", Matchers.hasKey("/foo/resource"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithSegmentsTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiPathWithSegmentsTestCase {
+    private static final String OPEN_API_PATH = "/path/with/segments";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiRoute.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithoutSegmentsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiPathWithoutSegmentsTestCase.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiPathWithoutSegmentsTestCase {
+    private static final String OPEN_API_PATH = "/path-without-segments";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiRoute.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=" + OPEN_API_PATH),
+                            "application.properties"));
+
+    @Test
+    public void testOpenApiPathAccessResource() {
+        RestAssured.given().header("Accept", "application/yaml")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().queryParam("format", "YAML")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/yaml;charset=UTF-8");
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then().header("Content-Type", "application/json;charset=UTF-8");
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiRoute.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiRoute.java
@@ -1,0 +1,28 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.core.http.HttpMethod;
+
+@ApplicationScoped
+@RouteBase(path = "resource", consumes = "application/json", produces = "application/json")
+public class OpenApiRoute {
+
+    @Route(methods = HttpMethod.GET)
+    public String root() {
+        return "resource";
+    }
+
+    @Route(path = "/test-enums", methods = HttpMethod.GET)
+    public Query testEnums(@Param("query") String query) {
+        return Query.QUERY_PARAM_1;
+    }
+
+    public enum Query {
+        QUERY_PARAM_1,
+        QUERY_PARAM_2;
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiWithConfigTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiWithConfigTestCase {
+    private static final String OPEN_API_PATH = "/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(OpenApiRoute.class)
+                    .addAsManifestResource("test-openapi.yaml", "openapi.yaml")
+                    .addAsResource(new StringAsset("mp.openapi.scan.disable=true\nmp.openapi.servers=https://api.acme.org/"),
+                            "application.properties"));
+
+    @Test
+    public void testOpenAPI() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("openapi", Matchers.startsWith("3.0"))
+                .body("info.title", Matchers.equalTo("Test OpenAPI"))
+                .body("info.description", Matchers.equalTo("Some description"))
+                .body("info.version", Matchers.equalTo("4.2"))
+                .body("servers[0].url", Matchers.equalTo("https://api.acme.org/"))
+                .body("paths", Matchers.hasKey("/openapi"))
+                .body("paths", Matchers.not(Matchers.hasKey("/resource")));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/SwaggerAndOpenAPIWithCommonPrefixTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/SwaggerAndOpenAPIWithCommonPrefixTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+/**
+ * This test is a reproducer for https://github.com/quarkusio/quarkus/issues/4613.
+ */
+public class SwaggerAndOpenAPIWithCommonPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(OpenApiRoute.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.path=/swagger"), "application.properties"));
+
+    @Test
+    public void shouldWorkEvenWithCommonPrefix() {
+        RestAssured.when().get("/swagger-ui/index.html").then().statusCode(200).body(containsString("/swagger"));
+        RestAssured.when().get("/swagger").then().statusCode(200)
+                .body(containsString("/resource"), containsString("QUERY_PARAM_1"));
+    }
+}


### PR DESCRIPTION
This PR adds initial support for Vert.x `@Route` to be included in the OpenAPI schema generation.

Fixes #10670

Fixes #8435

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>