### PR TITLE
Use a link instead of an empty reference

### DIFF
--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -581,7 +581,7 @@ paths:
                 type: string
 ----
 
-Also see <<openapi-swaggerui.adoc,the OpenAPI Guide>>
+Also see link:openapi-swaggerui[the OpenAPI Guide].
 
 === Adding MicroProfile OpenAPI Annotations
 


### PR DESCRIPTION
The build was complaining with:
INFO: possible invalid reference: openapi-swaggerui.adoc