### PR TITLE
Support for additional test-to-main directory mappings

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -64,9 +64,9 @@ javadoc {
 }
 
 pluginBundle {
-    website = 'https://quarkus.io/' 
-    vcsUrl = 'https://github.com/quarkusio/quarkus' 
-    tags = ['quarkus', 'quarkusio', 'graalvm'] 
+    website = 'https://quarkus.io/'
+    vcsUrl = 'https://github.com/quarkusio/quarkus'
+    tags = ['quarkus', 'quarkusio', 'graalvm']
 }
 
 gradlePlugin {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -11,6 +11,12 @@ public interface BootstrapConstants {
     String SERIALIZED_APP_MODEL = "quarkus-internal.serialized-app-model.path";
     String DESCRIPTOR_FILE_NAME = "quarkus-extension.properties";
 
+    /**
+     * Constant for sharing the additional mappings between test-sources and the corresponding application-sources.
+     * The Gradle plugin populates this data which is then read by the PathTestHelper when executing tests.
+     */
+    String TEST_TO_MAIN_MAPPINGS = "TEST_TO_MAIN_MAPPINGS";
+
     @Deprecated
     String EXTENSION_PROPS_JSON_FILE_NAME = "quarkus-extension.json";
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AdditionalSourceSetsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AdditionalSourceSetsTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for verifying that the plugin can work with test-sources which are included as part of a custom source set.
+ * E.g., functional-tests / integration-tests.
+ */
+public class AdditionalSourceSetsTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void executeFunctionalTest() throws URISyntaxException, IOException, InterruptedException {
+        final File projectDir = getProjectDir("additional-source-sets");
+        BuildResult result = runGradleWrapper(projectDir, "functionalTest");
+        assertEquals(BuildResult.SUCCESS_OUTCOME, result.getTasks().get(":functionalTest"),
+                "Failed to run tests defined in an alternate test sources directory");
+    }
+}

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/build.gradle
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/build.gradle
@@ -1,0 +1,50 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation "io.quarkus:quarkus-arc"
+    testImplementation "io.quarkus:quarkus-junit5"
+}
+
+sourceSets {
+    // Functional Tests
+    funcTest {
+        java.srcDir 'src/funcTest/java'
+        if (file('src/funcTest/resources').exists()) {
+            resources.srcDir 'src/funcTest/resources'
+        }
+
+        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath + configurations.compileOnly
+        runtimeClasspath += output + compileClasspath
+    }
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+/*
+ * Functional tests for this module.
+ */
+task functionalTest(type: Test, description: 'Functional tests', dependsOn: [processResources, classes]) {
+    description = 'Run the functional tests.'
+    group = 'verification'
+
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.funcTest.output.classesDirs
+    classpath = sourceSets.funcTest.runtimeClasspath
+
+    // Show standard streams on the console.
+    testLogging {
+        showStandardStreams = true
+    }
+    systemProperty 'quarkus.http.host', 'localhost'
+}

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name = 'additional-test-sources'

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/src/funcTest/java/ft/SimpleBeanTest.java
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/src/funcTest/java/ft/SimpleBeanTest.java
@@ -1,0 +1,19 @@
+package ft;
+
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import io.quarkus.test.junit.QuarkusTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class SimpleBeanTest {
+
+    @Inject
+    SimpleBean bean;
+
+    @Test
+    public void verify() {
+        assertEquals("hello", bean.hello(), "Did the implementation of the SimpleBean change?");
+    }
+}

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/src/main/java/ft/SimpleBean.java
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/src/main/java/ft/SimpleBean.java
@@ -1,0 +1,11 @@
+package ft;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SimpleBean {
+
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/additional-source-sets/src/main/resources/META-INF/beans.xml
+++ b/integration-tests/gradle/src/test/resources/additional-source-sets/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -9,7 +9,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
+import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.runtime.util.ClassPathUtils;
 
 /**
@@ -99,6 +101,20 @@ public final class PathTestHelper {
                 File.separator + "test-classes",
                 File.separator + "classes");
         //endregion
+
+        String mappings = System.getenv(BootstrapConstants.TEST_TO_MAIN_MAPPINGS);
+        if (mappings != null) {
+            Stream.of(mappings.split(","))
+                    .filter(s -> !s.isEmpty())
+                    .forEach(s -> {
+                        String[] entry = s.split(":");
+                        if (entry.length == 2) {
+                            TEST_TO_MAIN_DIR_FRAGMENTS.put(entry[0], entry[1]);
+                        } else {
+                            throw new IllegalStateException("Unable to parse additional test-to-main mapping: " + s);
+                        }
+                    });
+        }
     }
 
     private PathTestHelper() {


### PR DESCRIPTION
It is [common practice for Gradle projects](https://guides.gradle.org/testing-gradle-plugins/#organizing_test_source_code) to have more than one source set as part of the project setup. For example,
```
src/
  main/java
  test/java
  funcTest/java
  integTest/java
```
Currently Quarkus's `PathTestHelper` does not allow developers to include Quarkus tests in to any of these other locations. This commit proposes a change which will allow supplying the _additional source sets_ to the Quarkus test framework.

Once approved, the subsequent change would be to the Gradle plugin where we can determine the various source sets and supply them as environment variables.

E.g.,
Sample `build.gradle` snippet.

```groovy
sourceSets {
    // Functional Tests
    functionalTest {
        java.srcDir file('src/funcTest/java')
        resources.srcDir file('src/funcTest/resources')

        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath + configurations.compileOnly
        runtimeClasspath += output + compileClasspath + configurations.jacocoAnt
    }
}

/*
 * Functional tests for this module.
 */
task functionalTest(type: Test, description: 'Functional tests', dependsOn: [processResources, classes]) {
    description = 'Run the functional tests.'
    group = 'verification'
    testClassesDirs = sourceSets.functionalTest.output.classesDirs
    classpath = sourceSets.functionalTest.runtimeClasspath
}

test {
    SourceSet mainSS = project.sourceSets.main
    String mainRelativePath = project.buildDir.relativePath(mainSS.output.classesDirs.singleFile)
    String additionalMappings = project.sourceSets.findAll { ss -> ss != mainSS }
            .collect { SourceSet ss ->
                project.buildDir.relativePath(ss.output.classesDirs.singleFile) + ':' + mainRelativePath
            }.join(',')
    environment 'ADDITIONAL_TEST_TO_MAIN_MAPPINGS', additionalMappings
}
```
