### PR TITLE
Escape $ in maven log for native-image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -351,7 +351,7 @@ public class NativeImageBuildStep {
             String executableName = outputTargetBuildItem.getBaseName() + packageConfig.runnerSuffix;
             command.add(executableName);
 
-            log.info(String.join(" ", command));
+            log.info(String.join(" ", command).replace("$", "\\$"));
             CountDownLatch errorReportLatch = new CountDownLatch(1);
             final ProcessBuilder processBuilder = new ProcessBuilder(command).directory(outputDir.toFile());
             final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled);


### PR DESCRIPTION
This allows copy pasting the docker/podman command from the maven logs and running it directly.

## Before this patch
```
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] podman run -v /tmp/元気かい/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --env LANG=C --user 1000:1000 --userns=keep-id --rm quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Alpha2-java11 -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=1 -J-Duser.language=en -J-Dfile.encoding=UTF-8 --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime -H:+JNI -jar code-with-quarkus-1.0.0-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace code-with-quarkus-1.0.0-SNAPSHOT-runner
```
copy pasting the above command results in:
```
Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated.
com.oracle.svm.core.util.UserError$UserException: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated.
        at com.oracle.svm.core.util.UserError.abort(UserError.java:68)
        at com.oracle.svm.core.genscavenge.HeapPolicy.instantiatePolicy(HeapPolicy.java:88)
        at com.oracle.svm.core.genscavenge.CollectionPolicy.getInitialPolicy(CollectionPolicy.java:59)
        at com.oracle.svm.core.genscavenge.GCImpl.<init>(GCImpl.java:150)
        at com.oracle.svm.core.genscavenge.HeapImpl.<init>(HeapImpl.java:128)
        at com.oracle.svm.core.genscavenge.graal.HeapFeature.afterRegistration(HeapFeature.java:68)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$setupNativeImage$11(NativeImageGenerator.java:825)
        at com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:70)
        at com.oracle.svm.hosted.NativeImageGenerator.setupNativeImage(NativeImageGenerator.java:825)
        at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:536)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$0(NativeImageGenerator.java:451)
        at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```
The argument `-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime` contains a `$` so the shell tries to substitute `$BySpaceAndTime` and to work around it you need to escape the `$` like this:
`-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime`

## After this patch
```
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] podman run -v /tmp/元気かい/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --env LANG=C --user 1000:1000 --userns=keep-id --rm quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.1.Alpha2-java11 -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=1 -J-Duser.language=en -J-Dfile.encoding=UTF-8 --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -jar code-with-quarkus-1.0.0-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace code-with-quarkus-1.0.0-SNAPSHOT-runner
```
copy pasting the command works.