### PR TITLE
Invokes clean before compile

### DIFF
--- a/devtools/maven/pom.xml
+++ b/devtools/maven/pom.xml
@@ -142,13 +142,7 @@
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.3.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>2.3.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This ensures that the generated sources are always cleaned up if the compile plugin needs to be invoked

Fixes #11253