### PR TITLE
ArC - cleanup and optimizations

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -966,6 +966,13 @@ public class BeanDeployment {
     }
 
     private void addSyntheticBean(BeanInfo bean) {
+        for (BeanInfo b : beans) {
+            if (b.getIdentifier().equals(bean.getIdentifier())) {
+                throw new IllegalStateException(
+                        "A synthetic bean with identifier " + bean.getIdentifier() + " is already registered: "
+                                + b);
+            }
+        }
         beans.add(bean);
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -495,7 +495,7 @@ public class BeanInfo implements InjectionTargetInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier);
+        return identifier.hashCode();
     }
 
     @Override

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -114,6 +114,9 @@ public class InterceptorGenerator extends BeanGenerator {
         implementIntercept(interceptorCreator, interceptor, providerTypeName, reflectionRegistration, isApplicationClass);
         implementGetPriority(interceptorCreator, interceptor);
 
+        implementEquals(interceptor, interceptorCreator);
+        implementHashCode(interceptor, interceptorCreator);
+
         interceptorCreator.close();
         return classOutput.getResources();
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -14,6 +14,7 @@ import io.quarkus.arc.impl.InterceptedMethodMetadata;
 import io.quarkus.arc.impl.InterceptorInvocation;
 import io.quarkus.arc.impl.InvocationContexts;
 import io.quarkus.arc.impl.MapValueSupplier;
+import io.quarkus.arc.impl.Objects;
 import io.quarkus.arc.impl.Reflections;
 import io.quarkus.gizmo.MethodDescriptor;
 import java.lang.reflect.Constructor;
@@ -75,9 +76,14 @@ public final class MethodDescriptors {
     public static final MethodDescriptor OBJECT_EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
             Object.class);
 
+    public static final MethodDescriptor OBJECT_HASH_CODE = MethodDescriptor.ofMethod(Object.class, "hashCode", int.class);
+
     public static final MethodDescriptor OBJECT_TO_STRING = MethodDescriptor.ofMethod(Object.class, "toString", String.class);
 
     public static final MethodDescriptor OBJECT_CONSTRUCTOR = MethodDescriptor.ofConstructor(Object.class);
+
+    public static final MethodDescriptor OBJECTS_REFERENCE_EQUALS = MethodDescriptor.ofMethod(Objects.class, "referenceEquals",
+            boolean.class, Object.class, Object.class);
 
     public static final MethodDescriptor INTERCEPTOR_INVOCATION_POST_CONSTRUCT = MethodDescriptor.ofMethod(
             InterceptorInvocation.class,

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCache.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCache.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -21,29 +22,51 @@ import java.util.stream.Collectors;
 public class ComputingCache<K, V> {
 
     private final ConcurrentMap<K, LazyValue<V>> map;
+    private final Function<K, V> computingFunction;
 
-    private final Function<K, LazyValue<V>> function;
+    /**
+     * Note that {@link #getValue(Object)} cannot be used if no default computing function is specified.
+     */
+    public ComputingCache() {
+        this(null);
+    }
 
     public ComputingCache(Function<K, V> computingFunction) {
         this.map = new ConcurrentHashMap<>();
-        this.function = new CacheFunction(computingFunction);
+        this.computingFunction = computingFunction;
     }
 
     public V getValue(K key) {
+        return computeIfAbsent(key, computingFunction);
+    }
+
+    public V getValueIfPresent(K key) {
+        LazyValue<V> value = map.get(key);
+        return value != null ? value.getIfPresent() : null;
+    }
+
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> computingFunction) {
+        return computeIfAbsent(key, new Supplier<V>() {
+            @Override
+            public V get() {
+                return computingFunction.apply(key);
+            }
+        });
+    }
+
+    public V computeIfAbsent(K key, Supplier<V> supplier) {
+        if (supplier == null) {
+            throw new IllegalStateException("Computing function not defined");
+        }
         LazyValue<V> value = map.get(key);
         if (value == null) {
-            value = function.apply(key);
+            value = new LazyValue<V>(supplier);
             LazyValue<V> previous = map.putIfAbsent(key, value);
             if (previous != null) {
                 value = previous;
             }
         }
         return value.get();
-    }
-
-    public V getValueIfPresent(K key) {
-        LazyValue<V> value = map.get(key);
-        return value != null ? value.getIfPresent() : null;
     }
 
     public V remove(K key) {
@@ -84,21 +107,6 @@ public class ComputingCache<K, V> {
 
     public boolean isEmpty() {
         return map.isEmpty();
-    }
-
-    class CacheFunction implements Function<K, LazyValue<V>> {
-
-        private final Function<K, V> computingFunction;
-
-        public CacheFunction(Function<K, V> computingFunction) {
-            this.computingFunction = computingFunction;
-        }
-
-        @Override
-        public LazyValue<V> apply(K key) {
-            return new LazyValue<V>(() -> computingFunction.apply(key));
-        }
-
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Objects.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Objects.java
@@ -1,0 +1,12 @@
+package io.quarkus.arc.impl;
+
+public final class Objects {
+
+    private Objects() {
+    }
+
+    // https://github.com/quarkusio/gizmo/issues/50
+    public static boolean referenceEquals(Object obj1, Object obj2) {
+        return obj1 == obj2;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanCollisionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanCollisionTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.Map;
+import javax.enterprise.context.spi.CreationalContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SyntheticBeanCollisionTest {
+
+    public static volatile boolean beanDestroyerInvoked = false;
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new TestRegistrar()).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        assertNotNull(container.getFailure());
+        assertTrue(container.getFailure().getMessage().contains("A synthetic bean with identifier"),
+                container.getFailure().getMessage());
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(String.class).unremovable().types(String.class).param("name", "Frantisek")
+                    .creator(StringCreator.class).done();
+
+            context.configure(String.class).unremovable().types(String.class).param("name", "Martin")
+                    .creator(StringCreator.class).done();
+        }
+
+    }
+
+    public static class StringCreator implements BeanCreator<String> {
+
+        @Override
+        public String create(CreationalContext<String> creationalContext, Map<String, Object> params) {
+            return "Hello " + params.get("name") + "!";
+        }
+
+    }
+
+}


### PR DESCRIPTION
- AbstractSharedContext - replace Key with bean identifier
- ComputingCache - add computeIfAbsent() methods
- Generated beans implement equals()/hashCode() (based on bean
identifier)
- fail fast if multiple synthetic beans have the same bean identifier