### PR TITLE
Fix CNFE when MessageBundles are used with Dev-mode

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -433,30 +433,18 @@ public class MessageBundleProcessor {
 
         Map<String, String> generatedTypes = new HashMap<>();
 
-        ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, new Predicate<String>() {
-            @Override
-            public boolean test(String name) {
-                int idx = name.lastIndexOf(SUFFIX);
-                String className = name.substring(0, idx).replace("/", ".");
-                if (className.contains(ValueResolverGenerator.NESTED_SEPARATOR)) {
-                    className = className.replace(ValueResolverGenerator.NESTED_SEPARATOR, "$");
-                }
-                if (applicationArchivesBuildItem.getRootArchive().getIndex()
-                        .getClassByName(DotName.createSimple(className)) != null) {
-                    return true;
-                }
-                return false;
-            }
-        });
+        ClassOutput defaultClassOutput = new GeneratedClassGizmoAdaptor(generatedClasses,
+                new AppClassPredicate(applicationArchivesBuildItem));
 
         for (MessageBundleBuildItem bundle : bundles) {
             ClassInfo bundleInterface = bundle.getDefaultBundleInterface();
-            String bundleImpl = generateImplementation(null, null, bundleInterface, classOutput, messageTemplateMethods,
+            String bundleImpl = generateImplementation(null, null, bundleInterface, defaultClassOutput, messageTemplateMethods,
                     Collections.emptyMap(), null);
             generatedTypes.put(bundleInterface.name().toString(), bundleImpl);
             for (ClassInfo localizedInterface : bundle.getLocalizedInterfaces().values()) {
                 generatedTypes.put(localizedInterface.name().toString(),
-                        generateImplementation(bundle.getDefaultBundleInterface(), bundleImpl, localizedInterface, classOutput,
+                        generateImplementation(bundle.getDefaultBundleInterface(), bundleImpl, localizedInterface,
+                                defaultClassOutput,
                                 messageTemplateMethods, Collections.emptyMap(), null));
             }
 
@@ -482,9 +470,22 @@ public class MessageBundleProcessor {
                         keyToTemplate.put(key, value);
                     }
                 }
+                String locale = entry.getKey();
+                ClassOutput localeAwareGizmoAdaptor = new GeneratedClassGizmoAdaptor(generatedClasses,
+                        new AppClassPredicate(applicationArchivesBuildItem, new Function<String, String>() {
+                            @Override
+                            public String apply(String className) {
+                                String localeSuffix = "_" + locale;
+                                if (className.endsWith(localeSuffix)) {
+                                    return className.replace(localeSuffix, "");
+                                }
+                                return className;
+                            }
+                        }));
                 generatedTypes.put(localizedFile.toString(),
-                        generateImplementation(bundle.getDefaultBundleInterface(), bundleImpl, bundleInterface, classOutput,
-                                messageTemplateMethods, keyToTemplate, entry.getKey()));
+                        generateImplementation(bundle.getDefaultBundleInterface(), bundleImpl, bundleInterface,
+                                localeAwareGizmoAdaptor,
+                                messageTemplateMethods, keyToTemplate, locale));
             }
         }
         return generatedTypes;
@@ -811,4 +812,30 @@ public class MessageBundleProcessor {
         return messageFiles;
     }
 
+    private static class AppClassPredicate implements Predicate<String> {
+        private final ApplicationArchivesBuildItem applicationArchivesBuildItem;
+        private final Function<String, String> additionalClassNameSanitizer;
+
+        public AppClassPredicate(ApplicationArchivesBuildItem applicationArchivesBuildItem) {
+            this(applicationArchivesBuildItem, Function.identity());
+        }
+
+        public AppClassPredicate(ApplicationArchivesBuildItem applicationArchivesBuildItem,
+                Function<String, String> additionalClassNameSanitizer) {
+            this.applicationArchivesBuildItem = applicationArchivesBuildItem;
+            this.additionalClassNameSanitizer = additionalClassNameSanitizer;
+        }
+
+        @Override
+        public boolean test(String name) {
+            int idx = name.lastIndexOf(SUFFIX);
+            String className = name.substring(0, idx).replace("/", ".");
+            if (className.contains(ValueResolverGenerator.NESTED_SEPARATOR)) {
+                className = className.replace(ValueResolverGenerator.NESTED_SEPARATOR, "$");
+            }
+            className = additionalClassNameSanitizer.apply(className);
+            return applicationArchivesBuildItem.getRootArchive().getIndex()
+                    .getClassByName(DotName.createSimple(className)) != null;
+        }
+    }
 }

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/AppMessageHelloResource.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/AppMessageHelloResource.java
@@ -1,0 +1,23 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("hello")
+public class AppMessageHelloResource {
+
+    @Inject
+    Template hello;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public TemplateInstance get() {
+        return hello.instance();
+    }
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/AppMessages.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/AppMessages.java
@@ -1,0 +1,15 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+@MessageBundle
+public interface AppMessages {
+
+    @Message("Hello world!")
+    String hello();
+
+    @Message("Hello {name}!")
+    String hello_name(String name);
+
+}

--- a/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/MessageBundleDevModeTest.java
+++ b/extensions/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/MessageBundleDevModeTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.qute.resteasy.deployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class MessageBundleDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AppMessages.class, AppMessageHelloResource.class)
+                    .addAsResource(new StringAsset(
+                            "{msg:hello_name('Georg')}"),
+                            "templates/hello.html")
+                    .addAsResource(new StringAsset(
+                            "hello=Hallo Welt!\nhello_name=Hallo {name}!"),
+                            "messages/msg_de.properties"));
+
+    @Test
+    public void testMessageBundles() {
+        when().get("/hello").then().body(is("Hello Georg!"));
+
+        TEST.modifySourceFile("AppMessages.java", (s -> s.replace("Hello", "Heya")));
+
+        when().get("/hello").then().body(is("Heya Georg!"));
+    }
+}


### PR DESCRIPTION
Without this fix, generated classes containing the locale suffix (like 

`at.porscheinformatik.bazaar.ApplicationMessages_de_Bundle` 

or 

`at.porscheinformatik.bazaar.ApplicationMessages_msg_Bundle` 

in the original issue) get loaded from the Base Runtime Classloader (as they are not marked as application classes) - which in turn leads to the CNFE because that classloader does not cannot load application classes (`at.porscheinformatik.bazaar.ApplicationMessages` in the original issue), because application classes are loaded from the Runtime Classloader (which uses `Base Runtime Classloader` as its parent).

This PR fixes the issue by making sure these classes are also considered application classes - and concequently loaded by the Runtime Classloader.

Fixes: #11188