### PR TITLE
Better logging on startup failure

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -69,6 +69,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
 
+            boolean augmentDone = false;
             //ok, we have resolved all the deps
             try {
                 StartupAction start = augmentAction.createInitialRuntimeApplication();
@@ -104,13 +105,15 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
 
                 startCodeGenWatcher(deploymentClassLoader, codeGens);
 
+                augmentDone = true;
                 runner = start.runMainClass(context.getArgs());
                 firstStartCompleted = true;
             } catch (Throwable t) {
                 deploymentProblem = t;
-                if (context.isAbortOnFailedStart()) {
+                if (!augmentDone) {
                     log.error("Failed to start quarkus", t);
-                } else {
+                }
+                if (!context.isAbortOnFailedStart()) {
                     //we need to set this here, while we still have the correct TCCL
                     //this is so the config is still valid, and we can read HTTP config from application.properties
                     log.info("Attempting to start hot replacement endpoint to recover from previous Quarkus startup failure");

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -87,8 +87,10 @@ public class ApplicationLifecycleManager {
         } finally {
             stateLock.unlock();
         }
+        boolean appStarted = false;
         try {
             application.start(args);
+            appStarted = true;
             //now we are started, we either run the main application or just wait to exit
             if (quarkusApplication != null) {
                 BeanManager beanManager = CDI.current().getBeanManager();
@@ -135,7 +137,11 @@ public class ApplicationLifecycleManager {
                 }
             }
         } catch (Exception e) {
-            Logger.getLogger(Application.class).error("Error running Quarkus application", e);
+            if (appStarted) {
+                //we only log if the error occurred after the application was started
+                //as the generated application class already has logging
+                Logger.getLogger(Application.class).error("Error running Quarkus application", e);
+            }
             stateLock.lock();
             try {
                 shutdownRequested = true;


### PR DESCRIPTION
At present failures in startup are logged twice, and failured in augment
during dev mode are not logged at all. This fixes both these issues.

Fixes #11062