### PR TITLE
Fix broken link in websockets doc

### DIFF
--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -160,4 +160,4 @@ image:websocket-guide-screenshot.png[alt=Application]
 As usual, the application can be packaged using `./mvnw clean package` and executed using the `-runner.jar` file.
 You can also build the native executable using `./mvnw package -Pnative`.
 
-You can also test your web socket applications using the approach detailed {quickstarts-blob-url}/websockets-quickstart/src/test/java/org/acme/websockets/ChatTestCase.java[here].
+You can also test your web socket applications using the approach detailed {quickstarts-blob-url}/websockets-quickstart/src/test/java/org/acme/websockets/ChatTest.java[here].


### PR DESCRIPTION
Fixes #11404.

The file was renamed from `ChatTestCase` to `ChatTest` recently:
https://github.com/quarkusio/quarkus-quickstarts/blob/master/websockets-quickstart/src/test/java/org/acme/websockets/ChatTest.java