### PR TITLE
Ignore modules with missing main source set

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -107,7 +107,7 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         for (Project subproject : project.getAllprojects()) {
             final Convention convention = subproject.getConvention();
             JavaPluginConvention javaConvention = convention.findPlugin(JavaPluginConvention.class);
-            if (javaConvention == null) {
+            if (javaConvention == null || !javaConvention.getSourceSets().getNames().contains(SourceSet.MAIN_SOURCE_SET_NAME)) {
                 continue;
             }
             modules.add(getWorkspaceModule(subproject, mode));

--- a/devtools/gradle/src/test/resources/multi-module-project/nomain/build.gradle
+++ b/devtools/gradle/src/test/resources/multi-module-project/nomain/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'java-library'
+}
+
+
+sourceSets {
+    remove(named("main"))
+}

--- a/devtools/gradle/src/test/resources/multi-module-project/settings.gradle
+++ b/devtools/gradle/src/test/resources/multi-module-project/settings.gradle
@@ -16,4 +16,4 @@ pluginManagement {
 }
 rootProject.name='mutli-module-project'
 
-include 'common', 'application'
+include 'common', 'application', 'nomain'


### PR DESCRIPTION
Fixes #11370

i added a module to the multi-module test gradle project where the main source set gets deleted.

The test "shouldLoadMultiModuleModel" verifies that the module does not get added to the workspace

I also verified the build is working with my own project where it did previously not.