### PR TITLE
Disable the code flow access token verification by default (pre-1.7.0.Final status)

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -626,13 +626,20 @@ public class OidcTenantConfig {
         public boolean removeRedirectParameters = true;
 
         /**
-         * Both ID and access tokens are verified as part of the authorization code flow and every time
-         * these tokens are retrieved from the user session. One should disable the access token verification if
-         * it is only meant to be propagated to the downstream services.
-         * Note the ID token will always be verified.
+         * Both ID and access tokens are fetched from the OIDC provider as part of the authorization code flow.
+         * ID token is always verified on every user request as the primary token which is used
+         * to represent the principal and extract the roles.
+         * Access token is not verified by default since it is meant to be propagated to the downstream services.
+         * The verification of the access token should be enabled if it is injected as a JWT token.
+         *
+         * Access tokens obtained as part of the code flow will always be verified if `quarkus.oidc.roles.source`
+         * property is set to `accesstoken` which means the authorization decision will be based on the roles extracted from the
+         * access token.
+         * 
+         * Bearer access tokens are always verified.
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean verifyAccessToken = true;
+        @ConfigItem(defaultValue = "false")
+        public boolean verifyAccessToken;
 
         /**
          * Force 'https' as the 'redirect_uri' parameter scheme when running behind an SSL terminating reverse proxy.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -79,7 +79,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
         if (request.getToken() instanceof IdTokenCredential
                 && (resolvedContext.oidcConfig.authentication.verifyAccessToken
-                        || resolvedContext.oidcConfig.roles.source.get() == Source.accesstoken)) {
+                        || resolvedContext.oidcConfig.roles.source.orElse(null) == Source.accesstoken)) {
             vertxContext.put("code_flow_access_token_result",
                     verifyCodeFlowAccessToken(vertxContext, request, resolvedContext));
         }


### PR DESCRIPTION
Fixes #11460.
Fixes #11418.

In 1.7.0.Final we have the access tokens returned as part of the code flow verified by default. This has caused 2 regressions so far. 
Note this PR is simply restoring what was there all the time before 1.7.0.Final - i.e Quarkus OIDC has always been verifying ID tokens since ID tokens are treated as the primary principal tokens in the code flow but access tokens were only injected if required but they were not re-validated.

Verifying both ID and access tokens should be really encouraged, works fine with KC in the code flow, because the users can still inject access tokens as JWT tokens, etc.
But some providers are likely returning binary access tokens (definitely can be the the case with Auth0 now that I think about it) or JWTs signed by the key not available in the local JWK set (and no introspection endpoint is supported) so it causes side-effects when Vertx tries to introspect as a fallback when it fails to verify with the JWK. Hence it is better to make this feature optional but I've also updated the docs accordingly.

Also note that if `quarkus.oidc.roles.source=accesstoken` is set in the code flow (take the roles from the access token vs ID token, new in `1.7.0.Final`) then the access token will always be verified (test exists in `oidc-tenancy`) since we can't base the authorization decision on the non-re-validated access token.