### PR TITLE
handle testFixtures sourceset

### DIFF
--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/SourceSetImpl.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/SourceSetImpl.java
@@ -3,17 +3,22 @@ package io.quarkus.bootstrap.resolver.model.impl;
 import io.quarkus.bootstrap.resolver.model.SourceSet;
 import java.io.File;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class SourceSetImpl implements SourceSet, Serializable {
 
-    private final Set<File> sourceDirectories;
+    private Set<File> sourceDirectories = new HashSet<>();
     private final File resourceDirectory;
 
     public SourceSetImpl(Set<File> sourceDirectories, File resourceDirectory) {
-        this.sourceDirectories = sourceDirectories;
+        this.sourceDirectories.addAll(sourceDirectories);
         this.resourceDirectory = resourceDirectory;
+    }
+
+    public void addSourceDirectories(Set<File> files) {
+        sourceDirectories.addAll(files);
     }
 
     @Override

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+public class TestFixtureModuleTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testTaskShouldUseTestFixtures() throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir("test-fixtures-module");
+
+        final BuildResult result = runGradleWrapper(projectDir, "clean", "test");
+
+        assertThat(result.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/build.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'java'
+    id 'java-test-fixtures'
+    id 'io.quarkus'
+}
+
+repositories {
+     mavenLocal()
+     mavenCentral()
+}
+
+dependencies {
+    implementation 'io.quarkus:quarkus-resteasy-jsonb'
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'my-groupId'
+version 'my-version'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/gradle.properties
@@ -1,0 +1,4 @@
+#Quarkus Gradle TS
+#Sat May 23 23:11:14 CEST 2020
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        jcenter()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+rootProject.name='io.quarkus.reproducer'
+

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/src/main/java/org.my.group/MyFactory.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/src/main/java/org.my.group/MyFactory.java
@@ -1,0 +1,7 @@
+package org.my.group;
+
+public interface MyFactory {
+
+    MyService createMyService();
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/src/main/java/org.my.group/MyResource.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/src/main/java/org.my.group/MyResource.java
@@ -1,0 +1,16 @@
+package org.my.group;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class MyResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/src/main/java/org.my.group/MyService.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/src/main/java/org.my.group/MyService.java
@@ -1,0 +1,7 @@
+package org.my.group;
+
+public interface MyService {
+
+    String getSomething();
+
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/src/test/java/org.my.group/MyResourceTest.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/src/test/java/org.my.group/MyResourceTest.java
@@ -1,0 +1,20 @@
+package org.my.group;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.example.MyTestFactory;
+
+@QuarkusTest
+public class MyResourceTest {
+
+    @Test
+    public void testTestFixtures() {
+        MyService myService = new MyTestFactory().createMyService();
+
+        String result = myService.getSomething();
+
+        Assertions.assertEquals("test-fixtures", result);
+    }
+}

--- a/integration-tests/gradle/src/test/resources/test-fixtures-module/src/testFixtures/java/org.my.group/MyTestFactory.java
+++ b/integration-tests/gradle/src/test/resources/test-fixtures-module/src/testFixtures/java/org.my.group/MyTestFactory.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.my.group.MyFactory;
+import org.my.group.MyService;
+
+public class MyTestFactory implements MyFactory {
+
+    @Override
+    public MyService createMyService() {
+        return () -> "test-fixtures";
+    }
+
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
@@ -130,6 +131,10 @@ public class QuarkusTestExtension
                     rootBuilder.add(testResourcesLocation);
                 }
             }
+            if (Files.exists(testClassLocation.getParent().resolve("testFixtures"))) {
+                rootBuilder.add(testClassLocation.getParent().resolve("testFixtures"));
+            }
+
             originalCl = Thread.currentThread().getContextClassLoader();
             Map<String, String> sysPropRestore = new HashMap<>();
             sysPropRestore.put(ProfileManager.QUARKUS_TEST_PROFILE_PROP,


### PR DESCRIPTION
This branch partially fix #11144 by handling the `test-fixtures` source set. 

but the classloader issue is still present and I don't know how to fix it. Here is the error:

`````
java.lang.LinkageError: loader constraint violation: loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @27d4a09 wants to load interface org.my.group.MyService. A different interface with the same name was previously loaded by 'app'. (org.my.group.MyService is in unnamed module of loader 'app')

at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:420)
	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:363)
	at org.my.group.MyResourceTest.testTestFixtures(MyResourceTest.java:18)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:699)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestMethod(QuarkusTestExtension.java:606)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:212)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:208)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:137)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:71)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
`````
@aloubyansky have you an idea? 