### PR TITLE
Fixes Elasticsearch doc generation error

### DIFF
--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -414,4 +414,4 @@ Accessing an Elasticsearch cluster from a low level or a high level client is ea
 
 == Configuration Reference
 
-include::{generated-dir}/config/quarkus-elasticsearch-low-level-client.adoc[opts=optional, leveloffset=+1]
+include::{generated-dir}/config/quarkus-elasticsearch-restclient-lowlevel.adoc[opts=optional, leveloffset=+1]

--- a/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/deployment/ElasticsearchLowLevelClientProcessor.java
+++ b/extensions/elasticsearch-rest-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/deployment/ElasticsearchLowLevelClientProcessor.java
@@ -22,7 +22,7 @@ class ElasticsearchLowLevelClientProcessor {
     @BuildStep
     HealthBuildItem addHealthCheck(ElasticsearchBuildTimeConfig buildTimeConfig) {
         return new HealthBuildItem("io.quarkus.elasticsearch.restclient.lowlevel.runtime.health.ElasticsearchHealthCheck",
-                buildTimeConfig.healthEnabled, "elasticsearch");
+                buildTimeConfig.healthEnabled);
     }
 
 }


### PR DESCRIPTION
This fixes the following error message while building the docs:
```
[INFO] asciidoctor: INFO: elasticsearch.adoc: line 417: optional include
   dropped because include file not found:
   /home/ggastald/workspace/quarkus/target/asciidoc/generated/config/quarkus-elasticsearch-low-level-client.adoc
```