### PR TITLE
Do not register standalone extension's core versions as a valid option

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/builder/RegistryBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/registry/builder/RegistryBuilder.java
@@ -61,7 +61,6 @@ public class RegistryBuilder implements IndexVisitor {
         if (extension.isUnlisted()) {
             return;
         }
-        registryBuilder.putCoreVersions(new ComparableVersion(quarkusCore), new HashMap<>());
         ArtifactKey extensionKey = ImmutableArtifactKey.of(extension.getGroupId(), extension.getArtifactId());
         ModifiableExtension extensionBuilder = extensions
                 .computeIfAbsent(extensionKey, key -> ModifiableExtension.create()

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/registry/DefaultExtensionRegistryTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/registry/DefaultExtensionRegistryTest.java
@@ -50,9 +50,7 @@ class DefaultExtensionRegistryTest {
         assertThat(extensionRegistry.getQuarkusCoreVersions()).containsExactly(
                 "1.6.0.Final",
                 "1.5.2.Final",
-                "1.3.2.Final",
-                "1.3.1.Final",
-                "1.1.0.CR1");
+                "1.3.2.Final");
     }
 
     @Test


### PR DESCRIPTION
It should be used only to compare if an extension is compatible with the existing platforms.

This change should prevent, for example, displaying `1.5.0.Final` (because one extension was built with it) when you have platforms defined as `1.7.0.Final`