### PR TITLE
Use packages for the common RESTEasy reflection ignores and add the JSON packages to DEFAULT_IGNORED_PACKAGES

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveHierarchyBuildItem.java
@@ -96,7 +96,8 @@ public final class ReflectiveHierarchyBuildItem extends MultiBuildItem {
         public static final DefaultIgnorePredicate INSTANCE = new DefaultIgnorePredicate();
 
         private static final List<String> DEFAULT_IGNORED_PACKAGES = Arrays.asList("java.", "io.reactivex.",
-                "org.reactivestreams.", "org.slf4j.");
+                "org.reactivestreams.", "org.slf4j.", "javax.json.", "com.fasterxml.jackson.databind.",
+                "io.vertx.core.json.");
         // if this gets more complicated we will need to move to some tree like structure
         static final Set<String> WHITELISTED_FROM_IGNORED_PACKAGES = new HashSet<>(
                 Arrays.asList("java.math.BigDecimal", "java.math.BigInteger"));

--- a/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
+++ b/extensions/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyDotNames.java
@@ -80,28 +80,19 @@ public final class ResteasyDotNames {
 
     // Types ignored for reflection used by the RESTEasy and SmallRye REST client extensions.
     private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(Arrays.asList(
-            // Jackson
-            DotName.createSimple("com.fasterxml.jackson.databind.JsonNode"),
-
-            // JAX-RS
-            DotName.createSimple("javax.ws.rs.core.Response"),
-            DotName.createSimple("javax.ws.rs.core.Response.StatusType"),
-            DotName.createSimple("javax.ws.rs.container.AsyncResponse"),
-            DotName.createSimple("javax.ws.rs.core.StreamingOutput"),
-            DotName.createSimple("javax.ws.rs.core.Form"),
-            DotName.createSimple("javax.ws.rs.core.MultivaluedMap"),
-
-            // RESTEasy
-            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartInput"),
-            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput"),
-            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartOutput"),
-            DotName.createSimple("org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput"),
-
-            // Vert-x
-            DotName.createSimple("io.vertx.core.json.JsonArray"),
-            DotName.createSimple("io.vertx.core.json.JsonObject")));
+    // Consider adding packages below instead if it makes more sense
+    ));
 
     private static final String[] PACKAGES_IGNORED_FOR_REFLECTION = {
-            "javax.json."
+            // JSON-P
+            "javax.json.",
+            // Jackson
+            "com.fasterxml.jackson.databind.",
+            // JAX-RS
+            "javax.ws.rs.",
+            // RESTEasy
+            "org.jboss.resteasy.",
+            // Vert.x JSON layer
+            "io.vertx.core.json."
     };
 }


### PR DESCRIPTION
We used to add classes one at a time but in all those cases, adding the
whole package makes more sense as everything will be handled by RESTEasy
and specific (de)serializers.

I was sure I had created a PR for that branch but apparently missed it...

Fixes #11208