### PR TITLE
Keep dependency order in Gradle

### DIFF
--- a/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
+++ b/devtools/gradle/src/main/java/io/quarkus/gradle/builder/QuarkusModelBuilder.java
@@ -7,8 +7,10 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -81,10 +83,10 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
 
     @Override
     public Object buildAll(String modelName, ModelParameter parameter, Project project) {
-        LaunchMode mode = LaunchMode.valueOf(((ModelParameter) parameter).getMode());
+        LaunchMode mode = LaunchMode.valueOf(parameter.getMode());
 
         final Set<org.gradle.api.artifacts.Dependency> deploymentDeps = getEnforcedPlatforms(project);
-        final Map<ArtifactCoords, Dependency> appDependencies = new HashMap<>();
+        final Map<ArtifactCoords, Dependency> appDependencies = new LinkedHashMap<>();
         final Set<ArtifactCoords> visitedDeps = new HashSet<>();
 
         final ResolvedConfiguration configuration = classpathConfig(project, mode).getResolvedConfiguration();
@@ -92,13 +94,13 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         collectFirstMetDeploymentDeps(configuration.getFirstLevelModuleDependencies(), appDependencies,
                 deploymentDeps, visitedDeps);
 
-        final Set<Dependency> extensionDependencies = collectExtensionDependencies(project, deploymentDeps);
+        final List<Dependency> extensionDependencies = collectExtensionDependencies(project, deploymentDeps);
 
         ArtifactCoords appArtifactCoords = new ArtifactCoordsImpl(project.getGroup().toString(), project.getName(),
                 project.getVersion().toString());
 
         return new QuarkusModelImpl(new WorkspaceImpl(appArtifactCoords, getWorkspace(project.getRootProject(), mode)),
-                new HashSet<>(appDependencies.values()),
+                new LinkedList<>(appDependencies.values()),
                 extensionDependencies);
     }
 
@@ -211,9 +213,9 @@ public class QuarkusModelBuilder implements ParameterizedToolingModelBuilder<Mod
         return null;
     }
 
-    private Set<Dependency> collectExtensionDependencies(Project project,
+    private List<Dependency> collectExtensionDependencies(Project project,
             Collection<org.gradle.api.artifacts.Dependency> extensions) {
-        final Set<Dependency> platformDependencies = new HashSet<>();
+        final List<Dependency> platformDependencies = new LinkedList<>();
 
         final Configuration deploymentConfig = project.getConfigurations()
                 .detachedConfiguration(extensions.toArray(new org.gradle.api.artifacts.Dependency[0]));

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/QuarkusModel.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/QuarkusModel.java
@@ -1,13 +1,13 @@
 package io.quarkus.bootstrap.resolver.model;
 
-import java.util.Set;
+import java.util.List;
 
 public interface QuarkusModel {
 
     Workspace getWorkspace();
 
-    Set<Dependency> getAppDependencies();
+    List<Dependency> getAppDependencies();
 
-    Set<Dependency> getExtensionDependencies();
+    List<Dependency> getExtensionDependencies();
 
 }

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/QuarkusModelImpl.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/model/impl/QuarkusModelImpl.java
@@ -4,17 +4,17 @@ import io.quarkus.bootstrap.resolver.model.Dependency;
 import io.quarkus.bootstrap.resolver.model.QuarkusModel;
 import io.quarkus.bootstrap.resolver.model.Workspace;
 import java.io.Serializable;
-import java.util.Set;
+import java.util.List;
 
 public class QuarkusModelImpl implements QuarkusModel, Serializable {
 
     private final Workspace workspace;
-    private final Set<Dependency> appDependencies;
-    private final Set<Dependency> extensionDependencies;
+    private final List<Dependency> appDependencies;
+    private final List<Dependency> extensionDependencies;
 
     public QuarkusModelImpl(Workspace workspace,
-            Set<Dependency> appDependencies,
-            Set<Dependency> extensionDependencies) {
+            List<Dependency> appDependencies,
+            List<Dependency> extensionDependencies) {
         this.workspace = workspace;
         this.appDependencies = appDependencies;
         this.extensionDependencies = extensionDependencies;
@@ -26,12 +26,12 @@ public class QuarkusModelImpl implements QuarkusModel, Serializable {
     }
 
     @Override
-    public Set<Dependency> getAppDependencies() {
+    public List<Dependency> getAppDependencies() {
         return appDependencies;
     }
 
     @Override
-    public Set<Dependency> getExtensionDependencies() {
+    public List<Dependency> getExtensionDependencies() {
         return extensionDependencies;
     }
 }


### PR DESCRIPTION
As mentioned in #11388, this remove usage of `Set` in favor of `LinkedList` in order to keep dependency order.