### PR TITLE
Ensure quarkusBuild Gradle task works properly with fast-jar

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -14,6 +14,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -78,13 +79,18 @@ public class QuarkusBuild extends QuarkusTask {
     }
 
     @OutputFile
-    public File getOutputDir() {
+    public File getRunnerJar() {
         return new File(getProject().getBuildDir(), extension().finalName() + "-runner.jar");
+    }
+
+    @OutputDirectory
+    public File getFastJar() {
+        return new File(getProject().getBuildDir(), "quarkus-app");
     }
 
     @TaskAction
     public void buildQuarkus() {
-        getLogger().lifecycle("building quarkus runner");
+        getLogger().lifecycle("building quarkus jar");
 
         final AppArtifact appArtifact = extension().getAppArtifact();
         appArtifact.setPaths(QuarkusGradleUtils.getOutputPaths(getProject()));


### PR DESCRIPTION
When building a fast-jar, the typical runner jar is not created
so we need to make Gradle aware of this new output

Fixes: #11157