### PR TITLE
Use SourceSets for Test mode with Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -237,11 +237,13 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
                 continue;
             }
             final DependencyImpl dep = initDependency(a);
-            if (LaunchMode.DEVELOPMENT.equals(mode) &&
+            // Dev mode uses needs sources for hot reload,
+            // Tests needs sources when running from IDE
+            if (mode.isDevOrTest() &&
                     a.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier) {
                 Project projectDep = project.getRootProject()
                         .findProject(((ProjectComponentIdentifier) a.getId().getComponentIdentifier()).getProjectPath());
-                addDevModePaths(dep, a, projectDep);
+                addSourceSetsPath(dep, a, projectDep);
             } else {
                 dep.addPath(a.getFile());
             }
@@ -249,7 +251,7 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         }
     }
 
-    private void addDevModePaths(final DependencyImpl dep, ResolvedArtifact a, Project project) {
+    private void addSourceSetsPath(final DependencyImpl dep, ResolvedArtifact a, Project project) {
         final JavaPluginConvention javaConvention = project.getConvention().findPlugin(JavaPluginConvention.class);
         if (javaConvention != null) {
             SourceSet mainSourceSet = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);


### PR DESCRIPTION
It looks like that currently it is not possible to run QuarkusTests without Gradle runner in IntelliJ in multimodule project, since IntelliJ outputs classes to `out/` folder, but Quarkus expects everything in `build/` folder. Also IntelliJ does not output jars, but QuarkusTest expects jars. 

To workaround multimodule issue this change is needed. Additionally one has to use Idea plugin to set IntelliJ output folder like:
```
    idea {
        module {
            outputDir file('build/classes/java/main')
            testOutputDir file('build/classes/java/test')
        }
    }
```
IntelliJ will then output files to `build/` folder same as Gradle (but then you cannot use multiple languages in same module).

With that I will also be able to workaround issue #11318. I will still have to remove test-fixtures from our big fat project, but I can move it into a separate module and specify it as `testImplementation(project(":my-test-fixtures-module"))` .

Proper solution would be to auto discover IntelliJ output folders, but I am not sure if this is possible with Gradle without some custom workspace discovery logic.

What do you think?