### PR TITLE
Export Neo4j driver as dedicated BuildItem.

### DIFF
--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverBuildItem.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDriverBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.neo4j.deployment;
+
+import org.neo4j.driver.Driver;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+/**
+ * Allows access to the Neo4j Driver instance from within other extensions.
+ */
+public final class Neo4jDriverBuildItem extends SimpleBuildItem {
+
+    private final RuntimeValue<Driver> value;
+
+    public Neo4jDriverBuildItem(RuntimeValue<Driver> value) {
+        this.value = value;
+    }
+
+    public RuntimeValue<Driver> getValue() {
+        return value;
+    }
+}

--- a/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
+++ b/extensions/neo4j/runtime/src/main/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorder.java
@@ -14,6 +14,7 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Logging;
 
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.ssl.SslContextConfiguration;
@@ -23,17 +24,7 @@ public class Neo4jDriverRecorder {
 
     private static final Logger log = Logger.getLogger(Neo4jDriverRecorder.class);
 
-    public void configureNeo4jProducer(BeanContainer beanContainer, Neo4jConfiguration configuration,
-            ShutdownContext shutdownContext) {
-
-        Driver driver = initializeDriver(configuration, shutdownContext);
-
-        Neo4jDriverProducer driverProducer = beanContainer.instance(Neo4jDriverProducer.class);
-        driverProducer.initialize(driver);
-    }
-
-    private Driver initializeDriver(Neo4jConfiguration configuration,
-            ShutdownContext shutdownContext) {
+    public RuntimeValue<Driver> initializeDriver(Neo4jConfiguration configuration, ShutdownContext shutdownContext) {
 
         String uri = configuration.uri;
         AuthToken authToken = AuthTokens.none();
@@ -47,7 +38,12 @@ public class Neo4jDriverRecorder {
 
         Driver driver = GraphDatabase.driver(uri, authToken, configBuilder.build());
         shutdownContext.addShutdownTask(driver::close);
-        return driver;
+        return new RuntimeValue<>(driver);
+    }
+
+    public void configureNeo4jProducer(BeanContainer beanContainer, RuntimeValue<Driver> driverHolder) {
+        Neo4jDriverProducer driverProducer = beanContainer.instance(Neo4jDriverProducer.class);
+        driverProducer.initialize(driverHolder.getValue());
     }
 
     private static Config.ConfigBuilder createBaseConfig() {


### PR DESCRIPTION
This change allows other extensions to retrieve the driver during their deployment process and use it as dependency.

Background: I'm writing another extension and I need the driver in it. So my extension will depend on Neo4j. I thought Arc respectively CDI would also allow the `Driver` to be injected, but I'm pretty sure I'm wrong on that.

So with the dedicated `Neo4jDriverBuildItem` in addition to the CDI producer (both working on the same `Driver` value), the Neo4j extension provides the instance to the application and possible other extensions.