### PR TITLE
replace vertx-stack-depchain with vertx-dependencies

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -260,7 +260,7 @@
             <!-- Vert.x dependencies, imported as a BOM -->
             <dependency>
                 <groupId>io.vertx</groupId>
-                <artifactId>vertx-stack-depchain</artifactId>
+                <artifactId>vertx-dependencies</artifactId>
                 <version>${vertx.version}</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
Currently we import vetrx-stack-depchain. `vertx-stack-depchain`'s parent imports `vertx-dependencies`. This way we implicitly import `vertx-dependencies`. 

This PR changes the import to `vertx-dependencies` to cut out the middleman