### PR TITLE
Properly filter out transitive optional deployment dependencies

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExecutableOutputOutcomeTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExecutableOutputOutcomeTestBase.java
@@ -22,6 +22,7 @@ import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.update.CreatorOutcomeTestBase;
 
@@ -36,11 +37,15 @@ public abstract class ExecutableOutputOutcomeTestBase extends CreatorOutcomeTest
         expectedLib.add(entry.getGroupId() + '.' + entry.getArtifactId() + '-' + entry.getVersion() + '.' + entry.getType());
     }
 
+    protected void assertAppModel(AppModel appModel) throws Exception {
+    }
+
     @Override
     protected void testCreator(QuarkusBootstrap creator) throws Exception {
         System.setProperty("quarkus.package.type", "legacy");
         try {
             CuratedApplication curated = creator.bootstrap();
+            assertAppModel(curated.getAppModel());
             AugmentAction action = curated.createAugmentor();
             AugmentResult outcome = action.createProductionApplication();
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppDependency;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+
+public class OptionalDepsTest extends ExecutableOutputOutcomeTestBase {
+
+    @Override
+    protected TsArtifact modelApp() {
+
+        final TsArtifact extADep = TsArtifact.jar("ext-a-dep");
+        addToExpectedLib(extADep);
+
+        final TsArtifact extAOptionalDep = TsArtifact.jar("ext-a-optional-dep");
+        final TsArtifact extAOptionalDeploymentDep = TsArtifact.jar("ext-a-optional-deployment-dep");
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        addToExpectedLib(extA.getRuntime());
+        extA.getRuntime()
+                .addDependency(extADep)
+                .addDependency(new TsDependency(extAOptionalDep, true));
+        extA.getDeployment()
+                .addDependency(new TsDependency(extAOptionalDeploymentDep, true));
+
+        final TsArtifact extBOptionalDep = TsArtifact.jar("ext-b-optional-dep");
+        final TsArtifact extBDeploymentDep = TsArtifact.jar("ext-b-deployment-dep");
+        install(extBDeploymentDep);
+        final TsArtifact extBOptionalDeploymentDep = TsArtifact.jar("ext-b-optional-deployment-dep");
+        install(extBOptionalDeploymentDep);
+
+        final TsQuarkusExt extB = new TsQuarkusExt("ext-b");
+        extB.getRuntime().addDependency(new TsDependency(extBOptionalDep, true));
+        addToExpectedLib(extB.getRuntime());
+        extB.getDeployment().addDependency(new TsDependency(extBOptionalDeploymentDep, true));
+        extB.getDeployment().addDependency(new TsDependency(extBDeploymentDep, false));
+        install(extB);
+
+        final TsArtifact appOptionalDep = TsArtifact.jar("app-optional-dep")
+                .addDependency(extB.getRuntime());
+        addToExpectedLib(appOptionalDep);
+
+        final TsQuarkusExt extC = new TsQuarkusExt("ext-c");
+        install(extC);
+
+        final TsQuarkusExt extD = new TsQuarkusExt("ext-d");
+        extD.getRuntime().addDependency(new TsDependency(extC.getRuntime(), true));
+        extD.getDeployment().addDependency(new TsDependency(extC.getDeployment(), true));
+        install(extD);
+        addToExpectedLib(extD.getRuntime());
+
+        return TsArtifact.jar("app")
+                .addDependency(extA, true)
+                .addDependency(new TsDependency(appOptionalDep, true))
+                .addDependency(extD.getRuntime());
+    }
+
+    @Override
+    protected void assertAppModel(AppModel appModel) throws Exception {
+        final Set<AppDependency> expected = new HashSet<>();
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile", true));
+        expected.add(
+                new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment-dep", "1"), "compile", true));
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "compile", true));
+        expected.add(
+                new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-d-deployment", "1"), "compile", false));
+        assertEquals(expected, new HashSet<>(appModel.getDeploymentDependencies()));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.bootstrap.model.AppDependency;
+import io.quarkus.bootstrap.model.AppModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+
+public class ProvidedExtensionDepsTest extends ExecutableOutputOutcomeTestBase {
+
+    @Override
+    protected TsArtifact modelApp() {
+
+        final TsArtifact extADep = TsArtifact.jar("ext-a-dep");
+        addToExpectedLib(extADep);
+
+        final TsArtifact extAProvidedDep = TsArtifact.jar("ext-a-provided-dep");
+
+        final TsArtifact extADeploymentDep = TsArtifact.jar("ext-a-deployment-dep");
+        final TsArtifact extAOptionalDeploymentDep = TsArtifact.jar("ext-a-provided-deployment-dep");
+
+        final TsQuarkusExt extA = new TsQuarkusExt("ext-a");
+        addToExpectedLib(extA.getRuntime());
+        extA.getRuntime()
+                .addDependency(new TsDependency(extADep))
+                .addDependency(new TsDependency(extAProvidedDep, "provided"));
+        extA.getDeployment()
+                .addDependency(new TsDependency(extADeploymentDep))
+                .addDependency(new TsDependency(extAOptionalDeploymentDep, "provided"));
+
+        return TsArtifact.jar("app")
+                .addDependency(extA);
+    }
+
+    @Override
+    protected void assertAppModel(AppModel appModel) throws Exception {
+        final Set<AppDependency> expected = new HashSet<>();
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile"));
+        expected.add(new AppDependency(new AppArtifact("io.quarkus.bootstrap.test", "ext-a-deployment-dep", "1"), "compile"));
+        assertEquals(expected, new HashSet<>(appModel.getDeploymentDependencies()));
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -418,6 +418,9 @@ public class DevMojo extends AbstractMojo {
 
     private void triggerPrepare() throws MojoExecutionException {
         Plugin quarkusPlugin = project.getPlugin(QUARKUS_PLUGIN_GROUPID + ":" + QUARKUS_PLUGIN_ARTIFACTID);
+        if (quarkusPlugin == null) {
+            return;
+        }
         executeMojo(
                 quarkusPlugin,
                 goal(QUARKUS_PREPARE_GOAL),

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
@@ -60,17 +60,21 @@ public abstract class CollectDependenciesBase extends ResolverSetupCleanup {
     }
 
     protected TsArtifact install(TsArtifact dep, String collectedInScope) {
-        return install(dep, null, collectedInScope);
+        return install(dep, null, collectedInScope, false);
+    }
+
+    protected TsArtifact install(TsArtifact dep, String collectedInScope, boolean optional) {
+        return install(dep, null, collectedInScope, optional);
     }
 
     protected TsArtifact install(TsArtifact dep, Path p, boolean collected) {
-        return install(dep, p, collected ? "compile" : null);
+        return install(dep, p, collected ? "compile" : null, false);
     }
 
-    protected TsArtifact install(TsArtifact dep, Path p, String collectedInScope) {
+    protected TsArtifact install(TsArtifact dep, Path p, String collectedInScope, boolean optional) {
         install(dep, p);
         if (collectedInScope != null) {
-            addCollectedDep(dep, collectedInScope, false);
+            addCollectedDep(dep, collectedInScope, optional);
         }
         return dep;
     }

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
@@ -113,11 +113,15 @@ public class TsArtifact {
     }
 
     public TsArtifact addDependency(TsQuarkusExt dep) {
+        return addDependency(dep, false);
+    }
+
+    public TsArtifact addDependency(TsQuarkusExt dep, boolean optional) {
         if (extDeps.isEmpty()) {
             extDeps = new ArrayList<>(1);
         }
         extDeps.add(dep);
-        return addDependency(new TsDependency(dep.getRuntime()));
+        return addDependency(new TsDependency(dep.getRuntime(), optional));
     }
 
     public TsArtifact addDependency(TsDependency dep) {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/OnlyDirectOptionalDepsAreCollectedTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/OnlyDirectOptionalDepsAreCollectedTestCase.java
@@ -15,10 +15,14 @@ public class OnlyDirectOptionalDepsAreCollectedTestCase extends CollectDependenc
         installAsDep(new TsDependency(new TsArtifact("required-dep-a"), "compile"), true);
         installAsDep(new TsDependency(new TsArtifact("required-dep-b"), "runtime"), true);
 
+        final TsArtifact nonOptionalCommon = new TsArtifact("non-optional-common");
+        install(nonOptionalCommon, "compile", true);
+
         installAsDep(
                 new TsDependency(
                         new TsArtifact("optional-dep")
                                 .addDependency(new TsDependency(new TsArtifact("common", "1"), true))
+                                .addDependency(new TsDependency(nonOptionalCommon, false))
                                 .addDependency(new TsDependency(new TsArtifact("other", "1"), true)),
                         true),
                 true);

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -221,9 +221,10 @@ public class BootstrapAppModelResolver implements AppModelResolver {
         final List<RemoteRepository> repos = mvn.aggregateRepositories(managedRepos,
                 mvn.newResolutionRepositories(appArtifactDescr.getRepositories()));
 
-        final DeploymentInjectingDependencyVisitor deploymentInjector = new DeploymentInjectingDependencyVisitor(mvn,
-                managedDeps, repos, appBuilder);
+        final DeploymentInjectingDependencyVisitor deploymentInjector;
         try {
+            deploymentInjector = new DeploymentInjectingDependencyVisitor(mvn,
+                    managedDeps, repos, appBuilder);
             deploymentInjector.injectDeploymentDependencies(resolvedDeps);
         } catch (BootstrapDependencyProcessingException e) {
             throw new AppModelResolverException(

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
@@ -136,10 +136,7 @@ public class BuildDependencyGraphVisitor {
         if (deploymentNode != null) {
             if (runtimeNode == null && !appDeps.contains(new AppArtifactKey(artifact.getGroupId(),
                     artifact.getArtifactId(), artifact.getClassifier(), artifact.getExtension()))) {
-                //we never want optional deps on the deployment CP
-                if (!node.getDependency().isOptional()) {
-                    deploymentDepNodes.add(node);
-                }
+                deploymentDepNodes.add(node);
             } else if (runtimeNode == node) {
                 runtimeNode = null;
                 runtimeArtifact = null;

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentDependencySelector.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentDependencySelector.java
@@ -1,0 +1,28 @@
+package io.quarkus.bootstrap.resolver.maven;
+
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+
+class DeploymentDependencySelector implements DependencySelector {
+
+    private final DependencySelector delegate;
+
+    public DeploymentDependencySelector(DependencySelector delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean selectDependency(Dependency dependency) {
+        if (dependency.isOptional()) {
+            return false;
+        }
+        return delegate.selectDependency(dependency);
+    }
+
+    @Override
+    public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+        final DependencySelector newDelegate = delegate.deriveChildSelector(context);
+        return newDelegate == null ? null : new DeploymentDependencySelector(newDelegate);
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -126,6 +126,10 @@ public class MavenArtifactResolver {
         this.remoteRepoManager = mvnSettings.getRemoteRepositoryManager();
     }
 
+    public RemoteRepositoryManager getRemoteRepositoryManager() {
+        return remoteRepoManager;
+    }
+
     public MavenLocalRepositoryManager getLocalRepositoryManager() {
         return localRepoManager;
     }


### PR DESCRIPTION
Take into account whether the extension dependency is on an optional dependency branch when resolving the deployment dependencies

Fixes #11270