### PR TITLE
Use smallrye-common-bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,8 +61,7 @@ updates:
       - dependency-name: io.smallrye:smallrye-opentracing
       - dependency-name: io.smallrye:smallrye-fault-tolerance
       - dependency-name: io.smallrye:smallrye-context-propagation
-      - dependency-name: io.smallrye.common:smallrye-common-annotation
-      - dependency-name: io.smallrye.common:smallrye-common-io
+      - dependency-name: io.smallrye.common:smallrye-common-bom
       - dependency-name: io.smallrye.config:smallrye-config
       - dependency-name: io.smallrye.reactive:mutiny
       - dependency-name: io.smallrye.reactive:smallrye-reactive-messaging

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -32,7 +32,7 @@
         <microprofile-opentracing-api.version>1.3.3</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
-        <smallrye-common.version>1.2.0</smallrye-common.version>
+        <smallrye-common.version>1.3.0</smallrye-common.version>
         <smallrye-config.version>1.8.5</smallrye-config.version>
         <smallrye-health.version>2.2.3</smallrye-health.version>
         <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
@@ -282,6 +282,15 @@
                 <version>${awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Smallrye Common dependencies, imported as a BOM -->
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-bom</artifactId>
+                <version>${smallrye-common.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
             <!-- Quarkus core -->
@@ -2404,11 +2413,6 @@
                 <artifactId>smallrye-config-common</artifactId>
                 <!-- This is intentionally hard-coded -->
                 <version>1.5.0</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-annotation</artifactId>
-                <version>${smallrye-common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -48,7 +48,7 @@
         <graal-sdk.version>20.1.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
-        <smallrye-common.version>1.2.0</smallrye-common.version>
+        <smallrye-common.version>1.3.0</smallrye-common.version>
         <gradle-tooling.version>6.5</gradle-tooling.version>
     </properties>
     <modules>
@@ -366,10 +366,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Smallrye Common dependencies, imported as a BOM -->
             <dependency>
                 <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-io</artifactId>
+                <artifactId>smallrye-common-bom</artifactId>
                 <version>${smallrye-common.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This ensures that all smallrye-common subprojects used in Quarkus are in the same version