### PR TITLE
Move cache lock timeout logic to CacheResultInterceptor

### DIFF
--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/LockTimeoutTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/LockTimeoutTest.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -19,15 +18,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.cache.CacheResult;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class CaffeineCacheLockTimeoutTest {
+public class LockTimeoutTest {
 
     private static final Object TIMEOUT_KEY = new Object();
     private static final Object NO_TIMEOUT_KEY = new Object();
 
     @RegisterExtension
-    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-            .addAsResource(new StringAsset("quarkus.cache.type=caffeine"), "application.properties")
-            .addClass(CachedService.class));
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(CachedService.class));
 
     @Inject
     CachedService cachedService;

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheResultInterceptor.java
@@ -1,5 +1,12 @@
 package io.quarkus.cache.runtime;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
 import javax.annotation.Priority;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -19,11 +26,74 @@ public class CacheResultInterceptor extends CacheInterceptor {
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         CacheResultInterceptorBinding binding = getInterceptorBinding(context, CacheResultInterceptorBinding.class);
+
         CaffeineCache cache = cacheRepository.getCache(binding.cacheName());
         Object key = getCacheKey(cache, binding.cacheKeyParameterPositions(), context.getParameters());
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debugf("Loading entry with key [%s] from cache [%s]", key, cache.getName());
         }
-        return cache.get(key, () -> context.proceed(), binding.lockTimeout());
+
+        if (binding.lockTimeout() <= 0) {
+            CompletableFuture<Object> cacheValue = cache.get(key,
+                    new BiFunction<Object, Executor, CompletableFuture<Object>>() {
+                        @Override
+                        public CompletableFuture<Object> apply(Object k, Executor executor) {
+                            return getValueLoader(context, executor);
+                        }
+                    });
+            return cacheValue.get();
+        } else {
+
+            // The lock timeout logic starts here.
+
+            /*
+             * If the current key is not already associated with a value in the Caffeine cache, there's no way to know if the
+             * current thread or another one started the missing value computation. The following variable will be used to
+             * determine whether or not a timeout should be triggered during the computation depending on which thread started
+             * it.
+             */
+            boolean[] isCurrentThreadComputation = { false };
+
+            CompletableFuture<Object> cacheValue = cache.get(key,
+                    new BiFunction<Object, Executor, CompletableFuture<Object>>() {
+                        @Override
+                        public CompletableFuture<Object> apply(Object k, Executor executor) {
+                            isCurrentThreadComputation[0] = true;
+                            return getValueLoader(context, executor);
+                        }
+                    });
+
+            if (isCurrentThreadComputation[0]) {
+                // The value is missing and its computation was started from the current thread.
+                // We'll wait for the result no matter how long it takes.
+                return cacheValue.get();
+            } else {
+                // The value is either already present in the cache or missing and its computation was started from another thread.
+                // We want to retrieve it from the cache within the lock timeout delay.
+                try {
+                    return cacheValue.get(binding.lockTimeout(), TimeUnit.MILLISECONDS);
+                } catch (TimeoutException e) {
+                    // Timeout triggered! We don't want to wait any longer for the value computation and we'll simply invoke the
+                    // cached method and return its result without caching it.
+                    // TODO: Add statistics here to monitor the timeout.
+                    return context.proceed();
+                }
+            }
+        }
+    }
+
+    private CompletableFuture<Object> getValueLoader(InvocationContext context, Executor executor) {
+        return CompletableFuture.supplyAsync(new Supplier<Object>() {
+            @Override
+            public Object get() {
+                try {
+                    return context.proceed();
+                } catch (RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }, executor);
     }
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCache.java
@@ -1,20 +1,15 @@
 package io.quarkus.cache.runtime.caffeine;
 
-import static io.quarkus.cache.runtime.NullValueConverter.fromCacheValue;
-import static io.quarkus.cache.runtime.NullValueConverter.toCacheValue;
-
 import java.time.Duration;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
+import java.util.function.BiFunction;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.quarkus.cache.runtime.DefaultCacheKey;
+import io.quarkus.cache.runtime.NullValueConverter;
 
 public class CaffeineCache {
 
@@ -59,44 +54,17 @@ public class CaffeineCache {
         cache = builder.buildAsync();
     }
 
-    public Object get(Object key, Callable<Object> valueLoader, long lockTimeout) throws Exception {
+    public CompletableFuture<Object> get(Object key, BiFunction<Object, Executor, CompletableFuture<Object>> valueLoader) {
         if (key == null) {
             throw new NullPointerException(NULL_KEYS_NOT_SUPPORTED_MSG);
         }
-        if (lockTimeout <= 0) {
-            return fromCacheValue(cache.synchronous().get(key, k -> new MappingSupplier(valueLoader).get()));
-        }
-
-        // The lock timeout logic starts here.
-
-        /*
-         * If the current key is not already associated with a value in the Caffeine cache, there's no way to know if the
-         * current thread or another one started the missing value computation. The following variable will be used to
-         * determine whether or not a timeout should be triggered during the computation depending on which thread started it.
-         */
-        boolean[] isCurrentThreadComputation = { false };
-
-        CompletableFuture<Object> future = cache.get(key, (k, executor) -> {
-            isCurrentThreadComputation[0] = true;
-            return CompletableFuture.supplyAsync(new MappingSupplier(valueLoader), executor);
-        });
-
-        if (isCurrentThreadComputation[0]) {
-            // The value is missing and its computation was started from the current thread.
-            // We'll wait for the result no matter how long it takes.
-            return fromCacheValue(future.get());
-        } else {
-            // The value is either already present in the cache or missing and its computation was started from another thread.
-            // We want to retrieve it from the cache within the lock timeout delay.
-            try {
-                return fromCacheValue(future.get(lockTimeout, TimeUnit.MILLISECONDS));
-            } catch (TimeoutException e) {
-                // Timeout triggered! We don't want to wait any longer for the value computation and we'll simply invoke the
-                // cached method and return its result without caching it.
-                // TODO: Add statistics here to monitor the timeout.
-                return valueLoader.call();
-            }
-        }
+        return cache.get(key,
+                new BiFunction<Object, Executor, CompletableFuture<Object>>() {
+                    @Override
+                    public CompletableFuture<Object> apply(Object k, Executor executor) {
+                        return valueLoader.apply(k, executor).thenApply(NullValueConverter::toCacheValue);
+                    }
+                }).thenApply(NullValueConverter::fromCacheValue);
     }
 
     public void invalidate(Object key) {
@@ -146,25 +114,5 @@ public class CaffeineCache {
             defaultKey = new DefaultCacheKey(getName());
         }
         return defaultKey;
-    }
-
-    private static class MappingSupplier implements Supplier<Object> {
-
-        private final Callable<?> valueLoader;
-
-        public MappingSupplier(Callable<?> valueLoader) {
-            this.valueLoader = valueLoader;
-        }
-
-        @Override
-        public Object get() {
-            try {
-                return toCacheValue(valueLoader.call());
-            } catch (RuntimeException e) {
-                throw e;
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR lays some groundwork for #8631.

With the programmatic caching API in mind, I moved the cache lock timeout logic from the `CaffeineCache` implementation to `CacheResultInterceptor` since this is a feature that only makes sense while using the annotations caching API.

Please note that many things should change with #8631 if it ends up being merged, including the return types of all `CaffeineCache` methods which will all be async and rely on Mutiny. The purpose of this PR is only to move some misplaced code without changing anything to the cache extension behavior and performances.

@ben-manes: Could you please confirm this PR doesn't do any harm in terms of performances?