### PR TITLE
Fixes for incorrect .equals checks

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -142,9 +142,12 @@ public class BeanArchiveProcessor {
             AppArtifactKey key = archive.getArtifactKey();
             for (IndexDependencyConfig excludeDependency : config.excludeDependency.values()) {
                 if (Objects.equal(key.getArtifactId(), excludeDependency.artifactId)
-                        && Objects.equal(key.getGroupId(), excludeDependency.groupId)
-                        && Objects.equal(key.getClassifier(), excludeDependency.classifier)) {
-                    return true;
+                        && Objects.equal(key.getGroupId(), excludeDependency.groupId)) {
+                    if (excludeDependency.classifier.isPresent()) {
+                        return Objects.equal(key.getClassifier(), excludeDependency.classifier.get());
+                    } else {
+                        return true;
+                    }
                 }
             }
         }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -145,7 +145,7 @@ public class KubernetesDeployer {
         }
 
         if (OPENSHIFT.equals(selectedTarget.getName())) {
-            checkForMissingRegistry = Capability.CONTAINER_IMAGE_S2I.equals(activeContainerImageCapability);
+            checkForMissingRegistry = Capability.CONTAINER_IMAGE_S2I.getName().equals(activeContainerImageCapability);
         } else if (MINIKUBE.equals(selectedTarget.getName())) {
             checkForMissingRegistry = false;
         }


### PR DESCRIPTION
Fixes for incorrect `.equals` checks - comparing incompatible types for equality

 - Classifier is optional, equality check needs to reflect that
 - Capability is enum, not String

@mkouba please check my code changes