### PR TITLE
A bunch of new stuff for codestarts

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -75,10 +75,10 @@ public class CreateProjectMojo extends AbstractMojo {
     private String projectVersion;
 
     @Parameter(property = "codestartsEnabled", defaultValue = "false")
-    private Boolean codestartsEnabled;
+    private boolean codestartsEnabled;
 
-    @Parameter(property = "withExampleCode", defaultValue = "true")
-    private Boolean withExampleCode;
+    @Parameter(property = "skipExample", defaultValue = "false")
+    private boolean skipExample;
 
     /**
      * Group ID of the target platform BOM
@@ -198,7 +198,7 @@ public class CreateProjectMojo extends AbstractMojo {
                     .className(className)
                     .extensions(extensions)
                     .codestartsEnabled(codestartsEnabled)
-                    .withExampleCode(withExampleCode);
+                    .withExampleCode(!skipExample);
             if (path != null) {
                 createProject.setValue("path", path);
             }

--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/base-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/base-example/codestart.yml
@@ -1,4 +1,0 @@
----
-name: base-example
-type: example
-preselected: true

--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/codestart.yml
@@ -4,7 +4,6 @@ ref: commandmode
 type: example
 fallback: true
 missing-languages:
-  - kotlin
   - scala
 language:
   base:
@@ -12,3 +11,5 @@ language:
       greeting:
         message: "hello"
         default-name: "commando"
+    dependencies:
+      - io.quarkus:quarkus-arc

--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/kotlin/src/main/kotlin/org/acme/commandmode/GreetingMain.tpl.qute.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/kotlin/src/main/kotlin/org/acme/commandmode/GreetingMain.tpl.qute.kt
@@ -1,0 +1,22 @@
+package org.acme.commandmode
+
+import javax.inject.Inject
+
+import io.quarkus.runtime.QuarkusApplication
+import io.quarkus.runtime.annotations.QuarkusMain
+
+@QuarkusMain
+class GreetingMain: QuarkusApplication {
+
+    @Inject
+    lateinit var service: GreetingService
+    override fun run(vararg args: String?): Int {
+        if (args.isNotEmpty()) {
+            System.out.println(service.greeting(args.joinToString(",")))
+        } else {
+            System.out.println(service.greeting("{greeting.default-name}"))
+        }
+        return 0
+    }
+
+}

--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/kotlin/src/main/kotlin/org/acme/commandmode/GreetingService.tpl.qute.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/kotlin/src/main/kotlin/org/acme/commandmode/GreetingService.tpl.qute.kt
@@ -1,0 +1,8 @@
+package org.acme.commandmode
+
+import javax.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class GreetingService {
+    fun greeting(name: String) = "{greeting.message} $name"
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/codestart.yml
@@ -3,7 +3,6 @@ name: qute-example
 ref: qute
 type: example
 missing-languages:
-  - kotlin
   - scala
 language:
   base:

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/kotlin/org/acme/qute/HelloResource.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/kotlin/org/acme/qute/HelloResource.kt
@@ -1,0 +1,23 @@
+package org.acme.qute
+
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.QueryParam
+import javax.ws.rs.core.MediaType
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("/qute/hello")
+class HelloResource {
+
+    @Inject
+    lateinit var hello: Template;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    fun get(@QueryParam("name") name: String?): TemplateInstance = hello.data("name", name)
+
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/kotlin/org/acme/qute/Item.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/kotlin/org/acme/qute/Item.kt
@@ -1,0 +1,5 @@
+package org.acme.qute
+
+import java.math.BigDecimal
+
+data class Item (val price: BigDecimal, val name: String)

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/kotlin/org/acme/qute/ItemResource.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/kotlin/org/acme/qute/ItemResource.kt
@@ -1,0 +1,44 @@
+package org.acme.qute
+
+import io.quarkus.qute.Template
+import io.quarkus.qute.TemplateExtension
+import io.quarkus.qute.TemplateInstance
+import java.math.BigDecimal
+import java.util.*
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+
+@Path("qute/items")
+class ItemResource {
+
+    @Inject
+    lateinit var items: Template
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    fun get(): TemplateInstance {
+        val data: MutableList<Item> = ArrayList()
+        data.add(Item(BigDecimal(10), "Apple"))
+        data.add(Item(BigDecimal(16), "Pear"))
+        data.add(Item(BigDecimal(30), "Orange"))
+        return items.data("items", data)
+    }
+}
+
+@TemplateExtension
+class ItemExtension {
+
+    companion object {
+        /**
+         * This template extension method implements the "discountedPrice" computed property.
+         */
+        @JvmStatic
+        fun discountedPrice(item: Item): BigDecimal {
+            return item.price.multiply(BigDecimal("0.9"))
+        }
+    }
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/resources/templates/hello.qute.html
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/resources/templates/hello.qute.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Qute Hello World</title> 
+</head>
+<body>
+    <p>Hello {name ?: "world"}!</p>
+</body>
+</html>

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/resources/templates/items.qute.html
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/main/resources/templates/items.qute.html
@@ -1,0 +1,24 @@
+{! This parameter declarations makes it possible to validate expressions in the template !}
+{@java.util.List<org.acme.qute.Item> items}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Qute - Items</title> 
+</head>
+<body>
+    <h1>List of Items</h1>
+    <ul>
+        {#for item in items}
+        <li>
+            {item.name}:
+            {#if item.price < 15}
+              {item.price}
+            {#else}
+              <del>{item.price}</del> <strong>{item.discountedPrice}</strong>
+            {/if}
+        </li>
+        {/for}
+    </ul>
+</body>
+</html>

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/native-test/kotlin/org/acme/qute/NativeHelloResourceIT.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/native-test/kotlin/org/acme/qute/NativeHelloResourceIT.kt
@@ -1,0 +1,7 @@
+package codestarts.qute - example.kotlin.src.native - test.kotlin.org.acme.qute
+
+import io.quarkus.test.junit.NativeImageTest
+
+@NativeImageTest
+class NativeHelloResourceIT : HelloResourceTest() { // Execute the same tests but in native mode.
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/test/kotlin/org/acme/qute/HelloResourceTest.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/test/kotlin/org/acme/qute/HelloResourceTest.kt
@@ -1,0 +1,23 @@
+package org.acme.qute
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class HelloResourceTest {
+    @Test
+    fun testEndpoint() {
+        given()
+                .`when`().get("/qute/hello")
+                .then()
+                .statusCode(200)
+                .body(containsString("<p>Hello world!</p>"))
+        given()
+                .`when`().get("/qute/hello?name=Lucie")
+                .then()
+                .statusCode(200)
+                .body(containsString("<p>Hello Lucie!</p>"))
+    }
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/test/kotlin/org/acme/qute/ItemsResourceTest.kt
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/kotlin/src/test/kotlin/org/acme/qute/ItemsResourceTest.kt
@@ -1,0 +1,18 @@
+package org.acme.qute
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class ItemsResourceTest {
+    @Test
+    fun testEndpoint() {
+        given()
+                .`when`().get("/qute/items")
+                .then()
+                .statusCode(200)
+                .body(containsString("Apple:"), containsString("<del>30</del> <strong>27.0</strong>"))
+    }
+}

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/resteasy-example/base/src/main/resources/META-INF/resources/index.tpl.qute.html
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/resteasy-example/base/src/main/resources/META-INF/resources/index.tpl.qute.html
@@ -105,7 +105,7 @@
 
 <div class="container">
     <div class="left-column">
-        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+        <p class="lead"> Congratulations, you have created a new Quarkus application with RESTEasy.</p>
 
         <h2>Why do you see this?</h2>
 
@@ -117,6 +117,7 @@
         <p>If not already done, run the application in <em>dev mode</em> using: <code>{buildtool.cmd.dev}</code>.
         </p>
         <ul>
+            <li>Open the example <a href="{rest.path}" target="_blank">"/hello"</a> endpoint</li>
             <li>Add REST resources, Servlets, functions and other services in <code>{language.dir.code}</code>.</li>
             <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
             <li>Configure your application in <code>src/main/resources/{config.file-name}</code>.
@@ -149,7 +150,5 @@
         </div>
     </div>
 </div>
-
-
 </body>
 </html>

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/Codestart.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/Codestart.java
@@ -21,6 +21,18 @@ public final class Codestart {
         return spec;
     }
 
+    public String getName() {
+        return spec.getName();
+    }
+
+    public CodestartSpec.Type getType() {
+        return spec.getType();
+    }
+
+    public boolean implementsLanguage(String languageName) {
+        return spec.getMissingLanguages().isEmpty() || !spec.getMissingLanguages().contains(languageName);
+    }
+
     public Map<String, Object> getLocalData(String languageName) {
         return NestedMaps.deepMerge(Stream.of(getBaseLanguageSpec().getData(), getLanguageSpec(languageName).getData()));
     }

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartData.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartData.java
@@ -84,10 +84,12 @@ public final class CodestartData {
         return NestedMaps.deepMerge(Stream.of(codestart.getLocalData(languageName), data));
     }
 
-    public static Map<String, Object> buildCodestartProjectData(Collection<Codestart> codestarts) {
+    public static Map<String, Object> buildCodestartProjectData(Collection<Codestart> baseCodestarts,
+            Collection<Codestart> extraCodestarts) {
         final HashMap<String, Object> data = new HashMap<>();
-        codestarts.forEach((c) -> data.put("codestart-project." + c.getSpec().getType().toString().toLowerCase() + ".name",
-                c.getSpec().getName()));
+        baseCodestarts.forEach((c) -> data.put("codestart-project." + c.getSpec().getType().toString().toLowerCase() + ".name",
+                c.getName()));
+        data.put("codestart-project.codestarts", extraCodestarts.stream().map(Codestart::getName).collect(Collectors.toList()));
         return NestedMaps.unflatten(data);
     }
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartProcessor.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartProcessor.java
@@ -46,11 +46,6 @@ final class CodestartProcessor {
         resourceLoader.loadResourceAsPath(codestart.getResourceDir(), p -> {
             final Path baseDir = p.resolve(BASE_LANGUAGE);
             final Path languageDir = p.resolve(languageName);
-            if (!codestart.getSpec().getMissingLanguages().isEmpty()
-                    && codestart.getSpec().getMissingLanguages().contains(languageName)) {
-                // TODO print a warning to inform that this codestart miss this language
-                return null; // We ignore that codestart as it doesn't implement the specified language
-            }
             Stream.of(baseDir, languageDir)
                     .filter(Files::isDirectory)
                     .forEach(dirPath -> processCodestartDir(dirPath,

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartProject.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartProject.java
@@ -32,7 +32,7 @@ public final class CodestartProject {
     }
 
     public Optional<Codestart> getCodestart(Type type) {
-        return codestarts.stream().filter(c -> c.getSpec().getType() == type).findFirst();
+        return codestarts.stream().filter(c -> c.getType() == type).findFirst();
     }
 
     public Codestart getRequiredCodestart(Type type) {
@@ -40,7 +40,7 @@ public final class CodestartProject {
     }
 
     public String getLanguageName() {
-        return getRequiredCodestart(Type.LANGUAGE).getSpec().getName();
+        return getRequiredCodestart(Type.LANGUAGE).getName();
     }
 
     public Map<String, Object> getSharedData() {
@@ -54,7 +54,7 @@ public final class CodestartProject {
     }
 
     public Map<String, Object> getCodestartProjectData() {
-        return buildCodestartProjectData(getBaseCodestarts());
+        return buildCodestartProjectData(getBaseCodestarts(), getExtraCodestarts());
     }
 
     List<Codestart> getBaseCodestarts() {

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/NestedMaps.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/NestedMaps.java
@@ -1,6 +1,8 @@
 package io.quarkus.devtools.codestarts;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -38,6 +40,11 @@ public final class NestedMaps {
                 Map leftChild = (Map) left.get(key);
                 Map rightChild = (Map) right.get(key);
                 deepMerge(leftChild, rightChild);
+            } else if (right.get(key) instanceof Collection && left.get(key) instanceof Collection) {
+                Collection c = new LinkedHashSet();
+                c.addAll((Collection) left.get(key));
+                c.addAll((Collection) right.get(key));
+                left.put(key, c);
             } else {
                 // Override
                 left.put(key, right.get(key));

--- a/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/NestedMapsTest.java
+++ b/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/NestedMapsTest.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -28,6 +30,7 @@ class NestedMapsTest {
         assertThat(NestedMaps.getValue(NESTED_MAP_1, "foo.bar.foo")).hasValue("bar");
         assertThat(NestedMaps.getValue(NESTED_MAP_1, "foo.bar.bar")).hasValue("foo");
         assertThat(NestedMaps.getValue(NESTED_MAP_1, "bar.foo.bar.foo")).hasValue("baz");
+        assertThat((Collection) NestedMaps.getValue(NESTED_MAP_1, "list").get()).containsExactly("foo", "bar");
         assertThat(NestedMaps.getValue(NESTED_MAP_1, "bar.foo.bar")).hasValueSatisfying(v -> {
             assertThat(v).isInstanceOf(Map.class);
             assertThat((Map) v).hasFieldOrPropertyWithValue("foo", "baz");
@@ -61,6 +64,7 @@ class NestedMapsTest {
         assertThat(NestedMaps.getValue(target, "bar.foo.bar.foo")).hasValue("bar");
         assertThat(NestedMaps.getValue(target, "bar.foo.bar.baz")).hasValue("foo");
         assertThat(NestedMaps.getValue(target, "hello")).hasValue("world");
+        assertThat((Collection) NestedMaps.getValue(target, "list").get()).containsExactly("foo", "bar", "baz");
     }
 
     @Test
@@ -73,7 +77,7 @@ class NestedMapsTest {
         data.put("bar.foo.bar.foo", "bar");
         data.put("bar.foo.bar.baz", "foo");
         data.put("hello", "world");
-
+        data.put("list", Arrays.asList("foo", "bar", "baz"));
         final Map<String, Object> target = NestedMaps.unflatten(data);
 
         checkTargetMap(target);

--- a/independent-projects/tools/codestarts/src/test/resources/nested-map-1.yml
+++ b/independent-projects/tools/codestarts/src/test/resources/nested-map-1.yml
@@ -10,3 +10,6 @@ bar:
   foo:
     bar:
       foo: baz
+list:
+  - foo
+  - bar

--- a/independent-projects/tools/codestarts/src/test/resources/nested-map-2.yml
+++ b/independent-projects/tools/codestarts/src/test/resources/nested-map-2.yml
@@ -9,4 +9,5 @@ bar:
       baz: foo
 hello:
   world
-
+list:
+  - baz

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/CodestartsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/CodestartsTest.java
@@ -29,7 +29,7 @@ class CodestartsTest extends PlatformAwareTestBase {
     void loadBundledCodestartsTest() throws IOException {
         final Collection<Codestart> codestarts = CodestartLoader
                 .loadBundledCodestarts(inputBuilder(getPlatformDescriptor()).build());
-        assertThat(codestarts).hasSize(11);
+        assertThat(codestarts).hasSize(10);
     }
 
     @Test
@@ -102,7 +102,7 @@ class CodestartsTest extends PlatformAwareTestBase {
         assertThat(codestartProject.getBaseCodestarts()).extracting(Codestart::getResourceDir)
                 .contains("bundled-codestarts/config/properties");
         assertThat(codestartProject.getExtraCodestarts()).extracting(Codestart::getResourceDir)
-                .containsExactlyInAnyOrder("bundled-codestarts/example/base-example", "bundled-codestarts/tooling/dockerfiles",
+                .containsExactlyInAnyOrder("bundled-codestarts/tooling/dockerfiles",
                         "codestarts/resteasy-example");
     }
 
@@ -115,7 +115,7 @@ class CodestartsTest extends PlatformAwareTestBase {
         assertThat(codestartProject.getBaseCodestarts()).extracting(Codestart::getResourceDir)
                 .contains("bundled-codestarts/config/properties");
         assertThat(codestartProject.getExtraCodestarts()).extracting(Codestart::getResourceDir)
-                .containsExactlyInAnyOrder("bundled-codestarts/example/base-example", "bundled-codestarts/tooling/dockerfiles",
+                .containsExactlyInAnyOrder("bundled-codestarts/tooling/dockerfiles",
                         "bundled-codestarts/example/commandmode-example");
     }
 }


### PR DESCRIPTION
- Use -DskipExample instead of -DwithExampleCode=false
- Add list merge support in codestart.yml data 
- Fix a bug for missing languages
- Add Kotlin for Qute and Command Mode examples, Closes #11128 and #11129 (Scala could be implemented in the future if someone wants it)
- Improve integration tests (gradle and maven + command mode + package and devmode)