### PR TITLE
Removing ldap build time config at runtime

### DIFF
--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -16,8 +16,8 @@ import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
 import io.quarkus.elytron.security.deployment.SecurityRealmBuildItem;
 import io.quarkus.elytron.security.ldap.LdapRecorder;
 import io.quarkus.elytron.security.ldap.QuarkusDirContextFactory;
-import io.quarkus.elytron.security.ldap.config.LdapSecurityRealmBuildTimeConfig;
 import io.quarkus.elytron.security.ldap.config.LdapSecurityRealmRuntimeConfig;
+import io.quarkus.elytron.security.ldap.deployment.config.LdapSecurityRealmBuildTimeConfig;
 import io.quarkus.runtime.RuntimeValue;
 
 class ElytronSecurityLdapProcessor {

--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/config/LdapSecurityRealmBuildTimeConfig.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/config/LdapSecurityRealmBuildTimeConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.elytron.security.ldap.config;
+package io.quarkus.elytron.security.ldap.deployment.config;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -8,7 +8,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  * A configuration object for a LDAP based realm configuration,
  * {@linkplain org.wildfly.security.auth.realm.ldap.LdapSecurityRealm}
  */
-@ConfigRoot(name = "security.ldap", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(name = "security.ldap", phase = ConfigPhase.BUILD_TIME)
 public class LdapSecurityRealmBuildTimeConfig {
 
     /**


### PR DESCRIPTION
we don't need the build time config at runtime.