### PR TITLE
Simplify runtime class transformation

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/TransformedClassesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/TransformedClassesBuildItem.java
@@ -36,12 +36,16 @@ public final class TransformedClassesBuildItem extends SimpleBuildItem {
 
     public static class TransformedClass {
 
+        private final String className;
         private final byte[] data;
         private final String fileName;
+        private final boolean eager;
 
-        public TransformedClass(byte[] data, String fileName) {
+        public TransformedClass(String className, byte[] data, String fileName, boolean eager) {
+            this.className = className;
             this.data = data;
             this.fileName = fileName;
+            this.eager = eager;
         }
 
         public byte[] getData() {
@@ -50,6 +54,14 @@ public final class TransformedClassesBuildItem extends SimpleBuildItem {
 
         public String getFileName() {
             return fileName;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public boolean isEager() {
+            return eager;
         }
 
         @Override

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/AugmentActionImpl.java
@@ -32,7 +32,6 @@ import io.quarkus.builder.item.BuildItem;
 import io.quarkus.deployment.ExtensionLoader;
 import io.quarkus.deployment.QuarkusAugmentor;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
-import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.ConfigDescriptionBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedFileSystemResourceHandledBuildItem;
@@ -42,6 +41,7 @@ import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
 import io.quarkus.deployment.builditem.RawCommandLineArgumentsBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
@@ -56,8 +56,9 @@ public class AugmentActionImpl implements AugmentAction {
     private static final Logger log = Logger.getLogger(AugmentActionImpl.class);
 
     private static final Class[] NON_NORMAL_MODE_OUTPUTS = { GeneratedClassBuildItem.class,
-            GeneratedResourceBuildItem.class, BytecodeTransformerBuildItem.class, ApplicationClassNameBuildItem.class,
-            MainClassBuildItem.class, GeneratedFileSystemResourceHandledBuildItem.class };
+            GeneratedResourceBuildItem.class, ApplicationClassNameBuildItem.class,
+            MainClassBuildItem.class, GeneratedFileSystemResourceHandledBuildItem.class,
+            TransformedClassesBuildItem.class };
 
     private final QuarkusBootstrap quarkusBootstrap;
     private final CuratedApplication curatedApplication;
@@ -129,11 +130,9 @@ public class AugmentActionImpl implements AugmentAction {
             throw new IllegalStateException("Cannot launch a runtime application with NORMAL launch mode");
         }
         ClassLoader classLoader = curatedApplication.createDeploymentClassLoader();
-
         @SuppressWarnings("unchecked")
         BuildResult result = runAugment(true, Collections.emptySet(), classLoader, NON_NORMAL_MODE_OUTPUTS);
-
-        return new StartupActionImpl(curatedApplication, result, classLoader);
+        return new StartupActionImpl(curatedApplication, result);
     }
 
     @Override
@@ -146,7 +145,7 @@ public class AugmentActionImpl implements AugmentAction {
         @SuppressWarnings("unchecked")
         BuildResult result = runAugment(!hasStartedSuccessfully, changedResources, classLoader, NON_NORMAL_MODE_OUTPUTS);
 
-        return new StartupActionImpl(curatedApplication, result, classLoader);
+        return new StartupActionImpl(curatedApplication, result);
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -9,20 +9,15 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import org.jboss.logging.Logger;
-import org.objectweb.asm.ClassVisitor;
 
 import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.bootstrap.app.CuratedApplication;
@@ -32,12 +27,11 @@ import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildResult;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
-import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.MainClassBuildItem;
+import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
-import io.quarkus.deployment.index.ConstPoolScanner;
 import io.quarkus.dev.appstate.ApplicationStateNotification;
 import io.quarkus.runtime.Quarkus;
 
@@ -49,35 +43,30 @@ public class StartupActionImpl implements StartupAction {
     private final BuildResult buildResult;
     private final QuarkusClassLoader runtimeClassLoader;
 
-    public StartupActionImpl(CuratedApplication curatedApplication, BuildResult buildResult,
-            ClassLoader deploymentClassLoader) {
+    public StartupActionImpl(CuratedApplication curatedApplication, BuildResult buildResult) {
         this.curatedApplication = curatedApplication;
         this.buildResult = buildResult;
         Set<String> eagerClasses = new HashSet<>();
-        Map<String, Predicate<byte[]>> transformerPredicates = new HashMap<>();
-        Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> bytecodeTransformers = extractTransformers(
-                eagerClasses, transformerPredicates);
+        Map<String, byte[]> transformedClasses = extractTransformers(eagerClasses);
         QuarkusClassLoader baseClassLoader = curatedApplication.getBaseRuntimeClassLoader();
         QuarkusClassLoader runtimeClassLoader;
 
         //so we have some differences between dev and test mode here.
         //test mode only has a single class loader, while dev uses a disposable runtime class loader
         //that is discarded between restarts
+        Map<String, byte[]> resources = new HashMap<>();
+        resources.putAll(extractGeneratedResources(true));
         if (curatedApplication.getQuarkusBootstrap().getMode() == QuarkusBootstrap.Mode.DEV) {
-            baseClassLoader.reset(extractGeneratedResources(false), bytecodeTransformers, transformerPredicates,
-                    deploymentClassLoader);
+            baseClassLoader.reset(extractGeneratedResources(false),
+                    transformedClasses);
             runtimeClassLoader = curatedApplication.createRuntimeClassLoader(baseClassLoader,
-                    bytecodeTransformers, transformerPredicates,
-                    deploymentClassLoader, extractGeneratedResources(true));
+                    resources, transformedClasses);
         } else {
-            Map<String, byte[]> resources = new HashMap<>();
             resources.putAll(extractGeneratedResources(false));
-            resources.putAll(extractGeneratedResources(true));
-            baseClassLoader.reset(resources, bytecodeTransformers, transformerPredicates, deploymentClassLoader);
+            baseClassLoader.reset(resources, transformedClasses);
             runtimeClassLoader = baseClassLoader;
         }
         this.runtimeClassLoader = runtimeClassLoader;
-        handleEagerClasses(runtimeClassLoader, eagerClasses);
     }
 
     private void handleEagerClasses(QuarkusClassLoader runtimeClassLoader, Set<String> eagerClasses) {
@@ -262,40 +251,18 @@ public class StartupActionImpl implements StartupAction {
         return runtimeClassLoader;
     }
 
-    private Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> extractTransformers(Set<String> eagerClasses,
-            Map<String, Predicate<byte[]>> transformerPredicates) {
-        Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> bytecodeTransformers = new HashMap<>();
-        Set<String> noConstScanning = new HashSet<>();
-        Map<String, Set<String>> constScanning = new HashMap<>();
-        List<BytecodeTransformerBuildItem> transformers = buildResult.consumeMulti(BytecodeTransformerBuildItem.class);
-        for (BytecodeTransformerBuildItem i : transformers) {
-            List<BiFunction<String, ClassVisitor, ClassVisitor>> list = bytecodeTransformers.get(i.getClassToTransform());
-            if (list == null) {
-                bytecodeTransformers.put(i.getClassToTransform(), list = new ArrayList<>());
-            }
-            list.add(i.getVisitorFunction());
-            if (i.isEager()) {
-                eagerClasses.add(i.getClassToTransform());
-            }
-            if (i.getRequireConstPoolEntry() == null || i.getRequireConstPoolEntry().isEmpty()) {
-                noConstScanning.add(i.getClassToTransform());
-            } else {
-                constScanning.computeIfAbsent(i.getClassToTransform(), (s) -> new HashSet<>())
-                        .addAll(i.getRequireConstPoolEntry());
-            }
-        }
-        for (String i : noConstScanning) {
-            constScanning.remove(i);
-        }
-        for (Map.Entry<String, Set<String>> entry : constScanning.entrySet()) {
-            transformerPredicates.put(entry.getKey(), new Predicate<byte[]>() {
-                @Override
-                public boolean test(byte[] bytes) {
-                    return ConstPoolScanner.constPoolEntryPresent(bytes, entry.getValue());
+    private Map<String, byte[]> extractTransformers(Set<String> eagerClasses) {
+        Map<String, byte[]> ret = new HashMap<>();
+        TransformedClassesBuildItem transformers = buildResult.consume(TransformedClassesBuildItem.class);
+        for (Set<TransformedClassesBuildItem.TransformedClass> i : transformers.getTransformedClassesByJar().values()) {
+            for (TransformedClassesBuildItem.TransformedClass clazz : i) {
+                ret.put(clazz.getFileName(), clazz.getData());
+                if (clazz.isEager()) {
+                    eagerClasses.add(clazz.getClassName());
                 }
-            });
+            }
         }
-        return bytecodeTransformers;
+        return ret;
     }
 
     private Map<String, byte[]> extractGeneratedResources(boolean applicationClasses) {

--- a/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VerticleWithClassNameDeploymentTest.java
+++ b/extensions/vertx-core/deployment/src/test/java/io/quarkus/vertx/core/deployment/VerticleWithClassNameDeploymentTest.java
@@ -33,7 +33,7 @@ public class VerticleWithClassNameDeploymentTest {
     public void testDeploymentOfVerticleUsingClassName() {
         String resp1 = RestAssured.get("http://localhost:8080").asString();
         String resp2 = RestAssured.get("http://localhost:8080").asString();
-        Assertions.assertTrue(resp1.startsWith("OK"));
+        Assertions.assertTrue(resp1.startsWith("OK"), resp1);
         Assertions.assertTrue(resp2.startsWith("OK"));
         Assertions.assertNotEquals(resp1, resp2);
     }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -19,11 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import org.objectweb.asm.ClassVisitor;
 
 /**
  * The result of the curate step that is done by QuarkusBootstrap.
@@ -269,19 +266,16 @@ public class CuratedApplication implements Serializable, Closeable {
     }
 
     public QuarkusClassLoader createRuntimeClassLoader(QuarkusClassLoader loader,
-            Map<String, List<BiFunction<String, ClassVisitor, ClassVisitor>>> bytecodeTransformers,
-            Map<String, Predicate<byte[]>> transformerPredicates,
-            ClassLoader deploymentClassLoader, Map<String, byte[]> resources) {
+            Map<String, byte[]> resources, Map<String, byte[]> transformedClasses) {
         QuarkusClassLoader.Builder builder = QuarkusClassLoader.builder("Quarkus Runtime ClassLoader",
                 loader, false)
                 .setAggregateParentResources(true);
-        builder.setTransformerPredicates(transformerPredicates);
-        builder.setTransformerClassLoader(deploymentClassLoader);
+        builder.setTransformedClasses(transformedClasses);
 
+        builder.addElement(new MemoryClassPathElement(resources));
         for (Path root : quarkusBootstrap.getApplicationRoot()) {
             builder.addElement(ClassPathElement.fromPath(root));
         }
-        builder.addElement(new MemoryClassPathElement(resources));
 
         for (AdditionalDependency i : getQuarkusBootstrap().getAdditionalApplicationArchives()) {
             if (i.isHotReloadable()) {
@@ -290,7 +284,6 @@ public class CuratedApplication implements Serializable, Closeable {
                 }
             }
         }
-        builder.setBytecodeTransformers(bytecodeTransformers);
         return builder.build();
     }
 

--- a/independent-projects/bootstrap/maven-resolver/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>slf4j-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
         </dependency>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,7 +41,6 @@
         <jakarta.inject-api.version>1.0</jakarta.inject-api.version>
         <commons-lang.version>3.9</commons-lang.version>
         <guava.version>27.0.1-jre</guava.version>
-        <asm.version>8.0.1</asm.version>
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
         <jboss-logmanager-embedded.version>1.0.4</jboss-logmanager-embedded.version>
         <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
@@ -61,11 +60,6 @@
     </modules>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
Take 2

The previous version did not account for transformed classes being loaded
into different class loaders, which caused problems for dev mode in
multi module projects.