### PR TITLE
Do not attempt to parse empty SQL scripts

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -705,10 +705,7 @@ public final class HibernateOrmProcessor {
                 // sql-load-script
                 Optional<String> importFile = getSqlLoadScript(launchMode);
 
-                if (!importFile.isPresent()) {
-                    // explicitly set a no file and ignore all other operations
-                    desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES, NO_SQL_LOAD_SCRIPT_FILE);
-                } else {
+                if (importFile.isPresent()) {
                     Path loadScriptPath = applicationArchivesBuildItem.getRootArchive().getChildPath(importFile.get());
 
                     if (loadScriptPath != null && !Files.isDirectory(loadScriptPath)) {
@@ -721,6 +718,9 @@ public final class HibernateOrmProcessor {
                                 "Unable to find file referenced in '" + HIBERNATE_ORM_CONFIG_PREFIX + "sql-load-script="
                                         + hibernateConfig.sqlLoadScript.get() + "'. Remove property or add file to your path.");
                     }
+                } else {
+                    //Disable implicit loading of the default import script (import.sql)
+                    desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES, "");
                 }
 
                 // Caching

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -47,7 +47,6 @@ import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.loader.BatchFetchStyle;
 import org.hibernate.proxy.HibernateProxy;
-import org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
@@ -716,9 +715,6 @@ public final class HibernateOrmProcessor {
                         // enlist resource if present
                         resourceProducer.produce(new NativeImageResourceBuildItem(importFile.get()));
                         desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES, importFile.get());
-                        desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR,
-                                MultipleLinesSqlCommandExtractor.class.getName());
-
                     } else if (hibernateConfig.sqlLoadScript.isPresent()) {
                         //raise exception if explicit file is not present (i.e. not the default)
                         throw new ConfigurationError(

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusImportSqlCommandExtractorInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusImportSqlCommandExtractorInitiator.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.orm.runtime.service;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractor;
+import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractorInitiator;
+import org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor;
+
+public final class QuarkusImportSqlCommandExtractorInitiator implements StandardServiceInitiator<ImportSqlCommandExtractor> {
+    public static final ImportSqlCommandExtractorInitiator INSTANCE = new ImportSqlCommandExtractorInitiator();
+    private static final MultipleLinesSqlCommandExtractor SERVICE_INSTANCE = new MultipleLinesSqlCommandExtractor();
+
+    @Override
+    public ImportSqlCommandExtractor initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+        return SERVICE_INSTANCE;
+    }
+
+    @Override
+    public Class<ImportSqlCommandExtractor> getServiceInitiated() {
+        return ImportSqlCommandExtractor.class;
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
@@ -20,7 +20,6 @@ import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInit
 import org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator;
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
-import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractorInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
 
 import io.quarkus.hibernate.orm.runtime.customized.BootstrapOnlyProxyFactoryFactoryInitiator;
@@ -48,7 +47,7 @@ public final class StandardHibernateORMInitiatorListProvider implements InitialI
         serviceInitiators.add(ConfigurationServiceInitiator.INSTANCE);
         serviceInitiators.add(PropertyAccessStrategyResolverInitiator.INSTANCE);
 
-        serviceInitiators.add(ImportSqlCommandExtractorInitiator.INSTANCE);
+        serviceInitiators.add(QuarkusImportSqlCommandExtractorInitiator.INSTANCE);
         serviceInitiators.add(SchemaManagementToolInitiator.INSTANCE);
 
         serviceInitiators.add(JdbcEnvironmentInitiator.INSTANCE);

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -233,11 +233,7 @@ public final class HibernateReactiveProcessor {
         // sql-load-script
         Optional<String> importFile = getSqlLoadScript(launchMode);
 
-        if (!importFile.isPresent()) {
-            // explicitly set a no file and ignore all other operations
-            desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES,
-                    HibernateOrmProcessor.NO_SQL_LOAD_SCRIPT_FILE);
-        } else {
+        if (importFile.isPresent()) {
             Path loadScriptPath = applicationArchivesBuildItem.getRootArchive().getChildPath(importFile.get());
 
             if (loadScriptPath != null && !Files.isDirectory(loadScriptPath)) {
@@ -251,6 +247,9 @@ public final class HibernateReactiveProcessor {
                                 + "sql-load-script="
                                 + hibernateConfig.sqlLoadScript.get() + "'. Remove property or add file to your path.");
             }
+        } else {
+            //Disable implicit loading of the default import script (import.sql)
+            desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES, "");
         }
 
         // Caching

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -20,7 +20,6 @@ import javax.persistence.spi.PersistenceUnitTransactionType;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.loader.BatchFetchStyle;
-import org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
@@ -245,9 +244,6 @@ public final class HibernateReactiveProcessor {
                 // enlist resource if present
                 resourceProducer.produce(new NativeImageResourceBuildItem(importFile.get()));
                 desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES, importFile.get());
-                desc.getProperties().setProperty(AvailableSettings.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR,
-                        MultipleLinesSqlCommandExtractor.class.getName());
-
             } else if (hibernateConfig.sqlLoadScript.isPresent()) {
                 //raise exception if explicit file is not present (i.e. not the default)
                 throw new ConfigurationError(

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
@@ -25,7 +25,6 @@ import org.hibernate.reactive.provider.service.ReactiveSessionFactoryBuilderInit
 import org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator;
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
-import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractorInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
 
 import io.quarkus.hibernate.orm.runtime.customized.BootstrapOnlyProxyFactoryFactoryInitiator;
@@ -33,6 +32,7 @@ import io.quarkus.hibernate.orm.runtime.customized.QuarkusJndiServiceInitiator;
 import io.quarkus.hibernate.orm.runtime.service.DialectFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.DisabledJMXInitiator;
 import io.quarkus.hibernate.orm.runtime.service.InitialInitiatorListProvider;
+import io.quarkus.hibernate.orm.runtime.service.QuarkusImportSqlCommandExtractorInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusMutableIdentifierGeneratorFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
 import io.quarkus.hibernate.orm.runtime.service.StandardHibernateORMInitiatorListProvider;
@@ -64,7 +64,7 @@ public final class ReactiveHibernateInitiatorListProvider implements InitialInit
         serviceInitiators.add(ConfigurationServiceInitiator.INSTANCE);
         serviceInitiators.add(PropertyAccessStrategyResolverInitiator.INSTANCE);
 
-        serviceInitiators.add(ImportSqlCommandExtractorInitiator.INSTANCE);
+        serviceInitiators.add(QuarkusImportSqlCommandExtractorInitiator.INSTANCE);
         serviceInitiators.add(SchemaManagementToolInitiator.INSTANCE);
 
         serviceInitiators.add(JdbcEnvironmentInitiator.INSTANCE);


### PR DESCRIPTION
This is primarily meant to bypass the following issue, which is new in latest ORM release:
 - https://hibernate.atlassian.net/browse/HHH-14145

But I actually think to not fix HHH-14145, as it's correct to throw an error on attempting to parse empty input. We shouldn't try to parse it to begin with.. a performance win as well.