### PR TITLE
OptaPlanner guide: fix mvn quarkus-maven-plugin:create

### DIFF
--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -70,7 +70,7 @@ Alternatively, generate it from the command line with Maven:
 mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=optaplanner-quickstart \
-    -Dextensions="resteasy, resteasy-jackson, optaplanner, optaplanner-jackson"
+    -Dextensions="resteasy, resteasy-jackson, optaplanner-quarkus, optaplanner-quarkus-jackson"
 cd optaplanner-quickstart
 ----
 


### PR DESCRIPTION
Fixes this issue: https://issues.redhat.com/browse/PLANNER-2083
This was caused by the externalization of the optaplanner extension.

Can this be backported to 1.6 so the published guide is fixed too?