### PR TITLE
Add a counter of log events per log level

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogBuildTimeConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.runtime.logging;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "log", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class LogBuildTimeConfig {
+
+    /**
+     * Whether or not logging metrics are published in case a metrics extension is present.
+     */
+    @ConfigItem(name = "metrics.enabled", defaultValue = "false")
+    public boolean metricsEnabled;
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandler.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandler.java
@@ -1,0 +1,47 @@
+package io.quarkus.runtime.logging;
+
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.Level;
+
+/**
+ * Measures the number of log messages based on logger configurations quarkus.log.level and quarkus.log.category.*.level
+ * <p>
+ * It should reflect the values of the handler that logs the most, since best practice is to align its level with the root
+ * level.
+ * <p>
+ * Non-standard levels are counted with the lower standard level.
+ */
+public class LogMetricsHandler extends Handler {
+
+    final NavigableMap<Integer, LongAdder> logCounters;
+
+    public LogMetricsHandler(NavigableMap<Integer, LongAdder> logCounters) {
+        this.logCounters = logCounters;
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        if (isLoggable(record)) {
+            Entry<Integer, LongAdder> counter = logCounters.floorEntry(record.getLevel().intValue());
+            if (counter != null) {
+                counter.getValue().increment();
+            } else {
+                // Default to TRACE for anything lower
+                logCounters.get(Level.TRACE.intValue()).increment();
+            }
+        }
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() throws SecurityException {
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandlerRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogMetricsHandlerRecorder.java
@@ -1,0 +1,53 @@
+package io.quarkus.runtime.logging;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
+import java.util.logging.Handler;
+
+import org.jboss.logmanager.Level;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.runtime.metrics.MetricsFactory;
+
+@Recorder
+public class LogMetricsHandlerRecorder {
+
+    static final String METRIC_NAME = "log.total";
+
+    static final String METRIC_DESCRIPTION = "Number of log events, per log level. Non-standard levels are counted with the lower standard level.";
+
+    static final List<Level> STANDARD_LEVELS = Arrays.asList(Level.FATAL, Level.ERROR, Level.WARN, Level.INFO, Level.DEBUG,
+            Level.TRACE);
+
+    static final NavigableMap<Integer, LongAdder> COUNTERS = new TreeMap<>();
+
+    public void initCounters() {
+        for (Level level : STANDARD_LEVELS) {
+            LongAdder counter = new LongAdder();
+            // Use integer value to match any non-standard equivalent level
+            COUNTERS.put(level.intValue(), counter);
+        }
+    }
+
+    public Consumer<MetricsFactory> registerMetrics() {
+        return new Consumer<MetricsFactory>() {
+            @Override
+            public void accept(MetricsFactory metricsFactory) {
+                for (Level level : STANDARD_LEVELS) {
+                    metricsFactory.builder(METRIC_NAME).description(METRIC_DESCRIPTION).tag("level", level.getName())
+                            .buildCounter(COUNTERS.get(level.intValue())::sum);
+                }
+            }
+        };
+    }
+
+    public RuntimeValue<Optional<Handler>> getLogHandler() {
+        return new RuntimeValue(Optional.of(new LogMetricsHandler(COUNTERS)));
+    }
+}

--- a/core/runtime/src/test/java/io/quarkus/runtime/logging/LogMetricsHandlerTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/logging/LogMetricsHandlerTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.runtime.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LogMetricsHandlerTest {
+
+    LogMetricsHandler handler;
+
+    NavigableMap<Integer, LongAdder> counters;
+
+    @BeforeEach
+    public void setUp() {
+        counters = new TreeMap<>();
+        counters.put(Level.TRACE.intValue(), new LongAdder());
+        counters.put(Level.DEBUG.intValue(), new LongAdder());
+        counters.put(Level.WARN.intValue(), new LongAdder());
+        handler = new LogMetricsHandler(counters);
+    }
+
+    @Test
+    public void equivalentLevelsShouldBeMerged() {
+        handler.publish(new LogRecord(Level.DEBUG, "test"));
+        handler.publish(new LogRecord(Level.FINE, "test"));
+
+        assertEquals(2, counters.get(Level.DEBUG.intValue()).sum());
+    }
+
+    @Test
+    public void shouldFilterRecords() {
+        handler.setLevel(Level.INFO);
+
+        handler.publish(new LogRecord(Level.DEBUG, "test"));
+
+        assertEquals(0, counters.get(Level.DEBUG.intValue()).sum());
+    }
+
+    @Test
+    public void nonStandardLevelShouldBeCountedWithLowerStandardLevel() {
+        handler.publish(new LogRecord(new CustomLevel("IMPORTANT", 950), "test"));
+
+        assertEquals(1, counters.get(Level.WARN.intValue()).sum());
+    }
+
+    @Test
+    public void anythingBelowTraceShouldBeCountedAsTrace() {
+        handler.publish(new LogRecord(Level.FINEST, "test"));
+
+        assertEquals(1, counters.get(Level.TRACE.intValue()).sum());
+    }
+
+    static class CustomLevel extends java.util.logging.Level {
+        CustomLevel(final String name, final int value) {
+            super(name, value);
+        }
+    }
+}

--- a/extensions/smallrye-metrics/deployment/src/test/java/io/quarkus/smallrye/metrics/test/MetricsFromExtensionTestCase.java
+++ b/extensions/smallrye-metrics/deployment/src/test/java/io/quarkus/smallrye/metrics/test/MetricsFromExtensionTestCase.java
@@ -78,9 +78,8 @@ public class MetricsFromExtensionTestCase {
     @Test
     public void testVendorRegistryType() {
         String[] metricNames = RestAssured.when().get("/get-counters").then().extract().as(String[].class);
-        assertThat(metricNames, Matchers.arrayContainingInAnyOrder(
-                "io.quarkus.smallrye.metrics.test.MetricResource.countMePlease",
-                "io.quarkus.smallrye.metrics.test.MetricResource.countMePlease2"));
+        assertThat(metricNames, Matchers.hasItemInArray("io.quarkus.smallrye.metrics.test.MetricResource.countMePlease"));
+        assertThat(metricNames, Matchers.hasItemInArray("io.quarkus.smallrye.metrics.test.MetricResource.countMePlease2"));
     }
 
     @Test

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -41,3 +41,5 @@ configproperties.number=ONE
 quarkus.swagger-ui.always-include=true
 
 quarkus.native.resources.includes = test-resources/**.txt
+
+quarkus.log.metrics.enabled=true

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MetricsTestCase.java
@@ -145,7 +145,8 @@ public class MetricsTestCase {
                 // the spaces at the end are there on purpose to make sure the metrics are named exactly this way
                 .body(containsString("vendor_memory_committedNonHeap_bytes "))
                 .body(containsString("vendor_memory_usedNonHeap_bytes "))
-                .body(containsString("vendor_memory_maxNonHeap_bytes "));
+                .body(containsString("vendor_memory_maxNonHeap_bytes "))
+                .body(containsString("vendor_log_total{level=\"INFO\"} "));
     }
 
     /**


### PR DESCRIPTION
Add a metric related to logging:
- Create a `log_total` counter in Quarkus core module (since logging is core)
- Add a tag/label to segregate by the standard jboss-logging levels
- Add a build-time activation config `quarkus.log.metrics.enabled` (false by default, as for other metrics)

`log_total{level="ERROR"} 5`   <- too many ERROR is the most basic form of alert
`log_total{level="INFO"} 15`   <- too many INFO may mean some logs are generated per message and scale with TPS
`log_total{level="DEBUG"} 30`  <- allows to detect that log level is likely wrongly configured

Non-standard log levels are counted in the bucket of the lower standard level.

This is inspired by the Prometheus metric https://github.com/prometheus/client_java/blob/master/simpleclient_log4j/src/main/java/io/prometheus/client/log4j/InstrumentedAppender.java