### PR TITLE
Add support to configuration file per profile

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ApplicationPropertiesConfigSource.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ApplicationPropertiesConfigSource.java
@@ -25,7 +25,9 @@ public abstract class ApplicationPropertiesConfigSource extends PropertiesConfig
     private static final long serialVersionUID = -4694780118527396798L;
 
     static final String APPLICATION_PROPERTIES = "application.properties";
+    static final String APPLICATION_PROPERTIES_PROFILE = "application-%s.properties";
     static final String MP_PROPERTIES = "META-INF/microprofile-config.properties";
+    static final String MP_PROPERTIES_PROFILE = "META-INF/microprofile-config-%s.properties";
 
     ApplicationPropertiesConfigSource(InputStream is, int ordinal) {
         super(readProperties(is), APPLICATION_PROPERTIES, ordinal);
@@ -54,19 +56,25 @@ public abstract class ApplicationPropertiesConfigSource extends PropertiesConfig
 
     public static final class InJar extends ApplicationPropertiesConfigSource {
         public InJar() {
-            super(openStream(), 250);
+            super(openStream(null), 250);
         }
 
-        private static InputStream openStream() {
+        public InJar(String profile) {
+            super(openStream(profile), 251);
+        }
+
+        private static InputStream openStream(String profile) {
+            final String filename = profile == null ? APPLICATION_PROPERTIES
+                    : String.format(APPLICATION_PROPERTIES_PROFILE, profile);
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             if (cl == null) {
                 cl = ApplicationPropertiesConfigSource.class.getClassLoader();
             }
             InputStream is;
             if (cl == null) {
-                is = ClassLoader.getSystemResourceAsStream(APPLICATION_PROPERTIES);
+                is = ClassLoader.getSystemResourceAsStream(filename);
             } else {
-                is = cl.getResourceAsStream(APPLICATION_PROPERTIES);
+                is = cl.getResourceAsStream(filename);
             }
             return is;
         }
@@ -77,19 +85,25 @@ public abstract class ApplicationPropertiesConfigSource extends PropertiesConfig
      */
     public static final class MpConfigInJar extends ApplicationPropertiesConfigSource {
         public MpConfigInJar() {
-            super(openStream(), MP_PROPERTIES, 240);
+            super(openStream(null), MP_PROPERTIES, 240);
         }
 
-        private static InputStream openStream() {
+        public MpConfigInJar(String profile) {
+            super(openStream(profile), MP_PROPERTIES, 241);
+        }
+
+        private static InputStream openStream(String profile) {
+            final String filename = profile == null ? MP_PROPERTIES
+                    : String.format(MP_PROPERTIES_PROFILE, profile);
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             if (cl == null) {
                 cl = ApplicationPropertiesConfigSource.class.getClassLoader();
             }
             InputStream is;
             if (cl == null) {
-                is = ClassLoader.getSystemResourceAsStream(MP_PROPERTIES);
+                is = ClassLoader.getSystemResourceAsStream(filename);
             } else {
-                is = cl.getResourceAsStream(MP_PROPERTIES);
+                is = cl.getResourceAsStream(filename);
             }
             return is;
         }
@@ -97,11 +111,16 @@ public abstract class ApplicationPropertiesConfigSource extends PropertiesConfig
 
     public static final class InFileSystem extends ApplicationPropertiesConfigSource {
         public InFileSystem() {
-            super(openStream(), 260);
+            super(openStream(null), 260);
         }
 
-        private static InputStream openStream() {
-            final Path path = Paths.get("config", APPLICATION_PROPERTIES);
+        public InFileSystem(String profile) {
+            super(openStream(profile), 261);
+        }
+
+        private static InputStream openStream(final String profile) {
+            final Path path = Paths.get("config",
+                    profile == null ? APPLICATION_PROPERTIES : String.format(APPLICATION_PROPERTIES_PROFILE, profile));
             if (Files.exists(path)) {
                 try {
                     return Files.newInputStream(path);

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -1,28 +1,12 @@
 package io.quarkus.runtime.configuration;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Serializable;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntFunction;
 import java.util.regex.Pattern;
@@ -68,9 +52,16 @@ public final class ConfigUtils {
     public static SmallRyeConfigBuilder configBuilder(final boolean runTime, final boolean addDiscovered) {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
         final ApplicationPropertiesConfigSource.InFileSystem inFileSystem = new ApplicationPropertiesConfigSource.InFileSystem();
+        final ApplicationPropertiesConfigSource.InFileSystem inFileProfileSystem = new ApplicationPropertiesConfigSource.InFileSystem(
+                ProfileManager.getActiveProfile());
         final ApplicationPropertiesConfigSource.InJar inJar = new ApplicationPropertiesConfigSource.InJar();
+        final ApplicationPropertiesConfigSource.InJar inJarProfile = new ApplicationPropertiesConfigSource.InJar(
+                ProfileManager.getActiveProfile());
         final ApplicationPropertiesConfigSource.MpConfigInJar mpConfig = new ApplicationPropertiesConfigSource.MpConfigInJar();
-        builder.withSources(inFileSystem, inJar, mpConfig, new DotEnvConfigSource());
+        final ApplicationPropertiesConfigSource.MpConfigInJar mpConfigProfile = new ApplicationPropertiesConfigSource.MpConfigInJar(
+                ProfileManager.getActiveProfile());
+        builder.withSources(inFileSystem, inJar, mpConfig, mpConfigProfile, inFileProfileSystem, inJarProfile,
+                new DotEnvConfigSource());
         builder.withProfile(ProfileManager.getActiveProfile());
         builder.addDefaultInterceptors();
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigProfileFileTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigProfileFileTestCase.java
@@ -1,0 +1,46 @@
+package io.quarkus.runtime.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfig;
+
+public class ConfigProfileFileTestCase {
+
+    static ClassLoader classLoader;
+    static ConfigProviderResolver cpr;
+
+    @BeforeAll
+    public static void initConfig() {
+        classLoader = Thread.currentThread().getContextClassLoader();
+        cpr = ConfigProviderResolver.instance();
+    }
+
+    @AfterEach
+    public void doAfter() {
+        try {
+            cpr.releaseConfig(cpr.getConfig());
+        } catch (IllegalStateException ignored) {
+            // just means no config was installed, which is fine
+        }
+    }
+
+    private SmallRyeConfig buildConfig() {
+        final SmallRyeConfig config = ConfigUtils.configBuilder(true).build();
+        cpr.registerConfig(config, classLoader);
+        return config;
+    }
+
+    @Test
+    void shouldLoadProdProfileFile() throws IOException {
+        final SmallRyeConfig config = buildConfig();
+        assertEquals("v2", config.getValue("foo.version", String.class));
+    }
+
+}

--- a/core/runtime/src/test/resources/application-prod.properties
+++ b/core/runtime/src/test/resources/application-prod.properties
@@ -1,0 +1,1 @@
+foo.version=v2

--- a/core/runtime/src/test/resources/application.properties
+++ b/core/runtime/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+foo.version=v1

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -451,6 +451,8 @@ quarkus.http.port=9090
 %dev.quarkus.http.port=8181
 ----
 
+You can also have multiple configuration files that is going to be selected by the profile name in the filename (i.e. `application-{profile}.properties`)
+
 The Quarkus HTTP port will be 9090, unless the `dev` profile is active, in which case it will be 8181.
 
 By default Quarkus has three profiles, although it is possible to use as many as you like. The default profiles are:


### PR DESCRIPTION
As described on issue #6810, this change adds the support to use a configuration file per-profile.

The user can have an ```application.properties``` with general configuration and one file for each profile, like ```application-dev.profile``` for ```dev``` profile.

Closes #6810