### PR TITLE
add gradle label notifier

### DIFF
--- a/.github/autoissuelabeler.yml
+++ b/.github/autoissuelabeler.yml
@@ -16,7 +16,7 @@
   description: "(?i).*dev mode.*"
 - labels: [area/gradle]
   title: "(?i).*gradle.*"
-  notify: [quarkusio/devtools]
+  notify: [quarkusio/devtools,glefloch]
 - labels: [area/maven]
   title: "(?i).*maven.*"
   notify: [quarkusio/devtools]


### PR DESCRIPTION
As mentioned in a previous topic of the quarkus-dev mailing list, I would like to be notified in case of a new Gradle related issue. Currently, the `devtools` group is notified. I don't know if I can add myself directly here or if I could be added to the `devtools` group.