### PR TITLE
Avoid generated-sources clash with MapStruct in codegen

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/CodeGenMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CodeGenMojo.java
@@ -102,9 +102,8 @@ public class CodeGenMojo extends AbstractMojo {
                     .setTargetDirectory(buildDir.toPath())
                     .build().bootstrap();
 
-            Path generatedSourcesDir = test
-                    ? buildDir.toPath().resolve("generated-test-sources")
-                    : buildDir.toPath().resolve("generated-sources");
+            Path generatedSourcesDir = buildDir.toPath().resolve(test ? "generated-test-sources" : "generated-sources")
+                    .resolve("quarkus");
 
             sourceRegistrar.accept(generatedSourcesDir);
 


### PR DESCRIPTION
Fixes #11253 

This avoids recreation attempts of annotation processors like MapStruct that are writing to `${project.build.directory}/generated-sources/annotations` by default.
See also: http://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#generatedSourcesDirectory

The additon of `${project.build.directory}/generated-sources` by `CodeGenMojo` _seems_ to make MapStruct (or any other processor) see its own output a second time. This change is preventing this by introducing a disjunct subdirectory.