### PR TITLE
Hibernate Validator: don't skip interface annotation lookup if impl method has annotations

### DIFF
--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/MethodValidatedAnnotationsTransformer.java
@@ -78,25 +78,20 @@ public class MethodValidatedAnnotationsTransformer implements AnnotationsTransfo
     }
 
     private boolean requiresValidation(MethodInfo method) {
-        if (method.annotations().isEmpty()) {
-            // This method has no annotations of its own: look for inherited annotations
-            ClassInfo clazz = method.declaringClass();
-            String methodName = method.name().toString();
-            for (Map.Entry<DotName, Set<String>> validatedMethod : inheritedAnnotationsToBeValidated.entrySet()) {
-                if (clazz.interfaceNames().contains(validatedMethod.getKey())
-                        && validatedMethod.getValue().contains(methodName)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         for (DotName consideredAnnotation : consideredAnnotations) {
             if (method.hasAnnotation(consideredAnnotation)) {
                 return true;
             }
         }
-
+        // This method has no annotations of its own: look for inherited annotations
+        ClassInfo clazz = method.declaringClass();
+        String methodName = method.name().toString();
+        for (Map.Entry<DotName, Set<String>> validatedMethod : inheritedAnnotationsToBeValidated.entrySet()) {
+            if (clazz.interfaceNames().contains(validatedMethod.getKey())
+                    && validatedMethod.getValue().contains(methodName)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -1,5 +1,9 @@
 package io.quarkus.it.hibernate.validator;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -9,6 +13,7 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
+import javax.interceptor.InterceptorBinding;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
@@ -35,7 +40,7 @@ import io.quarkus.runtime.StartupEvent;
 
 @Path("/hibernate-validator/test")
 public class HibernateValidatorTestResource
-        implements HibernateValidatorTestResourceGenericInterface<Integer> {
+        implements HibernateValidatorTestResourceGenericInterface<Integer>, HibernateValidatorTestResourceInterface {
 
     @Inject
     Validator validator;
@@ -117,6 +122,19 @@ public class HibernateValidatorTestResource
     @Path("/rest-end-point-validation/{id}/")
     @Produces(MediaType.TEXT_PLAIN)
     public String testRestEndPointValidation(@Digits(integer = 5, fraction = 0) @PathParam("id") String id) {
+        return id;
+    }
+
+    // all JAX-RS annotations are defined in the interface
+    @Override
+    public String testRestEndPointInterfaceValidation(String id) {
+        return id;
+    }
+
+    // all JAX-RS annotations are defined in the interface
+    @Override
+    @SomeInterceptorBindingAnnotation
+    public String testRestEndPointInterfaceValidationWithAnnotationOnImplMethod(String id) {
         return id;
     }
 
@@ -306,6 +324,12 @@ public class HibernateValidatorTestResource
         public String getValue() {
             return value;
         }
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    public static @interface SomeInterceptorBindingAnnotation {
     }
 
     private static class ResultBuilder {

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResourceInterface.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResourceInterface.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.hibernate.validator;
+
+import javax.validation.constraints.Digits;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+public interface HibernateValidatorTestResourceInterface {
+
+    @GET
+    @Path("/rest-end-point-interface-validation/{id}/")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testRestEndPointInterfaceValidation(@Digits(integer = 5, fraction = 0) @PathParam("id") String id);
+
+    @GET
+    @Path("/rest-end-point-interface-validation-annotation-on-impl-method/{id}/")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testRestEndPointInterfaceValidationWithAnnotationOnImplMethod(
+            @Digits(integer = 5, fraction = 0) @PathParam("id") String id);
+}

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -70,6 +70,36 @@ public class HibernateValidatorFunctionalityTest {
     }
 
     @Test
+    public void testRestEndPointInterfaceValidation() {
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-interface-validation/plop/")
+                .then()
+                // 500 until this is fixed: https://github.com/quarkusio/quarkus/issues/11341#issuecomment-673146350
+                .statusCode(500)
+                .body(containsString("numeric value out of bounds"));
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-interface-validation/42/")
+                .then()
+                .body(is("42"));
+    }
+
+    @Test
+    public void testRestEndPointInterfaceValidationWithAnnotationOnImplMethod() {
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-impl-method/plop/")
+                .then()
+                // 500 until this is fixed: https://github.com/quarkusio/quarkus/issues/11341#issuecomment-673146350
+                .statusCode(500)
+                .body(containsString("numeric value out of bounds"));
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-impl-method/42/")
+                .then()
+                .body(is("42"));
+    }
+
+    @Test
     public void testRestEndPointGenericMethodValidation() {
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-generic-method-validation/9999999/")


### PR DESCRIPTION
Fixes #11341 (the main problem, not the [400 vs. 500 problem](https://github.com/quarkusio/quarkus/issues/11341#issuecomment-673146350)).

This basically just drops the `method.annotations().isEmpty()` check in `MethodValidatedAnnotationsTransformer`.

Before this fix the added test yielded:
```
[ERROR] Failures:
[ERROR]   HibernateValidatorFunctionalityTest.testRestEndPointInterfaceValidationWithAnnotationOnImplMethod:93 1 expectation failed.
Expected status code <500> but was <200>.
```

Turns out that the custom annotation _does indeed_ have to be annotated with `@InterceptorBinding`, otherwise the test will _not_ show the behaviour as reported in #11341 (results in 400 instead of 200). I did _not_ dig deeper to find out why this makes a difference (maybe some jandex thing).