### PR TITLE
Make quarkus-bootstrap-maven-plugin:build-tree work for not installed local projects

### DIFF
--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/AbstractTreeMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/AbstractTreeMojo.java
@@ -2,65 +2,38 @@ package io.quarkus.maven;
 
 import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
-import java.util.List;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.repository.RemoteRepository;
 
 public class AbstractTreeMojo extends AbstractMojo {
-    /**
-     * The entry point to Aether, i.e. the component doing all the work.
-     *
-     * @component
-     */
-    @Component
-    protected RepositorySystem repoSystem;
-
-    /**
-     * The current repository/network configuration of Maven.
-     *
-     * @parameter default-value="${repositorySystemSession}"
-     * @readonly
-     */
-    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
-    protected RepositorySystemSession repoSession;
-
-    /**
-     * The project's remote repositories to use for the resolution of artifacts and their dependencies.
-     *
-     * @parameter default-value="${project.remoteProjectRepositories}"
-     * @readonly
-     */
-    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
-    protected List<RemoteRepository> repos;
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     protected MavenProject project;
+
+    protected MavenArtifactResolver resolver;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final AppArtifact appArtifact = new AppArtifact(project.getGroupId(), project.getArtifactId(), project.getVersion());
         final BootstrapAppModelResolver modelResolver;
         try {
-            modelResolver = new BootstrapAppModelResolver(
-                    MavenArtifactResolver.builder()
-                            .setRepositorySystem(repoSystem)
-                            .setRepositorySystemSession(repoSession)
-                            .setRemoteRepositories(repos)
-                            .build());
+            modelResolver = new BootstrapAppModelResolver(resolver());
             setupResolver(modelResolver);
             modelResolver.setBuildTreeLogger(s -> getLog().info(s));
             modelResolver.resolveModel(appArtifact);
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to resolve application model " + appArtifact + " dependencies", e);
         }
+    }
+
+    protected MavenArtifactResolver resolver() throws BootstrapMavenException {
+        return resolver == null ? resolver = new MavenArtifactResolver(new BootstrapMavenContext()) : resolver;
     }
 
     protected void setupResolver(BootstrapAppModelResolver modelResolver) {

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/BuildTreeMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/BuildTreeMojo.java
@@ -10,6 +10,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Displays Quarkus application build dependency tree including the deployment ones.
  */
-@Mojo(name = "build-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "build-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE)
 public class BuildTreeMojo extends AbstractTreeMojo {
 }

--- a/independent-projects/bootstrap/maven-plugin/src/test/java/io/quarkus/maven/TreeMojoTestBase.java
+++ b/independent-projects/bootstrap/maven-plugin/src/test/java/io/quarkus/maven/TreeMojoTestBase.java
@@ -86,10 +86,7 @@ public abstract class TreeMojoTestBase {
                 app.getType(), app.getClassifier(), new DefaultArtifactHandler("jar")));
         mojo.project.setModel(appModel);
         mojo.project.setOriginalModel(appModel);
-
-        mojo.repoSystem = mvnResolver.getSystem();
-        mojo.repoSession = mvnResolver.getSession();
-        mojo.repos = mvnResolver.getRepositories();
+        mojo.resolver = mvnResolver;
 
         final Path mojoLog = workDir.resolve("mojo.log");
         final PrintStream defaultOut = System.out;


### PR DESCRIPTION
This change removes to requirement to `mvn install` local project dependencies for `quarkus-bootstrap-maven-plugin:build-tree` to work.