### PR TITLE
Improve IDE launch from Gradle project

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IDEDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IDEDevModeMain.java
@@ -14,7 +14,6 @@ import io.quarkus.bootstrap.BootstrapGradleException;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
-import io.quarkus.bootstrap.resolver.QuarkusGradleModelFactory;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.model.QuarkusModel;
 import io.quarkus.bootstrap.resolver.model.WorkspaceModule;
@@ -43,18 +42,17 @@ public class IDEDevModeMain implements BiConsumer<CuratedApplication, Map<String
                     devModeContext.getAdditionalModules().add(toModule(module.getValue()));
                 }
             } else {
-                // TODO find a way to reuse the previously model instead of building a new one.
-                QuarkusModel quarkusModel = QuarkusGradleModelFactory.createForTasks(
-                        BuildToolHelper.getBuildFile(appClasses, BuildToolHelper.BuildTool.GRADLE).toFile(),
-                        QuarkusModelHelper.DEVMODE_REQUIRED_TASKS);
-                final WorkspaceModule launchingModule = quarkusModel.getWorkspace().getMainModule();
-                DevModeContext.ModuleInfo root = toModule(quarkusModel.getWorkspace().getMainModule());
+                final QuarkusModel model = QuarkusModelHelper
+                        .deserializeQuarkusModel((Path) stringObjectMap.get(QuarkusModelHelper.SERIALIZED_QUARKUS_MODEL));
+                final WorkspaceModule launchingModule = model.getWorkspace().getMainModule();
+                DevModeContext.ModuleInfo root = toModule(launchingModule);
                 devModeContext.setApplicationRoot(root);
-                for (WorkspaceModule additionalModule : quarkusModel.getWorkspace().getAllModules()) {
+                for (WorkspaceModule additionalModule : model.getWorkspace().getAllModules()) {
                     if (!additionalModule.getArtifactCoords().equals(launchingModule.getArtifactCoords())) {
                         devModeContext.getAdditionalModules().add(toModule(additionalModule));
                     }
                 }
+
             }
 
         } catch (AppModelResolverException e) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
@@ -32,10 +32,12 @@ public class IDELauncherImpl {
 
             if (!BuildToolHelper.isMavenProject(projectRoot)) {
                 final QuarkusModel quarkusModel = BuildToolHelper.enableGradleAppModelForDevMode(projectRoot);
-                // Gradle uses a different output directory for classes, we override the one used by the IDE
+                context.put(QuarkusModelHelper.SERIALIZED_QUARKUS_MODEL,
+                        QuarkusModelHelper.serializeQuarkusModel(quarkusModel));
+
                 final WorkspaceModule launchingModule = quarkusModel.getWorkspace().getMainModule();
                 Path launchingModulePath = QuarkusModelHelper.getClassPath(launchingModule);
-
+                // Gradle uses a different output directory for classes, we override the one used by the IDE
                 builder.setProjectRoot(launchingModulePath)
                         .setApplicationRoot(launchingModulePath);
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicJavaApplicationModuleDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicJavaApplicationModuleDevModeTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import com.google.common.collect.ImmutableMap;
+
+@DisabledOnOs(OS.WINDOWS)
+public class BasicJavaApplicationModuleDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "basic-java-application-project";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "run", "-s" };
+    }
+
+    protected void testDevMode() throws Exception {
+        assertThat(getHttpResponse("/hello")).contains("hello");
+
+        final String uuid = UUID.randomUUID().toString();
+        replace("src/main/java/org/acme/ExampleResource.java",
+                ImmutableMap.of("return \"hello\";", "return \"" + uuid + "\";"));
+
+        assertUpdatedResponseContains("/hello", uuid);
+    }
+}

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'application'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+application {
+    mainClass = 'org.acme.EntryPoint'
+}

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/gradle.properties
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/settings.gradle
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/settings.gradle
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'
+include 'library'
+include 'application'
+

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/src/main/java/org/acme/EntryPoint.java
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/src/main/java/org/acme/EntryPoint.java
@@ -1,0 +1,11 @@
+package org.acme;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class EntryPoint {
+    public static void main(String[] args) {
+        Quarkus.run();
+    }
+}

--- a/integration-tests/gradle/src/test/resources/basic-java-application-project/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/test/resources/basic-java-application-project/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class ExampleResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}


### PR DESCRIPTION
ATM, to start dev mode from the IDE, we were requesting the gradle model two times. 

Due to some change, it appears that there were some classloader issues the second time (in `IDELauncherImpl`).
In order to avoid the second gradle connection (which is quite slow) this branch serialize the model after it has been generated the first time and then use it in the `IDELauncherImpl` class. 

I also add a `devmode` test using the gradle `application` plugin.

Close #11310 
