### PR TITLE
Don't use --no-server on Mandrel

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -183,8 +183,10 @@ public class NativeImageBuildStep {
             throw new RuntimeException("Failed to get GraalVM version", e);
         }
 
+        boolean isMandrel = false;
         if (graalVMVersion.isPresent()) {
             checkGraalVMVersion(graalVMVersion.get());
+            isMandrel = graalVMVersion.get().contains("Mandrel");
         } else {
             log.error("Unable to get GraalVM version from the native-image binary.");
         }
@@ -307,7 +309,7 @@ public class NativeImageBuildStep {
                         + " Please consider removing this configuration key as it is ignored (JNI is always enabled) and it"
                         + " will be removed in a future Quarkus version.");
             }
-            if (!nativeConfig.enableServer && !SystemUtils.IS_OS_WINDOWS) {
+            if (!nativeConfig.enableServer && !SystemUtils.IS_OS_WINDOWS && !isMandrel) {
                 command.add("--no-server");
             }
             if (nativeConfig.enableVmInspection) {


### PR DESCRIPTION
Mandel produces a warning when `--no-server` is used, so let's make life easier for users and make sure the log is clean.

Fixes: #11060