### PR TITLE
ignore jax-rs Response.StatusType for reflection

### DIFF
--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
@@ -85,6 +85,7 @@ public final class ResteasyDotNames {
 
             // JAX-RS
             DotName.createSimple("javax.ws.rs.core.Response"),
+            DotName.createSimple("javax.ws.rs.core.Response.StatusType"),
             DotName.createSimple("javax.ws.rs.container.AsyncResponse"),
             DotName.createSimple("javax.ws.rs.core.StreamingOutput"),
             DotName.createSimple("javax.ws.rs.core.Form"),

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/IgnoreDotNames.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/IgnoreDotNames.java
@@ -37,6 +37,7 @@ public final class IgnoreDotNames {
             DotName.createSimple("com.fasterxml.jackson.databind.JsonNode"),
             // JAX-RS
             DotName.createSimple("javax.ws.rs.core.Response"),
+            DotName.createSimple("javax.ws.rs.core.Response.StatusType"),
             DotName.createSimple("javax.ws.rs.container.AsyncResponse"),
             DotName.createSimple("javax.ws.rs.core.StreamingOutput"),
             DotName.createSimple("javax.ws.rs.core.Form"),


### PR DESCRIPTION
Add 'javax.ws.rs.core.Response.StatusType' to set of types ignored for reflection.

Is there a workaround I can use until this makes it into a release?