### PR TITLE
Disable snapshot resolution for releases repositories and only add the Gradle repository where needed

### DIFF
--- a/independent-projects/bootstrap/gradle-resolver/pom.xml
+++ b/independent-projects/bootstrap/gradle-resolver/pom.xml
@@ -70,4 +70,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>gradle-dependencies</id>
+            <name>Gradle releases repository</name>
+            <url>https://repo.gradle.org/gradle/libs-releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -517,14 +517,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>gradle-dependencies</id>
-            <name>Gradle releases repository</name>
-            <url>https://repo.gradle.org/gradle/libs-releases</url>
-        </repository>
-    </repositories>
-
     <profiles>
         <profile>
             <id>quick-build</id>

--- a/integration-tests/kafka-avro/pom.xml
+++ b/integration-tests/kafka-avro/pom.xml
@@ -138,6 +138,9 @@
         <repository>
             <id>confluent</id>
             <url>https://packages.confluent.io/maven/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,14 +83,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>gradle-dependencies</id>
-            <name>Gradle releases repository</name>
-            <url>https://repo.gradle.org/gradle/libs-releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,17 @@
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>gradle-dependencies</id>
             <name>Gradle releases repository</name>
             <url>https://repo.gradle.org/gradle/libs-releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Right now, we try to download maven-metadata.xml from all the repositories present whereas it makes no sense to do it for releases repositories.

I think we should probably also fixed that in the JBoss Parent /cc @dmlloyd .

Noticed because right now the Gradle repository is timing out for me making it really cumbersome to build Quarkus.

In passing, I pushed the Gradle repo to where it's strictly needed because we have absolutely no idea what's there and better be conservative rather than enabling it globally.