### PR TITLE
Retire includeAllTimeZones for native executables entirely

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/NativeImageEnableAllTimeZonesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/NativeImageEnableAllTimeZonesBuildItem.java
@@ -2,6 +2,15 @@ package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ * All timezones are now included in native executables by default so this build item does not change the build behavior
+ * anymore.
+ * <p>
+ * Keeping it around for now as it marks the extension requiring all the timezones
+ * and better wait for the situation to fully settle on the GraalVM side
+ * before removing it entirely.
+ */
+@Deprecated
 public final class NativeImageEnableAllTimeZonesBuildItem extends MultiBuildItem {
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -50,12 +50,6 @@ public class NativeConfig {
     public boolean addAllCharsets;
 
     /**
-     * If all time zones should be added to the native image. This increases image size
-     */
-    @ConfigItem
-    public boolean includeAllTimeZones;
-
-    /**
      * The location of the Graal distribution
      */
     @ConfigItem(defaultValue = "${GRAALVM_HOME:}")

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -212,8 +212,6 @@ public class NativeImageBuildStep {
                     nativeConfig.enableAllSecurityServices |= Boolean.parseBoolean(prop.getValue());
                 } else if (prop.getKey().equals("quarkus.native.enable-all-charsets") && prop.getValue() != null) {
                     nativeConfig.addAllCharsets |= Boolean.parseBoolean(prop.getValue());
-                } else if (prop.getKey().equals("quarkus.native.enable-all-timezones") && prop.getValue() != null) {
-                    nativeConfig.includeAllTimeZones |= Boolean.parseBoolean(prop.getValue());
                 } else {
                     // todo maybe just -D is better than -J-D in this case
                     if (prop.getValue() == null) {
@@ -290,11 +288,6 @@ public class NativeImageBuildStep {
                 command.add("-H:+AddAllCharsets");
             } else {
                 command.add("-H:-AddAllCharsets");
-            }
-            //if 'includeAllTimeZones' is set, don't request it explicitly as native-image will log a warning about this being now the default.
-            //(But still disable it when necessary)
-            if (!nativeConfig.includeAllTimeZones) {
-                command.add("-H:-IncludeAllTimeZones");
             }
             if (!protocols.isEmpty()) {
                 command.add("-H:EnableURLProtocols=" + String.join(",", protocols));

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageConfigBuildStep.java
@@ -15,7 +15,6 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.JavaLibraryPathAdditionalPathBuildItem;
 import io.quarkus.deployment.builditem.JniBuildItem;
 import io.quarkus.deployment.builditem.NativeImageEnableAllCharsetsBuildItem;
-import io.quarkus.deployment.builditem.NativeImageEnableAllTimeZonesBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
@@ -38,7 +37,6 @@ class NativeImageConfigBuildStep {
             SslNativeConfigBuildItem sslNativeConfig,
             List<JniBuildItem> jniBuildItems,
             List<NativeImageEnableAllCharsetsBuildItem> nativeImageEnableAllCharsetsBuildItems,
-            List<NativeImageEnableAllTimeZonesBuildItem> nativeImageEnableAllTimeZonesBuildItems,
             List<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
             List<EnableAllSecurityServicesBuildItem> enableAllSecurityServicesBuildItems,
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxy,
@@ -87,10 +85,6 @@ class NativeImageConfigBuildStep {
 
         if (!nativeImageEnableAllCharsetsBuildItems.isEmpty()) {
             nativeImage.produce(new NativeImageSystemPropertyBuildItem("quarkus.native.enable-all-charsets", "true"));
-        }
-
-        if (!nativeImageEnableAllTimeZonesBuildItems.isEmpty()) {
-            nativeImage.produce(new NativeImageSystemPropertyBuildItem("quarkus.native.enable-all-timezones", "true"));
         }
     }
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2021,9 +2021,6 @@ A convenience feature that allows you to control most of the above features from
 `io.quarkus.deployment.builditem.NativeImageEnableAllCharsetsBuildItem`::
 Indicates that all charsets should be enabled in native image.
 
-`io.quarkus.deployment.builditem.NativeImageEnableAllTimeZonesBuildItem`::
-Indicates that all timezones should be enabled in native image.
-
 `io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem`::
 A convenient way to tell Quarkus that the extension requires SSL and it should be enabled during native image build.
 When using this feature, remember to add your extension to the list of extensions that offer SSL support automatically on the https://github.com/quarkusio/quarkus/blob/master/docs/src/main/asciidoc/native-and-ssl.adoc[native and ssl guide].


### PR DESCRIPTION
It's deprecated by GraalVM: all timezones are now included.

@jaikiran @galder does it make sense?

Fix #11054