### PR TITLE
Share the Admin client in KafkaStreams

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsTopologyManager.java
@@ -3,13 +3,12 @@ package io.quarkus.kafka.streams.runtime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.jboss.logging.Logger;
 
@@ -17,16 +16,16 @@ public class KafkaStreamsTopologyManager {
 
     private static final Logger LOGGER = Logger.getLogger(KafkaStreamsTopologyManager.class.getName());
 
-    private final Properties adminClientConfig;
+    private final Admin adminClient;
 
-    public KafkaStreamsTopologyManager(Properties adminClientConfig) {
-        this.adminClientConfig = adminClientConfig;
+    public KafkaStreamsTopologyManager(Admin adminClient) {
+        this.adminClient = adminClient;
     }
 
     public Set<String> getMissingTopics(Collection<String> topicsToCheck) throws InterruptedException {
         HashSet<String> missing = new HashSet<>(topicsToCheck);
 
-        try (AdminClient adminClient = AdminClient.create(adminClientConfig)) {
+        try {
             ListTopicsResult topics = adminClient.listTopics();
             Set<String> topicNames = topics.names().get(10, TimeUnit.SECONDS);
 


### PR DESCRIPTION
It avoids costly instantiation during readiness checks, which also generates noisy INFO logs.

That should be in-line with smallrye-reactive-messaging-kafka (https://github.com/smallrye/smallrye-reactive-messaging/blob/master/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java#L94 )

Fixes #9967