### PR TITLE
Don't use -Xverify:none on Java 13+ in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JavaVersionUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JavaVersionUtil.java
@@ -8,14 +8,30 @@ public class JavaVersionUtil {
     private static final Pattern PATTERN = Pattern.compile("(?:1\\.)?(\\d+)(?:\\..*)?");
 
     private static boolean IS_JAVA_11_OR_NEWER;
+    private static boolean IS_JAVA_13_OR_NEWER;
 
     static {
-        Matcher matcher = PATTERN.matcher(System.getProperty("java.version", ""));
-        IS_JAVA_11_OR_NEWER = !matcher.matches() || Integer.parseInt(matcher.group(1)) >= 11;
+        performChecks();
+    }
 
+    // visible for testing
+    static void performChecks() {
+        Matcher matcher = PATTERN.matcher(System.getProperty("java.version", ""));
+        if (matcher.matches()) {
+            int first = Integer.parseInt(matcher.group(1));
+            IS_JAVA_11_OR_NEWER = (first >= 11);
+            IS_JAVA_13_OR_NEWER = (first >= 13);
+        } else {
+            IS_JAVA_11_OR_NEWER = false;
+            IS_JAVA_13_OR_NEWER = false;
+        }
     }
 
     public static boolean isJava11OrHigher() {
         return IS_JAVA_11_OR_NEWER;
+    }
+
+    public static boolean isJava13OrHigher() {
+        return IS_JAVA_13_OR_NEWER;
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/JavaVersionUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/JavaVersionUtilTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.deployment.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class JavaVersionUtilTest {
+
+    private static final String JAVA_VERSION = "java.version";
+
+    @Test
+    void testJava8() {
+        testWithVersion("1.8.0_242", () -> {
+            assertFalse(JavaVersionUtil.isJava11OrHigher());
+            assertFalse(JavaVersionUtil.isJava13OrHigher());
+        });
+    }
+
+    @Test
+    void testJava11() {
+        testWithVersion("11.0.7", () -> {
+            assertTrue(JavaVersionUtil.isJava11OrHigher());
+            assertFalse(JavaVersionUtil.isJava13OrHigher());
+        });
+    }
+
+    @Test
+    void testJava14() {
+        testWithVersion("14.0.1", () -> {
+            assertTrue(JavaVersionUtil.isJava11OrHigher());
+            assertTrue(JavaVersionUtil.isJava13OrHigher());
+        });
+    }
+
+    private void testWithVersion(String javaVersion, Runnable test) {
+        String previous = System.getProperty(JAVA_VERSION);
+        System.setProperty(JAVA_VERSION, javaVersion);
+        JavaVersionUtil.performChecks();
+        try {
+            test.run();
+        } finally {
+            System.setProperty(JAVA_VERSION, previous);
+            JavaVersionUtil.performChecks();
+        }
+
+    }
+
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -72,6 +72,7 @@ import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.DevModeMain;
+import io.quarkus.deployment.util.JavaVersionUtil;
 import io.quarkus.maven.components.MavenVersionEnforcer;
 import io.quarkus.maven.utilities.MojoUtils;
 import io.quarkus.utilities.JavaBinFinder;
@@ -322,7 +323,13 @@ public class DevMojo extends AbstractMojo {
             // the following flags reduce startup time and are acceptable only for dev purposes
             args.add("-XX:TieredStopAtLevel=1");
             if (!preventnoverify) {
-                args.add("-Xverify:none");
+                // in Java 13 and up, preventing verification is deprecated - see https://bugs.openjdk.java.net/browse/JDK-8218003
+                // this test isn't absolutely correct in the sense that depending on the user setup, the actual Java binary
+                // that is used might be different that the one running Maven, but given how small of an impact this has
+                // it's probably better than running an extra command on 'javaTool' just to figure out the version
+                if (!JavaVersionUtil.isJava13OrHigher()) {
+                    args.add("-Xverify:none");
+                }
             }
 
             DevModeRunner runner = new DevModeRunner(args);


### PR DESCRIPTION
This is done because the flag has been deprecated from Java 13
[onward](https://bugs.openjdk.java.net/browse/JDK-8218003) and its use results in:

```
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify
were deprecated in JDK 13 and will likely be removed in a future release.
```