### PR TITLE
This prevents the io.quarkus artifacts being installed.

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -99,6 +99,9 @@ jobs:
         with:
           name: maven-repo
           path: maven-repo.tgz
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -r ~/.m2/repository/io/quarkus
 
   linux-jvm-tests:
     name: JDK ${{matrix.java.name}} JVM Tests


### PR DESCRIPTION
Remove io.quarkus artifacts before the cache is uploaded