### PR TITLE
Go back to previous behavior regarding Surefire and Maven IT

### DIFF
--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -123,7 +123,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skipTests>${native.surefire.skip}</skipTests>
+                            <skipTests>true</skipTests>
                         </configuration>
                     </plugin>
 


### PR DESCRIPTION
Follow up of https://github.com/quarkusio/quarkus/pull/10919

We better get back to the previous behavior which was to never run the plugin rather than introducing some change in this area.

Remember when I said this whole native surefire skip thing was a bad idea?