### PR TITLE
If no Accept header is set default to the first 'produces' type

### DIFF
--- a/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
+++ b/extensions/vertx-web/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
@@ -163,7 +163,7 @@ class Methods {
     static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
 
     static final MethodDescriptor ROUTE_HANDLERS_SET_CONTENT_TYPE = MethodDescriptor
-            .ofMethod(RouteHandlers.class, "setContentType", void.class, RoutingContext.class);
+            .ofMethod(RouteHandlers.class, "setContentType", void.class, RoutingContext.class, String.class);
 
     static final MethodDescriptor OPTIONAL_OF_NULLABLE = MethodDescriptor
             .ofMethod(Optional.class, "ofNullable", Optional.class, Object.class);

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/Route.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/Route.java
@@ -110,7 +110,7 @@ public @interface Route {
     /**
      * If set to a positive number, it indicates the place of the route in the chain.
      * 
-     * @see io.vertx.ext.web.Route#order()
+     * @see io.vertx.ext.web.Route#order(int)
      */
     int order() default 0;
 
@@ -118,6 +118,9 @@ public @interface Route {
      * Used for content-based routing.
      * <p>
      * If no {@code Content-Type} header is set then try to use the most acceptable content type.
+     *
+     * If the request does not contain an 'Accept' header and no content type is explicitly set in the
+     * handler then the content type will be set to the first content type in the array.
      * 
      * @see io.vertx.ext.web.Route#produces(String)
      * @see RoutingContext#getAcceptableContentType()

--- a/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandlers.java
+++ b/extensions/vertx-web/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandlers.java
@@ -5,6 +5,7 @@ import javax.enterprise.event.Event;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
@@ -18,14 +19,22 @@ public final class RouteHandlers {
     private static final LazyValue<Event<SecurityIdentity>> SECURITY_IDENTITY_EVENT = new LazyValue<>(
             RouteHandlers::createEvent);
 
-    public static void setContentType(RoutingContext context) {
+    public static void setContentType(RoutingContext context, String defaultContentType) {
         HttpServerResponse response = context.response();
-        if (response.headers().get(CONTENT_TYPE) == null) {
-            String acceptableContentType = context.getAcceptableContentType();
-            if (acceptableContentType != null) {
-                response.putHeader(CONTENT_TYPE, acceptableContentType);
+        context.addHeadersEndHandler(new Handler<Void>() {
+            @Override
+            public void handle(Void aVoid) {
+                //use a listener to set the content type if it has not been set
+                if (response.headers().get(CONTENT_TYPE) == null) {
+                    String acceptableContentType = context.getAcceptableContentType();
+                    if (acceptableContentType != null) {
+                        response.putHeader(CONTENT_TYPE, acceptableContentType);
+                    } else if (defaultContentType != null) {
+                        response.putHeader(CONTENT_TYPE, defaultContentType);
+                    }
+                }
             }
-        }
+        });
     }
 
     static void fireSecurityIdentity(SecurityIdentity identity) {


### PR DESCRIPTION
Currently if the request does not include an Accept header the
method will still be invoked but the content type will not
always be automatically set.

Fixes #10960