### PR TITLE
Substitute attributes where necessary.

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -100,7 +100,7 @@ Now that everything is explained, we can start coding!
 
 Quarkus provides `create-extension` Maven Mojo to initialize your extension project.
 
-[source, shell]
+[source, shell, subs=attributes+]
 ----
 $ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create-extension -N \
     -DgroupId=org.acme \ #<1>
@@ -133,7 +133,7 @@ Maven has generated a `quarkus-greeting` directory containing the extension proj
 
 Your extension is a multi-module project. So let's start by checking out the parent POM at `./quarkus-greeting/pom.xml`.
 
-[source, xml]
+[source, xml, subs=attributes+]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -626,7 +626,7 @@ public class GreetingTest {
 
 Time to test!
 
-[source, shell]
+[source, shell, subs=attributes+]
 ----
 $ mvn clean test
 [INFO] Scanning for projects...
@@ -731,7 +731,7 @@ Now that you just finish to build your first extension you should be eager to us
 Because your extension produces traditional JARs, the easiest way to share your extension is to publish it to a Maven repository.
 Once published you can simply declare it with your project dependencies. Let's demonstrate that by creating a simple Quarkus application
 
-[source, schell]
+[source, shell, subs=attributes+]
 ----
 $mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
      -DprojectGroupId=org.acme \
@@ -761,7 +761,7 @@ NOTE: `quarkus-greeting` extension has to be installed in the local Maven reposi
 
 Run the application and notice the `Install Features` list contains the `quarkus-greeting` extension.
 
-[source, shell]
+[source, shell, subs=attributes+]
 ----
 $ mvn clean compile quarkus:dev
 [INFO] Scanning for projects...


### PR DESCRIPTION
This is necessary to make the Quarkus version show up in code blocks.