### PR TITLE
Return URL with a trailing / if required

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResource.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathResource.java
@@ -30,4 +30,10 @@ public interface ClassPathResource {
      */
     byte[] getData();
 
+    /**
+     *
+     * @return <code>true</code> if the entry is a directory
+     */
+    boolean isDirectory();
+
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/DirectoryClassPathElement.java
@@ -108,6 +108,11 @@ public class DirectoryClassPathElement extends AbstractClassPathElement {
                         throw new RuntimeException("Unable to read " + file, e);
                     }
                 }
+
+                @Override
+                public boolean isDirectory() {
+                    return Files.isDirectory(file);
+                }
             };
         }
         return null;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/JarClassPathElement.java
@@ -105,6 +105,11 @@ public class JarClassPathElement implements ClassPathElement {
                                 }
                             });
                         }
+
+                        @Override
+                        public boolean isDirectory() {
+                            return res.getName().endsWith("/");
+                        }
                     };
                 }
                 return null;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/MemoryClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/MemoryClassPathElement.java
@@ -79,6 +79,11 @@ public class MemoryClassPathElement extends AbstractClassPathElement {
             public byte[] getData() {
                 return res;
             }
+
+            @Override
+            public boolean isDirectory() {
+                return false;
+            }
         };
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
@@ -152,6 +153,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     public Enumeration<URL> getResources(String unsanitisedName) throws IOException {
+        boolean endsWithTrailingSlash = unsanitisedName.endsWith("/");
         ClassLoaderState state = getState();
         String name = sanitizeName(unsanitisedName);
         //for resources banned means that we don't delegate to the parent, as there can be multiple resources
@@ -184,7 +186,21 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         ClassPathElement[] providers = state.loadableResources.get(name);
         if (providers != null) {
             for (ClassPathElement element : providers) {
-                resources.add(element.getResource(name).getUrl());
+                ClassPathResource res = element.getResource(name);
+                //if the requested name ends with a trailing / we make sure
+                //that the resource is a directory, and return a URL that ends with a /
+                //this matches the behaviour of URLClassLoader
+                if (endsWithTrailingSlash) {
+                    if (res.isDirectory()) {
+                        try {
+                            resources.add(new URL(res.getUrl().toString() + "/"));
+                        } catch (MalformedURLException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                } else {
+                    resources.add(res.getUrl());
+                }
             }
         } else if (name.isEmpty()) {
             for (ClassPathElement i : elements) {
@@ -263,6 +279,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
 
     @Override
     public URL getResource(String unsantisedName) {
+        boolean endsWithTrailingSlash = unsantisedName.endsWith("/");
         String name = sanitizeName(unsantisedName);
         ClassLoaderState state = getState();
         if (state.bannedResources.contains(name)) {
@@ -271,7 +288,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         //TODO: because of dev mode we iterate, to see if any resources were added
         //not for .class files though, adding them causes a restart
         //this is very important for bytebuddy performance
-        if (name.endsWith(".class")) {
+        if (name.endsWith(".class") && !endsWithTrailingSlash) {
             ClassPathElement[] providers = state.loadableResources.get(name);
             if (providers != null) {
                 return providers[0].getResource(name).getUrl();
@@ -280,7 +297,20 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             for (ClassPathElement i : elements) {
                 ClassPathResource res = i.getResource(name);
                 if (res != null) {
-                    return res.getUrl();
+                    //if the requested name ends with a trailing / we make sure
+                    //that the resource is a directory, and return a URL that ends with a /
+                    //this matches the behaviour of URLClassLoader
+                    if (endsWithTrailingSlash) {
+                        if (res.isDirectory()) {
+                            try {
+                                return new URL(res.getUrl().toString() + "/");
+                            } catch (MalformedURLException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    } else {
+                        return res.getUrl();
+                    }
                 }
             }
         }


### PR DESCRIPTION
URLClassLoader will add a trailing / to the
URL if the passed in name contains a /.

This makes our behaviour mirror this.

It also adds a check that if the name ends with
a / we only return directory entries.

Fixes #10943