### PR TITLE
URL patterns for WebFilters are optional

### DIFF
--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -417,14 +417,29 @@ public class UndertowBuildStep {
         }
         if (webMetaData.getFilterMappings() != null) {
             for (FilterMappingMetaData mapping : webMetaData.getFilterMappings()) {
-                for (String m : mapping.getUrlPatterns()) {
-                    if (mapping.getDispatchers() == null || mapping.getDispatchers().isEmpty()) {
-                        recorder.addFilterURLMapping(deployment, mapping.getFilterName(), m, REQUEST);
-                    } else {
-
-                        for (DispatcherType dispatcher : mapping.getDispatchers()) {
-                            recorder.addFilterURLMapping(deployment, mapping.getFilterName(), m,
-                                    javax.servlet.DispatcherType.valueOf(dispatcher.name()));
+                List<String> urlPatterns = mapping.getUrlPatterns();
+                List<String> servletNames = mapping.getServletNames();
+                if (urlPatterns != null && !urlPatterns.isEmpty()) {
+                    for (String m : urlPatterns) {
+                        if (mapping.getDispatchers() == null || mapping.getDispatchers().isEmpty()) {
+                            recorder.addFilterURLMapping(deployment, mapping.getFilterName(), m, REQUEST);
+                        } else {
+                            for (DispatcherType dispatcher : mapping.getDispatchers()) {
+                                recorder.addFilterURLMapping(deployment, mapping.getFilterName(), m,
+                                        javax.servlet.DispatcherType.valueOf(dispatcher.name()));
+                            }
+                        }
+                    }
+                } else if (servletNames != null && !servletNames.isEmpty()) {
+                    // No URL Patterns found, map to servlet name instead
+                    for (String name : servletNames) {
+                        if (mapping.getDispatchers() == null || mapping.getDispatchers().isEmpty()) {
+                            recorder.addFilterServletNameMapping(deployment, mapping.getFilterName(), name, REQUEST);
+                        } else {
+                            for (DispatcherType dispatcher : mapping.getDispatchers()) {
+                                recorder.addFilterServletNameMapping(deployment, mapping.getFilterName(), name,
+                                        javax.servlet.DispatcherType.valueOf(dispatcher.name()));
+                            }
                         }
                     }
                 }
@@ -991,14 +1006,17 @@ public class UndertowBuildStep {
         if (description.length() > 0 || displayName.length() > 0 || smallIcon.length() > 0 || largeIcon.length() > 0) {
             dg = new DescriptionGroupMetaData();
             Descriptions descriptions = getDescription(description);
-            if (descriptions != null)
+            if (descriptions != null) {
                 dg.setDescriptions(descriptions);
+            }
             DisplayNames displayNames = getDisplayName(displayName);
-            if (displayNames != null)
+            if (displayNames != null) {
                 dg.setDisplayNames(displayNames);
+            }
             Icons icons = getIcons(smallIcon, largeIcon);
-            if (icons != null)
+            if (icons != null) {
                 dg.setIcons(icons);
+            }
         }
         return dg;
     }

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/MultipartConfigTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/MultipartConfigTestCase.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
@@ -15,7 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 
-import org.apache.commons.codec.Charsets;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,7 +48,7 @@ public class MultipartConfigTestCase {
     @ParameterizedTest
     @ValueSource(strings = { "/foo", "/servlet-item" })
     public void testMultipartConfig(String path) {
-        given().multiPart("file", "random.txt", "Some random file".getBytes(Charsets.UTF_8))
+        given().multiPart("file", "random.txt", "Some random file".getBytes(StandardCharsets.UTF_8))
                 .when().post(path).then()
                 .statusCode(201)
                 .body(is("OK"));

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/NamedServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/NamedServlet.java
@@ -1,0 +1,19 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(name = "named", urlPatterns = "/named")
+public class NamedServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().write("Hello World");
+    }
+
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/NoUrlPatternWebFilter.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/NoUrlPatternWebFilter.java
@@ -1,0 +1,20 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+
+@WebFilter(filterName = "MyFilter", servletNames = "named", asyncSupported = true)
+public class NoUrlPatternWebFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        response.getWriter().write("Goodbye");
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/WebFilterWithNoUrlPatternTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/WebFilterWithNoUrlPatternTestCase.java
@@ -1,0 +1,26 @@
+package io.quarkus.undertow.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WebFilterWithNoUrlPatternTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(NoUrlPatternWebFilter.class, NamedServlet.class));
+
+    @Test
+    public void testFilterWithNoUrlPattern() {
+        when().get("/named").then()
+                .statusCode(200)
+                .body(is("Goodbye"));
+    }
+}


### PR DESCRIPTION
According to the spec, servlet names can be specified instead
Fixes #11417