### PR TITLE
Disable the Cron Job CI that runs Java 8 native image tests

### DIFF
--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -1,3 +1,4 @@
+# Disabled because we mostly don't care about Java 8 native image
 name: "Quarkus CI - JDK 8 Native Build"
 on:
   schedule:


### PR DESCRIPTION
We no longer care about this as per
https://groups.google.com/g/quarkus-dev/c/2HhcWDzD5nM/m/h1aVdi1vAAAJ