### PR TITLE
Run mvn package when caching the maven repo

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -90,7 +90,7 @@ jobs:
           restore-only: ${{ github.event_name == 'pull_request' }}
       - name: Build
         run: |
-          mvn -e -B -DskipTests -DskipITs -Dno-format -Ddocumentation-pdf clean install
+          mvn -e -B -DskipTests -DskipITs -Dno-format -Ddocumentation-pdf clean package
       - name: Tar Maven Repo
         shell: bash
         run: tar -czf maven-repo.tgz -C ~ .m2/repository


### PR DESCRIPTION
This prevents the io.quarkus artifacts being installed.