### PR TITLE
Vertx - fix default value for VertxConfiguration#maxWorkerExecuteTime

### DIFF
--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -8,11 +8,9 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOpt
 import static io.vertx.core.file.impl.FileResolver.CACHE_DIR_BASE_PROP_NAME;
 
 import java.io.File;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -235,17 +233,11 @@ public class VertxCoreRecorder {
             options.setEventLoopPoolSize(calculateDefaultIOThreads());
         }
 
-        Optional<Duration> maxEventLoopExecuteTime = conf.maxEventLoopExecuteTime;
-        if (maxEventLoopExecuteTime.isPresent()) {
-            options.setMaxEventLoopExecuteTime(maxEventLoopExecuteTime.get().toMillis());
-            options.setMaxEventLoopExecuteTimeUnit(TimeUnit.MILLISECONDS);
-        }
+        options.setMaxEventLoopExecuteTime(conf.maxEventLoopExecuteTime.toMillis());
+        options.setMaxEventLoopExecuteTimeUnit(TimeUnit.MILLISECONDS);
 
-        Optional<Duration> maxWorkerExecuteTime = conf.maxWorkerExecuteTime;
-        if (maxWorkerExecuteTime.isPresent()) {
-            options.setMaxWorkerExecuteTime(maxWorkerExecuteTime.get().toMillis());
-            options.setMaxWorkerExecuteTimeUnit(TimeUnit.MILLISECONDS);
-        }
+        options.setMaxWorkerExecuteTime(conf.maxWorkerExecuteTime.toMillis());
+        options.setMaxWorkerExecuteTimeUnit(TimeUnit.MILLISECONDS);
 
         options.setWarningExceptionTime(conf.warningExceptionTime.toNanos());
 

--- a/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx-core/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.core.runtime.config;
 
 import java.time.Duration;
-import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -31,10 +30,9 @@ public class VertxConfiguration {
 
     /**
      * The maximum amount of time the event loop can be blocked.
-     * Default is 2s.
      */
-    @ConfigItem
-    public Optional<Duration> maxEventLoopExecuteTime;
+    @ConfigItem(defaultValue = "2")
+    public Duration maxEventLoopExecuteTime;
 
     /**
      * The amount of time before a warning is displayed if the event loop is blocked.
@@ -50,10 +48,9 @@ public class VertxConfiguration {
 
     /**
      * The maximum amount of time the worker thread can be blocked.
-     * Default is 10s.
      */
-    @ConfigItem
-    public Optional<Duration> maxWorkerExecuteTime;
+    @ConfigItem(defaultValue = "60")
+    public Duration maxWorkerExecuteTime;
 
     /**
      * The size of the internal thread pool (used for the file system).

--- a/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx-core/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -80,10 +80,10 @@ public class VertxCoreProducerTest {
         vc.caching = true;
         vc.classpathResolving = true;
         vc.eventLoopsPoolSize = OptionalInt.empty();
-        vc.maxEventLoopExecuteTime = Optional.of(Duration.ofSeconds(2));
+        vc.maxEventLoopExecuteTime = Duration.ofSeconds(2);
         vc.warningExceptionTime = Duration.ofSeconds(2);
         vc.workerPoolSize = 20;
-        vc.maxWorkerExecuteTime = Optional.of(Duration.ofSeconds(1));
+        vc.maxWorkerExecuteTime = Duration.ofSeconds(1);
         vc.internalBlockingPoolSize = 20;
         vc.useAsyncDNS = false;
         vc.preferNativeTransport = false;


### PR DESCRIPTION
- see also
https://vertx.io/docs/apidocs/io/vertx/core/VertxOptions.html#DEFAULT_MAX_WORKER_EXECUTE_TIME
- also add some info how to pass the duration value