### PR TITLE
Get rid of lambdas in InfinispanClientProducer

### DIFF
--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientProducer.java
@@ -163,38 +163,51 @@ public class InfinispanClientProducer {
         }
         InfinispanClientRuntimeConfig infinispanClientRuntimeConfig = this.infinispanClientRuntimeConfig.get();
 
-        infinispanClientRuntimeConfig.serverList
-                .ifPresent(v -> properties.put(ConfigurationProperties.SERVER_LIST, v));
+        if (infinispanClientRuntimeConfig.serverList.isPresent()) {
+            properties.put(ConfigurationProperties.SERVER_LIST, infinispanClientRuntimeConfig.serverList.get());
+        }
 
-        infinispanClientRuntimeConfig.clientIntelligence
-                .ifPresent(v -> properties.put(ConfigurationProperties.CLIENT_INTELLIGENCE, v));
+        if (infinispanClientRuntimeConfig.clientIntelligence.isPresent()) {
+            properties.put(ConfigurationProperties.CLIENT_INTELLIGENCE, infinispanClientRuntimeConfig.clientIntelligence.get());
+        }
 
-        infinispanClientRuntimeConfig.useAuth
-                .ifPresent(v -> properties.put(ConfigurationProperties.USE_AUTH, v));
-        infinispanClientRuntimeConfig.authUsername
-                .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_USERNAME, v));
-        infinispanClientRuntimeConfig.authPassword
-                .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_PASSWORD, v));
-        infinispanClientRuntimeConfig.authRealm
-                .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_REALM, v));
-        infinispanClientRuntimeConfig.authServerName
-                .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_SERVER_NAME, v));
-        infinispanClientRuntimeConfig.authClientSubject
-                .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_CLIENT_SUBJECT, v));
-        infinispanClientRuntimeConfig.authCallbackHandler
-                .ifPresent(v -> properties.put(ConfigurationProperties.AUTH_CALLBACK_HANDLER, v));
+        if (infinispanClientRuntimeConfig.useAuth.isPresent()) {
+            properties.put(ConfigurationProperties.USE_AUTH, infinispanClientRuntimeConfig.useAuth.get());
+        }
+        if (infinispanClientRuntimeConfig.authUsername.isPresent()) {
+            properties.put(ConfigurationProperties.AUTH_USERNAME, infinispanClientRuntimeConfig.authUsername.get());
+        }
+        if (infinispanClientRuntimeConfig.authPassword.isPresent()) {
+            properties.put(ConfigurationProperties.AUTH_PASSWORD, infinispanClientRuntimeConfig.authPassword.get());
+        }
+        if (infinispanClientRuntimeConfig.authRealm.isPresent()) {
+            properties.put(ConfigurationProperties.AUTH_REALM, infinispanClientRuntimeConfig.authRealm.get());
+        }
+        if (infinispanClientRuntimeConfig.authServerName.isPresent()) {
+            properties.put(ConfigurationProperties.AUTH_SERVER_NAME, infinispanClientRuntimeConfig.authServerName.get());
+        }
+        if (infinispanClientRuntimeConfig.authClientSubject.isPresent()) {
+            properties.put(ConfigurationProperties.AUTH_CLIENT_SUBJECT, infinispanClientRuntimeConfig.authClientSubject.get());
+        }
+        if (infinispanClientRuntimeConfig.authCallbackHandler.isPresent()) {
+            properties.put(ConfigurationProperties.AUTH_CALLBACK_HANDLER,
+                    infinispanClientRuntimeConfig.authCallbackHandler.get());
+        }
 
-        infinispanClientRuntimeConfig.saslMechanism
-                .ifPresent(v -> properties.put(ConfigurationProperties.SASL_MECHANISM, v));
+        if (infinispanClientRuntimeConfig.saslMechanism.isPresent()) {
+            properties.put(ConfigurationProperties.SASL_MECHANISM, infinispanClientRuntimeConfig.saslMechanism.get());
+        }
 
-        infinispanClientRuntimeConfig.trustStore
-                .ifPresent(v -> properties.put(ConfigurationProperties.TRUST_STORE_FILE_NAME, v));
-
-        infinispanClientRuntimeConfig.trustStorePassword
-                .ifPresent(v -> properties.put(ConfigurationProperties.TRUST_STORE_PASSWORD, v));
-
-        infinispanClientRuntimeConfig.trustStoreType
-                .ifPresent(v -> properties.put(ConfigurationProperties.TRUST_STORE_TYPE, v));
+        if (infinispanClientRuntimeConfig.trustStore.isPresent()) {
+            properties.put(ConfigurationProperties.TRUST_STORE_FILE_NAME, infinispanClientRuntimeConfig.trustStore.get());
+        }
+        if (infinispanClientRuntimeConfig.trustStorePassword.isPresent()) {
+            properties.put(ConfigurationProperties.TRUST_STORE_PASSWORD,
+                    infinispanClientRuntimeConfig.trustStorePassword.get());
+        }
+        if (infinispanClientRuntimeConfig.trustStoreType.isPresent()) {
+            properties.put(ConfigurationProperties.TRUST_STORE_TYPE, infinispanClientRuntimeConfig.trustStoreType.get());
+        }
 
         builder.withProperties(properties);
 
@@ -208,10 +221,10 @@ public class InfinispanClientProducer {
         Set<SerializationContextInitializer> initializers = (Set) properties
                 .get(InfinispanClientProducer.PROTOBUF_INITIALIZERS);
         if (initializers != null) {
-            initializers.forEach(sci -> {
-                sci.registerSchema(serializationContext);
-                sci.registerMarshallers(serializationContext);
-            });
+            for (SerializationContextInitializer initializer : initializers) {
+                initializer.registerSchema(serializationContext);
+                initializer.registerMarshallers(serializationContext);
+            }
         }
 
         FileDescriptorSource fileDescriptorSource = null;


### PR DESCRIPTION
We avoid lambdas in runtime code because of the implied additional
memory consumption.