### PR TITLE
Use official maven-compiler-plugin version 3.8.1 in independent-projects

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -46,6 +46,7 @@
         <version.gizmo>1.0.4.Final</version.gizmo>
         <version.jpa>2.2.3</version.jpa>
 
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -47,6 +47,7 @@
         <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
         <graal-sdk.version>20.1.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <smallrye-common.version>1.2.0</smallrye-common.version>
         <gradle-tooling.version>6.5</gradle-tooling.version>

--- a/independent-projects/ide-config/pom.xml
+++ b/independent-projects/ide-config/pom.xml
@@ -34,6 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     </properties>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -38,6 +38,7 @@
         <version.junit>5.6.2</version.junit>
         <version.gizmo>1.0.4.Final</version.gizmo>
         <version.jboss-logging>3.3.2.Final</version.jboss-logging>
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
         <version.smallrye-mutiny>0.7.0</version.smallrye-mutiny>


### PR DESCRIPTION
Reasoning: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/maven-compiler-plugin.203.2E8.2E0-jboss-2.20in.20independent-projects