### PR TITLE
Auto-detect codestarts implemented languages

### DIFF
--- a/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/bundled-codestarts/example/commandmode-example/codestart.yml
@@ -3,8 +3,6 @@ name: commandmode-example
 ref: commandmode
 type: example
 fallback: true
-missing-languages:
-  - scala
 language:
   base:
     data:

--- a/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/codestart.yml
+++ b/devtools/platform-descriptor-json/src/main/resources/codestarts/qute-example/codestart.yml
@@ -2,8 +2,6 @@
 name: qute-example
 ref: qute
 type: example
-missing-languages:
-  - scala
 language:
   base:
     dependencies:

--- a/independent-projects/tools/codestarts/codestarts.adoc
+++ b/independent-projects/tools/codestarts/codestarts.adoc
@@ -129,9 +129,6 @@ codestart.yml:
 name: foo-example
 ref: foo
 type: example
-missing-languages:
-  - kotlin
-  - scala
 spec:
   base:
     data:
@@ -179,7 +176,7 @@ class ExampleResource {
 
 *NOTE* Just add `.tpl.qute` if you want it to be rendered with qute and use some data and simple logic
 
-*NOTE* Most of the time you won't need it for code, but you can use a `base` directory to add files to process for all languages.
+*NOTE* You can use a `base` directory to add files to process for all languages: readme, configs, ...
 
 
 2. Add some configuration (if needed)

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/Codestart.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/Codestart.java
@@ -1,16 +1,19 @@
 package io.quarkus.devtools.codestarts;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public final class Codestart {
     public static final String BASE_LANGUAGE = "base";
     private final String resourceDir;
     private final CodestartSpec spec;
+    private final Set<String> implementedLanguages;
 
-    public Codestart(final String resourceName, final CodestartSpec spec) {
+    public Codestart(final String resourceName, final CodestartSpec spec, Set<String> implementedLanguages) {
         this.resourceDir = resourceName;
         this.spec = spec;
+        this.implementedLanguages = implementedLanguages;
     }
 
     public String getResourceDir() {
@@ -25,12 +28,24 @@ public final class Codestart {
         return spec.getName();
     }
 
+    public String getRef() {
+        return spec.getRef();
+    }
+
+    public boolean isSelected(Set<String> selection) {
+        return selection.contains(getName()) || selection.contains(spec.getRef());
+    }
+
     public CodestartSpec.Type getType() {
         return spec.getType();
     }
 
+    public Set<String> getImplementedLanguages() {
+        return implementedLanguages;
+    }
+
     public boolean implementsLanguage(String languageName) {
-        return spec.getMissingLanguages().isEmpty() || !spec.getMissingLanguages().contains(languageName);
+        return implementedLanguages.isEmpty() || implementedLanguages.contains(languageName);
     }
 
     public Map<String, Object> getLocalData(String languageName) {

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartProcessor.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartProcessor.java
@@ -95,8 +95,8 @@ final class CodestartProcessor {
     }
 
     private List<Path> findSources(Path sourceDirectory) {
-        try {
-            return Files.walk(sourceDirectory)
+        try (final Stream<Path> pathStream = Files.walk(sourceDirectory)) {
+            return pathStream
                     .filter(path -> !path.equals(sourceDirectory))
                     .collect(Collectors.toList());
         } catch (IOException e) {

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartSpec.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartSpec.java
@@ -37,7 +37,6 @@ public final class CodestartSpec {
     private final String ref;
     private final Type type;
     private final boolean isFallback;
-    private final List<String> missingLanguages;
     private final Map<String, String> outputStrategy;
     private final Map<String, LanguageSpec> languagesSpec;
 
@@ -47,7 +46,6 @@ public final class CodestartSpec {
             @JsonProperty(value = "type") Type type,
             @JsonProperty("fallback") boolean isFallback,
             @JsonProperty("preselected") boolean isPreselected,
-            @JsonProperty(value = "missing-languages") List<String> missingLanguages,
             @JsonProperty("output-strategy") Map<String, String> outputStrategy,
             @JsonProperty("language") Map<String, LanguageSpec> languagesSpec) {
         this.name = requireNonNull(name, "name is required");
@@ -55,7 +53,6 @@ public final class CodestartSpec {
         this.type = type != null ? type : Type.EXAMPLE;
         this.isFallback = isFallback;
         this.isPreselected = isPreselected;
-        this.missingLanguages = missingLanguages != null ? missingLanguages : Collections.emptyList();
         this.outputStrategy = outputStrategy != null ? outputStrategy : Collections.emptyMap();
         this.languagesSpec = languagesSpec != null ? languagesSpec : Collections.emptyMap();
     }
@@ -78,10 +75,6 @@ public final class CodestartSpec {
 
     public boolean isPreselected() {
         return isPreselected;
-    }
-
-    public List<String> getMissingLanguages() {
-        return missingLanguages;
     }
 
     public boolean isExample() {

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/Codestarts.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/Codestarts.java
@@ -41,7 +41,7 @@ public class Codestarts {
 
         // include fallback example codestarts if none selected
         if (input.includeExamples()
-                && selectedCodestarts.stream().noneMatch(c -> c.getSpec().isExample() && !c.getSpec().isPreselected())) {
+                && extraCodestarts.stream().noneMatch(c -> c.getSpec().isExample() && !c.getSpec().isPreselected())) {
             final List<Codestart> fallbackExampleCodestarts = resolveFallbackExampleCodestarts(allCodestarts,
                     languageName);
             selectedCodestarts.addAll(fallbackExampleCodestarts);
@@ -83,7 +83,7 @@ public class Codestarts {
             String languageName) {
         return allCodestarts.stream()
                 .filter(c -> !c.getSpec().getType().isBase())
-                .filter(c -> c.getSpec().isPreselected() || selectedCodestartNames.contains(c.getSpec().getRef()))
+                .filter(c -> c.getSpec().isPreselected() || c.isSelected(selectedCodestartNames))
                 .filter(c -> !c.getSpec().isExample() || input.includeExamples())
                 .filter(c -> c.implementsLanguage(languageName))
                 .collect(Collectors.toList());
@@ -93,7 +93,7 @@ public class Codestarts {
             Set<String> selectedCodestartNames) {
         return allCodestarts.stream()
                 .filter(c -> c.getSpec().getType().isBase())
-                .filter(c -> c.getSpec().isFallback() || selectedCodestartNames.contains(c.getSpec().getRef()))
+                .filter(c -> c.getSpec().isFallback() || c.isSelected(selectedCodestartNames))
                 .collect(Collectors.toMap(c -> c.getSpec().getType(), c -> c, (a, b) -> {
                     // When there is multiple matches for one key, one should be selected and the other a fallback.
                     if (a.getSpec().isFallback() && b.getSpec().isFallback()) {

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/reader/CodestartFileReader.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/reader/CodestartFileReader.java
@@ -13,10 +13,11 @@ import java.util.Optional;
 public interface CodestartFileReader {
 
     CodestartFileReader DEFAULT = new DefaultCodestartFileReader();
-    CodestartFileReader QUTE = new QuteCodestartFileReader();
 
     List<CodestartFileReader> ALL = Collections.unmodifiableList(Arrays.asList(
-            DEFAULT, QUTE));
+            DEFAULT,
+            new QuteCodestartFileReader(),
+            new IgnoreCodestartFileReader()));
 
     boolean matches(String fileName);
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/reader/IgnoreCodestartFileReader.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/reader/IgnoreCodestartFileReader.java
@@ -1,0 +1,28 @@
+package io.quarkus.devtools.codestarts.reader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+final class IgnoreCodestartFileReader implements CodestartFileReader {
+
+    private static final Set<String> TO_IGNORE = Collections.singleton(".gitkeep");
+
+    @Override
+    public boolean matches(String fileName) {
+        return TO_IGNORE.contains(fileName);
+    }
+
+    @Override
+    public String cleanFileName(String fileName) {
+        return fileName;
+    }
+
+    public Optional<String> read(Path sourceDirectory, Path relativeSourcePath, String languageName, Map<String, Object> data)
+            throws IOException {
+        return Optional.empty();
+    }
+}

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/strategy/SmartPomMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/strategy/SmartPomMergeCodestartFileStrategyHandler.java
@@ -2,6 +2,8 @@ package io.quarkus.devtools.codestarts.strategy;
 
 import io.fabric8.maven.Maven;
 import io.fabric8.maven.merge.SmartModelMerger;
+import io.quarkus.devtools.codestarts.CodestartDefinitionException;
+import io.quarkus.devtools.codestarts.NestedMaps;
 import io.quarkus.devtools.codestarts.reader.CodestartFile;
 import java.io.IOException;
 import java.io.StringReader;
@@ -9,6 +11,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.maven.model.Model;
 
 final class SmartPomMergeCodestartFileStrategyHandler implements CodestartFileStrategyHandler {
@@ -23,6 +26,11 @@ final class SmartPomMergeCodestartFileStrategyHandler implements CodestartFileSt
             throws IOException {
         checkNotEmptyCodestartFiles(codestartFiles);
         checkTargetDoesNotExist(targetDirectory.resolve(relativePath));
+
+        NestedMaps.<String> getValue(data, "codestart-project.buildtool.name")
+                .filter(b -> Objects.equals(b, "maven"))
+                .orElseThrow(() -> new CodestartDefinitionException(
+                        "something is wrong, smart-pom-merge file strategy must only be used on maven projects"));
 
         final SmartModelMerger merger = new SmartModelMerger();
         final Model targetModel = Maven.readModel(new StringReader(codestartFiles.get(0).getContent()));

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/CodestartProjectRunTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/CodestartProjectRunTest.java
@@ -68,6 +68,7 @@ class CodestartProjectRunTest extends PlatformAwareTestBase {
             name += "-" + String.join("-", codestarts);
         }
         final CodestartInput input = inputBuilder(getPlatformDescriptor())
+                .includeExamples()
                 .addData(getTestInputData(Collections.singletonMap("artifact-id", name)))
                 .addCodestarts(codestarts)
                 .putData("buildtool.name", buildtool)

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/CodestartsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/CodestartsTest.java
@@ -30,6 +30,31 @@ class CodestartsTest extends PlatformAwareTestBase {
         final Collection<Codestart> codestarts = CodestartLoader
                 .loadBundledCodestarts(inputBuilder(getPlatformDescriptor()).build());
         assertThat(codestarts).hasSize(10);
+        assertThat(codestarts)
+                .filteredOn(c -> c.getType().isBase())
+                .extracting(Codestart::getImplementedLanguages)
+                .allSatisfy(s -> assertThat(s.isEmpty() || s.size() == 3).isTrue());
+
+        assertThat(codestarts).filteredOn("ref", "commandmode")
+                .extracting(Codestart::getImplementedLanguages)
+                .hasSize(1)
+                .allSatisfy(s -> assertThat(s).containsExactlyInAnyOrder("java", "kotlin"));
+    }
+
+    @Test
+    void loadExtensionCodestartsTest() throws IOException {
+        final Collection<Codestart> codestarts = CodestartLoader
+                .loadCodestartsFromExtensions(inputBuilder(getPlatformDescriptor()).build());
+
+        assertThat(codestarts).filteredOn("ref", "qute")
+                .extracting(Codestart::getImplementedLanguages)
+                .hasSize(1)
+                .allSatisfy(s -> assertThat(s).containsExactlyInAnyOrder("java", "kotlin"));
+
+        assertThat(codestarts).filteredOn("ref", "resteasy")
+                .extracting(Codestart::getImplementedLanguages)
+                .hasSize(1)
+                .allSatisfy(s -> assertThat(s).containsExactlyInAnyOrder("java", "kotlin", "scala"));
     }
 
     @Test


### PR DESCRIPTION
it also:
- fixes the test that wasn't activating the examples to run them..
- fail if a pom.xml is present in a codestart for a non maven project