### PR TITLE
Add quarkus table prefix prop

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
@@ -42,6 +42,14 @@ public class QuartzBuildTimeConfig {
     public Optional<String> dataSourceName;
 
     /**
+     * The prefix for quartz job store tables.
+     * <p>
+     * Ignored if using a `ram` store.
+     */
+    @ConfigItem(defaultValue = "QRTZ_")
+    public String tablePrefix;
+
+    /**
      * The named trigged listeners list
      */
     @ConfigItem(name = "triggerListener")

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -307,7 +307,7 @@ public class QuartzScheduler implements Scheduler {
             QuarkusQuartzConnectionPoolProvider.setDataSourceName(dataSource);
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".useProperties", "true");
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".misfireThreshold", "60000");
-            props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".tablePrefix", "QRTZ_");
+            props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".tablePrefix", buildTimeConfig.tablePrefix);
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".dataSource", dataSource);
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".driverDelegateClass",
                     quartzSupport.getDriverDialect().get());


### PR DESCRIPTION
This PR allows us to optionally set the `org.quartz.jobStore.tablePrefix` (quartz docs [here](http://www.quartz-scheduler.org/documentation/quartz-2.2.2/configuration/ConfigJobStoreTX.html)) config property, as opposed to hardcoding 'QRTZ'. 

This is useful for situations where there are multiple schedulers that need to use different sets of tables. 


