### PR TITLE
made ldap server test resource reusable

### DIFF
--- a/test-framework/ldap/src/main/java/io/quarkus/test/ldap/LdapServerTestResource.java
+++ b/test-framework/ldap/src/main/java/io/quarkus/test/ldap/LdapServerTestResource.java
@@ -7,25 +7,28 @@ import java.util.Map;
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldif.LDIFReader;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class LdapServerTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private InMemoryDirectoryServer ldapServer;
+    protected InMemoryDirectoryServer ldapServer;
+
+    public LdapServerTestResource() throws LDAPException {
+        InMemoryListenerConfig listenerConfig = new InMemoryListenerConfig("listener", InetAddress.getLoopbackAddress(),
+                10389, null, null, null);
+        InMemoryDirectoryServerConfig inMemoryDirectoryServerConfig = new InMemoryDirectoryServerConfig("dc=quarkus,dc=io");
+        inMemoryDirectoryServerConfig.setListenerConfigs(listenerConfig);
+        inMemoryDirectoryServerConfig.addAdditionalBindCredentials("uid=admin,ou=system", "secret");
+        ldapServer = new InMemoryDirectoryServer(inMemoryDirectoryServerConfig);
+        ldapServer.importFromLDIF(true, new LDIFReader(ClassLoader.getSystemResourceAsStream("quarkus-io.ldif")));
+    }
 
     @Override
     public Map<String, String> start() {
         try {
-            InMemoryListenerConfig listenerConfig = new InMemoryListenerConfig("listener", InetAddress.getByName("127.0.0.1"),
-                    10389, null, null, null);
-
-            InMemoryDirectoryServerConfig inMemoryDirectoryServerConfig = new InMemoryDirectoryServerConfig("dc=quarkus,dc=io");
-            inMemoryDirectoryServerConfig.setListenerConfigs(listenerConfig);
-            inMemoryDirectoryServerConfig.addAdditionalBindCredentials("uid=admin,ou=system", "secret");
-            ldapServer = new InMemoryDirectoryServer(inMemoryDirectoryServerConfig);
-            ldapServer.importFromLDIF(true, new LDIFReader(ClassLoader.getSystemResourceAsStream("quarkus-io.ldif")));
             ldapServer.startListening();
             System.out.println("[INFO] LDAP server started");
         } catch (Exception e) {


### PR DESCRIPTION
So quarkus users can reuse the class LdapServerTestResource. Example:

```
public class SdsLdapServerTestResource extends LdapServerTestResource {

    public SdsLdapServerTestResource() throws LDAPException {
        super();
        System.out.println("Applying additional ldap changes!");
        this.ldapServer.applyChangesFromLDIF(new LDIFReader(ClassLoader.getSystemResourceAsStream("add-ldap-roles.ldif")));
    }
}
```