### PR TITLE
Make sure REST clients are closed

### DIFF
--- a/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
+++ b/extensions/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
@@ -44,6 +44,7 @@ import org.jboss.resteasy.microprofile.client.RestClientProxy;
 import org.jboss.resteasy.microprofile.client.async.AsyncInterceptorRxInvokerProvider;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
 
+import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrarBuildItem;
@@ -218,6 +219,7 @@ class RestClientProcessor {
                                 MethodDescriptor.ofMethod(RestClientBase.class, "create", Object.class), baseHandle);
                         m.returnValue(ret);
                     });
+                    configurator.destroyer(BeanDestroyer.CloseableDestroyer.class);
                     configurator.done();
                 }
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -224,7 +224,7 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
             ResultHandle destoyerHandle = mc.newInstance(MethodDescriptor.ofConstructor(destroyerClazz));
             ResultHandle[] params = { mc.getMethodParam(0), mc.getMethodParam(1), paramsHandle };
             mc.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(BeanDestroyer.class, "destroy", Void.class, Object.class, CreationalContext.class,
+                    MethodDescriptor.ofMethod(BeanDestroyer.class, "destroy", void.class, Object.class, CreationalContext.class,
                             Map.class),
                     destoyerHandle, params);
             mc.returnValue(null);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -283,7 +283,7 @@ public class BeanInfo implements InjectionTargetInfo {
             return getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()
                     && Beans.getCallbacks(target.get().asClass(), DotNames.PRE_DESTROY, beanDeployment.getIndex()).isEmpty();
         } else {
-            return disposer == null;
+            return disposer == null && destroyerConsumer == null;
         }
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/BeanDestroyer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/BeanDestroyer.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
@@ -19,5 +21,16 @@ public interface BeanDestroyer<T> {
      * @param params
      */
     void destroy(T instance, CreationalContext<T> creationalContext, Map<String, Object> params);
+
+    class CloseableDestroyer implements BeanDestroyer<Closeable> {
+        @Override
+        public void destroy(Closeable instance, CreationalContext<Closeable> creationalContext, Map<String, Object> params) {
+            try {
+                instance.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/BeanRegistrarTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/BeanRegistrarTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.BeanDestroyer;
 import io.quarkus.arc.processor.BeanConfigurator;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BeanRegistrar;
@@ -25,16 +26,26 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BeanRegistrarTest {
+
+    public static volatile boolean beanDestroyerInvoked = false;
 
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(UselessBean.class, MyQualifier.class, NextQualifier.class)
             .removeUnusedBeans(true)
             .beanRegistrars(new TestRegistrar()).build();
+
+    @AfterAll
+    public static void assertDestroyerInvoked() {
+        Assertions.assertTrue(beanDestroyerInvoked);
+    }
 
     @SuppressWarnings("serial")
     static class NextQualifierLiteral extends AnnotationLiteral<NextQualifier> implements NextQualifier {
@@ -85,6 +96,8 @@ public class BeanRegistrarTest {
                 ResultHandle ret = mc.newInstance(MethodDescriptor.ofConstructor(Integer.class, int.class), mc.load(152));
                 mc.returnValue(ret);
             });
+            integerConfigurator.destroyer(SimpleDestroyer.class);
+            integerConfigurator.scope(Singleton.class);
             integerConfigurator.done();
 
             context.configure(String.class).unremovable().types(String.class).param("name", "Frantisek")
@@ -105,6 +118,14 @@ public class BeanRegistrarTest {
             return "Hello " + params.get("name") + "!";
         }
 
+    }
+
+    public static class SimpleDestroyer implements BeanDestroyer<Integer> {
+
+        @Override
+        public void destroy(Integer instance, CreationalContext<Integer> creationalContext, Map<String, Object> params) {
+            beanDestroyerInvoked = true;
+        }
     }
 
     @Qualifier


### PR DESCRIPTION
The destroyer was not setup, so request scoped
instances (or @Dependent instances injected into
request scoped beans) would not be destroyed.

Also wired this up correctly in ArC.

Fixes #10813