### PR TITLE
Funqy HTTP query parameter binding

### DIFF
--- a/docs/src/main/asciidoc/funqy-amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/funqy-amazon-lambda-http.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Funqy HTTP with Amazon Lambda 
+= Quarkus - Funqy HTTP Binding with Amazon Lambda 
 :extension-status: preview
 
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/funqy-amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-amazon-lambda.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Funqy Amazon Lambdas
+= Quarkus - Funqy Amazon Lambda Binding
 :extension-status: preview
 
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Funqy Azure Functions
+= Quarkus - Funqy HTTP Binding with Azure Functions
 :extension-status: preview
 
 include::./attributes.adoc[]

--- a/docs/src/main/asciidoc/funqy-http.adoc
+++ b/docs/src/main/asciidoc/funqy-http.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Funqy HTTP (Standalone)
+= Quarkus - Funqy HTTP Binding (Standalone)
 
 include::./attributes.adoc[]
 :extension-status: preview
@@ -39,6 +39,18 @@ The solution is located in the `funqy-http-quickstart` {quickstarts-tree-url}/fu
 If you look at the Java code, you'll see that there is no HTTP specific API.  Its just simple Java methods
 annotated with `@Funq`.  Simple, easy, straightforward.
 
+== Maven Dependencies
+
+To write Funqy HTTP functions, simply include the `quarkus-funqy-http` dependency into your Quarkus `pom.xml` file:
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-funqy-http</artifactId>
+</dependency>
+----
+
 == Build Project
 
 [source, shell]
@@ -50,14 +62,12 @@ This starts your functions in Quarkus dev mode.
 
 == Execute Funqy HTTP functions
 
-Funqy HTTP input and output is always JSON.  The Jackson JSON parser is used behind the scenes and you can
-use Jackson annotations to fine tune your JSON mappings for your input and output objects.
-
-The HTTP POST method can be used to execute any Funqy function.  HTTP GET can be used if your function does
-not have any input.  No other HTTP method can be used besides POST and GET.
-
 The URL path to execute a function is the function name.  For example if your function name is `foo` then the URL path
 to execute the function would be `/foo`.
+
+The HTTP POST or GET methods can be used to invoke on a function.  The return value of the function
+is marshalled to JSON using the Jackson JSON library.  Jackson annotations can be used.  If your function
+has an input parameter, a POST invocation must use JSON as the input type.  Jackson is also used here for unmarshalling.
 
 You can invoke the `hello` function defined in {quickstarts-tree-url}/funqy-quickstarts/funqy-http-quickstart/src/main/java/org/acme/funqy/PrimitiveFunctions.java[PrimitiveFunctions.java]
 by pointing your browser to http://localhost:8080/hello
@@ -97,15 +107,198 @@ curl "http://localhost:8080/double" \
 -d '2'
 ----
 
-== Maven Dependencies
+== GET Query Parameter Mapping
 
-To write Funqy HTTP functions, simply include the `quarkus-funqy-http` dependency into your Quarkus `pom.xml` file:
+For GET requests, the Funqy HTTP Binding also has a query parameter mapping for function input parameters.
+Only bean style classes and `java.util.Map` can be used for your input parameter.  For bean style
+classes, query parameter names are mapped to properties on the bean class.  Here's an example of a simple
+`Map`:
 
-[source, xml]
+[source, java]
 ----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-funqy-http</artifactId>
-</dependency>
+@Funq
+public String hello(Map<String, Integer> map) {
+...
+}
 ----
 
+Key values must be a primitive type (except char) or `String`.  Values can be primitives (except char), `String`, `OffsetDateTime` or a complex
+bean style class.  For the above example, here's the corresponding curl request:
+
+[source, shell]
+----
+curl "http://localhost:8080/a=1&b=2"
+----
+
+The `map` input parameter of the `hello` function would have the key value pairs: `a`->1, `b`->2.
+
+Bean style classes can also be use as the input parameter type.  Here's an example:
+
+[source, java]
+----
+public class Person {
+    String first;
+    String last;
+
+    public String getFirst() { return first; }
+    public void setFirst(String first) { this.first = first; }
+    public String getLast() { return last; }
+    public void setLast(String last) { this.last = last; }
+}
+
+public class MyFunctions {
+    @Funq
+    public String greet(Person p) {
+       return "Hello " + p.getFirst() + " " + p.getLast();
+    }
+}
+----
+
+Property values can be any primitive type except `char`. It can also be `String`, and `OffsetDateTime`.
+`OffsetDateTime` query param values must be in ISO-8601 format.
+
+You can invoke on this using an HTTP GET and query parameters:
+
+[source, shell]
+----
+curl "http://localhost:8080/greet?first=Bill&last=Burke"
+----
+
+In the above request, the query parameter names are mapped to corresponding properties in the input class.
+
+The input class can also have nested bean classes.  Expanding on the previous example:
+
+[source, java]
+----
+public class Family {
+    private Person dad;
+    private Person mom;
+
+    public Person getDad() { return dad; }
+    public void setDad(Person dad) { this.dad = dad; }
+    public Person getMom() { return mom; }
+    public void setMom(Person mom) { this.mom = mom; }
+}
+
+public class MyFunctions {
+    @Funq
+    public String greet(Family family) {
+       ...
+    }
+}
+
+----
+
+In this case, query parameters for nested values use the `.` notation.  For example:
+
+[source, shell]
+----
+curl "http://localhost:8080/greet?dad.first=John&dad.last=Smith&mom.first=Martha&mom.last=Smith"
+----
+
+`java.util.List` and `Set` are also supported as property values.  For example:
+
+[source, java]
+----
+public class Family {
+    ...
+
+    List<String> pets;
+}
+
+public class MyFunctions {
+    @Funq
+    public String greet(Family family) {
+       ...
+    }
+}
+
+----
+
+To invoke a GET request, just list the `pets` query parameter multiple times.
+
+[source, shell]
+----
+curl "http://localhost:8080/greet?pets=itchy&pets=scratchy"
+----
+
+For more complex types, `List` and `Set` members must have an identifier in the
+query parameter.  For example:
+
+[source, java]
+----
+public class Family {
+    ...
+
+    List<Person> kids;
+}
+
+public class MyFunctions {
+    @Funq
+    public String greet(Family family) {
+       ...
+    }
+}
+
+----
+
+Each `kids` query parameter must identify the kid they are referencing so that
+the runtime can figure out which
+property values go to which members in the list.  Here's the curl request:
+
+[source, shell]
+----
+curl "http://localhost:8080/greet?kids.1.first=Buffy&kids.2.first=Charlie"
+----
+
+The above URL uses the value `1` and `2` to identity the target member of the list, but any unique
+string can be used.
+
+A property can also be a `java.util.Map`.  The key of the map can be any primitive type and `String`.
+For example:
+
+[source, java]
+----
+public class Family {
+    ...
+
+    Map<String, String> address;
+}
+
+public class MyFunctions {
+    @Funq
+    public String greet(Family family) {
+       ...
+    }
+}
+----
+
+The corresponding call would look like this:
+
+[source, shell]
+----
+curl "http://localhost:8080/greet?address.state=MA&address.city=Boston"
+----
+
+If your `Map` value is a complex type, then just continue the notation by adding the property to set at the end.
+
+[source, java]
+----
+public class Family {
+    ...
+
+    Map<String, Address> addresses;
+}
+
+public class MyFunctions {
+    @Funq
+    public String greet(Family family) {
+       ...
+    }
+}
+----
+
+[source, shell]
+----
+curl "http://localhost:8080/greet?addresses.home.state=MA&addresses.home.city=Boston"
+----

--- a/docs/src/main/asciidoc/funqy-knative-events.adoc
+++ b/docs/src/main/asciidoc/funqy-knative-events.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc
 ////
-= Quarkus - Funqy Knative Events
+= Quarkus - Funqy Knative Events Binding
 
 include::./attributes.adoc[]
 :extension-status: preview

--- a/extensions/funqy/funqy-amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-amazon-lambda/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+---
+name: "Funqy AWS Lambda Binding"
+metadata:
+  keywords:
+  - "funqy"
+  - "function"
+  - "lambda"
+  - "aws"
+  - "amazon"
+  guide: "https://quarkus.io/guides/funqy-amazon-lambda"
+  categories:
+  - "cloud"
+  status: "experimental"

--- a/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/Nested.java
+++ b/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/Nested.java
@@ -1,0 +1,22 @@
+package io.quarkus.funqy.test;
+
+public class Nested {
+    private Simple nestedOne;
+    private Simple nestedTwo;
+
+    public Simple getNestedOne() {
+        return nestedOne;
+    }
+
+    public void setNestedOne(Simple nestedOne) {
+        this.nestedOne = nestedOne;
+    }
+
+    public Simple getNestedTwo() {
+        return nestedTwo;
+    }
+
+    public void setNestedTwo(Simple nestedTwo) {
+        this.nestedTwo = nestedTwo;
+    }
+}

--- a/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/NestedCollection.java
+++ b/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/NestedCollection.java
@@ -1,0 +1,52 @@
+package io.quarkus.funqy.test;
+
+import java.util.List;
+import java.util.Map;
+
+public class NestedCollection {
+    private Map<String, Integer> intMap;
+    private Map<Integer, String> intKeyMap;
+    private Map<String, Simple> simpleMap;
+    private List<String> stringList;
+    private List<Simple> simpleList;
+
+    public Map<Integer, String> getIntKeyMap() {
+        return intKeyMap;
+    }
+
+    public void setIntKeyMap(Map<Integer, String> intKeyMap) {
+        this.intKeyMap = intKeyMap;
+    }
+
+    public Map<String, Integer> getIntMap() {
+        return intMap;
+    }
+
+    public void setIntMap(Map<String, Integer> intMap) {
+        this.intMap = intMap;
+    }
+
+    public Map<String, Simple> getSimpleMap() {
+        return simpleMap;
+    }
+
+    public void setSimpleMap(Map<String, Simple> simpleMap) {
+        this.simpleMap = simpleMap;
+    }
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    public List<Simple> getSimpleList() {
+        return simpleList;
+    }
+
+    public void setSimpleList(List<Simple> simpleList) {
+        this.simpleList = simpleList;
+    }
+}

--- a/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/QueryFunction.java
+++ b/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/QueryFunction.java
@@ -1,0 +1,28 @@
+package io.quarkus.funqy.test;
+
+import java.util.Map;
+
+import io.quarkus.funqy.Funq;
+
+public class QueryFunction {
+
+    @Funq
+    public Simple simple(Simple simple) {
+        return simple;
+    }
+
+    @Funq
+    public Nested nested(Nested nested) {
+        return nested;
+    }
+
+    @Funq
+    public NestedCollection nestedCollection(NestedCollection nested) {
+        return nested;
+    }
+
+    @Funq
+    public Map<String, String> map(Map<String, String> nested) {
+        return nested;
+    }
+}

--- a/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/QueryReaderTest.java
+++ b/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/QueryReaderTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.funqy.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
+
+public class QueryReaderTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Simple.class, Nested.class, NestedCollection.class, QueryFunction.class));
+
+    @Test
+    public void testSimple() throws Exception {
+        RestAssured.given()
+                .queryParam("intVal", 42)
+                .queryParam("shortVal", 4)
+                .queryParam("longVal", 442)
+                .queryParam("doubleVal", "4.2")
+                .queryParam("floatVal", "4.2")
+                .queryParam("b", "1")
+                .queryParam("boolVal", "true")
+                .queryParam("value", "hello world")
+                .get("/simple")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("intVal", equalTo(42))
+                .body("shortVal", equalTo(4))
+                .body("longVal", equalTo(442))
+                .body("floatVal", equalTo(4.2f))
+                .body("doubleVal", equalTo(4.2f))
+                .body("b", equalTo(1))
+                .body("boolVal", equalTo(true))
+                .body("value", equalTo("hello world"));
+    }
+
+    @Test
+    public void testNested() throws Exception {
+        RestAssured.given()
+                .queryParam("nestedOne.intVal", 42)
+                .queryParam("nestedOne.shortVal", 4)
+                .queryParam("nestedOne.longVal", 442)
+                .queryParam("nestedOne.doubleVal", "4.2")
+                .queryParam("nestedOne.floatVal", "4.2")
+                .queryParam("nestedOne.b", "1")
+                .queryParam("nestedOne.boolVal", "true")
+                .queryParam("nestedOne.value", "hello world")
+                .queryParam("nestedTwo.intVal", 32)
+                .queryParam("nestedTwo.shortVal", 3)
+                .queryParam("nestedTwo.longVal", 332)
+                .queryParam("nestedTwo.doubleVal", "3.2")
+                .queryParam("nestedTwo.floatVal", "3.2")
+                .queryParam("nestedTwo.b", "2")
+                .queryParam("nestedTwo.boolVal", "true")
+                .queryParam("nestedTwo.value", "hello world too")
+                .get("/nested")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("nestedOne.intVal", equalTo(42))
+                .body("nestedOne.shortVal", equalTo(4))
+                .body("nestedOne.longVal", equalTo(442))
+                .body("nestedOne.floatVal", equalTo(4.2f))
+                .body("nestedOne.doubleVal", equalTo(4.2f))
+                .body("nestedOne.b", equalTo(1))
+                .body("nestedOne.boolVal", equalTo(true))
+                .body("nestedOne.value", equalTo("hello world"))
+                .body("nestedTwo.intVal", equalTo(32))
+                .body("nestedTwo.shortVal", equalTo(3))
+                .body("nestedTwo.longVal", equalTo(332))
+                .body("nestedTwo.floatVal", equalTo(3.2f))
+                .body("nestedTwo.doubleVal", equalTo(3.2f))
+                .body("nestedTwo.b", equalTo(2))
+                .body("nestedTwo.boolVal", equalTo(true))
+                .body("nestedTwo.value", equalTo("hello world too"));
+    }
+
+    @Test
+    public void testNestedCollection() throws Exception {
+        RestAssured.given()
+                .queryParam("intMap.one", 1)
+                .queryParam("intMap.two", 2)
+                .queryParam("intKeyMap.1", "one")
+                .queryParam("intKeyMap.2", "two")
+                .queryParam("stringList", "one")
+                .queryParam("stringList", "two")
+                .get("/nestedCollection")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("intMap.one", equalTo(1))
+                .body("intMap.two", equalTo(2))
+                .body("stringList[0]", equalTo("one"))
+                .body("stringList[1]", equalTo("two"))
+                .body("intKeyMap.1", equalTo("one"))
+                .body("intKeyMap.1", equalTo("one"));
+
+        RestAssured.given()
+                .queryParam("simpleMap.one.value", "one")
+                .queryParam("simpleMap.two.value", "two")
+                .queryParam("simpleMap.one.intVal", 1)
+                .queryParam("simpleMap.two.intVal", 2)
+                .queryParam("simpleList.one.value", "one")
+                .queryParam("simpleList.two.value", "two")
+                .queryParam("simpleList.one.intVal", 1)
+                .queryParam("simpleList.two.intVal", 2)
+                .get("/nestedCollection")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("simpleMap.one.intVal", equalTo(1))
+                .body("simpleMap.two.intVal", equalTo(2))
+                .body("simpleMap.one.value", equalTo("one"))
+                .body("simpleMap.two.value", equalTo("two"))
+                .body("simpleList[0].intVal", equalTo(1))
+                .body("simpleList[1].intVal", equalTo(2))
+                .body("simpleList[0].value", equalTo("one"))
+                .body("simpleList[1].value", equalTo("two"));
+
+    }
+
+}

--- a/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/Simple.java
+++ b/extensions/funqy/funqy-http/deployment/src/test/java/io/quarkus/funqy/test/Simple.java
@@ -1,0 +1,76 @@
+package io.quarkus.funqy.test;
+
+public class Simple {
+    private String value;
+    private int intVal;
+    private short shortVal;
+    private long longVal;
+    private byte b;
+    private float floatVal;
+    private double doubleVal;
+    private boolean boolVal;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public int getIntVal() {
+        return intVal;
+    }
+
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    public short getShortVal() {
+        return shortVal;
+    }
+
+    public void setShortVal(short shortVal) {
+        this.shortVal = shortVal;
+    }
+
+    public long getLongVal() {
+        return longVal;
+    }
+
+    public void setLongVal(long longVal) {
+        this.longVal = longVal;
+    }
+
+    public byte getB() {
+        return b;
+    }
+
+    public void setB(byte b) {
+        this.b = b;
+    }
+
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    public double getDoubleVal() {
+        return doubleVal;
+    }
+
+    public void setDoubleVal(double doubleVal) {
+        this.doubleVal = doubleVal;
+    }
+
+    public boolean isBoolVal() {
+        return boolVal;
+    }
+
+    public void setBoolVal(boolean boolVal) {
+        this.boolVal = boolVal;
+    }
+}

--- a/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/FunqyHttpBindingRecorder.java
+++ b/extensions/funqy/funqy-http/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/http/FunqyHttpBindingRecorder.java
@@ -15,6 +15,8 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.funqy.runtime.FunctionConstructor;
 import io.quarkus.funqy.runtime.FunctionInvoker;
 import io.quarkus.funqy.runtime.FunctionRecorder;
+import io.quarkus.funqy.runtime.query.QueryObjectMapper;
+import io.quarkus.funqy.runtime.query.QueryReader;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
@@ -27,15 +29,19 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class FunqyHttpBindingRecorder {
     private static ObjectMapper objectMapper;
+    private static QueryObjectMapper queryMapper;
 
     public void init() {
         objectMapper = getObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        queryMapper = new QueryObjectMapper();
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {
                 ObjectReader reader = objectMapper.readerFor(invoker.getInputType());
+                QueryReader queryReader = queryMapper.readerFor(invoker.getInputType(), invoker.getInputGenericType());
                 invoker.getBindingContext().put(ObjectReader.class.getName(), reader);
+                invoker.getBindingContext().put(QueryReader.class.getName(), queryReader);
             }
             if (invoker.hasOutput()) {
                 ObjectWriter writer = objectMapper.writerFor(invoker.getOutputType());

--- a/extensions/funqy/funqy-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+name: "Funqy HTTP Binding"
+metadata:
+  keywords:
+  - "funqy"
+  - "function"
+  - "http"
+  guide: "https://quarkus.io/guides/funqy-http"
+  categories:
+  - "cloud"
+  status: "experimental"

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/Nested.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/Nested.java
@@ -1,0 +1,22 @@
+package io.quarkus.funqy.test;
+
+public class Nested {
+    private Simple nestedOne;
+    private Simple nestedTwo;
+
+    public Simple getNestedOne() {
+        return nestedOne;
+    }
+
+    public void setNestedOne(Simple nestedOne) {
+        this.nestedOne = nestedOne;
+    }
+
+    public Simple getNestedTwo() {
+        return nestedTwo;
+    }
+
+    public void setNestedTwo(Simple nestedTwo) {
+        this.nestedTwo = nestedTwo;
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NestedCollection.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NestedCollection.java
@@ -1,0 +1,52 @@
+package io.quarkus.funqy.test;
+
+import java.util.List;
+import java.util.Map;
+
+public class NestedCollection {
+    private Map<String, Integer> intMap;
+    private Map<Integer, String> intKeyMap;
+    private Map<String, Simple> simpleMap;
+    private List<String> stringList;
+    private List<Simple> simpleList;
+
+    public Map<Integer, String> getIntKeyMap() {
+        return intKeyMap;
+    }
+
+    public void setIntKeyMap(Map<Integer, String> intKeyMap) {
+        this.intKeyMap = intKeyMap;
+    }
+
+    public Map<String, Integer> getIntMap() {
+        return intMap;
+    }
+
+    public void setIntMap(Map<String, Integer> intMap) {
+        this.intMap = intMap;
+    }
+
+    public Map<String, Simple> getSimpleMap() {
+        return simpleMap;
+    }
+
+    public void setSimpleMap(Map<String, Simple> simpleMap) {
+        this.simpleMap = simpleMap;
+    }
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    public List<Simple> getSimpleList() {
+        return simpleList;
+    }
+
+    public void setSimpleList(List<Simple> simpleList) {
+        this.simpleList = simpleList;
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/QueryFunction.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/QueryFunction.java
@@ -1,0 +1,28 @@
+package io.quarkus.funqy.test;
+
+import java.util.Map;
+
+import io.quarkus.funqy.Funq;
+
+public class QueryFunction {
+
+    @Funq
+    public Simple simple(Simple simple) {
+        return simple;
+    }
+
+    @Funq
+    public Nested nested(Nested nested) {
+        return nested;
+    }
+
+    @Funq
+    public NestedCollection nestedCollection(NestedCollection nested) {
+        return nested;
+    }
+
+    @Funq
+    public Map<String, String> map(Map<String, String> nested) {
+        return nested;
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/QueryReaderTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/QueryReaderTest.java
@@ -1,0 +1,126 @@
+package io.quarkus.funqy.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
+
+public class QueryReaderTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Simple.class, Nested.class, NestedCollection.class, QueryFunction.class));
+
+    @Test
+    public void testSimple() throws Exception {
+        RestAssured.given()
+                .queryParam("intVal", 42)
+                .queryParam("shortVal", 4)
+                .queryParam("longVal", 442)
+                .queryParam("doubleVal", "4.2")
+                .queryParam("floatVal", "4.2")
+                .queryParam("b", "1")
+                .queryParam("boolVal", "true")
+                .queryParam("value", "hello world")
+                .get("/simple")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("intVal", equalTo(42))
+                .body("shortVal", equalTo(4))
+                .body("longVal", equalTo(442))
+                .body("floatVal", equalTo(4.2f))
+                .body("doubleVal", equalTo(4.2f))
+                .body("b", equalTo(1))
+                .body("boolVal", equalTo(true))
+                .body("value", equalTo("hello world"));
+    }
+
+    @Test
+    public void testNested() throws Exception {
+        RestAssured.given()
+                .queryParam("nestedOne.intVal", 42)
+                .queryParam("nestedOne.shortVal", 4)
+                .queryParam("nestedOne.longVal", 442)
+                .queryParam("nestedOne.doubleVal", "4.2")
+                .queryParam("nestedOne.floatVal", "4.2")
+                .queryParam("nestedOne.b", "1")
+                .queryParam("nestedOne.boolVal", "true")
+                .queryParam("nestedOne.value", "hello world")
+                .queryParam("nestedTwo.intVal", 32)
+                .queryParam("nestedTwo.shortVal", 3)
+                .queryParam("nestedTwo.longVal", 332)
+                .queryParam("nestedTwo.doubleVal", "3.2")
+                .queryParam("nestedTwo.floatVal", "3.2")
+                .queryParam("nestedTwo.b", "2")
+                .queryParam("nestedTwo.boolVal", "true")
+                .queryParam("nestedTwo.value", "hello world too")
+                .get("/nested")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("nestedOne.intVal", equalTo(42))
+                .body("nestedOne.shortVal", equalTo(4))
+                .body("nestedOne.longVal", equalTo(442))
+                .body("nestedOne.floatVal", equalTo(4.2f))
+                .body("nestedOne.doubleVal", equalTo(4.2f))
+                .body("nestedOne.b", equalTo(1))
+                .body("nestedOne.boolVal", equalTo(true))
+                .body("nestedOne.value", equalTo("hello world"))
+                .body("nestedTwo.intVal", equalTo(32))
+                .body("nestedTwo.shortVal", equalTo(3))
+                .body("nestedTwo.longVal", equalTo(332))
+                .body("nestedTwo.floatVal", equalTo(3.2f))
+                .body("nestedTwo.doubleVal", equalTo(3.2f))
+                .body("nestedTwo.b", equalTo(2))
+                .body("nestedTwo.boolVal", equalTo(true))
+                .body("nestedTwo.value", equalTo("hello world too"));
+    }
+
+    @Test
+    public void testNestedCollection() throws Exception {
+        RestAssured.given()
+                .queryParam("intMap.one", 1)
+                .queryParam("intMap.two", 2)
+                .queryParam("intKeyMap.1", "one")
+                .queryParam("intKeyMap.2", "two")
+                .queryParam("stringList", "one")
+                .queryParam("stringList", "two")
+                .get("/nestedCollection")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("intMap.one", equalTo(1))
+                .body("intMap.two", equalTo(2))
+                .body("stringList[0]", equalTo("one"))
+                .body("stringList[1]", equalTo("two"))
+                .body("intKeyMap.1", equalTo("one"))
+                .body("intKeyMap.1", equalTo("one"));
+
+        RestAssured.given()
+                .queryParam("simpleMap.one.value", "one")
+                .queryParam("simpleMap.two.value", "two")
+                .queryParam("simpleMap.one.intVal", 1)
+                .queryParam("simpleMap.two.intVal", 2)
+                .queryParam("simpleList.one.value", "one")
+                .queryParam("simpleList.two.value", "two")
+                .queryParam("simpleList.one.intVal", 1)
+                .queryParam("simpleList.two.intVal", 2)
+                .get("/nestedCollection")
+                .then().statusCode(200)
+                .defaultParser(Parser.JSON)
+                .body("simpleMap.one.intVal", equalTo(1))
+                .body("simpleMap.two.intVal", equalTo(2))
+                .body("simpleMap.one.value", equalTo("one"))
+                .body("simpleMap.two.value", equalTo("two"))
+                .body("simpleList[0].intVal", equalTo(1))
+                .body("simpleList[1].intVal", equalTo(2))
+                .body("simpleList[0].value", equalTo("one"))
+                .body("simpleList[1].value", equalTo("two"));
+
+    }
+
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/Simple.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/Simple.java
@@ -1,0 +1,76 @@
+package io.quarkus.funqy.test;
+
+public class Simple {
+    private String value;
+    private int intVal;
+    private short shortVal;
+    private long longVal;
+    private byte b;
+    private float floatVal;
+    private double doubleVal;
+    private boolean boolVal;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public int getIntVal() {
+        return intVal;
+    }
+
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    public short getShortVal() {
+        return shortVal;
+    }
+
+    public void setShortVal(short shortVal) {
+        this.shortVal = shortVal;
+    }
+
+    public long getLongVal() {
+        return longVal;
+    }
+
+    public void setLongVal(long longVal) {
+        this.longVal = longVal;
+    }
+
+    public byte getB() {
+        return b;
+    }
+
+    public void setB(byte b) {
+        this.b = b;
+    }
+
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    public double getDoubleVal() {
+        return doubleVal;
+    }
+
+    public void setDoubleVal(double doubleVal) {
+        this.doubleVal = doubleVal;
+    }
+
+    public boolean isBoolVal() {
+        return boolVal;
+    }
+
+    public void setBoolVal(boolean boolVal) {
+        this.boolVal = boolVal;
+    }
+}

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -29,6 +29,7 @@ import io.quarkus.funqy.runtime.FunctionInvoker;
 import io.quarkus.funqy.runtime.FunctionRecorder;
 import io.quarkus.funqy.runtime.FunqyServerResponse;
 import io.quarkus.funqy.runtime.RequestContextImpl;
+import io.quarkus.funqy.runtime.query.QueryReader;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
@@ -68,23 +69,6 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
         Instance<CurrentIdentityAssociation> association = CDI.current().select(CurrentIdentityAssociation.class);
         this.association = association.isResolvable() ? association.get() : null;
         this.currentVertxRequest = CDI.current().select(CurrentVertxRequest.class).get();
-    }
-
-    private boolean checkHttpMethod(RoutingContext routingContext, FunctionInvoker invoker) {
-        if (invoker.hasInput()) {
-            if (routingContext.request().method() != HttpMethod.POST) {
-                routingContext.fail(405);
-                log.error("Must be POST for: " + invoker.getName());
-                return false;
-            }
-        }
-        if (routingContext.request().method() != HttpMethod.POST && routingContext.request().method() != HttpMethod.GET) {
-            routingContext.fail(405);
-            log.error("Must be POST or GET for: " + invoker.getName());
-            return false;
-
-        }
-        return true;
     }
 
     @Override
@@ -158,57 +142,82 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
 
     private void processHttpRequest(CloudEvent event, RoutingContext routingContext, ResponseProcessing handler,
             FunctionInvoker invoker) {
-        if (!checkHttpMethod(routingContext, invoker)) {
-            return;
-        }
-        routingContext.request().bodyHandler(buff -> {
-            try {
-                Object input = null;
-                if (buff.length() > 0) {
-                    ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
-                    ObjectReader reader = (ObjectReader) invoker.getBindingContext().get(ObjectReader.class.getName());
-                    try {
-                        input = reader.readValue((InputStream) in);
-                    } catch (JsonProcessingException e) {
-                        log.error("Failed to unmarshal input", e);
-                        routingContext.fail(400);
-                        return;
-                    }
+        if (routingContext.request().method() == HttpMethod.GET) {
+            Object input = null;
+            if (invoker.hasInput()) {
+                QueryReader reader = (QueryReader) invoker.getBindingContext().get(QueryReader.class.getName());
+                try {
+                    input = reader.readValue(routingContext.request().params().iterator());
+                } catch (Exception e) {
+                    log.error("Failed to unmarshal input", e);
+                    routingContext.fail(400);
+                    return;
                 }
-                Object finalInput = input;
-                executor.execute(() -> {
-                    try {
-                        final HttpServerResponse httpResponse = routingContext.response();
-                        FunqyServerResponse response = dispatch(event, routingContext, invoker, finalInput);
-
-                        response.getOutput().emitOn(executor).subscribe().with(
-                                obj -> {
-                                    if (invoker.hasOutput()) {
-                                        try {
-                                            httpResponse.setStatusCode(200);
-                                            handler.handle();
-                                            ObjectWriter writer = (ObjectWriter) invoker.getBindingContext()
-                                                    .get(ObjectWriter.class.getName());
-                                            httpResponse.putHeader("Content-Type", "application/json");
-                                            httpResponse.end(writer.writeValueAsString(obj));
-                                        } catch (JsonProcessingException jpe) {
-                                            log.error("Failed to unmarshal input", jpe);
-                                            routingContext.fail(400);
-                                        } catch (Throwable e) {
-                                            routingContext.fail(e);
-                                        }
-                                    } else {
-                                        httpResponse.setStatusCode(204);
-                                        httpResponse.end();
-                                    }
-                                },
-                                t -> routingContext.fail(t));
-
-                    } catch (Throwable t) {
-                        log.error(t);
-                        routingContext.fail(500, t);
+            }
+            try {
+                execute(event, routingContext, handler, invoker, input);
+            } catch (Throwable t) {
+                log.error(t);
+                routingContext.fail(500, t);
+            }
+        } else if (routingContext.request().method() == HttpMethod.POST) {
+            routingContext.request().bodyHandler(buff -> {
+                try {
+                    Object input = null;
+                    if (buff.length() > 0) {
+                        ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());
+                        ObjectReader reader = (ObjectReader) invoker.getBindingContext().get(ObjectReader.class.getName());
+                        try {
+                            input = reader.readValue((InputStream) in);
+                        } catch (JsonProcessingException e) {
+                            log.error("Failed to unmarshal input", e);
+                            routingContext.fail(400);
+                            return;
+                        }
                     }
-                });
+                    execute(event, routingContext, handler, invoker, input);
+                } catch (Throwable t) {
+                    log.error(t);
+                    routingContext.fail(500, t);
+                }
+            });
+        } else {
+            routingContext.fail(405);
+            log.error("Must be POST or GET for: " + invoker.getName());
+        }
+
+    }
+
+    private void execute(CloudEvent event, RoutingContext routingContext, ResponseProcessing handler, FunctionInvoker invoker,
+            Object finalInput) {
+        executor.execute(() -> {
+            try {
+                final HttpServerResponse httpResponse = routingContext.response();
+                FunqyServerResponse response = dispatch(event, routingContext, invoker, finalInput);
+
+                response.getOutput().emitOn(executor).subscribe().with(
+                        obj -> {
+                            if (invoker.hasOutput()) {
+                                try {
+                                    httpResponse.setStatusCode(200);
+                                    handler.handle();
+                                    ObjectWriter writer = (ObjectWriter) invoker.getBindingContext()
+                                            .get(ObjectWriter.class.getName());
+                                    httpResponse.putHeader("Content-Type", "application/json");
+                                    httpResponse.end(writer.writeValueAsString(obj));
+                                } catch (JsonProcessingException jpe) {
+                                    log.error("Failed to unmarshal input", jpe);
+                                    routingContext.fail(400);
+                                } catch (Throwable e) {
+                                    routingContext.fail(e);
+                                }
+                            } else {
+                                httpResponse.setStatusCode(204);
+                                httpResponse.end();
+                            }
+                        },
+                        t -> routingContext.fail(t));
+
             } catch (Throwable t) {
                 log.error(t);
                 routingContext.fail(500, t);

--- a/extensions/funqy/funqy-knative-events/runtime/src/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-knative-events/runtime/src/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: "Funqy Knative Events Binding"
+metadata:
+  keywords:
+    - "knative"
+    - "function"
+    - "funqy"
+    - "cloud event"
+  categories:
+    - "cloud"
+  guide: "https://quarkus.io/guides/funqy-knative-events"
+  status: "experimental"

--- a/extensions/funqy/funqy-server-common/runtime/pom.xml
+++ b/extensions/funqy/funqy-server-common/runtime/pom.xml
@@ -27,6 +27,11 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
@@ -15,6 +15,7 @@ public class FunctionInvoker {
     protected FunctionConstructor<?> constructor;
     protected ArrayList<ValueInjector> parameterInjectors;
     protected Class<?> inputType;
+    protected Type inputGenericType;
     protected Class<?> outputType;
     protected boolean isAsync;
 
@@ -33,6 +34,7 @@ public class FunctionInvoker {
                 ValueInjector injector = ParameterInjector.createInjector(type, clz, annotations);
                 if (injector instanceof InputValueInjector) {
                     inputType = clz;
+                    inputGenericType = method.getGenericParameterTypes()[i];
                 }
                 parameterInjectors.add(injector);
             }
@@ -76,6 +78,10 @@ public class FunctionInvoker {
 
     public Class getInputType() {
         return inputType;
+    }
+
+    public Type getInputGenericType() {
+        return inputGenericType;
     }
 
     public Class getOutputType() {

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/BaseCollectionReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/BaseCollectionReader.java
@@ -1,0 +1,71 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.quarkus.arc.impl.Reflections;
+
+public abstract class BaseCollectionReader extends BaseObjectReader implements BaseObjectReader.ValueSetter {
+    protected Function<String, Object> valueExtractor;
+    protected QueryPropertySetter setter;
+
+    public BaseCollectionReader(Type genericType, QueryObjectMapper mapper) {
+        if (genericType == null) {
+            valueExtractor = mapper.extractor(String.class);
+            return;
+        }
+        if (genericType instanceof ParameterizedType) {
+            Type valueType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            if (valueType != null) {
+                Class<Object> rawType = Reflections.getRawType(valueType);
+                valueExtractor = mapper.extractor(valueType);
+                if (valueExtractor == null) {
+                    setter = mapper.setterFor(rawType, valueType);
+                }
+            } else {
+                valueExtractor = mapper.extractor(String.class);
+            }
+        } else {
+            Class<Object> rawType = Reflections.getRawType(genericType);
+            valueExtractor = mapper.extractor(rawType);
+            if (valueExtractor == null) {
+                setter = mapper.setterFor(rawType, genericType);
+            }
+        }
+    }
+
+    @Override
+    public Function<String, Object> getExtractor() {
+        return valueExtractor;
+    }
+
+    @Override
+    public QueryPropertySetter getSetter() {
+        return setter;
+    }
+
+    @Override
+    ValueSetter getValueSetter(String propName) {
+        return this;
+    }
+
+    @Override
+    public void setValue(Object target, String propName, Object value) {
+        ((Collection) target).add(value);
+    }
+
+    @Override
+    public void setValue(Object target, String name, String value, Map<String, List<Object>> paramToObject) {
+        if (valueExtractor != null) {
+            if (name != null)
+                return; // ignore query parameter
+            ((Collection) target).add(valueExtractor.apply(value));
+        } else {
+            super.setValue(target, name, value, paramToObject);
+        }
+    }
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/BaseObjectReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/BaseObjectReader.java
@@ -1,0 +1,82 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public abstract class BaseObjectReader implements QueryReader<Object>, QueryPropertySetter {
+    interface ValueSetter {
+        void setValue(Object target, String propName, Object value);
+
+        Function<String, Object> getExtractor();
+
+        QueryPropertySetter getSetter();
+    }
+
+    @Override
+    public Object readValue(Iterator<Map.Entry<String, String>> params) {
+        Object target = create();
+        // exists to track nested non-primitive objects
+        Map<String, List<Object>> paramToObject = new HashMap<>();
+
+        while (params.hasNext()) {
+            Map.Entry<String, String> entry = params.next();
+            String name = entry.getKey();
+            String value = entry.getValue();
+            setValue(target, name, value, paramToObject);
+        }
+
+        return target;
+    }
+
+    abstract ValueSetter getValueSetter(String propName);
+
+    @Override
+    public void setValue(Object target, String name, String value, Map<String, List<Object>> paramToObject) {
+        try {
+            if (name == null)
+                return;
+            String propName = name;
+            String suffix = null;
+            int dot = propName.indexOf('.');
+            if (dot == 0)
+                return;
+            else if (dot > 0) {
+                propName = name.substring(0, dot);
+                suffix = name.substring(dot + 1);
+            }
+            ValueSetter setter = getValueSetter(propName);
+            if (setter == null)
+                return;
+            if (suffix != null && setter.getSetter() == null)
+                return;
+            if (setter.getExtractor() != null) {
+                Object val = setter.getExtractor().apply(value);
+                setter.setValue(target, propName, val);
+            } else if (setter.getSetter() != null) {
+                List<Object> propEntry = paramToObject.get(propName);
+                Object obj;
+                Map<String, List<Object>> paramEntries;
+                if (propEntry == null) {
+                    obj = setter.getSetter().create();
+                    paramEntries = new HashMap<>();
+                    propEntry = Arrays.asList(obj, paramEntries);
+                    paramToObject.put(propName, propEntry);
+                    setter.setValue(target, propName, obj);
+                } else {
+                    obj = propEntry.get(0);
+                    paramEntries = (Map<String, List<Object>>) propEntry.get(1);
+                }
+                setter.getSetter().setValue(obj, suffix, value, paramEntries);
+            } else {
+                // throw Exception?
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryListReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryListReader.java
@@ -1,0 +1,21 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.lang.reflect.Type;
+import java.util.LinkedList;
+
+/**
+ * Value can be any primitive, primitive object, string, or bean style class
+ *
+ */
+class QueryListReader extends BaseCollectionReader {
+
+    public QueryListReader(Type genericType, QueryObjectMapper mapper) {
+        super(genericType, mapper);
+    }
+
+    @Override
+    public Object create() {
+        return new LinkedList<>();
+    }
+
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryMapReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryMapReader.java
@@ -1,0 +1,77 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.quarkus.arc.impl.Reflections;
+
+/**
+ * Key can be any primitive, primitive object (i.e. Integer), or String
+ * Value can be any primitive, primitive object, string, or bean style class
+ *
+ */
+class QueryMapReader extends BaseObjectReader implements BaseObjectReader.ValueSetter {
+    private Function<String, Object> keyExtractor;
+    private Function<String, Object> valueExtractor;
+    private QueryPropertySetter setter;
+
+    public QueryMapReader(Type genericType, QueryObjectMapper mapper) {
+        if (genericType == null) {
+            keyExtractor = mapper.extractor(String.class);
+            valueExtractor = mapper.extractor(String.class);
+            return;
+        }
+        if (genericType instanceof ParameterizedType) {
+            Type keyType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            keyExtractor = mapper.extractor(keyType);
+            if (keyType == null)
+                throw new RuntimeException("Illegal key type for map");
+            Type valueType = ((ParameterizedType) genericType).getActualTypeArguments()[1];
+            if (valueType != null) {
+                Class<Object> rawType = Reflections.getRawType(valueType);
+                valueExtractor = mapper.extractor(valueType);
+                if (valueExtractor == null) {
+                    setter = mapper.setterFor(rawType, valueType);
+                }
+            } else {
+                valueExtractor = mapper.extractor(String.class);
+            }
+        } else {
+            keyExtractor = mapper.extractor(String.class);
+            Class<Object> rawType = Reflections.getRawType(genericType);
+            valueExtractor = mapper.extractor(rawType);
+            if (valueExtractor == null) {
+                setter = mapper.setterFor(rawType, genericType);
+            }
+        }
+    }
+
+    @Override
+    public void setValue(Object target, String propName, Object value) {
+        ((Map) target).put(keyExtractor.apply(propName), value);
+    }
+
+    @Override
+    public Function<String, Object> getExtractor() {
+        return valueExtractor;
+    }
+
+    @Override
+    public QueryPropertySetter getSetter() {
+        return setter;
+    }
+
+    @Override
+    ValueSetter getValueSetter(String propName) {
+        return this;
+    }
+
+    @Override
+    public Object create() {
+        return new HashMap();
+    }
+
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryObjectMapper.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryObjectMapper.java
@@ -1,0 +1,99 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.lang.reflect.Type;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import io.quarkus.arc.impl.Reflections;
+
+/**
+ * Turn URI parameter map into an object
+ *
+ */
+public class QueryObjectMapper {
+    Function<String, Object> extractor(Type type) {
+        return extractor(Reflections.getRawType(type));
+    }
+
+    Function<String, Object> extractor(Class clz) {
+        if (String.class.equals(clz)) {
+            return (strVal) -> {
+                return strVal;
+            };
+        }
+        if (clz.equals(long.class) || clz.equals(Long.class)) {
+            return (strVal) -> {
+                return Long.valueOf(strVal);
+            };
+        }
+        if (clz.equals(int.class) || clz.equals(Integer.class)) {
+            return (strVal) -> {
+                return Integer.valueOf(strVal);
+            };
+        }
+        if (clz.equals(short.class) || clz.equals(Short.class)) {
+            return (strVal) -> {
+                return Short.valueOf(strVal);
+            };
+        }
+        if (clz.equals(float.class) || clz.equals(Float.class)) {
+            return (strVal) -> {
+                return Float.valueOf(strVal);
+            };
+        }
+        if (clz.equals(double.class) || clz.equals(Double.class)) {
+            return (strVal) -> {
+                return Double.valueOf(strVal);
+            };
+        }
+        if (clz.equals(boolean.class) || clz.equals(Boolean.class)) {
+            return (strVal) -> {
+                return Boolean.valueOf(strVal);
+            };
+        }
+        if (clz.equals(byte.class) || clz.equals(Byte.class)) {
+            return (strVal) -> {
+                return Byte.valueOf(strVal);
+            };
+        }
+        if (clz.equals(OffsetDateTime.class)) {
+            return (strVal) -> {
+                return OffsetDateTime.parse(strVal);
+            };
+        }
+        return null;
+    }
+
+    Map<Class, QueryObjectReader> readers = new HashMap<>();
+
+    public <T> QueryReader<T> readerFor(Class<T> clz) {
+        return readerFor(clz, null);
+    }
+
+    public <T> QueryReader<T> readerFor(Class<T> clz, Type genericType) {
+        if (clz.equals(Map.class)) {
+            return (QueryReader<T>) new QueryMapReader(genericType, this);
+        }
+        QueryObjectReader reader = readers.get(clz);
+        if (reader != null)
+            return (QueryReader<T>) reader;
+        reader = new QueryObjectReader(clz, this);
+        readers.put(clz, reader);
+        return (QueryReader<T>) reader;
+    }
+
+    QueryPropertySetter setterFor(Class clz, Type genericType) {
+        if (clz.equals(List.class)) {
+            return new QueryListReader(genericType, this);
+        }
+        if (clz.equals(Set.class)) {
+            return new QuerySetReader(genericType, this);
+        }
+        return (QueryPropertySetter) readerFor(clz, genericType);
+    }
+
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryObjectReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryObjectReader.java
@@ -1,0 +1,82 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Turn URI parameter map into an object
+ *
+ */
+class QueryObjectReader extends BaseObjectReader {
+
+    Map<String, ValueSetter> properties = new HashMap<>();
+    Class clz;
+
+    @Override
+    public Object create() {
+        try {
+            return clz.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    QueryObjectReader(Class clz, QueryObjectMapper mapper) {
+        this.clz = clz;
+        for (Method m : clz.getMethods()) {
+            if (!isSetter(m))
+                continue;
+            Class paramType = m.getParameterTypes()[0];
+            Type paramGenericType = m.getGenericParameterTypes()[0];
+            Function<String, Object> extractor = mapper.extractor(paramType);
+            QueryPropertySetter propertySetter = null;
+            if (extractor == null) { // not string or primitive
+                propertySetter = mapper.setterFor(paramType, paramGenericType);
+            }
+
+            String name;
+            if (m.getName().length() > 4) {
+                name = Character.toLowerCase(m.getName().charAt(3)) + m.getName().substring(4);
+            } else {
+                name = m.getName().substring(3).toLowerCase();
+            }
+            final QueryPropertySetter finalPropertySetter = propertySetter;
+            ValueSetter setter = new ValueSetter() {
+                @Override
+                public void setValue(Object target, String propName, Object value) {
+                    try {
+                        m.invoke(target, value);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                public Function<String, Object> getExtractor() {
+                    return extractor;
+                }
+
+                @Override
+                public QueryPropertySetter getSetter() {
+                    return finalPropertySetter;
+                }
+            };
+            properties.put(name, setter);
+        }
+
+    }
+
+    static boolean isSetter(Method m) {
+        return !Modifier.isStatic(m.getModifiers()) && m.getName().startsWith("set") && m.getName().length() > "set".length()
+                && m.getParameterCount() == 1;
+    }
+
+    @Override
+    ValueSetter getValueSetter(String propName) {
+        return properties.get(propName);
+    }
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryPropertySetter.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryPropertySetter.java
@@ -1,0 +1,10 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.util.List;
+import java.util.Map;
+
+interface QueryPropertySetter {
+    Object create();
+
+    void setValue(Object target, String name, String value, Map<String, List<Object>> paramToObject);
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QueryReader.java
@@ -1,0 +1,8 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public interface QueryReader<T> {
+    T readValue(Iterator<Map.Entry<String, String>> params);
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QuerySetReader.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/query/QuerySetReader.java
@@ -1,0 +1,21 @@
+package io.quarkus.funqy.runtime.query;
+
+import java.lang.reflect.Type;
+import java.util.HashSet;
+
+/**
+ * Value can be any primitive, primitive object, string, or bean style class
+ *
+ */
+class QuerySetReader extends BaseCollectionReader {
+
+    public QuerySetReader(Type genericType, QueryObjectMapper mapper) {
+        super(genericType, mapper);
+    }
+
+    @Override
+    public Object create() {
+        return new HashSet<>();
+    }
+
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/Nested.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/Nested.java
@@ -1,0 +1,22 @@
+package io.quarkus.funqy.test;
+
+public class Nested {
+    private Simple nestedOne;
+    private Simple nestedTwo;
+
+    public Simple getNestedOne() {
+        return nestedOne;
+    }
+
+    public void setNestedOne(Simple nestedOne) {
+        this.nestedOne = nestedOne;
+    }
+
+    public Simple getNestedTwo() {
+        return nestedTwo;
+    }
+
+    public void setNestedTwo(Simple nestedTwo) {
+        this.nestedTwo = nestedTwo;
+    }
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/NestedCollection.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/NestedCollection.java
@@ -1,0 +1,71 @@
+package io.quarkus.funqy.test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class NestedCollection {
+    private Map<String, Integer> intMap;
+    private Map<Integer, String> intKeyMap;
+    private Map<String, Simple> simpleMap;
+    private List<String> stringList;
+    private List<Simple> simpleList;
+    private Set<Integer> intSet;
+    private Set<Simple> simpleSet;
+
+    public Set<Integer> getIntSet() {
+        return intSet;
+    }
+
+    public void setIntSet(Set<Integer> intSet) {
+        this.intSet = intSet;
+    }
+
+    public Set<Simple> getSimpleSet() {
+        return simpleSet;
+    }
+
+    public void setSimpleSet(Set<Simple> simpleSet) {
+        this.simpleSet = simpleSet;
+    }
+
+    public Map<Integer, String> getIntKeyMap() {
+        return intKeyMap;
+    }
+
+    public void setIntKeyMap(Map<Integer, String> intKeyMap) {
+        this.intKeyMap = intKeyMap;
+    }
+
+    public Map<String, Integer> getIntMap() {
+        return intMap;
+    }
+
+    public void setIntMap(Map<String, Integer> intMap) {
+        this.intMap = intMap;
+    }
+
+    public Map<String, Simple> getSimpleMap() {
+        return simpleMap;
+    }
+
+    public void setSimpleMap(Map<String, Simple> simpleMap) {
+        this.simpleMap = simpleMap;
+    }
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    public List<Simple> getSimpleList() {
+        return simpleList;
+    }
+
+    public void setSimpleList(List<Simple> simpleList) {
+        this.simpleList = simpleList;
+    }
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/QueryReaderTest.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/QueryReaderTest.java
@@ -1,0 +1,189 @@
+package io.quarkus.funqy.test;
+
+import java.time.Month;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.funqy.runtime.query.QueryObjectMapper;
+import io.quarkus.funqy.runtime.query.QueryReader;
+
+public class QueryReaderTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        QueryObjectMapper mapper = new QueryObjectMapper();
+        QueryReader<Simple> reader = mapper.readerFor(Simple.class);
+        Map<String, String> params = new HashMap<>();
+        params.put("time", "2020-07-29T10:15:30+01:00");
+        params.put("intVal", "42");
+        params.put("shortVal", "4");
+        params.put("longVal", "442");
+        params.put("doubleVal", "4.2");
+        params.put("floatVal", "4.2");
+        params.put("b", "1");
+        params.put("boolVal", "true");
+        params.put("value", "hello");
+
+        Simple simple = reader.readValue(params.entrySet().iterator());
+
+        Assertions.assertEquals(42, simple.getIntVal());
+        Assertions.assertEquals(4, simple.getShortVal());
+        Assertions.assertEquals(442, simple.getLongVal());
+        Assertions.assertTrue(simple.getDoubleVal() <= 4.2 && simple.getDoubleVal() > 4.1);
+        Assertions.assertTrue(simple.getFloatVal() <= 4.2 && simple.getFloatVal() > 4.1);
+        Assertions.assertEquals(1, simple.getB());
+        Assertions.assertEquals(true, simple.isBoolVal());
+        Assertions.assertEquals("hello", simple.getValue());
+        Assertions.assertEquals(Month.JULY, simple.getTime().getMonth());
+        Assertions.assertEquals(29, simple.getTime().getDayOfMonth());
+    }
+
+    @Test
+    public void testNested() throws Exception {
+        QueryObjectMapper mapper = new QueryObjectMapper();
+        QueryReader<Nested> reader = mapper.readerFor(Nested.class);
+        Map<String, String> params = new HashMap<>();
+        params.put("nestedOne.intVal", "42");
+        params.put("nestedOne.shortVal", "4");
+        params.put("nestedOne.longVal", "442");
+        params.put("nestedOne.doubleVal", "4.2");
+        params.put("nestedOne.floatVal", "4.2");
+        params.put("nestedOne.b", "1");
+        params.put("nestedOne.boolVal", "true");
+        params.put("nestedOne.value", "hello");
+
+        params.put("nestedTwo.intVal", "32");
+        params.put("nestedTwo.shortVal", "3");
+        params.put("nestedTwo.longVal", "332");
+        params.put("nestedTwo.doubleVal", "3.2");
+        params.put("nestedTwo.floatVal", "3.2");
+        params.put("nestedTwo.b", "2");
+        params.put("nestedTwo.boolVal", "true");
+        params.put("nestedTwo.value", "world");
+
+        Nested nested = reader.readValue(params.entrySet().iterator());
+
+        Assertions.assertEquals(42, nested.getNestedOne().getIntVal());
+        Assertions.assertEquals(4, nested.getNestedOne().getShortVal());
+        Assertions.assertEquals(442, nested.getNestedOne().getLongVal());
+        Assertions.assertTrue(nested.getNestedOne().getDoubleVal() <= 4.3 && nested.getNestedOne().getDoubleVal() > 4.1);
+        Assertions.assertTrue(nested.getNestedOne().getFloatVal() <= 4.3 && nested.getNestedOne().getFloatVal() > 4.1);
+        Assertions.assertEquals(1, nested.getNestedOne().getB());
+        Assertions.assertEquals(true, nested.getNestedOne().isBoolVal());
+        Assertions.assertEquals("hello", nested.getNestedOne().getValue());
+
+        Assertions.assertEquals(32, nested.getNestedTwo().getIntVal());
+        Assertions.assertEquals(3, nested.getNestedTwo().getShortVal());
+        Assertions.assertEquals(332, nested.getNestedTwo().getLongVal());
+        Assertions.assertTrue(nested.getNestedTwo().getDoubleVal() <= 3.3 && nested.getNestedTwo().getDoubleVal() > 3.1);
+        Assertions.assertTrue(nested.getNestedTwo().getFloatVal() <= 3.3 && nested.getNestedTwo().getFloatVal() > 3.1);
+        Assertions.assertEquals(2, nested.getNestedTwo().getB());
+        Assertions.assertEquals(true, nested.getNestedTwo().isBoolVal());
+        Assertions.assertEquals("world", nested.getNestedTwo().getValue());
+    }
+
+    @Test
+    public void testDirectMap() {
+        QueryObjectMapper mapper = new QueryObjectMapper();
+        QueryReader reader = mapper.readerFor(Map.class);
+        Map<String, String> params = new HashMap<>();
+
+        params.put("val", "42");
+
+        Map<String, String> map = (Map<String, String>) reader.readValue(params.entrySet().iterator());
+
+        Assertions.assertEquals("42", map.get("val"));
+
+    }
+
+    @Test
+    public void testNestedCollections() {
+        QueryObjectMapper mapper = new QueryObjectMapper();
+        QueryReader<NestedCollection> reader = mapper.readerFor(NestedCollection.class);
+        List<Map.Entry<String, String>> params = new LinkedList<>();
+
+        params.add(entry("intMap.one", "1"));
+        params.add(entry("intMap.two", "2"));
+        params.add(entry("intKeyMap.1", "one"));
+        params.add(entry("intKeyMap.2", "two"));
+        params.add(entry("stringList", "one"));
+        params.add(entry("stringList", "two"));
+        params.add(entry("intSet", "1"));
+        params.add(entry("intSet", "2"));
+        params.add(entry("simpleMap.one.value", "one"));
+        params.add(entry("simpleMap.two.value", "two"));
+        params.add(entry("simpleList.one.value", "one"));
+        params.add(entry("simpleList.one.intVal", "1"));
+        params.add(entry("simpleList.two.value", "two"));
+        params.add(entry("simpleList.two.intVal", "2"));
+        params.add(entry("simpleSet.one.value", "one"));
+        params.add(entry("simpleSet.one.intVal", "1"));
+        params.add(entry("simpleSet.two.value", "two"));
+        params.add(entry("simpleSet.two.intVal", "2"));
+        params.add(entry("time", "2020-07-29T10:15:30+01:00"));
+
+        NestedCollection nested = reader.readValue(params.iterator());
+
+        Assertions.assertEquals(1, nested.getIntMap().get("one"));
+        Assertions.assertEquals(2, nested.getIntMap().get("two"));
+        Assertions.assertEquals("one", nested.getIntKeyMap().get(1));
+        Assertions.assertEquals("two", nested.getIntKeyMap().get(2));
+        Assertions.assertEquals("one", nested.getSimpleMap().get("one").getValue());
+        Assertions.assertEquals("two", nested.getSimpleMap().get("two").getValue());
+        Assertions.assertTrue(nested.getStringList().contains("one"));
+        Assertions.assertTrue(nested.getStringList().contains("two"));
+        Assertions.assertTrue(nested.getIntSet().contains(1));
+        Assertions.assertTrue(nested.getIntSet().contains(2));
+
+        Assertions.assertNotNull(nested.getSimpleList());
+        Assertions.assertEquals(2, nested.getSimpleList().size());
+        Assertions.assertEquals(1, nested.getSimpleList().get(0).getIntVal());
+        Assertions.assertEquals("one", nested.getSimpleList().get(0).getValue());
+        Assertions.assertEquals(2, nested.getSimpleList().get(1).getIntVal());
+        Assertions.assertEquals("two", nested.getSimpleList().get(1).getValue());
+
+        Assertions.assertNotNull(nested.getSimpleSet());
+        Assertions.assertEquals(2, nested.getSimpleSet().size());
+        boolean hasOne = false;
+        boolean hasTwo = false;
+        for (Simple simple : nested.getSimpleSet()) {
+            if (simple.getIntVal() == 1) {
+                hasOne = true;
+                Assertions.assertEquals("one", simple.getValue());
+            }
+            if (simple.getIntVal() == 2) {
+                hasTwo = true;
+                Assertions.assertEquals("two", simple.getValue());
+            }
+
+        }
+        Assertions.assertTrue(hasOne);
+        Assertions.assertTrue(hasTwo);
+
+    }
+
+    static Map.Entry<String, String> entry(String key, String value) {
+        return new Map.Entry() {
+            @Override
+            public Object getKey() {
+                return key;
+            }
+
+            @Override
+            public Object getValue() {
+                return value;
+            }
+
+            @Override
+            public Object setValue(Object o) {
+                throw new RuntimeException();
+            }
+        };
+    }
+
+}

--- a/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/Simple.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/test/java/io/quarkus/funqy/test/Simple.java
@@ -1,0 +1,87 @@
+package io.quarkus.funqy.test;
+
+import java.time.OffsetDateTime;
+
+public class Simple {
+    private String value;
+    private int intVal;
+    private short shortVal;
+    private long longVal;
+    private byte b;
+    private float floatVal;
+    private double doubleVal;
+    private boolean boolVal;
+    private OffsetDateTime time;
+
+    public OffsetDateTime getTime() {
+        return time;
+    }
+
+    public void setTime(OffsetDateTime time) {
+        this.time = time;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public int getIntVal() {
+        return intVal;
+    }
+
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    public short getShortVal() {
+        return shortVal;
+    }
+
+    public void setShortVal(short shortVal) {
+        this.shortVal = shortVal;
+    }
+
+    public long getLongVal() {
+        return longVal;
+    }
+
+    public void setLongVal(long longVal) {
+        this.longVal = longVal;
+    }
+
+    public byte getB() {
+        return b;
+    }
+
+    public void setB(byte b) {
+        this.b = b;
+    }
+
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    public double getDoubleVal() {
+        return doubleVal;
+    }
+
+    public void setDoubleVal(double doubleVal) {
+        this.doubleVal = doubleVal;
+    }
+
+    public boolean isBoolVal() {
+        return boolVal;
+    }
+
+    public void setBoolVal(boolean boolVal) {
+        this.boolVal = boolVal;
+    }
+}


### PR DESCRIPTION
For GET requests, query parameters can now be mapped to the input parameter.  Previously, GET requests could not send input to functions.

@gunnarmorling 