### PR TITLE
Bootstrap Maven Resolver: add respecting maven batch-mode and ntp

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -20,7 +20,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.cli.transfer.BatchModeMavenTransferListener;
 import org.apache.maven.cli.transfer.ConsoleMavenTransferListener;
+import org.apache.maven.cli.transfer.QuietMavenTransferListener;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelProblemCollector;
@@ -68,6 +70,7 @@ import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transfer.TransferListener;
 import org.eclipse.aether.transport.wagon.WagonConfigurator;
 import org.eclipse.aether.transport.wagon.WagonProvider;
 import org.eclipse.aether.transport.wagon.WagonTransporterFactory;
@@ -386,7 +389,16 @@ public class BootstrapMavenContext {
         }
 
         if (session.getTransferListener() == null && artifactTransferLogging) {
-            session.setTransferListener(new ConsoleMavenTransferListener(System.out, true));
+            TransferListener transferListener;
+            if (mvnArgs.hasOption(BootstrapMavenOptions.NO_TRANSFER_PROGRESS)) {
+                transferListener = new QuietMavenTransferListener();
+            } else if (mvnArgs.hasOption(BootstrapMavenOptions.BATCH_MODE)) {
+                transferListener = new BatchModeMavenTransferListener(System.out);
+            } else {
+                transferListener = new ConsoleMavenTransferListener(System.out, true);
+            }
+
+            session.setTransferListener(transferListener);
         }
 
         return session;

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptions.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptions.java
@@ -39,6 +39,8 @@ public class BootstrapMavenOptions {
     public static final String UPDATE_SNAPSHOTS = "U";
     public static final String CHECKSUM_FAILURE_POLICY = "C";
     public static final String CHECKSUM_WARNING_POLICY = "c";
+    public static final String BATCH_MODE = "B";
+    public static final String NO_TRANSFER_PROGRESS = "ntp";
 
     public static Map<String, Object> parse(String cmdLine) {
         if (cmdLine == null) {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptionsParser.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/options/BootstrapMavenOptionsParser.java
@@ -27,6 +27,8 @@ public class BootstrapMavenOptionsParser {
         putBoolean(cmdLine, map, CLIManager.UPDATE_SNAPSHOTS);
         putBoolean(cmdLine, map, CLIManager.CHECKSUM_FAILURE_POLICY);
         putBoolean(cmdLine, map, CLIManager.CHECKSUM_WARNING_POLICY);
+        putBoolean(cmdLine, map, CLIManager.BATCH_MODE);
+        putBoolean(cmdLine, map, CLIManager.NO_TRANSFER_PROGRESS);
 
         return map;
     }

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/test/BootstrapMavenOptionsTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/test/BootstrapMavenOptionsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
+import org.apache.maven.cli.CLIManager;
 import org.junit.jupiter.api.Test;
 
 public class BootstrapMavenOptionsTest {
@@ -56,6 +57,20 @@ public class BootstrapMavenOptionsTest {
     public void testChecksumWarningPolicy() throws Exception {
         final BootstrapMavenOptions parseOptions = parseOptions("clean install -c");
         assertTrue(parseOptions.hasOption(BootstrapMavenOptions.CHECKSUM_WARNING_POLICY));
+    }
+
+    @Test
+    public void testBatchMode() {
+        assertEquals("" + CLIManager.BATCH_MODE, BootstrapMavenOptions.BATCH_MODE);
+        assertTrue(parseOptions("clean install -B").hasOption(BootstrapMavenOptions.BATCH_MODE));
+        assertTrue(parseOptions("clean install --batch-mode").hasOption(BootstrapMavenOptions.BATCH_MODE));
+    }
+
+    @Test
+    public void testNoTransferProgress() {
+        assertEquals(CLIManager.NO_TRANSFER_PROGRESS, BootstrapMavenOptions.NO_TRANSFER_PROGRESS);
+        assertTrue(parseOptions("clean install -ntp").hasOption(BootstrapMavenOptions.NO_TRANSFER_PROGRESS));
+        assertTrue(parseOptions("clean install --no-transfer-progress").hasOption(BootstrapMavenOptions.NO_TRANSFER_PROGRESS));
     }
 
     private BootstrapMavenOptions parseOptions(String line) {


### PR DESCRIPTION
Improvement of bootstrap-maven-resolver in order to respect maven --batch-mode and --no-transfer-progress flags, which are usually used by automated builds in CI.
Without this fix some builds can exceed logs limit due to by-default verbose transfer progress output in stdout resulting in loosing build error informations, e.g. on gitlab CI.